### PR TITLE
feat(benchmark): modernize strategies with vector and fusion retrieval

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,7 +50,7 @@ jobs:
           name: benchmark-results-bm25
           path: benchmarks/results/bm25/
 
-  benchmark-hybrid:
+  benchmark-fusion:
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
@@ -70,30 +70,30 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Run benchmarks (hybrid, all tasks)
+      - name: Run benchmarks (fusion, all tasks)
         run: |
           uv run archex benchmark run \
             --tasks-dir benchmarks/tasks \
-            --output benchmarks/results/hybrid \
-            --strategy archex_query_hybrid
+            --output benchmarks/results/fusion \
+            --strategy archex_query_fusion
 
-      - name: Quality gate (hybrid)
+      - name: Quality gate (fusion)
         run: |
           uv run archex benchmark gate \
-            --input benchmarks/results/hybrid \
+            --input benchmarks/results/fusion \
             --min-recall 0.60 \
             --min-f1 0.30 \
             --min-mrr 0.55
 
-      - name: Upload hybrid results
+      - name: Upload fusion results
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-results-hybrid
-          path: benchmarks/results/hybrid/
+          name: benchmark-results-fusion
+          path: benchmarks/results/fusion/
 
   commit-results:
     runs-on: ubuntu-latest
-    needs: [benchmark-bm25, benchmark-hybrid]
+    needs: [benchmark-bm25, benchmark-fusion]
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
     steps:
@@ -105,11 +105,11 @@ jobs:
           name: benchmark-results-bm25
           path: benchmarks/results/bm25/
 
-      - name: Download hybrid results
+      - name: Download fusion results
         uses: actions/download-artifact@v4
         with:
-          name: benchmark-results-hybrid
-          path: benchmarks/results/hybrid/
+          name: benchmark-results-fusion
+          path: benchmarks/results/fusion/
 
       - name: Commit results
         run: |

--- a/src/archex/benchmark/gate.py
+++ b/src/archex/benchmark/gate.py
@@ -20,6 +20,15 @@ class QualityThresholds(BaseModel):
     min_token_efficiency: float = 0.0
     # Latency: warn-only, does not fail the gate
     warn_latency_ms: float = 5000.0
+    # Strategies exempt from gate checks (results are informational only)
+    gate_exempt_strategies: set[str] = {
+        "raw_files",
+        "raw_grepped",
+        "archex_query_vector",
+        "archex_symbol_lookup",
+    }
+    # Per-strategy threshold overrides; keyed by strategy value string
+    strategy_thresholds: dict[str, QualityThresholds] = {}
 
 
 class GateViolation(BaseModel):
@@ -37,34 +46,46 @@ class LatencyWarning(BaseModel):
     actual_ms: float
 
 
+def _gate_checks(t: QualityThresholds) -> list[tuple[str, float]]:
+    return [
+        ("recall", t.min_recall),
+        ("precision", t.min_precision),
+        ("f1_score", t.min_f1),
+        ("mrr", t.min_mrr),
+        ("ndcg", t.min_ndcg),
+        ("map_score", t.min_map),
+        ("token_efficiency", t.min_token_efficiency),
+    ]
+
+
 def check_gate(
     reports: list[BenchmarkReport],
     thresholds: QualityThresholds | None = None,
 ) -> list[GateViolation]:
-    """Check all results against quality thresholds. Returns list of violations."""
+    """Check all results against quality thresholds. Returns list of violations.
+
+    Results whose strategy is in ``thresholds.gate_exempt_strategies`` are
+    skipped entirely. When ``thresholds.strategy_thresholds`` contains an entry
+    for a strategy, those per-strategy thresholds are used instead of the
+    default ones.
+    """
     if thresholds is None:
         thresholds = QualityThresholds()
-
-    checks = [
-        ("recall", thresholds.min_recall),
-        ("precision", thresholds.min_precision),
-        ("f1_score", thresholds.min_f1),
-        ("mrr", thresholds.min_mrr),
-        ("ndcg", thresholds.min_ndcg),
-        ("map_score", thresholds.min_map),
-        ("token_efficiency", thresholds.min_token_efficiency),
-    ]
 
     violations: list[GateViolation] = []
     for report in reports:
         for r in report.results:
-            for metric_name, threshold_val in checks:
+            strategy_val = r.strategy.value
+            if strategy_val in thresholds.gate_exempt_strategies:
+                continue
+            effective = thresholds.strategy_thresholds.get(strategy_val, thresholds)
+            for metric_name, threshold_val in _gate_checks(effective):
                 actual = getattr(r, metric_name)
                 if actual < threshold_val:
                     violations.append(
                         GateViolation(
                             task_id=r.task_id,
-                            strategy=r.strategy.value,
+                            strategy=strategy_val,
                             metric=metric_name,
                             threshold=threshold_val,
                             actual=actual,

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -13,7 +13,8 @@ class Strategy(StrEnum):
     RAW_FILES = "raw_files"
     RAW_GREPPED = "raw_grepped"
     ARCHEX_QUERY = "archex_query"
-    ARCHEX_QUERY_HYBRID = "archex_query_hybrid"
+    ARCHEX_QUERY_VECTOR = "archex_query_vector"
+    ARCHEX_QUERY_FUSION = "archex_query_fusion"
     ARCHEX_SYMBOL_LOOKUP = "archex_symbol_lookup"
 
 

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -20,11 +20,15 @@ AVAILABLE_STRATEGIES: list[Strategy] = [
     Strategy.RAW_FILES,
     Strategy.RAW_GREPPED,
     Strategy.ARCHEX_QUERY,
-    Strategy.ARCHEX_QUERY_HYBRID,
+    Strategy.ARCHEX_QUERY_FUSION,
 ]
 
+_VECTOR_STRATEGIES: frozenset[Strategy] = frozenset(
+    {Strategy.ARCHEX_QUERY_VECTOR, Strategy.ARCHEX_QUERY_FUSION}
+)
 
-def _check_hybrid_available() -> bool:
+
+def _check_vector_available() -> bool:
     """Check if vector embedding dependencies are available (fastembed or sentence-transformers)."""
     try:
         import fastembed as _fe  # noqa: F401  # pyright: ignore[reportUnusedImport]
@@ -81,8 +85,8 @@ def run_benchmark(
     """Run a benchmark task across strategies. Clones repo if repo_path not provided."""
     if strategies is None:
         strategies = list(AVAILABLE_STRATEGIES)
-        if not _check_hybrid_available():
-            strategies = [s for s in strategies if s != Strategy.ARCHEX_QUERY_HYBRID]
+        if not _check_vector_available():
+            strategies = [s for s in strategies if s not in _VECTOR_STRATEGIES]
 
     needs_cleanup = False
     if repo_path is None:

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -513,8 +513,71 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     )
 
 
-def run_archex_query_hybrid(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
-    """archex hybrid query strategy: BM25 + vector retrieval."""
+def run_archex_query_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
+    """Pure vector retrieval strategy: vector search without BM25."""
+    from archex.api import query
+    from archex.models import Config, IndexConfig
+
+    t0 = time.perf_counter()
+    timing = PipelineTiming()
+    source = RepoSource(local_path=str(repo_path))
+    config = Config(cache=False, languages=task.languages)
+    index_config = IndexConfig(bm25=False, vector=True, embedder="fastembed")
+
+    bundle = query(
+        source,
+        task.question,
+        token_budget=task.token_budget,
+        config=config,
+        index_config=index_config,
+        timing=timing,
+    )
+
+    ranked_files = [c.chunk.file_path for c in bundle.chunks]
+    result_files = set(_deduplicate_ranked(ranked_files))
+    wall_ms = (time.perf_counter() - t0) * 1000
+    recall = compute_recall(result_files, task.expected_files)
+    precision = compute_precision(result_files, task.expected_files)
+    f1 = compute_f1(recall, precision)
+    mrr_val = compute_mrr(ranked_files, task.expected_files)
+    ndcg_val = compute_ndcg(ranked_files, task.expected_files)
+    map_val = compute_map(ranked_files, task.expected_files)
+    af = _archex_fields(bundle, task, repo_path)
+
+    return BenchmarkResult(
+        task_id=task.task_id,
+        strategy=Strategy.ARCHEX_QUERY_VECTOR,
+        tokens_total=bundle.token_count,
+        tokens_input=af.tokens_input,
+        tokens_output=af.tokens_output,
+        token_efficiency=af.token_efficiency,
+        tokens_raw_baseline=af.tokens_raw_baseline,
+        symbol_recall=af.symbol_recall,
+        tool_calls=1,
+        files_accessed=len(result_files),
+        recall=recall,
+        precision=precision,
+        f1_score=f1,
+        mrr=mrr_val,
+        ndcg=ndcg_val,
+        map_score=map_val,
+        savings_vs_raw=0.0,  # backfilled by runner
+        wall_time_ms=wall_ms,
+        cached=timing.cached,
+        timing=timing,
+        timestamp=now_iso(),
+        unique_ranked_files=af.unique_ranked_files,
+        seed_files=af.seed_files,
+        expanded_files=af.expanded_files,
+        expansion_ratio=af.expansion_ratio,
+        seed_recall=af.seed_recall,
+        seed_precision=af.seed_precision,
+        category=task.category,
+    )
+
+
+def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
+    """Full fusion strategy: BM25 + independent vector + confidence-aware RRF."""
     from archex.api import query
     from archex.models import Config, IndexConfig
 
@@ -546,7 +609,7 @@ def run_archex_query_hybrid(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
 
     return BenchmarkResult(
         task_id=task.task_id,
-        strategy=Strategy.ARCHEX_QUERY_HYBRID,
+        strategy=Strategy.ARCHEX_QUERY_FUSION,
         tokens_total=bundle.token_count,
         tokens_input=af.tokens_input,
         tokens_output=af.tokens_output,
@@ -634,8 +697,6 @@ default_strategy_registry = StrategyRegistry()
 default_strategy_registry.register(Strategy.RAW_FILES.value, run_raw_files)
 default_strategy_registry.register(Strategy.RAW_GREPPED.value, run_raw_grepped)
 default_strategy_registry.register(Strategy.ARCHEX_QUERY.value, run_archex_query)
-default_strategy_registry.register(Strategy.ARCHEX_QUERY_HYBRID.value, run_archex_query_hybrid)
+default_strategy_registry.register(Strategy.ARCHEX_QUERY_VECTOR.value, run_archex_query_vector)
+default_strategy_registry.register(Strategy.ARCHEX_QUERY_FUSION.value, run_archex_query_fusion)
 default_strategy_registry.register(Strategy.ARCHEX_SYMBOL_LOOKUP.value, run_archex_symbol_lookup)
-
-# Backward-compat reference
-STRATEGY_RUNNERS = default_strategy_registry._runners  # pyright: ignore[reportPrivateUsage]

--- a/tests/benchmark/test_gate.py
+++ b/tests/benchmark/test_gate.py
@@ -103,3 +103,75 @@ def test_check_gate_token_efficiency_default_passes() -> None:
     violations = check_gate(reports)
     violated_metrics = {v.metric for v in violations}
     assert "token_efficiency" not in violated_metrics
+
+
+def _make_report_for_strategy(strategy: Strategy, recall: float = 0.1) -> BenchmarkReport:
+    result = BenchmarkResult(
+        task_id="test_task",
+        strategy=strategy,
+        tokens_total=1000,
+        tool_calls=1,
+        files_accessed=3,
+        recall=recall,
+        precision=0.05,
+        f1_score=0.05,
+        mrr=0.0,
+        savings_vs_raw=0.0,
+        wall_time_ms=100.0,
+        cached=False,
+        timestamp="2026-01-01T00:00:00Z",
+    )
+    return BenchmarkReport(
+        task_id="test_task",
+        repo="test/repo",
+        question="test question",
+        results=[result],
+        baseline_tokens=2000,
+    )
+
+
+def test_check_gate_exempt_strategies_skipped() -> None:
+    """Strategies in gate_exempt_strategies produce no violations even when below threshold."""
+    for strategy in (
+        Strategy.RAW_FILES,
+        Strategy.RAW_GREPPED,
+        Strategy.ARCHEX_QUERY_VECTOR,
+        Strategy.ARCHEX_SYMBOL_LOOKUP,
+    ):
+        reports = [_make_report_for_strategy(strategy, recall=0.0)]
+        violations = check_gate(reports)
+        assert violations == [], f"Expected no violations for exempt strategy {strategy}"
+
+
+def test_check_gate_non_exempt_strategy_still_checked() -> None:
+    """Non-exempt strategies (e.g. archex_query) are still checked."""
+    reports = [_make_report_for_strategy(Strategy.ARCHEX_QUERY, recall=0.0)]
+    violations = check_gate(reports)
+    assert any(v.metric == "recall" for v in violations)
+
+
+def test_check_gate_strategy_thresholds_override() -> None:
+    """Per-strategy threshold overrides apply instead of the default."""
+    reports = [_make_report(recall=0.4, precision=0.4, f1_score=0.4, mrr=0.4)]
+    # Default thresholds would flag recall=0.4 (min 0.60) and mrr=0.4 (min 0.55)
+    per_strategy = QualityThresholds(
+        min_recall=0.3,
+        min_precision=0.3,
+        min_f1=0.3,
+        min_mrr=0.3,
+    )
+    thresholds = QualityThresholds(
+        strategy_thresholds={"archex_query": per_strategy},
+    )
+    violations = check_gate(reports, thresholds)
+    assert violations == []
+
+
+def test_check_gate_custom_exempt_set() -> None:
+    """A custom gate_exempt_strategies set overrides the default."""
+    reports = [_make_report(recall=0.0, precision=0.0, f1_score=0.0, mrr=0.0)]
+    thresholds = QualityThresholds(
+        gate_exempt_strategies={"archex_query"},
+    )
+    violations = check_gate(reports, thresholds)
+    assert violations == []

--- a/tests/benchmark/test_models.py
+++ b/tests/benchmark/test_models.py
@@ -18,7 +18,8 @@ class TestStrategy:
         assert Strategy.RAW_FILES == "raw_files"
         assert Strategy.RAW_GREPPED == "raw_grepped"
         assert Strategy.ARCHEX_QUERY == "archex_query"
-        assert Strategy.ARCHEX_QUERY_HYBRID == "archex_query_hybrid"
+        assert Strategy.ARCHEX_QUERY_VECTOR == "archex_query_vector"
+        assert Strategy.ARCHEX_QUERY_FUSION == "archex_query_fusion"
         assert Strategy.ARCHEX_SYMBOL_LOOKUP == "archex_symbol_lookup"
 
     def test_enum_from_value(self) -> None:

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -30,8 +30,8 @@ class TestAvailableStrategies:
         assert Strategy.RAW_FILES in AVAILABLE_STRATEGIES
         assert Strategy.RAW_GREPPED in AVAILABLE_STRATEGIES
         assert Strategy.ARCHEX_QUERY in AVAILABLE_STRATEGIES
-        # Hybrid is in the default set (skipped at runtime if deps missing)
-        assert Strategy.ARCHEX_QUERY_HYBRID in AVAILABLE_STRATEGIES
+        # Fusion is in the default set (skipped at runtime if vector deps missing)
+        assert Strategy.ARCHEX_QUERY_FUSION in AVAILABLE_STRATEGIES
         assert Strategy.ARCHEX_SYMBOL_LOOKUP not in AVAILABLE_STRATEGIES
 
 

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -19,7 +19,8 @@ from archex.benchmark.strategies import (
     count_file_tokens,
     extract_keywords,
     run_archex_query,
-    run_archex_query_hybrid,
+    run_archex_query_fusion,
+    run_archex_query_vector,
     run_archex_symbol_lookup,
     run_raw_files,
     run_raw_grepped,
@@ -320,7 +321,7 @@ class TestRunArchexQuery:
 
 
 class _StubEmbedder:
-    """Deterministic stub embedder for hybrid tests without onnxruntime."""
+    """Deterministic stub embedder for vector/fusion tests without onnxruntime."""
 
     @property
     def dimension(self) -> int:
@@ -341,8 +342,8 @@ def _stub_get_embedder(_index_config: object) -> _StubEmbedder:
     return _StubEmbedder()
 
 
-class TestRunArchexQueryHybrid:
-    def test_hybrid_strategy(self, python_simple_repo: Path) -> None:
+class TestRunArchexQueryVector:
+    def test_vector_strategy(self, python_simple_repo: Path) -> None:
         task = BenchmarkTask(
             task_id="test",
             repo="test/repo",
@@ -352,15 +353,15 @@ class TestRunArchexQueryHybrid:
             token_budget=4096,
         )
         with patch("archex.api._get_embedder", _stub_get_embedder):
-            result = run_archex_query_hybrid(task, python_simple_repo)
-        assert result.strategy == Strategy.ARCHEX_QUERY_HYBRID
+            result = run_archex_query_vector(task, python_simple_repo)
+        assert result.strategy == Strategy.ARCHEX_QUERY_VECTOR
         assert result.tokens_total >= 0
         assert result.tool_calls == 1
         assert result.timing is not None
         assert 0.0 <= result.recall <= 1.0
         assert 0.0 <= result.precision <= 1.0
 
-    def test_hybrid_recall_precision(self, python_simple_repo: Path) -> None:
+    def test_vector_recall_precision(self, python_simple_repo: Path) -> None:
         task = BenchmarkTask(
             task_id="test",
             repo="test/repo",
@@ -370,8 +371,42 @@ class TestRunArchexQueryHybrid:
             token_budget=8192,
         )
         with patch("archex.api._get_embedder", _stub_get_embedder):
-            result = run_archex_query_hybrid(task, python_simple_repo)
-        # Should return files and compute metrics
+            result = run_archex_query_vector(task, python_simple_repo)
+        assert result.files_accessed >= 0
+        assert isinstance(result.recall, float)
+        assert isinstance(result.precision, float)
+
+
+class TestRunArchexQueryFusion:
+    def test_fusion_strategy(self, python_simple_repo: Path) -> None:
+        task = BenchmarkTask(
+            task_id="test",
+            repo="test/repo",
+            commit="abc",
+            question="How does the main module work?",
+            expected_files=["main.py"],
+            token_budget=4096,
+        )
+        with patch("archex.api._get_embedder", _stub_get_embedder):
+            result = run_archex_query_fusion(task, python_simple_repo)
+        assert result.strategy == Strategy.ARCHEX_QUERY_FUSION
+        assert result.tokens_total >= 0
+        assert result.tool_calls == 1
+        assert result.timing is not None
+        assert 0.0 <= result.recall <= 1.0
+        assert 0.0 <= result.precision <= 1.0
+
+    def test_fusion_recall_precision(self, python_simple_repo: Path) -> None:
+        task = BenchmarkTask(
+            task_id="test",
+            repo="test/repo",
+            commit="abc",
+            question="authentication login service",
+            expected_files=["services/auth.py", "main.py"],
+            token_budget=8192,
+        )
+        with patch("archex.api._get_embedder", _stub_get_embedder):
+            result = run_archex_query_fusion(task, python_simple_repo)
         assert result.files_accessed >= 0
         assert isinstance(result.recall, float)
         assert isinstance(result.precision, float)

--- a/tests/benchmark/test_strategy_registry.py
+++ b/tests/benchmark/test_strategy_registry.py
@@ -45,7 +45,8 @@ class TestStrategyRegistry:
         assert Strategy.RAW_FILES.value in names
         assert Strategy.RAW_GREPPED.value in names
         assert Strategy.ARCHEX_QUERY.value in names
-        assert Strategy.ARCHEX_QUERY_HYBRID.value in names
+        assert Strategy.ARCHEX_QUERY_VECTOR.value in names
+        assert Strategy.ARCHEX_QUERY_FUSION.value in names
         assert Strategy.ARCHEX_SYMBOL_LOOKUP.value in names
 
     def test_load_entry_points_registers_runner(self) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -163,10 +163,10 @@ class TestQueryEndToEnd:
         assert isinstance(bundle, ContextBundle)
 
 
-class TestQueryHybrid:
-    """Query with vector=True using a mock embedder."""
+class TestQueryVector:
+    """Query with vector=True configuration."""
 
-    def test_hybrid_query_no_embedder_falls_back(self, python_simple_repo: Path) -> None:
+    def test_vector_query_no_embedder_falls_back(self, python_simple_repo: Path) -> None:
         source = RepoSource(local_path=str(python_simple_repo))
         # vector=True but no embedder configured → falls back to bm25-only
         index_cfg = IndexConfig(vector=True, embedder=None)


### PR DESCRIPTION
## Summary
- Add `ARCHEX_QUERY_VECTOR` strategy (pure vector, diagnostic) and `ARCHEX_QUERY_FUSION` strategy (BM25 + independent vector + confidence-aware RRF)
- Remove obsolete `ARCHEX_QUERY_HYBRID` strategy (22s reranker with hard recall ceiling)
- Add per-strategy quality gate thresholds and gate exemptions for baseline/diagnostic strategies
- Update `AVAILABLE_STRATEGIES` default to `[RAW_FILES, RAW_GREPPED, ARCHEX_QUERY, ARCHEX_QUERY_FUSION]`
- Rename `_check_hybrid_available()` → `_check_vector_available()` with `_VECTOR_STRATEGIES` filter set
- Rename integration test class `TestQueryHybrid` → `TestQueryVector`

### Strategy matrix after implementation

| Strategy | Role | BM25 | Vector | Fusion | Gate? |
|----------|------|------|--------|--------|-------|
| `raw_files` | Oracle baseline | — | — | — | No |
| `raw_grepped` | Naive keyword baseline | — | — | — | No |
| `archex_query` | BM25-only (control) | Yes | No | — | Yes |
| `archex_query_vector` | Vector-only (diagnostic) | No | Yes | — | No |
| `archex_query_fusion` | Full pipeline (target) | Yes | Yes | Confidence-aware RRF | Yes |

## Test plan
- [x] New strategy enum members registered and functional
- [x] Quality gates skip exempt strategies
- [x] Per-strategy threshold overrides apply correctly
- [x] All `archex_query_hybrid` references removed from Python code
- [x] Full suite: 1612 passed, 92.37% coverage

Depends on: #61

**Note:** `benchmarks/baseline.json` and `benchmarks/results/*.json` still contain historical hybrid entries — these will be overwritten on the next benchmark run.