### PR TITLE
feat(cli): add project reset command

### DIFF
--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -14,6 +14,7 @@ from archex.cli.init_cmd import init_cmd
 from archex.cli.mcp_cmd import mcp_cmd
 from archex.cli.outline_cmd import outline_cmd
 from archex.cli.query_cmd import query_cmd
+from archex.cli.reset_cmd import reset_cmd
 from archex.cli.serve_cmd import serve_cmd
 from archex.cli.status_cmd import status_cmd
 from archex.cli.symbol_cmd import symbol_cmd
@@ -35,6 +36,7 @@ cli.add_command(cache_cmd)
 cli.add_command(init_cmd)
 cli.add_command(index_cmd)
 cli.add_command(status_cmd)
+cli.add_command(reset_cmd)
 cli.add_command(mcp_cmd)
 cli.add_command(tree_cmd)
 cli.add_command(outline_cmd)

--- a/src/archex/cli/reset_cmd.py
+++ b/src/archex/cli/reset_cmd.py
@@ -1,0 +1,40 @@
+"""Project lifecycle reset command."""
+
+from __future__ import annotations
+
+import click
+
+from archex.project import reset_project
+
+
+@click.command("reset")
+@click.argument("source")
+@click.option("--force", is_flag=True, default=False, help="Delete generated state.")
+@click.option(
+    "--all",
+    "all_state",
+    is_flag=True,
+    default=False,
+    help="Delete the whole .archex directory.",
+)
+def reset_cmd(source: str, force: bool, all_state: bool) -> None:
+    """Delete repo-local archex generated state."""
+    try:
+        result = reset_project(source, force=force, all_state=all_state)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if result.removed_all:
+        if result.removed_paths:
+            click.echo(f"Removed project state: {result.state.project_dir}")
+        else:
+            click.echo(f"No project state found at {result.state.project_dir}")
+        return
+
+    if not result.removed_paths:
+        click.echo(f"No generated archex state found at {result.state.project_dir}")
+        return
+
+    click.echo(f"Removed {len(result.removed_paths)} generated path(s):")
+    for path in result.removed_paths:
+        click.echo(f"  {path}")

--- a/src/archex/project.py
+++ b/src/archex/project.py
@@ -108,6 +108,15 @@ class ProjectInitResult:
     gitignore_updated: bool
 
 
+@dataclass(frozen=True)
+class ProjectResetResult:
+    """Result of deleting repo-local generated state."""
+
+    state: ProjectState
+    removed_paths: list[Path]
+    removed_all: bool
+
+
 def init_project(
     source: str | Path,
     *,
@@ -146,6 +155,56 @@ def init_project(
         settings_written=settings_written,
         gitignore_updated=gitignore_updated,
     )
+
+
+def reset_project(
+    source: str | Path,
+    *,
+    force: bool = False,
+    all_state: bool = False,
+) -> ProjectResetResult:
+    """Delete generated repo-local archex state."""
+    if not force:
+        raise ValueError("reset requires --force")
+
+    state = ProjectState.resolve(source)
+    removed: list[Path] = []
+
+    if all_state:
+        if state.project_dir.exists():
+            shutil.rmtree(state.project_dir)
+            removed.append(state.project_dir)
+        return ProjectResetResult(state=state, removed_paths=removed, removed_all=True)
+
+    for path in _generated_state_paths(state):
+        if path.is_dir():
+            shutil.rmtree(path)
+            removed.append(path)
+        elif path.exists():
+            path.unlink()
+            removed.append(path)
+
+    return ProjectResetResult(state=state, removed_paths=removed, removed_all=False)
+
+
+def _generated_state_paths(state: ProjectState) -> list[Path]:
+    paths: list[Path] = [
+        state.index_path,
+        state.project_dir / "index.meta",
+        state.vector_dir,
+    ]
+    if state.project_dir.exists():
+        paths.extend(state.project_dir.glob("*.db"))
+        paths.extend(state.project_dir.glob("*.meta"))
+        paths.extend(state.project_dir.glob("*.vectors.npz"))
+    seen: set[Path] = set()
+    deduped: list[Path] = []
+    for path in paths:
+        if path in seen:
+            continue
+        seen.add(path)
+        deduped.append(path)
+    return deduped
 
 
 def ensure_project_gitignore(gitignore_path: Path) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,7 @@ def test_help_contains_subcommands() -> None:
     assert "init" in output
     assert "index" in output
     assert "status" in output
+    assert "reset" in output
 
 
 def test_init_command_creates_project_state(python_simple_repo: Path) -> None:
@@ -222,6 +223,45 @@ def test_status_command_fails_on_corrupt_index(python_simple_repo: Path) -> None
     data = json.loads(result.output)
     assert data["state"] == "corrupt"
     assert data["error"]
+
+
+def test_reset_command_requires_force(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["reset", str(python_simple_repo)])
+
+    assert result.exit_code != 0
+    assert "reset requires --force" in result.output
+
+
+def test_reset_command_preserves_settings(python_simple_repo: Path) -> None:
+    from archex.project import init_project
+
+    init_project(python_simple_repo)
+    runner = CliRunner()
+    indexed = runner.invoke(cli, ["index", str(python_simple_repo), "--format", "json"])
+    assert indexed.exit_code == 0, indexed.output
+
+    result = runner.invoke(cli, ["reset", str(python_simple_repo), "--force"])
+
+    assert result.exit_code == 0, result.output
+    assert (python_simple_repo / ".archex" / "settings.toml").exists()
+    assert not (python_simple_repo / ".archex" / "index.db").exists()
+    status = runner.invoke(cli, ["status", str(python_simple_repo), "--format", "json"])
+    assert status.exit_code == 0, status.output
+    assert json.loads(status.output)["state"] == "missing_index"
+
+
+def test_reset_command_all_removes_project_state(python_simple_repo: Path) -> None:
+    from archex.project import init_project
+
+    init_project(python_simple_repo)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["reset", str(python_simple_repo), "--all", "--force"])
+
+    assert result.exit_code == 0, result.output
+    assert not (python_simple_repo / ".archex").exists()
 
 
 def test_analyze_local_json(python_simple_repo: Path) -> None:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from archex.project import DEFAULT_SETTINGS_TOML, ProjectState, init_project
+from archex.project import DEFAULT_SETTINGS_TOML, ProjectState, init_project, reset_project
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -112,3 +112,43 @@ def test_init_project_force_reset_removes_existing_state(tmp_path: Path) -> None
     assert result.settings_written is True
     assert not generated.exists()
     assert (repo / ".archex" / "settings.toml").exists()
+
+
+def test_reset_project_requires_force(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+
+    with pytest.raises(ValueError, match="reset requires --force"):
+        reset_project(repo)
+
+
+def test_reset_project_preserves_settings_and_deletes_generated_state(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    init_project(repo)
+    project_dir = repo / ".archex"
+    settings = project_dir / "settings.toml"
+    index = project_dir / "index.db"
+    meta = project_dir / "index.meta"
+    vector_dir = project_dir / "vectors"
+    vector_dir.mkdir()
+    index.write_text("db", encoding="utf-8")
+    meta.write_text("meta", encoding="utf-8")
+    (vector_dir / "raw.vectors.npz").write_text("vectors", encoding="utf-8")
+
+    result = reset_project(repo, force=True)
+
+    assert settings.exists()
+    assert not index.exists()
+    assert not meta.exists()
+    assert not vector_dir.exists()
+    assert result.removed_all is False
+    assert len(result.removed_paths) == 3
+
+
+def test_reset_project_all_removes_project_dir(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    init_project(repo)
+
+    result = reset_project(repo, force=True, all_state=True)
+
+    assert result.removed_all is True
+    assert not (repo / ".archex").exists()


### PR DESCRIPTION
## Scope

This slice adds repo-local project reset lifecycle support.

- adds `archex reset SOURCE --force`
- deletes generated repo-local index DB, index metadata, and vector artifacts while preserving `.archex/settings.toml`
- adds `archex reset SOURCE --all --force` to delete the entire `.archex/` directory
- refuses destructive execution unless `--force` is passed
- leaves global `~/.archex/cache` untouched

Out of scope: cwd-default CLI parsing, dogfood reporting, failure-class reporting, corpus expansion, CI dogfood job, and docs updates.

## Stack

| Order | PR | Branch | Base | Scope |
| ---: | --- | --- | --- | --- |
| 1 | #100 | `fix/dogfood-query-pipeline-recall` | `main` | Query pipeline recall fix |
| 2 | #101 | `feat/project-init-lifecycle` | `fix/dogfood-query-pipeline-recall` | `archex init` lifecycle |
| 3 | #102 | `feat/project-config-resolution` | `feat/project-init-lifecycle` | Repo-local config resolution |
| 4 | #103 | `feat/project-index-command` | `feat/project-config-resolution` | Explicit `archex index` command |
| 5 | #104 | `feat/project-local-index-storage` | `feat/project-index-command` | Fixed `.archex/index.db` storage |
| 6 | #105 | `feat/working-tree-freshness` | `feat/project-local-index-storage` | Dirty working-tree freshness |
| 7 | #106 | `feat/project-status-command` | `feat/working-tree-freshness` | `archex status` lifecycle command |
| 8 | This PR | `feat/project-reset-command` | `feat/project-status-command` | `archex reset` lifecycle command |

## Validation

- `uv run ruff check`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest --no-cov tests/test_project.py::test_reset_project_requires_force tests/test_project.py::test_reset_project_preserves_settings_and_deletes_generated_state tests/test_project.py::test_reset_project_all_removes_project_dir tests/test_cli.py::test_help_contains_subcommands tests/test_cli.py::test_reset_command_requires_force tests/test_cli.py::test_reset_command_preserves_settings tests/test_cli.py::test_reset_command_all_removes_project_state`
- `uv run pytest --no-cov tests/test_cli.py tests/test_project.py tests/test_config.py tests/test_cache.py tests/index/test_delta.py tests/test_integration.py::TestDeltaIndexIntegration`
- temporary-repo smoke: `uv run archex init`, `uv run archex index --format json`, `uv run archex reset --force`, `uv run archex status --format json` returned `missing_index`
