### PR TITLE
feat(impact): add deterministic blast radius command

### DIFF
--- a/src/archex/cli/impact_cmd.py
+++ b/src/archex/cli/impact_cmd.py
@@ -1,0 +1,66 @@
+"""Impact analysis command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from archex.api import index_repository
+from archex.config import load_config, load_index_config
+from archex.exceptions import ArchexError
+from archex.impact import (
+    ImpactError,
+    ImpactFileChange,
+    analyze_impact,
+    git_changed_files,
+    render_impact_report,
+)
+from archex.models import RepoSource
+
+
+@click.command("impact")
+@click.argument("source", required=False, default=".")
+@click.option("--base", default="main", help="Base ref for git diff mode.")
+@click.option(
+    "--changed-file",
+    "changed_files",
+    multiple=True,
+    help="Changed file path. Repeat to bypass git diff mode.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="markdown",
+    type=click.Choice(["markdown", "json"]),
+    help="Output format.",
+)
+def impact_cmd(
+    source: str,
+    base: str,
+    changed_files: tuple[str, ...],
+    output_format: str,
+) -> None:
+    """Analyze deterministic blast radius for changed files."""
+    repo_root = Path(source).expanduser().resolve()
+    if changed_files:
+        changes = [ImpactFileChange(path=path) for path in changed_files]
+    else:
+        try:
+            changes = git_changed_files(repo_root, base)
+        except ImpactError as exc:
+            raise click.ClickException(str(exc)) from exc
+
+    repo_source = RepoSource(local_path=source)
+    config = load_config(repo_source)
+    index_config = load_index_config(repo_source)
+    try:
+        store = index_repository(repo_source, config=config, index_config=index_config)
+        try:
+            report = analyze_impact(store, changes)
+        finally:
+            store.close()
+    except (ArchexError, ImpactError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo(render_impact_report(report, output_format), nl=False)

--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -12,6 +12,7 @@ from archex.cli.compare_cmd import compare_cmd
 from archex.cli.dogfood_cmd import dogfood_cmd
 from archex.cli.explain_cmd import explain_cmd
 from archex.cli.graph_cmd import graph_cmd
+from archex.cli.impact_cmd import impact_cmd
 from archex.cli.index_cmd import index_cmd
 from archex.cli.init_cmd import init_cmd
 from archex.cli.mcp_cmd import mcp_cmd
@@ -47,6 +48,7 @@ cli.add_command(symbols_cmd)
 cli.add_command(symbol_cmd)
 cli.add_command(graph_cmd)
 cli.add_command(explain_cmd)
+cli.add_command(impact_cmd)
 
 
 if __name__ == "__main__":

--- a/src/archex/impact.py
+++ b/src/archex/impact.py
@@ -33,16 +33,16 @@ class ImpactFileChange(BaseModel):
 
 class ImpactRisk(BaseModel):
     level: ImpactRiskLevel
-    reasons: list[str] = Field(default_factory=list)
+    reasons: list[str] = []
 
 
 class ImpactReport(BaseModel):
-    changed_files: list[ImpactFileChange] = Field(default_factory=list)
-    affected_files: list[str] = Field(default_factory=list)
-    affected_modules: list[str] = Field(default_factory=list)
-    affected_interfaces: list[str] = Field(default_factory=list)
-    affected_tests: list[str] = Field(default_factory=list)
-    unmapped_files: list[str] = Field(default_factory=list)
+    changed_files: list[ImpactFileChange] = []
+    affected_files: list[str] = []
+    affected_modules: list[str] = []
+    affected_interfaces: list[str] = []
+    affected_tests: list[str] = []
+    unmapped_files: list[str] = []
     risk: ImpactRisk = Field(default_factory=lambda: ImpactRisk(level=ImpactRiskLevel.LOW))
 
     def to_json(self) -> str:

--- a/src/archex/impact.py
+++ b/src/archex/impact.py
@@ -1,0 +1,236 @@
+"""Deterministic impact analysis from git changes and index dependencies."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from archex.index.store import IndexStore
+    from archex.models import CodeChunk, Edge
+
+
+class ImpactError(ValueError):
+    """Raised when impact analysis cannot run."""
+
+
+class ImpactRiskLevel(StrEnum):
+    LOW = "low"
+    MODERATE = "moderate"
+    HIGH = "high"
+
+
+class ImpactFileChange(BaseModel):
+    path: str
+    status: str = "M"
+    old_path: str | None = None
+
+
+class ImpactRisk(BaseModel):
+    level: ImpactRiskLevel
+    reasons: list[str] = Field(default_factory=list)
+
+
+class ImpactReport(BaseModel):
+    changed_files: list[ImpactFileChange] = Field(default_factory=list)
+    affected_files: list[str] = Field(default_factory=list)
+    affected_modules: list[str] = Field(default_factory=list)
+    affected_interfaces: list[str] = Field(default_factory=list)
+    affected_tests: list[str] = Field(default_factory=list)
+    unmapped_files: list[str] = Field(default_factory=list)
+    risk: ImpactRisk = Field(default_factory=lambda: ImpactRisk(level=ImpactRiskLevel.LOW))
+
+    def to_json(self) -> str:
+        return json.dumps(self.model_dump(mode="json"), indent=2, sort_keys=True)
+
+    def to_markdown(self) -> str:
+        lines = [
+            "# Impact Analysis",
+            "",
+            "## Summary",
+            "",
+            f"- **Changed files:** {len(self.changed_files)}",
+            f"- **Affected files:** {len(self.affected_files)}",
+            f"- **Risk:** `{self.risk.level.value}`",
+            "",
+            "## Changed Files",
+            "",
+        ]
+        lines.extend(f"- `{change.status}` `{change.path}`" for change in self.changed_files)
+        lines.extend(["", "## Affected Modules", ""])
+        lines.extend(_path_lines(self.affected_modules))
+        lines.extend(["", "## Affected Files", ""])
+        lines.extend(_path_lines(self.affected_files))
+        lines.extend(["", "## Public Interface Impact", ""])
+        lines.extend(_path_lines(self.affected_interfaces))
+        lines.extend(["", "## Test Surface", ""])
+        lines.extend(_path_lines(self.affected_tests))
+        lines.extend(["", "## Risk Assessment", ""])
+        lines.append(f"- **Level:** `{self.risk.level.value}`")
+        lines.extend(f"- `{reason}`" for reason in self.risk.reasons)
+        lines.extend(["", "## Unmapped Files", ""])
+        lines.extend(_path_lines(self.unmapped_files))
+        return "\n".join(lines).rstrip() + "\n"
+
+
+def git_changed_files(repo_root: Path, base_ref: str) -> list[ImpactFileChange]:
+    command = ["git", "diff", "--name-status", base_ref]
+    completed = subprocess.run(
+        command,
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip() or completed.stdout.strip()
+        raise ImpactError(f"git diff failed for base {base_ref}: {stderr}")
+    return [_parse_name_status(line) for line in completed.stdout.splitlines() if line.strip()]
+
+
+def analyze_impact(
+    store: IndexStore,
+    changes: list[ImpactFileChange],
+) -> ImpactReport:
+    indexed_files = {str(item["file_path"]) for item in store.get_file_metadata()}
+    edges = store.get_edges()
+    changed_paths = {change.path for change in changes}
+    mapped_changed = changed_paths & indexed_files
+    affected_files = _affected_files(edges, mapped_changed)
+    all_relevant_files = sorted(mapped_changed | affected_files)
+    unmapped = sorted(changed_paths - indexed_files)
+    chunks = store.get_chunks_for_files(all_relevant_files)
+    affected_interfaces = _public_interfaces(chunks)
+    affected_tests = sorted(path for path in all_relevant_files if _is_test_path(path))
+    modules = sorted(
+        {_module_for_path(path) for path in all_relevant_files if _module_for_path(path)}
+    )
+    reasons = _risk_reasons(
+        store,
+        changes,
+        all_relevant_files,
+        affected_interfaces,
+        unmapped,
+        modules,
+    )
+    return ImpactReport(
+        changed_files=sorted(changes, key=lambda change: (change.path, change.status)),
+        affected_files=all_relevant_files,
+        affected_modules=modules,
+        affected_interfaces=affected_interfaces,
+        affected_tests=affected_tests,
+        unmapped_files=unmapped,
+        risk=ImpactRisk(level=_risk_level(reasons), reasons=reasons),
+    )
+
+
+def render_impact_report(report: ImpactReport, output_format: str) -> str:
+    if output_format == "json":
+        return report.to_json()
+    if output_format == "markdown":
+        return report.to_markdown()
+    raise ImpactError(f"Unsupported impact output format: {output_format}")
+
+
+def _parse_name_status(line: str) -> ImpactFileChange:
+    parts = line.split("\t")
+    status = parts[0]
+    if status.startswith("R"):
+        if len(parts) != 3:
+            raise ImpactError(f"Malformed rename diff line: {line}")
+        return ImpactFileChange(path=parts[2], status="R", old_path=parts[1])
+    if len(parts) != 2:
+        raise ImpactError(f"Malformed diff line: {line}")
+    return ImpactFileChange(path=parts[1], status=status[:1])
+
+
+def _affected_files(edges: list[Edge], changed_files: set[str]) -> set[str]:
+    affected = set(changed_files)
+    for edge in edges:
+        if edge.target in changed_files:
+            affected.add(edge.source)
+        if edge.source in changed_files:
+            affected.add(edge.target)
+    return affected
+
+
+def _public_interfaces(chunks: list[CodeChunk]) -> list[str]:
+    interfaces: list[str] = []
+    for chunk in chunks:
+        if chunk.symbol_name is None or chunk.symbol_kind is None:
+            continue
+        if chunk.visibility not in (None, "public"):
+            continue
+        if str(chunk.symbol_kind) not in {"function", "class", "interface"}:
+            continue
+        qualified_name = chunk.qualified_name or chunk.symbol_name
+        interfaces.append(f"{chunk.file_path}::{qualified_name}#{chunk.symbol_kind}")
+    return sorted(interfaces)
+
+
+def _risk_reasons(
+    store: IndexStore,
+    changes: list[ImpactFileChange],
+    affected_files: list[str],
+    affected_interfaces: list[str],
+    unmapped_files: list[str],
+    modules: list[str],
+) -> list[str]:
+    reasons: set[str] = set()
+    changed_paths = {change.path for change in changes}
+    if affected_interfaces:
+        reasons.add("public_interface_changed")
+    if len(modules) > 1:
+        reasons.add("cross_module_impact")
+    if unmapped_files:
+        reasons.add("unmapped_file")
+    if any(_is_config_path(path) for path in changed_paths):
+        reasons.add("config_changed")
+    if any(_is_test_path(path) for path in changed_paths):
+        reasons.add("test_surface_changed")
+    for path in affected_files:
+        if store.get_file_tokens(path) >= 1000:
+            reasons.add("large_file_changed")
+    fan_in = _fan_in(store.get_edges(), changed_paths)
+    if fan_in >= 3:
+        reasons.add("high_fan_in")
+    return sorted(reasons)
+
+
+def _risk_level(reasons: list[str]) -> ImpactRiskLevel:
+    if {"public_interface_changed", "high_fan_in", "cross_module_impact"} & set(reasons):
+        return ImpactRiskLevel.HIGH
+    if reasons:
+        return ImpactRiskLevel.MODERATE
+    return ImpactRiskLevel.LOW
+
+
+def _fan_in(edges: list[Edge], changed_paths: set[str]) -> int:
+    return len({edge.source for edge in edges if edge.target in changed_paths})
+
+
+def _module_for_path(path: str) -> str:
+    if "/" not in path:
+        return ""
+    return path.split("/", maxsplit=1)[0]
+
+
+def _is_test_path(path: str) -> bool:
+    name = path.rsplit("/", maxsplit=1)[-1]
+    return path.startswith("tests/") or name.startswith("test_") or name.endswith("_test.py")
+
+
+def _is_config_path(path: str) -> bool:
+    name = path.rsplit("/", maxsplit=1)[-1]
+    return name in {"pyproject.toml", "package.json", "Cargo.toml", "go.mod", "tsconfig.json"}
+
+
+def _path_lines(paths: list[str]) -> list[str]:
+    if not paths:
+        return ["- None"]
+    return [f"- `{path}`" for path in paths]

--- a/tests/test_impact_cli.py
+++ b/tests/test_impact_cli.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+
+
+def test_impact_explicit_changed_file_reports_dependents(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        [
+            "impact",
+            str(python_simple_repo),
+            "--changed-file",
+            "utils.py",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["changed_files"] == [{"old_path": None, "path": "utils.py", "status": "M"}]
+    assert "utils.py" in data["affected_files"]
+    assert "main.py" in data["affected_files"]
+    assert "services/auth.py" in data["affected_files"]
+    assert "public_interface_changed" in data["risk"]["reasons"]
+
+
+def test_impact_explicit_unmapped_file_reports_risk(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        [
+            "impact",
+            str(python_simple_repo),
+            "--changed-file",
+            "README.md",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["affected_files"] == []
+    assert data["unmapped_files"] == ["README.md"]
+    assert data["risk"]["level"] == "moderate"
+    assert data["risk"]["reasons"] == ["unmapped_file"]
+
+
+def test_impact_git_diff_mode_handles_no_changes(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["impact", str(python_simple_repo), "--base", "HEAD", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["changed_files"] == []
+    assert data["risk"]["level"] == "low"
+
+
+def test_impact_git_error_is_not_hidden(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["impact", str(python_simple_repo), "--base", "missing-ref"],
+    )
+
+    assert result.exit_code != 0
+    assert "git diff failed for base missing-ref" in result.output


### PR DESCRIPTION
## Summary
- add `archex impact` with git diff and explicit `--changed-file` modes
- map changed files to affected files, modules, interfaces, tests, unmapped files, and deterministic risk reasons
- propagate git diff failures instead of hiding them

## Stack
Base: `feat/explain-context`
Parent: #124

1. `feat/graph-artifact-model`
2. `feat/graph-export-cli`
3. `feat/explain-context`
4. `feat/impact-analysis` -> this PR
5. `feat/onboarding-artifact` -> child
6. `feat/graph-load`

## Validation
- Passed: `uv run ruff check src/archex/impact.py src/archex/cli/impact_cmd.py src/archex/cli/main.py tests/test_impact_cli.py`
- Passed: `uv run pytest tests/test_impact_cli.py --no-cov`
- Stack tip passed full gate; see leaf PR for full validation.