### PR TITLE
feat: retrieval quality regression harness with F1/MRR metrics

### DIFF
--- a/benchmarks/tasks/archex_adapter_registry.yaml
+++ b/benchmarks/tasks/archex_adapter_registry.yaml
@@ -1,0 +1,18 @@
+task_id: archex_adapter_registry
+repo: "."
+commit: "HEAD"
+question: "How does archex register language adapters?"
+expected_files:
+  - src/archex/parse/adapters/__init__.py
+  - src/archex/parse/adapters/python.py
+  - src/archex/parse/adapters/base.py
+expected_symbols:
+  - AdapterRegistry
+  - PythonAdapter
+  - LanguageAdapter
+token_budget: 8192
+keywords:
+  - adapter
+  - registry
+  - language
+  - parser

--- a/benchmarks/tasks/archex_delta_indexing.yaml
+++ b/benchmarks/tasks/archex_delta_indexing.yaml
@@ -1,0 +1,18 @@
+task_id: archex_delta_indexing
+repo: "."
+commit: "HEAD"
+question: "How does delta indexing detect and apply changes?"
+expected_files:
+  - src/archex/index/delta.py
+  - src/archex/index/cache.py
+  - src/archex/api.py
+expected_symbols:
+  - compute_delta
+  - apply_delta
+  - DeltaManifest
+token_budget: 8192
+keywords:
+  - delta
+  - index
+  - cache
+  - compute

--- a/benchmarks/tasks/archex_pattern_detection.yaml
+++ b/benchmarks/tasks/archex_pattern_detection.yaml
@@ -1,0 +1,16 @@
+task_id: archex_pattern_detection
+repo: "."
+commit: "HEAD"
+question: "How does archex detect architectural patterns?"
+expected_files:
+  - src/archex/analyze/patterns.py
+  - src/archex/models.py
+expected_symbols:
+  - detect_patterns
+  - PatternRegistry
+  - PatternMatch
+token_budget: 8192
+keywords:
+  - pattern
+  - detect
+  - registry

--- a/benchmarks/tasks/archex_query_pipeline.yaml
+++ b/benchmarks/tasks/archex_query_pipeline.yaml
@@ -1,0 +1,18 @@
+task_id: archex_query_pipeline
+repo: "."
+commit: "HEAD"
+question: "How does archex implement the query pipeline?"
+expected_files:
+  - src/archex/api.py
+  - src/archex/index/bm25.py
+  - src/archex/index/context.py
+expected_symbols:
+  - query
+  - BM25Index
+  - assemble_context
+token_budget: 8192
+keywords:
+  - query
+  - bm25
+  - context
+  - retrieval

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,4 +81,7 @@ venv = ".venv"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=archex --cov-report=term-missing"
+addopts = "--cov=archex --cov-report=term-missing -m 'not slow'"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]

--- a/src/archex/analyze/modules.py
+++ b/src/archex/analyze/modules.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -12,6 +13,8 @@ from archex.models import Module, ParsedFile, SymbolKind, SymbolRef, Visibility,
 
 if TYPE_CHECKING:
     from archex.index.graph import DependencyGraph
+
+logger = logging.getLogger(__name__)
 
 
 def _build_nx_graph(graph: DependencyGraph, parsed_files: list[ParsedFile]) -> Any:
@@ -150,7 +153,11 @@ def detect_modules(
 
     try:
         raw_communities: list[Any] = louvain_communities(g, seed=42)  # type: ignore[no-untyped-call]
-    except Exception:
+    except (nx.NetworkXError, ValueError):
+        logger.warning(
+            "Louvain community detection failed, falling back to single module",
+            exc_info=True,
+        )
         # Fall back: treat all files as one module
         raw_communities = [g.nodes()]  # type: ignore[misc]
 

--- a/src/archex/benchmark/baseline.py
+++ b/src/archex/benchmark/baseline.py
@@ -1,0 +1,103 @@
+"""Baseline snapshot: save, load, and compare benchmark baselines for regression detection."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic import BaseModel
+
+from archex.benchmark.models import BenchmarkReport  # noqa: TCH001 — Pydantic needs at runtime
+
+
+class BaselineEntry(BaseModel):
+    task_id: str
+    strategy: str
+    recall: float
+    precision: float
+    f1_score: float
+    mrr: float
+
+
+class Baseline(BaseModel):
+    entries: list[BaselineEntry] = []
+    created_at: str = ""
+    archex_version: str = ""
+
+
+class BaselineComparison(BaseModel):
+    task_id: str
+    strategy: str
+    metric: str
+    baseline_value: float
+    current_value: float
+    delta: float
+    regression: bool
+
+
+def save_baseline(
+    reports: list[BenchmarkReport],
+    archex_version: str = "",
+) -> Baseline:
+    """Extract metrics from reports into a Baseline snapshot."""
+    entries: list[BaselineEntry] = []
+    for report in reports:
+        for r in report.results:
+            entries.append(
+                BaselineEntry(
+                    task_id=r.task_id,
+                    strategy=r.strategy.value,
+                    recall=r.recall,
+                    precision=r.precision,
+                    f1_score=r.f1_score,
+                    mrr=r.mrr,
+                )
+            )
+    return Baseline(
+        entries=entries,
+        created_at=datetime.now(tz=UTC).isoformat(),
+        archex_version=archex_version,
+    )
+
+
+def load_baseline(data: dict[str, object]) -> Baseline:
+    """Validate and load a baseline from parsed JSON data."""
+    return Baseline.model_validate(data)
+
+
+_METRICS = ("recall", "precision", "f1_score", "mrr")
+_DEFAULT_TOLERANCE = 0.05
+
+
+def compare_baseline(
+    reports: list[BenchmarkReport],
+    baseline: Baseline,
+    tolerance: float = _DEFAULT_TOLERANCE,
+) -> list[BaselineComparison]:
+    """Compare current reports against a baseline. Flag regressions beyond tolerance."""
+    baseline_lookup: dict[tuple[str, str], BaselineEntry] = {
+        (e.task_id, e.strategy): e for e in baseline.entries
+    }
+    comparisons: list[BaselineComparison] = []
+    for report in reports:
+        for r in report.results:
+            key = (r.task_id, r.strategy.value)
+            entry = baseline_lookup.get(key)
+            if entry is None:
+                continue
+            for metric in _METRICS:
+                baseline_val = getattr(entry, metric)
+                current_val = getattr(r, metric)
+                delta = current_val - baseline_val
+                regression = current_val < baseline_val - tolerance
+                comparisons.append(
+                    BaselineComparison(
+                        task_id=r.task_id,
+                        strategy=r.strategy.value,
+                        metric=metric,
+                        baseline_value=baseline_val,
+                        current_value=current_val,
+                        delta=delta,
+                        regression=regression,
+                    )
+                )
+    return comparisons

--- a/src/archex/benchmark/gate.py
+++ b/src/archex/benchmark/gate.py
@@ -1,0 +1,55 @@
+"""Quality gate: check benchmark results against minimum thresholds."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from archex.benchmark.models import BenchmarkReport  # noqa: TCH001 — Pydantic needs at runtime
+
+
+class QualityThresholds(BaseModel):
+    min_recall: float = 0.6
+    min_precision: float = 0.3
+    min_f1: float = 0.4
+    min_mrr: float = 0.3
+
+
+class GateViolation(BaseModel):
+    task_id: str
+    strategy: str
+    metric: str
+    threshold: float
+    actual: float
+
+
+def check_gate(
+    reports: list[BenchmarkReport],
+    thresholds: QualityThresholds | None = None,
+) -> list[GateViolation]:
+    """Check all results against quality thresholds. Returns list of violations."""
+    if thresholds is None:
+        thresholds = QualityThresholds()
+
+    checks = [
+        ("recall", thresholds.min_recall),
+        ("precision", thresholds.min_precision),
+        ("f1_score", thresholds.min_f1),
+        ("mrr", thresholds.min_mrr),
+    ]
+
+    violations: list[GateViolation] = []
+    for report in reports:
+        for r in report.results:
+            for metric_name, threshold_val in checks:
+                actual = getattr(r, metric_name)
+                if actual < threshold_val:
+                    violations.append(
+                        GateViolation(
+                            task_id=r.task_id,
+                            strategy=r.strategy.value,
+                            metric=metric_name,
+                            threshold=threshold_val,
+                            actual=actual,
+                        )
+                    )
+    return violations

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -36,6 +36,8 @@ class BenchmarkResult(BaseModel):
     files_accessed: int
     recall: float
     precision: float
+    f1_score: float = 0.0
+    mrr: float = 0.0
     symbol_recall: float = 0.0
     savings_vs_raw: float
     wall_time_ms: float

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -16,13 +16,16 @@ def format_markdown(report: BenchmarkReport) -> str:
     lines.append(f"**Question:** {report.question}")
     lines.append(f"**Baseline tokens:** {report.baseline_tokens:,}")
     lines.append("")
-    lines.append("| Strategy | Tokens | Savings | Recall | Precision | Files | Time (ms) |")
-    lines.append("|----------|--------|---------|--------|-----------|-------|-----------|")
+    header = "| Strategy | Tokens | Savings | Recall | Precision | F1 | MRR | Files | Time (ms) |"
+    lines.append(header)
+    lines.append(
+        "|----------|--------|---------|--------|-----------|------|------|-------|-----------|"
+    )  # noqa: E501
     for r in report.results:
         lines.append(
             f"| {r.strategy.value} | {r.tokens_total:,} | {r.savings_vs_raw:.1f}% "
-            f"| {r.recall:.2f} | {r.precision:.2f} | {r.files_accessed} "
-            f"| {r.wall_time_ms:.0f} |"
+            f"| {r.recall:.2f} | {r.precision:.2f} | {r.f1_score:.2f} | {r.mrr:.2f} "
+            f"| {r.files_accessed} | {r.wall_time_ms:.0f} |"
         )
     lines.append("")
     return "\n".join(lines)
@@ -47,6 +50,8 @@ def format_summary(reports: list[BenchmarkReport]) -> str:
     strategy_totals: dict[str, list[float]] = {}
     strategy_recalls: dict[str, list[float]] = {}
     strategy_savings: dict[str, list[float]] = {}
+    strategy_f1s: dict[str, list[float]] = {}
+    strategy_mrrs: dict[str, list[float]] = {}
 
     for report in reports:
         for r in report.results:
@@ -54,20 +59,27 @@ def format_summary(reports: list[BenchmarkReport]) -> str:
             strategy_totals.setdefault(name, []).append(float(r.tokens_total))
             strategy_recalls.setdefault(name, []).append(r.recall)
             strategy_savings.setdefault(name, []).append(r.savings_vs_raw)
+            strategy_f1s.setdefault(name, []).append(r.f1_score)
+            strategy_mrrs.setdefault(name, []).append(r.mrr)
 
-    lines.append("| Strategy | Avg Tokens | Avg Savings | Avg Recall | Tasks |")
-    lines.append("|----------|------------|-------------|------------|-------|")
+    lines.append("| Strategy | Avg Tokens | Avg Savings | Avg Recall | Avg F1 | Avg MRR | Tasks |")
+    lines.append("|----------|------------|-------------|------------|--------|---------|-------|")
 
     for name in sorted(strategy_totals.keys()):
         tokens_list = strategy_totals[name]
         recalls_list = strategy_recalls[name]
         savings_list = strategy_savings[name]
+        f1s_list = strategy_f1s[name]
+        mrrs_list = strategy_mrrs[name]
         count = len(tokens_list)
         avg_tokens = sum(tokens_list) / count
         avg_recall = sum(recalls_list) / count
         avg_savings = sum(savings_list) / count
+        avg_f1 = sum(f1s_list) / count
+        avg_mrr = sum(mrrs_list) / count
         lines.append(
-            f"| {name} | {avg_tokens:,.0f} | {avg_savings:.1f}% | {avg_recall:.2f} | {count} |"
+            f"| {name} | {avg_tokens:,.0f} | {avg_savings:.1f}% "
+            f"| {avg_recall:.2f} | {avg_f1:.2f} | {avg_mrr:.2f} | {count} |"
         )
 
     lines.append("")

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -53,7 +53,10 @@ def run_benchmark(
 
     needs_cleanup = False
     if repo_path is None:
-        repo_path, needs_cleanup = clone_at_commit(task.repo, task.commit)
+        if task.repo == ".":
+            repo_path = Path.cwd()
+        else:
+            repo_path, needs_cleanup = clone_at_commit(task.repo, task.commit)
 
     try:
         results: list[BenchmarkResult] = []
@@ -118,7 +121,10 @@ def run_all(
 
     for task in tasks:
         print(f"Running benchmark: {task.task_id} ({task.repo})", file=sys.stderr)
-        report = run_benchmark(task, strategies=strategies)
+        task_repo_path: Path | None = None
+        if task.repo == ".":
+            task_repo_path = Path.cwd()
+        report = run_benchmark(task, strategies=strategies, repo_path=task_repo_path)
         reports.append(report)
 
         result_path = output_dir / f"{task.task_id}.json"

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -124,6 +124,22 @@ _STOPWORDS = frozenset(
 )
 
 
+def compute_f1(recall: float, precision: float) -> float:
+    """Harmonic mean of recall and precision."""
+    if recall + precision == 0.0:
+        return 0.0
+    return 2 * (recall * precision) / (recall + precision)
+
+
+def compute_mrr(ranked_files: list[str], expected_files: list[str]) -> float:
+    """Mean reciprocal rank: reciprocal of the rank of the first expected file found."""
+    expected_set = set(expected_files)
+    for i, f in enumerate(ranked_files, 1):
+        if f in expected_set:
+            return 1.0 / i
+    return 0.0
+
+
 def compute_recall(result_files: set[str], expected_files: list[str]) -> float:
     """Fraction of expected files found in results."""
     if not expected_files:
@@ -224,6 +240,7 @@ def run_raw_grepped(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     wall_ms = (time.perf_counter() - t0) * 1000
     recall = compute_recall(matched_files, task.expected_files)
     precision = compute_precision(matched_files, task.expected_files)
+    f1 = compute_f1(recall, precision)
 
     return BenchmarkResult(
         task_id=task.task_id,
@@ -233,6 +250,7 @@ def run_raw_grepped(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         files_accessed=len(matched_files),
         recall=recall,
         precision=precision,
+        f1_score=f1,
         savings_vs_raw=0.0,  # backfilled by runner
         wall_time_ms=wall_ms,
         cached=False,
@@ -261,9 +279,12 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     )
 
     result_files = {c.chunk.file_path for c in bundle.chunks}
+    ranked_files = [c.chunk.file_path for c in bundle.chunks]
     wall_ms = (time.perf_counter() - t0) * 1000
     recall = compute_recall(result_files, task.expected_files)
     precision = compute_precision(result_files, task.expected_files)
+    f1 = compute_f1(recall, precision)
+    mrr_val = compute_mrr(ranked_files, task.expected_files)
 
     return BenchmarkResult(
         task_id=task.task_id,
@@ -273,6 +294,8 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         files_accessed=len(result_files),
         recall=recall,
         precision=precision,
+        f1_score=f1,
+        mrr=mrr_val,
         savings_vs_raw=0.0,  # backfilled by runner
         wall_time_ms=wall_ms,
         cached=timing.cached,
@@ -311,6 +334,8 @@ def run_archex_query_hybrid(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
             files_accessed=0,
             recall=0.0,
             precision=0.0,
+            f1_score=0.0,
+            mrr=0.0,
             savings_vs_raw=0.0,
             wall_time_ms=wall_ms,
             cached=False,
@@ -319,9 +344,12 @@ def run_archex_query_hybrid(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
         )
 
     result_files = {c.chunk.file_path for c in bundle.chunks}
+    ranked_files = [c.chunk.file_path for c in bundle.chunks]
     wall_ms = (time.perf_counter() - t0) * 1000
     recall = compute_recall(result_files, task.expected_files)
     precision = compute_precision(result_files, task.expected_files)
+    f1 = compute_f1(recall, precision)
+    mrr_val = compute_mrr(ranked_files, task.expected_files)
 
     return BenchmarkResult(
         task_id=task.task_id,
@@ -331,6 +359,8 @@ def run_archex_query_hybrid(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
         files_accessed=len(result_files),
         recall=recall,
         precision=precision,
+        f1_score=f1,
+        mrr=mrr_val,
         savings_vs_raw=0.0,  # backfilled by runner
         wall_time_ms=wall_ms,
         cached=timing.cached,

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import click
 
+from archex.benchmark.baseline import compare_baseline, load_baseline, save_baseline
+from archex.benchmark.gate import QualityThresholds, check_gate
 from archex.benchmark.loader import load_tasks
 from archex.benchmark.models import BenchmarkReport, Strategy
 from archex.benchmark.reporter import format_json, format_markdown, format_summary
@@ -133,3 +135,132 @@ def validate_cmd(tasks_dir: str) -> None:
     if has_errors:
         raise SystemExit(1)
     click.echo(f"\nAll {len(tasks)} task(s) valid.")
+
+
+@benchmark_cmd.group("baseline")
+def baseline_cmd() -> None:
+    """Manage benchmark baselines for regression detection."""
+
+
+@baseline_cmd.command("save")
+@click.option(
+    "--input",
+    "input_dir",
+    default="benchmarks/results",
+    type=click.Path(exists=True),
+    help="Directory containing result JSON files.",
+)
+@click.option(
+    "--output",
+    "output_path",
+    default="benchmarks/baseline.json",
+    type=click.Path(),
+    help="Output path for baseline JSON.",
+)
+def baseline_save_cmd(input_dir: str, output_path: str) -> None:
+    """Save current benchmark results as a golden baseline."""
+    input_path = Path(input_dir)
+    reports: list[BenchmarkReport] = []
+    for json_file in sorted(input_path.glob("*.json")):
+        data = json.loads(json_file.read_text(encoding="utf-8"))
+        reports.append(BenchmarkReport.model_validate(data))
+
+    if not reports:
+        raise click.ClickException(f"No result files found in {input_dir}")
+
+    baseline = save_baseline(reports)
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(baseline.model_dump_json(indent=2), encoding="utf-8")
+    click.echo(f"Saved baseline with {len(baseline.entries)} entries to {output_path}")
+
+
+@baseline_cmd.command("compare")
+@click.option(
+    "--input",
+    "input_dir",
+    default="benchmarks/results",
+    type=click.Path(exists=True),
+    help="Directory containing result JSON files.",
+)
+@click.option(
+    "--baseline",
+    "baseline_path",
+    required=True,
+    type=click.Path(exists=True),
+    help="Path to baseline JSON file.",
+)
+def baseline_compare_cmd(input_dir: str, baseline_path: str) -> None:
+    """Compare current results against a saved baseline."""
+    input_path = Path(input_dir)
+    reports: list[BenchmarkReport] = []
+    for json_file in sorted(input_path.glob("*.json")):
+        data = json.loads(json_file.read_text(encoding="utf-8"))
+        reports.append(BenchmarkReport.model_validate(data))
+
+    if not reports:
+        raise click.ClickException(f"No result files found in {input_dir}")
+
+    baseline_data = json.loads(Path(baseline_path).read_text(encoding="utf-8"))
+    baseline = load_baseline(baseline_data)
+
+    comparisons = compare_baseline(reports, baseline)
+    regressions = [c for c in comparisons if c.regression]
+
+    click.echo(f"Compared {len(comparisons)} metric(s) against baseline.")
+    if regressions:
+        click.echo(f"\nREGRESSIONS DETECTED: {len(regressions)}")
+        for r in regressions:
+            click.echo(
+                f"  {r.task_id}/{r.strategy} {r.metric}: "
+                f"{r.baseline_value:.3f} -> {r.current_value:.3f} (delta: {r.delta:+.3f})"
+            )
+        raise SystemExit(1)
+    else:
+        click.echo("No regressions detected.")
+
+
+@benchmark_cmd.command("gate")
+@click.option(
+    "--input",
+    "input_dir",
+    default="benchmarks/results",
+    type=click.Path(exists=True),
+    help="Directory containing result JSON files.",
+)
+@click.option("--min-recall", default=0.6, type=float, help="Minimum recall threshold.")
+@click.option("--min-precision", default=0.3, type=float, help="Minimum precision threshold.")
+@click.option("--min-f1", default=0.4, type=float, help="Minimum F1 threshold.")
+@click.option("--min-mrr", default=0.3, type=float, help="Minimum MRR threshold.")
+def gate_cmd(
+    input_dir: str,
+    min_recall: float,
+    min_precision: float,
+    min_f1: float,
+    min_mrr: float,
+) -> None:
+    """Check benchmark results against quality thresholds."""
+    input_path = Path(input_dir)
+    reports: list[BenchmarkReport] = []
+    for json_file in sorted(input_path.glob("*.json")):
+        data = json.loads(json_file.read_text(encoding="utf-8"))
+        reports.append(BenchmarkReport.model_validate(data))
+
+    if not reports:
+        raise click.ClickException(f"No result files found in {input_dir}")
+
+    thresholds = QualityThresholds(
+        min_recall=min_recall,
+        min_precision=min_precision,
+        min_f1=min_f1,
+        min_mrr=min_mrr,
+    )
+    violations = check_gate(reports, thresholds)
+
+    if violations:
+        click.echo(f"QUALITY GATE FAILED: {len(violations)} violation(s)")
+        for v in violations:
+            click.echo(f"  {v.task_id}/{v.strategy} {v.metric}: {v.actual:.3f} < {v.threshold:.3f}")
+        raise SystemExit(1)
+    else:
+        click.echo("Quality gate passed.")

--- a/src/archex/index/bm25.py
+++ b/src/archex/index/bm25.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+import sqlite3
 from typing import TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
@@ -70,7 +71,7 @@ class BM25Index:
                 "FROM chunks_fts WHERE chunks_fts MATCH ? ORDER BY score LIMIT ?",
                 (escaped, top_k),
             )
-        except Exception:
+        except sqlite3.OperationalError:
             logger.warning("FTS5 query failed for: %s", escaped, exc_info=True)
             return []
 

--- a/tests/analyze/test_modules.py
+++ b/tests/analyze/test_modules.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from archex.analyze.modules import detect_modules
 from archex.index.graph import DependencyGraph
 from archex.models import ParsedFile
@@ -148,7 +150,30 @@ def test_infer_module_name_common_prefix() -> None:
 
 
 def test_detect_modules_louvain_fallback() -> None:
-    """When louvain_communities raises, all files collapse into one module."""
+    """When louvain_communities raises NetworkXError, all files collapse into one module."""
+    from unittest.mock import patch
+
+    import networkx as nx  # type: ignore[import-untyped]
+
+    pf_a = ParsedFile(path="pkg/a.py", language="python", lines=5)
+    pf_b = ParsedFile(path="pkg/b.py", language="python", lines=8)
+    graph = DependencyGraph()
+    graph.add_file_node("pkg/a.py")
+    graph.add_file_node("pkg/b.py")
+    graph.add_file_edge("pkg/a.py", "pkg/b.py")
+
+    with patch(
+        "archex.analyze.modules.louvain_communities",
+        side_effect=nx.NetworkXError("fail"),
+    ):
+        modules = detect_modules(graph, [pf_a, pf_b])
+
+    assert len(modules) == 1
+    assert set(modules[0].files) == {"pkg/a.py", "pkg/b.py"}
+
+
+def test_detect_modules_louvain_unexpected_error_propagates() -> None:
+    """Unexpected errors from louvain_communities must propagate, not be silently caught."""
     from unittest.mock import patch
 
     pf_a = ParsedFile(path="pkg/a.py", language="python", lines=5)
@@ -158,11 +183,11 @@ def test_detect_modules_louvain_fallback() -> None:
     graph.add_file_node("pkg/b.py")
     graph.add_file_edge("pkg/a.py", "pkg/b.py")
 
-    with patch("archex.analyze.modules.louvain_communities", side_effect=RuntimeError("fail")):
-        modules = detect_modules(graph, [pf_a, pf_b])
-
-    assert len(modules) == 1
-    assert set(modules[0].files) == {"pkg/a.py", "pkg/b.py"}
+    with (
+        patch("archex.analyze.modules.louvain_communities", side_effect=TypeError("unexpected")),
+        pytest.raises(TypeError, match="unexpected"),
+    ):
+        detect_modules(graph, [pf_a, pf_b])
 
 
 def test_detect_modules_single_node_graph() -> None:

--- a/tests/benchmark/test_baseline.py
+++ b/tests/benchmark/test_baseline.py
@@ -1,0 +1,98 @@
+"""Tests for baseline save/load/compare functionality."""
+
+from __future__ import annotations
+
+from archex.benchmark.baseline import (
+    Baseline,
+    BaselineEntry,
+    compare_baseline,
+    load_baseline,
+    save_baseline,
+)
+from archex.benchmark.models import BenchmarkReport, BenchmarkResult, Strategy
+
+
+def _make_report(
+    task_id: str = "test_task",
+    recall: float = 0.8,
+    precision: float = 0.6,
+    f1_score: float = 0.685,
+    mrr: float = 0.5,
+) -> BenchmarkReport:
+    result = BenchmarkResult(
+        task_id=task_id,
+        strategy=Strategy.ARCHEX_QUERY,
+        tokens_total=1000,
+        tool_calls=1,
+        files_accessed=3,
+        recall=recall,
+        precision=precision,
+        f1_score=f1_score,
+        mrr=mrr,
+        savings_vs_raw=50.0,
+        wall_time_ms=100.0,
+        cached=False,
+        timestamp="2026-01-01T00:00:00Z",
+    )
+    return BenchmarkReport(
+        task_id=task_id,
+        repo="test/repo",
+        question="test question",
+        results=[result],
+        baseline_tokens=2000,
+    )
+
+
+def test_save_load_baseline_roundtrip() -> None:
+    reports = [_make_report()]
+    baseline = save_baseline(reports)
+    assert len(baseline.entries) == 1
+    assert baseline.entries[0].task_id == "test_task"
+
+    # Roundtrip through JSON
+    data = baseline.model_dump()
+    loaded = load_baseline(data)
+    assert len(loaded.entries) == 1
+    assert loaded.entries[0].recall == 0.8
+
+
+def test_compare_baseline_detects_regression() -> None:
+    baseline = Baseline(
+        entries=[
+            BaselineEntry(
+                task_id="test_task",
+                strategy="archex_query",
+                recall=0.9,
+                precision=0.8,
+                f1_score=0.85,
+                mrr=0.7,
+            )
+        ]
+    )
+    # Current results are worse
+    reports = [_make_report(recall=0.5, precision=0.3, f1_score=0.37, mrr=0.2)]
+    comparisons = compare_baseline(reports, baseline)
+    regressions = [c for c in comparisons if c.regression]
+    assert len(regressions) > 0
+    regressed_metrics = {c.metric for c in regressions}
+    assert "recall" in regressed_metrics
+
+
+def test_compare_baseline_no_regression() -> None:
+    baseline = Baseline(
+        entries=[
+            BaselineEntry(
+                task_id="test_task",
+                strategy="archex_query",
+                recall=0.8,
+                precision=0.6,
+                f1_score=0.685,
+                mrr=0.5,
+            )
+        ]
+    )
+    # Current results are the same or better
+    reports = [_make_report(recall=0.85, precision=0.65, f1_score=0.72, mrr=0.55)]
+    comparisons = compare_baseline(reports, baseline)
+    regressions = [c for c in comparisons if c.regression]
+    assert len(regressions) == 0

--- a/tests/benchmark/test_gate.py
+++ b/tests/benchmark/test_gate.py
@@ -1,0 +1,58 @@
+"""Tests for quality gate checks."""
+
+from __future__ import annotations
+
+from archex.benchmark.gate import QualityThresholds, check_gate
+from archex.benchmark.models import BenchmarkReport, BenchmarkResult, Strategy
+
+
+def _make_report(
+    recall: float = 0.8,
+    precision: float = 0.5,
+    f1_score: float = 0.6,
+    mrr: float = 0.5,
+) -> BenchmarkReport:
+    result = BenchmarkResult(
+        task_id="test_task",
+        strategy=Strategy.ARCHEX_QUERY,
+        tokens_total=1000,
+        tool_calls=1,
+        files_accessed=3,
+        recall=recall,
+        precision=precision,
+        f1_score=f1_score,
+        mrr=mrr,
+        savings_vs_raw=50.0,
+        wall_time_ms=100.0,
+        cached=False,
+        timestamp="2026-01-01T00:00:00Z",
+    )
+    return BenchmarkReport(
+        task_id="test_task",
+        repo="test/repo",
+        question="test question",
+        results=[result],
+        baseline_tokens=2000,
+    )
+
+
+def test_check_gate_all_pass() -> None:
+    reports = [_make_report()]
+    violations = check_gate(reports)
+    assert violations == []
+
+
+def test_check_gate_violation_detected() -> None:
+    reports = [_make_report(recall=0.1, precision=0.05, f1_score=0.05, mrr=0.0)]
+    violations = check_gate(reports)
+    assert len(violations) > 0
+    violated_metrics = {v.metric for v in violations}
+    assert "recall" in violated_metrics
+
+
+def test_check_gate_custom_thresholds() -> None:
+    reports = [_make_report(recall=0.5, precision=0.4, f1_score=0.4, mrr=0.3)]
+    # With lower thresholds, should pass
+    thresholds = QualityThresholds(min_recall=0.4, min_precision=0.3, min_f1=0.3, min_mrr=0.2)
+    violations = check_gate(reports, thresholds)
+    assert violations == []

--- a/tests/benchmark/test_metrics.py
+++ b/tests/benchmark/test_metrics.py
@@ -1,0 +1,32 @@
+"""Tests for F1 and MRR metric functions."""
+
+from __future__ import annotations
+
+from archex.benchmark.strategies import compute_f1, compute_mrr
+
+
+def test_compute_f1_perfect() -> None:
+    assert compute_f1(1.0, 1.0) == 1.0
+
+
+def test_compute_f1_zero() -> None:
+    assert compute_f1(0.0, 0.0) == 0.0
+
+
+def test_compute_f1_typical() -> None:
+    f1 = compute_f1(0.8, 0.6)
+    expected = 2 * (0.8 * 0.6) / (0.8 + 0.6)
+    assert abs(f1 - expected) < 1e-9
+
+
+def test_compute_mrr_first_match() -> None:
+    assert compute_mrr(["a.py", "b.py", "c.py"], ["a.py"]) == 1.0
+
+
+def test_compute_mrr_third_match() -> None:
+    result = compute_mrr(["x.py", "y.py", "a.py"], ["a.py"])
+    assert abs(result - 1 / 3) < 1e-9
+
+
+def test_compute_mrr_no_match() -> None:
+    assert compute_mrr(["x.py", "y.py"], ["a.py"]) == 0.0

--- a/tests/benchmark/test_regression.py
+++ b/tests/benchmark/test_regression.py
@@ -1,0 +1,37 @@
+"""Regression test: run self-benchmark tasks and verify minimum quality."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from archex.benchmark.loader import load_task
+from archex.benchmark.models import Strategy
+from archex.benchmark.runner import run_benchmark
+
+
+@pytest.mark.slow
+def test_self_benchmark_minimum_quality() -> None:
+    """Run self-benchmark tasks against archex repo, assert minimum recall and MRR."""
+    tasks_dir = Path.cwd() / "benchmarks" / "tasks"
+    self_tasks = sorted(tasks_dir.glob("archex_*.yaml"))
+    assert len(self_tasks) > 0, "No self-benchmark tasks found"
+
+    for task_path in self_tasks:
+        task = load_task(task_path)
+        assert task.repo == ".", f"Self-benchmark task {task.task_id} must use repo='.'"
+
+        report = run_benchmark(
+            task,
+            strategies=[Strategy.ARCHEX_QUERY],
+            repo_path=Path.cwd(),
+        )
+
+        for result in report.results:
+            assert result.recall >= 0.5, (
+                f"{task.task_id}/{result.strategy.value}: recall {result.recall:.2f} < 0.5"
+            )
+            assert result.mrr > 0.0, (
+                f"{task.task_id}/{result.strategy.value}: mrr {result.mrr:.2f} == 0.0"
+            )

--- a/tests/index/test_bm25.py
+++ b/tests/index/test_bm25.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from typing import TYPE_CHECKING
 
 import pytest
@@ -255,7 +256,7 @@ def test_search_survives_fts5_error(tmp_path: Path) -> None:
 
         def execute(self, sql: str, parameters: object = None, /) -> object:
             if "MATCH" in sql:
-                raise RuntimeError("FTS5 error")
+                raise sqlite3.OperationalError("FTS5 error")
             if parameters is not None:
                 return real_conn.execute(sql, parameters)  # type: ignore[arg-type]
             return real_conn.execute(sql)
@@ -264,4 +265,32 @@ def test_search_survives_fts5_error(tmp_path: Path) -> None:
     results = idx.search("authenticate")
     s._conn = real_conn  # type: ignore[assignment]
     assert results == []
+    s.close()
+
+
+def test_search_propagates_non_operational_error(tmp_path: Path) -> None:
+    """Non-OperationalError exceptions from FTS5 must propagate."""
+    db = tmp_path / "bm25_prop.db"
+    s = IndexStore(db)
+    idx = BM25Index(s)
+    s.insert_chunks(SAMPLE_CHUNKS)
+    idx.build(SAMPLE_CHUNKS)
+
+    real_conn = s.conn
+
+    class _FailIntegrity:
+        def __getattr__(self, name: str) -> object:
+            return getattr(real_conn, name)
+
+        def execute(self, sql: str, parameters: object = None, /) -> object:
+            if "MATCH" in sql:
+                raise sqlite3.IntegrityError("integrity violation")
+            if parameters is not None:
+                return real_conn.execute(sql, parameters)  # type: ignore[arg-type]
+            return real_conn.execute(sql)
+
+    s._conn = _FailIntegrity()  # type: ignore[assignment]
+    with pytest.raises(sqlite3.IntegrityError, match="integrity violation"):
+        idx.search("authenticate")
+    s._conn = real_conn  # type: ignore[assignment]
     s.close()


### PR DESCRIPTION
## Summary
- Add F1 score and MRR (mean reciprocal rank) metrics to benchmark results
- Add 4 self-benchmark tasks (dogfooding archex's own repo) with `repo: "."`
- Add baseline snapshot module for saving/loading/comparing benchmark baselines
- Add quality gate module with configurable thresholds (recall, precision, F1, MRR)
- Add CLI subcommands: `benchmark baseline save/compare`, `benchmark gate`
- Runner detects `repo == "."` and uses local project root instead of cloning
- Reporter tables now include F1 and MRR columns

## Test plan
- [x] Unit tests for compute_f1 and compute_mrr
- [x] Baseline save/load roundtrip and regression detection tests
- [x] Quality gate pass/fail/custom-threshold tests
- [x] Self-benchmark regression test (marked @pytest.mark.slow)
- [x] Full test suite passes (1053 passed)
- [x] pyright clean (0 errors in changed files), ruff clean