### PR TITLE
feat(index): add explicit project index command

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -249,6 +249,21 @@ def _ensure_index(
     return _full_index(source, config, cache, cache_key, timing, index_config=index_config)
 
 
+def index_repository(
+    source: RepoSource,
+    config: Config | None = None,
+    timing: PipelineTiming | None = None,
+    index_config: IndexConfig | None = None,
+) -> IndexStore:
+    """Build or load the index for a repository without running analysis or retrieval."""
+    return _ensure_index(
+        source,
+        config=config,
+        timing=timing,
+        index_config=index_config,
+    )
+
+
 def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
     source = attempt.source
     config = attempt.config

--- a/src/archex/cli/index_cmd.py
+++ b/src/archex/cli/index_cmd.py
@@ -1,0 +1,89 @@
+"""Explicit indexing command for repo-local archex project workflows."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import click
+
+from archex.api import index_repository
+from archex.cache import CacheManager
+from archex.config import load_config, load_index_config
+from archex.exceptions import ArchexError
+from archex.models import PipelineTiming, RepoSource
+
+
+def _language_counts(file_metadata: list[dict[str, str | int]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in file_metadata:
+        language = str(item["language"])
+        counts[language] = counts.get(language, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+@click.command("index")
+@click.argument("source")
+@click.option(
+    "--format",
+    "output_format",
+    default="text",
+    type=click.Choice(["text", "json"]),
+    help="Output format.",
+)
+def index_cmd(source: str, output_format: str) -> None:
+    """Build or refresh the index for SOURCE without running a query."""
+    repo_source = RepoSource(local_path=source)
+    repo_root = Path(source).expanduser().resolve()
+    config = load_config(repo_source)
+    index_config = load_index_config(repo_source)
+    timing = PipelineTiming()
+    started = time.perf_counter()
+    cache = CacheManager(cache_dir=config.cache_dir) if config.cache else None
+    cache_key = cache.cache_key(repo_source) if cache is not None else None
+
+    try:
+        store = index_repository(
+            repo_source,
+            config=config,
+            timing=timing,
+            index_config=index_config,
+        )
+    except ArchexError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    try:
+        file_metadata = store.get_file_metadata()
+        languages = _language_counts(file_metadata)
+        cached_path = cache.get(cache_key) if cache is not None and cache_key is not None else None
+        duration_ms = int((time.perf_counter() - started) * 1000)
+        summary = {
+            "repo_root": str(repo_root),
+            "index_path": str(cached_path or store.db_path),
+            "commit_hash": store.get_metadata("commit_hash") or "",
+            "strategy": timing.strategy or "full",
+            "files_indexed": store.get_file_count(),
+            "chunks_indexed": store.get_chunk_count(),
+            "languages": languages,
+            "duration_ms": duration_ms,
+        }
+    finally:
+        store.close()
+
+    if output_format == "json":
+        click.echo(json.dumps(summary, indent=2, sort_keys=True))
+        return
+
+    click.echo(f"Indexed repository: {summary['repo_root']}")
+    click.echo(f"Index path:         {summary['index_path']}")
+    click.echo(f"Commit:             {summary['commit_hash'] or 'none'}")
+    click.echo(f"Strategy:           {summary['strategy']}")
+    click.echo(f"Files indexed:      {summary['files_indexed']}")
+    click.echo(f"Chunks indexed:     {summary['chunks_indexed']}")
+    if languages:
+        language_summary = ", ".join(f"{language}={count}" for language, count in languages.items())
+    else:
+        language_summary = "none"
+    click.echo(f"Languages:          {language_summary}")
+    click.echo(f"Duration:           {summary['duration_ms']} ms")

--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -9,6 +9,7 @@ from archex.cli.analyze_cmd import analyze_cmd
 from archex.cli.benchmark_cmd import benchmark_cmd
 from archex.cli.cache_cmd import cache_cmd
 from archex.cli.compare_cmd import compare_cmd
+from archex.cli.index_cmd import index_cmd
 from archex.cli.init_cmd import init_cmd
 from archex.cli.mcp_cmd import mcp_cmd
 from archex.cli.outline_cmd import outline_cmd
@@ -31,6 +32,7 @@ cli.add_command(query_cmd)
 cli.add_command(compare_cmd)
 cli.add_command(cache_cmd)
 cli.add_command(init_cmd)
+cli.add_command(index_cmd)
 cli.add_command(mcp_cmd)
 cli.add_command(tree_cmd)
 cli.add_command(outline_cmd)

--- a/src/archex/config.py
+++ b/src/archex/config.py
@@ -47,7 +47,15 @@ def _load_toml(path: Path) -> dict[str, Any]:
 
 
 def _config_overrides_from_mapping(data: dict[str, Any]) -> dict[str, Any]:
-    return {k: v for k, v in data.items() if k in Config.model_fields}
+    overrides: dict[str, Any] = {}
+    for key, value in data.items():
+        if key not in Config.model_fields:
+            continue
+        if key == "languages" and value == []:
+            overrides[key] = None
+        else:
+            overrides[key] = value
+    return overrides
 
 
 def _index_overrides_from_mapping(data: dict[str, Any]) -> dict[str, Any]:

--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -613,6 +613,11 @@ class IndexStore:
         return Path(self._db_path).with_suffix(f".{vector_mode}.{surrogate_version}.vectors.npz")
 
     @property
+    def db_path(self) -> Path:
+        """Path to the SQLite database backing this store."""
+        return Path(self._db_path)
+
+    @property
     def vector_index_path(self) -> Path:
         """Backward-compatible raw vector index path."""
         return self.vector_index_path_for()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,7 @@ def test_help_contains_subcommands() -> None:
     assert "compare" in output
     assert "cache" in output
     assert "init" in output
+    assert "index" in output
 
 
 def test_init_command_creates_project_state(python_simple_repo: Path) -> None:
@@ -59,6 +60,72 @@ def test_init_command_reset_requires_force(python_simple_repo: Path) -> None:
 
     assert result.exit_code != 0
     assert "--reset requires --force" in result.output
+
+
+class FakeIndexStore:
+    db_path = Path("/tmp/archex-index.db")
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def get_file_metadata(self) -> list[dict[str, str | int]]:
+        return [
+            {"file_path": "src/app.py", "language": "python", "lines": 10, "symbol_count": 2},
+            {"file_path": "src/util.py", "language": "python", "lines": 8, "symbol_count": 1},
+            {"file_path": "web/app.ts", "language": "typescript", "lines": 20, "symbol_count": 3},
+        ]
+
+    def get_metadata(self, key: str) -> str | None:
+        if key == "commit_hash":
+            return "abc123"
+        return None
+
+    def get_file_count(self) -> int:
+        return 3
+
+    def get_chunk_count(self) -> int:
+        return 6
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_index_command_uses_project_config(python_simple_repo: Path) -> None:
+    from archex.project import init_project
+
+    init_project(python_simple_repo)
+    store = FakeIndexStore()
+    runner = CliRunner()
+
+    with patch("archex.cli.index_cmd.index_repository", return_value=store) as index_mock:
+        result = runner.invoke(cli, ["index", str(python_simple_repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "Indexed repository:" in result.output
+    assert "Strategy:" in result.output
+    assert "python=2" in result.output
+    config = index_mock.call_args.kwargs["config"]
+    index_config = index_mock.call_args.kwargs["index_config"]
+    assert config.cache_dir == str(python_simple_repo / ".archex")
+    assert index_config.vector is False
+    assert store.closed is True
+
+
+def test_index_command_json_output(python_simple_repo: Path) -> None:
+    store = FakeIndexStore()
+    runner = CliRunner()
+
+    with patch("archex.cli.index_cmd.index_repository", return_value=store):
+        result = runner.invoke(cli, ["index", str(python_simple_repo), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["repo_root"] == str(python_simple_repo.resolve())
+    assert data["index_path"] == "/tmp/archex-index.db"
+    assert data["commit_hash"] == "abc123"
+    assert data["files_indexed"] == 3
+    assert data["chunks_indexed"] == 6
+    assert data["languages"] == {"python": 2, "typescript": 1}
 
 
 def test_analyze_local_json(python_simple_repo: Path) -> None:
@@ -138,7 +205,7 @@ def test_query_uses_project_config_when_cli_args_omitted(python_simple_repo: Pat
     config = query_mock.call_args.kwargs["config"]
     index_config = query_mock.call_args.kwargs["index_config"]
     assert config.cache_dir == str(python_simple_repo / ".archex")
-    assert config.languages == []
+    assert config.languages is None
     assert index_config.vector is False
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -161,7 +161,7 @@ def test_load_config_project_settings_override_user_defaults(
     config = load_config(RepoSource(local_path=str(python_simple_repo)))
 
     assert config.cache_dir == str(python_simple_repo / ".archex")
-    assert config.languages == []
+    assert config.languages is None
     assert config.delta_threshold == 0.5
 
 


### PR DESCRIPTION
## Summary

- Add explicit `archex index .` command that builds or loads an index without running query/analyze flows.
- Route the command through the existing `_ensure_index(...)` path via public `index_repository(...)`.
- Load repo-local project config from `.archex/settings.toml` and report the persisted cache DB path under `.archex/` when caching is enabled.
- Treat `languages = []` in TOML config as no language filter so initialized projects index all supported languages while explicit API/CLI language overrides remain explicit.

## Stack

| Order | PR | Branch | Base | Status |
| ---: | --- | --- | --- | --- |
| 1 | #100 | `fix/dogfood-query-pipeline-recall` | `main` | CI green |
| 2 | #101 | `feat/project-init-lifecycle` | `fix/dogfood-query-pipeline-recall` | CI green |
| 3 | #102 | `feat/project-config-resolution` | `feat/project-init-lifecycle` | CI green |
| 4 | This PR | `feat/project-index-command` | `feat/project-config-resolution` | local validation passed |

## Scope Boundaries

- Does not implement working-tree dirty detection or freshness semantics.
- Does not add `archex status`, `archex reset`, or `archex dogfood`.
- Does not change fixed `.archex/index.db` storage identity; this slice keeps the existing cache-keyed storage path under repo-local `.archex/`.

## Validation

- `uv run ruff check`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest --no-cov tests/test_cli.py tests/test_config.py tests/test_cache.py tests/test_project.py tests/index/test_delta.py tests/benchmark/test_delta_strategies.py`
- `uv run archex index . --format json` -> 266 files, 4169 chunks, repo-local `.archex/<key>.db`, cached strategy after fresh build
