### PR TITLE
feat(benchmark): add readiness report

### DIFF
--- a/src/archex/benchmark/readiness.py
+++ b/src/archex/benchmark/readiness.py
@@ -1,0 +1,301 @@
+"""Product-readiness reporting for persisted benchmark results."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from archex.benchmark.models import BenchmarkReport, BenchmarkResult, BenchmarkTask, Strategy
+from archex.benchmark.triage import TriageFinding, triage_failures
+
+TARGET_MEAN_RECALL = 0.80
+TARGET_MEAN_PRECISION = 0.60
+TARGET_MEAN_F1 = 0.70
+TARGET_ZERO_RECALL_TASKS = 1
+LOW_F1_THRESHOLD = 0.40
+LOW_PRECISION_THRESHOLD = 0.35
+
+
+@dataclass(frozen=True)
+class ReadinessTargetStatus:
+    """Pass/fail status for one readiness target."""
+
+    name: str
+    actual: float | int
+    target: float | int
+    passed: bool
+    comparator: str
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "actual": self.actual,
+            "target": self.target,
+            "passed": self.passed,
+            "comparator": self.comparator,
+        }
+
+
+@dataclass(frozen=True)
+class CategoryReadiness:
+    """Aggregated metrics for one benchmark category."""
+
+    category: str
+    task_count: int
+    mean_recall: float
+    mean_precision: float
+    mean_f1_score: float
+    mean_mrr: float
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "category": self.category,
+            "task_count": self.task_count,
+            "mean_recall": self.mean_recall,
+            "mean_precision": self.mean_precision,
+            "mean_f1_score": self.mean_f1_score,
+            "mean_mrr": self.mean_mrr,
+        }
+
+
+@dataclass(frozen=True)
+class ReadinessReport:
+    """Non-blocking product-readiness report for one strategy."""
+
+    strategy: str
+    task_count: int
+    mean_recall: float
+    mean_precision: float
+    mean_f1_score: float
+    mean_mrr: float
+    zero_recall_tasks: int
+    low_f1_tasks: int
+    low_precision_tasks: int
+    targets: list[ReadinessTargetStatus]
+    categories: list[CategoryReadiness]
+    blocking_tasks: list[TriageFinding]
+
+    @property
+    def ready(self) -> bool:
+        return all(target.passed for target in self.targets)
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "strategy": self.strategy,
+            "ready": self.ready,
+            "task_count": self.task_count,
+            "mean_recall": self.mean_recall,
+            "mean_precision": self.mean_precision,
+            "mean_f1_score": self.mean_f1_score,
+            "mean_mrr": self.mean_mrr,
+            "zero_recall_tasks": self.zero_recall_tasks,
+            "low_f1_tasks": self.low_f1_tasks,
+            "low_precision_tasks": self.low_precision_tasks,
+            "targets": [target.to_json() for target in self.targets],
+            "categories": [category.to_json() for category in self.categories],
+            "blocking_tasks": [finding.to_json() for finding in self.blocking_tasks],
+        }
+
+
+def build_readiness_report(
+    reports: list[BenchmarkReport],
+    tasks_by_id: dict[str, BenchmarkTask],
+    *,
+    strategy: Strategy = Strategy.ARCHEX_QUERY,
+) -> ReadinessReport:
+    """Build a non-blocking readiness report for persisted benchmark results."""
+    results: list[tuple[BenchmarkReport, BenchmarkResult]] = []
+    for report in reports:
+        result = _find_result(report, strategy)
+        if result is not None:
+            results.append((report, result))
+
+    if not results:
+        return ReadinessReport(
+            strategy=strategy.value,
+            task_count=0,
+            mean_recall=0.0,
+            mean_precision=0.0,
+            mean_f1_score=0.0,
+            mean_mrr=0.0,
+            zero_recall_tasks=0,
+            low_f1_tasks=0,
+            low_precision_tasks=0,
+            targets=[],
+            categories=[],
+            blocking_tasks=[],
+        )
+
+    metric_results = [result for _, result in results]
+    mean_recall = _mean([result.recall for result in metric_results])
+    mean_precision = _mean([result.precision for result in metric_results])
+    mean_f1 = _mean([result.f1_score for result in metric_results])
+    mean_mrr = _mean([result.mrr for result in metric_results])
+    zero_recall_tasks = sum(1 for result in metric_results if result.recall <= 0.0)
+    low_f1_tasks = sum(1 for result in metric_results if result.f1_score < LOW_F1_THRESHOLD)
+    low_precision_tasks = sum(
+        1 for result in metric_results if result.precision < LOW_PRECISION_THRESHOLD
+    )
+    targets = [
+        ReadinessTargetStatus(
+            name="mean_recall",
+            actual=mean_recall,
+            target=TARGET_MEAN_RECALL,
+            passed=mean_recall >= TARGET_MEAN_RECALL,
+            comparator=">=",
+        ),
+        ReadinessTargetStatus(
+            name="mean_precision",
+            actual=mean_precision,
+            target=TARGET_MEAN_PRECISION,
+            passed=mean_precision >= TARGET_MEAN_PRECISION,
+            comparator=">=",
+        ),
+        ReadinessTargetStatus(
+            name="mean_f1_score",
+            actual=mean_f1,
+            target=TARGET_MEAN_F1,
+            passed=mean_f1 >= TARGET_MEAN_F1,
+            comparator=">=",
+        ),
+        ReadinessTargetStatus(
+            name="zero_recall_tasks",
+            actual=zero_recall_tasks,
+            target=TARGET_ZERO_RECALL_TASKS,
+            passed=zero_recall_tasks <= TARGET_ZERO_RECALL_TASKS,
+            comparator="<=",
+        ),
+    ]
+    categories = _category_readiness(results, tasks_by_id)
+    blocking_tasks = triage_failures(reports, tasks_by_id, strategy=strategy)[:10]
+    return ReadinessReport(
+        strategy=strategy.value,
+        task_count=len(results),
+        mean_recall=mean_recall,
+        mean_precision=mean_precision,
+        mean_f1_score=mean_f1,
+        mean_mrr=mean_mrr,
+        zero_recall_tasks=zero_recall_tasks,
+        low_f1_tasks=low_f1_tasks,
+        low_precision_tasks=low_precision_tasks,
+        targets=targets,
+        categories=categories,
+        blocking_tasks=blocking_tasks,
+    )
+
+
+def format_readiness_markdown(report: ReadinessReport) -> str:
+    """Render a readiness report as Markdown."""
+    if report.task_count == 0:
+        return f"# Benchmark Readiness\n\nNo `{report.strategy}` results found."
+
+    lines = ["# Benchmark Readiness", ""]
+    lines.append(f"Strategy: `{report.strategy}`")
+    lines.append(f"Tasks: `{report.task_count}`")
+    lines.append(f"Ready: `{'yes' if report.ready else 'no'}`")
+    lines.append("")
+    lines.append("| Metric | Actual | Target | Status |")
+    lines.append("|---|---:|---:|---|")
+    for target in report.targets:
+        status = "pass" if target.passed else "fail"
+        lines.append(
+            f"| {target.name} | {_format_number(target.actual)} "
+            f"| {target.comparator} {_format_number(target.target)} | {status} |"
+        )
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(
+        f"- Mean recall: `{report.mean_recall:.3f}`\n"
+        f"- Mean precision: `{report.mean_precision:.3f}`\n"
+        f"- Mean F1: `{report.mean_f1_score:.3f}`\n"
+        f"- Mean MRR: `{report.mean_mrr:.3f}`\n"
+        f"- Zero-recall tasks: `{report.zero_recall_tasks}`\n"
+        f"- Tasks below F1 {LOW_F1_THRESHOLD:.2f}: `{report.low_f1_tasks}`\n"
+        f"- Tasks below precision {LOW_PRECISION_THRESHOLD:.2f}: `{report.low_precision_tasks}`"
+    )
+    lines.append("")
+    lines.append("## Categories")
+    lines.append("")
+    lines.append("| Category | Tasks | Recall | Precision | F1 | MRR |")
+    lines.append("|---|---:|---:|---:|---:|---:|")
+    for category in report.categories:
+        lines.append(
+            f"| {category.category} | {category.task_count} | {category.mean_recall:.3f} "
+            f"| {category.mean_precision:.3f} | {category.mean_f1_score:.3f} "
+            f"| {category.mean_mrr:.3f} |"
+        )
+    lines.append("")
+    lines.append("## Top Blocking Tasks")
+    lines.append("")
+    if not report.blocking_tasks:
+        lines.append("No blocking tasks matched the triage thresholds.")
+    else:
+        lines.append("| Rank | Task | Category | Bucket | Recall | Precision | F1 |")
+        lines.append("|---:|---|---|---|---:|---:|---:|")
+        for index, finding in enumerate(report.blocking_tasks, start=1):
+            lines.append(
+                f"| {index} | `{finding.task_id}` | {finding.category} "
+                f"| {finding.failure_bucket} | {finding.recall:.3f} "
+                f"| {finding.precision:.3f} | {finding.f1_score:.3f} |"
+            )
+    return "\n".join(lines)
+
+
+def format_readiness_json(report: ReadinessReport) -> str:
+    """Render a readiness report as stable JSON."""
+    return json.dumps(report.to_json(), indent=2, sort_keys=True)
+
+
+def _find_result(report: BenchmarkReport, strategy: Strategy) -> BenchmarkResult | None:
+    for result in report.results:
+        if result.strategy == strategy:
+            return result
+    return None
+
+
+def _category_readiness(
+    results: list[tuple[BenchmarkReport, BenchmarkResult]],
+    tasks_by_id: dict[str, BenchmarkTask],
+) -> list[CategoryReadiness]:
+    by_category: dict[str, list[BenchmarkResult]] = {}
+    for report, result in results:
+        category = _category(report, result, tasks_by_id)
+        by_category.setdefault(category, []).append(result)
+
+    categories: list[CategoryReadiness] = []
+    for category, category_results in sorted(by_category.items()):
+        categories.append(
+            CategoryReadiness(
+                category=category,
+                task_count=len(category_results),
+                mean_recall=_mean([result.recall for result in category_results]),
+                mean_precision=_mean([result.precision for result in category_results]),
+                mean_f1_score=_mean([result.f1_score for result in category_results]),
+                mean_mrr=_mean([result.mrr for result in category_results]),
+            )
+        )
+    return categories
+
+
+def _category(
+    report: BenchmarkReport,
+    result: BenchmarkResult,
+    tasks_by_id: dict[str, BenchmarkTask],
+) -> str:
+    if result.category is not None:
+        return result.category.value
+    task = tasks_by_id.get(report.task_id)
+    if task is not None and task.category is not None:
+        return task.category.value
+    return "uncategorized"
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _format_number(value: float | int) -> str:
+    if isinstance(value, int):
+        return str(value)
+    return f"{value:.3f}"

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -19,6 +19,11 @@ from archex.benchmark.gate import (
 )
 from archex.benchmark.loader import load_tasks
 from archex.benchmark.models import BenchmarkReport, DeltaBenchmarkResult, Strategy
+from archex.benchmark.readiness import (
+    build_readiness_report,
+    format_readiness_json,
+    format_readiness_markdown,
+)
 from archex.benchmark.reporter import (
     format_bucketed_summary,
     format_delta_summary,
@@ -193,6 +198,48 @@ def triage_cmd(input_dir: str, tasks_dir: str, strategy_name: str, output_format
         click.echo(format_triage_json(findings))
     else:
         click.echo(format_triage_markdown(findings))
+
+
+@benchmark_cmd.command("readiness")
+@click.option(
+    "--input",
+    "input_dir",
+    default="benchmarks/results",
+    type=click.Path(exists=True),
+    help="Directory containing result JSON files.",
+)
+@click.option(
+    "--tasks-dir",
+    default="benchmarks/tasks",
+    type=click.Path(exists=True),
+    help="Directory containing task YAML files.",
+)
+@click.option(
+    "--strategy",
+    "strategy_name",
+    default=Strategy.ARCHEX_QUERY.value,
+    type=click.Choice([s.value for s in Strategy]),
+    help="Strategy to assess.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="markdown",
+    type=click.Choice(["markdown", "json"]),
+    help="Output format.",
+)
+def readiness_cmd(input_dir: str, tasks_dir: str, strategy_name: str, output_format: str) -> None:
+    """Generate a non-blocking benchmark readiness report."""
+    reports = load_benchmark_reports(Path(input_dir))
+    if not reports:
+        raise click.ClickException(f"No result files found in {input_dir}")
+
+    tasks_by_id = load_benchmark_tasks(Path(tasks_dir))
+    readiness = build_readiness_report(reports, tasks_by_id, strategy=Strategy(strategy_name))
+    if output_format == "json":
+        click.echo(format_readiness_json(readiness))
+    else:
+        click.echo(format_readiness_markdown(readiness))
 
 
 @benchmark_cmd.command("validate")

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -165,6 +165,38 @@ expected_files:
         assert json.loads(output.output) == []
 
 
+class TestReadinessCommand:
+    def test_markdown_output(self, runner: CliRunner, results_dir: Path, tasks_dir: Path) -> None:
+        output = runner.invoke(
+            benchmark_cmd,
+            ["readiness", "--input", str(results_dir), "--tasks-dir", str(tasks_dir)],
+        )
+
+        assert output.exit_code == 0
+        assert "# Benchmark Readiness" in output.output
+        assert "No `archex_query` results found" in output.output
+
+    def test_json_output(self, runner: CliRunner, results_dir: Path, tasks_dir: Path) -> None:
+        output = runner.invoke(
+            benchmark_cmd,
+            [
+                "readiness",
+                "--format",
+                "json",
+                "--input",
+                str(results_dir),
+                "--tasks-dir",
+                str(tasks_dir),
+            ],
+        )
+
+        assert output.exit_code == 0
+        payload = json.loads(output.output)
+        assert payload["strategy"] == "archex_query"
+        assert payload["task_count"] == 0
+        assert payload["ready"] is True
+
+
 class TestValidateCommand:
     def test_valid_tasks(self, runner: CliRunner, tasks_dir: Path) -> None:
         result = runner.invoke(benchmark_cmd, ["validate", "--tasks-dir", str(tasks_dir)])

--- a/tests/benchmark/test_readiness.py
+++ b/tests/benchmark/test_readiness.py
@@ -1,0 +1,175 @@
+"""Tests for benchmark readiness reporting."""
+
+from __future__ import annotations
+
+import json
+
+from archex.benchmark.models import (
+    BenchmarkReport,
+    BenchmarkResult,
+    BenchmarkTask,
+    Strategy,
+    TaskCategory,
+)
+from archex.benchmark.readiness import (
+    build_readiness_report,
+    format_readiness_json,
+    format_readiness_markdown,
+)
+
+
+def _result(
+    task_id: str,
+    *,
+    recall: float,
+    precision: float,
+    f1_score: float,
+    mrr: float = 1.0,
+    category: TaskCategory | None = None,
+    strategy: Strategy = Strategy.ARCHEX_QUERY,
+) -> BenchmarkResult:
+    return BenchmarkResult(
+        task_id=task_id,
+        strategy=strategy,
+        tokens_total=100,
+        tool_calls=1,
+        files_accessed=1,
+        recall=recall,
+        precision=precision,
+        f1_score=f1_score,
+        mrr=mrr,
+        savings_vs_raw=0.0,
+        wall_time_ms=10.0,
+        cached=False,
+        timestamp="2026-01-01T00:00:00Z",
+        seed_files=["src/main.py"],
+        category=category,
+    )
+
+
+def _report(task_id: str, result: BenchmarkResult) -> BenchmarkReport:
+    return BenchmarkReport(
+        task_id=task_id,
+        repo="owner/repo",
+        question="How does retrieval work?",
+        results=[result],
+        baseline_tokens=100,
+    )
+
+
+def _task(task_id: str, category: TaskCategory) -> BenchmarkTask:
+    return BenchmarkTask(
+        task_id=task_id,
+        repo="owner/repo",
+        commit="abc123",
+        question="How does retrieval work?",
+        expected_files=["src/main.py", "src/context.py"],
+        category=category,
+    )
+
+
+def test_build_readiness_report_tracks_targets_and_counts() -> None:
+    reports = [
+        _report(
+            "good",
+            _result(
+                "good",
+                recall=1.0,
+                precision=0.8,
+                f1_score=0.89,
+                category=TaskCategory.SELF,
+            ),
+        ),
+        _report(
+            "miss",
+            _result(
+                "miss",
+                recall=0.0,
+                precision=0.0,
+                f1_score=0.0,
+                mrr=0.0,
+                category=TaskCategory.EXTERNAL_LARGE,
+            ),
+        ),
+    ]
+    tasks = {
+        "good": _task("good", TaskCategory.SELF),
+        "miss": _task("miss", TaskCategory.EXTERNAL_LARGE),
+    }
+
+    readiness = build_readiness_report(reports, tasks)
+
+    assert readiness.task_count == 2
+    assert readiness.mean_recall == 0.5
+    assert readiness.mean_precision == 0.4
+    assert readiness.zero_recall_tasks == 1
+    assert readiness.low_f1_tasks == 1
+    assert readiness.low_precision_tasks == 1
+    assert readiness.ready is False
+    assert [target.name for target in readiness.targets] == [
+        "mean_recall",
+        "mean_precision",
+        "mean_f1_score",
+        "zero_recall_tasks",
+    ]
+    assert readiness.blocking_tasks[0].task_id == "miss"
+
+
+def test_build_readiness_report_groups_by_task_category_when_result_missing() -> None:
+    report = _report(
+        "semantic",
+        _result("semantic", recall=0.7, precision=0.6, f1_score=0.65, category=None),
+    )
+    tasks = {"semantic": _task("semantic", TaskCategory.FRAMEWORK_SEMANTIC)}
+
+    readiness = build_readiness_report([report], tasks)
+
+    assert len(readiness.categories) == 1
+    assert readiness.categories[0].category == "framework-semantic"
+
+
+def test_build_readiness_report_handles_missing_strategy() -> None:
+    report = _report(
+        "raw",
+        _result(
+            "raw",
+            recall=1.0,
+            precision=1.0,
+            f1_score=1.0,
+            strategy=Strategy.RAW_FILES,
+        ),
+    )
+
+    readiness = build_readiness_report([report], {}, strategy=Strategy.ARCHEX_QUERY)
+
+    assert readiness.task_count == 0
+    assert readiness.targets == []
+    assert readiness.blocking_tasks == []
+
+
+def test_format_readiness_outputs_are_stable() -> None:
+    report = _report(
+        "miss",
+        _result(
+            "miss",
+            recall=0.0,
+            precision=0.0,
+            f1_score=0.0,
+            category=TaskCategory.EXTERNAL_LARGE,
+        ),
+    )
+    readiness = build_readiness_report(
+        [report],
+        {"miss": _task("miss", TaskCategory.EXTERNAL_LARGE)},
+    )
+
+    markdown = format_readiness_markdown(readiness)
+    assert "# Benchmark Readiness" in markdown
+    assert "mean_recall" in markdown
+    assert "Top Blocking Tasks" in markdown
+    assert "`miss`" in markdown
+
+    payload = json.loads(format_readiness_json(readiness))
+    assert payload["strategy"] == "archex_query"
+    assert payload["ready"] is False
+    assert payload["blocking_tasks"][0]["task_id"] == "miss"


### PR DESCRIPTION
## Stack

Base: `main`

1. `feat/benchmark-triage` -> #115
2. `feat/readiness-report` -> this PR
3. `feat/retrieval-quality-slice` -> pending
4. `refactor/api-boundaries` -> pending

## Summary

- Add non-blocking product-readiness reporting for persisted benchmark results.
- Track mean recall, mean precision, mean F1, mean MRR, zero-recall tasks, low-F1 tasks, and low-precision tasks.
- Evaluate readiness targets separately from existing hard benchmark gates.
- Include category-level metrics and top blocking tasks from the triage report.
- Add Markdown and JSON CLI output via `archex benchmark readiness`.

## Current Readiness From Committed Results

- `archex_query` mean recall: `0.567`
- `archex_query` mean precision: `0.348`
- `archex_query` mean F1: `0.425`
- `archex_query` zero-recall tasks: `1`
- Status: not ready against product targets

## Validation

- `uv run archex benchmark readiness --input benchmarks/results --tasks-dir benchmarks/tasks --strategy archex_query --format markdown`: passed
- `uv run pytest tests/benchmark/test_readiness.py tests/benchmark/test_cli.py --no-cov`: passed
- `uv run ruff check`: passed
- `uv run ruff format --check .`: passed
- `uv run pyright`: passed
- `uv run pytest tests/benchmark`: benchmark tests passed, command failed at repo-wide coverage gate with 39.64% partial-suite coverage below 85%
