### PR TITLE
refactor(benchmark): drive strategy progress via click.progressbar

### DIFF
--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -9,6 +9,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import click
+
 from archex.benchmark.loader import load_tasks
 from archex.benchmark.models import BenchmarkReport, BenchmarkResult, BenchmarkTask, Strategy
 from archex.benchmark.strategies import default_strategy_registry
@@ -109,25 +111,29 @@ def run_benchmark(
 
     try:
         results: list[BenchmarkResult] = []
-        for strategy in strategies:
-            runner = default_strategy_registry.get(strategy)
-            if runner is None:
-                logger.warning("No runner for strategy %s, skipping", strategy)
-                continue
-            _label = f"  [{strategy.value}]"
-            try:
-                print(f"{_label} running...", end="", file=sys.stderr, flush=True)
-                result = runner(task, repo_path)
-                results.append(result)
-                _msg = (
-                    f"{_label} {result.tokens_total:,} tokens, "
-                    f"recall={result.recall:.2f}, {result.wall_time_ms:.0f}ms"
-                )
-                print(f"\r{_msg:<60}", file=sys.stderr)
-            except (NotImplementedError, ArchexIndexError) as exc:
-                logger.info("Skipping %s: %s", strategy.value, exc)
-                _msg = f"{_label} skipped: {exc}"
-                print(f"\r{_msg:<60}", file=sys.stderr)
+        with click.progressbar(
+            strategies,
+            label=f"  {task.task_id}",
+            item_show_func=lambda s: s.value if s is not None else "",
+            file=sys.stderr,
+        ) as bar:
+            for strategy in bar:
+                runner = default_strategy_registry.get(strategy)
+                if runner is None:
+                    logger.warning("No runner for strategy %s, skipping", strategy)
+                    continue
+                try:
+                    result = runner(task, repo_path)
+                    results.append(result)
+                    logger.info(
+                        "%s: %d tokens, recall=%.2f, %.0fms",
+                        strategy.value,
+                        result.tokens_total,
+                        result.recall,
+                        result.wall_time_ms,
+                    )
+                except (NotImplementedError, ArchexIndexError) as exc:
+                    logger.info("Skipping %s: %s", strategy.value, exc)
 
         # Compute baseline and backfill savings_vs_raw
         baseline_tokens = 0


### PR DESCRIPTION
## Summary

Replaces the hand-rolled carriage-return progress printing in `run_benchmark` with `click.progressbar`. The benchmark runner had two progress paths: a fine-grained per-strategy display using manual `\r` overwrites, and a per-task line counter in `run_all`. The per-strategy `\r` hack is the one converted here; `run_all`'s full-line task header/footer prints are left intact and nest cleanly around the new bar.

`click` is already a direct dependency (`click>=8.1`), so no new package is introduced.

## Why

The previous approach hand-managed cursor positioning (`print(f"\r{_msg:<60}", file=sys.stderr)`), which:
- Flickers and produces noise on non-TTY stderr (CI logs accumulate `\r`-padded lines that never repaint).
- Is brittle to message width (`:<60` padding is a magic constant guessing terminal behavior).

`click.progressbar` is TTY-aware and handles both cases correctly with no manual cursor math.

## Behavior

| Environment | Before | After |
|-------------|--------|-------|
| Terminal (TTY) | manual `\r`-overwritten status line per strategy | live per-task progress bar, current strategy shown via `item_show_func` |
| CI (non-TTY stderr) | `\r`-padded lines repeated per strategy | label printed once, no ANSI / no live bar |
| stdout (JSON / markdown) | unaffected | unaffected |

The bar is written explicitly with `file=sys.stderr`. This matters: `click.progressbar`'s `file` argument defaults to `None`, which click resolves to **stdout** internally. Routing it to stderr keeps the stdout result streams (`format_json`, `format_markdown`) clean for piping (`| jq`), redirection (`> report.json`), and the quality gates in `gate.py` that parse them.

Per-strategy token / recall / timing detail moves from the printed status line to `logger.info`. The numbers are not lost — the CLI's final report (`format_summary` / `format_bucketed_summary`) still carries the complete set.

## Implementation notes

- `item_show_func=lambda s: s.value if s is not None else ""` — `click` calls this with the current `Strategy` before each step and with `None` on the final tick; the guard renders an empty suffix instead of raising `AttributeError` on `None.value`.
- The `try`/`finally` repo-cleanup structure and the `savings_vs_raw` backfill below the loop are unchanged.
- `run_all` is untouched: no nested progress bars (two bars writing to the same stderr line would corrupt each other).

## Validation

- `uv run ruff check src/archex/benchmark/runner.py` — pass
- `uv run ruff format --check src/archex/benchmark/runner.py` — pass
- `uv run mypy --strict src/archex/benchmark/runner.py` — clean except a pre-existing `fastembed` optional-import error in `_check_vector_available`, outside this diff
- `uv run pytest tests/benchmark/test_runner.py tests/benchmark/test_cli.py` — 23 passed

No existing tests assert on the removed progress strings.