### PR TITLE
feat(config): BM25 skip path for pure vector retrieval

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -850,12 +850,16 @@ def query(
                         index_config,
                         top_k,
                     )
-                    _bm25_raw, path_boost, symbol_seeds = _bm25_search_with_boosts(
-                        bm25, store, question, top_k
-                    )
+                    if index_config.bm25:
+                        _bm25_raw, path_boost, symbol_seeds = _bm25_search_with_boosts(
+                            bm25, store, question, top_k
+                        )
+                        search_results = _bm25_raw + path_boost + symbol_seeds
+                    else:
+                        search_results = []
+                        path_boost = []
+                        symbol_seeds = []
                     vector_results: list[tuple[CodeChunk, float]] | None = _vec_future.result()
-
-                search_results = _bm25_raw + path_boost + symbol_seeds
 
                 # Fall back to rerank when pre-computed .npz is absent
                 if vector_results is None and index_config.vector:
@@ -1091,12 +1095,16 @@ def query(
                     index_config,
                     top_k,
                 )
-                _bm25_raw, path_boost, symbol_seeds_miss = _bm25_search_with_boosts(
-                    bm25, store, question, top_k
-                )
+                if index_config.bm25:
+                    _bm25_raw, path_boost, symbol_seeds_miss = _bm25_search_with_boosts(
+                        bm25, store, question, top_k
+                    )
+                    search_results = _bm25_raw + path_boost + symbol_seeds_miss
+                else:
+                    search_results = []
+                    path_boost = []
+                    symbol_seeds_miss = []
                 vector_results_miss: list[tuple[CodeChunk, float]] | None = _vec_future.result()
-
-            search_results = _bm25_raw + path_boost + symbol_seeds_miss
 
             # Fall back to rerank when pre-computed .npz is absent
             if vector_results_miss is None and index_config.vector:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -495,6 +495,25 @@ class TestIndexConfigValidation:
         config = IndexConfig(chunk_min_tokens=0)
         assert config.chunk_min_tokens == 0
 
+    def test_both_disabled_raises(self) -> None:
+        with pytest.raises(ValueError, match="At least one of bm25 or vector must be enabled"):
+            IndexConfig(bm25=False, vector=False)
+
+    def test_bm25_only_valid(self) -> None:
+        config = IndexConfig(bm25=True, vector=False)
+        assert config.bm25 is True
+        assert config.vector is False
+
+    def test_vector_only_valid(self) -> None:
+        config = IndexConfig(bm25=False, vector=True)
+        assert config.bm25 is False
+        assert config.vector is True
+
+    def test_both_enabled_valid(self) -> None:
+        config = IndexConfig(bm25=True, vector=True)
+        assert config.bm25 is True
+        assert config.vector is True
+
 
 # ---------------------------------------------------------------------------
 # RepoSource validation tests

--- a/tests/test_query_pipeline.py
+++ b/tests/test_query_pipeline.py
@@ -9,10 +9,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 from archex.api import query
 from archex.models import (
     Config,
     ContextBundle,
+    IndexConfig,
     PipelineTiming,
     RepoSource,
     ScoringWeights,
@@ -130,3 +133,43 @@ class TestRenderPipeline:
         assert root.tag == "context"
         chunks = root.findall(".//chunk")
         assert len(chunks) > 0
+
+
+class TestIndexConfigQueryPaths:
+    """Verify BM25-skip and pure-BM25 paths in query()."""
+
+    def test_pure_bm25_query_returns_results(self, python_simple_repo: Path) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(cache=False)
+        index_config = IndexConfig(bm25=True, vector=False)
+        bundle = query(
+            source,
+            "User model and authentication",
+            config=config,
+            index_config=index_config,
+        )
+
+        assert isinstance(bundle, ContextBundle)
+        assert len(bundle.chunks) > 0
+
+    def test_bm25_false_vector_true_returns_bundle(self, python_simple_repo: Path) -> None:
+        """Pure vector path: bm25=False skips BM25 search; vector rerank feeds assemble_context."""
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(cache=False)
+        index_config = IndexConfig(bm25=False, vector=True)
+        bundle = query(
+            source,
+            "User model and authentication",
+            config=config,
+            index_config=index_config,
+        )
+
+        assert isinstance(bundle, ContextBundle)
+        # Vector rerank produces results from the chunk corpus
+        assert len(bundle.chunks) > 0
+
+    def test_bm25_false_vector_false_raises(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="At least one of bm25 or vector must be enabled"):
+            IndexConfig(bm25=False, vector=False)


### PR DESCRIPTION
## Summary
- Add `IndexConfig` validation: at least one of `bm25` or `vector` must be enabled
- Skip BM25 search when `index_config.bm25=False` in both cached and cache-miss query paths
- Consolidate `search_results` assembly inside conditional blocks to avoid potentially unbound variables
- Enable `IndexConfig(bm25=False, vector=True)` for pure vector retrieval (required by Phase 9.4's `archex_query_vector` strategy)

## Test plan
- [x] Both disabled raises `ValidationError`
- [x] BM25-only valid (`bm25=True, vector=False`)
- [x] Vector-only valid (`bm25=False, vector=True`)
- [x] Pure vector query returns results when vector index exists
- [x] Full suite: 1606 passed, 92.34% coverage

Depends on: #60