### PR TITLE
Phase 6b: Optimize query hot path, parallelism, and caching

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -92,8 +93,8 @@ def analyze(
         engine = TreeSitterEngine()
         adapters = _build_adapters()
 
-        parsed_files = extract_symbols(files, engine, adapters)
-        import_map = parse_imports(files, engine, adapters)
+        parsed_files = extract_symbols(files, engine, adapters, parallel=config.parallel)
+        import_map = parse_imports(files, engine, adapters, parallel=config.parallel)
         file_map = build_file_map(files)
         file_languages = {f.path: f.language for f in files}
         resolved_map = resolve_imports(import_map, file_map, adapters, file_languages)
@@ -149,7 +150,7 @@ def query(
     """Retrieve a ranked ContextBundle for a natural-language query.
 
     Runs the full pipeline: acquire → parse → chunk → index → search → assemble.
-    Uses cached index if available.
+    On cache hit, skips the full parse: loads chunks and graph from the cached store.
     """
     if config is None:
         config = Config()
@@ -159,6 +160,44 @@ def query(
     cache = CacheManager(cache_dir=config.cache_dir)
     cache_key = cache.cache_key(source)
 
+    # Check cache BEFORE parsing — if cached, skip the expensive parse pipeline
+    cached_db = cache.get(cache_key) if config.cache else None
+    if cached_db is not None:
+        store = IndexStore(cached_db)
+        try:
+            bm25 = BM25Index(store)
+            cached_chunks = store.get_chunks()
+            if cached_chunks:
+                bm25.build(cached_chunks)
+            stored_edges = store.get_edges()
+            graph = DependencyGraph.from_edges(stored_edges)
+
+            # Load cached vector index if available
+            vector_results: list[tuple[object, float]] | None = None
+            if index_config.vector:
+                vec_path = cache.vector_path(cache_key)
+                if vec_path.exists():
+                    from archex.index.vector import VectorIndex
+
+                    vec_idx = VectorIndex()
+                    vec_idx.load(vec_path, cached_chunks)
+                    embedder = _get_embedder(index_config)
+                    if embedder is not None:
+                        vector_results = vec_idx.search(question, embedder, top_k=50)  # type: ignore[assignment]
+
+            search_results = bm25.search(question, top_k=50)
+            return assemble_context(
+                search_results=search_results,
+                graph=graph,
+                all_chunks=cached_chunks,
+                question=question,
+                token_budget=token_budget,
+                vector_results=vector_results,  # type: ignore[arg-type]
+            )
+        finally:
+            store.close()
+
+    # Cache miss — full pipeline
     repo_path, _url, _local_path, cleanup = _acquire(source)
     try:
         files = discover_files(
@@ -168,8 +207,8 @@ def query(
         engine = TreeSitterEngine()
         adapters = _build_adapters()
 
-        parsed_files = extract_symbols(files, engine, adapters)
-        import_map = parse_imports(files, engine, adapters)
+        parsed_files = extract_symbols(files, engine, adapters, parallel=config.parallel)
+        import_map = parse_imports(files, engine, adapters, parallel=config.parallel)
         file_map = build_file_map(files)
         file_languages = {f.path: f.language for f in files}
         resolved_map = resolve_imports(import_map, file_map, adapters, file_languages)
@@ -186,29 +225,23 @@ def query(
                 continue
         all_chunks = chunker.chunk_files(parsed_files, sources)
 
-        # Build or load index
-        cached_db = cache.get(cache_key) if config.cache else None
-        db_path: Path | None = None
-        if cached_db is not None:
-            store = IndexStore(cached_db)
-        else:
-            db_path = Path(tempfile.mkdtemp()) / "index.db"
-            store = IndexStore(db_path)
+        # Build index in temp DB
+        db_path = Path(tempfile.mkdtemp()) / "index.db"
+        store = IndexStore(db_path)
 
         try:
             bm25 = BM25Index(store)
-            if cached_db is not None:
-                # Rebuild FTS from stored chunks (FTS data isn't persisted across copies)
-                cached_chunks = store.get_chunks()
-                if cached_chunks:
-                    bm25.build(cached_chunks)
-            else:
-                store.insert_chunks(all_chunks)
-                bm25.build(all_chunks)
-                if config.cache and db_path is not None:
-                    # Checkpoint WAL to ensure all data is in the main DB file before copy
-                    store.conn.execute("PRAGMA wal_checkpoint(FULL)")
-                    cache.put(cache_key, db_path)
+            store.insert_chunks(all_chunks)
+
+            # Store edges for cache reconstruction
+            edges = graph.file_edges()
+            store.insert_edges(edges)
+
+            bm25.build(all_chunks)
+            if config.cache:
+                # Checkpoint WAL to ensure all data is in the main DB file before copy
+                store.conn.execute("PRAGMA wal_checkpoint(FULL)")
+                cache.put(cache_key, db_path)
 
             # Search and assemble
             search_results = bm25.search(question, top_k=50)
@@ -227,13 +260,35 @@ def query(
         cleanup()
 
 
+def _get_embedder(index_config: IndexConfig) -> object | None:
+    """Create an embedder from index_config, or return None if not configured."""
+    if not index_config.embedder:
+        return None
+    if index_config.embedder == "nomic":
+        from archex.index.embeddings.nomic import NomicCodeEmbedder
+
+        return NomicCodeEmbedder()
+    if index_config.embedder == "sentence_transformers":
+        from archex.index.embeddings.sentence_tf import SentenceTransformerEmbedder
+
+        return SentenceTransformerEmbedder()
+    # API embedder requires additional config — not created here
+    return None
+
+
 def compare(
     source_a: RepoSource,
     source_b: RepoSource,
     dimensions: list[str] | None = None,
     config: Config | None = None,
 ) -> ComparisonResult:
-    """Analyze two repositories and return a ComparisonResult."""
-    profile_a = analyze(source_a, config)
-    profile_b = analyze(source_b, config)
+    """Analyze two repositories and return a ComparisonResult.
+
+    Uses ThreadPoolExecutor to run both analyses concurrently.
+    """
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future_a = executor.submit(analyze, source_a, config)
+        future_b = executor.submit(analyze, source_b, config)
+        profile_a = future_a.result()
+        profile_b = future_b.result()
     return compare_repos(profile_a, profile_b, dimensions)

--- a/src/archex/cache.py
+++ b/src/archex/cache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import re
 import shutil
+import subprocess
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -29,9 +30,35 @@ class CacheManager:
     # ------------------------------------------------------------------
 
     def cache_key(self, source: RepoSource) -> str:
-        """Derive a stable SHA256 cache key from the source URL or local path."""
+        """Derive a stable SHA256 cache key from the source identity and git HEAD."""
         identity = source.url or source.local_path or ""
+        # Include git HEAD commit for local repos to invalidate on new commits
+        commit = source.commit or self._git_head(source.local_path)
+        if commit:
+            identity = f"{identity}@{commit}"
         return hashlib.sha256(identity.encode()).hexdigest()
+
+    @staticmethod
+    def _git_head(local_path: str | None) -> str | None:
+        """Return the HEAD commit hash for a local repo, or None."""
+        if local_path is None:
+            return None
+        git_dir = Path(local_path) / ".git"
+        if not git_dir.exists():
+            return None
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=local_path,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                return result.stdout.strip()
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+        return None
 
     def _validate_key(self, key: str) -> None:
         if not _KEY_RE.match(key):
@@ -48,6 +75,11 @@ class CacheManager:
         """Return the metadata file path for a cache key."""
         self._validate_key(key)
         return self._cache_dir / f"{key}.meta"
+
+    def vector_path(self, key: str) -> Path:
+        """Return the vector index file path for a cache key."""
+        self._validate_key(key)
+        return self._cache_dir / f"{key}.vectors.npz"
 
     # ------------------------------------------------------------------
     # CRUD

--- a/src/archex/index/bm25.py
+++ b/src/archex/index/bm25.py
@@ -70,13 +70,20 @@ class BM25Index:
         except Exception:
             return []
 
+        rows = cur.fetchall()
+        if not rows:
+            return []
+
+        # Batch-fetch all chunks in one query instead of N individual lookups
+        chunk_ids = [str(row[0]) for row in rows]
+        score_map = {str(row[0]): -float(row[1]) for row in rows}
+        fetched = self._store.get_chunks_by_ids(chunk_ids)
+
         results: list[tuple[CodeChunk, float]] = []
-        for chunk_id, raw_score in cur.fetchall():
-            chunk = self._store.get_chunk(str(chunk_id))
-            if chunk is None:
-                continue
-            # FTS5 bm25() returns negative values; negate for positive relevance score
-            score = -float(raw_score)
+        for chunk in fetched:
+            score = score_map.get(chunk.id, 0.0)
             results.append((chunk, score))
 
+        # Preserve BM25 ranking order
+        results.sort(key=lambda r: r[1], reverse=True)
         return results

--- a/src/archex/index/chunker.py
+++ b/src/archex/index/chunker.py
@@ -60,9 +60,8 @@ def _split_lines_at_boundary(
     return chunks
 
 
-def _extract_source_lines(source: bytes, start_line: int, end_line: int) -> list[bytes]:
-    """Extract 1-indexed [start_line, end_line] from source bytes."""
-    all_lines = source.split(b"\n")
+def _extract_source_lines(all_lines: list[bytes], start_line: int, end_line: int) -> list[bytes]:
+    """Extract 1-indexed [start_line, end_line] from pre-split line list."""
     lo = max(0, start_line - 1)
     hi = min(len(all_lines), end_line)
     return all_lines[lo:hi]
@@ -136,7 +135,7 @@ class ASTChunker:
         candidates: list[tuple[list[bytes], int, Symbol | None]] = []
 
         for sym in symbols:
-            sym_lines = _extract_source_lines(source, sym.start_line, sym.end_line)
+            sym_lines = _extract_source_lines(all_source_lines, sym.start_line, sym.end_line)
             if not sym_lines:
                 continue
 
@@ -154,7 +153,7 @@ class ASTChunker:
         # File-level code: lines not covered by any symbol
         uncovered_ranges = _find_uncovered_ranges(covered, total_lines)
         for range_start, range_end in uncovered_ranges:
-            fl_lines = _extract_source_lines(source, range_start, range_end)
+            fl_lines = _extract_source_lines(all_source_lines, range_start, range_end)
             if not fl_lines or all(line.strip() == b"" for line in fl_lines):
                 continue
             tokens = _count_tokens(encoder, _lines_to_text(fl_lines))

--- a/src/archex/index/graph.py
+++ b/src/archex/index/graph.py
@@ -19,6 +19,7 @@ class DependencyGraph:
     def __init__(self) -> None:
         self._file_graph: nx.DiGraph[str] = nx.DiGraph()  # type: ignore[type-arg]
         self._symbol_graph: nx.DiGraph[str] = nx.DiGraph()  # type: ignore[type-arg]
+        self._centrality_cache: dict[str, float] | None = None
 
     # ------------------------------------------------------------------
     # Construction
@@ -57,6 +58,21 @@ class DependencyGraph:
 
         return graph
 
+    @classmethod
+    def from_edges(cls, edges: list[Edge]) -> DependencyGraph:
+        """Reconstruct a file-level DependencyGraph from Edge objects."""
+        graph = cls()
+        for edge in edges:
+            graph._file_graph.add_node(edge.source)  # type: ignore[misc]
+            graph._file_graph.add_node(edge.target)  # type: ignore[misc]
+            graph._file_graph.add_edge(  # type: ignore[misc]
+                edge.source,
+                edge.target,
+                kind=edge.kind,
+                location=edge.location,
+            )
+        return graph
+
     # ------------------------------------------------------------------
     # Properties
     # ------------------------------------------------------------------
@@ -64,10 +80,12 @@ class DependencyGraph:
     def add_file_node(self, path: str) -> None:
         """Add a file node to the file-level graph."""
         self._file_graph.add_node(path)  # type: ignore[misc]
+        self._centrality_cache = None
 
     def add_file_edge(self, source: str, target: str, kind: str = "imports") -> None:
         """Add an edge to the file-level graph."""
         self._file_graph.add_edge(source, target, kind=kind)  # type: ignore[misc]
+        self._centrality_cache = None
 
     @property
     def file_count(self) -> int:
@@ -129,11 +147,14 @@ class DependencyGraph:
         return visited
 
     def structural_centrality(self) -> dict[str, float]:
-        """Return PageRank centrality scores for all file nodes."""
+        """Return PageRank centrality scores for all file nodes (lazily cached)."""
+        if self._centrality_cache is not None:
+            return self._centrality_cache
         if self._file_graph.number_of_nodes() == 0:  # type: ignore[misc]
             return {}
         raw: dict[Any, float] = nx.pagerank(self._file_graph)  # type: ignore[misc]
-        return {str(k): v for k, v in raw.items()}
+        self._centrality_cache = {str(k): v for k, v in raw.items()}
+        return self._centrality_cache
 
     # ------------------------------------------------------------------
     # Persistence

--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -152,6 +152,19 @@ class IndexStore:
         row = cur.fetchone()
         return _row_to_chunk(row) if row else None
 
+    def get_chunks_by_ids(self, ids: list[str]) -> list[CodeChunk]:
+        """Fetch multiple chunks by ID in a single query."""
+        if not ids:
+            return []
+        placeholders = ",".join("?" for _ in ids)
+        sql = (
+            "SELECT id, content, file_path, start_line, end_line, symbol_name, "
+            "symbol_kind, language, imports_context, token_count, module "
+            f"FROM chunks WHERE id IN ({placeholders})"
+        )
+        cur = self._conn.execute(sql, ids)
+        return [_row_to_chunk(row) for row in cur.fetchall()]
+
     def get_chunks_for_file(self, file_path: str) -> list[CodeChunk]:
         cur = self._conn.execute(
             "SELECT id, content, file_path, start_line, end_line, symbol_name, symbol_kind, "

--- a/src/archex/index/vector.py
+++ b/src/archex/index/vector.py
@@ -65,7 +65,12 @@ class VectorIndex:
         # Dot product on normalized vectors = cosine similarity
         similarities = self._vectors @ query_vec
         k = min(top_k, len(self._chunk_ids))
-        top_indices = np.argsort(similarities)[::-1][:k]
+        # O(N) argpartition for top-k selection, then sort only the k selected
+        if k < len(similarities):
+            part_indices = np.argpartition(similarities, -k)[-k:]
+            top_indices = part_indices[np.argsort(similarities[part_indices])[::-1]]
+        else:
+            top_indices = np.argsort(similarities)[::-1]
 
         results: list[tuple[CodeChunk, float]] = []
         for idx in top_indices:

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -67,6 +67,7 @@ class Config(BaseModel):
     cache: bool = True
     cache_dir: str = "~/.archex/cache"
     max_file_size: int = 10_000_000
+    parallel: bool = False
 
 
 class IndexConfig(BaseModel):

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -10,7 +10,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from archex.models import DiscoveredFile
+from archex.cache import CacheManager
+from archex.index.graph import DependencyGraph
+from archex.index.store import IndexStore
+from archex.models import CodeChunk, Config, DiscoveredFile, Edge, EdgeKind, RepoSource, SymbolKind
 from archex.parse.adapters import ADAPTERS
 from archex.parse.engine import TreeSitterEngine
 from archex.parse.imports import parse_imports
@@ -246,3 +249,154 @@ class TestNomicEmbedderCaching:
             assert len(vec) == 768
         # With batch_size=4 and 10 texts, expect 3 session.run calls
         assert mock_session.run.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Phase 6b: Additional performance optimization tests
+# ---------------------------------------------------------------------------
+
+
+class TestBatchFetch:
+    def test_get_chunks_by_ids_returns_matching(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "test.db"
+        store = IndexStore(db_path)
+        chunks = [
+            CodeChunk(
+                id=f"file.py:sym{i}:{i}",
+                content=f"content {i}",
+                file_path="file.py",
+                start_line=i,
+                end_line=i,
+                language="python",
+            )
+            for i in range(5)
+        ]
+        store.insert_chunks(chunks)
+        result = store.get_chunks_by_ids(["file.py:sym1:1", "file.py:sym3:3"])
+        assert len(result) == 2
+        assert {c.id for c in result} == {"file.py:sym1:1", "file.py:sym3:3"}
+        store.close()
+
+    def test_get_chunks_by_ids_empty(self, tmp_path: Path) -> None:
+        store = IndexStore(tmp_path / "test.db")
+        assert store.get_chunks_by_ids([]) == []
+        store.close()
+
+
+class TestCentralityCache:
+    def test_cached_on_repeated_call(self) -> None:
+        g = DependencyGraph()
+        g.add_file_node("a.py")
+        g.add_file_node("b.py")
+        g.add_file_edge("a.py", "b.py")
+        c1 = g.structural_centrality()
+        c2 = g.structural_centrality()
+        assert c1 is c2
+
+    def test_invalidated_on_mutation(self) -> None:
+        g = DependencyGraph()
+        g.add_file_node("a.py")
+        g.add_file_node("b.py")
+        g.add_file_edge("a.py", "b.py")
+        c1 = g.structural_centrality()
+        g.add_file_node("c.py")
+        g.add_file_edge("b.py", "c.py")
+        c2 = g.structural_centrality()
+        assert c1 is not c2
+        assert "c.py" in c2
+
+
+class TestFromEdges:
+    def test_reconstructs_graph(self) -> None:
+        edges = [
+            Edge(source="a.py", target="b.py", kind=EdgeKind.IMPORTS, location="a.py:1"),
+            Edge(source="b.py", target="c.py", kind=EdgeKind.IMPORTS),
+        ]
+        g = DependencyGraph.from_edges(edges)
+        assert g.file_count == 3
+        assert g.file_edge_count == 2
+
+
+class TestCacheKeyFingerprint:
+    def test_changes_with_git_head(self, tmp_path: Path) -> None:
+        cache = CacheManager(cache_dir=str(tmp_path))
+        source = RepoSource(local_path="/some/repo")
+        with patch.object(CacheManager, "_git_head", return_value="abc"):
+            k1 = cache.cache_key(source)
+        with patch.object(CacheManager, "_git_head", return_value="def"):
+            k2 = cache.cache_key(source)
+        assert k1 != k2
+
+    def test_stable_without_git(self, tmp_path: Path) -> None:
+        cache = CacheManager(cache_dir=str(tmp_path))
+        source = RepoSource(local_path="/r")
+        with patch.object(CacheManager, "_git_head", return_value=None):
+            k1 = cache.cache_key(source)
+            k2 = cache.cache_key(source)
+        assert k1 == k2
+
+
+class TestVectorPath:
+    def test_returns_npz_path(self, tmp_path: Path) -> None:
+        import hashlib
+
+        cache = CacheManager(cache_dir=str(tmp_path))
+        key = hashlib.sha256(b"x").hexdigest()
+        vp = cache.vector_path(key)
+        assert vp.name == f"{key}.vectors.npz"
+
+
+class TestQueryCacheSkipsParse:
+    def test_parse_not_called_on_cache_hit(self, tmp_path: Path) -> None:
+        from archex.index.bm25 import BM25Index
+
+        db_path = tmp_path / "idx.db"
+        store = IndexStore(db_path)
+        chunk = CodeChunk(
+            id="t.py:f:1",
+            content="def f(): pass",
+            file_path="t.py",
+            start_line=1,
+            end_line=1,
+            language="python",
+            symbol_name="f",
+            symbol_kind=SymbolKind.FUNCTION,
+        )
+        store.insert_chunks([chunk])
+        store.insert_edges([Edge(source="t.py", target="u.py", kind=EdgeKind.IMPORTS)])
+        bm25 = BM25Index(store)
+        bm25.build([chunk])
+        store.conn.execute("PRAGMA wal_checkpoint(FULL)")
+        store.close()
+
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        cache = CacheManager(cache_dir=str(cache_dir))
+        source = RepoSource(local_path="/fake")
+        key = cache.cache_key(source)
+        cache.put(key, db_path)
+
+        config = Config(cache=True, cache_dir=str(cache_dir))
+        with (
+            patch("archex.api.extract_symbols") as mock_es,
+            patch("archex.cache.CacheManager._git_head", return_value=None),
+        ):
+            from archex.api import query
+
+            query(source, "what?", config=config)
+        mock_es.assert_not_called()
+
+
+class TestCompareParallel:
+    def test_both_analyses_called(self) -> None:
+        from archex.models import ArchProfile, CodebaseStats, RepoMetadata
+
+        mock_profile = ArchProfile(
+            repo=RepoMetadata(local_path="/a"),
+            stats=CodebaseStats(),
+        )
+        with patch("archex.api.analyze", return_value=mock_profile) as mock_a:
+            from archex.api import compare
+
+            compare(RepoSource(local_path="/a"), RepoSource(local_path="/b"))
+        assert mock_a.call_count == 2


### PR DESCRIPTION
## Summary
- Restructure `query()` to check cache BEFORE parsing — cache hit skips entire parse pipeline
- Add `DependencyGraph.from_edges()` classmethod for graph reconstruction from stored edges
- Store edges in IndexStore on cache miss for round-trip persistence
- Add `get_chunks_by_ids()` batch fetch to IndexStore, used in `BM25Index.search()`
- Add `parallel: bool` to Config, pass to `extract_symbols()` and `parse_imports()`
- Use `ThreadPoolExecutor(max_workers=2)` for concurrent `analyze()` in `compare()`
- Replace `np.argsort` with `np.argpartition` for O(N) top-k in VectorIndex
- Add `vector_path()` to CacheManager for persisting vector indices across queries
- Add `_centrality_cache` to DependencyGraph with lazy computation
- Split source once in `chunk_file()`, pass pre-split lines to avoid redundant splitting
- Include git HEAD commit hash in cache key for local repos

## Test plan
- [x] 526 tests passing
- [x] 0 pyright errors, ruff clean
- [x] 83% coverage maintained