### PR TITLE
feat(cli): add project status command

### DIFF
--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -15,6 +15,7 @@ from archex.cli.mcp_cmd import mcp_cmd
 from archex.cli.outline_cmd import outline_cmd
 from archex.cli.query_cmd import query_cmd
 from archex.cli.serve_cmd import serve_cmd
+from archex.cli.status_cmd import status_cmd
 from archex.cli.symbol_cmd import symbol_cmd
 from archex.cli.symbols_cmd import symbols_cmd
 from archex.cli.tree_cmd import tree_cmd
@@ -33,6 +34,7 @@ cli.add_command(compare_cmd)
 cli.add_command(cache_cmd)
 cli.add_command(init_cmd)
 cli.add_command(index_cmd)
+cli.add_command(status_cmd)
 cli.add_command(mcp_cmd)
 cli.add_command(tree_cmd)
 cli.add_command(outline_cmd)

--- a/src/archex/cli/status_cmd.py
+++ b/src/archex/cli/status_cmd.py
@@ -1,0 +1,77 @@
+"""Project lifecycle status command."""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from archex.status import ProjectStatus, inspect_project_status
+
+
+@click.command("status")
+@click.argument("source")
+@click.option("--strict", is_flag=True, default=False, help="Fail unless the index is fresh.")
+@click.option(
+    "--format",
+    "output_format",
+    default="text",
+    type=click.Choice(["text", "json"]),
+    help="Output format.",
+)
+def status_cmd(source: str, strict: bool, output_format: str) -> None:
+    """Inspect repo-local archex project status without indexing."""
+    try:
+        status = inspect_project_status(source)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if output_format == "json":
+        click.echo(json.dumps(_status_payload(status), indent=2, sort_keys=True))
+    else:
+        _render_text(status)
+
+    if status.state == "corrupt" or (strict and status.state != "fresh"):
+        raise click.exceptions.Exit(1)
+
+
+def _status_payload(status: ProjectStatus) -> dict[str, object]:
+    return {
+        "repo_root": str(status.repo_root),
+        "initialized": status.initialized,
+        "state": status.state,
+        "index_path": str(status.index_path),
+        "current_commit": status.current_commit,
+        "indexed_commit": status.indexed_commit,
+        "working_tree": status.working_tree,
+        "files_indexed": status.files_indexed,
+        "chunks_indexed": status.chunks_indexed,
+        "languages": status.languages,
+        "vector_index_available": status.vector_index_available,
+        "dogfood_latest_path": (
+            str(status.dogfood_latest_path) if status.dogfood_latest_path is not None else ""
+        ),
+        "error": status.error,
+    }
+
+
+def _render_text(status: ProjectStatus) -> None:
+    click.echo(f"Repository:         {status.repo_root}")
+    click.echo(f"State:              {status.state}")
+    click.echo(f"Initialized:        {'yes' if status.initialized else 'no'}")
+    click.echo(f"Index path:         {status.index_path}")
+    click.echo(f"Current commit:     {status.current_commit or 'none'}")
+    click.echo(f"Indexed commit:     {status.indexed_commit or 'none'}")
+    click.echo(f"Working tree:       {status.working_tree}")
+    click.echo(f"Files indexed:      {status.files_indexed}")
+    click.echo(f"Chunks indexed:     {status.chunks_indexed}")
+    if status.languages:
+        languages = ", ".join(f"{language}={count}" for language, count in status.languages.items())
+    else:
+        languages = "none"
+    click.echo(f"Languages:          {languages}")
+    click.echo(f"Vector index:       {'yes' if status.vector_index_available else 'no'}")
+    if status.dogfood_latest_path is not None:
+        click.echo(f"Dogfood latest:     {status.dogfood_latest_path}")
+    if status.error:
+        click.echo(f"Error:              {status.error}")

--- a/src/archex/status.py
+++ b/src/archex/status.py
@@ -1,0 +1,155 @@
+"""Read-only repo-local project status inspection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from archex.cache import CacheManager
+from archex.config import load_config
+from archex.index.delta import compute_working_tree_signature
+from archex.index.store import IndexStore
+from archex.project import ProjectState
+
+
+@dataclass(frozen=True)
+class ProjectStatus:
+    repo_root: Path
+    initialized: bool
+    state: str
+    index_path: Path
+    current_commit: str
+    indexed_commit: str
+    working_tree: str
+    files_indexed: int
+    chunks_indexed: int
+    languages: dict[str, int]
+    vector_index_available: bool
+    dogfood_latest_path: Path | None
+    error: str = ""
+
+
+def inspect_project_status(source: str | Path) -> ProjectStatus:
+    """Inspect repo-local lifecycle state without building an index."""
+    project = ProjectState.resolve(source)
+    current_commit = CacheManager.git_head(str(project.repo_root)) or ""
+    index_path = project.index_path
+    dogfood_latest = project.dogfood_dir / "latest.json"
+
+    if not project.initialized():
+        return ProjectStatus(
+            repo_root=project.repo_root,
+            initialized=False,
+            state="uninitialized",
+            index_path=index_path,
+            current_commit=current_commit,
+            indexed_commit="",
+            working_tree="unknown",
+            files_indexed=0,
+            chunks_indexed=0,
+            languages={},
+            vector_index_available=False,
+            dogfood_latest_path=dogfood_latest if dogfood_latest.exists() else None,
+        )
+
+    if not index_path.exists():
+        return ProjectStatus(
+            repo_root=project.repo_root,
+            initialized=True,
+            state="missing_index",
+            index_path=index_path,
+            current_commit=current_commit,
+            indexed_commit="",
+            working_tree="unknown",
+            files_indexed=0,
+            chunks_indexed=0,
+            languages={},
+            vector_index_available=False,
+            dogfood_latest_path=dogfood_latest if dogfood_latest.exists() else None,
+        )
+
+    config = load_config(project.repo_root)
+    current_signature = compute_working_tree_signature(project.repo_root, config)
+
+    try:
+        store = IndexStore(index_path)
+    except Exception as exc:
+        return ProjectStatus(
+            repo_root=project.repo_root,
+            initialized=True,
+            state="corrupt",
+            index_path=index_path,
+            current_commit=current_commit,
+            indexed_commit="",
+            working_tree="unknown",
+            files_indexed=0,
+            chunks_indexed=0,
+            languages={},
+            vector_index_available=False,
+            dogfood_latest_path=dogfood_latest if dogfood_latest.exists() else None,
+            error=str(exc),
+        )
+
+    try:
+        indexed_commit = store.get_metadata("commit_hash") or ""
+        indexed_signature = store.get_metadata("working_tree_signature") or ""
+        files_indexed = store.get_file_count()
+        chunks_indexed = store.get_chunk_count()
+        languages = _language_counts(store.get_file_metadata())
+        needs_reindex = store.needs_reindex()
+    except Exception as exc:
+        return ProjectStatus(
+            repo_root=project.repo_root,
+            initialized=True,
+            state="corrupt",
+            index_path=index_path,
+            current_commit=current_commit,
+            indexed_commit="",
+            working_tree="unknown",
+            files_indexed=0,
+            chunks_indexed=0,
+            languages={},
+            vector_index_available=False,
+            dogfood_latest_path=dogfood_latest if dogfood_latest.exists() else None,
+            error=str(exc),
+        )
+    finally:
+        store.close()
+
+    if needs_reindex:
+        state = "needs_reindex"
+    elif indexed_commit and current_commit and indexed_commit != current_commit:
+        state = "stale"
+    elif indexed_signature != current_signature:
+        state = "dirty"
+    else:
+        state = "fresh"
+
+    return ProjectStatus(
+        repo_root=project.repo_root,
+        initialized=True,
+        state=state,
+        index_path=index_path,
+        current_commit=current_commit,
+        indexed_commit=indexed_commit,
+        working_tree="clean" if current_signature == "clean" else "dirty",
+        files_indexed=files_indexed,
+        chunks_indexed=chunks_indexed,
+        languages=languages,
+        vector_index_available=_vector_index_available(project),
+        dogfood_latest_path=dogfood_latest if dogfood_latest.exists() else None,
+    )
+
+
+def _language_counts(file_metadata: list[dict[str, str | int]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in file_metadata:
+        language = str(item["language"])
+        counts[language] = counts.get(language, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _vector_index_available(project: ProjectState) -> bool:
+    if project.vector_dir.exists() and any(project.vector_dir.glob("*.vectors.npz")):
+        return True
+    return any(project.project_dir.glob("*.vectors.npz"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,7 @@ def test_help_contains_subcommands() -> None:
     assert "cache" in output
     assert "init" in output
     assert "index" in output
+    assert "status" in output
 
 
 def test_init_command_creates_project_state(python_simple_repo: Path) -> None:
@@ -141,6 +142,86 @@ def test_index_command_writes_fixed_project_index_path(python_simple_repo: Path)
     assert data["index_path"] == str(python_simple_repo / ".archex" / "index.db")
     assert (python_simple_repo / ".archex" / "index.db").exists()
     assert not list((python_simple_repo / ".archex").glob("[0-9a-f]" * 64 + ".db"))
+
+
+def test_status_command_reports_uninitialized(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["status", str(python_simple_repo), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["state"] == "uninitialized"
+    assert data["initialized"] is False
+
+
+def test_status_command_reports_missing_index(python_simple_repo: Path) -> None:
+    from archex.project import init_project
+
+    init_project(python_simple_repo)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["status", str(python_simple_repo), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["state"] == "missing_index"
+    assert data["initialized"] is True
+
+
+def test_status_command_reports_fresh_index(python_simple_repo: Path) -> None:
+    from archex.project import init_project
+
+    init_project(python_simple_repo)
+    runner = CliRunner()
+    indexed = runner.invoke(cli, ["index", str(python_simple_repo), "--format", "json"])
+    assert indexed.exit_code == 0, indexed.output
+
+    result = runner.invoke(cli, ["status", str(python_simple_repo), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["state"] == "fresh"
+    assert data["index_path"] == str(python_simple_repo / ".archex" / "index.db")
+    assert data["files_indexed"] > 0
+    assert data["chunks_indexed"] > 0
+    assert data["languages"]["python"] > 0
+
+
+def test_status_command_strict_fails_on_dirty_index(python_simple_repo: Path) -> None:
+    from archex.project import init_project
+
+    init_project(python_simple_repo)
+    runner = CliRunner()
+    indexed = runner.invoke(cli, ["index", str(python_simple_repo), "--format", "json"])
+    assert indexed.exit_code == 0, indexed.output
+    (python_simple_repo / "utils.py").write_text("def dirty_symbol(): return 1\n")
+
+    result = runner.invoke(
+        cli,
+        ["status", str(python_simple_repo), "--format", "json", "--strict"],
+    )
+
+    assert result.exit_code == 1, result.output
+    data = json.loads(result.output)
+    assert data["state"] == "dirty"
+    assert data["working_tree"] == "dirty"
+
+
+def test_status_command_fails_on_corrupt_index(python_simple_repo: Path) -> None:
+    from archex.project import init_project
+
+    init_project(python_simple_repo)
+    index_path = python_simple_repo / ".archex" / "index.db"
+    index_path.write_text("not sqlite", encoding="utf-8")
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["status", str(python_simple_repo), "--format", "json"])
+
+    assert result.exit_code == 1, result.output
+    data = json.loads(result.output)
+    assert data["state"] == "corrupt"
+    assert data["error"]
 
 
 def test_analyze_local_json(python_simple_repo: Path) -> None:


### PR DESCRIPTION
## Scope

This slice adds read-only repo-local project status inspection.

- adds `archex status SOURCE` with text and JSON output
- reports `uninitialized`, `missing_index`, `fresh`, `dirty`, `stale`, `needs_reindex`, and `corrupt` states
- reads `.archex/index.db` without building or refreshing an index
- compares indexed commit and working-tree signature against live HEAD/signature
- reports indexed file/chunk/language counts, vector index availability, and latest dogfood report path when present
- supports `--strict`, which fails unless the status is `fresh`; non-strict only fails on `corrupt`

Out of scope: `archex reset`, cwd-default CLI parsing, dogfood reporting, failure-class reporting, corpus expansion, CI dogfood job, and docs updates.

## Stack

| Order | PR | Branch | Base | Scope |
| ---: | --- | --- | --- | --- |
| 1 | #100 | `fix/dogfood-query-pipeline-recall` | `main` | Query pipeline recall fix |
| 2 | #101 | `feat/project-init-lifecycle` | `fix/dogfood-query-pipeline-recall` | `archex init` lifecycle |
| 3 | #102 | `feat/project-config-resolution` | `feat/project-init-lifecycle` | Repo-local config resolution |
| 4 | #103 | `feat/project-index-command` | `feat/project-config-resolution` | Explicit `archex index` command |
| 5 | #104 | `feat/project-local-index-storage` | `feat/project-index-command` | Fixed `.archex/index.db` storage |
| 6 | #105 | `feat/working-tree-freshness` | `feat/project-local-index-storage` | Dirty working-tree freshness |
| 7 | This PR | `feat/project-status-command` | `feat/working-tree-freshness` | `archex status` lifecycle command |

## Validation

- `uv run ruff check`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest --no-cov tests/test_cli.py::test_help_contains_subcommands tests/test_cli.py::test_status_command_reports_uninitialized tests/test_cli.py::test_status_command_reports_missing_index tests/test_cli.py::test_status_command_reports_fresh_index tests/test_cli.py::test_status_command_strict_fails_on_dirty_index tests/test_cli.py::test_status_command_fails_on_corrupt_index`
- `uv run pytest --no-cov tests/test_cli.py tests/test_project.py tests/test_config.py tests/test_cache.py tests/index/test_delta.py tests/test_integration.py::TestDeltaIndexIntegration`
- `uv run archex status . --format json`
