### PR TITLE
feat(config): load repo-local project settings

### DIFF
--- a/src/archex/__init__.py
+++ b/src/archex/__init__.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from archex.api import analyze, compare, query
-
 __version__ = "0.5.0"
+
+from archex.api import analyze, compare, query
 
 __all__ = ["analyze", "query", "compare", "__version__"]

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -53,6 +53,7 @@ from archex.analyze.interfaces import extract_interfaces
 from archex.analyze.modules import detect_modules
 from archex.analyze.patterns import detect_patterns
 from archex.cache import CacheManager
+from archex.config import load_config, load_index_config
 from archex.exceptions import ArchexIndexError, DeltaIndexError
 from archex.index.bm25 import BM25Index
 from archex.index.graph import DependencyGraph
@@ -210,7 +211,7 @@ def _ensure_index(
     The caller is responsible for closing the returned store.
     """
     if config is None:
-        config = Config()
+        config = load_config(source)
 
     t_start = time.perf_counter()
     cache = CacheManager(cache_dir=config.cache_dir)
@@ -822,7 +823,7 @@ def analyze(
     The optional ``timing`` parameter records per-phase millisecond breakdowns.
     """
     if config is None:
-        config = Config()
+        config = load_config(source)
     _bootstrap_plugins()
 
     t0 = time.perf_counter()
@@ -922,9 +923,9 @@ def query(
     search, assemble) into the PipelineTrace for structured observability.
     """
     if config is None:
-        config = Config()
+        config = load_config(source)
     if index_config is None:
-        index_config = IndexConfig()
+        index_config = load_index_config(source)
     _bootstrap_plugins()
 
     t0 = time.perf_counter()

--- a/src/archex/cli/analyze_cmd.py
+++ b/src/archex/cli/analyze_cmd.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import click
 
 from archex.api import analyze, get_repo_total_tokens
+from archex.config import load_config
 from archex.exceptions import ArchexError
-from archex.models import Config, PipelineTiming
+from archex.models import PipelineTiming
 from archex.reporting import count_tokens, print_savings, print_timing
 from archex.utils import resolve_source
 
@@ -33,8 +34,9 @@ def analyze_cmd(source: str, output_format: str, languages: tuple[str, ...], tim
     """Analyze a repository and produce an architecture profile."""
     source_obj = resolve_source(source)
 
-    lang_list: list[str] | None = list(languages) if languages else None
-    config = Config(languages=lang_list)
+    config = load_config(source_obj)
+    if languages:
+        config = config.model_copy(update={"languages": list(languages)})
 
     pt = PipelineTiming() if timing else None
     try:

--- a/src/archex/cli/query_cmd.py
+++ b/src/archex/cli/query_cmd.py
@@ -25,8 +25,7 @@ from archex.utils import resolve_source
 @click.option(
     "--strategy",
     type=click.Choice(["bm25", "hybrid"]),
-    default="bm25",
-    show_default=True,
+    default=None,
     help="Retrieval strategy.",
 )
 @click.option("--timing", is_flag=True, default=False, help="Print timing breakdown.")
@@ -37,16 +36,21 @@ def query_cmd(
     budget: int,
     output_format: str,
     language: tuple[str, ...],
-    strategy: str,
+    strategy: str | None,
     timing: bool,
     metrics: bool,
 ) -> None:
     """Query a repository and return a context bundle."""
-    from archex.models import Config, IndexConfig, PipelineTiming
+    from archex.config import load_config, load_index_config
+    from archex.models import PipelineTiming
 
     repo_source = resolve_source(source)
-    config = Config(languages=list(language) if language else None)
-    index_config = IndexConfig(vector=(strategy == "hybrid"))
+    config = load_config(repo_source)
+    if language:
+        config = config.model_copy(update={"languages": list(language)})
+    index_config = load_index_config(repo_source)
+    if strategy is not None:
+        index_config = index_config.model_copy(update={"vector": strategy == "hybrid"})
 
     pt = PipelineTiming() if (timing or metrics) else None
     try:

--- a/src/archex/config.py
+++ b/src/archex/config.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import os
 import tomllib
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
-from archex.models import Config, IndexConfig
+from archex.models import Config, IndexConfig, RepoSource
+from archex.project import ProjectState
 
 DEFAULT_CONFIG = Config()
 
@@ -39,28 +40,105 @@ def _parse_env_value(key: str, value: str) -> Any:
     return value
 
 
-def load_config() -> Config:
-    """Load Config from TOML file and/or ARCHEX_* environment variables.
+def _load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    return data
 
-    Priority: env vars > TOML file > defaults.
-    """
+
+def _config_overrides_from_mapping(data: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in data.items() if k in Config.model_fields}
+
+
+def _index_overrides_from_mapping(data: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in data.items() if k in IndexConfig.model_fields}
+
+
+def _env_overrides(model_fields: dict[str, Any]) -> dict[str, Any]:
     overrides: dict[str, Any] = {}
-
-    # Load from TOML if present
-    if _CONFIG_FILE.exists():
-        with open(_CONFIG_FILE, "rb") as f:
-            toml_data = tomllib.load(f)
-        # Flatten top-level keys into overrides
-        for k, v in toml_data.items():
-            if k in Config.model_fields:
-                overrides[k] = v
-
-    # Environment variables override TOML
     for env_key, env_val in os.environ.items():
         if not env_key.startswith(_ENV_PREFIX):
             continue
         config_key = env_key[len(_ENV_PREFIX) :].lower()
-        if config_key in Config.model_fields:
+        if config_key in model_fields:
             overrides[config_key] = _parse_env_value(config_key, env_val)
+    return overrides
+
+
+def _project_state(source: RepoSource | str | Path | None) -> ProjectState | None:
+    if source is None:
+        return None
+    if isinstance(source, RepoSource):
+        if source.url or not source.local_path:
+            return None
+        path: str | Path = source.local_path
+    else:
+        path = source
+    try:
+        state = ProjectState.resolve(path)
+    except ValueError:
+        return None
+    return state if state.settings_path.exists() else None
+
+
+def _project_index_settings(
+    source: RepoSource | str | Path | None,
+) -> tuple[ProjectState, dict[str, Any]] | None:
+    state = _project_state(source)
+    if state is None:
+        return None
+    settings = _load_toml(state.settings_path)
+    raw_index_settings = settings.get("index", {})
+    if not isinstance(raw_index_settings, dict):
+        raise ValueError(f"Invalid project index settings in {state.settings_path}")
+    index_settings = cast("dict[str, Any]", raw_index_settings)
+    return state, index_settings
+
+
+def _resolve_project_path(value: Any, repo_root: Path) -> Any:
+    if not isinstance(value, str):
+        return value
+    path = Path(value).expanduser()
+    if path.is_absolute():
+        return str(path)
+    return str(repo_root / path)
+
+
+def load_config(source: RepoSource | str | Path | None = None) -> Config:
+    """Load Config from TOML files and ARCHEX_* environment variables.
+
+    Priority: env vars > project TOML > user TOML > defaults.
+    """
+    overrides: dict[str, Any] = {}
+
+    if _CONFIG_FILE.exists():
+        overrides.update(_config_overrides_from_mapping(_load_toml(_CONFIG_FILE)))
+
+    project_settings = _project_index_settings(source)
+    if project_settings is not None:
+        state, index_settings = project_settings
+        project_overrides = _config_overrides_from_mapping(index_settings)
+        if "cache_dir" in project_overrides:
+            project_overrides["cache_dir"] = _resolve_project_path(
+                project_overrides["cache_dir"],
+                state.repo_root,
+            )
+        overrides.update(project_overrides)
+
+    overrides.update(_env_overrides(Config.model_fields))
 
     return Config(**overrides) if overrides else Config()
+
+
+def load_index_config(source: RepoSource | str | Path | None = None) -> IndexConfig:
+    """Load IndexConfig from project settings and ARCHEX_* environment variables."""
+    overrides: dict[str, Any] = {}
+
+    project_settings = _project_index_settings(source)
+    if project_settings is not None:
+        _state, index_settings = project_settings
+        overrides.update(_index_overrides_from_mapping(index_settings))
+
+    overrides.update(_env_overrides(IndexConfig.model_fields))
+
+    return IndexConfig(**overrides) if overrides else IndexConfig()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
 
 from archex import __version__
 from archex.cli.main import cli
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def test_version() -> None:
@@ -114,6 +112,68 @@ def test_query_success_outputs_prompt(python_simple_repo: Path) -> None:
     )
     assert result.exit_code == 0, result.output
     assert len(result.output.strip()) > 0
+
+
+def test_query_uses_project_config_when_cli_args_omitted(python_simple_repo: Path) -> None:
+    from archex.project import init_project
+
+    class FakeBundle:
+        chunks: list[object] = []
+        token_count = 0
+
+        def to_prompt(self, *, format: str) -> str:
+            return f"format={format}"
+
+    init_project(python_simple_repo)
+    runner = CliRunner()
+
+    with patch("archex.cli.query_cmd.query", return_value=FakeBundle()) as query_mock:
+        result = runner.invoke(
+            cli,
+            ["query", str(python_simple_repo), "what functions exist?"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "format=xml"
+    config = query_mock.call_args.kwargs["config"]
+    index_config = query_mock.call_args.kwargs["index_config"]
+    assert config.cache_dir == str(python_simple_repo / ".archex")
+    assert config.languages == []
+    assert index_config.vector is False
+
+
+def test_query_cli_options_override_project_config(python_simple_repo: Path) -> None:
+    from archex.project import init_project
+
+    class FakeBundle:
+        chunks: list[object] = []
+        token_count = 0
+
+        def to_prompt(self, *, format: str) -> str:
+            return f"format={format}"
+
+    init_project(python_simple_repo)
+    runner = CliRunner()
+
+    with patch("archex.cli.query_cmd.query", return_value=FakeBundle()) as query_mock:
+        result = runner.invoke(
+            cli,
+            [
+                "query",
+                str(python_simple_repo),
+                "what functions exist?",
+                "--language",
+                "python",
+                "--strategy",
+                "hybrid",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    config = query_mock.call_args.kwargs["config"]
+    index_config = query_mock.call_args.kwargs["index_config"]
+    assert config.languages == ["python"]
+    assert index_config.vector is True
 
 
 def test_query_timing_flag(python_simple_repo: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,17 +1,20 @@
 """Tests for archex.config — load_config and _parse_env_value."""
+# pyright: reportPrivateUsage=false
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 
 import archex.config as cfg_module
-from archex.config import _parse_env_value, load_config  # pyright: ignore[reportPrivateUsage]
-from archex.models import Config
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from archex.config import (  # pyright: ignore[reportPrivateUsage]
+    _parse_env_value,
+    load_config,
+    load_index_config,
+)
+from archex.models import Config, IndexConfig, RepoSource
+from archex.project import init_project
 
 # ---------------------------------------------------------------------------
 # _parse_env_value
@@ -139,6 +142,69 @@ def test_load_config_env_overrides_toml(tmp_path: Path, monkeypatch: pytest.Monk
     config = load_config()
 
     assert config.depth == "full"
+
+
+def test_load_config_project_settings_override_user_defaults(
+    python_simple_repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_config = tmp_path / "config.toml"
+    user_config.write_text(
+        'cache_dir = "/tmp/global-cache"\nlanguages = ["go"]\n', encoding="utf-8"
+    )
+    monkeypatch.setattr(cfg_module, "_CONFIG_FILE", user_config)
+    monkeypatch.delenv("ARCHEX_CACHE_DIR", raising=False)
+    monkeypatch.delenv("ARCHEX_LANGUAGES", raising=False)
+    init_project(python_simple_repo)
+
+    config = load_config(RepoSource(local_path=str(python_simple_repo)))
+
+    assert config.cache_dir == str(python_simple_repo / ".archex")
+    assert config.languages == []
+    assert config.delta_threshold == 0.5
+
+
+def test_load_config_environment_overrides_project_settings(
+    python_simple_repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cfg_module, "_CONFIG_FILE", tmp_path / "missing.toml")
+    monkeypatch.setenv("ARCHEX_CACHE_DIR", "/tmp/env-cache")
+    init_project(python_simple_repo)
+
+    config = load_config(python_simple_repo)
+
+    assert config.cache_dir == "/tmp/env-cache"
+
+
+def test_load_index_config_project_settings(
+    python_simple_repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cfg_module, "_CONFIG_FILE", tmp_path / "missing.toml")
+    monkeypatch.delenv("ARCHEX_VECTOR", raising=False)
+    init_project(python_simple_repo)
+
+    index_config = load_index_config(python_simple_repo)
+
+    assert index_config == IndexConfig(vector=False)
+
+
+def test_load_index_config_environment_overrides_project_settings(
+    python_simple_repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cfg_module, "_CONFIG_FILE", tmp_path / "missing.toml")
+    monkeypatch.setenv("ARCHEX_VECTOR", "true")
+    init_project(python_simple_repo)
+
+    index_config = load_index_config(python_simple_repo)
+
+    assert index_config.vector is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Load repo-local `.archex/settings.toml` `[index]` values into existing `Config` and `IndexConfig` models.
- Preserve explicit caller behavior: passed `Config` / `IndexConfig` instances still bypass implicit loading.
- Resolve relative project `cache_dir` values against the repository root.
- Wire `analyze` and `query` CLI defaults through project config while keeping CLI flags as explicit overrides.

## Stack

Base: `main`

1. #100 `fix/dogfood-query-pipeline-recall` -> `main`
2. #101 `feat/project-init-lifecycle` -> #100
3. This PR `feat/project-config-resolution` -> #101

## Validation

- `uv run ruff check`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest --no-cov tests/test_config.py tests/test_cli.py tests/test_project.py`