### PR TITLE
feat(cache): use fixed project index storage

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -90,6 +90,7 @@ from archex.parse import (
 from archex.parse.adapters import LanguageAdapter, default_adapter_registry
 from archex.pipeline.chunker import ASTChunker, Chunker
 from archex.pipeline.service import build_chunk_surrogates
+from archex.project import uses_project_cache_layout
 from archex.serve.compare import compare_repos
 from archex.serve.context import assemble_context, passthrough_context
 from archex.serve.profile import build_profile
@@ -104,6 +105,16 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Acquisition + Indexing — shared helpers for all entry points
 # ---------------------------------------------------------------------------
+
+
+def _cache_manager_for_source(source: RepoSource, config: Config) -> CacheManager:
+    project_layout = False
+    if source.local_path:
+        try:
+            project_layout = uses_project_cache_layout(source.local_path, config.cache_dir)
+        except ValueError:
+            project_layout = False
+    return CacheManager(cache_dir=config.cache_dir, project_layout=project_layout)
 
 
 def _full_index(
@@ -214,7 +225,7 @@ def _ensure_index(
         config = load_config(source)
 
     t_start = time.perf_counter()
-    cache = CacheManager(cache_dir=config.cache_dir)
+    cache = _cache_manager_for_source(source, config)
     cache_key = cache.cache_key(source)
 
     # Path 1: Exact cache hit (same commit) — fast path
@@ -947,7 +958,7 @@ def query(
     if trace is not None:
         trace.operation = "query"
         trace.start_ns = time.perf_counter_ns()
-    cache = CacheManager(cache_dir=config.cache_dir)
+    cache = _cache_manager_for_source(source, config)
     cache_key = cache.cache_key(source)
 
     # Check cache BEFORE parsing — if cached, skip the expensive parse pipeline

--- a/src/archex/cache.py
+++ b/src/archex/cache.py
@@ -22,9 +22,15 @@ _KEY_RE = re.compile(r"^[0-9a-f]{64}$")
 class CacheManager:
     """Manage cached SQLite analysis artifacts on disk."""
 
-    def __init__(self, cache_dir: str = "~/.archex/cache") -> None:
+    def __init__(
+        self,
+        cache_dir: str = "~/.archex/cache",
+        *,
+        project_layout: bool = False,
+    ) -> None:
         self._cache_dir = Path(cache_dir).expanduser()
         self._cache_dir.mkdir(parents=True, exist_ok=True)
+        self._project_layout = project_layout
 
     # ------------------------------------------------------------------
     # Key helpers
@@ -107,11 +113,15 @@ class CacheManager:
 
     def db_path(self, key: str) -> Path:
         """Return the database path for a cache key."""
+        if self._project_layout:
+            return self._cache_dir / "index.db"
         self._validate_key(key)
         return self._cache_dir / f"{key}.db"
 
     def meta_path(self, key: str) -> Path:
         """Return the metadata file path for a cache key."""
+        if self._project_layout:
+            return self._cache_dir / "index.meta"
         self._validate_key(key)
         return self._cache_dir / f"{key}.meta"
 
@@ -123,6 +133,12 @@ class CacheManager:
         surrogate_version: str = "v1",
     ) -> Path:
         """Return the representation-specific vector index file path for a cache key."""
+        if self._project_layout:
+            vector_dir = self._cache_dir / "vectors"
+            vector_dir.mkdir(parents=True, exist_ok=True)
+            if vector_mode == "raw":
+                return vector_dir / "raw.vectors.npz"
+            return vector_dir / f"{vector_mode}.{surrogate_version}.vectors.npz"
         self._validate_key(key)
         if vector_mode == "raw":
             return self._cache_dir / f"{key}.vectors.npz"
@@ -135,9 +151,11 @@ class CacheManager:
     def get(self, key: str) -> Path | None:
         """Return cached db Path if it exists, else None."""
         db = self.db_path(key)
-        if db.exists():
-            return db
-        return None
+        if not db.exists():
+            return None
+        if self._project_layout and self.get_meta(key).get("cache_key") != key:
+            return None
+        return db
 
     def put(
         self,
@@ -155,6 +173,7 @@ class CacheManager:
         shutil.copy2(str(source_db), str(dest))
         meta = self.meta_path(key)
         meta_data = {
+            "cache_key": key,
             "created_at": str(time.time()),
             "resolved_commit": resolved_commit or "",
             "source_identity": source_identity or "",
@@ -205,6 +224,21 @@ class CacheManager:
     def list_entries(self) -> list[dict[str, str]]:
         """Return a list of cache entries with key, path, size_bytes, created_at."""
         entries: list[dict[str, str]] = []
+        if self._project_layout:
+            db = self._cache_dir / "index.db"
+            if not db.exists():
+                return entries
+            meta_data = self.get_meta("")
+            entries.append(
+                {
+                    "key": "project",
+                    "path": str(db),
+                    "size_bytes": str(db.stat().st_size),
+                    "created_at": meta_data.get("created_at", "0"),
+                }
+            )
+            return entries
+
         for db in sorted(self._cache_dir.glob("*.db")):
             key = db.stem
             meta_data = self.get_meta(key)
@@ -221,6 +255,16 @@ class CacheManager:
 
     def clean(self, max_age_hours: int = 24) -> int:
         """Remove entries older than max_age_hours. Return count removed."""
+        if self._project_layout:
+            db = self._cache_dir / "index.db"
+            if db.exists() and self.is_stale("", max_age_hours):
+                db.unlink()
+                meta = self._cache_dir / "index.meta"
+                if meta.exists():
+                    meta.unlink()
+                return 1
+            return 0
+
         removed = 0
         for db in list(self._cache_dir.glob("*.db")):
             key = db.stem

--- a/src/archex/cli/index_cmd.py
+++ b/src/archex/cli/index_cmd.py
@@ -13,6 +13,7 @@ from archex.cache import CacheManager
 from archex.config import load_config, load_index_config
 from archex.exceptions import ArchexError
 from archex.models import PipelineTiming, RepoSource
+from archex.project import uses_project_cache_layout
 
 
 def _language_counts(file_metadata: list[dict[str, str | int]]) -> dict[str, int]:
@@ -40,7 +41,15 @@ def index_cmd(source: str, output_format: str) -> None:
     index_config = load_index_config(repo_source)
     timing = PipelineTiming()
     started = time.perf_counter()
-    cache = CacheManager(cache_dir=config.cache_dir) if config.cache else None
+    try:
+        project_layout = uses_project_cache_layout(source, config.cache_dir)
+    except ValueError:
+        project_layout = False
+    cache = (
+        CacheManager(cache_dir=config.cache_dir, project_layout=project_layout)
+        if config.cache
+        else None
+    )
     cache_key = cache.cache_key(repo_source) if cache is not None else None
 
     try:

--- a/src/archex/project.py
+++ b/src/archex/project.py
@@ -50,6 +50,14 @@ class ProjectState:
         return self.project_dir / "metadata.json"
 
     @property
+    def index_path(self) -> Path:
+        return self.project_dir / "index.db"
+
+    @property
+    def vector_dir(self) -> Path:
+        return self.project_dir / "vectors"
+
+    @property
     def dogfood_dir(self) -> Path:
         return self.project_dir / "dogfood"
 
@@ -156,3 +164,12 @@ def ensure_project_gitignore(gitignore_path: Path) -> bool:
     lines.append(PROJECT_GITIGNORE_ENTRY)
     gitignore_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return True
+
+
+def uses_project_cache_layout(source: str | Path, cache_dir: str) -> bool:
+    """Return whether cache_dir points at an initialized repo-local `.archex` store."""
+    state = ProjectState.resolve(source)
+    configured = Path(cache_dir).expanduser()
+    if not configured.is_absolute():
+        configured = state.repo_root / configured
+    return state.initialized() and configured.resolve() == state.project_dir

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -109,6 +109,32 @@ def test_info_returns_summary(cache: CacheManager, sample_db: Path) -> None:
     assert "cache_dir" in info
 
 
+def test_project_layout_uses_fixed_repo_local_paths(tmp_path: Path, sample_db: Path) -> None:
+    cache = CacheManager(cache_dir=str(tmp_path / ".archex"), project_layout=True)
+
+    stored = cache.put(KEY_A, sample_db, resolved_commit="abc123")
+
+    assert stored == tmp_path / ".archex" / "index.db"
+    assert cache.get(KEY_A) == stored
+    assert cache.get(KEY_B) is None
+    assert cache.meta_path(KEY_A) == tmp_path / ".archex" / "index.meta"
+    assert cache.vector_path(KEY_A) == tmp_path / ".archex" / "vectors" / "raw.vectors.npz"
+    assert cache.vector_path(
+        KEY_A,
+        vector_mode="surrogate",
+        surrogate_version="v2",
+    ) == (tmp_path / ".archex" / "vectors" / "surrogate.v2.vectors.npz")
+    entries = cache.list_entries()
+    assert entries == [
+        {
+            "key": "project",
+            "path": str(stored),
+            "size_bytes": str(stored.stat().st_size),
+            "created_at": cache.get_meta(KEY_A)["created_at"],
+        }
+    ]
+
+
 def test_cache_key_is_stable(cache: CacheManager) -> None:
     source = RepoSource(url="https://github.com/example/repo")
     key1 = cache.cache_key(source)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,6 +128,21 @@ def test_index_command_json_output(python_simple_repo: Path) -> None:
     assert data["languages"] == {"python": 2, "typescript": 1}
 
 
+def test_index_command_writes_fixed_project_index_path(python_simple_repo: Path) -> None:
+    from archex.project import init_project
+
+    init_project(python_simple_repo)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["index", str(python_simple_repo), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["index_path"] == str(python_simple_repo / ".archex" / "index.db")
+    assert (python_simple_repo / ".archex" / "index.db").exists()
+    assert not list((python_simple_repo / ".archex").glob("[0-9a-f]" * 64 + ".db"))
+
+
 def test_analyze_local_json(python_simple_repo: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["analyze", str(python_simple_repo), "--format", "json"])


### PR DESCRIPTION
## Scope

This slice completes fixed repo-local index storage for initialized projects.

- routes initialized project cache config to a fixed `.archex/index.db` layout
- stores project vectors under `.archex/vectors/`
- keeps global cache behavior on keyed `<sha>.db` paths unchanged
- records the active cache key in project metadata so a changed HEAD does not become a false exact-hit on the fixed path
- adds cache and CLI smoke coverage for fixed repo-local storage

Out of scope: working-tree freshness detection, `archex status`, `archex reset`, cwd-default CLI parsing, dogfood reporting, and docs updates.

## Stack

| Order | PR | Branch | Base | Scope |
| ---: | --- | --- | --- | --- |
| 1 | #100 | `fix/dogfood-query-pipeline-recall` | `main` | Query pipeline recall fix |
| 2 | #101 | `feat/project-init-lifecycle` | `fix/dogfood-query-pipeline-recall` | `archex init` lifecycle |
| 3 | #102 | `feat/project-config-resolution` | `feat/project-init-lifecycle` | Repo-local config resolution |
| 4 | #103 | `feat/project-index-command` | `feat/project-config-resolution` | Explicit `archex index` command |
| 5 | This PR | `feat/project-local-index-storage` | `feat/project-index-command` | Fixed `.archex/index.db` storage |

## Validation

- `uv run ruff check`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest --no-cov tests/test_cache.py::test_project_layout_uses_fixed_repo_local_paths tests/test_cli.py::test_index_command_writes_fixed_project_index_path tests/test_cli.py::test_index_command_uses_project_config tests/test_cli.py::test_index_command_json_output`
- `uv run pytest --no-cov tests/test_cache.py tests/test_cli.py tests/test_config.py tests/test_project.py tests/index/test_delta.py tests/benchmark/test_delta_strategies.py`
- `uv run archex init .`
- `uv run archex index . --format json`
