### PR TITLE
feat(onboard): generate structural guide

### DIFF
--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -16,6 +16,7 @@ from archex.cli.impact_cmd import impact_cmd
 from archex.cli.index_cmd import index_cmd
 from archex.cli.init_cmd import init_cmd
 from archex.cli.mcp_cmd import mcp_cmd
+from archex.cli.onboard_cmd import onboard_cmd
 from archex.cli.outline_cmd import outline_cmd
 from archex.cli.query_cmd import query_cmd
 from archex.cli.reset_cmd import reset_cmd
@@ -49,6 +50,7 @@ cli.add_command(symbol_cmd)
 cli.add_command(graph_cmd)
 cli.add_command(explain_cmd)
 cli.add_command(impact_cmd)
+cli.add_command(onboard_cmd)
 
 
 if __name__ == "__main__":

--- a/src/archex/cli/onboard_cmd.py
+++ b/src/archex/cli/onboard_cmd.py
@@ -1,0 +1,66 @@
+"""Onboarding guide command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from archex.api import index_repository
+from archex.config import load_config, load_index_config
+from archex.exceptions import ArchexError
+from archex.graph_artifact import build_arch_graph_from_store
+from archex.models import RepoSource
+from archex.onboarding import OnboardingError, render_onboarding_markdown
+
+
+@click.command("onboard")
+@click.argument("source", required=False, default=".")
+@click.option(
+    "--output",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Output markdown path. Defaults to stdout.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="markdown",
+    type=click.Choice(["markdown"]),
+    help="Output format.",
+)
+@click.option(
+    "--max-files",
+    default=40,
+    show_default=True,
+    help="Maximum paths per capped section.",
+)
+def onboard_cmd(
+    source: str,
+    output: Path | None,
+    output_format: str,
+    max_files: int,
+) -> None:
+    """Generate a deterministic onboarding guide from graph/profile data."""
+    if output_format != "markdown":
+        raise click.ClickException(f"Unsupported onboarding output format: {output_format}")
+    repo_root = Path(source).expanduser().resolve()
+    repo_source = RepoSource(local_path=source)
+    config = load_config(repo_source)
+    index_config = load_index_config(repo_source)
+    try:
+        store = index_repository(repo_source, config=config, index_config=index_config)
+        try:
+            graph = build_arch_graph_from_store(store, repo_root=repo_root)
+        finally:
+            store.close()
+        rendered = render_onboarding_markdown(graph, max_files=max_files)
+    except (ArchexError, OnboardingError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if output is None:
+        click.echo(rendered, nl=False)
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(rendered, encoding="utf-8")
+    click.echo(str(output))

--- a/src/archex/onboarding.py
+++ b/src/archex/onboarding.py
@@ -102,14 +102,19 @@ def _reading_order(
     max_files: int,
 ) -> list[str]:
     ordered: list[str] = []
-    for node in entry_nodes + interface_nodes + sorted(
-        file_nodes,
-        key=lambda item: (
-            -item.complexity.public_interface_count,
-            -item.complexity.import_fan_in,
-            item.path or item.label,
-        ),
-    ) + test_nodes:
+    for node in (
+        entry_nodes
+        + interface_nodes
+        + sorted(
+            file_nodes,
+            key=lambda item: (
+                -item.complexity.public_interface_count,
+                -item.complexity.import_fan_in,
+                item.path or item.label,
+            ),
+        )
+        + test_nodes
+    ):
         path = node.path or node.label
         if path not in ordered:
             ordered.append(path)

--- a/src/archex/onboarding.py
+++ b/src/archex/onboarding.py
@@ -1,0 +1,139 @@
+"""Deterministic onboarding guide rendering from graph artifacts."""
+
+from __future__ import annotations
+
+from archex.graph_artifact import ArchGraph, GraphNode, GraphNodeType
+
+
+class OnboardingError(ValueError):
+    """Raised when onboarding output cannot be rendered."""
+
+
+def render_onboarding_markdown(graph: ArchGraph, *, max_files: int = 40) -> str:
+    if max_files <= 0:
+        raise OnboardingError("max-files must be greater than zero")
+    file_nodes = _nodes_of_type(graph, GraphNodeType.FILE)
+    entry_nodes = _nodes_of_type(graph, GraphNodeType.ENTRY_POINT)
+    interface_nodes = _nodes_of_type(graph, GraphNodeType.INTERFACE)
+    config_nodes = _nodes_of_type(graph, GraphNodeType.CONFIG)
+    test_nodes = _nodes_of_type(graph, GraphNodeType.TEST)
+    modules = _modules(file_nodes)
+    reading_order = _reading_order(entry_nodes, interface_nodes, file_nodes, test_nodes, max_files)
+    hotspots = _complexity_hotspots(file_nodes, max_files)
+    lines = [
+        f"# Onboarding: {graph.project.name}",
+        "",
+        "## Repository Overview",
+        "",
+        f"- **Files:** {graph.project.total_files}",
+        f"- **Lines:** {graph.project.total_lines}",
+        f"- **Graph nodes:** {len(graph.nodes)}",
+        f"- **Graph edges:** {len(graph.edges)}",
+        "",
+        "## Languages And File Counts",
+        "",
+    ]
+    lines.extend(_language_lines(graph))
+    lines.extend(["", "## Architecture Modules", ""])
+    lines.extend(_module_lines(modules))
+    lines.extend(["", "## Entry Points", ""])
+    lines.extend(_node_path_lines(entry_nodes, max_files))
+    lines.extend(["", "## Public Interfaces", ""])
+    lines.extend(_node_path_lines(interface_nodes, max_files))
+    lines.extend(["", "## Recommended Reading Order", ""])
+    lines.extend(f"{index}. `{path}`" for index, path in enumerate(reading_order, start=1))
+    lines.extend(["", "## Complexity Hotspots", ""])
+    lines.extend(_hotspot_lines(hotspots))
+    lines.extend(["", "## Test Surface", ""])
+    lines.extend(_node_path_lines(test_nodes, max_files))
+    lines.extend(["", "## Configuration Surface", ""])
+    lines.extend(_node_path_lines(config_nodes, max_files))
+    lines.extend(["", "## Generated Artifact Metadata", ""])
+    lines.extend(
+        [
+            f"- **Schema version:** `{graph.schema_version.value}`",
+            f"- **archex version:** `{graph.metadata.archex_version}`",
+            f"- **Commit:** `{graph.metadata.commit_hash or 'none'}`",
+        ]
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _nodes_of_type(graph: ArchGraph, node_type: GraphNodeType) -> list[GraphNode]:
+    return [node for node in graph.nodes if node.type == node_type]
+
+
+def _language_lines(graph: ArchGraph) -> list[str]:
+    if not graph.project.languages:
+        return ["- None"]
+    return [
+        f"- `{language}`: {count} files"
+        for language, count in sorted(graph.project.languages.items())
+    ]
+
+
+def _modules(file_nodes: list[GraphNode]) -> dict[str, list[str]]:
+    modules: dict[str, list[str]] = {}
+    for node in file_nodes:
+        if node.path is None:
+            continue
+        module_name = node.path.split("/", maxsplit=1)[0] if "/" in node.path else "root"
+        modules.setdefault(module_name, []).append(node.path)
+    return {name: sorted(paths) for name, paths in sorted(modules.items())}
+
+
+def _module_lines(modules: dict[str, list[str]]) -> list[str]:
+    if not modules:
+        return ["- None"]
+    return [f"- `{name}`: {len(paths)} files" for name, paths in modules.items()]
+
+
+def _node_path_lines(nodes: list[GraphNode], max_items: int) -> list[str]:
+    if not nodes:
+        return ["- None"]
+    return [f"- `{node.path or node.label}`" for node in nodes[:max_items]]
+
+
+def _reading_order(
+    entry_nodes: list[GraphNode],
+    interface_nodes: list[GraphNode],
+    file_nodes: list[GraphNode],
+    test_nodes: list[GraphNode],
+    max_files: int,
+) -> list[str]:
+    ordered: list[str] = []
+    for node in entry_nodes + interface_nodes + sorted(
+        file_nodes,
+        key=lambda item: (
+            -item.complexity.public_interface_count,
+            -item.complexity.import_fan_in,
+            item.path or item.label,
+        ),
+    ) + test_nodes:
+        path = node.path or node.label
+        if path not in ordered:
+            ordered.append(path)
+        if len(ordered) >= max_files:
+            break
+    return ordered
+
+
+def _complexity_hotspots(file_nodes: list[GraphNode], max_files: int) -> list[GraphNode]:
+    return sorted(
+        file_nodes,
+        key=lambda node: (
+            -node.complexity.token_count,
+            -node.complexity.symbol_count,
+            node.path or node.label,
+        ),
+    )[:max_files]
+
+
+def _hotspot_lines(nodes: list[GraphNode]) -> list[str]:
+    if not nodes:
+        return ["- None"]
+    return [
+        f"- `{node.path or node.label}`: {node.complexity.token_count} tokens, "
+        f"{node.complexity.symbol_count} symbols"
+        for node in nodes
+    ]

--- a/tests/test_onboard_cli.py
+++ b/tests/test_onboard_cli.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+
+
+def test_onboard_outputs_deterministic_markdown(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["onboard", str(python_simple_repo), "--max-files", "5"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.startswith("# Onboarding:")
+    assert "## Repository Overview" in result.output
+    assert "## Recommended Reading Order" in result.output
+    assert "`main.py`" in result.output
+    assert "`pyproject.toml`" in result.output
+
+
+def test_onboard_writes_output_file(python_simple_repo: Path, tmp_path: Path) -> None:
+    runner = CliRunner()
+    output_path = tmp_path / "ONBOARDING.md"
+
+    result = runner.invoke(
+        cli,
+        ["onboard", str(python_simple_repo), "--output", str(output_path), "--max-files", "3"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == str(output_path)
+    rendered = output_path.read_text(encoding="utf-8")
+    assert "## Architecture Modules" in rendered
+    assert "## Generated Artifact Metadata" in rendered
+
+
+def test_onboard_rejects_invalid_max_files(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["onboard", str(python_simple_repo), "--max-files", "0"])
+
+    assert result.exit_code != 0
+    assert "max-files must be greater than zero" in result.output


### PR DESCRIPTION
## Summary
- add `archex onboard` for deterministic markdown onboarding guides
- derive exact paths, entry points, interfaces, reading order, hotspots, tests, config surface, and metadata from graph/index data
- add `--max-files` and explicit output file support

## Stack
Base: `feat/impact-analysis`
Parent: #125

1. `feat/graph-artifact-model`
2. `feat/graph-export-cli`
3. `feat/explain-context`
4. `feat/impact-analysis`
5. `feat/onboarding-artifact` -> this PR
6. `feat/graph-load` -> child

## Validation
- Passed: `uv run ruff check src/archex/onboarding.py src/archex/cli/onboard_cmd.py src/archex/cli/main.py tests/test_onboard_cli.py`
- Passed: `uv run pytest tests/test_onboard_cli.py --no-cov`
- Stack tip passed full gate; see leaf PR for full validation.