### PR TITLE
feat(cli): default local source to cwd

### DIFF
--- a/src/archex/cli/analyze_cmd.py
+++ b/src/archex/cli/analyze_cmd.py
@@ -13,7 +13,7 @@ from archex.utils import resolve_source
 
 
 @click.command("analyze")
-@click.argument("source")
+@click.argument("source", required=False, default=".")
 @click.option(
     "--format",
     "output_format",

--- a/src/archex/cli/index_cmd.py
+++ b/src/archex/cli/index_cmd.py
@@ -25,7 +25,7 @@ def _language_counts(file_metadata: list[dict[str, str | int]]) -> dict[str, int
 
 
 @click.command("index")
-@click.argument("source")
+@click.argument("source", required=False, default=".")
 @click.option(
     "--format",
     "output_format",

--- a/src/archex/cli/init_cmd.py
+++ b/src/archex/cli/init_cmd.py
@@ -8,7 +8,7 @@ from archex.project import init_project
 
 
 @click.command("init")
-@click.argument("source")
+@click.argument("source", required=False, default=".")
 @click.option("--force", is_flag=True, default=False, help="Rewrite project settings.")
 @click.option(
     "--reset",

--- a/src/archex/cli/query_cmd.py
+++ b/src/archex/cli/query_cmd.py
@@ -11,8 +11,7 @@ from archex.utils import resolve_source
 
 
 @click.command("query")
-@click.argument("source")
-@click.argument("question")
+@click.argument("args", nargs=-1, required=True)
 @click.option("--budget", default=8192, type=int, help="Token budget for the context bundle.")
 @click.option(
     "--format",
@@ -31,8 +30,7 @@ from archex.utils import resolve_source
 @click.option("--timing", is_flag=True, default=False, help="Print timing breakdown.")
 @click.option("--metrics", is_flag=True, default=False, help="Print timing metrics as JSON.")
 def query_cmd(
-    source: str,
-    question: str,
+    args: tuple[str, ...],
     budget: int,
     output_format: str,
     language: tuple[str, ...],
@@ -44,6 +42,7 @@ def query_cmd(
     from archex.config import load_config, load_index_config
     from archex.models import PipelineTiming
 
+    source, question = _source_and_question(args)
     repo_source = resolve_source(source)
     config = load_config(repo_source)
     if language:
@@ -85,3 +84,11 @@ def query_cmd(
             dm = metrics_dict["delta_meta"]
             metrics_dict["delta_meta"] = {k: v for k, v in dm.items()}
         click.echo(json.dumps(metrics_dict, indent=2), err=True)
+
+
+def _source_and_question(args: tuple[str, ...]) -> tuple[str, str]:
+    if len(args) == 1:
+        return ".", args[0]
+    if len(args) >= 2:
+        return args[0], " ".join(args[1:])
+    raise click.UsageError("query requires a question")

--- a/src/archex/cli/reset_cmd.py
+++ b/src/archex/cli/reset_cmd.py
@@ -8,7 +8,7 @@ from archex.project import reset_project
 
 
 @click.command("reset")
-@click.argument("source")
+@click.argument("source", required=False, default=".")
 @click.option("--force", is_flag=True, default=False, help="Delete generated state.")
 @click.option(
     "--all",

--- a/src/archex/cli/status_cmd.py
+++ b/src/archex/cli/status_cmd.py
@@ -10,7 +10,7 @@ from archex.status import ProjectStatus, inspect_project_status
 
 
 @click.command("status")
-@click.argument("source")
+@click.argument("source", required=False, default=".")
 @click.option("--strict", is_flag=True, default=False, help="Fail unless the index is fresh.")
 @click.option(
     "--format",

--- a/src/archex/cli/symbols_cmd.py
+++ b/src/archex/cli/symbols_cmd.py
@@ -14,16 +14,14 @@ from archex.utils import resolve_source
 
 
 @click.command("symbols")
-@click.argument("source")
-@click.argument("query")
+@click.argument("args", nargs=-1, required=True)
 @click.option("--kind", default=None, help="Filter by kind: function, class, method, etc.")
 @click.option("-l", "--language", default=None, help="Filter to specific language.")
 @click.option("--limit", default=20, type=int, help="Maximum results.")
 @click.option("--json", "output_json", is_flag=True, default=False, help="Output as JSON.")
 @click.option("--timing", is_flag=True, default=False, help="Print timing breakdown.")
 def symbols_cmd(
-    source: str,
-    query: str,
+    args: tuple[str, ...],
     kind: str | None,
     language: str | None,
     limit: int,
@@ -31,6 +29,7 @@ def symbols_cmd(
     timing: bool,
 ) -> None:
     """Search symbols by name across a repository."""
+    source, query = _source_and_query(args)
     source_obj = resolve_source(source)
 
     pt = PipelineTiming() if timing else None
@@ -67,3 +66,11 @@ def symbols_cmd(
         unique_files = list({m.file_path for m in results})
         raw = get_files_token_count(source_obj, unique_files)
         print_savings(returned, raw, pt.total_ms, file_count=len(unique_files))
+
+
+def _source_and_query(args: tuple[str, ...]) -> tuple[str, str]:
+    if len(args) == 1:
+        return ".", args[0]
+    if len(args) >= 2:
+        return args[0], " ".join(args[1:])
+    raise click.UsageError("symbols requires a query")

--- a/src/archex/cli/tree_cmd.py
+++ b/src/archex/cli/tree_cmd.py
@@ -37,7 +37,7 @@ def _render_tree(
 
 
 @click.command("tree")
-@click.argument("source")
+@click.argument("source", required=False, default=".")
 @click.option("--depth", default=5, type=int, help="Maximum directory depth.")
 @click.option("-l", "--language", default=None, help="Filter to specific language.")
 @click.option("--json", "output_json", is_flag=True, default=False, help="Output as JSON.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -264,6 +264,86 @@ def test_reset_command_all_removes_project_state(python_simple_repo: Path) -> No
     assert not (python_simple_repo / ".archex").exists()
 
 
+def test_lifecycle_commands_default_source_to_cwd(
+    python_simple_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(python_simple_repo)
+    runner = CliRunner()
+
+    initialized = runner.invoke(cli, ["init"])
+    indexed = runner.invoke(cli, ["index", "--format", "json"])
+    status = runner.invoke(cli, ["status", "--format", "json"])
+    reset = runner.invoke(cli, ["reset", "--force"])
+
+    assert initialized.exit_code == 0, initialized.output
+    assert indexed.exit_code == 0, indexed.output
+    assert json.loads(indexed.output)["repo_root"] == str(python_simple_repo)
+    assert status.exit_code == 0, status.output
+    assert json.loads(status.output)["state"] == "fresh"
+    assert reset.exit_code == 0, reset.output
+
+
+def test_query_command_defaults_source_to_cwd(
+    python_simple_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from archex.project import init_project
+
+    class FakeBundle:
+        chunks: list[object] = []
+        token_count = 0
+
+        def to_prompt(self, *, format: str) -> str:
+            return f"format={format}"
+
+    init_project(python_simple_repo)
+    monkeypatch.chdir(python_simple_repo)
+    runner = CliRunner()
+
+    with patch("archex.cli.query_cmd.query", return_value=FakeBundle()) as query_mock:
+        result = runner.invoke(cli, ["query", "How does the query pipeline work?"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "format=xml"
+    assert query_mock.call_args.args[0].local_path == "."
+    assert query_mock.call_args.args[1] == "How does the query pipeline work?"
+
+
+def test_analyze_tree_and_symbols_default_source_to_cwd(
+    python_simple_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from archex.models import FileTree
+    from archex.project import init_project
+
+    class FakeProfile:
+        def to_json(self) -> str:
+            return "{}"
+
+        def to_markdown(self) -> str:
+            return "# profile"
+
+    init_project(python_simple_repo)
+    monkeypatch.chdir(python_simple_repo)
+    runner = CliRunner()
+
+    with patch("archex.cli.analyze_cmd.analyze", return_value=FakeProfile()) as analyze_mock:
+        analyze_result = runner.invoke(cli, ["analyze"])
+    with patch(
+        "archex.cli.tree_cmd.file_tree",
+        return_value=FileTree(root=".", entries=[], total_files=0, languages={}),
+    ) as tree_mock:
+        tree_result = runner.invoke(cli, ["tree"])
+    with patch("archex.cli.symbols_cmd.search_symbols", return_value=[]) as symbols_mock:
+        symbols_result = runner.invoke(cli, ["symbols", "query"])
+
+    assert analyze_result.exit_code == 0, analyze_result.output
+    assert tree_result.exit_code == 0, tree_result.output
+    assert symbols_result.exit_code == 0, symbols_result.output
+    assert analyze_mock.call_args.args[0].local_path == "."
+    assert tree_mock.call_args.args[0].local_path == "."
+    assert symbols_mock.call_args.args[0].local_path == "."
+    assert symbols_mock.call_args.kwargs["query"] == "query"
+
+
 def test_analyze_local_json(python_simple_repo: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["analyze", str(python_simple_repo), "--format", "json"])


### PR DESCRIPTION
## Scope

This slice adds cwd-default local source ergonomics for repo-local commands.

- `archex init`, `index`, `status`, and `reset` default `source` to `.`
- `archex analyze` and `tree` default `source` to `.`
- `archex query "question"` queries cwd, while `archex query SOURCE "question"` remains supported
- `archex symbols "query"` searches cwd, while `archex symbols SOURCE "query"` remains supported
- preserves explicit source behavior for existing scripts and non-cwd repositories
- leaves public Python APIs unchanged

Out of scope: dogfood reporting, failure-class reporting, corpus expansion, CI dogfood job, and docs updates.

## Stack

| Order | PR | Branch | Base | Scope |
| ---: | --- | --- | --- | --- |
| 1 | #100 | `fix/dogfood-query-pipeline-recall` | `main` | Query pipeline recall fix |
| 2 | #101 | `feat/project-init-lifecycle` | `fix/dogfood-query-pipeline-recall` | `archex init` lifecycle |
| 3 | #102 | `feat/project-config-resolution` | `feat/project-init-lifecycle` | Repo-local config resolution |
| 4 | #103 | `feat/project-index-command` | `feat/project-config-resolution` | Explicit `archex index` command |
| 5 | #104 | `feat/project-local-index-storage` | `feat/project-index-command` | Fixed `.archex/index.db` storage |
| 6 | #105 | `feat/working-tree-freshness` | `feat/project-local-index-storage` | Dirty working-tree freshness |
| 7 | #106 | `feat/project-status-command` | `feat/working-tree-freshness` | `archex status` lifecycle command |
| 8 | #107 | `feat/project-reset-command` | `feat/project-status-command` | `archex reset` lifecycle command |
| 9 | This PR | `feat/cwd-default-source` | `feat/project-reset-command` | cwd-default local source ergonomics |

## Validation

- `uv run ruff check`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest --no-cov tests/test_cli.py::test_lifecycle_commands_default_source_to_cwd tests/test_cli.py::test_query_command_defaults_source_to_cwd tests/test_cli.py::test_analyze_tree_and_symbols_default_source_to_cwd tests/test_cli.py::test_query_uses_project_config_when_cli_args_omitted tests/test_cli.py::test_query_cli_options_override_project_config`
- `uv run pytest --no-cov tests/test_cli.py tests/test_project.py tests/test_config.py tests/test_cache.py tests/index/test_delta.py tests/test_integration.py::TestDeltaIndexIntegration`
- temporary-repo smoke from cwd: `archex init`, `archex index`, `archex query "How does the query pipeline work?"`, `archex analyze`, `archex tree`, `archex symbols "query"`
