### PR TITLE
Refactor retrieval and benchmark route helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ testpaths = ["tests"]
 addopts = "--cov=archex --cov-report=term-missing --cov-fail-under=85 -m 'not slow'"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "network: marks tests that require network access",
 ]
 
 [tool.coverage.run]

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -43,6 +43,7 @@ import shutil
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -184,6 +185,17 @@ def _full_index(
         cleanup()
 
 
+@dataclass(frozen=True)
+class _DeltaIndexAttempt:
+    source: RepoSource
+    config: Config
+    cache: CacheManager
+    cache_key: str
+    timing: PipelineTiming | None
+    index_config: IndexConfig | None
+    t_start: float
+
+
 def _ensure_index(
     source: RepoSource,
     config: Config | None = None,
@@ -218,66 +230,91 @@ def _ensure_index(
         cache.invalidate(cache_key)
 
     # Path 2: Delta path — same repo, different commit (local repos only)
-    if config.cache and source.local_path:
-        existing = cache.find_store_for_source(source)
-        if existing is not None:
-            db_path, cached_commit = existing
-            current_commit = CacheManager.git_head(source.local_path)
-            if current_commit and cached_commit != current_commit:
-                try:
-                    from archex.index.delta import apply_delta, compute_delta
-
-                    repo_path = (
-                        Path(source.local_path).resolve() if source.local_path else Path(".")
-                    )
-                    manifest = compute_delta(repo_path, cached_commit, current_commit)
-                    total_files = len(
-                        discover_files(
-                            repo_path,
-                            languages=config.languages,
-                            max_file_size=config.max_file_size,
-                        )
-                    )
-                    change_ratio = len(manifest.changes) / total_files if total_files > 0 else 1.0
-                    if change_ratio < config.delta_threshold:
-                        if timing is not None:
-                            timing.delta_attempted = True
-                        store = IndexStore(db_path)
-                        graph = DependencyGraph.from_edges(store.get_edges())
-                        delta_meta = apply_delta(
-                            store,
-                            graph,
-                            manifest,
-                            repo_path,
-                            config,
-                            index_config=index_config,
-                        )
-                        identity = source.url or source.local_path or ""
-                        store.set_metadata("commit_hash", current_commit)
-                        store.set_metadata("source_identity", identity)
-                        store.set_metadata("indexed_at", str(time.time()))
-                        store.conn.execute("PRAGMA wal_checkpoint(FULL)")
-                        cache.put(
-                            cache_key,
-                            db_path,
-                            resolved_commit=current_commit,
-                            source_identity=identity,
-                        )
-                        if timing is not None:
-                            timing.delta_ms = delta_meta.delta_time_ms
-                            timing.delta_meta = delta_meta
-                            timing.index_ms = _elapsed_ms(t_start)
-                            timing.delta_succeeded = True
-                            timing.strategy = "delta"
-                        logger.info("Delta index applied in %.0fms", delta_meta.delta_time_ms)
-                        return store
-                except DeltaIndexError:
-                    if timing is not None:
-                        timing.delta_attempted = True
-                    logger.info("Delta indexing failed, falling back to full re-index")
+    delta_store = _try_delta_index(
+        _DeltaIndexAttempt(
+            source=source,
+            config=config,
+            cache=cache,
+            cache_key=cache_key,
+            timing=timing,
+            index_config=index_config,
+            t_start=t_start,
+        )
+    )
+    if delta_store is not None:
+        return delta_store
 
     # Path 3: Full re-index
     return _full_index(source, config, cache, cache_key, timing, index_config=index_config)
+
+
+def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
+    source = attempt.source
+    config = attempt.config
+    if not config.cache or not source.local_path:
+        return None
+
+    existing = attempt.cache.find_store_for_source(source)
+    if existing is None:
+        return None
+
+    db_path, cached_commit = existing
+    current_commit = CacheManager.git_head(source.local_path)
+    if not current_commit or cached_commit == current_commit:
+        return None
+
+    try:
+        from archex.index.delta import apply_delta, compute_delta
+
+        repo_path = Path(source.local_path).resolve()
+        manifest = compute_delta(repo_path, cached_commit, current_commit)
+        total_files = len(
+            discover_files(
+                repo_path,
+                languages=config.languages,
+                max_file_size=config.max_file_size,
+            )
+        )
+        change_ratio = len(manifest.changes) / total_files if total_files > 0 else 1.0
+        if change_ratio >= config.delta_threshold:
+            return None
+
+        if attempt.timing is not None:
+            attempt.timing.delta_attempted = True
+        store = IndexStore(db_path)
+        graph = DependencyGraph.from_edges(store.get_edges())
+        delta_meta = apply_delta(
+            store,
+            graph,
+            manifest,
+            repo_path,
+            config,
+            index_config=attempt.index_config,
+        )
+        identity = source.url or source.local_path or ""
+        store.set_metadata("commit_hash", current_commit)
+        store.set_metadata("source_identity", identity)
+        store.set_metadata("indexed_at", str(time.time()))
+        store.conn.execute("PRAGMA wal_checkpoint(FULL)")
+        attempt.cache.put(
+            attempt.cache_key,
+            db_path,
+            resolved_commit=current_commit,
+            source_identity=identity,
+        )
+        if attempt.timing is not None:
+            attempt.timing.delta_ms = delta_meta.delta_time_ms
+            attempt.timing.delta_meta = delta_meta
+            attempt.timing.index_ms = _elapsed_ms(attempt.t_start)
+            attempt.timing.delta_succeeded = True
+            attempt.timing.strategy = "delta"
+        logger.info("Delta index applied in %.0fms", delta_meta.delta_time_ms)
+        return store
+    except DeltaIndexError:
+        if attempt.timing is not None:
+            attempt.timing.delta_attempted = True
+        logger.info("Delta indexing failed, falling back to full re-index")
+        return None
 
 
 def _chunk_to_symbol_source(chunk: CodeChunk) -> SymbolSource:

--- a/src/archex/serve/app.py
+++ b/src/archex/serve/app.py
@@ -31,6 +31,9 @@ from archex.models import (
 # ---------------------------------------------------------------------------
 
 
+_BENCHMARK_BASELINE_PATH = Path.home() / ".archex" / "benchmark_baseline.json"
+
+
 class AnalyzeRequest(BaseModel):
     source: RepoSource
     config: Config | None = None
@@ -50,6 +53,50 @@ class CompareRequest(BaseModel):
     source_b: RepoSource
     dimensions: list[str] | None = None
     config: Config | None = None
+
+
+def _load_benchmark_baseline() -> Any:
+    from archex.benchmark.baseline import load_baseline
+
+    data = json.loads(_BENCHMARK_BASELINE_PATH.read_text())
+    return load_baseline(data)
+
+
+def _benchmark_summary_text() -> str:
+    baseline = _load_benchmark_baseline()
+    if not baseline.entries:
+        return "No benchmark baseline found"
+    return "\n".join(
+        [
+            "# Benchmark Baseline Summary",
+            f"**Created:** {baseline.created_at}",
+            f"**Version:** {baseline.archex_version or 'unknown'}",
+            f"**Entries:** {len(baseline.entries)}",
+        ]
+    )
+
+
+def _benchmark_gate_status() -> dict[str, Any]:
+    baseline = _load_benchmark_baseline()
+    if not baseline.entries:
+        return {"passed": False, "reason": "No benchmark baseline found"}
+
+    min_recall = 0.6
+    min_f1 = 0.4
+    violations: list[str] = []
+    for entry in baseline.entries:
+        if entry.recall < min_recall:
+            violations.append(
+                f"{entry.task_id}/{entry.strategy}: recall {entry.recall:.2f} < {min_recall}"
+            )
+        if entry.f1_score < min_f1:
+            violations.append(
+                f"{entry.task_id}/{entry.strategy}: f1 {entry.f1_score:.2f} < {min_f1}"
+            )
+
+    if violations:
+        return {"passed": False, "violations": violations}
+    return {"passed": True}
 
 
 # ---------------------------------------------------------------------------
@@ -139,14 +186,10 @@ def create_app() -> FastAPI:
     @app.get("/benchmark/results")
     def benchmark_results() -> dict[str, Any]:  # pyright: ignore[reportUnusedFunction]
         """Return latest benchmark results if available."""
-        baseline_path = Path.home() / ".archex" / "benchmark_baseline.json"
-        if not baseline_path.exists():
+        if not _BENCHMARK_BASELINE_PATH.exists():
             return {"results": [], "message": "No benchmark results found"}
         try:
-            from archex.benchmark.baseline import load_baseline
-
-            data = json.loads(baseline_path.read_text())
-            baseline = load_baseline(data)
+            baseline = _load_benchmark_baseline()
             return {"results": [e.model_dump() for e in baseline.entries]}
         except Exception as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -154,55 +197,20 @@ def create_app() -> FastAPI:
     @app.get("/benchmark/summary")
     def benchmark_summary() -> dict[str, Any]:  # pyright: ignore[reportUnusedFunction]
         """Return formatted benchmark summary."""
-        baseline_path = Path.home() / ".archex" / "benchmark_baseline.json"
-        if not baseline_path.exists():
+        if not _BENCHMARK_BASELINE_PATH.exists():
             return {"summary": "No benchmark results found"}
         try:
-            from archex.benchmark.baseline import load_baseline
-
-            data = json.loads(baseline_path.read_text())
-            baseline = load_baseline(data)
-            if not baseline.entries:
-                return {"summary": "No benchmark baseline found"}
-            lines: list[str] = []
-            lines.append("# Benchmark Baseline Summary")
-            lines.append(f"**Created:** {baseline.created_at}")
-            lines.append(f"**Version:** {baseline.archex_version or 'unknown'}")
-            lines.append(f"**Entries:** {len(baseline.entries)}")
-            return {"summary": "\n".join(lines)}
+            return {"summary": _benchmark_summary_text()}
         except Exception as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
     @app.get("/benchmark/gate")
     def benchmark_gate() -> dict[str, Any]:  # pyright: ignore[reportUnusedFunction]
         """Return quality gate check result based on baseline entries."""
-        baseline_path = Path.home() / ".archex" / "benchmark_baseline.json"
-        if not baseline_path.exists():
+        if not _BENCHMARK_BASELINE_PATH.exists():
             return {"passed": False, "reason": "No benchmark baseline found"}
         try:
-            from archex.benchmark.baseline import load_baseline
-
-            data = json.loads(baseline_path.read_text())
-            baseline = load_baseline(data)
-            if not baseline.entries:
-                return {"passed": False, "reason": "No benchmark baseline found"}
-            # Check entries against minimum thresholds
-            min_recall = 0.6
-            min_f1 = 0.4
-            violations: list[str] = []
-            for entry in baseline.entries:
-                if entry.recall < min_recall:
-                    violations.append(
-                        f"{entry.task_id}/{entry.strategy}: "
-                        f"recall {entry.recall:.2f} < {min_recall}"
-                    )
-                if entry.f1_score < min_f1:
-                    violations.append(
-                        f"{entry.task_id}/{entry.strategy}: f1 {entry.f1_score:.2f} < {min_f1}"
-                    )
-            if violations:
-                return {"passed": False, "violations": violations}
-            return {"passed": True}
+            return _benchmark_gate_status()
         except Exception as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from archex.models import (
@@ -21,6 +22,20 @@ from archex.observe import PipelineTrace, StepTiming
 
 if TYPE_CHECKING:
     from archex.index.graph import DependencyGraph
+
+
+@dataclass(frozen=True)
+class _Hop2Expansion:
+    graph: DependencyGraph
+    candidate_map: dict[str, CodeChunk]
+    chunks_by_file: dict[str, list[CodeChunk]]
+    hop1_files_added: list[str]
+    seed_files: set[str]
+    expansion_priority: dict[str, float]
+    query_terms: set[str]
+    remaining_budget: int
+    max_per_file: int
+
 
 logger = logging.getLogger(__name__)
 
@@ -366,6 +381,56 @@ def _add_file_chunks(
     return added
 
 
+def _initial_candidate_map(
+    search_results: list[tuple[CodeChunk, float]],
+    vector_results: list[tuple[CodeChunk, float]] | None,
+) -> dict[str, CodeChunk]:
+    candidate_map = {chunk.id: chunk for chunk, _ in search_results}
+    if vector_results:
+        for chunk, _ in vector_results:
+            candidate_map.setdefault(chunk.id, chunk)
+    return candidate_map
+
+
+def _hop2_expansion_priority(expansion: _Hop2Expansion) -> dict[str, float]:
+    hop1_files = set(expansion.hop1_files_added)
+    hop2_priority: dict[str, float] = {}
+    for hop1_fp in expansion.hop1_files_added:
+        hop1_score = expansion.expansion_priority.get(hop1_fp, 0.0)
+        for dep in expansion.graph.imports_of(hop1_fp):
+            if dep in expansion.seed_files or dep in hop1_files:
+                continue
+            path_match = any(term in dep.lower() for term in expansion.query_terms)
+            priority = hop1_score * (1.5 if path_match else 1.0)
+            hop2_priority[dep] = max(hop2_priority.get(dep, 0.0), priority)
+    return hop2_priority
+
+
+def _add_hop2_expansion(expansion: _Hop2Expansion) -> int:
+    hop2_priority = _hop2_expansion_priority(expansion)
+    hop2_added = 0
+    for file_path in sorted(hop2_priority.keys(), key=lambda f: -hop2_priority[f]):
+        if hop2_added >= expansion.remaining_budget:
+            break
+        if _is_test_file(file_path):
+            continue
+        added = _add_file_chunks(
+            expansion.candidate_map,
+            expansion.chunks_by_file,
+            file_path,
+            max_per_file=expansion.max_per_file,
+        )
+        if added > 0:
+            hop2_added += 1
+
+    logger.debug(
+        "graph_expansion 2-hop: arch_query=True, hop2_candidates=%d, hop2_added=%d",
+        len(hop2_priority),
+        hop2_added,
+    )
+    return hop2_added
+
+
 def _dependency_subgraph(
     graph: DependencyGraph,
     included_files: list[str],
@@ -603,15 +668,9 @@ def assemble_context(
     # Cap per-file to prevent one large file from monopolizing the expansion budget.
     # Skip test files in expansion — they add noise without improving relevance.
     max_per_file = 3
-    candidate_map: dict[str, CodeChunk] = {}
-    for chunk, _ in search_results:
-        candidate_map[chunk.id] = chunk
-    # Vector-only seeds: add their chunks so they participate in scoring even when
-    # BM25 returned nothing for that file.
-    if vector_results:
-        for chunk, _ in vector_results:
-            if chunk.id not in candidate_map:
-                candidate_map[chunk.id] = chunk
+    # Vector-only seeds participate in scoring even when BM25 returned nothing
+    # for that file.
+    candidate_map = _initial_candidate_map(search_results, vector_results)
     expansion_files_added = 0
     hop1_files_added: list[str] = []
     for file_path in sorted_expansion:
@@ -633,37 +692,18 @@ def assemble_context(
     if is_arch_query and hop1_files_added:
         remaining_budget = MAX_EXPANSION_FILES - expansion_files_added
         if remaining_budget > 0:
-            hop2_priority: dict[str, float] = {}
-            for hop1_fp in hop1_files_added:
-                hop1_score = expansion_priority.get(hop1_fp, 0.0)
-                for dep in graph.imports_of(hop1_fp):
-                    if dep not in seed_files and dep not in set(hop1_files_added):
-                        path_lower = dep.lower()
-                        path_match = any(t in path_lower for t in q_terms)
-                        priority = hop1_score * (1.5 if path_match else 1.0)
-                        hop2_priority[dep] = max(hop2_priority.get(dep, 0.0), priority)
-
-            sorted_hop2 = sorted(hop2_priority.keys(), key=lambda f: -hop2_priority[f])
-            hop2_added = 0
-            for file_path in sorted_hop2:
-                if _is_test_file(file_path):
-                    continue
-                if hop2_added >= remaining_budget:
-                    break
-                added = _add_file_chunks(
-                    candidate_map,
-                    chunks_by_file,
-                    file_path,
+            expansion_files_added += _add_hop2_expansion(
+                _Hop2Expansion(
+                    graph=graph,
+                    candidate_map=candidate_map,
+                    chunks_by_file=chunks_by_file,
+                    hop1_files_added=hop1_files_added,
+                    seed_files=seed_files,
+                    expansion_priority=expansion_priority,
+                    query_terms=q_terms,
+                    remaining_budget=remaining_budget,
                     max_per_file=max_per_file,
                 )
-                if added > 0:
-                    hop2_added += 1
-                    expansion_files_added += 1
-
-            logger.debug(
-                "graph_expansion 2-hop: arch_query=True, hop2_candidates=%d, hop2_added=%d",
-                len(hop2_priority),
-                hop2_added,
             )
 
     candidates_after_expansion = len(candidate_map)


### PR DESCRIPTION
## Summary

This PR reduces complexity in three existing hotspots without changing public APIs or retrieval behavior. The branch keeps the changes split by ownership area: indexing flow, context assembly, HTTP benchmark routes, and pytest marker configuration.

## Changes

- Extracts the delta-indexing branch of `_ensure_index` into `_try_delta_index` and groups its inputs in `_DeltaIndexAttempt`. This keeps the cache-hit/full-index routing visible at the top level while preserving the existing delta fallback behavior.
- Extracts context candidate-map construction and architecture-query 2-hop graph expansion into helper functions backed by `_Hop2Expansion`. This reduces `assemble_context` nesting while preserving expansion priority, test-file filtering, per-file caps, and metadata counts.
- Extracts benchmark baseline loading, summary formatting, and gate evaluation from FastAPI route closures into route-local helpers. This removes repeated baseline path/read/load code from the endpoint definitions.
- Registers the `network` pytest marker so the real clone smoke test no longer emits `PytestUnknownMarkWarning`.

## Complexity impact

- `_ensure_index`: 48 cognitive complexity -> 8
- `assemble_context`: 99 cognitive complexity -> 64
- `create_app`: 52 cognitive complexity -> 37

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest`

Full pytest result from the branch: `1867 passed, 4 deselected`, coverage `91.52%` against the configured `85%` gate. The 4 deselected tests are the repo-configured `slow` tests excluded by `-m 'not slow'`.

## Notes

No new dependencies, public API changes, or behavior changes are introduced. The refactor is structural: helper extraction, parameter grouping, and pytest marker registration.
