### PR TITLE
feat(cli): add project initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,7 @@ __marimo__/
 
 # Developer workspace
 .docs/
+.archex/
 
 # Benchmark results (keep .gitkeep)
 benchmarks/results/*.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "UP", "B", "SIM", "TCH"]
+ignore = ["TC003"]
 
 [tool.pyright]
 pythonVersion = "3.11"

--- a/src/archex/cli/init_cmd.py
+++ b/src/archex/cli/init_cmd.py
@@ -1,0 +1,37 @@
+"""Project lifecycle initialization command."""
+
+from __future__ import annotations
+
+import click
+
+from archex.project import init_project
+
+
+@click.command("init")
+@click.argument("source")
+@click.option("--force", is_flag=True, default=False, help="Rewrite project settings.")
+@click.option(
+    "--reset",
+    is_flag=True,
+    default=False,
+    help="Delete existing .archex state before initialization. Requires --force.",
+)
+def init_cmd(source: str, force: bool, reset: bool) -> None:
+    """Initialize repo-local archex project state."""
+    try:
+        result = init_project(source, force=force, reset=reset)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if result.created:
+        click.echo(f"Initialized archex project at {result.state.project_dir}")
+    else:
+        click.echo(f"archex project already initialized at {result.state.project_dir}")
+
+    if result.settings_written:
+        click.echo(f"Wrote settings: {result.state.settings_path}")
+    else:
+        click.echo(f"Preserved settings: {result.state.settings_path}")
+
+    if result.gitignore_updated:
+        click.echo(f"Updated ignore rules: {result.state.gitignore_path}")

--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -9,6 +9,7 @@ from archex.cli.analyze_cmd import analyze_cmd
 from archex.cli.benchmark_cmd import benchmark_cmd
 from archex.cli.cache_cmd import cache_cmd
 from archex.cli.compare_cmd import compare_cmd
+from archex.cli.init_cmd import init_cmd
 from archex.cli.mcp_cmd import mcp_cmd
 from archex.cli.outline_cmd import outline_cmd
 from archex.cli.query_cmd import query_cmd
@@ -29,6 +30,7 @@ cli.add_command(benchmark_cmd)
 cli.add_command(query_cmd)
 cli.add_command(compare_cmd)
 cli.add_command(cache_cmd)
+cli.add_command(init_cmd)
 cli.add_command(mcp_cmd)
 cli.add_command(tree_cmd)
 cli.add_command(outline_cmd)

--- a/src/archex/project.py
+++ b/src/archex/project.py
@@ -1,0 +1,158 @@
+"""Repo-local archex project state helpers."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from archex import __version__
+
+PROJECT_DIR_NAME = ".archex"
+PROJECT_GITIGNORE_ENTRY = f"{PROJECT_DIR_NAME}/"
+
+DEFAULT_SETTINGS_TOML = """[project]
+mode = "local"
+
+[index]
+cache_dir = ".archex"
+languages = []
+vector = false
+delta_threshold = 0.5
+
+[dogfood]
+tasks_dir = "benchmarks/tasks"
+output_dir = ".archex/dogfood"
+default_task_prefix = "archex_"
+strategies = ["raw_files", "raw_grepped", "archex_query"]
+"""
+
+
+@dataclass(frozen=True)
+class ProjectState:
+    """Resolved repo-local archex state paths."""
+
+    repo_root: Path
+
+    @property
+    def project_dir(self) -> Path:
+        return self.repo_root / PROJECT_DIR_NAME
+
+    @property
+    def settings_path(self) -> Path:
+        return self.project_dir / "settings.toml"
+
+    @property
+    def metadata_path(self) -> Path:
+        return self.project_dir / "metadata.json"
+
+    @property
+    def dogfood_dir(self) -> Path:
+        return self.project_dir / "dogfood"
+
+    @property
+    def dogfood_history_dir(self) -> Path:
+        return self.dogfood_dir / "history"
+
+    @property
+    def gitignore_path(self) -> Path:
+        return self.repo_root / ".gitignore"
+
+    @classmethod
+    def resolve(cls, source: str | Path) -> ProjectState:
+        """Resolve a source path to its Git repository root."""
+        path = Path(source).expanduser().resolve()
+        if not path.exists():
+            raise ValueError(f"Source path does not exist: {path}")
+        if not path.is_dir():
+            raise ValueError(f"Source path is not a directory: {path}")
+
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or "not a Git repository"
+            raise ValueError(f"Could not resolve repository root for {path}: {detail}")
+        root_text = result.stdout.strip()
+        if not root_text:
+            raise ValueError(f"git rev-parse returned an empty repository root for {path}")
+        return cls(repo_root=Path(root_text).resolve())
+
+    def initialized(self) -> bool:
+        return self.settings_path.exists()
+
+
+@dataclass(frozen=True)
+class ProjectInitResult:
+    """Result of initializing repo-local project state."""
+
+    state: ProjectState
+    created: bool
+    settings_written: bool
+    gitignore_updated: bool
+
+
+def init_project(
+    source: str | Path,
+    *,
+    force: bool = False,
+    reset: bool = False,
+) -> ProjectInitResult:
+    """Create or refresh repo-local archex state."""
+    if reset and not force:
+        raise ValueError("--reset requires --force")
+
+    state = ProjectState.resolve(source)
+    existed = state.initialized()
+
+    if reset and state.project_dir.exists():
+        shutil.rmtree(state.project_dir)
+        existed = False
+
+    state.dogfood_history_dir.mkdir(parents=True, exist_ok=True)
+
+    settings_written = False
+    if force or not state.settings_path.exists():
+        state.settings_path.write_text(DEFAULT_SETTINGS_TOML, encoding="utf-8")
+        settings_written = True
+
+    metadata = {
+        "archex_version": __version__,
+        "created_at": datetime.now(tz=UTC).isoformat(),
+    }
+    state.metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+
+    gitignore_updated = ensure_project_gitignore(state.gitignore_path)
+
+    return ProjectInitResult(
+        state=state,
+        created=not existed,
+        settings_written=settings_written,
+        gitignore_updated=gitignore_updated,
+    )
+
+
+def ensure_project_gitignore(gitignore_path: Path) -> bool:
+    """Ensure `.archex/` is ignored exactly once."""
+    if gitignore_path.exists():
+        lines = gitignore_path.read_text(encoding="utf-8").splitlines()
+    else:
+        lines = []
+
+    if PROJECT_GITIGNORE_ENTRY in {line.strip() for line in lines}:
+        return False
+
+    if lines and lines[-1] != "":
+        lines.append("")
+    lines.append("# archex project state")
+    lines.append(PROJECT_GITIGNORE_ENTRY)
+    gitignore_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return True

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,38 @@ def test_help_contains_subcommands() -> None:
     assert "query" in output
     assert "compare" in output
     assert "cache" in output
+    assert "init" in output
+
+
+def test_init_command_creates_project_state(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["init", str(python_simple_repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "Initialized archex project" in result.output
+    assert (python_simple_repo / ".archex" / "settings.toml").exists()
+    assert (python_simple_repo / ".archex" / "dogfood" / "history").is_dir()
+    assert ".archex/" in (python_simple_repo / ".gitignore").read_text(encoding="utf-8")
+
+
+def test_init_command_is_idempotent(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+    first = runner.invoke(cli, ["init", str(python_simple_repo)])
+    second = runner.invoke(cli, ["init", str(python_simple_repo)])
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    assert "already initialized" in second.output
+
+
+def test_init_command_reset_requires_force(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["init", str(python_simple_repo), "--reset"])
+
+    assert result.exit_code != 0
+    assert "--reset requires --force" in result.output
 
 
 def test_analyze_local_json(python_simple_repo: Path) -> None:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -17,6 +17,8 @@ def _init_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
     _git(repo, "init")
+    _git(repo, "config", "user.email", "test@archex.test")
+    _git(repo, "config", "user.name", "archex-test")
     (repo / "README.md").write_text("# repo\n", encoding="utf-8")
     _git(repo, "add", ".")
     _git(repo, "commit", "-m", "initial")

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from archex.project import DEFAULT_SETTINGS_TOML, ProjectState, init_project
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    (repo / "README.md").write_text("# repo\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def test_project_state_resolves_git_root_from_subdirectory(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    subdir = repo / "src" / "pkg"
+    subdir.mkdir(parents=True)
+
+    state = ProjectState.resolve(subdir)
+
+    assert state.repo_root == repo.resolve()
+    assert state.settings_path == repo / ".archex" / "settings.toml"
+
+
+def test_project_state_rejects_non_git_directory(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Could not resolve repository root"):
+        ProjectState.resolve(tmp_path)
+
+
+def test_init_project_creates_settings_metadata_dogfood_and_gitignore(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+
+    result = init_project(repo)
+
+    assert result.created is True
+    assert result.settings_written is True
+    assert result.gitignore_updated is True
+    assert (repo / ".archex" / "settings.toml").read_text(encoding="utf-8") == (
+        DEFAULT_SETTINGS_TOML
+    )
+    assert (repo / ".archex" / "dogfood" / "history").is_dir()
+    metadata = json.loads((repo / ".archex" / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["archex_version"]
+    assert metadata["created_at"]
+    assert ".archex/" in (repo / ".gitignore").read_text(encoding="utf-8").splitlines()
+
+
+def test_init_project_is_idempotent_and_does_not_duplicate_gitignore(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    init_project(repo)
+    settings = repo / ".archex" / "settings.toml"
+    settings.write_text("custom = true\n", encoding="utf-8")
+
+    result = init_project(repo)
+
+    assert result.created is False
+    assert result.settings_written is False
+    assert result.gitignore_updated is False
+    assert settings.read_text(encoding="utf-8") == "custom = true\n"
+    gitignore_lines = (repo / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert gitignore_lines.count(".archex/") == 1
+
+
+def test_init_project_force_rewrites_settings_but_preserves_generated_files(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    init_project(repo)
+    settings = repo / ".archex" / "settings.toml"
+    generated = repo / ".archex" / "index.db"
+    settings.write_text("custom = true\n", encoding="utf-8")
+    generated.write_text("db", encoding="utf-8")
+
+    result = init_project(repo, force=True)
+
+    assert result.created is False
+    assert result.settings_written is True
+    assert settings.read_text(encoding="utf-8") == DEFAULT_SETTINGS_TOML
+    assert generated.read_text(encoding="utf-8") == "db"
+
+
+def test_init_project_reset_requires_force(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+
+    with pytest.raises(ValueError, match="--reset requires --force"):
+        init_project(repo, reset=True)
+
+
+def test_init_project_force_reset_removes_existing_state(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    init_project(repo)
+    generated = repo / ".archex" / "index.db"
+    generated.write_text("db", encoding="utf-8")
+
+    result = init_project(repo, force=True, reset=True)
+
+    assert result.created is True
+    assert result.settings_written is True
+    assert not generated.exists()
+    assert (repo / ".archex" / "settings.toml").exists()


### PR DESCRIPTION
## Scope

Replacement for #101 after GitHub closed the original stacked PR when its base branch was deleted during root merge.

This is the same project initialization lifecycle slice rebased onto `main`.

Included:
- repo-local `ProjectState`
- `archex init`
- `.archex/settings.toml`
- `.archex/metadata.json`
- `.archex/dogfood/history/`
- deterministic `.gitignore` update
- `--force`
- `--reset --force`

Out of scope:
- config resolution
- index command
- status/reset/dogfood commands beyond initialization scaffolding

## Stack

This replaces closed PR #101 and keeps the stack landing order intact.

| Order | PR | Branch | Base | Scope |
| ---: | --- | --- | --- | --- |
| 1 | #100 | `fix/dogfood-query-pipeline-recall` | `main` | merged |
| 2 | This PR | `feat/project-init-lifecycle` | `main` | project init lifecycle |
| 3 | #102 | `feat/project-config-resolution` | `feat/project-init-lifecycle` | project config resolution |

## Validation

Previously validated in #101:
- `uv run ruff check`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest --no-cov tests/test_project.py tests/test_cli.py`
