### PR TITLE
fix(api): gate reranker on explicit flag; warm benchmark vector index

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -390,18 +390,15 @@ def _build_adapters() -> dict[str, LanguageAdapter]:
 
 
 def _maybe_reranker(index_config: IndexConfig) -> CrossEncoderReranker | None:
-    """Return a CrossEncoderReranker when reranking should be active.
+    """Return a CrossEncoderReranker only when reranking is explicitly enabled.
 
-    Reranking activates when explicitly enabled via index_config.rerank,
-    or auto-enabled when sentence-transformers is installed.
+    Reranking activates solely on index_config.rerank. Callers that leave it
+    unset (the default) opt out regardless of whether sentence-transformers is
+    installed, so the flag remains observable as on/off.
     """
-    from archex.index.rerank import (
-        DEFAULT_MODEL,
-        CrossEncoderReranker,
-        is_available,
-    )
+    from archex.index.rerank import DEFAULT_MODEL, CrossEncoderReranker
 
-    if index_config.rerank or is_available():
+    if index_config.rerank:
         return CrossEncoderReranker(
             model_name=index_config.rerank_model or DEFAULT_MODEL,
         )
@@ -983,8 +980,7 @@ def query(
                         )
                     )
                 query_avg_idf = bm25.avg_idf(question) if vector_results is not None else None
-                # Cross-encoder reranker: enabled explicitly via index_config.rerank,
-                # or auto-enabled when sentence-transformers is installed.
+                # Cross-encoder reranker: enabled only when index_config.rerank is set.
                 _reranker = _maybe_reranker(index_config)
                 bundle = assemble_context(
                     search_results=search_results,

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -58,6 +58,32 @@ def _check_vector_available() -> bool:
         return False
 
 
+def _warm_repo_index(task: BenchmarkTask, repo_path: Path) -> None:
+    """Pre-build the shared vector index so every vector strategy runs warm.
+
+    The first vector strategy to execute otherwise absorbs the full embedding
+    build (cold) while later ones reuse the cached store and .npz (warm), making
+    per-strategy timings incomparable. One discarded query with the same vector
+    config the strategies use populates both caches before the timed loop. The
+    config must match run_archex_query_fusion so the cache key and vector .npz
+    path line up; this warms VectorMode.RAW only (fusion, rerank, query_vector),
+    not surrogate-mode strategies.
+    """
+    from archex.api import query
+    from archex.models import Config, IndexConfig, RepoSource
+
+    source = RepoSource(local_path=str(repo_path))
+    config = Config(cache=True, languages=task.languages)
+    index_config = IndexConfig(vector=True, embedder="fastembed")
+    query(
+        source,
+        task.question,
+        token_budget=task.token_budget,
+        config=config,
+        index_config=index_config,
+    )
+
+
 def clone_at_commit(repo_slug: str, commit: str) -> tuple[Path, bool]:
     """Clone a GitHub repo and checkout a specific commit/tag. Returns (path, needs_cleanup)."""
     url = f"https://github.com/{repo_slug}.git"
@@ -110,6 +136,10 @@ def run_benchmark(
             repo_path, needs_cleanup = clone_at_commit(task.repo, task.commit)
 
     try:
+        if _check_vector_available() and any(s in _VECTOR_STRATEGIES for s in strategies):
+            print(f"  warming vector index for {task.task_id}...", file=sys.stderr, flush=True)
+            _warm_repo_index(task, repo_path)
+
         results: list[BenchmarkResult] = []
         with click.progressbar(
             strategies,

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -99,6 +99,60 @@ class TestRunBenchmark:
         assert len(report.results) == 1
         assert report.results[0].strategy == Strategy.RAW_FILES
 
+    def test_warms_vector_index_when_vector_strategy_present(
+        self,
+        fixture_task: tuple[BenchmarkTask, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        task, repo_path = fixture_task
+        from archex.benchmark import runner as runner_mod
+        from archex.benchmark.strategies import default_strategy_registry
+        from archex.exceptions import ArchexIndexError
+
+        warmed: list[Path] = []
+
+        def _record(_task: BenchmarkTask, path: Path) -> None:
+            warmed.append(path)
+
+        def _raise(_task: BenchmarkTask, _path: Path) -> None:
+            raise ArchexIndexError("no vector backend in test")
+
+        monkeypatch.setattr(runner_mod, "_check_vector_available", lambda: True)
+        monkeypatch.setattr(runner_mod, "_warm_repo_index", _record)
+
+        key = Strategy.ARCHEX_QUERY_FUSION.value
+        monkeypatch.setitem(default_strategy_registry._runners, key, _raise)  # pyright: ignore[reportPrivateUsage]
+
+        run_benchmark(
+            task,
+            strategies=[Strategy.RAW_FILES, Strategy.ARCHEX_QUERY_FUSION],
+            repo_path=repo_path,
+        )
+        assert warmed == [repo_path]
+
+    def test_skips_warmup_for_raw_only_strategies(
+        self,
+        fixture_task: tuple[BenchmarkTask, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        task, repo_path = fixture_task
+        from archex.benchmark import runner as runner_mod
+
+        warmed: list[Path] = []
+
+        def _record(_task: BenchmarkTask, path: Path) -> None:
+            warmed.append(path)
+
+        monkeypatch.setattr(runner_mod, "_check_vector_available", lambda: True)
+        monkeypatch.setattr(runner_mod, "_warm_repo_index", _record)
+
+        run_benchmark(
+            task,
+            strategies=[Strategy.RAW_FILES, Strategy.RAW_GREPPED],
+            repo_path=repo_path,
+        )
+        assert warmed == []
+
     def test_symbol_lookup_skipped_gracefully(
         self,
         fixture_task: tuple[BenchmarkTask, Path],

--- a/tests/index/test_rerank.py
+++ b/tests/index/test_rerank.py
@@ -1,4 +1,4 @@
-"""Tests for CrossEncoderReranker and auto-enable logic."""
+"""Tests for CrossEncoderReranker and explicit-enable logic."""
 
 from __future__ import annotations
 
@@ -64,13 +64,13 @@ class TestConstants:
 
 
 class TestMaybeReranker:
-    @pytest.mark.skipif(not _HAS_CROSS_ENCODER, reason="sentence-transformers not installed")
-    def test_auto_enables_when_available(self) -> None:
+    def test_returns_none_when_rerank_disabled(self) -> None:
         from archex.api import _maybe_reranker  # pyright: ignore[reportPrivateUsage]
 
-        config = IndexConfig()
-        result = _maybe_reranker(config)
-        assert isinstance(result, CrossEncoderReranker)
+        # Default config leaves rerank unset; reranking stays off even when
+        # sentence-transformers is installed, so the flag is observably on/off.
+        result = _maybe_reranker(IndexConfig())
+        assert result is None
 
     @pytest.mark.skipif(not _HAS_CROSS_ENCODER, reason="sentence-transformers not installed")
     def test_explicit_rerank_true(self) -> None:
@@ -88,18 +88,6 @@ class TestMaybeReranker:
         result = _maybe_reranker(config)
         assert result is not None
         assert result._model_name == "custom/model"  # pyright: ignore[reportPrivateUsage]
-
-    def test_returns_none_when_unavailable(self) -> None:
-        from archex.api import _maybe_reranker  # pyright: ignore[reportPrivateUsage]
-
-        with patch("archex.index.rerank.is_available", return_value=False):
-            config = IndexConfig()
-            result = _maybe_reranker(config)
-            # When is_available() returns False and rerank is not explicit, returns None
-            # Note: _maybe_reranker imports is_available at call time so we need
-            # to also ensure the patched version is used
-            if not _HAS_CROSS_ENCODER:
-                assert result is None
 
 
 class TestCrossEncoderReranker:


### PR DESCRIPTION
## Summary

Two related fixes that together make the reranker's contribution measurable and correct. The first restores the documented `rerank` flag semantics; the second removes a cold/warm cache confound from the benchmark harness so the two fusion arms become comparable. Both surfaced while investigating why `archex_query_fusion` and `archex_query_fusion_rerank` produced near-identical benchmark numbers.

2 commits, 4 files, +97/−29. Each commit builds and passes its tests independently (bisectable).

## Commit 1 — `fix(api): gate cross-encoder reranker on explicit rerank flag`

`_maybe_reranker` activated on `index_config.rerank or is_available()`. `is_available()` returns True whenever `sentence-transformers` is installed, so **any caller with the backend installed got reranking whether or not they asked for it**. `assemble_context` compounds this — it applies the reranker on `if reranker is not None`, never checking the flag. Net effect: `run_archex_query_fusion` (rerank=False) silently reranked exactly like `run_archex_query_fusion_rerank` (rerank=True), and the benchmark's fusion-vs-rerank comparison measured noise.

Change:
- Gate on `index_config.rerank` only, so the flag is observably on/off and the documented default (`rerank: bool = False`) takes effect.
- Drop the now-unused `is_available` import; update the docstring and the call-site comment.
- `rerank_model=None` continues to resolve to `cross-encoder/ms-marco-MiniLM-L-6-v2` (unchanged).

The `rerank=True` path is unaffected: `True or is_available()` already short-circuited, so explicit reranking — including its fail-loud `ArchexIndexError` when the backend is absent — behaves exactly as before. Only the `rerank=False` branch changes (was auto-on-if-installed, now off).

Tests: replaced `test_auto_enables_when_available` with `test_returns_none_when_rerank_disabled`; removed `test_returns_none_when_unavailable` (its `is_available` patch is dead now that `_maybe_reranker` never calls it). `test_explicit_rerank_true` and `test_uses_custom_model` retained.

### BREAKING CHANGE

`query()` no longer auto-enables reranking when `sentence-transformers` is installed. Callers that relied on implicit reranking must now pass `IndexConfig(rerank=True)`. Retrieval results change for those callers (fewer, higher-precision files; see measured effect below).

## Commit 2 — `feat(benchmark): warm vector index before timed strategies`

Strategies run sequentially per task. The chunk store is cached by source key and the vector embeddings as an `.npz` keyed by `cache_key + vector_mode + surrogate_version`. The first vector strategy to execute absorbed the entire cold embedding build while later ones reused the warm cache — so `archex_query_fusion` was always **cold** and `archex_query_fusion_rerank` always **warm**, conflating the rerank flag with cache state in both timings and candidate pools.

Change:
- Add `_warm_repo_index`, which runs one discarded `query()` with the same vector config the fusion strategies use (`IndexConfig(vector=True, embedder="fastembed")`) before the timed loop. Every cache artifact (store key, `.npz` path) matches by construction, so all vector strategies then start warm.
- Gated on `_check_vector_available()` and the presence of a vector strategy; raw-only runs skip it. Warms `VectorMode.RAW` only (fusion, rerank, query_vector) — surrogate-mode strategies are out of scope and noted in the docstring.

Tests: `test_warms_vector_index_when_vector_strategy_present` (warm-up fires) and `test_skips_warmup_for_raw_only_strategies` (skipped for raw-only).

Trade-off: total per-task wall time is unchanged (the cold build still happens, now untimed in the warm-up), but per-strategy timings and candidate pools become comparable — the right trade for a benchmark.

## Measured effect (full warm n=25 run, after both fixes)

| strategy | mrr | ndcg | map | recall | prec | tokens |
|---|---|---|---|---|---|---|
| archex_query (bm25) | 0.601 | 0.425 | 0.313 | 0.460 | 0.192 | 6453 |
| archex_query_fusion (rerank off) | 0.533 | 0.345 | 0.237 | 0.367 | 0.207 | 5737 |
| archex_query_fusion_rerank (rerank on) | 0.720 | 0.437 | 0.321 | 0.400 | 0.447 | 2008 |

With the arms finally isolated: reranking lifts mrr +0.187 and precision +0.240 (doubles) at −65% tokens, helping 9/25 tasks, hurting 5, neutral 11 — concentrated on the hard buckets (external-large, architecture-broad). It trades ~6 points of recall vs bm25 and costs ~7.8s/task. Plain fusion is strictly worse than bm25.

## Validation

- `ruff check` + `ruff format --check`: pass (all four files)
- `mypy --strict`: clean except pre-existing notes outside this diff (`fastembed` import in `_check_vector_available`; `unused type: ignore` comments in `api.py` confirmed present on unmodified main)
- `pytest tests/index/test_rerank.py tests/benchmark/test_runner.py`: 34 passed
- query/context/api regression cluster (test_api_precision, test_api_robustness, test_query_pipeline, test_integration, serve/test_context, serve/test_context_recall): 181 passed — nothing relied on the silent auto-rerank default

## Out of scope (follow-up)

The n=25 run also surfaced a **bm25 baseline regression** — `archex_query` dropped mrr 0.707 → 0.601 and recall 0.507 → 0.460 vs the recorded 2026-03-22 baseline on identical task buckets, likely from a Phase 12–14 addition to the shared bm25 path. Tracked separately; not addressed here to keep this PR's scope to reranker gating and benchmark measurement.