### PR TITLE
Fix URL-source cache identity with cloned HEAD

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -72,7 +72,7 @@ def _full_index(
 ) -> IndexStore:
     """Run the full acquire → parse → chunk → store pipeline."""
     t_acq = time.perf_counter()
-    repo_path, _url, _local_path, cleanup = _acquire(source)
+    repo_path, _url, _local_path, cleanup, cloned_head = _acquire(source)
     if timing is not None:
         timing.acquire_ms = _elapsed_ms(t_acq)
     try:
@@ -110,7 +110,7 @@ def _full_index(
         store.insert_edges(edges)
 
         if config.cache:
-            commit = cache.git_head(source.local_path) or source.commit or ""
+            commit = cloned_head or cache.git_head(source.local_path) or source.commit or ""
             identity = source.url or source.local_path or ""
             store.set_metadata("commit_hash", commit)
             store.set_metadata("source_identity", identity)
@@ -156,8 +156,8 @@ def _ensure_index(
         store.close()
         cache.invalidate(cache_key)
 
-    # Path 2: Delta path — same repo, different commit
-    if config.cache:
+    # Path 2: Delta path — same repo, different commit (local repos only)
+    if config.cache and source.local_path:
         existing = cache.find_store_for_source(source)
         if existing is not None:
             db_path, cached_commit = existing
@@ -255,22 +255,26 @@ def _elapsed_ms(start: float) -> float:
     return (time.perf_counter() - start) * 1000
 
 
-def _acquire(source: RepoSource) -> tuple[Path, str | None, str | None, Callable[[], None]]:
-    """Resolve a RepoSource to a local path, returning a cleanup callable."""
+def _acquire(
+    source: RepoSource,
+) -> tuple[Path, str | None, str | None, Callable[[], None], str | None]:
+    """Resolve a RepoSource to a local path, returning a cleanup callable and cloned HEAD."""
     if source.url and (source.url.startswith("http://") or source.url.startswith("https://")):
         target_dir = tempfile.mkdtemp()
 
         def _url_cleanup() -> None:
             shutil.rmtree(target_dir, ignore_errors=True)
 
-        return clone_repo(source.url, target_dir), source.url, None, _url_cleanup
+        repo_path = clone_repo(source.url, target_dir)
+        cloned_head = CacheManager.git_head(str(repo_path))
+        return repo_path, source.url, None, _url_cleanup, cloned_head
 
     if source.local_path is not None:
 
         def _noop() -> None:
             pass
 
-        return open_local(source.local_path), None, source.local_path, _noop
+        return open_local(source.local_path), None, source.local_path, _noop, None
     raise ValueError("RepoSource must have a url or local_path")
 
 
@@ -293,7 +297,7 @@ def analyze(
         config = Config()
 
     t0 = time.perf_counter()
-    repo_path, url, local_path, cleanup = _acquire(source)
+    repo_path, url, local_path, cleanup, _cloned_head = _acquire(source)
     acquire_ms = _elapsed_ms(t0)
     logger.info("Acquired repo %s in %.0fms", url or local_path, acquire_ms)
     if timing is not None:
@@ -456,7 +460,7 @@ def query(
     # Cache miss — full pipeline
     logger.info("Cache miss — running full pipeline")
     t1 = time.perf_counter()
-    repo_path, _url, _local_path, cleanup = _acquire(source)
+    repo_path, _url, _local_path, cleanup, cloned_head = _acquire(source)
     acquire_ms = _elapsed_ms(t1)
     logger.info("Acquired repo in %.0fms", acquire_ms)
     if timing is not None:
@@ -524,7 +528,7 @@ def query(
                         vec_idx.save(cache.vector_path(cache_key))
 
             if config.cache:
-                commit = cache.git_head(source.local_path) or source.commit or ""
+                commit = cloned_head or cache.git_head(source.local_path) or source.commit or ""
                 identity = source.url or source.local_path or ""
                 store.set_metadata("commit_hash", commit)
                 store.set_metadata("source_identity", identity)

--- a/src/archex/cache.py
+++ b/src/archex/cache.py
@@ -30,11 +30,10 @@ class CacheManager:
     # Key helpers
     # ------------------------------------------------------------------
 
-    def cache_key(self, source: RepoSource) -> str:
+    def cache_key(self, source: RepoSource, *, head_override: str | None = None) -> str:
         """Derive a stable SHA256 cache key from the source identity and git HEAD."""
         identity = source.url or source.local_path or ""
-        # Include git HEAD commit for local repos to invalidate on new commits
-        commit = source.commit or self.git_head(source.local_path)
+        commit = source.commit or head_override or self.git_head(source.local_path)
         if commit:
             identity = f"{identity}@{commit}"
         return hashlib.sha256(identity.encode()).hexdigest()

--- a/tests/test_api_robustness.py
+++ b/tests/test_api_robustness.py
@@ -15,7 +15,7 @@ def test_acquire_local_path_returns_noop_cleanup(tmp_path: Path) -> None:
     """Local path _acquire returns a no-op cleanup callable."""
     source = RepoSource(local_path=str(tmp_path))
     with patch("archex.api.open_local", return_value=tmp_path):
-        repo_path, url, local_path, cleanup = _acquire(source)
+        repo_path, url, local_path, cleanup, _head = _acquire(source)
 
     assert repo_path == tmp_path
     assert url is None
@@ -37,7 +37,7 @@ def test_acquire_url_cleanup_removes_tempdir() -> None:
 
     source = RepoSource(url="https://example.com/repo.git")
     with patch("archex.api.clone_repo", side_effect=fake_clone):
-        _repo_path, _url, _local_path, cleanup = _acquire(source)
+        _repo_path, _url, _local_path, cleanup, _head = _acquire(source)
 
     assert len(cloned_dir) == 1
     target = cloned_dir[0]
@@ -57,7 +57,7 @@ def test_acquire_url_cleanup_called_on_exception() -> None:
 
     source = RepoSource(url="https://example.com/repo.git")
     with patch("archex.api.clone_repo", side_effect=fake_clone):
-        _repo_path, _url, _local_path, cleanup = _acquire(source)
+        _repo_path, _url, _local_path, cleanup, _head = _acquire(source)
 
     target = _repo_path
     assert target.exists()
@@ -82,7 +82,7 @@ def test_acquire_local_path_cleanup_is_idempotent(tmp_path: Path) -> None:
     """Local path cleanup can be called multiple times without error."""
     source = RepoSource(local_path=str(tmp_path))
     with patch("archex.api.open_local", return_value=tmp_path):
-        _repo_path, _url, _local_path, cleanup = _acquire(source)
+        _repo_path, _url, _local_path, cleanup, _head = _acquire(source)
     cleanup()
     cleanup()  # second call should not raise
 
@@ -95,7 +95,7 @@ def test_acquire_url_cleanup_safe_on_missing_dir() -> None:
 
     source = RepoSource(url="https://example.com/repo.git")
     with patch("archex.api.clone_repo", side_effect=fake_clone):
-        _repo_path, _url, _local_path, cleanup = _acquire(source)
+        _repo_path, _url, _local_path, cleanup, _head = _acquire(source)
 
     # Dir was never actually created; cleanup with ignore_errors=True should not raise
     cleanup()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -127,6 +127,15 @@ def test_cache_key_local_path(cache: CacheManager) -> None:
     assert len(key) == 64
 
 
+def test_cache_key_head_override(tmp_path: Path) -> None:
+    """cache_key with head_override produces a different key than without."""
+    cm = CacheManager(cache_dir=str(tmp_path))
+    source = RepoSource(url="https://example.com/repo.git")
+    key_no_head = cm.cache_key(source)
+    key_with_head = cm.cache_key(source, head_override="abc123")
+    assert key_no_head != key_with_head
+
+
 # ---------------------------------------------------------------------------
 # Key validation — adversarial
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `head_override` param to `CacheManager.cache_key()` for explicit commit pinning
- Capture cloned HEAD in `_acquire()` 5-tuple return for URL sources
- Thread `cloned_head` through `_full_index()` and `query()` commit metadata
- Guard delta path to local repos only (`source.local_path` check)
- Update all `_acquire()` unpack sites to 5-tuple

## Test plan
- [x] `test_cache_key_head_override` verifies different keys with/without head override
- [x] All existing robustness tests updated for 5-tuple unpack
- [x] `uv run pytest -q` — all 1027 tests pass
- [x] `uv run pyright` — 0 new errors
- [x] `uv run ruff check .` — clean