### PR TITLE
chore: update repo URLs after org transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Adapters are extensible via Python entry points — add a new language without m
 ## Development
 
 ```bash
-git clone https://github.com/Mathews-Tom/archex.git
+git clone https://github.com/determ-ai/archex.git
 cd archex
 uv sync --all-extras
 

--- a/docs/WHY_ARCHEX.md
+++ b/docs/WHY_ARCHEX.md
@@ -427,7 +427,7 @@ Your agent now has access to `analyze_repo`, `query_repo`, `compare_repos`, `get
 archex is Apache 2.0 licensed. Contributions welcome.
 
 ```bash
-git clone https://github.com/Mathews-Tom/archex.git
+git clone https://github.com/determ-ai/archex.git
 cd archex
 uv sync --all-extras
 uv run pytest  # 1274 tests, 92% coverage


### PR DESCRIPTION
## Summary

- Update git clone URLs from `Mathews-Tom/archex` to `determ-ai/archex` in README.md and docs/WHY_ARCHEX.md

## Test plan

- [x] `grep -r "Mathews-Tom/archex"` returns no results
- [x] Documentation only — no code changes