### PR TITLE
Refactor parsing, reporting, and delta helpers

### DIFF
--- a/src/archex/analyze/interfaces.py
+++ b/src/archex/analyze/interfaces.py
@@ -31,6 +31,29 @@ _PARAM_RE = re.compile(
 )
 
 
+def _split_parameter_parts(raw_params: str) -> list[str]:
+    parts: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for char in raw_params:
+        if char in "([{":
+            depth += 1
+            current.append(char)
+            continue
+        if char in ")]}":
+            depth -= 1
+            current.append(char)
+            continue
+        if char == "," and depth == 0:
+            parts.append("".join(current).strip())
+            current = []
+            continue
+        current.append(char)
+    if current:
+        parts.append("".join(current).strip())
+    return parts
+
+
 def _parse_parameters(sig: str) -> list[Parameter]:
     """Extract parameters from a function signature string like 'def foo(a: int, b=1)'."""
     # Extract the params substring between the first ( and matching )
@@ -44,26 +67,7 @@ def _parse_parameters(sig: str) -> list[Parameter]:
         return []
 
     params: list[Parameter] = []
-    # Split on commas — careful with nested brackets (generics)
-    depth = 0
-    current: list[str] = []
-    parts: list[str] = []
-    for char in raw_params:
-        if char in "([{":
-            depth += 1
-            current.append(char)
-        elif char in ")]}":
-            depth -= 1
-            current.append(char)
-        elif char == "," and depth == 0:
-            parts.append("".join(current).strip())
-            current = []
-        else:
-            current.append(char)
-    if current:
-        parts.append("".join(current).strip())
-
-    for part in parts:
+    for part in _split_parameter_parts(raw_params):
         part = part.strip()
         if not part or part in ("*", "/", "**kwargs", "*args"):
             continue
@@ -117,12 +121,9 @@ def _build_used_by(graph: DependencyGraph) -> dict[str, list[str]]:
     """Map each file path to the list of files that import it."""
     used_by: dict[str, list[str]] = {}
     for edge in graph.file_edges():
-        target = edge.target
-        source = edge.source
-        if target not in used_by:
-            used_by[target] = []
-        if source not in used_by[target]:
-            used_by[target].append(source)
+        importers = used_by.setdefault(edge.target, [])
+        if edge.source not in importers:
+            importers.append(edge.source)
     return used_by
 
 
@@ -131,6 +132,14 @@ def _build_used_by(graph: DependencyGraph) -> dict[str, list[str]]:
 # ---------------------------------------------------------------------------
 
 _TOP_LEVEL_KINDS = {SymbolKind.FUNCTION, SymbolKind.CLASS, SymbolKind.INTERFACE}
+
+
+def _is_public_top_level_symbol(symbol_name: str, parent: str | None) -> bool:
+    if parent is not None:
+        return False
+    if not symbol_name.startswith("_"):
+        return True
+    return symbol_name.startswith("__") and symbol_name.endswith("__")
 
 
 def extract_interfaces(
@@ -154,13 +163,7 @@ def extract_interfaces(
                 continue
             if sym.kind not in _TOP_LEVEL_KINDS:
                 continue
-            # Exclude methods (they have a parent class)
-            if sym.parent is not None:
-                continue
-            # Exclude private names (redundant but explicit)
-            if sym.name.startswith("_") and not (
-                sym.name.startswith("__") and sym.name.endswith("__")
-            ):
+            if not _is_public_top_level_symbol(sym.name, sym.parent):
                 continue
 
             ref = SymbolRef(

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -9,6 +9,78 @@ if TYPE_CHECKING:
     from archex.benchmark.models import BenchmarkReport, DeltaBenchmarkResult
 
 
+_SUMMARY_FIELDS = (
+    "tokens_total",
+    "savings_vs_raw",
+    "token_efficiency",
+    "recall",
+    "f1_score",
+    "mrr",
+    "ndcg",
+    "map_score",
+)
+_BUCKET_FIELDS = (
+    "recall",
+    "precision",
+    "f1_score",
+    "mrr",
+    "ndcg",
+    "map_score",
+    "seed_recall",
+    "seed_precision",
+)
+_COMPARISON_METRICS = (
+    "recall",
+    "precision",
+    "f1_score",
+    "mrr",
+    "ndcg",
+    "map_score",
+    "token_efficiency",
+)
+_COMPARISON_LABELS = {
+    "recall": "Recall",
+    "precision": "Precision",
+    "f1_score": "F1",
+    "mrr": "MRR",
+    "ndcg": "nDCG",
+    "map_score": "MAP",
+    "token_efficiency": "Efficiency",
+}
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values)
+
+
+def _aggregate_strategy_metrics(
+    reports: list[BenchmarkReport],
+    fields: tuple[str, ...],
+) -> dict[str, dict[str, list[float]]]:
+    strategy_metrics: dict[str, dict[str, list[float]]] = defaultdict(
+        lambda: {field: [] for field in fields}
+    )
+    for report in reports:
+        for result in report.results:
+            metrics = strategy_metrics[result.strategy.value]
+            for field in fields:
+                metrics[field].append(float(getattr(result, field)))
+    return strategy_metrics
+
+
+def _strategy_win_counts(
+    reports: list[BenchmarkReport],
+    metrics: tuple[str, ...],
+) -> dict[str, dict[str, int]]:
+    wins: dict[str, dict[str, int]] = {}
+    for report in reports:
+        for metric in metrics:
+            best_result = max(report.results, key=lambda result: float(getattr(result, metric)))
+            wins.setdefault(best_result.strategy.value, {}).setdefault(metric, 0)
+            wins[best_result.strategy.value][metric] += 1
+    return wins
+
+
 def format_markdown(report: BenchmarkReport) -> str:
     """Render a single benchmark report as a markdown table."""
     lines: list[str] = []
@@ -54,27 +126,7 @@ def format_summary(reports: list[BenchmarkReport]) -> str:
     lines.append(f"**Tasks:** {len(reports)}")
     lines.append("")
 
-    # Aggregate per-strategy averages
-    strategy_totals: dict[str, list[float]] = {}
-    strategy_recalls: dict[str, list[float]] = {}
-    strategy_savings: dict[str, list[float]] = {}
-    strategy_f1s: dict[str, list[float]] = {}
-    strategy_mrrs: dict[str, list[float]] = {}
-    strategy_ndcgs: dict[str, list[float]] = {}
-    strategy_maps: dict[str, list[float]] = {}
-    strategy_efficiencies: dict[str, list[float]] = {}
-
-    for report in reports:
-        for r in report.results:
-            name = r.strategy.value
-            strategy_totals.setdefault(name, []).append(float(r.tokens_total))
-            strategy_recalls.setdefault(name, []).append(r.recall)
-            strategy_savings.setdefault(name, []).append(r.savings_vs_raw)
-            strategy_f1s.setdefault(name, []).append(r.f1_score)
-            strategy_mrrs.setdefault(name, []).append(r.mrr)
-            strategy_ndcgs.setdefault(name, []).append(r.ndcg)
-            strategy_maps.setdefault(name, []).append(r.map_score)
-            strategy_efficiencies.setdefault(name, []).append(r.token_efficiency)
+    strategy_metrics = _aggregate_strategy_metrics(reports, _SUMMARY_FIELDS)
 
     lines.append(
         "| Strategy | Avg Tokens | Avg Savings | Avg Efficiency | Avg Recall | Avg F1 "
@@ -85,28 +137,16 @@ def format_summary(reports: list[BenchmarkReport]) -> str:
         "|---------|----------|---------|-------|"
     )
 
-    for name in sorted(strategy_totals.keys()):
-        tokens_list = strategy_totals[name]
-        recalls_list = strategy_recalls[name]
-        savings_list = strategy_savings[name]
-        f1s_list = strategy_f1s[name]
-        mrrs_list = strategy_mrrs[name]
-        ndcgs_list = strategy_ndcgs[name]
-        maps_list = strategy_maps[name]
-        effs_list = strategy_efficiencies[name]
-        count = len(tokens_list)
-        avg_tokens = sum(tokens_list) / count
-        avg_recall = sum(recalls_list) / count
-        avg_savings = sum(savings_list) / count
-        avg_f1 = sum(f1s_list) / count
-        avg_mrr = sum(mrrs_list) / count
-        avg_ndcg = sum(ndcgs_list) / count
-        avg_map = sum(maps_list) / count
-        avg_eff = sum(effs_list) / count
+    for name in sorted(strategy_metrics):
+        metrics = strategy_metrics[name]
+        count = len(metrics["tokens_total"])
         lines.append(
-            f"| {name} | {avg_tokens:,.0f} | {avg_savings:.1f}% | {avg_eff:.2f} "
-            f"| {avg_recall:.2f} | {avg_f1:.2f} | {avg_mrr:.2f} "
-            f"| {avg_ndcg:.2f} | {avg_map:.2f} | {count} |"
+            f"| {name} | {_mean(metrics['tokens_total']):,.0f} "
+            f"| {_mean(metrics['savings_vs_raw']):.1f}% "
+            f"| {_mean(metrics['token_efficiency']):.2f} "
+            f"| {_mean(metrics['recall']):.2f} | {_mean(metrics['f1_score']):.2f} "
+            f"| {_mean(metrics['mrr']):.2f} | {_mean(metrics['ndcg']):.2f} "
+            f"| {_mean(metrics['map_score']):.2f} | {count} |"
         )
 
     lines.append("")
@@ -145,21 +185,7 @@ def format_bucketed_summary(reports: list[BenchmarkReport]) -> str:
         tbl.append(f"## {label} ({len(bucket_reports)} tasks)")
         tbl.append("")
 
-        strategy_metrics: dict[str, list[dict[str, float]]] = defaultdict(list)
-        for report in bucket_reports:
-            for r in report.results:
-                strategy_metrics[r.strategy.value].append(
-                    {
-                        "recall": r.recall,
-                        "precision": r.precision,
-                        "f1": r.f1_score,
-                        "mrr": r.mrr,
-                        "ndcg": r.ndcg,
-                        "map": r.map_score,
-                        "seed_recall": r.seed_recall,
-                        "seed_precision": r.seed_precision,
-                    }
-                )
+        strategy_metrics = _aggregate_strategy_metrics(bucket_reports, _BUCKET_FIELDS)
 
         tbl.append(
             "| Strategy | Recall | Precision | F1 | MRR | nDCG | MAP "
@@ -169,23 +195,16 @@ def format_bucketed_summary(reports: list[BenchmarkReport]) -> str:
             "|----------|--------|-----------|------|------|------|------"
             "|-------------|----------------|-------|"
         )
-        for name in sorted(strategy_metrics.keys()):
-            entries = strategy_metrics[name]
-            count = len(entries)
-
-            def _avg(
-                key: str,
-                _entries: list[dict[str, float]] = entries,
-                _count: int = count,
-            ) -> float:
-                return sum(e[key] for e in _entries) / _count
-
+        for name in sorted(strategy_metrics):
+            metrics = strategy_metrics[name]
+            count = len(metrics["recall"])
             tbl.append(
                 f"| {name} "
-                f"| {_avg('recall'):.2f} | {_avg('precision'):.2f} "
-                f"| {_avg('f1'):.2f} | {_avg('mrr'):.2f} "
-                f"| {_avg('ndcg'):.2f} | {_avg('map'):.2f} "
-                f"| {_avg('seed_recall'):.2f} | {_avg('seed_precision'):.2f} "
+                f"| {_mean(metrics['recall']):.2f} | {_mean(metrics['precision']):.2f} "
+                f"| {_mean(metrics['f1_score']):.2f} | {_mean(metrics['mrr']):.2f} "
+                f"| {_mean(metrics['ndcg']):.2f} | {_mean(metrics['map_score']):.2f} "
+                f"| {_mean(metrics['seed_recall']):.2f} "
+                f"| {_mean(metrics['seed_precision']):.2f} "
                 f"| {count} |"
             )
         tbl.append("")
@@ -210,17 +229,6 @@ def format_strategy_comparison(reports: list[BenchmarkReport]) -> str:
     lines.append("# Strategy Comparison")
     lines.append("")
 
-    metrics = ("recall", "precision", "f1_score", "mrr", "ndcg", "map_score", "token_efficiency")
-    metric_labels = {
-        "recall": "Recall",
-        "precision": "Precision",
-        "f1_score": "F1",
-        "mrr": "MRR",
-        "ndcg": "nDCG",
-        "map_score": "MAP",
-        "token_efficiency": "Efficiency",
-    }
-
     # Per-task tables
     for report in reports:
         lines.append(f"## {report.task_id}")
@@ -239,39 +247,27 @@ def format_strategy_comparison(reports: list[BenchmarkReport]) -> str:
         lines.append("")
 
     # Head-to-head wins
-    wins: dict[str, dict[str, int]] = {}
-    for report in reports:
-        for metric in metrics:
-            best_val = -1.0
-            best_strategy = ""
-            for r in report.results:
-                val = getattr(r, metric)
-                if val > best_val:
-                    best_val = val
-                    best_strategy = r.strategy.value
-            if best_strategy:
-                wins.setdefault(best_strategy, {}).setdefault(metric, 0)
-                wins[best_strategy][metric] += 1
+    wins = _strategy_win_counts(reports, _COMPARISON_METRICS)
 
     lines.append("## Head-to-Head Wins")
     lines.append("")
-    metric_headers = " | ".join(metric_labels[m] for m in metrics)
+    metric_headers = " | ".join(_COMPARISON_LABELS[m] for m in _COMPARISON_METRICS)
     lines.append(f"| Strategy | {metric_headers} | Total |")
-    sep = " | ".join("------" for _ in metrics)
+    sep = " | ".join("------" for _ in _COMPARISON_METRICS)
     lines.append(f"|----------|{sep}|-------|")
 
     all_strategies = sorted({r.strategy.value for report in reports for r in report.results})
     for strategy in all_strategies:
         strat_wins = wins.get(strategy, {})
-        counts = [str(strat_wins.get(m, 0)) for m in metrics]
-        total = sum(strat_wins.get(m, 0) for m in metrics)
+        counts = [str(strat_wins.get(metric, 0)) for metric in _COMPARISON_METRICS]
+        total = sum(strat_wins.get(metric, 0) for metric in _COMPARISON_METRICS)
         lines.append(f"| {strategy} | {' | '.join(counts)} | {total} |")
     lines.append("")
 
     # Best strategy per metric
     lines.append("## Best Strategy per Metric")
     lines.append("")
-    for metric in metrics:
+    for metric in _COMPARISON_METRICS:
         best_count = 0
         best_strategy = ""
         for strategy in all_strategies:
@@ -279,7 +275,7 @@ def format_strategy_comparison(reports: list[BenchmarkReport]) -> str:
             if count > best_count:
                 best_count = count
                 best_strategy = strategy
-        label = metric_labels[metric]
+        label = _COMPARISON_LABELS[metric]
         lines.append(f"- **{label}**: {best_strategy} ({best_count} wins)")
     lines.append("")
 

--- a/src/archex/index/delta.py
+++ b/src/archex/index/delta.py
@@ -23,9 +23,54 @@ from archex.pipeline.service import build_chunk_surrogates
 if TYPE_CHECKING:
     from archex.index.graph import DependencyGraph
     from archex.index.store import IndexStore
-    from archex.models import CodeChunk, Config
+    from archex.models import CodeChunk, Config, DiscoveredFile, ImportStatement
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_name_status_line(line: str) -> FileChange | None:
+    parts = line.split("\t")
+    if len(parts) < 2:
+        return None
+
+    status_code = parts[0]
+    if status_code == "M":
+        return FileChange(path=parts[1], status=ChangeStatus.MODIFIED)
+    if status_code == "A":
+        return FileChange(path=parts[1], status=ChangeStatus.ADDED)
+    if status_code == "D":
+        return FileChange(path=parts[1], status=ChangeStatus.DELETED)
+    if status_code.startswith("R") and len(parts) >= 3:
+        return FileChange(
+            path=parts[2],
+            status=ChangeStatus.RENAMED,
+            old_path=parts[1],
+        )
+    return None
+
+
+def _build_import_edges(resolved_map: dict[str, list[ImportStatement]]) -> list[Edge]:
+    return [
+        Edge(
+            source=file_path,
+            target=imp.resolved_path,
+            kind=EdgeKind.IMPORTS,
+            location=f"{file_path}:{imp.line}",
+        )
+        for file_path, imports in resolved_map.items()
+        for imp in imports
+        if imp.resolved_path is not None
+    ]
+
+
+def _changed_sources(changed_files: list[DiscoveredFile]) -> dict[str, bytes]:
+    sources: dict[str, bytes] = {}
+    for discovered_file in changed_files:
+        try:
+            sources[discovered_file.path] = Path(discovered_file.absolute_path).read_bytes()
+        except OSError:
+            continue
+    return sources
 
 
 def _is_commit_reachable(repo_path: Path, commit: str) -> bool:
@@ -87,25 +132,9 @@ def compute_delta(
     for line in result.stdout.strip().splitlines():
         if not line:
             continue
-        parts = line.split("\t")
-        if len(parts) < 2:
-            continue
-
-        status_code = parts[0]
-        if status_code == "M":
-            changes.append(FileChange(path=parts[1], status=ChangeStatus.MODIFIED))
-        elif status_code == "A":
-            changes.append(FileChange(path=parts[1], status=ChangeStatus.ADDED))
-        elif status_code == "D":
-            changes.append(FileChange(path=parts[1], status=ChangeStatus.DELETED))
-        elif status_code.startswith("R") and len(parts) >= 3:
-            changes.append(
-                FileChange(
-                    path=parts[2],
-                    status=ChangeStatus.RENAMED,
-                    old_path=parts[1],
-                )
-            )
+        change = _parse_name_status_line(line)
+        if change is not None:
+            changes.append(change)
 
     return DeltaManifest(
         base_commit=base_commit,
@@ -195,29 +224,13 @@ def apply_delta(
             resolved_map = resolve_imports(import_map, file_map, adapters, file_languages)
 
             chunker = ASTChunker(config=effective_index_config)
-            sources: dict[str, bytes] = {}
-            for f in changed_files:
-                try:
-                    sources[f.path] = Path(f.absolute_path).read_bytes()
-                except OSError:
-                    continue
-            new_chunks = chunker.chunk_files(parsed_files, sources)
+            new_chunks = chunker.chunk_files(parsed_files, _changed_sources(changed_files))
             new_surrogates = build_chunk_surrogates(
                 new_chunks,
                 version=effective_index_config.surrogate_version,
             )
 
-            new_edges = [
-                Edge(
-                    source=file_path,
-                    target=imp.resolved_path,
-                    kind=EdgeKind.IMPORTS,
-                    location=f"{file_path}:{imp.line}",
-                )
-                for file_path, imps in resolved_map.items()
-                for imp in imps
-                if imp.resolved_path is not None
-            ]
+            new_edges = _build_import_edges(resolved_map)
 
             logger.info(
                 "Re-parsed %d files: %d chunks, %d edges",

--- a/src/archex/parse/symbols.py
+++ b/src/archex/parse/symbols.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from archex.exceptions import ParseError
@@ -19,6 +20,51 @@ if TYPE_CHECKING:
     from archex.parse.engine import TreeSitterEngine
 
 
+def _count_lines(source: bytes) -> int:
+    return source.count(b"\n") + (1 if source and not source.endswith(b"\n") else 0)
+
+
+def _parse_with_adapter(
+    *,
+    absolute_path: str,
+    relative_path: str,
+    language: str,
+    engine: TreeSitterEngine,
+    adapter: LanguageAdapter,
+) -> ParsedFile:
+    tree = engine.parse_file(absolute_path, language)
+    source = Path(absolute_path).read_bytes()
+    symbols = adapter.extract_symbols(tree, source, relative_path)
+    return ParsedFile(
+        path=relative_path,
+        language=language,
+        symbols=symbols,
+        lines=_count_lines(source),
+    )
+
+
+def _extract_symbols_sequential(
+    files: list[DiscoveredFile],
+    engine: TreeSitterEngine,
+    adapters: Mapping[str, LanguageAdapter],
+) -> list[ParsedFile]:
+    results: list[ParsedFile] = []
+    for discovered_file in files:
+        adapter = adapters.get(discovered_file.language)
+        if adapter is None:
+            continue
+        results.append(
+            _parse_with_adapter(
+                absolute_path=str(discovered_file.absolute_path),
+                relative_path=discovered_file.path,
+                language=discovered_file.language,
+                engine=engine,
+                adapter=adapter,
+            )
+        )
+    return results
+
+
 def _parse_file_worker(absolute_path: str, relative_path: str, language: str) -> ParsedFile | None:
     """Worker function for parallel parsing — creates its own engine and adapter."""
     from archex.parse.adapters import ADAPTERS
@@ -29,20 +75,12 @@ def _parse_file_worker(absolute_path: str, relative_path: str, language: str) ->
     if adapter_class is None:
         return None
 
-    adapter = adapter_class()
-    tree = engine.parse_file(absolute_path, language)
-
-    with open(absolute_path, "rb") as fh:
-        source = fh.read()
-
-    symbols = adapter.extract_symbols(tree, source, relative_path)
-    line_count = source.count(b"\n") + (1 if source and not source.endswith(b"\n") else 0)
-
-    return ParsedFile(
-        path=relative_path,
+    return _parse_with_adapter(
+        absolute_path=absolute_path,
+        relative_path=relative_path,
         language=language,
-        symbols=symbols,
-        lines=line_count,
+        engine=engine,
+        adapter=adapter_class(),
     )
 
 
@@ -92,28 +130,4 @@ def extract_symbols(
                 raise ParseError(f"Parallel parsing failed: {e}") from e
             logger.error("Parallel executor failed, falling back to sequential: %s", e)
 
-    results_seq: list[ParsedFile] = []
-
-    for f in eligible:
-        adapter = adapters.get(f.language)
-        if adapter is None:
-            continue
-
-        tree = engine.parse_file(f.absolute_path, f.language)
-
-        with open(f.absolute_path, "rb") as fh:
-            source = fh.read()
-
-        symbols = adapter.extract_symbols(tree, source, f.path)
-        line_count = source.count(b"\n") + (1 if source and not source.endswith(b"\n") else 0)
-
-        results_seq.append(
-            ParsedFile(
-                path=f.path,
-                language=f.language,
-                symbols=symbols,
-                lines=line_count,
-            )
-        )
-
-    return results_seq
+    return _extract_symbols_sequential(eligible, engine, adapters)


### PR DESCRIPTION
## Summary

This PR is a structural cleanup pass across parsing, benchmark reporting, and delta indexing code.

It keeps behavior and public APIs unchanged while reducing duplicated control flow and consolidating repeated data-shaping logic in:

- `src/archex/analyze/interfaces.py`
- `src/archex/parse/symbols.py`
- `src/archex/benchmark/reporter.py`
- `src/archex/index/delta.py`

Net committed diff:

- 4 files changed
- 237 insertions
- 211 deletions

## What Changed

### 1. Parse and interface extraction cleanup

Files:

- `src/archex/analyze/interfaces.py`
- `src/archex/parse/symbols.py`

Changes:

- Extracted parameter token splitting into `_split_parameter_parts` so `_parse_parameters` only handles parameter conversion.
- Centralized the top-level public symbol predicate in `_is_public_top_level_symbol`.
- Simplified `used_by` map construction with `setdefault`.
- Unified sequential and worker parsing behind `_parse_with_adapter`.
- Centralized line counting in `_count_lines`.
- Moved the sequential parse loop into `_extract_symbols_sequential` instead of maintaining a second inline implementation.

Why this matters:

- Removes duplicated parse/file-read/line-count logic.
- Makes sequential and parallel parsing paths easier to reason about and less likely to drift.
- Keeps symbol filtering rules explicit and localized.

### 2. Benchmark reporter aggregation cleanup

File:

- `src/archex/benchmark/reporter.py`

Changes:

- Added shared metric field definitions for summary, bucketed, and comparison reports.
- Added `_mean` to centralize averaging.
- Added `_aggregate_strategy_metrics` to replace repeated per-function accumulation logic.
- Added `_strategy_win_counts` to isolate head-to-head winner computation.
- Rewired `format_summary`, `format_bucketed_summary`, and `format_strategy_comparison` to use the shared helpers.

Why this matters:

- Removes repeated metric bookkeeping across report renderers.
- Keeps reporting logic consistent when metrics are added or adjusted later.
- Makes report formatting functions focus on rendering rather than data preparation.

### 3. Delta indexing helper extraction

File:

- `src/archex/index/delta.py`

Changes:

- Added `_parse_name_status_line` to isolate git `--name-status` parsing.
- Added `_changed_sources` to isolate changed-file source loading.
- Added `_build_import_edges` to isolate resolved-import to edge conversion.
- Replaced inline list/dict construction in `compute_delta` and `apply_delta` with the new helpers.

Why this matters:

- Flattens the delta update path.
- Makes git parsing, source hydration, and edge construction independently readable and testable.
- Reduces repeated transformation logic inside the main indexing flow.

## Commits

- `refactor(parse): deduplicate interface and symbol extraction`
- `refactor(benchmark): centralize reporter aggregations`
- `refactor(index): extract delta update helpers`

## Validation

Passed:

- `uv run ruff check src/archex tests`
- `uv run ruff format --check .`
- `uv run pytest -o addopts='' tests/analyze/test_interfaces.py tests/parse/test_symbols.py tests/benchmark/test_reporter.py tests/index/test_delta.py`

Notes:

- Running the same focused pytest selection with repo-default `addopts` fails coverage gating because `pyproject.toml` enforces global `--cov-fail-under=85`, which is not compatible with a narrow subset run.
- `uv run pyright` still reports pre-existing provider typing issues in `src/archex/providers/anthropic.py`, `src/archex/providers/openai.py`, and `src/archex/providers/openrouter.py`.
- `uv run mypy --strict src/archex tests` still reports broad pre-existing repo issues across fixtures, optional dependencies, and unrelated modules.

## Scope

This PR covers the committed branch changes listed above. It does not include the unrelated uncommitted work currently present in the local working tree.
