### PR TITLE
feat(graph): export deterministic artifacts

### DIFF
--- a/src/archex/cli/graph_cmd.py
+++ b/src/archex/cli/graph_cmd.py
@@ -1,0 +1,61 @@
+"""Graph artifact export commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from archex.api import index_repository
+from archex.config import load_config, load_index_config
+from archex.exceptions import ArchexError
+from archex.graph_artifact import build_arch_graph_from_store
+from archex.models import RepoSource
+
+
+@click.group("graph")
+def graph_cmd() -> None:
+    """Export and inspect deterministic architecture graph artifacts."""
+
+
+@graph_cmd.command("export")
+@click.argument("source", required=False, default=".")
+@click.option(
+    "--output",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Output artifact path. Defaults to .archex/archgraph.json for JSON.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "markdown"]),
+    help="Output format.",
+)
+def export_cmd(source: str, output: Path | None, output_format: str) -> None:
+    """Export a deterministic graph artifact for SOURCE."""
+    repo_root = Path(source).expanduser().resolve()
+    repo_source = RepoSource(local_path=source)
+    config = load_config(repo_source)
+    index_config = load_index_config(repo_source)
+    try:
+        store = index_repository(repo_source, config=config, index_config=index_config)
+    except ArchexError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    try:
+        graph = build_arch_graph_from_store(store, repo_root=repo_root)
+    finally:
+        store.close()
+
+    rendered = graph.to_json() if output_format == "json" else graph.to_markdown()
+    target = output
+    if target is None and output_format == "json":
+        target = repo_root / ".archex" / "archgraph.json"
+    if target is None:
+        click.echo(rendered, nl=False)
+        return
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(rendered, encoding="utf-8")
+    click.echo(str(target))

--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -10,6 +10,7 @@ from archex.cli.benchmark_cmd import benchmark_cmd
 from archex.cli.cache_cmd import cache_cmd
 from archex.cli.compare_cmd import compare_cmd
 from archex.cli.dogfood_cmd import dogfood_cmd
+from archex.cli.graph_cmd import graph_cmd
 from archex.cli.index_cmd import index_cmd
 from archex.cli.init_cmd import init_cmd
 from archex.cli.mcp_cmd import mcp_cmd
@@ -43,6 +44,7 @@ cli.add_command(tree_cmd)
 cli.add_command(outline_cmd)
 cli.add_command(symbols_cmd)
 cli.add_command(symbol_cmd)
+cli.add_command(graph_cmd)
 
 
 if __name__ == "__main__":

--- a/src/archex/graph_artifact.py
+++ b/src/archex/graph_artifact.py
@@ -3,13 +3,32 @@
 from __future__ import annotations
 
 import json
+from collections import defaultdict
+from dataclasses import dataclass
 from enum import StrEnum
-from typing import Literal
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
+from archex import __version__
+from archex.models import CodeChunk, Edge, EdgeKind
+
+if TYPE_CHECKING:
+    from archex.index.store import IndexStore
+
 GRAPH_SCHEMA_VERSION = "1.0.0"
 SUPPORTED_GRAPH_SCHEMA_MAJOR = 1
+_KNOWN_CONFIG_NAMES = {
+    "pyproject.toml",
+    "package.json",
+    "tsconfig.json",
+    "Cargo.toml",
+    "go.mod",
+    "requirements.txt",
+    "setup.py",
+}
+_KNOWN_CONFIG_PATHS = tuple(sorted(_KNOWN_CONFIG_NAMES))
 
 
 class GraphArtifactError(ValueError):
@@ -142,6 +161,93 @@ class ArchGraph(BaseModel):
             sort_keys=True,
         )
 
+    def to_markdown(self) -> str:
+        lines = [
+            f"# Architecture Graph: {self.project.name}",
+            "",
+            "## Summary",
+            "",
+            "| Metric | Value |",
+            "| --- | ---: |",
+            f"| Files | {self.project.total_files} |",
+            f"| Lines | {self.project.total_lines} |",
+            f"| Nodes | {len(self.nodes)} |",
+            f"| Edges | {len(self.edges)} |",
+            "",
+        ]
+        if self.project.languages:
+            lines.extend(["## Languages", "", "| Language | Files |", "| --- | ---: |"])
+            for language, count in sorted(self.project.languages.items()):
+                lines.append(f"| {language} | {count} |")
+            lines.append("")
+        if self.nodes:
+            lines.extend(["## Nodes", "", "| Type | ID | Label |", "| --- | --- | --- |"])
+            for node in self.nodes[:50]:
+                lines.append(f"| {node.type.value} | `{node.id}` | {node.label} |")
+            lines.append("")
+        return "\n".join(lines).rstrip() + "\n"
+
+
+@dataclass(frozen=True)
+class _FileFacts:
+    path: str
+    language: str
+    line_count: int
+    symbol_count: int
+    token_count: int
+    public_interface_count: int
+    fan_in: int
+    fan_out: int
+
+
+def build_arch_graph_from_store(
+    store: IndexStore,
+    *,
+    repo_root: Path | None = None,
+) -> ArchGraph:
+    chunks = sorted(
+        store.get_chunks(),
+        key=lambda chunk: (chunk.file_path, chunk.start_line, chunk.id),
+    )
+    edges = sorted(
+        store.get_edges(),
+        key=lambda edge: (edge.source, edge.target, str(edge.kind)),
+    )
+    file_facts = _collect_file_facts(store, chunks, edges)
+    nodes = (
+        _build_file_nodes(file_facts)
+        + _build_symbol_nodes(chunks)
+        + _build_entry_nodes(chunks)
+        + _build_config_nodes(repo_root, file_facts)
+    )
+    graph_edges = _build_graph_edges(chunks, edges)
+    languages = _language_counts(file_facts)
+    total_lines = sum(fact.line_count for fact in file_facts.values())
+    source_identity = store.get_metadata("source_identity")
+    commit_hash = store.get_metadata("commit_hash")
+    project_name = (
+        Path(source_identity).name
+        if source_identity
+        else (repo_root.name if repo_root else "unknown")
+    )
+    return ArchGraph(
+        project=GraphProject(
+            name=project_name or "unknown",
+            root_path=str(repo_root) if repo_root is not None else None,
+            languages=languages,
+            total_files=len(file_facts),
+            total_lines=total_lines,
+        ),
+        metadata=GraphExportMetadata(
+            archex_version=__version__,
+            repo_root=str(repo_root) if repo_root is not None else None,
+            commit_hash=commit_hash,
+            source_identity=source_identity,
+        ),
+        nodes=nodes,
+        edges=graph_edges,
+    )
+
 
 def file_node_id(path: str) -> str:
     return f"file:{_normalize_path(path)}"
@@ -171,6 +277,15 @@ def test_node_id(path: str) -> str:
     return f"test:{_normalize_path(path)}"
 
 
+def node_id_for_path(path: str) -> str:
+    normalized = _normalize_path(path)
+    if _is_config_path(normalized):
+        return config_node_id(normalized)
+    if _is_test_path(normalized):
+        return test_node_id(normalized)
+    return file_node_id(normalized)
+
+
 def assert_supported_schema_version(version: GraphSchemaVersion) -> None:
     if version.major != SUPPORTED_GRAPH_SCHEMA_MAJOR:
         raise GraphArtifactError(
@@ -184,3 +299,235 @@ def _normalize_path(path: str) -> str:
     while normalized.startswith("./"):
         normalized = normalized[2:]
     return normalized
+
+
+def _collect_file_facts(
+    store: IndexStore,
+    chunks: list[CodeChunk],
+    edges: list[Edge],
+) -> dict[str, _FileFacts]:
+    metadata_by_path = {
+        str(item["file_path"]): item
+        for item in store.get_file_metadata()
+        if str(item["file_path"]).strip()
+    }
+    tokens_by_path: defaultdict[str, int] = defaultdict(int)
+    public_by_path: defaultdict[str, int] = defaultdict(int)
+    for chunk in chunks:
+        tokens_by_path[chunk.file_path] += chunk.token_count
+        if _is_public_interface_chunk(chunk):
+            public_by_path[chunk.file_path] += 1
+    fan_in: defaultdict[str, int] = defaultdict(int)
+    fan_out: defaultdict[str, int] = defaultdict(int)
+    for edge in edges:
+        if edge.kind == EdgeKind.IMPORTS:
+            fan_out[edge.source] += 1
+            fan_in[edge.target] += 1
+    facts: dict[str, _FileFacts] = {}
+    for path, item in metadata_by_path.items():
+        facts[path] = _FileFacts(
+            path=path,
+            language=str(item["language"]),
+            line_count=int(item["lines"]),
+            symbol_count=int(item["symbol_count"]),
+            token_count=tokens_by_path[path],
+            public_interface_count=public_by_path[path],
+            fan_in=fan_in[path],
+            fan_out=fan_out[path],
+        )
+    return facts
+
+
+def _build_file_nodes(file_facts: dict[str, _FileFacts]) -> list[GraphNode]:
+    nodes: list[GraphNode] = []
+    for fact in file_facts.values():
+        normalized = _normalize_path(fact.path)
+        node_type = _node_type_for_path(normalized)
+        nodes.append(
+            GraphNode(
+                id=node_id_for_path(normalized),
+                type=node_type,
+                label=normalized,
+                path=normalized,
+                language=fact.language,
+                description=_file_description(node_type, fact),
+                complexity=GraphComplexity(
+                    line_count=fact.line_count,
+                    token_count=fact.token_count,
+                    symbol_count=fact.symbol_count,
+                    public_interface_count=fact.public_interface_count,
+                    import_fan_in=fact.fan_in,
+                    import_fan_out=fact.fan_out,
+                ),
+            )
+        )
+    return nodes
+
+
+def _build_symbol_nodes(chunks: list[CodeChunk]) -> list[GraphNode]:
+    nodes: list[GraphNode] = []
+    for chunk in chunks:
+        if chunk.symbol_name is None or chunk.symbol_kind is None:
+            continue
+        qualified_name = chunk.qualified_name or chunk.symbol_name
+        kind = str(chunk.symbol_kind)
+        nodes.append(
+            GraphNode(
+                id=symbol_node_id(chunk.file_path, qualified_name, kind),
+                type=GraphNodeType.SYMBOL,
+                label=qualified_name,
+                path=_normalize_path(chunk.file_path),
+                language=chunk.language,
+                symbol_kind=kind,
+                line_start=chunk.start_line,
+                line_end=chunk.end_line,
+                description=f"{kind} symbol",
+                complexity=GraphComplexity(
+                    line_count=max(chunk.end_line - chunk.start_line + 1, 0),
+                    token_count=chunk.token_count,
+                ),
+            )
+        )
+        if _is_public_interface_chunk(chunk):
+            nodes.append(
+                GraphNode(
+                    id=interface_node_id(chunk.file_path, qualified_name),
+                    type=GraphNodeType.INTERFACE,
+                    label=qualified_name,
+                    path=_normalize_path(chunk.file_path),
+                    language=chunk.language,
+                    symbol_kind=kind,
+                    line_start=chunk.start_line,
+                    line_end=chunk.end_line,
+                    description="public interface symbol",
+                )
+            )
+    return nodes
+
+
+def _build_entry_nodes(chunks: list[CodeChunk]) -> list[GraphNode]:
+    nodes: list[GraphNode] = []
+    for chunk in chunks:
+        if not _is_entry_point_chunk(chunk):
+            continue
+        name = chunk.qualified_name or chunk.symbol_name or Path(chunk.file_path).stem
+        nodes.append(
+            GraphNode(
+                id=entry_point_node_id(chunk.file_path, name),
+                type=GraphNodeType.ENTRY_POINT,
+                label=name,
+                path=_normalize_path(chunk.file_path),
+                language=chunk.language,
+                symbol_kind=str(chunk.symbol_kind) if chunk.symbol_kind is not None else None,
+                line_start=chunk.start_line,
+                line_end=chunk.end_line,
+                description="entry point detected by adapter metadata",
+            )
+        )
+    return nodes
+
+
+def _build_config_nodes(
+    repo_root: Path | None,
+    file_facts: dict[str, _FileFacts],
+) -> list[GraphNode]:
+    if repo_root is None:
+        return []
+    nodes: list[GraphNode] = []
+    for relative_path in _KNOWN_CONFIG_PATHS:
+        if relative_path in file_facts:
+            continue
+        if not (repo_root / relative_path).is_file():
+            continue
+        nodes.append(
+            GraphNode(
+                id=config_node_id(relative_path),
+                type=GraphNodeType.CONFIG,
+                label=relative_path,
+                path=relative_path,
+                description="config file",
+            )
+        )
+    return nodes
+
+
+def _build_graph_edges(chunks: list[CodeChunk], edges: list[Edge]) -> list[GraphEdge]:
+    graph_edges = [
+        GraphEdge(
+            source=node_id_for_path(edge.source),
+            target=node_id_for_path(edge.target),
+            type=GraphEdgeType.IMPORTS,
+            location=edge.location,
+        )
+        for edge in edges
+        if edge.kind == EdgeKind.IMPORTS
+    ]
+    for chunk in chunks:
+        if chunk.symbol_name is None or chunk.symbol_kind is None:
+            continue
+        qualified_name = chunk.qualified_name or chunk.symbol_name
+        kind = str(chunk.symbol_kind)
+        symbol_id = symbol_node_id(chunk.file_path, qualified_name, kind)
+        graph_edges.append(
+            GraphEdge(
+                source=node_id_for_path(chunk.file_path),
+                target=symbol_id,
+                type=GraphEdgeType.CONTAINS,
+            )
+        )
+        if _is_public_interface_chunk(chunk):
+            graph_edges.append(
+                GraphEdge(
+                    source=node_id_for_path(chunk.file_path),
+                    target=interface_node_id(chunk.file_path, qualified_name),
+                    type=GraphEdgeType.EXPOSES,
+                )
+            )
+    return graph_edges
+
+
+def _language_counts(file_facts: dict[str, _FileFacts]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for fact in file_facts.values():
+        counts[fact.language] = counts.get(fact.language, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _node_type_for_path(path: str) -> GraphNodeType:
+    if _is_config_path(path):
+        return GraphNodeType.CONFIG
+    if _is_test_path(path):
+        return GraphNodeType.TEST
+    return GraphNodeType.FILE
+
+
+def _is_config_path(path: str) -> bool:
+    name = path.rsplit("/", maxsplit=1)[-1]
+    return name in _KNOWN_CONFIG_NAMES
+
+
+def _is_test_path(path: str) -> bool:
+    name = path.rsplit("/", maxsplit=1)[-1]
+    return path.startswith("tests/") or name.startswith("test_") or name.endswith("_test.py")
+
+
+def _is_public_interface_chunk(chunk: CodeChunk) -> bool:
+    if chunk.symbol_name is None or chunk.symbol_kind is None:
+        return False
+    if chunk.visibility not in (None, "public"):
+        return False
+    return str(chunk.symbol_kind) in {"function", "class", "interface"}
+
+
+def _is_entry_point_chunk(chunk: CodeChunk) -> bool:
+    normalized = _normalize_path(chunk.file_path)
+    name = chunk.symbol_name or ""
+    return normalized.endswith("/main.py") and name == "run"
+
+
+def _file_description(node_type: GraphNodeType, fact: _FileFacts) -> str:
+    if node_type == GraphNodeType.CONFIG:
+        return "config file"
+    if node_type == GraphNodeType.TEST:
+        return f"test file with {fact.symbol_count} symbols"
+    return f"file with {fact.symbol_count} symbols and {fact.fan_out} imports"

--- a/tests/test_graph_export_cli.py
+++ b/tests/test_graph_export_cli.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+
+
+def test_graph_export_writes_default_json_artifact(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["graph", "export", str(python_simple_repo)])
+
+    assert result.exit_code == 0, result.output
+    output_path = python_simple_repo / ".archex" / "archgraph.json"
+    assert result.output.strip() == str(output_path)
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    node_ids = [node["id"] for node in data["nodes"]]
+    edge_types = [edge["type"] for edge in data["edges"]]
+    assert data["schema_version"]["value"] == "1.0.0"
+    assert data["project"]["total_files"] >= 4
+    assert node_ids == sorted(node_ids, key=lambda node_id: (node_id.split(":", 1)[0], node_id))
+    assert "file:main.py" in node_ids
+    assert "config:pyproject.toml" in node_ids
+    assert "symbol:main.py::run#function" in node_ids
+    assert "contains" in edge_types
+    assert "imports" in edge_types
+
+
+def test_graph_export_json_is_deterministic(python_simple_repo: Path, tmp_path: Path) -> None:
+    runner = CliRunner()
+    first_path = tmp_path / "first.json"
+    second_path = tmp_path / "second.json"
+
+    first = runner.invoke(
+        cli,
+        ["graph", "export", str(python_simple_repo), "--output", str(first_path)],
+    )
+    second = runner.invoke(
+        cli,
+        ["graph", "export", str(python_simple_repo), "--output", str(second_path)],
+    )
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    assert first_path.read_text(encoding="utf-8") == second_path.read_text(encoding="utf-8")
+
+
+def test_graph_export_markdown_can_write_explicit_output(
+    python_simple_repo: Path, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    output_path = tmp_path / "archgraph.md"
+
+    result = runner.invoke(
+        cli,
+        [
+            "graph",
+            "export",
+            str(python_simple_repo),
+            "--format",
+            "markdown",
+            "--output",
+            str(output_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    rendered = output_path.read_text(encoding="utf-8")
+    assert rendered.startswith("# Architecture Graph:")
+    assert "| Files |" in rendered
+    assert "`file:main.py`" in rendered


### PR DESCRIPTION
## Summary
- add `archex graph export` with deterministic JSON artifact output
- add optional markdown summary rendering over the same artifact
- reuse the existing index path through `index_repository()` and avoid duplicating parse/index orchestration

## Stack
Base: `feat/graph-artifact-model`
Parent: #122

1. `feat/graph-artifact-model`
2. `feat/graph-export-cli` -> this PR
3. `feat/explain-context` -> child
4. `feat/impact-analysis`
5. `feat/onboarding-artifact`
6. `feat/graph-load`

## Validation
- Passed: `uv run ruff check src/archex/graph_artifact.py src/archex/cli/graph_cmd.py src/archex/cli/main.py tests/test_graph_artifact.py tests/test_graph_export_cli.py`
- Passed: `uv run pytest tests/test_graph_artifact.py tests/test_graph_export_cli.py --no-cov`
- Stack tip passed full gate; see leaf PR for full validation.