### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.2.0 (2026-02-28)
+
+### Phase 5 — Ecosystem
+
+- **MCP server:** 3 tools (analyze_repo, query_repo, compare_repos) with async stdio transport, `archex mcp` CLI command
+- **LangChain integration:** `ArchexRetriever(BaseRetriever)` mapping RankedChunks to Documents
+- **LlamaIndex integration:** `ArchexRetriever(BaseRetriever)` mapping RankedChunks to NodeWithScore
+- **Parallel parsing:** `extract_symbols()` and `parse_imports()` accept `parallel=True` for ProcessPoolExecutor concurrency
+- **ONNX model caching:** `NomicCodeEmbedder` supports `cache_dir` for persistent model storage at `~/.archex/models/`
+- **Publish workflow:** GitHub Actions publishes to PyPI on `v*` tag push
+- **New optional deps:** `archex[mcp]`, `archex[langchain]`, `archex[llamaindex]`
+- 422 tests, 81% coverage
+
 ## 0.1.0 (2026-02-28)
 
 ### Phase 0 — Scaffold

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archex"
-version = "0.1.0"
+version = "0.2.0"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/archex/__init__.py
+++ b/src/archex/__init__.py
@@ -4,6 +4,6 @@ from __future__ import annotations
 
 from archex.api import analyze, compare, query
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = ["analyze", "query", "compare", "__version__"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ def test_version() -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["--version"])
     assert result.exit_code == 0
-    assert "archex, version 0.1.0" in result.output
+    assert "archex, version 0.2.0" in result.output
 
 
 def test_help_contains_subcommands() -> None:


### PR DESCRIPTION
## Summary

- Bump version from 0.1.0 to 0.2.0
- Add Phase 5 (Ecosystem) section to CHANGELOG

## Test plan

- [x] `uv run pytest tests/test_cli.py::test_version` — passes with 0.2.0
- [x] `uv build` — produces archex-0.2.0 wheel