### PR TITLE
Release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.0dev0 (unreleased)
+## 0.1.0 (2026-02-28)
 
 ### Phase 0 — Scaffold
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -67,7 +67,7 @@ gantt
 # pyproject.toml
 [project]
 name = "archex"
-version = "0.1.0dev0"
+version = "0.1.0"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archex"
-version = "0.1.0dev0"
+version = "0.1.0"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/archex/__init__.py
+++ b/src/archex/__init__.py
@@ -4,6 +4,6 @@ from __future__ import annotations
 
 from archex.api import analyze, compare, query
 
-__version__ = "0.1.0dev0"
+__version__ = "0.1.0"
 
 __all__ = ["analyze", "query", "compare", "__version__"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ def test_version() -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["--version"])
     assert result.exit_code == 0
-    assert "archex, version 0.1.0dev0" in result.output
+    assert "archex, version 0.1.0" in result.output
 
 
 def test_help_contains_subcommands() -> None:


### PR DESCRIPTION
## Summary

- Bump version from `0.1.0dev0` to `0.1.0` across pyproject.toml, `__init__.py`, CHANGELOG, ROADMAP, and test assertions
- Tag `v0.1.0` will be created after merge

## Test plan

- [x] `uv run pytest tests/test_cli.py` — version string assertion passes
- [x] `uv build` — produces `archex-0.1.0-py3-none-any.whl`