### PR TITLE
feat(cli): add dogfood command

### DIFF
--- a/src/archex/cli/dogfood_cmd.py
+++ b/src/archex/cli/dogfood_cmd.py
@@ -1,0 +1,91 @@
+"""Project dogfood command."""
+
+from __future__ import annotations
+
+import click
+
+from archex.dogfood import run_dogfood
+
+
+@click.command("dogfood")
+@click.argument("source", required=False, default=".")
+@click.option("--task", "task_id", default=None, help="Run a single dogfood task by task_id.")
+@click.option(
+    "--all",
+    "run_all_self",
+    is_flag=True,
+    default=False,
+    help="Run all self dogfood tasks.",
+)
+@click.option(
+    "--include-external",
+    is_flag=True,
+    default=False,
+    help="Include non-self benchmark tasks.",
+)
+@click.option(
+    "--query-fusion",
+    is_flag=True,
+    default=False,
+    help="Include the experimental archex_query_fusion strategy.",
+)
+@click.option(
+    "--baseline",
+    "baseline_path",
+    default=None,
+    type=click.Path(),
+    help="Baseline JSON path. Defaults to local dogfood baseline, or committed CI baseline.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="text",
+    type=click.Choice(["text", "json"]),
+    help="Output format.",
+)
+def dogfood_cmd(
+    source: str,
+    task_id: str | None,
+    run_all_self: bool,
+    include_external: bool,
+    query_fusion: bool,
+    baseline_path: str | None,
+    output_format: str,
+) -> None:
+    """Run self-benchmark dogfood tasks and gate against a stored baseline."""
+    del run_all_self
+    try:
+        result = run_dogfood(
+            source,
+            task_id=task_id,
+            include_external=include_external,
+            include_query_fusion=query_fusion,
+            baseline_path=baseline_path,
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if output_format == "json":
+        click.echo(result.latest_json_path.read_text(encoding="utf-8").rstrip())
+    else:
+        click.echo(f"Dogfood tasks:      {len(result.tasks)}")
+        click.echo(f"Reports:            {result.latest_json_path}")
+        click.echo(f"Markdown:           {result.latest_markdown_path}")
+        click.echo(f"History:            {result.history_json_path}")
+        if result.baseline_path is None:
+            click.echo("Baseline:           none")
+        else:
+            click.echo(f"Baseline:           {result.baseline_path}")
+        if result.regressions:
+            click.echo(f"Regressions:        {len(result.regressions)}")
+            for regression in result.regressions:
+                click.echo(
+                    f"  {regression.task_id}/{regression.strategy} {regression.metric}: "
+                    f"{regression.baseline_value:.3f} -> {regression.current_value:.3f} "
+                    f"({regression.delta:+.3f})"
+                )
+        else:
+            click.echo("Regressions:        0")
+
+    if result.regressions:
+        raise click.exceptions.Exit(1)

--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -9,6 +9,7 @@ from archex.cli.analyze_cmd import analyze_cmd
 from archex.cli.benchmark_cmd import benchmark_cmd
 from archex.cli.cache_cmd import cache_cmd
 from archex.cli.compare_cmd import compare_cmd
+from archex.cli.dogfood_cmd import dogfood_cmd
 from archex.cli.index_cmd import index_cmd
 from archex.cli.init_cmd import init_cmd
 from archex.cli.mcp_cmd import mcp_cmd
@@ -37,6 +38,7 @@ cli.add_command(init_cmd)
 cli.add_command(index_cmd)
 cli.add_command(status_cmd)
 cli.add_command(reset_cmd)
+cli.add_command(dogfood_cmd)
 cli.add_command(mcp_cmd)
 cli.add_command(tree_cmd)
 cli.add_command(outline_cmd)

--- a/src/archex/dogfood.py
+++ b/src/archex/dogfood.py
@@ -1,0 +1,339 @@
+"""Dogfood benchmark orchestration for repo-local lifecycle runs."""
+
+from __future__ import annotations
+
+import json
+import os
+import tomllib
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+from archex.benchmark.baseline import BaselineComparison, compare_baseline, load_baseline
+from archex.benchmark.loader import load_tasks
+from archex.benchmark.models import BenchmarkReport, BenchmarkTask, Strategy, TaskCategory
+from archex.benchmark.reporter import format_markdown, format_summary
+from archex.benchmark.runner import DEFAULT_STRATEGIES, run_benchmark
+from archex.project import ProjectState
+
+DOGFOOD_BASELINE_PATH = Path("benchmarks/dogfood_baseline.json")
+DEFAULT_TASKS_DIR = Path("benchmarks/tasks")
+DEFAULT_OUTPUT_DIR = Path(".archex/dogfood")
+DEFAULT_TASK_PREFIX = "archex_"
+
+
+@dataclass(frozen=True)
+class DogfoodRunResult:
+    """Persisted dogfood run artifacts and baseline comparison."""
+
+    repo_root: Path
+    tasks: list[BenchmarkTask]
+    reports: list[BenchmarkReport]
+    comparisons: list[BaselineComparison]
+    baseline_path: Path | None
+    output_dir: Path
+    latest_json_path: Path
+    latest_markdown_path: Path
+    history_json_path: Path
+
+    @property
+    def regressions(self) -> list[BaselineComparison]:
+        return [comparison for comparison in self.comparisons if comparison.regression]
+
+
+def run_dogfood(
+    source: str | Path = ".",
+    *,
+    task_id: str | None = None,
+    include_external: bool = False,
+    include_query_fusion: bool = False,
+    baseline_path: str | Path | None = None,
+) -> DogfoodRunResult:
+    """Run dogfood benchmark tasks against a local repository."""
+    state = ProjectState.resolve(source)
+    settings = _load_dogfood_settings(state)
+    tasks_dir = _resolve_repo_path(settings.tasks_dir, state.repo_root)
+    output_dir = _resolve_repo_path(settings.output_dir, state.repo_root)
+    selected_tasks = _select_tasks(
+        tasks_dir,
+        task_id=task_id,
+        include_external=include_external,
+        default_task_prefix=settings.default_task_prefix,
+    )
+    strategies = _selected_strategies(
+        settings.strategies,
+        include_query_fusion=include_query_fusion,
+    )
+
+    reports = [
+        run_benchmark(task, strategies=strategies, repo_path=state.repo_root)
+        for task in selected_tasks
+    ]
+    baseline_file = _resolve_baseline_path(
+        state,
+        explicit_baseline=baseline_path,
+        output_dir=output_dir,
+    )
+    comparisons = _compare_to_baseline(reports, baseline_file)
+    latest_json_path, latest_markdown_path, history_json_path = _write_reports(
+        output_dir,
+        selected_tasks,
+        reports,
+        comparisons,
+        baseline_file,
+    )
+
+    return DogfoodRunResult(
+        repo_root=state.repo_root,
+        tasks=selected_tasks,
+        reports=reports,
+        comparisons=comparisons,
+        baseline_path=baseline_file,
+        output_dir=output_dir,
+        latest_json_path=latest_json_path,
+        latest_markdown_path=latest_markdown_path,
+        history_json_path=history_json_path,
+    )
+
+
+@dataclass(frozen=True)
+class _DogfoodSettings:
+    tasks_dir: Path
+    output_dir: Path
+    default_task_prefix: str
+    strategies: list[Strategy]
+
+
+def _load_dogfood_settings(state: ProjectState) -> _DogfoodSettings:
+    if not state.settings_path.exists():
+        return _DogfoodSettings(
+            tasks_dir=DEFAULT_TASKS_DIR,
+            output_dir=DEFAULT_OUTPUT_DIR,
+            default_task_prefix=DEFAULT_TASK_PREFIX,
+            strategies=list(DEFAULT_STRATEGIES),
+        )
+
+    data = tomllib.loads(state.settings_path.read_text(encoding="utf-8"))
+    dogfood_data = data.get("dogfood", {})
+    if not isinstance(dogfood_data, dict):
+        raise ValueError(f"Invalid dogfood settings in {state.settings_path}")
+    dogfood_settings = cast("dict[str, Any]", dogfood_data)
+
+    tasks_dir = Path(_string_setting(dogfood_settings, "tasks_dir", str(DEFAULT_TASKS_DIR)))
+    output_dir = Path(_string_setting(dogfood_settings, "output_dir", str(DEFAULT_OUTPUT_DIR)))
+    default_task_prefix = _string_setting(
+        dogfood_settings,
+        "default_task_prefix",
+        DEFAULT_TASK_PREFIX,
+    )
+    raw_strategies: object = dogfood_settings.get(
+        "strategies",
+        [strategy.value for strategy in DEFAULT_STRATEGIES],
+    )
+    if not isinstance(raw_strategies, list):
+        raise ValueError(f"Invalid dogfood strategies in {state.settings_path}")
+    strategy_values: list[str] = []
+    for raw_strategy in cast("list[object]", raw_strategies):
+        if not isinstance(raw_strategy, str):
+            raise ValueError(f"Invalid dogfood strategies in {state.settings_path}")
+        strategy_values.append(raw_strategy)
+    strategies = [Strategy(value) for value in strategy_values]
+    return _DogfoodSettings(
+        tasks_dir=tasks_dir,
+        output_dir=output_dir,
+        default_task_prefix=default_task_prefix,
+        strategies=strategies,
+    )
+
+
+def _string_setting(data: dict[str, Any], key: str, default: str) -> str:
+    value = data.get(key, default)
+    if not isinstance(value, str):
+        raise ValueError(f"Invalid dogfood setting {key}: expected string")
+    return value
+
+
+def _resolve_repo_path(path: Path, repo_root: Path) -> Path:
+    expanded = path.expanduser()
+    if expanded.is_absolute():
+        return expanded
+    return repo_root / expanded
+
+
+def _select_tasks(
+    tasks_dir: Path,
+    *,
+    task_id: str | None,
+    include_external: bool,
+    default_task_prefix: str,
+) -> list[BenchmarkTask]:
+    tasks = load_tasks(tasks_dir)
+    if not include_external:
+        tasks = [
+            task
+            for task in tasks
+            if task.category == TaskCategory.SELF or task.task_id.startswith(default_task_prefix)
+        ]
+    if task_id is not None:
+        tasks = [task for task in tasks if task.task_id == task_id]
+    if not tasks:
+        target = task_id if task_id is not None else f"{default_task_prefix}*"
+        raise ValueError(f"No dogfood tasks found for {target}")
+    return tasks
+
+
+def _selected_strategies(
+    configured_strategies: list[Strategy],
+    *,
+    include_query_fusion: bool,
+) -> list[Strategy]:
+    strategies = list(configured_strategies)
+    if include_query_fusion and Strategy.ARCHEX_QUERY_FUSION not in strategies:
+        strategies.append(Strategy.ARCHEX_QUERY_FUSION)
+    return strategies
+
+
+def _resolve_baseline_path(
+    state: ProjectState,
+    *,
+    explicit_baseline: str | Path | None,
+    output_dir: Path,
+) -> Path | None:
+    if explicit_baseline is not None:
+        path = Path(explicit_baseline).expanduser()
+        if not path.is_absolute():
+            path = state.repo_root / path
+        if not path.is_file():
+            raise ValueError(f"Dogfood baseline not found: {path}")
+        return path
+
+    if os.environ.get("CI"):
+        ci_baseline = state.repo_root / DOGFOOD_BASELINE_PATH
+        return ci_baseline if ci_baseline.is_file() else None
+
+    local_baseline = output_dir / "baseline.json"
+    return local_baseline if local_baseline.is_file() else None
+
+
+def _compare_to_baseline(
+    reports: list[BenchmarkReport],
+    baseline_path: Path | None,
+) -> list[BaselineComparison]:
+    if baseline_path is None:
+        return []
+    baseline_data = json.loads(baseline_path.read_text(encoding="utf-8"))
+    baseline = load_baseline(baseline_data)
+    return compare_baseline(reports, baseline)
+
+
+def _write_reports(
+    output_dir: Path,
+    tasks: list[BenchmarkTask],
+    reports: list[BenchmarkReport],
+    comparisons: list[BaselineComparison],
+    baseline_path: Path | None,
+) -> tuple[Path, Path, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    history_dir = output_dir / "history"
+    history_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(tz=UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    payload = _json_payload(timestamp, tasks, reports, comparisons, baseline_path)
+
+    latest_json_path = output_dir / "latest.json"
+    latest_markdown_path = output_dir / "latest.md"
+    history_json_path = history_dir / f"{timestamp.replace(':', '-')}.json"
+
+    serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    latest_json_path.write_text(serialized, encoding="utf-8")
+    history_json_path.write_text(serialized, encoding="utf-8")
+    latest_markdown_path.write_text(
+        _markdown_report(reports, comparisons, baseline_path),
+        encoding="utf-8",
+    )
+    return latest_json_path, latest_markdown_path, history_json_path
+
+
+def _json_payload(
+    timestamp: str,
+    tasks: list[BenchmarkTask],
+    reports: list[BenchmarkReport],
+    comparisons: list[BaselineComparison],
+    baseline_path: Path | None,
+) -> dict[str, object]:
+    return {
+        "timestamp": timestamp,
+        "baseline_path": str(baseline_path) if baseline_path is not None else "",
+        "tasks": [task.task_id for task in tasks],
+        "reports": [report.model_dump(mode="json") for report in reports],
+        "comparisons": [comparison.model_dump(mode="json") for comparison in comparisons],
+        "regressions": [
+            comparison.model_dump(mode="json")
+            for comparison in comparisons
+            if comparison.regression
+        ],
+        "retrieval_gaps": _retrieval_gaps(tasks, reports),
+    }
+
+
+def _retrieval_gaps(
+    tasks: list[BenchmarkTask],
+    reports: list[BenchmarkReport],
+) -> list[dict[str, object]]:
+    expected_by_task = {task.task_id: set(task.expected_files) for task in tasks}
+    gaps: list[dict[str, object]] = []
+    for report in reports:
+        expected = expected_by_task[report.task_id]
+        for result in report.results:
+            retrieved = set(result.seed_files) | set(result.expanded_files)
+            if not retrieved:
+                missing: list[str] = []
+                unexpected: list[str] = []
+            else:
+                missing = sorted(expected - retrieved)
+                unexpected = sorted(retrieved - expected)
+            gaps.append(
+                {
+                    "task_id": report.task_id,
+                    "strategy": result.strategy.value,
+                    "missing_expected_files": missing,
+                    "unexpected_files": unexpected,
+                }
+            )
+    return gaps
+
+
+def _markdown_report(
+    reports: list[BenchmarkReport],
+    comparisons: list[BaselineComparison],
+    baseline_path: Path | None,
+) -> str:
+    lines: list[str] = ["# Dogfood Report", ""]
+    if baseline_path is None:
+        lines.append("Baseline: none")
+    else:
+        lines.append(f"Baseline: `{baseline_path}`")
+    lines.append("")
+    lines.append(format_summary(reports))
+    lines.append("")
+    lines.append("## Baseline Regressions")
+    lines.append("")
+    regressions = [comparison for comparison in comparisons if comparison.regression]
+    if not comparisons:
+        lines.append("No baseline comparison was run.")
+    elif not regressions:
+        lines.append("No baseline regressions detected.")
+    else:
+        lines.append("| Task | Strategy | Metric | Baseline | Current | Delta |")
+        lines.append("|------|----------|--------|----------|---------|-------|")
+        for regression in regressions:
+            lines.append(
+                f"| {regression.task_id} | {regression.strategy} | {regression.metric} "
+                f"| {regression.baseline_value:.3f} | {regression.current_value:.3f} "
+                f"| {regression.delta:+.3f} |"
+            )
+    lines.append("")
+    for report in reports:
+        lines.append(format_markdown(report))
+    return "\n".join(lines)

--- a/tests/benchmark/test_dogfood.py
+++ b/tests/benchmark/test_dogfood.py
@@ -1,0 +1,228 @@
+"""Tests for dogfood benchmark orchestration."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from archex.benchmark.baseline import Baseline, BaselineEntry
+from archex.benchmark.models import BenchmarkReport, BenchmarkResult, BenchmarkTask, Strategy
+from archex.cli.main import cli
+from archex.dogfood import run_dogfood
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
+
+
+def _write_tasks(path: Path) -> Path:
+    tasks_dir = path / "benchmarks" / "tasks"
+    tasks_dir.mkdir(parents=True)
+    (tasks_dir / "archex_query_pipeline.yaml").write_text(
+        """\
+task_id: archex_query_pipeline
+repo: "."
+commit: "HEAD"
+category: self
+question: "How does archex implement the query pipeline?"
+expected_files:
+  - src/archex/api.py
+expected_symbols: []
+""",
+        encoding="utf-8",
+    )
+    (tasks_dir / "external_task.yaml").write_text(
+        """\
+task_id: external_task
+repo: owner/repo
+commit: abc123
+question: "How does an external project work?"
+expected_files:
+  - src/main.py
+expected_symbols: []
+""",
+        encoding="utf-8",
+    )
+    return tasks_dir
+
+
+def _report(task: BenchmarkTask, recall: float = 1.0) -> BenchmarkReport:
+    result = BenchmarkResult(
+        task_id=task.task_id,
+        strategy=Strategy.ARCHEX_QUERY,
+        tokens_total=100,
+        tool_calls=1,
+        files_accessed=1,
+        recall=recall,
+        precision=1.0,
+        f1_score=recall,
+        mrr=recall,
+        ndcg=recall,
+        map_score=recall,
+        token_efficiency=recall,
+        savings_vs_raw=0.0,
+        wall_time_ms=10.0,
+        cached=False,
+        timestamp="2026-05-24T00:00:00Z",
+        seed_files=["src/archex/api.py"],
+    )
+    return BenchmarkReport(
+        task_id=task.task_id,
+        repo=task.repo,
+        question=task.question,
+        results=[result],
+        baseline_tokens=100,
+    )
+
+
+def _regressing_report(
+    task: BenchmarkTask,
+    strategies: list[Strategy] | None = None,
+    repo_path: Path | None = None,
+) -> BenchmarkReport:
+    del strategies, repo_path
+    return _report(task, recall=0.5)
+
+
+def _passing_report(
+    task: BenchmarkTask,
+    strategies: list[Strategy] | None = None,
+    repo_path: Path | None = None,
+) -> BenchmarkReport:
+    del strategies, repo_path
+    return _report(task)
+
+
+def test_dogfood_runs_self_tasks_and_writes_reports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_tasks(tmp_path)
+    captured: list[str] = []
+
+    def fake_run_benchmark(
+        task: BenchmarkTask,
+        strategies: list[Strategy] | None = None,
+        repo_path: Path | None = None,
+    ) -> BenchmarkReport:
+        captured.append(task.task_id)
+        assert repo_path == tmp_path
+        assert strategies == [Strategy.RAW_FILES, Strategy.RAW_GREPPED, Strategy.ARCHEX_QUERY]
+        return _report(task)
+
+    monkeypatch.setattr("archex.dogfood.run_benchmark", fake_run_benchmark)
+
+    result = run_dogfood(tmp_path)
+
+    assert captured == ["archex_query_pipeline"]
+    assert result.latest_json_path == tmp_path / ".archex" / "dogfood" / "latest.json"
+    assert result.latest_json_path.is_file()
+    assert result.latest_markdown_path.is_file()
+    assert result.history_json_path.is_file()
+    payload = json.loads(result.latest_json_path.read_text(encoding="utf-8"))
+    assert payload["tasks"] == ["archex_query_pipeline"]
+    assert payload["regressions"] == []
+    assert payload["retrieval_gaps"][0]["missing_expected_files"] == []
+
+
+def test_dogfood_compares_explicit_baseline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_tasks(tmp_path)
+    baseline_path = tmp_path / "baseline.json"
+    baseline = Baseline(
+        entries=[
+            BaselineEntry(
+                task_id="archex_query_pipeline",
+                strategy=Strategy.ARCHEX_QUERY.value,
+                recall=1.0,
+                precision=1.0,
+                f1_score=1.0,
+                mrr=1.0,
+                ndcg=1.0,
+                map_score=1.0,
+                token_efficiency=1.0,
+            )
+        ]
+    )
+    baseline_path.write_text(baseline.model_dump_json(indent=2), encoding="utf-8")
+
+    monkeypatch.setattr("archex.dogfood.run_benchmark", _regressing_report)
+
+    result = run_dogfood(tmp_path, task_id="archex_query_pipeline", baseline_path=baseline_path)
+
+    assert result.baseline_path == baseline_path
+    assert result.regressions
+    assert {regression.metric for regression in result.regressions} >= {"recall", "f1_score", "mrr"}
+
+
+def test_dogfood_command_exits_nonzero_on_regression(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_tasks(tmp_path)
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(
+        Baseline(
+            entries=[
+                BaselineEntry(
+                    task_id="archex_query_pipeline",
+                    strategy=Strategy.ARCHEX_QUERY.value,
+                    recall=1.0,
+                    precision=1.0,
+                    f1_score=1.0,
+                    mrr=1.0,
+                )
+            ]
+        ).model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("archex.dogfood.run_benchmark", _regressing_report)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "dogfood",
+            str(tmp_path),
+            "--task",
+            "archex_query_pipeline",
+            "--baseline",
+            str(baseline_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Regressions:" in result.output
+    assert "archex_query_pipeline/archex_query recall" in result.output
+
+
+def test_dogfood_command_json_outputs_latest_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_tasks(tmp_path)
+    monkeypatch.setattr("archex.dogfood.run_benchmark", _passing_report)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["dogfood", str(tmp_path), "--task", "archex_query_pipeline", "--format", "json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["tasks"] == ["archex_query_pipeline"]
+    assert payload["regressions"] == []


### PR DESCRIPTION
## Scope

Adds the first `archex dogfood` lifecycle command as the baseline-relative self-benchmark runner for repo-local dogfood reports.

Included:
- `archex dogfood [SOURCE]` with cwd default source behavior
- default self-task selection from `benchmarks/tasks` using `category: self` or the configured `archex_` task prefix
- default product-candidate strategies: `raw_files`, `raw_grepped`, `archex_query`
- opt-in `--task`, `--include-external`, `--query-fusion`, `--baseline`, and `--format json`
- report persistence to `.archex/dogfood/latest.json`, `.archex/dogfood/latest.md`, and timestamped history
- baseline-relative gating against an explicit baseline, local `.archex/dogfood/baseline.json`, or CI `benchmarks/dogfood_baseline.json` when present

Out of scope:
- failure-class movement gating
- self-task corpus expansion
- CI dogfood workflow wiring
- README/docs updates

## Stack

| PR | Branch | Base | Scope |
| --- | --- | --- | --- |
| #100 | `fix/dogfood-query-pipeline-recall` | `main` | Query pipeline recall fix |
| #101 | `feat/project-init-lifecycle` | `fix/dogfood-query-pipeline-recall` | Project init lifecycle |
| #102 | `feat/project-config-resolution` | `feat/project-init-lifecycle` | Project config resolution |
| #103 | `feat/project-index-command` | `feat/project-config-resolution` | Project index command |
| #104 | `feat/project-local-index-storage` | `feat/project-index-command` | Fixed repo-local index storage |
| #105 | `feat/working-tree-freshness` | `feat/project-local-index-storage` | Working-tree freshness detection |
| #106 | `feat/project-status-command` | `feat/working-tree-freshness` | Project status command |
| #107 | `feat/project-reset-command` | `feat/project-status-command` | Project reset command |
| #108 | `feat/cwd-default-source` | `feat/project-reset-command` | cwd default source ergonomics |
| This PR | `feat/dogfood-command` | `feat/cwd-default-source` | Dogfood command with baseline-relative gate |

## Validation

- `uv run ruff check`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest --no-cov tests/benchmark/test_dogfood.py tests/benchmark/test_baseline.py tests/benchmark/test_cli.py tests/test_cli.py`
- `uv run archex dogfood . --task archex_query_pipeline --format json`

Dogfood smoke result: `archex_query_pipeline` completed with no baseline regressions; no baseline file was present for the local run.
