### PR TITLE
fix(retrieval): restore sum-based file aggregation to fix bm25 recall regression

### DIFF
--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -781,10 +781,14 @@ def assemble_context(
 
     # File-level ranking: aggregate per-file scores, apply score-relative cutoff,
     # then hard-cap at adaptive MAX_FILES to limit tail noise.
+    # Aggregate per-file score as the sum of its chunk scores: a file with
+    # several relevant chunks outranks one with a single strong match. Max-based
+    # aggregation under-ranks large multi-chunk files and regresses recall on
+    # framework-heavy repos — do not switch back to max.
     file_agg: dict[str, float] = {}
     for rc in ranked:
         fp = rc.chunk.file_path
-        file_agg[fp] = max(file_agg.get(fp, 0.0), rc.final_score)
+        file_agg[fp] = file_agg.get(fp, 0.0) + rc.final_score
     sorted_files = sorted(file_agg.items(), key=lambda x: -x[1])
     top_file_score = sorted_files[0][1] if sorted_files else 0.0
     score_cutoff = top_file_score * FILE_SCORE_CUTOFF

--- a/tests/serve/test_context_recall.py
+++ b/tests/serve/test_context_recall.py
@@ -1,4 +1,4 @@
-"""Tests for recall-plateau fixes: max aggregation, adaptive limits, decay tuning."""
+"""Tests for retrieval recall: sum-based aggregation, adaptive limits, decay tuning."""
 
 from __future__ import annotations
 
@@ -29,49 +29,49 @@ def make_chunk(
 
 
 # ---------------------------------------------------------------------------
-# Max-based file aggregation
+# Sum-based file aggregation
 # ---------------------------------------------------------------------------
 
 
-def test_max_aggregation_prevents_chunk_count_bias() -> None:
-    """File with many chunks must not outrank file with fewer but equally scored chunks.
+def test_sum_aggregation_rewards_multi_chunk_files() -> None:
+    """A file matched by many chunks aggregates above a single-chunk file.
 
-    Sum-based aggregation inflated files with many BM25 chunks. Max-based
-    aggregation ranks files by their single best chunk, removing chunk-count bias.
+    Sum-based aggregation accumulates per-file chunk scores, so a central file
+    with several relevant chunks ranks above a file with one equally scored
+    chunk. Max-based aggregation collapsed each file to its best chunk and
+    regressed recall on framework-heavy repos.
     """
     graph = DependencyGraph()
-    graph.add_file_node("many_chunks.py")
-    graph.add_file_node("few_chunks.py")
-    many = [make_chunk(f"cm{i}", "many_chunks.py", token_count=10) for i in range(8)]
-    few = [make_chunk("cf0", "few_chunks.py", token_count=10)]
-    all_chunks = many + few
-    results = [(c, 5.0) for c in many] + [(few[0], 5.0)]
+    graph.add_file_node("central.py")
+    graph.add_file_node("peripheral.py")
+    central = [make_chunk(f"cc{i}", "central.py", token_count=10) for i in range(6)]
+    peripheral = [make_chunk("cp0", "peripheral.py", token_count=10)]
+    all_chunks = central + peripheral
+    results = [(c, 4.0) for c in central] + [(peripheral[0], 4.0)]
     bundle = assemble_context(results, graph, all_chunks, "q", token_budget=5000)
-    included_files = {rc.chunk.file_path for rc in bundle.chunks}
-    assert "few_chunks.py" in included_files, (
-        "few_chunks.py must survive cutoff despite having fewer chunks"
+    files = [rc.chunk.file_path for rc in bundle.chunks]
+    assert "central.py" in files
+    assert files.index("central.py") < files.index("peripheral.py"), (
+        "multi-chunk file must rank above single-chunk file under sum aggregation"
     )
 
 
-def test_expansion_file_survives_cutoff_with_max_aggregation() -> None:
-    """Expansion file with strong neighbor_boost must pass FILE_SCORE_CUTOFF.
+def test_single_chunk_file_survives_cutoff_when_above_threshold() -> None:
+    """A strong single-chunk file still clears FILE_SCORE_CUTOFF under sum.
 
-    With sum aggregation, seed files with many chunks inflated the cutoff
-    threshold, eliminating expansion files. Max aggregation fixes this.
+    Sum aggregation rewards chunk count but does not eliminate a single-chunk
+    file whose score sits above the relative cutoff.
     """
     graph = DependencyGraph()
-    graph.add_file_node("seed.py")
-    graph.add_file_node("dep.py")
-    graph.add_file_edge("seed.py", "dep.py", kind="imports")
-    seed_chunks = [make_chunk(f"cs{i}", "seed.py", token_count=10) for i in range(10)]
-    dep_chunk = make_chunk("cd0", "dep.py", token_count=10)
-    all_chunks = seed_chunks + [dep_chunk]
-    results = [(c, 8.0) for c in seed_chunks]
+    graph.add_file_node("many.py")
+    graph.add_file_node("solo.py")
+    many = [make_chunk(f"cm{i}", "many.py", token_count=10) for i in range(3)]
+    solo = [make_chunk("cs0", "solo.py", token_count=10)]
+    all_chunks = many + solo
+    results = [(c, 5.0) for c in many] + [(solo[0], 5.0)]
     bundle = assemble_context(results, graph, all_chunks, "q", token_budget=5000)
     included_files = {rc.chunk.file_path for rc in bundle.chunks}
-    assert "dep.py" in included_files, (
-        "dep.py (import target) must survive cutoff even when seed has many chunks"
-    )
+    assert "solo.py" in included_files
 
 
 # ---------------------------------------------------------------------------
@@ -159,78 +159,38 @@ def test_importer_relevance_score_reflects_decay() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Architecture query multi-file retrieval
+# Graph expansion multi-file retrieval
 # ---------------------------------------------------------------------------
 
 
-def test_architecture_query_retrieves_three_related_files() -> None:
-    """Architecture query spanning 3 files via imports retrieves all three.
+def test_graph_expansion_retrieves_import_connected_files() -> None:
+    """Graph expansion pulls import-connected files in alongside a BM25 seed.
 
-    Simulates the django_middleware / express_middleware pattern where the
-    query expects files from a BM25 seed plus two import-connected files.
+    When the seed does not dominate by chunk count, sum aggregation keeps the
+    import target above the cutoff so multi-file architecture queries still
+    retrieve the connected files.
     """
     graph = DependencyGraph()
-    for name in ("handlers/base.py", "handlers/wsgi.py", "middleware/common.py"):
-        graph.add_file_node(name)
+    graph.add_file_node("handlers/base.py")
+    graph.add_file_node("handlers/wsgi.py")
     graph.add_file_edge("handlers/base.py", "handlers/wsgi.py", kind="imports")
-    graph.add_file_edge("middleware/common.py", "handlers/base.py", kind="imports")
 
-    base_chunks = [make_chunk(f"cb{i}", "handlers/base.py", token_count=10) for i in range(5)]
+    base_chunk = make_chunk("cb0", "handlers/base.py", token_count=10)
     wsgi_chunk = make_chunk("cw0", "handlers/wsgi.py", token_count=10)
-    common_chunk = make_chunk("cc0", "middleware/common.py", token_count=10)
-    all_chunks = base_chunks + [wsgi_chunk, common_chunk]
+    all_chunks = [base_chunk, wsgi_chunk]
 
-    results = [(c, 6.0) for c in base_chunks] + [(common_chunk, 2.0)]
+    results = [(base_chunk, 6.0)]
     bundle = assemble_context(
         results,
         graph,
         all_chunks,
-        "How does the middleware chain handle requests?",
+        "How does the handler chain handle requests?",
         token_budget=5000,
     )
     included_files = {rc.chunk.file_path for rc in bundle.chunks}
     assert "handlers/base.py" in included_files
     assert "handlers/wsgi.py" in included_files, (
-        "wsgi.py (import target of seed) must be included via expansion"
-    )
-    assert "middleware/common.py" in included_files, (
-        "common.py (BM25 hit) must survive cutoff with max aggregation"
-    )
-
-
-def test_express_like_three_file_retrieval() -> None:
-    """Express-like query retrieves router/index.js, route.js, and layer.js.
-
-    Simulates express_middleware where all three files are in BM25 but only
-    one survived the old sum-based cutoff.
-    """
-    graph = DependencyGraph()
-    for name in ("lib/router/index.js", "lib/router/route.js", "lib/router/layer.js"):
-        graph.add_file_node(name)
-    graph.add_file_edge("lib/router/index.js", "lib/router/route.js", kind="imports")
-    graph.add_file_edge("lib/router/index.js", "lib/router/layer.js", kind="imports")
-
-    idx_chunks = [make_chunk(f"ci{i}", "lib/router/index.js", token_count=10) for i in range(6)]
-    route_chunk = make_chunk("cr0", "lib/router/route.js", token_count=10)
-    layer_chunk = make_chunk("cl0", "lib/router/layer.js", token_count=10)
-    all_chunks = idx_chunks + [route_chunk, layer_chunk]
-
-    # index.js dominates BM25, route and layer have lower scores
-    results = [(c, 7.0) for c in idx_chunks] + [(route_chunk, 3.0), (layer_chunk, 2.5)]
-    bundle = assemble_context(
-        results,
-        graph,
-        all_chunks,
-        "How does the middleware chain and next() function work?",
-        token_budget=5000,
-    )
-    included_files = {rc.chunk.file_path for rc in bundle.chunks}
-    assert "lib/router/index.js" in included_files
-    assert "lib/router/route.js" in included_files, (
-        "route.js must survive cutoff with max aggregation"
-    )
-    assert "lib/router/layer.js" in included_files, (
-        "layer.js must survive cutoff with max aggregation"
+        "wsgi.py (import target of seed) must be retrieved via graph expansion"
     )
 
 


### PR DESCRIPTION
## Summary

Reverts per-file score aggregation from max back to sum, fixing a recall/MRR regression in the bm25-only `archex_query` path. Found by bisecting `archex_query` against the recorded Phase-11 baseline.

1 commit, 2 files: the one-line aggregation change plus corrected tests.

## Root cause

`cd2be9c` (PR #84, "recall-plateau-fix") changed file aggregation:

```python
- file_agg[fp] = file_agg.get(fp, 0.0) + rc.final_score   # sum
+ file_agg[fp] = max(file_agg.get(fp, 0.0), rc.final_score) # max
```

Max collapses each file to its single best chunk, neutralizing chunk-count bias. That lifted the 2-task **framework-semantic** bucket off its 0.333-recall plateau to 0.50 — but it under-ranks large, central framework files that match on *many* chunks, demoting them below `FILE_SCORE_CUTOFF`. Net effect on `archex_query` vs the Phase-11 baseline:

- MRR 0.707 → 0.601, Recall 0.507 → 0.460
- concentrated in **external-framework** (recall 0.74 → 0.50, the 9-task bucket) and **external-large**

It traded 17 external tasks to gain 2 framework-semantic tasks.

## Why it stayed hidden

The regression was masked for ~10 commits. `007c00e` auto-enabled the cross-encoder reranker for *every* query (the `index_config.rerank or is_available()` bug fixed in #96). With the reranker silently re-ranking `archex_query`'s candidates, the demoted files were re-promoted, hiding the aggregation regression. Removing that auto-enable in #96 unmasked it — which is what surfaced the "bm25 regression" in the first place.

## Bisect

Tracked `archex_query` (pure bm25) against the 0.707/0.507 baseline, using only pre-#86 / post-#96 commits where `archex_query` does not auto-rerank (so the metric measures the same thing):

| commit | MRR | Recall | verdict |
|--------|-----|--------|---------|
| #68 (Phase-11 baseline) | 0.707 | 0.507 | GOOD (reproduces recorded baseline exactly) |
| #72 (Phase-14 end) | 0.710 | 0.507 | GOOD — Phase 12–14 innocent |
| #83 (zero-recall-fix) | 0.543 | 0.447 | BAD |
| current main | 0.601 | 0.460 | BAD |

Window #72→#83 isolated to four PRs; elimination (style-only / fusion-only / recall-loosening / already-tested-neutral changes) plus the commit's own stated mechanism pinned it to `cd2be9c`. A single-variable max→sum revert on current main confirmed it.

## Fix result (25-task benchmark, archex_query)

| metric | this PR (sum) | main (max) | Phase-11 baseline |
|--------|---------------|------------|-------------------|
| MRR | **0.778** | 0.601 | 0.707 |
| Recall | **0.580** | 0.460 | 0.507 |

Every bucket lands at or above baseline; external-large recovers far above it (MRR 0.14 → 0.64). framework-semantic returns to its **true baseline** recall of 0.333 — `cd2be9c`'s 0.50 was a local over-fit, not part of the baseline this restores.

A hybrid `max + damp·(sum − max)` was prototyped and rejected: at every damping value that recovered the external buckets, framework-semantic still collapsed to 0.333, so the hybrid was strictly dominated by pure sum.

## Tests

`tests/serve/test_context_recall.py`: three tests asserted max-aggregation cutoff-survival (expansion files surviving when a seed has many chunks) — they encoded the over-fit being reverted. Replaced with assertions of the restored sum behavior: multi-chunk files outrank single-chunk files, single-chunk files above the cutoff still survive, and graph expansion still retrieves import-connected files (with a seed that doesn't dominate by chunk count).

## Validation

- `ruff check` + `ruff format --check`: pass
- `mypy --strict src/archex/serve/context.py`: only a pre-existing `Module | None` error at the same line on unmodified main (outside this diff)
- `pytest tests/serve/ tests/test_api_precision.py tests/test_query_pipeline.py tests/test_integration.py`: 298 passed

## Note / follow-up

framework-semantic's 0.333 plateau (2 tasks) is a real hard case, now at its baseline. If worth addressing, it should be tackled directly (e.g. query/expansion tuning for those tasks) rather than via a global aggregation change that costs the external buckets.