### PR TITLE
fix(benchmark): isolate clone failures instead of aborting the run

### DIFF
--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -14,7 +14,7 @@ import click
 from archex.benchmark.loader import load_tasks
 from archex.benchmark.models import BenchmarkReport, BenchmarkResult, BenchmarkTask, Strategy
 from archex.benchmark.strategies import default_strategy_registry
-from archex.exceptions import ArchexIndexError
+from archex.exceptions import ArchexIndexError, BenchmarkCloneError
 
 logger = logging.getLogger(__name__)
 
@@ -84,36 +84,49 @@ def _warm_repo_index(task: BenchmarkTask, repo_path: Path) -> None:
     )
 
 
+def _run_git(
+    args: list[str], *, cwd: Path | None = None, timeout: int
+) -> subprocess.CompletedProcess[str]:
+    """Run a git command with captured output, converting a timeout into BenchmarkCloneError."""
+    try:
+        return subprocess.run(args, cwd=cwd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise BenchmarkCloneError(f"git timed out after {timeout}s: {' '.join(args)}") from exc
+
+
 def clone_at_commit(repo_slug: str, commit: str) -> tuple[Path, bool]:
-    """Clone a GitHub repo and checkout a specific commit/tag. Returns (path, needs_cleanup)."""
+    """Clone a GitHub repo and checkout a specific commit/tag. Returns (path, needs_cleanup).
+
+    Raises BenchmarkCloneError (carrying git's stderr) when both the shallow-ref
+    clone and the full-clone fallback fail — e.g. network error, rate limit, or
+    an unresolvable ref — leaving no temp directory behind.
+    """
     url = f"https://github.com/{repo_slug}.git"
     target = Path(tempfile.mkdtemp(prefix="archex-bench-"))
 
     # Try shallow clone at ref (works for tags and branches, much faster)
-    result = subprocess.run(
+    shallow = _run_git(
         ["git", "clone", "--quiet", "--depth", "1", "--branch", commit, url, str(target)],
-        capture_output=True,
         timeout=300,
     )
-    if result.returncode == 0:
+    if shallow.returncode == 0:
         return target, True
 
     # Fallback: full clone + checkout (needed for bare commit hashes)
     shutil.rmtree(target, ignore_errors=True)
     target = Path(tempfile.mkdtemp(prefix="archex-bench-"))
-    subprocess.run(
-        ["git", "clone", "--quiet", url, str(target)],
-        check=True,
-        capture_output=True,
-        timeout=300,
-    )
-    subprocess.run(
-        ["git", "checkout", "--quiet", commit],
-        cwd=target,
-        check=True,
-        capture_output=True,
-        timeout=30,
-    )
+    full = _run_git(["git", "clone", "--quiet", url, str(target)], timeout=300)
+    if full.returncode != 0:
+        shutil.rmtree(target, ignore_errors=True)
+        detail = full.stderr.strip() or shallow.stderr.strip() or "unknown git error"
+        raise BenchmarkCloneError(f"clone failed for {repo_slug}@{commit}: {detail}")
+
+    checkout = _run_git(["git", "checkout", "--quiet", commit], cwd=target, timeout=30)
+    if checkout.returncode != 0:
+        shutil.rmtree(target, ignore_errors=True)
+        detail = checkout.stderr.strip() or "unknown git error"
+        raise BenchmarkCloneError(f"checkout {commit} failed for {repo_slug}: {detail}")
+
     return target, True
 
 
@@ -206,17 +219,31 @@ def run_all(
 
     output_dir.mkdir(parents=True, exist_ok=True)
     reports: list[BenchmarkReport] = []
+    failures: list[tuple[str, str]] = []
 
     for i, task in enumerate(tasks, 1):
         print(f"[{i}/{len(tasks)}] {task.task_id} ({task.repo})", file=sys.stderr)
         task_repo_path: Path | None = None
         if task.repo == ".":
             task_repo_path = Path.cwd()
-        report = run_benchmark(task, strategies=strategies, repo_path=task_repo_path)
+        try:
+            report = run_benchmark(task, strategies=strategies, repo_path=task_repo_path)
+        except BenchmarkCloneError as exc:
+            # Isolate per-task clone failures (network, rate limit, bad ref) so one
+            # bad repo does not abort the whole batch.
+            logger.warning("Skipping task %s: %s", task.task_id, exc)
+            print(f"  SKIPPED {task.task_id}: {exc}", file=sys.stderr)
+            failures.append((task.task_id, str(exc)))
+            continue
         reports.append(report)
 
         result_path = output_dir / f"{task.task_id}.json"
         result_path.write_text(report.model_dump_json(indent=2), encoding="utf-8")
         print(f"  → Wrote {result_path}", file=sys.stderr)
+
+    if failures:
+        print(f"\n{len(failures)} task(s) skipped due to clone failures:", file=sys.stderr)
+        for task_id, detail in failures:
+            print(f"  - {task_id}: {detail}", file=sys.stderr)
 
     return reports

--- a/src/archex/exceptions.py
+++ b/src/archex/exceptions.py
@@ -41,3 +41,7 @@ class ConfigError(ArchexError):
 
 class LSAPError(ArchexError):
     """Raised when LSAP/LSP client operations fail."""
+
+
+class BenchmarkCloneError(ArchexError):
+    """Raised when cloning or checking out a benchmark task repository fails."""

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -291,6 +291,42 @@ class TestCloneAtCommit:
         # clone_dir should have been cleaned up
         assert not clone_dir.exists()
 
+    def test_clone_failure_raises_benchmark_clone_error(self) -> None:
+        """Both clones failing raises BenchmarkCloneError carrying git's stderr."""
+        import subprocess
+
+        import archex.benchmark.runner as runner_mod
+        from archex.exceptions import BenchmarkCloneError
+
+        def fail_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(cmd, 1, "", "fatal: could not read from remote")
+
+        original = runner_mod.subprocess.run
+        runner_mod.subprocess.run = fail_run  # type: ignore[assignment]
+        try:
+            with pytest.raises(BenchmarkCloneError, match="could not read from remote"):
+                runner_mod.clone_at_commit("owner/repo", "v1.0")
+        finally:
+            runner_mod.subprocess.run = original  # type: ignore[assignment]
+
+    def test_clone_timeout_raises_benchmark_clone_error(self) -> None:
+        """A git timeout is converted to BenchmarkCloneError, not propagated raw."""
+        import subprocess
+
+        import archex.benchmark.runner as runner_mod
+        from archex.exceptions import BenchmarkCloneError
+
+        def timeout_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(cmd, 300)
+
+        original = runner_mod.subprocess.run
+        runner_mod.subprocess.run = timeout_run  # type: ignore[assignment]
+        try:
+            with pytest.raises(BenchmarkCloneError, match="timed out"):
+                runner_mod.clone_at_commit("owner/repo", "v1.0")
+        finally:
+            runner_mod.subprocess.run = original  # type: ignore[assignment]
+
 
 class TestRunAll:
     def _make_tasks_dir(self, tmp_path: Path) -> Path:
@@ -336,6 +372,49 @@ expected_files:
         assert len(reports) == 1
         assert reports[0].task_id == "test_all"
         assert (output_dir / "test_all.json").exists()
+
+    def test_run_all_skips_failed_clone_and_continues(
+        self,
+        python_simple_repo: Path,
+        tmp_path: Path,
+    ) -> None:
+        """A clone failure on one task is isolated; the batch continues."""
+        from archex.benchmark.runner import run_all
+        from archex.exceptions import BenchmarkCloneError
+
+        tasks_dir = self._make_tasks_dir(tmp_path)  # task_id=test_all, repo=test/repo
+        (tasks_dir / "bad.yaml").write_text("""\
+task_id: bad_clone
+repo: bad/repo
+commit: v1
+question: "Bad?"
+expected_files:
+  - main.py
+""")
+        output_dir = tmp_path / "results"
+
+        import archex.benchmark.runner as runner_mod
+
+        def _fake_clone(repo_slug: str, commit: str) -> tuple[Path, bool]:
+            if repo_slug == "bad/repo":
+                raise BenchmarkCloneError(f"clone failed for {repo_slug}@{commit}: rate limit")
+            return python_simple_repo, False
+
+        original = runner_mod.clone_at_commit
+        runner_mod.clone_at_commit = _fake_clone  # type: ignore[assignment]
+        try:
+            reports = run_all(
+                tasks_dir=tasks_dir,
+                output_dir=output_dir,
+                strategies=[Strategy.RAW_FILES],
+            )
+        finally:
+            runner_mod.clone_at_commit = original  # type: ignore[assignment]
+
+        # The good task ran and was written; the bad task was skipped, not crashed.
+        assert {r.task_id for r in reports} == {"test_all"}
+        assert (output_dir / "test_all.json").exists()
+        assert not (output_dir / "bad_clone.json").exists()
 
     def test_task_filter_nonexistent_raises(self, tmp_path: Path) -> None:
         from archex.benchmark.runner import run_all


### PR DESCRIPTION
## Summary

A single failed `git clone` during a benchmark run aborted the entire batch and leaked a temp directory. This isolates per-task clone failures so the run continues, and replaces the opaque crash with a typed, descriptive error.

1 commit, 3 files (+129/−19).

## Problem

`clone_at_commit`'s full-clone fallback used `check=True`:

```python
subprocess.run(["git", "clone", "--quiet", url, str(target)], check=True, ...)
```

When a clone failed — GitHub rate limit (hit repeatedly during the recent bisect, which re-clones 19 external repos per run), network error, or an unresolvable ref — this raised a bare `subprocess.CalledProcessError` that:

- propagated uncaught through `run_benchmark` → `run_all`, **aborting the whole batch** (e.g. crashing at task 12/25 and discarding the remaining 13), and
- **leaked the temp directory** created just before the failing clone.

The error carried only the git command and exit code, not git's actual stderr.

## Changes

**`src/archex/exceptions.py`**
- New `BenchmarkCloneError(ArchexError)`.

**`src/archex/benchmark/runner.py`**
- `_run_git(args, *, cwd, timeout)` helper: runs git with captured output and converts `subprocess.TimeoutExpired` into `BenchmarkCloneError`, so a hung clone fails the same way as any other.
- `clone_at_commit`: checks return codes explicitly (no `check=True`), raises `BenchmarkCloneError` carrying git's stderr on either a failed full clone or a failed checkout, and `rmtree`s the temp directory on every failure path (no leak).
- `run_all`: catches `BenchmarkCloneError` per task — logs a warning, prints `SKIPPED <task>: <reason>`, records the failure, and continues. After the loop it prints a summary of all skipped tasks.

## Behavior change

| scenario | before | after |
|----------|--------|-------|
| clone fails mid-batch | whole run crashes, remaining tasks lost, temp dir leaked | failing task skipped with a clear reason, batch completes, summary printed |
| clone times out | `TimeoutExpired` propagates raw | converted to `BenchmarkCloneError`, isolated like any clone failure |
| single-task run, clone fails | opaque `CalledProcessError` (cmd + exit code) | `BenchmarkCloneError` with git's actual stderr |

Single-task runs still surface the failure (it's not swallowed) — they just get a useful message instead of a stack trace. Successful runs are unchanged.

## Tests (`tests/benchmark/test_runner.py`, +3)

- `test_clone_failure_raises_benchmark_clone_error`: both clones returning non-zero raises `BenchmarkCloneError` carrying git's stderr.
- `test_clone_timeout_raises_benchmark_clone_error`: a `TimeoutExpired` is converted to `BenchmarkCloneError`.
- `test_run_all_skips_failed_clone_and_continues`: a two-task run where one clone raises `BenchmarkCloneError` — the failing task is skipped (no result file written), the good task runs and is written, and `run_all` does not raise.

## Validation

- `ruff check` + `ruff format --check`: pass on all three files
- pyright (project type gate, `typeCheckingMode = strict`): only non-blocking unused-parameter notes, matching the file's existing mock convention
- `mypy --strict` on the src files: clean except the pre-existing `fastembed` import note in `_check_vector_available` (outside this diff)
- `pytest tests/benchmark/`: 176 passed

## Context

Surfaced during the bm25-regression bisect (the exit-128 crash on `expressjs/express`), flagged as out-of-scope in PR #97 and tracked as a follow-up. This is that follow-up.