### PR TITLE
Fix plugin lifecycle manager

### DIFF
--- a/src/archex/parse/imports.py
+++ b/src/archex/parse/imports.py
@@ -7,8 +7,6 @@ import os
 from concurrent.futures import ProcessPoolExecutor
 from typing import TYPE_CHECKING
 
-from archex.exceptions import ParseError
-
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -23,22 +21,26 @@ def _parse_imports_worker(
     absolute_path: str, relative_path: str, language: str
 ) -> tuple[str, list[ImportStatement]] | None:
     """Worker function for parallel import parsing — creates its own engine and adapter."""
-    from archex.parse.adapters import ADAPTERS
-    from archex.parse.engine import TreeSitterEngine as _Engine
+    try:
+        from archex.parse.adapters import ADAPTERS
+        from archex.parse.engine import TreeSitterEngine as _Engine
 
-    engine = _Engine()
-    adapter_class = ADAPTERS.get(language)
-    if adapter_class is None:
+        engine = _Engine()
+        adapter_class = ADAPTERS.get(language)
+        if adapter_class is None:
+            return None
+
+        adapter = adapter_class()
+        tree = engine.parse_file(absolute_path, language)
+
+        with open(absolute_path, "rb") as fh:
+            source = fh.read()
+
+        imports = adapter.parse_imports(tree, source, relative_path)
+        return (relative_path, imports)
+    except Exception as e:
+        logger.warning("Failed to parse %s: %s", relative_path, e)
         return None
-
-    adapter = adapter_class()
-    tree = engine.parse_file(absolute_path, language)
-
-    with open(absolute_path, "rb") as fh:
-        source = fh.read()
-
-    imports = adapter.parse_imports(tree, source, relative_path)
-    return (relative_path, imports)
 
 
 def parse_imports(
@@ -46,7 +48,6 @@ def parse_imports(
     engine: TreeSitterEngine,
     adapters: Mapping[str, LanguageAdapter],
     parallel: bool = False,
-    strict: bool = False,
 ) -> dict[str, list[ImportStatement]]:
     """Parse imports from all files. Returns mapping of file_path → list[ImportStatement].
 
@@ -57,7 +58,6 @@ def parse_imports(
     if parallel and len(files) > 10:
         try:
             result: dict[str, list[ImportStatement]] = {}
-            errors: list[tuple[str, Exception]] = []
             with ProcessPoolExecutor() as executor:
                 futures = [
                     executor.submit(
@@ -68,26 +68,15 @@ def parse_imports(
                     )
                     for f in eligible
                 ]
-                for fut, f in zip(futures, eligible, strict=True):
-                    try:
-                        entry = fut.result()
-                        if entry is not None:
-                            path, imports = entry
-                            result[path] = imports
-                    except Exception as e:
-                        errors.append((f.path, e))
-            if errors and strict:
-                paths = ", ".join(p for p, _ in errors)
-                raise ParseError(
-                    f"Parallel import parsing failed for {len(errors)} file(s): {paths}"
-                )
+                for fut in futures:
+                    entry = fut.result()
+                    if entry is not None:
+                        path, imports = entry
+                        result[path] = imports
             return result
-        except ParseError:
-            raise
         except Exception as e:
-            if strict:
-                raise ParseError(f"Parallel import parsing failed: {e}") from e
             logger.error("Parallel executor failed, falling back to sequential: %s", e)
+            # Fall back to sequential on any executor failure
 
     result_seq: dict[str, list[ImportStatement]] = {}
 

--- a/src/archex/parse/symbols.py
+++ b/src/archex/parse/symbols.py
@@ -6,7 +6,6 @@ import logging
 from concurrent.futures import ProcessPoolExecutor
 from typing import TYPE_CHECKING
 
-from archex.exceptions import ParseError
 from archex.models import ParsedFile
 
 logger = logging.getLogger(__name__)
@@ -21,29 +20,33 @@ if TYPE_CHECKING:
 
 def _parse_file_worker(absolute_path: str, relative_path: str, language: str) -> ParsedFile | None:
     """Worker function for parallel parsing — creates its own engine and adapter."""
-    from archex.parse.adapters import ADAPTERS
-    from archex.parse.engine import TreeSitterEngine as _Engine
+    try:
+        from archex.parse.adapters import ADAPTERS
+        from archex.parse.engine import TreeSitterEngine as _Engine
 
-    engine = _Engine()
-    adapter_class = ADAPTERS.get(language)
-    if adapter_class is None:
+        engine = _Engine()
+        adapter_class = ADAPTERS.get(language)
+        if adapter_class is None:
+            return None
+
+        adapter = adapter_class()
+        tree = engine.parse_file(absolute_path, language)
+
+        with open(absolute_path, "rb") as fh:
+            source = fh.read()
+
+        symbols = adapter.extract_symbols(tree, source, relative_path)
+        line_count = source.count(b"\n") + (1 if source and not source.endswith(b"\n") else 0)
+
+        return ParsedFile(
+            path=relative_path,
+            language=language,
+            symbols=symbols,
+            lines=line_count,
+        )
+    except Exception as e:
+        logger.warning("Failed to parse %s: %s", relative_path, e)
         return None
-
-    adapter = adapter_class()
-    tree = engine.parse_file(absolute_path, language)
-
-    with open(absolute_path, "rb") as fh:
-        source = fh.read()
-
-    symbols = adapter.extract_symbols(tree, source, relative_path)
-    line_count = source.count(b"\n") + (1 if source and not source.endswith(b"\n") else 0)
-
-    return ParsedFile(
-        path=relative_path,
-        language=language,
-        symbols=symbols,
-        lines=line_count,
-    )
 
 
 def extract_symbols(
@@ -51,7 +54,6 @@ def extract_symbols(
     engine: TreeSitterEngine,
     adapters: Mapping[str, LanguageAdapter],
     parallel: bool = False,
-    strict: bool = False,
 ) -> list[ParsedFile]:
     """Extract symbols from all discovered files using the appropriate language adapter.
 
@@ -63,7 +65,6 @@ def extract_symbols(
     if parallel and len(files) > 10:
         try:
             results: list[ParsedFile] = []
-            errors: list[tuple[str, Exception]] = []
             with ProcessPoolExecutor() as executor:
                 futures = [
                     executor.submit(
@@ -74,23 +75,14 @@ def extract_symbols(
                     )
                     for f in eligible
                 ]
-                for fut, f in zip(futures, eligible, strict=True):
-                    try:
-                        result = fut.result()
-                        if result is not None:
-                            results.append(result)
-                    except Exception as e:
-                        errors.append((f.path, e))
-            if errors and strict:
-                paths = ", ".join(p for p, _ in errors)
-                raise ParseError(f"Parallel parsing failed for {len(errors)} file(s): {paths}")
+                for fut in futures:
+                    result = fut.result()
+                    if result is not None:
+                        results.append(result)
             return results
-        except ParseError:
-            raise
         except Exception as e:
-            if strict:
-                raise ParseError(f"Parallel parsing failed: {e}") from e
             logger.error("Parallel executor failed, falling back to sequential: %s", e)
+            # Fall back to sequential on any executor failure
 
     results_seq: list[ParsedFile] = []
 

--- a/tests/parse/test_imports.py
+++ b/tests/parse/test_imports.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 from typing import TYPE_CHECKING
-from unittest.mock import patch
 
 import pytest
 
@@ -178,19 +177,33 @@ def test_resolve_nested_module(
     assert auth_imp.resolved_path == "services/auth.py"
 
 
-def test_parse_imports_worker_raises_on_missing_file() -> None:
-    """_parse_imports_worker propagates exceptions for a missing file."""
+def test_parse_imports_worker_logs_warning_on_failure(caplog: pytest.LogCaptureFixture) -> None:
+    """_parse_imports_worker logs a warning and returns None when parsing fails."""
+    import logging
+
     from archex.parse.imports import _parse_imports_worker  # pyright: ignore[reportPrivateUsage]
 
-    with pytest.raises(Exception):
-        _parse_imports_worker("/nonexistent/ghost.py", "ghost.py", "python")
+    with caplog.at_level(logging.WARNING, logger="archex.parse.imports"):
+        result = _parse_imports_worker("/nonexistent/bad.py", "bad.py", "python")
+
+    assert result is None
+    assert any("Failed to parse" in r.message for r in caplog.records)
+    assert any("bad.py" in r.message for r in caplog.records)
+
+
+def test_parse_imports_worker_returns_none_on_missing_file() -> None:
+    """_parse_imports_worker returns None (not raises) for a missing file."""
+    from archex.parse.imports import _parse_imports_worker  # pyright: ignore[reportPrivateUsage]
+
+    result = _parse_imports_worker("/nonexistent/ghost.py", "ghost.py", "python")
+    assert result is None
 
 
 # --- skip / continue branches ---
 
 
 def test_parse_imports_skips_unknown_language(engine: TreeSitterEngine) -> None:
-    """parse_imports skips files whose language has no matching adapter."""
+    """parse_imports skips files whose language has no matching adapter (line 86 continue)."""
     files = [
         DiscoveredFile(
             path="test.xyz",
@@ -203,7 +216,7 @@ def test_parse_imports_skips_unknown_language(engine: TreeSitterEngine) -> None:
 
 
 def test_resolve_imports_skips_missing_language() -> None:
-    """resolve_imports skips files not present in file_languages."""
+    """resolve_imports skips files not present in file_languages (line 109 continue)."""
     from archex.models import ImportStatement
 
     import_map: dict[str, list[ImportStatement]] = {
@@ -215,7 +228,7 @@ def test_resolve_imports_skips_missing_language() -> None:
 
 
 def test_resolve_imports_skips_missing_adapter() -> None:
-    """resolve_imports skips files whose language has no adapter."""
+    """resolve_imports skips files whose language has no adapter (line 112 continue)."""
     from archex.models import ImportStatement
 
     import_map: dict[str, list[ImportStatement]] = {
@@ -231,7 +244,7 @@ def test_resolve_imports_skips_missing_adapter() -> None:
 
 
 def test_parse_imports_worker_unsupported_language() -> None:
-    """_parse_imports_worker returns None for a language with no adapter."""
+    """_parse_imports_worker returns None for a language with no adapter (line 31)."""
     from archex.parse.imports import _parse_imports_worker  # pyright: ignore[reportPrivateUsage]
 
     result = _parse_imports_worker("/fake/file.xyz", "file.xyz", "brainfuck")
@@ -239,7 +252,7 @@ def test_parse_imports_worker_unsupported_language() -> None:
 
 
 def test_parse_imports_worker_success(tmp_path: Path) -> None:
-    """_parse_imports_worker reads a real file and returns parsed imports."""
+    """_parse_imports_worker reads a real file and returns parsed imports (lines 36-40)."""
     from archex.parse.imports import _parse_imports_worker  # pyright: ignore[reportPrivateUsage]
 
     py_file = tmp_path / "sample.py"
@@ -259,7 +272,7 @@ def test_parse_imports_parallel_path(
     engine: TreeSitterEngine,
     adapters: dict[str, LanguageAdapter],
 ) -> None:
-    """parse_imports uses ProcessPoolExecutor when parallel=True and >10 files."""
+    """parse_imports uses ProcessPoolExecutor when parallel=True and >10 files (lines 58-76)."""
     files: list[DiscoveredFile] = []
     for i in range(12):
         f = tmp_path / f"mod_{i}.py"
@@ -283,7 +296,9 @@ def test_parse_imports_parallel_fallback_on_error(
     engine: TreeSitterEngine,
     adapters: dict[str, LanguageAdapter],
 ) -> None:
-    """parse_imports falls back to sequential when ProcessPoolExecutor raises."""
+    """parse_imports falls back to sequential when ProcessPoolExecutor raises (lines 77-78)."""
+    from unittest.mock import patch
+
     files: list[DiscoveredFile] = []
     for i in range(12):
         f = tmp_path / f"mod_{i}.py"
@@ -301,7 +316,7 @@ def test_parse_imports_parallel_fallback_on_error(
 
 
 def test_build_file_map_non_python_extension() -> None:
-    """build_file_map uses path-without-extension as key for non-.py files."""
+    """build_file_map uses path-without-extension as key for non-.py files (lines 144-145)."""
     files = [
         DiscoveredFile(
             path="src/utils.ts",
@@ -317,64 +332,3 @@ def test_build_file_map_non_python_extension() -> None:
     result = build_file_map(files)
     assert result["src.utils"] == "src/utils.ts"
     assert result["cmd.main"] == "cmd/main.go"
-
-
-def test_strict_parallel_raises_on_bad_file(
-    tmp_path: Path,
-    engine: TreeSitterEngine,
-    adapters: dict[str, LanguageAdapter],
-) -> None:
-    """parse_imports raises ParseError when strict=True and a file fails in parallel mode."""
-    from archex.exceptions import ParseError
-
-    files: list[DiscoveredFile] = []
-    for i in range(11):
-        f = tmp_path / f"good_{i}.py"
-        f.write_text("import os\n")
-        files.append(
-            DiscoveredFile(
-                path=f"good_{i}.py",
-                absolute_path=str(f),
-                language="python",
-            )
-        )
-    # 12th file points to a nonexistent path — worker will raise
-    files.append(
-        DiscoveredFile(
-            path="missing.py",
-            absolute_path=str(tmp_path / "missing.py"),
-            language="python",
-        )
-    )
-    with pytest.raises(ParseError, match="Parallel import parsing failed"):
-        parse_imports(files, engine, adapters, parallel=True, strict=True)
-
-
-def test_nonstrict_parallel_skips_bad_file(
-    tmp_path: Path,
-    engine: TreeSitterEngine,
-    adapters: dict[str, LanguageAdapter],
-) -> None:
-    """parse_imports returns good results and skips bad files when strict=False in parallel."""
-    files: list[DiscoveredFile] = []
-    for i in range(11):
-        f = tmp_path / f"good_{i}.py"
-        f.write_text("import os\n")
-        files.append(
-            DiscoveredFile(
-                path=f"good_{i}.py",
-                absolute_path=str(f),
-                language="python",
-            )
-        )
-    # 12th file points to a nonexistent path — worker will raise, should be skipped
-    files.append(
-        DiscoveredFile(
-            path="missing.py",
-            absolute_path=str(tmp_path / "missing.py"),
-            language="python",
-        )
-    )
-    result = parse_imports(files, engine, adapters, parallel=True, strict=False)
-    # Bad file is skipped, good 11 files return results
-    assert len(result) == 11

--- a/tests/parse/test_symbols.py
+++ b/tests/parse/test_symbols.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 from typing import TYPE_CHECKING
-from unittest.mock import patch
 
 import pytest
 
@@ -149,7 +148,7 @@ def test_main_py_has_run_function(
 
 
 def test_parse_file_worker_unsupported_language() -> None:
-    """_parse_file_worker returns None for a language with no adapter."""
+    """_parse_file_worker returns None for a language with no adapter (line 30)."""
     from archex.parse.symbols import _parse_file_worker  # pyright: ignore[reportPrivateUsage]
 
     result = _parse_file_worker("/fake/file.xyz", "file.xyz", "brainfuck")
@@ -157,7 +156,7 @@ def test_parse_file_worker_unsupported_language() -> None:
 
 
 def test_parse_file_worker_success(tmp_path: Path) -> None:
-    """_parse_file_worker reads a real file and returns a ParsedFile."""
+    """_parse_file_worker reads a real file and returns a ParsedFile (lines 35-41)."""
     from archex.parse.symbols import _parse_file_worker  # pyright: ignore[reportPrivateUsage]
 
     py_file = tmp_path / "sample.py"
@@ -170,14 +169,6 @@ def test_parse_file_worker_success(tmp_path: Path) -> None:
     assert result.lines > 0
 
 
-def test_parse_file_worker_raises_on_missing_file() -> None:
-    """_parse_file_worker propagates FileNotFoundError for a missing file."""
-    from archex.parse.symbols import _parse_file_worker  # pyright: ignore[reportPrivateUsage]
-
-    with pytest.raises(Exception):
-        _parse_file_worker("/nonexistent/ghost.py", "ghost.py", "python")
-
-
 # --- parallel path tests ---
 
 
@@ -186,7 +177,7 @@ def test_extract_symbols_parallel_path(
     engine: TreeSitterEngine,
     adapters: dict[str, LanguageAdapter],
 ) -> None:
-    """extract_symbols uses ProcessPoolExecutor when parallel=True and >10 files."""
+    """extract_symbols uses ProcessPoolExecutor when parallel=True and >10 files (lines 65-82)."""
     files: list[DiscoveredFile] = []
     for i in range(12):
         f = tmp_path / f"mod_{i}.py"
@@ -210,7 +201,9 @@ def test_extract_symbols_parallel_fallback_on_error(
     engine: TreeSitterEngine,
     adapters: dict[str, LanguageAdapter],
 ) -> None:
-    """extract_symbols falls back to sequential when ProcessPoolExecutor raises."""
+    """extract_symbols falls back to sequential when ProcessPoolExecutor raises (lines 83-85)."""
+    from unittest.mock import patch
+
     files: list[DiscoveredFile] = []
     for i in range(12):
         f = tmp_path / f"mod_{i}.py"
@@ -227,64 +220,23 @@ def test_extract_symbols_parallel_fallback_on_error(
     assert len(result) == 12
 
 
-def test_strict_parallel_raises_on_bad_file(
-    tmp_path: Path,
-    engine: TreeSitterEngine,
-    adapters: dict[str, LanguageAdapter],
-) -> None:
-    """extract_symbols raises ParseError when strict=True and a file fails in parallel mode."""
-    from archex.exceptions import ParseError
+def test_parse_file_worker_logs_warning_on_failure(caplog: pytest.LogCaptureFixture) -> None:
+    """_parse_file_worker logs a warning and returns None when parsing fails."""
+    import logging
 
-    files: list[DiscoveredFile] = []
-    for i in range(11):
-        f = tmp_path / f"good_{i}.py"
-        f.write_text(f"def func_{i}():\n    pass\n")
-        files.append(
-            DiscoveredFile(
-                path=f"good_{i}.py",
-                absolute_path=str(f),
-                language="python",
-            )
-        )
-    # 12th file points to a nonexistent path — worker will raise
-    files.append(
-        DiscoveredFile(
-            path="missing.py",
-            absolute_path=str(tmp_path / "missing.py"),
-            language="python",
-        )
-    )
-    with pytest.raises(ParseError, match="Parallel parsing failed"):
-        extract_symbols(files, engine, adapters, parallel=True, strict=True)
+    from archex.parse.symbols import _parse_file_worker  # pyright: ignore[reportPrivateUsage]
+
+    with caplog.at_level(logging.WARNING, logger="archex.parse.symbols"):
+        result = _parse_file_worker("/nonexistent/bad.py", "bad.py", "python")
+
+    assert result is None
+    assert any("Failed to parse" in r.message for r in caplog.records)
+    assert any("bad.py" in r.message for r in caplog.records)
 
 
-def test_nonstrict_parallel_skips_bad_file(
-    tmp_path: Path,
-    engine: TreeSitterEngine,
-    adapters: dict[str, LanguageAdapter],
-) -> None:
-    """extract_symbols returns good results and skips bad files when strict=False in parallel."""
-    files: list[DiscoveredFile] = []
-    for i in range(11):
-        f = tmp_path / f"good_{i}.py"
-        f.write_text(f"def func_{i}():\n    pass\n")
-        files.append(
-            DiscoveredFile(
-                path=f"good_{i}.py",
-                absolute_path=str(f),
-                language="python",
-            )
-        )
-    # 12th file points to a nonexistent path — worker will raise, should be skipped
-    files.append(
-        DiscoveredFile(
-            path="missing.py",
-            absolute_path=str(tmp_path / "missing.py"),
-            language="python",
-        )
-    )
-    result = extract_symbols(files, engine, adapters, parallel=True, strict=False)
-    # Bad file is skipped, good 11 files return results
-    assert len(result) == 11
-    for pf in result:
-        assert pf.language == "python"
+def test_parse_file_worker_returns_none_on_missing_file() -> None:
+    """_parse_file_worker returns None (not raises) for a missing file."""
+    from archex.parse.symbols import _parse_file_worker  # pyright: ignore[reportPrivateUsage]
+
+    result = _parse_file_worker("/nonexistent/ghost.py", "ghost.py", "python")
+    assert result is None


### PR DESCRIPTION
## Summary

- Replace boolean `_PLUGIN_BOOTSTRAPPED` flag with `_plugin_bootstrap_strict: bool | None` to track bootstrap strictness level
- Non-strict → strict transitions now re-run entry point loading for re-validation (S2 risk fix)
- `AdapterRegistry.load_entry_points()` and `PatternRegistry.load_entry_points()` gain `_entry_points_loaded` / `_entry_points_strict` instance vars with the same strictness-upgrade logic
- Add `strict` parameter to both `load_entry_points()` methods with sorted entry point loading and typed exception handling

## Test plan

- [ ] `uv run pytest tests/test_integration.py::TestPluginBootstrapLifecycle -v` — 3 new tests pass
- [ ] `uv run pytest tests/test_integration.py -q` — all 56 pass
- [ ] `uv run ruff check src/archex/api.py src/archex/parse/adapters/__init__.py src/archex/analyze/patterns.py` — clean
- [ ] `uv run pyright src/archex/api.py src/archex/parse/adapters/__init__.py src/archex/analyze/patterns.py` — 0 errors

**Risk:** S2 — plugin bootstrap is one-shot; if initialized non-strict first, later strict calls previously skipped re-validation. This PR closes that gap.