### PR TITLE
chore(release): 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.6.1 (2026-05-25)
+
+### Changed
+
+- Removed the redundant `web` optional-dependency extra. `fastapi` and `uvicorn` are core dependencies, so the HTTP API server (`archex serve`) works on a bare install; `archex[web]` is no longer a recognized extra.
+- Simplified `archex serve` to import `uvicorn` directly instead of guarding an import that cannot fail (it is a core dependency).
+
+### Fixed
+
+- Corrected the cross-encoder reranker model name in the 0.6.0 changelog entry: the default is `cross-encoder/ms-marco-MiniLM-L-6-v2`, not Jina Reranker v2.
+
+### Docs
+
+- Refreshed the README to the current system: documented the `archex serve` HTTP API and its endpoints, the wired retrieval pipeline (BM25F, confidence-weighted RRF + adaptive RSF behind an AvgIDF fusion gate, intent-based weight routing, Personalized PageRank expansion, opt-in `cross-encoder/ms-marco-MiniLM` reranking), the `vector-fast` and `graph` extras, and the `benchmark triage`/`readiness` subcommands. Corrected stale benchmark-task and test counts and removed dead links to gitignored artifacts.
+
 ## 0.6.0 (2026-05-21)
 
 ### Removed — LLM dependencies (breaking)
@@ -30,7 +45,7 @@ archex is now fully local, fully deterministic, no API keys, no per-query cost. 
 
 **What stayed (still local, still LLM-free):**
 
-- Cross-encoder reranking (Jina Reranker v2) — local sentence-transformers model, not an LLM API.
+- Cross-encoder reranking (`cross-encoder/ms-marco-MiniLM-L-6-v2`) — local sentence-transformers model, not an LLM API.
 - Vector embeddings (FastEmbed, CodeRankEmbed) — local ONNX/Torch.
 - All structural analysis (Louvain modules, pattern catalog, interface extraction, dependency graph + PPR expansion).
 - The full 25-task benchmark corpus, now runnable end-to-end with zero API calls.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ uv add "archex[vector-torch]"        # Torch-backed sentence-transformers — GP
 
 ```bash
 uv add "archex[graph]"               # igraph + leidenalg — faster Leiden module detection
-uv add "archex[web]"                 # FastAPI HTTP server (archex serve)
 uv add "archex[language-pack]"       # Fallback tree-sitter grammars
 uv add "archex[all]"                 # vector + graph + mcp + langchain + llamaindex + language-pack
 ```
@@ -327,7 +326,7 @@ archex serve --port 8080
 | `GET /benchmark/summary`  | Aggregate benchmark summary                |
 | `GET /benchmark/gate`     | Quality-gate status                        |
 
-FastAPI and uvicorn ship in the core install; the `archex[web]` extra pins the same dependencies. An optional `/dashboard` is served when its assets are present.
+FastAPI and uvicorn ship in the core install, so `archex serve` works out of the box. An optional `/dashboard` is served when its assets are present.
 
 ### When to Use archex
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archex"
-version = "0.6.0"
+version = "0.6.1"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -58,10 +58,6 @@ llamaindex = ["llama-index-core>=0.10"]
 lsap = ["lsp-client>=0.3; python_version >= '3.12'"]
 language-pack = ["tree-sitter-language-pack>=0.13"]
 all = ["archex[vector,graph,mcp,langchain,llamaindex,language-pack]"]
-web = [
-    "fastapi>=0.115",
-    "uvicorn[standard]>=0.34",
-]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",

--- a/src/archex/__init__.py
+++ b/src/archex/__init__.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-__version__ = "0.5.0"
+from importlib.metadata import version
+
+__version__ = version("archex")
 
 from archex.api import analyze, compare, query
 

--- a/src/archex/cli/serve_cmd.py
+++ b/src/archex/cli/serve_cmd.py
@@ -11,12 +11,7 @@ import click
 @click.option("--reload", is_flag=True, help="Enable auto-reload for development.")
 def serve_cmd(host: str, port: int, reload: bool) -> None:
     """Start the archex HTTP API server."""
-    try:
-        import uvicorn
-    except ImportError as exc:
-        raise click.ClickException(
-            "uvicorn is required. Install with: uv add 'archex[web]'"
-        ) from exc
+    import uvicorn
 
     uvicorn.run(
         "archex.serve.app:create_app",

--- a/uv.lock
+++ b/uv.lock
@@ -183,7 +183,7 @@ wheels = [
 
 [[package]]
 name = "archex"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -258,10 +258,6 @@ vector-fast = [
 vector-torch = [
     { name = "sentence-transformers" },
 ]
-web = [
-    { name = "fastapi" },
-    { name = "uvicorn", extra = ["standard"] },
-]
 
 [package.dev-dependencies]
 dev = [
@@ -282,7 +278,6 @@ requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "einops", specifier = ">=0.8.2" },
     { name = "fastapi", specifier = ">=0.115" },
-    { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.115" },
     { name = "fastembed", marker = "extra == 'vector-fast'", specifier = ">=0.4" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=0.2" },
@@ -317,9 +312,8 @@ requires-dist = [
     { name = "tree-sitter-rust", specifier = ">=0.23" },
     { name = "tree-sitter-typescript", specifier = ">=0.23" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
-    { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.34" },
 ]
-provides-extras = ["vector", "vector-fast", "graph", "vector-torch", "splade", "mcp", "langchain", "llamaindex", "lsap", "language-pack", "all", "web", "dev"]
+provides-extras = ["vector", "vector-fast", "graph", "vector-torch", "splade", "mcp", "langchain", "llamaindex", "lsap", "language-pack", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Patch release addressing the three follow-ups from the README/release pass, plus a latent version-drift bug found while bumping.

## Changes
- **Drop redundant `web` extra** — `fastapi`/`uvicorn` are core deps, so `archex serve` works on a bare install. `archex[web]` is no longer a recognized extra; `serve_cmd` imports `uvicorn` directly instead of guarding an import that cannot fail. Non-breaking (functionality unchanged).
- **Fix `__version__` drift** — was a hardcoded literal stuck at `0.5.0`, so **0.6.0 shipped reporting `0.5.0`** from `archex --version`. The CLI test compares against `__version__` itself, so it never caught it. Now derived from `importlib.metadata.version("archex")` — pyproject is the single source of truth.
- **Correct CHANGELOG** — the 0.6.0 entry said the reranker is "Jina Reranker v2"; the actual default is `cross-encoder/ms-marco-MiniLM-L-6-v2`.
- README `web`-extra references updated to reflect the server shipping in core.

## Not changed (deliberate)
- `index/splade.py` kept as-is: it's a fully-tested (30 tests, real-model smoke test) but unintegrated optional module, not dead code.

## Validation
- `archex --version` now reports `0.6.1`.
- `ruff check`, `ruff format --check`, `pyright`: clean.
- `uv run pytest`: 1928 passed, 4 deselected, coverage 91.60%.