### PR TITLE
feat(index): detect dirty working trees

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -181,6 +181,7 @@ def _full_index(
             store.set_metadata("commit_hash", commit)
             store.set_metadata("source_identity", identity)
             store.set_metadata("indexed_at", str(time.time()))
+            _set_working_tree_signature(store, repo_path, config)
             store.conn.execute("PRAGMA wal_checkpoint(FULL)")
             cache.put(
                 cache_key,
@@ -203,6 +204,7 @@ class _DeltaIndexAttempt:
     config: Config
     cache: CacheManager
     cache_key: str
+    working_tree_signature: str | None
     timing: PipelineTiming | None
     index_config: IndexConfig | None
     t_start: float
@@ -227,19 +229,26 @@ def _ensure_index(
     t_start = time.perf_counter()
     cache = _cache_manager_for_source(source, config)
     cache_key = cache.cache_key(source)
+    working_tree_signature = _working_tree_signature(source, config)
 
     # Path 1: Exact cache hit (same commit) — fast path
     cached_db = cache.get(cache_key) if config.cache else None
     if cached_db is not None:
         store = IndexStore(cached_db)
-        if not store.needs_reindex():
+        store_signature = store.get_metadata("working_tree_signature")
+        signature_matches = (
+            working_tree_signature is None or store_signature == working_tree_signature
+        )
+        needs_reindex = store.needs_reindex()
+        if not needs_reindex and signature_matches:
             if timing is not None:
                 timing.cached = True
                 timing.strategy = "cached"
                 timing.index_ms = _elapsed_ms(t_start)
             return store
         store.close()
-        cache.invalidate(cache_key)
+        if needs_reindex:
+            cache.invalidate(cache_key)
 
     # Path 2: Delta path — same repo, different commit (local repos only)
     delta_store = _try_delta_index(
@@ -248,6 +257,7 @@ def _ensure_index(
             config=config,
             cache=cache,
             cache_key=cache_key,
+            working_tree_signature=working_tree_signature,
             timing=timing,
             index_config=index_config,
             t_start=t_start,
@@ -287,14 +297,37 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
 
     db_path, cached_commit = existing
     current_commit = CacheManager.git_head(source.local_path)
-    if not current_commit or cached_commit == current_commit:
+    if not current_commit:
+        return None
+    same_commit = cached_commit == current_commit
+    if same_commit and attempt.working_tree_signature is None:
         return None
 
     try:
-        from archex.index.delta import apply_delta, compute_delta
+        from archex.index.delta import apply_delta, compute_delta, compute_mtime_delta
 
         repo_path = Path(source.local_path).resolve()
-        manifest = compute_delta(repo_path, cached_commit, current_commit)
+        store = IndexStore(db_path) if same_commit else None
+        try:
+            if same_commit:
+                if store is None:
+                    return None
+                indexed_signature = store.get_metadata("working_tree_signature")
+                if indexed_signature == attempt.working_tree_signature:
+                    return None
+                indexed_at = _metadata_float(store.get_metadata("indexed_at"))
+                manifest = compute_mtime_delta(repo_path, store, indexed_at)
+                manifest.base_commit = cached_commit
+                manifest.current_commit = current_commit
+            else:
+                manifest = compute_delta(repo_path, cached_commit, current_commit)
+        finally:
+            if store is not None:
+                store.close()
+
+        if not manifest.changes and same_commit:
+            return None
+
         total_files = len(
             discover_files(
                 repo_path,
@@ -322,6 +355,8 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
         store.set_metadata("commit_hash", current_commit)
         store.set_metadata("source_identity", identity)
         store.set_metadata("indexed_at", str(time.time()))
+        if attempt.working_tree_signature is not None:
+            store.set_metadata("working_tree_signature", attempt.working_tree_signature)
         store.conn.execute("PRAGMA wal_checkpoint(FULL)")
         attempt.cache.put(
             attempt.cache_key,
@@ -342,6 +377,34 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
             attempt.timing.delta_attempted = True
         logger.info("Delta indexing failed, falling back to full re-index")
         return None
+
+
+def _working_tree_signature(source: RepoSource, config: Config) -> str | None:
+    if not source.local_path:
+        return None
+    repo_path = Path(source.local_path).expanduser().resolve()
+    if not (repo_path / ".git").exists():
+        return None
+    from archex.index.delta import compute_working_tree_signature
+
+    return compute_working_tree_signature(repo_path, config)
+
+
+def _set_working_tree_signature(store: IndexStore, repo_path: Path, config: Config) -> None:
+    if not (repo_path / ".git").exists():
+        return
+    from archex.index.delta import compute_working_tree_signature
+
+    store.set_metadata("working_tree_signature", compute_working_tree_signature(repo_path, config))
+
+
+def _metadata_float(value: str | None) -> float:
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except ValueError:
+        return 0.0
 
 
 def _chunk_to_symbol_source(chunk: CodeChunk) -> SymbolSource:
@@ -1301,6 +1364,7 @@ def query(
                 store.set_metadata("commit_hash", commit)
                 store.set_metadata("source_identity", identity)
                 store.set_metadata("indexed_at", str(time.time()))
+                _set_working_tree_signature(store, repo_path, config)
                 store.conn.execute("PRAGMA wal_checkpoint(FULL)")
                 cache.put(
                     cache_key,

--- a/src/archex/cache.py
+++ b/src/archex/cache.py
@@ -170,7 +170,8 @@ class CacheManager:
         import json
 
         dest = self.db_path(key)
-        shutil.copy2(str(source_db), str(dest))
+        if source_db.resolve() != dest.resolve():
+            shutil.copy2(str(source_db), str(dest))
         meta = self.meta_path(key)
         meta_data = {
             "cache_key": key,

--- a/src/archex/index/delta.py
+++ b/src/archex/index/delta.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import subprocess
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from archex.acquire.discovery import EXTENSION_MAP
 from archex.exceptions import DeltaIndexError
 from archex.models import (
     ChangeStatus,
@@ -26,6 +29,68 @@ if TYPE_CHECKING:
     from archex.models import CodeChunk, Config, DiscoveredFile, ImportStatement
 
 logger = logging.getLogger(__name__)
+
+
+def _is_source_path(path: str, languages: list[str] | None) -> bool:
+    language = EXTENSION_MAP.get(Path(path).suffix.lower())
+    if language is None:
+        return False
+    return languages is None or language in languages
+
+
+def _parse_porcelain_path(line: str) -> tuple[str, str] | None:
+    if len(line) < 4:
+        return None
+    status = line[:2]
+    path = line[3:]
+    if " -> " in path:
+        path = path.rsplit(" -> ", maxsplit=1)[1]
+    return status, path
+
+
+def compute_working_tree_signature(repo_path: Path, config: Config) -> str:
+    """Return a content signature for changed source files in a git working tree."""
+    if not (repo_path / ".git").exists():
+        return ""
+
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain", "--untracked-files=all"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise DeltaIndexError("git status timed out after 30s") from exc
+    except OSError as exc:
+        raise DeltaIndexError(f"git status failed: {exc}") from exc
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise DeltaIndexError(f"git status failed: {stderr}")
+
+    changed: list[dict[str, str | int]] = []
+    for line in result.stdout.splitlines():
+        parsed = _parse_porcelain_path(line)
+        if parsed is None:
+            continue
+        status, path = parsed
+        if not _is_source_path(path, config.languages):
+            continue
+
+        item: dict[str, str | int] = {"path": path, "status": status}
+        file_path = repo_path / path
+        if file_path.is_file():
+            stat = file_path.stat()
+            item["size"] = stat.st_size
+            item["sha256"] = hashlib.sha256(file_path.read_bytes()).hexdigest()
+        changed.append(item)
+
+    if not changed:
+        return "clean"
+    payload = json.dumps(sorted(changed, key=lambda item: str(item["path"])), sort_keys=True)
+    return hashlib.sha256(payload.encode()).hexdigest()
 
 
 def _parse_name_status_line(line: str) -> FileChange | None:

--- a/tests/index/test_delta.py
+++ b/tests/index/test_delta.py
@@ -10,7 +10,12 @@ from pathlib import Path
 import pytest
 
 from archex.exceptions import DeltaIndexError
-from archex.index.delta import apply_delta, compute_delta, compute_mtime_delta
+from archex.index.delta import (
+    apply_delta,
+    compute_delta,
+    compute_mtime_delta,
+    compute_working_tree_signature,
+)
 from archex.index.store import IndexStore
 from archex.models import ChangeStatus, CodeChunk, Config, IndexConfig
 from archex.pipeline.service import build_chunk_surrogates
@@ -564,6 +569,39 @@ class TestComputeMtimeDelta:
             assert manifest.current_commit == "mtime"
         finally:
             store.close()
+
+
+# ---------------------------------------------------------------------------
+# TestComputeWorkingTreeSignature
+# ---------------------------------------------------------------------------
+
+
+class TestComputeWorkingTreeSignature:
+    def test_clean_git_repo_returns_clean(self, delta_test_repo: Path) -> None:
+        signature = compute_working_tree_signature(delta_test_repo, Config(languages=["python"]))
+
+        assert signature == "clean"
+
+    def test_tracked_source_edit_changes_signature(self, delta_test_repo: Path) -> None:
+        clean = compute_working_tree_signature(delta_test_repo, Config(languages=["python"]))
+
+        (delta_test_repo / "utils.py").write_text("def local_edit(): return 1\n")
+        dirty = compute_working_tree_signature(delta_test_repo, Config(languages=["python"]))
+
+        assert clean == "clean"
+        assert dirty != "clean"
+
+    def test_ignored_project_state_does_not_change_signature(self, delta_test_repo: Path) -> None:
+        (delta_test_repo / ".gitignore").write_text(".archex/\n", encoding="utf-8")
+        _git(delta_test_repo, "add", ".gitignore")
+        _git(delta_test_repo, "commit", "-m", "ignore archex state")
+
+        (delta_test_repo / ".archex").mkdir()
+        (delta_test_repo / ".archex" / "index.db").write_text("ignored", encoding="utf-8")
+
+        signature = compute_working_tree_signature(delta_test_repo, Config(languages=["python"]))
+
+        assert signature == "clean"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -833,6 +833,39 @@ class TestDeltaIndexIntegration:
         finally:
             store2.close()
 
+    def test_uncommitted_working_tree_edit_triggers_delta(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        """Uncommitted source edits on the same HEAD refresh the cached index."""
+        import time as _time
+
+        from archex.api import _ensure_index  # pyright: ignore[reportPrivateUsage]
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(
+            languages=["python"],
+            cache=True,
+            cache_dir=str(tmp_path / "cache"),
+        )
+
+        _ensure_index(source, config=config).close()
+
+        _time.sleep(0.01)
+        (python_simple_repo / "utils.py").write_text(
+            "def uncommitted_delta_symbol():\n    return 1\n",
+            encoding="utf-8",
+        )
+
+        timing = PipelineTiming()
+        store = _ensure_index(source, config=config, timing=timing)
+        try:
+            utils_chunks = store.get_chunks_for_file("utils.py")
+            assert any("uncommitted_delta_symbol" in chunk.content for chunk in utils_chunks)
+            assert store.get_metadata("working_tree_signature") != "clean"
+        finally:
+            store.close()
+        assert timing.strategy == "delta"
+
     def test_delta_meta_in_timing(self, python_simple_repo: Path, tmp_path: Path) -> None:
         """PipelineTiming.delta_meta is populated after the delta path executes."""
         source = RepoSource(local_path=str(python_simple_repo))


### PR DESCRIPTION
## Scope

This slice adds working-tree freshness detection to the index lifecycle.

- computes a content signature for changed tracked and untracked source files from `git status --porcelain --untracked-files=all`
- stores `working_tree_signature` in index metadata during full indexing and query indexing
- checks the stored signature before exact cache hits so uncommitted source edits do not serve a stale index
- routes same-HEAD dirty working trees through the existing mtime delta classifier
- preserves ignored `.archex/` state by relying on Git's exclude-standard status behavior
- avoids copying a project fixed-path DB onto itself during in-place delta updates

Out of scope: `archex status`, `archex reset`, cwd-default CLI parsing, dogfood reporting, failure-class reporting, corpus expansion, CI dogfood job, and docs updates.

## Stack

| Order | PR | Branch | Base | Scope |
| ---: | --- | --- | --- | --- |
| 1 | #100 | `fix/dogfood-query-pipeline-recall` | `main` | Query pipeline recall fix |
| 2 | #101 | `feat/project-init-lifecycle` | `fix/dogfood-query-pipeline-recall` | `archex init` lifecycle |
| 3 | #102 | `feat/project-config-resolution` | `feat/project-init-lifecycle` | Repo-local config resolution |
| 4 | #103 | `feat/project-index-command` | `feat/project-config-resolution` | Explicit `archex index` command |
| 5 | #104 | `feat/project-local-index-storage` | `feat/project-index-command` | Fixed `.archex/index.db` storage |
| 6 | This PR | `feat/working-tree-freshness` | `feat/project-local-index-storage` | Dirty working-tree freshness |

## Validation

- `uv run ruff check`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest --no-cov tests/index/test_delta.py::TestComputeWorkingTreeSignature tests/test_integration.py::TestDeltaIndexIntegration::test_uncommitted_working_tree_edit_triggers_delta tests/test_cache.py::test_project_layout_uses_fixed_repo_local_paths`
- `uv run pytest --no-cov tests/test_cache.py tests/test_cli.py tests/test_config.py tests/test_project.py tests/index/test_delta.py tests/benchmark/test_delta_strategies.py tests/test_integration.py::TestDeltaIndexIntegration`
- `uv run archex index . --format json` while the working tree had uncommitted source edits; output reported `strategy: "delta"` and `index_path: ".archex/index.db"`
