### PR TITLE
Fix delta file-map correctness

### DIFF
--- a/src/archex/index/delta.py
+++ b/src/archex/index/delta.py
@@ -13,6 +13,8 @@ from archex.models import (
     ChangeStatus,
     DeltaManifest,
     DeltaMeta,
+    Edge,
+    EdgeKind,
     FileChange,
     IndexConfig,
 )
@@ -20,7 +22,7 @@ from archex.models import (
 if TYPE_CHECKING:
     from archex.index.graph import DependencyGraph
     from archex.index.store import IndexStore
-    from archex.models import CodeChunk, Config, Edge
+    from archex.models import CodeChunk, Config
 
 logger = logging.getLogger(__name__)
 
@@ -136,7 +138,6 @@ def apply_delta(
     from archex.acquire import discover_files
     from archex.index.bm25 import BM25Index
     from archex.index.chunker import ASTChunker
-    from archex.index.graph import DependencyGraph as _DepGraph
     from archex.parse import (
         TreeSitterEngine,
         build_file_map,
@@ -185,8 +186,8 @@ def apply_delta(
 
             parsed_files = extract_symbols(changed_files, engine, adapters)
             import_map = parse_imports(changed_files, engine, adapters)
-            file_map = build_file_map(changed_files)
-            file_languages = {f.path: f.language for f in changed_files}
+            file_map = build_file_map(all_files)
+            file_languages = {f.path: f.language for f in all_files}
             resolved_map = resolve_imports(import_map, file_map, adapters, file_languages)
 
             index_config = IndexConfig()
@@ -199,8 +200,17 @@ def apply_delta(
                     continue
             new_chunks = chunker.chunk_files(parsed_files, sources)
 
-            temp_graph = _DepGraph.from_parsed_files(parsed_files, resolved_map)
-            new_edges = temp_graph.file_edges()
+            new_edges = [
+                Edge(
+                    source=file_path,
+                    target=imp.resolved_path,
+                    kind=EdgeKind.IMPORTS,
+                    location=f"{file_path}:{imp.line}",
+                )
+                for file_path, imps in resolved_map.items()
+                for imp in imps
+                if imp.resolved_path is not None
+            ]
 
             logger.info(
                 "Re-parsed %d files: %d chunks, %d edges",

--- a/tests/index/test_delta.py
+++ b/tests/index/test_delta.py
@@ -341,6 +341,59 @@ class TestApplyDelta:
         finally:
             store.close()
 
+    def test_delta_import_resolution_uses_full_file_map(self, tmp_path: Path) -> None:
+        """Verify that delta re-parse resolves imports targeting unchanged files.
+
+        File A imports from file B. Only A is modified in the delta. The edge
+        A→B must be present after apply_delta, proving build_file_map received
+        all_files (including unchanged B) rather than only changed_files.
+        """
+        from archex.index.graph import DependencyGraph
+
+        repo = tmp_path / "import_repo"
+        repo.mkdir()
+        (repo / "library.py").write_text("def helper():\n    return 1\n")
+        (repo / "consumer.py").write_text(
+            "from library import helper\n\ndef run():\n    return helper()\n"
+        )
+        _git(repo, "init")
+        _git(repo, "config", "user.email", "test@archex.test")
+        _git(repo, "config", "user.name", "archex-test")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "initial")
+
+        db_dir = tmp_path / "db_initial"
+        db_dir.mkdir()
+        store, graph = self._build_initial_index(repo, db_dir)
+        assert isinstance(graph, DependencyGraph)
+        try:
+            initial_edges = {(e.source, e.target) for e in store.get_edges()}
+            assert ("consumer.py", "library.py") in initial_edges, (
+                "initial index must have consumer.py -> library.py edge"
+            )
+
+            base = _git_head(repo)
+            # Modify only consumer.py; library.py is unchanged
+            (repo / "consumer.py").write_text(
+                "from library import helper\n\ndef run():\n    return helper() + 1\n"
+            )
+            _git(repo, "add", ".")
+            _git(repo, "commit", "-m", "modify consumer only")
+            current = _git_head(repo)
+
+            manifest = compute_delta(repo, base, current)
+            assert manifest.modified_files == ["consumer.py"]
+            assert "library.py" not in manifest.modified_files
+
+            apply_delta(store, graph, manifest, repo, Config(cache=False))
+
+            after_edges = {(e.source, e.target) for e in store.get_edges()}
+            assert ("consumer.py", "library.py") in after_edges, (
+                "edge consumer.py -> library.py must survive delta when only consumer.py changed"
+            )
+        finally:
+            store.close()
+
 
 # ---------------------------------------------------------------------------
 # TestComputeMtimeDelta


### PR DESCRIPTION
## Summary

- **Root cause**: `apply_delta` built `file_map` and `file_languages` from `changed_files` only, so imports from re-parsed files to unchanged files failed to resolve — the import resolver could not find `library.py` when only `consumer.py` was in the changed set.
- **Fix 1**: Changed `build_file_map(changed_files)` → `build_file_map(all_files)` and `file_languages` likewise, so the full repository file map is available during import resolution.
- **Fix 2**: Replaced `DependencyGraph.from_parsed_files(...).file_edges()` with direct edge derivation from `resolved_map`. The graph's `has_node` guard was filtering out edges where the target was an unchanged file (not in `parsed_files`), which caused cross-file edges to be silently dropped even after resolution succeeded.
- **Risk**: S1 — delta index missing edges between changed and unchanged files, causing incorrect dependency analysis.

## Test plan

- [ ] `test_delta_import_resolution_uses_full_file_map`: creates a 2-file repo where `consumer.py` imports from `library.py`, modifies only `consumer.py`, and asserts the `consumer.py → library.py` edge persists after `apply_delta`
- [ ] All 24 `tests/index/test_delta.py` tests pass
- [ ] `uv run ruff check` — clean
- [ ] `uv run ruff format` — no changes
- [ ] `uv run pyright src/archex/index/delta.py` — 0 errors