### PR TITLE
feat(benchmark): expand archex self-task corpus

### DIFF
--- a/benchmarks/tasks/archex_benchmark_gate_lifecycle.yaml
+++ b/benchmarks/tasks/archex_benchmark_gate_lifecycle.yaml
@@ -1,0 +1,25 @@
+task_id: archex_benchmark_gate_lifecycle
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "How does archex turn benchmark and dogfood results into a regression gate?"
+# Expected files cover dogfood orchestration, CLI benchmark gates, baseline comparison,
+# quality thresholds, and report rendering.
+expected_files:
+  - src/archex/dogfood.py
+  - src/archex/cli/benchmark_cmd.py
+  - src/archex/benchmark/baseline.py
+  - src/archex/benchmark/gate.py
+  - src/archex/benchmark/reporter.py
+expected_symbols:
+  - run_dogfood
+  - baseline_compare_cmd
+  - compare_baseline
+  - check_gate
+token_budget: 8192
+keywords:
+  - dogfood
+  - benchmark
+  - baseline
+  - gate

--- a/benchmarks/tasks/archex_delta_index_lifecycle.yaml
+++ b/benchmarks/tasks/archex_delta_index_lifecycle.yaml
@@ -1,0 +1,24 @@
+task_id: archex_delta_index_lifecycle
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "How does archex decide between delta indexing and a full reindex during project lifecycle operations?"
+# Expected files cover the API decision point, delta computation/application,
+# cache metadata, and status freshness checks.
+expected_files:
+  - src/archex/api.py
+  - src/archex/index/delta.py
+  - src/archex/cache.py
+  - src/archex/status.py
+expected_symbols:
+  - _try_delta_index
+  - compute_delta
+  - apply_delta
+  - inspect_project_status
+token_budget: 8192
+keywords:
+  - delta
+  - reindex
+  - freshness
+  - cache

--- a/benchmarks/tasks/archex_mcp_query_lifecycle.yaml
+++ b/benchmarks/tasks/archex_mcp_query_lifecycle.yaml
@@ -1,0 +1,25 @@
+task_id: archex_mcp_query_lifecycle
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "How does archex expose repository query workflows through its MCP integration?"
+# Expected files cover the MCP CLI entry point, MCP tool handlers, public query API,
+# context assembly, and response model contracts.
+expected_files:
+  - src/archex/cli/mcp_cmd.py
+  - src/archex/integrations/mcp.py
+  - src/archex/api.py
+  - src/archex/serve/context.py
+  - src/archex/models.py
+expected_symbols:
+  - mcp_cmd
+  - handle_query_repo
+  - run_stdio_server
+  - query
+token_budget: 8192
+keywords:
+  - mcp
+  - query
+  - tool
+  - context

--- a/benchmarks/tasks/archex_project_config_resolution.yaml
+++ b/benchmarks/tasks/archex_project_config_resolution.yaml
@@ -1,0 +1,24 @@
+task_id: archex_project_config_resolution
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "How does archex resolve project settings into runtime configuration?"
+# Expected files cover project settings creation, config precedence, runtime config models,
+# and cache layout behavior driven by those settings.
+expected_files:
+  - src/archex/project.py
+  - src/archex/config.py
+  - src/archex/models.py
+  - src/archex/cache.py
+expected_symbols:
+  - DEFAULT_SETTINGS_TOML
+  - load_config
+  - load_index_config
+  - Config
+token_budget: 8192
+keywords:
+  - config
+  - settings
+  - project
+  - cache_dir

--- a/benchmarks/tasks/archex_project_index.yaml
+++ b/benchmarks/tasks/archex_project_index.yaml
@@ -1,0 +1,25 @@
+task_id: archex_project_index
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "How does archex explicitly build or refresh a repo-local index?"
+# Expected files cover the CLI command, public indexing API, cache layout,
+# project-local path resolution, and project config loading.
+expected_files:
+  - src/archex/cli/index_cmd.py
+  - src/archex/api.py
+  - src/archex/cache.py
+  - src/archex/project.py
+  - src/archex/config.py
+expected_symbols:
+  - index_cmd
+  - index_repository
+  - CacheManager
+  - uses_project_cache_layout
+token_budget: 8192
+keywords:
+  - index
+  - project
+  - cache
+  - refresh

--- a/benchmarks/tasks/archex_project_init.yaml
+++ b/benchmarks/tasks/archex_project_init.yaml
@@ -1,0 +1,24 @@
+task_id: archex_project_init
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "How does archex initialize repo-local project state?"
+# Expected files cover command registration, CLI option handling, project-state creation,
+# and the settings loader that consumes the generated project configuration.
+expected_files:
+  - src/archex/cli/main.py
+  - src/archex/cli/init_cmd.py
+  - src/archex/project.py
+  - src/archex/config.py
+expected_symbols:
+  - cli
+  - init_cmd
+  - init_project
+  - load_config
+token_budget: 8192
+keywords:
+  - init
+  - project
+  - settings
+  - gitignore

--- a/benchmarks/tasks/archex_project_reset.yaml
+++ b/benchmarks/tasks/archex_project_reset.yaml
@@ -1,0 +1,23 @@
+task_id: archex_project_reset
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "How does archex reset generated repo-local project state?"
+# Expected files cover command registration, reset CLI behavior, and the project-state
+# deletion logic that preserves settings unless all state is requested.
+expected_files:
+  - src/archex/cli/main.py
+  - src/archex/cli/reset_cmd.py
+  - src/archex/project.py
+expected_symbols:
+  - cli
+  - reset_cmd
+  - reset_project
+  - ProjectResetResult
+token_budget: 8192
+keywords:
+  - reset
+  - generated
+  - state
+  - force

--- a/benchmarks/tasks/archex_project_status.yaml
+++ b/benchmarks/tasks/archex_project_status.yaml
@@ -1,0 +1,24 @@
+task_id: archex_project_status
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "How does archex inspect whether a repo-local index is fresh, stale, dirty, or corrupt?"
+# Expected files cover CLI rendering, status-state inspection, project path resolution,
+# and working-tree signature calculation.
+expected_files:
+  - src/archex/cli/status_cmd.py
+  - src/archex/status.py
+  - src/archex/project.py
+  - src/archex/index/delta.py
+expected_symbols:
+  - status_cmd
+  - inspect_project_status
+  - ProjectState
+  - compute_working_tree_signature
+token_budget: 8192
+keywords:
+  - status
+  - fresh
+  - dirty
+  - stale

--- a/benchmarks/tasks/archex_query_cache_lifecycle.yaml
+++ b/benchmarks/tasks/archex_query_cache_lifecycle.yaml
@@ -1,0 +1,25 @@
+task_id: archex_query_cache_lifecycle
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "How does a query use project configuration and cache state across the indexing lifecycle?"
+# Expected files cover CLI query defaults, public query orchestration, cache management,
+# config loading, and project-local layout detection.
+expected_files:
+  - src/archex/cli/query_cmd.py
+  - src/archex/api.py
+  - src/archex/cache.py
+  - src/archex/config.py
+  - src/archex/project.py
+expected_symbols:
+  - query_cmd
+  - query
+  - CacheManager
+  - load_config
+token_budget: 8192
+keywords:
+  - query
+  - cache
+  - lifecycle
+  - project

--- a/benchmarks/tasks/archex_vector_cache_lifecycle.yaml
+++ b/benchmarks/tasks/archex_vector_cache_lifecycle.yaml
@@ -1,0 +1,25 @@
+task_id: archex_vector_cache_lifecycle
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "How does archex build, cache, and reload vector indexes for query retrieval?"
+# Expected files cover vector cache paths, API vector loading/search, vector index
+# persistence, embedding contracts, and vector configuration models.
+expected_files:
+  - src/archex/api.py
+  - src/archex/cache.py
+  - src/archex/index/vector.py
+  - src/archex/index/embeddings/base.py
+  - src/archex/models.py
+expected_symbols:
+  - _vector_search_precomputed
+  - vector_path
+  - VectorIndex
+  - Embedder
+token_budget: 8192
+keywords:
+  - vector
+  - cache
+  - embedder
+  - retrieval


### PR DESCRIPTION
## Scope

Expands the archex self-task corpus so dogfood covers lifecycle and maintainer workflow questions, not only the original retrieval examples.

Included lifecycle tasks:
- `archex_project_init`
- `archex_project_index`
- `archex_project_status`
- `archex_project_reset`
- `archex_project_config_resolution`

Included maintainer workflow tasks:
- `archex_query_cache_lifecycle`
- `archex_delta_index_lifecycle`
- `archex_vector_cache_lifecycle`
- `archex_benchmark_gate_lifecycle`
- `archex_mcp_query_lifecycle`

Each task is `category: self`, uses `repo: "."`, keeps expected files to source files, and documents why the expected-file set belongs to the maintainer question.

Out of scope:
- dogfood CI workflow wiring
- baseline file updates
- README/docs updates
- retrieval tuning for the new tasks

## Stack

| PR | Branch | Base | Scope |
| --- | --- | --- | --- |
| #100 | `fix/dogfood-query-pipeline-recall` | `main` | Query pipeline recall fix |
| #101 | `feat/project-init-lifecycle` | `fix/dogfood-query-pipeline-recall` | Project init lifecycle |
| #102 | `feat/project-config-resolution` | `feat/project-init-lifecycle` | Project config resolution |
| #103 | `feat/project-index-command` | `feat/project-config-resolution` | Project index command |
| #104 | `feat/project-local-index-storage` | `feat/project-index-command` | Fixed repo-local index storage |
| #105 | `feat/working-tree-freshness` | `feat/project-local-index-storage` | Working-tree freshness detection |
| #106 | `feat/project-status-command` | `feat/working-tree-freshness` | Project status command |
| #107 | `feat/project-reset-command` | `feat/project-status-command` | Project reset command |
| #108 | `feat/cwd-default-source` | `feat/project-reset-command` | cwd default source ergonomics |
| #109 | `feat/dogfood-command` | `feat/cwd-default-source` | Dogfood command with baseline-relative gate |
| #110 | `feat/failure-class-reporting` | `feat/dogfood-command` | Dogfood retrieval failure-class reporting |
| This PR | `feat/self-task-corpus-expansion` | `feat/failure-class-reporting` | Expanded self-task corpus |

## Validation

- `uv run archex benchmark validate --tasks-dir benchmarks/tasks`
- `uv run ruff check`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest --no-cov tests/benchmark/test_loader.py tests/benchmark/test_models.py tests/benchmark/test_cli.py tests/benchmark/test_dogfood.py tests/test_cli.py`
- `uv run archex dogfood . --task archex_project_status --format json`

Dogfood smoke result: `archex_project_status` ran successfully and produced `partial_recall` plus `seed_miss` diagnostics for `archex_query`, which is expected evidence for future retrieval work rather than a gate failure without a baseline.
