### PR TITLE
feat(dogfood): report retrieval failure classes

### DIFF
--- a/src/archex/dogfood.py
+++ b/src/archex/dogfood.py
@@ -12,7 +12,13 @@ from typing import Any, cast
 
 from archex.benchmark.baseline import BaselineComparison, compare_baseline, load_baseline
 from archex.benchmark.loader import load_tasks
-from archex.benchmark.models import BenchmarkReport, BenchmarkTask, Strategy, TaskCategory
+from archex.benchmark.models import (
+    BenchmarkReport,
+    BenchmarkResult,
+    BenchmarkTask,
+    Strategy,
+    TaskCategory,
+)
 from archex.benchmark.reporter import format_markdown, format_summary
 from archex.benchmark.runner import DEFAULT_STRATEGIES, run_benchmark
 from archex.project import ProjectState
@@ -249,7 +255,7 @@ def _write_reports(
     latest_json_path.write_text(serialized, encoding="utf-8")
     history_json_path.write_text(serialized, encoding="utf-8")
     latest_markdown_path.write_text(
-        _markdown_report(reports, comparisons, baseline_path),
+        _markdown_report(tasks, reports, comparisons, baseline_path),
         encoding="utf-8",
     )
     return latest_json_path, latest_markdown_path, history_json_path
@@ -273,38 +279,98 @@ def _json_payload(
             for comparison in comparisons
             if comparison.regression
         ],
-        "retrieval_gaps": _retrieval_gaps(tasks, reports),
+        "retrieval_diagnostics": _retrieval_diagnostics(tasks, reports),
     }
 
 
-def _retrieval_gaps(
+def _retrieval_diagnostics(
     tasks: list[BenchmarkTask],
     reports: list[BenchmarkReport],
 ) -> list[dict[str, object]]:
     expected_by_task = {task.task_id: set(task.expected_files) for task in tasks}
-    gaps: list[dict[str, object]] = []
+    diagnostics: list[dict[str, object]] = []
     for report in reports:
         expected = expected_by_task[report.task_id]
         for result in report.results:
-            retrieved = set(result.seed_files) | set(result.expanded_files)
-            if not retrieved:
-                missing: list[str] = []
-                unexpected: list[str] = []
-            else:
-                missing = sorted(expected - retrieved)
-                unexpected = sorted(retrieved - expected)
-            gaps.append(
+            ranked_files = _ranked_files(result)
+            missing = _missing_expected_files(expected, ranked_files, result)
+            unexpected = [path for path in ranked_files if path not in expected]
+            failure_classes = _failure_classes(
+                expected,
+                ranked_files,
+                missing,
+                result,
+            )
+            diagnostics.append(
                 {
                     "task_id": report.task_id,
                     "strategy": result.strategy.value,
+                    "failure_classes": failure_classes,
                     "missing_expected_files": missing,
-                    "unexpected_files": unexpected,
+                    "top_unexpected_files": unexpected[:5],
+                    "seed_files": result.seed_files,
+                    "expanded_files": result.expanded_files,
+                    "seed_recall": result.seed_recall,
+                    "recall": result.recall,
                 }
             )
-    return gaps
+    return diagnostics
+
+
+def _ranked_files(result: BenchmarkResult) -> list[str]:
+    ranked: list[str] = []
+    seen: set[str] = set()
+    for path in [*result.seed_files, *result.expanded_files]:
+        if path in seen:
+            continue
+        seen.add(path)
+        ranked.append(path)
+    return ranked
+
+
+def _missing_expected_files(
+    expected: set[str],
+    ranked_files: list[str],
+    result: BenchmarkResult,
+) -> list[str]:
+    if ranked_files:
+        return sorted(expected - set(ranked_files))
+    if result.recall >= 1.0:
+        return []
+    return sorted(expected)
+
+
+def _failure_classes(
+    expected: set[str],
+    ranked_files: list[str],
+    missing: list[str],
+    result: BenchmarkResult,
+) -> list[str]:
+    classes: list[str] = []
+    if result.recall <= 0:
+        classes.append("zero_recall")
+    elif result.recall < 1.0 or missing:
+        classes.append("partial_recall")
+
+    if result.mrr < 1.0 and any(path in expected for path in ranked_files):
+        classes.append("ranking_miss")
+
+    if result.seed_files:
+        seed_missing = expected - set(result.seed_files)
+        if seed_missing:
+            classes.append("seed_miss")
+
+    if result.seed_recall > result.recall:
+        classes.append("packing_miss")
+
+    if result.expanded_files and missing:
+        classes.append("expansion_miss")
+
+    return classes
 
 
 def _markdown_report(
+    tasks: list[BenchmarkTask],
     reports: list[BenchmarkReport],
     comparisons: list[BaselineComparison],
     baseline_path: Path | None,
@@ -334,6 +400,49 @@ def _markdown_report(
                 f"| {regression.delta:+.3f} |"
             )
     lines.append("")
+    lines.extend(_markdown_retrieval_diagnostics(tasks, reports))
+    lines.append("")
     for report in reports:
         lines.append(format_markdown(report))
     return "\n".join(lines)
+
+
+def _markdown_retrieval_diagnostics(
+    tasks: list[BenchmarkTask],
+    reports: list[BenchmarkReport],
+) -> list[str]:
+    diagnostics = _retrieval_diagnostics(tasks, reports)
+    lines: list[str] = ["## Retrieval Diagnostics", ""]
+    lines.append("| Task | Strategy | Failure Classes | Missing Expected | Top Unexpected |")
+    lines.append("|------|----------|-----------------|------------------|----------------|")
+    for diagnostic in diagnostics:
+        classes = _join_markdown_list(cast("list[str]", diagnostic["failure_classes"]))
+        missing = _join_markdown_list(cast("list[str]", diagnostic["missing_expected_files"]))
+        unexpected = _join_markdown_list(cast("list[str]", diagnostic["top_unexpected_files"]))
+        lines.append(
+            f"| {diagnostic['task_id']} | {diagnostic['strategy']} "
+            f"| {classes} | {missing} | {unexpected} |"
+        )
+    lines.append("")
+    for diagnostic in diagnostics:
+        lines.append(f"### {diagnostic['task_id']} / {diagnostic['strategy']}")
+        lines.append("")
+        lines.append("Seed files:")
+        lines.extend(_markdown_bullets(cast("list[str]", diagnostic["seed_files"])))
+        lines.append("")
+        lines.append("Expanded files:")
+        lines.extend(_markdown_bullets(cast("list[str]", diagnostic["expanded_files"])))
+        lines.append("")
+    return lines
+
+
+def _join_markdown_list(values: list[str]) -> str:
+    if not values:
+        return "none"
+    return "<br>".join(f"`{value}`" for value in values)
+
+
+def _markdown_bullets(values: list[str]) -> list[str]:
+    if not values:
+        return ["- none"]
+    return [f"- `{value}`" for value in values]

--- a/tests/benchmark/test_dogfood.py
+++ b/tests/benchmark/test_dogfood.py
@@ -34,6 +34,7 @@ category: self
 question: "How does archex implement the query pipeline?"
 expected_files:
   - src/archex/api.py
+  - src/archex/serve/context.py
 expected_symbols: []
 """,
         encoding="utf-8",
@@ -71,7 +72,8 @@ def _report(task: BenchmarkTask, recall: float = 1.0) -> BenchmarkReport:
         wall_time_ms=10.0,
         cached=False,
         timestamp="2026-05-24T00:00:00Z",
-        seed_files=["src/archex/api.py"],
+        seed_files=["src/archex/api.py", "src/archex/serve/context.py"],
+        seed_recall=recall,
     )
     return BenchmarkReport(
         task_id=task.task_id,
@@ -130,7 +132,63 @@ def test_dogfood_runs_self_tasks_and_writes_reports(
     payload = json.loads(result.latest_json_path.read_text(encoding="utf-8"))
     assert payload["tasks"] == ["archex_query_pipeline"]
     assert payload["regressions"] == []
-    assert payload["retrieval_gaps"][0]["missing_expected_files"] == []
+    assert payload["retrieval_diagnostics"][0]["missing_expected_files"] == []
+    assert payload["retrieval_diagnostics"][0]["failure_classes"] == []
+
+
+def test_dogfood_reports_failure_classes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_tasks(tmp_path)
+
+    def partial_report(
+        task: BenchmarkTask,
+        strategies: list[Strategy] | None = None,
+        repo_path: Path | None = None,
+    ) -> BenchmarkReport:
+        del strategies, repo_path
+        result = BenchmarkResult(
+            task_id=task.task_id,
+            strategy=Strategy.ARCHEX_QUERY,
+            tokens_total=100,
+            tool_calls=1,
+            files_accessed=2,
+            recall=0.5,
+            precision=0.5,
+            f1_score=0.5,
+            mrr=0.5,
+            ndcg=0.5,
+            map_score=0.5,
+            token_efficiency=0.5,
+            savings_vs_raw=0.0,
+            wall_time_ms=10.0,
+            cached=False,
+            timestamp="2026-05-24T00:00:00Z",
+            seed_files=["src/archex/api.py", "src/archex/models.py"],
+            seed_recall=0.5,
+        )
+        return BenchmarkReport(
+            task_id=task.task_id,
+            repo=task.repo,
+            question=task.question,
+            results=[result],
+            baseline_tokens=100,
+        )
+
+    monkeypatch.setattr("archex.dogfood.run_benchmark", partial_report)
+
+    result = run_dogfood(tmp_path, task_id="archex_query_pipeline")
+    payload = json.loads(result.latest_json_path.read_text(encoding="utf-8"))
+    diagnostic = payload["retrieval_diagnostics"][0]
+
+    assert diagnostic["missing_expected_files"] == ["src/archex/serve/context.py"]
+    assert diagnostic["top_unexpected_files"] == ["src/archex/models.py"]
+    assert diagnostic["failure_classes"] == ["partial_recall", "ranking_miss", "seed_miss"]
+    markdown = result.latest_markdown_path.read_text(encoding="utf-8")
+    assert "## Retrieval Diagnostics" in markdown
+    assert "`src/archex/serve/context.py`" in markdown
 
 
 def test_dogfood_compares_explicit_baseline(


### PR DESCRIPTION
## Scope

Adds actionable retrieval diagnostics to dogfood reports.

Included:
- `retrieval_diagnostics` in dogfood JSON output
- Markdown `Retrieval Diagnostics` section with failure classes, missing expected files, top unexpected files, seed files, and expanded files
- failure labels for `zero_recall`, `partial_recall`, `ranking_miss`, `seed_miss`, `packing_miss`, and `expansion_miss`
- tests covering partial recall, seed miss, ranking miss, missing expected files, and top unexpected files

Out of scope:
- self-task corpus expansion
- CI dogfood workflow wiring
- docs/README updates
- baseline file updates

## Stack

| PR | Branch | Base | Scope |
| --- | --- | --- | --- |
| #100 | `fix/dogfood-query-pipeline-recall` | `main` | Query pipeline recall fix |
| #101 | `feat/project-init-lifecycle` | `fix/dogfood-query-pipeline-recall` | Project init lifecycle |
| #102 | `feat/project-config-resolution` | `feat/project-init-lifecycle` | Project config resolution |
| #103 | `feat/project-index-command` | `feat/project-config-resolution` | Project index command |
| #104 | `feat/project-local-index-storage` | `feat/project-index-command` | Fixed repo-local index storage |
| #105 | `feat/working-tree-freshness` | `feat/project-local-index-storage` | Working-tree freshness detection |
| #106 | `feat/project-status-command` | `feat/working-tree-freshness` | Project status command |
| #107 | `feat/project-reset-command` | `feat/project-status-command` | Project reset command |
| #108 | `feat/cwd-default-source` | `feat/project-reset-command` | cwd default source ergonomics |
| #109 | `feat/dogfood-command` | `feat/cwd-default-source` | Dogfood command with baseline-relative gate |
| This PR | `feat/failure-class-reporting` | `feat/dogfood-command` | Dogfood retrieval failure-class reporting |

## Validation

- `uv run ruff check`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest --no-cov tests/benchmark/test_dogfood.py tests/benchmark/test_baseline.py tests/benchmark/test_cli.py tests/test_cli.py`
- `uv run archex dogfood . --task archex_query_pipeline --format json`

Dogfood smoke result: `archex_query_pipeline` completed with no baseline regressions; `archex_query` reported `ranking_miss`, no missing expected files, and two top unexpected seed files.
