### PR TITLE
fix: narrow except clauses in modules and bm25 for error-policy consistency

### DIFF
--- a/src/archex/analyze/modules.py
+++ b/src/archex/analyze/modules.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -12,6 +13,8 @@ from archex.models import Module, ParsedFile, SymbolKind, SymbolRef, Visibility,
 
 if TYPE_CHECKING:
     from archex.index.graph import DependencyGraph
+
+logger = logging.getLogger(__name__)
 
 
 def _build_nx_graph(graph: DependencyGraph, parsed_files: list[ParsedFile]) -> Any:
@@ -150,7 +153,11 @@ def detect_modules(
 
     try:
         raw_communities: list[Any] = louvain_communities(g, seed=42)  # type: ignore[no-untyped-call]
-    except Exception:
+    except (nx.NetworkXError, ValueError):
+        logger.warning(
+            "Louvain community detection failed, falling back to single module",
+            exc_info=True,
+        )
         # Fall back: treat all files as one module
         raw_communities = [g.nodes()]  # type: ignore[misc]
 

--- a/src/archex/index/bm25.py
+++ b/src/archex/index/bm25.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+import sqlite3
 from typing import TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
@@ -70,7 +71,7 @@ class BM25Index:
                 "FROM chunks_fts WHERE chunks_fts MATCH ? ORDER BY score LIMIT ?",
                 (escaped, top_k),
             )
-        except Exception:
+        except sqlite3.OperationalError:
             logger.warning("FTS5 query failed for: %s", escaped, exc_info=True)
             return []
 

--- a/tests/analyze/test_modules.py
+++ b/tests/analyze/test_modules.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from archex.analyze.modules import detect_modules
 from archex.index.graph import DependencyGraph
 from archex.models import ParsedFile
@@ -148,7 +150,30 @@ def test_infer_module_name_common_prefix() -> None:
 
 
 def test_detect_modules_louvain_fallback() -> None:
-    """When louvain_communities raises, all files collapse into one module."""
+    """When louvain_communities raises NetworkXError, all files collapse into one module."""
+    from unittest.mock import patch
+
+    import networkx as nx  # type: ignore[import-untyped]
+
+    pf_a = ParsedFile(path="pkg/a.py", language="python", lines=5)
+    pf_b = ParsedFile(path="pkg/b.py", language="python", lines=8)
+    graph = DependencyGraph()
+    graph.add_file_node("pkg/a.py")
+    graph.add_file_node("pkg/b.py")
+    graph.add_file_edge("pkg/a.py", "pkg/b.py")
+
+    with patch(
+        "archex.analyze.modules.louvain_communities",
+        side_effect=nx.NetworkXError("fail"),
+    ):
+        modules = detect_modules(graph, [pf_a, pf_b])
+
+    assert len(modules) == 1
+    assert set(modules[0].files) == {"pkg/a.py", "pkg/b.py"}
+
+
+def test_detect_modules_louvain_unexpected_error_propagates() -> None:
+    """Unexpected errors from louvain_communities must propagate, not be silently caught."""
     from unittest.mock import patch
 
     pf_a = ParsedFile(path="pkg/a.py", language="python", lines=5)
@@ -158,11 +183,11 @@ def test_detect_modules_louvain_fallback() -> None:
     graph.add_file_node("pkg/b.py")
     graph.add_file_edge("pkg/a.py", "pkg/b.py")
 
-    with patch("archex.analyze.modules.louvain_communities", side_effect=RuntimeError("fail")):
-        modules = detect_modules(graph, [pf_a, pf_b])
-
-    assert len(modules) == 1
-    assert set(modules[0].files) == {"pkg/a.py", "pkg/b.py"}
+    with (
+        patch("archex.analyze.modules.louvain_communities", side_effect=TypeError("unexpected")),
+        pytest.raises(TypeError, match="unexpected"),
+    ):
+        detect_modules(graph, [pf_a, pf_b])
 
 
 def test_detect_modules_single_node_graph() -> None:

--- a/tests/index/test_bm25.py
+++ b/tests/index/test_bm25.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from typing import TYPE_CHECKING
 
 import pytest
@@ -255,7 +256,7 @@ def test_search_survives_fts5_error(tmp_path: Path) -> None:
 
         def execute(self, sql: str, parameters: object = None, /) -> object:
             if "MATCH" in sql:
-                raise RuntimeError("FTS5 error")
+                raise sqlite3.OperationalError("FTS5 error")
             if parameters is not None:
                 return real_conn.execute(sql, parameters)  # type: ignore[arg-type]
             return real_conn.execute(sql)
@@ -264,4 +265,32 @@ def test_search_survives_fts5_error(tmp_path: Path) -> None:
     results = idx.search("authenticate")
     s._conn = real_conn  # type: ignore[assignment]
     assert results == []
+    s.close()
+
+
+def test_search_propagates_non_operational_error(tmp_path: Path) -> None:
+    """Non-OperationalError exceptions from FTS5 must propagate."""
+    db = tmp_path / "bm25_prop.db"
+    s = IndexStore(db)
+    idx = BM25Index(s)
+    s.insert_chunks(SAMPLE_CHUNKS)
+    idx.build(SAMPLE_CHUNKS)
+
+    real_conn = s.conn
+
+    class _FailIntegrity:
+        def __getattr__(self, name: str) -> object:
+            return getattr(real_conn, name)
+
+        def execute(self, sql: str, parameters: object = None, /) -> object:
+            if "MATCH" in sql:
+                raise sqlite3.IntegrityError("integrity violation")
+            if parameters is not None:
+                return real_conn.execute(sql, parameters)  # type: ignore[arg-type]
+            return real_conn.execute(sql)
+
+    s._conn = _FailIntegrity()  # type: ignore[assignment]
+    with pytest.raises(sqlite3.IntegrityError, match="integrity violation"):
+        idx.search("authenticate")
+    s._conn = real_conn  # type: ignore[assignment]
     s.close()


### PR DESCRIPTION
## Summary
- Narrow `except Exception` to specific exception types in `analyze/modules.py` and `index/bm25.py`
- `modules.py`: catch `(nx.NetworkXError, ValueError)` instead of bare `Exception`, add `logger.warning` with `exc_info=True`
- `bm25.py`: catch `sqlite3.OperationalError` instead of bare `Exception`
- Update existing tests to match narrowed exception types
- Add propagation tests verifying unexpected errors are not swallowed

## Test plan
- [x] Existing fallback tests updated to use specific exception types
- [x] New propagation tests verify unexpected errors bubble up
- [x] Full test suite passes (1041 tests)
- [x] pyright clean (no new errors), ruff clean