### PR TITLE
feat(graph): load exported artifacts

### DIFF
--- a/src/archex/cli/explain_cmd.py
+++ b/src/archex/cli/explain_cmd.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import click
 
 from archex.api import index_repository
@@ -10,10 +12,14 @@ from archex.exceptions import ArchexError
 from archex.explain import (
     ExplainError,
     explain_file,
+    explain_graph_file,
+    explain_graph_module,
+    explain_graph_symbol,
     explain_module,
     explain_symbol,
     render_explain_context,
 )
+from archex.graph_artifact import GraphArtifactError, load_arch_graph
 from archex.models import RepoSource
 
 
@@ -21,6 +27,13 @@ from archex.models import RepoSource
 @click.argument("source", required=False, default=".")
 @click.argument("target", required=False)
 @click.option("--module", "module_name", default=None, help="Explain an indexed module path.")
+@click.option(
+    "--graph",
+    "graph_path",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help="Read an exported graph artifact instead of indexing SOURCE.",
+)
 @click.option(
     "--format",
     "output_format",
@@ -32,13 +45,33 @@ def explain_cmd(
     source: str,
     target: str | None,
     module_name: str | None,
+    graph_path: str | None,
     output_format: str,
 ) -> None:
     """Explain a file, symbol, or module from indexed structural data."""
     if module_name is None and target is None:
-        raise click.ClickException("explain requires TARGET or --module")
+        if graph_path is None or source == ".":
+            raise click.ClickException("explain requires TARGET or --module")
+        target = source
+        source = "."
     if module_name is not None and target is not None:
         raise click.ClickException("use either TARGET or --module, not both")
+
+    if graph_path is not None:
+        try:
+            graph = load_arch_graph(Path(graph_path))
+            if module_name is not None:
+                context = explain_graph_module(graph, module_name)
+            elif target is not None and ("::" in target or "#" in target):
+                context = explain_graph_symbol(graph, target)
+            elif target is not None:
+                context = explain_graph_file(graph, target)
+            else:
+                raise click.ClickException("explain requires TARGET or --module")
+        except (GraphArtifactError, ExplainError) as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(render_explain_context(context, output_format), nl=False)
+        return
 
     repo_source = RepoSource(local_path=source)
     config = load_config(repo_source)

--- a/src/archex/cli/graph_cmd.py
+++ b/src/archex/cli/graph_cmd.py
@@ -9,7 +9,7 @@ import click
 from archex.api import index_repository
 from archex.config import load_config, load_index_config
 from archex.exceptions import ArchexError
-from archex.graph_artifact import build_arch_graph_from_store
+from archex.graph_artifact import GraphArtifactError, build_arch_graph_from_store, load_arch_graph
 from archex.models import RepoSource
 
 
@@ -59,3 +59,38 @@ def export_cmd(source: str, output: Path | None, output_format: str) -> None:
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(rendered, encoding="utf-8")
     click.echo(str(target))
+
+
+@graph_cmd.command("inspect")
+@click.argument("graph", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--format",
+    "output_format",
+    default="markdown",
+    type=click.Choice(["markdown", "json"]),
+    help="Output format.",
+)
+def inspect_cmd(graph: Path, output_format: str) -> None:
+    """Inspect an exported graph artifact without indexing source files."""
+    try:
+        artifact = load_arch_graph(graph)
+    except GraphArtifactError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    summary = {
+        "schema_version": artifact.schema_version.value,
+        "project": artifact.project.model_dump(mode="json"),
+        "metadata": artifact.metadata.model_dump(mode="json"),
+        "nodes": len(artifact.nodes),
+        "edges": len(artifact.edges),
+        "layers": len(artifact.layers),
+    }
+    if output_format == "json":
+        import json
+
+        click.echo(json.dumps(summary, indent=2, sort_keys=True))
+        return
+    click.echo(f"Graph: {artifact.project.name}")
+    click.echo(f"Schema: {artifact.schema_version.value}")
+    click.echo(f"Nodes: {len(artifact.nodes)}")
+    click.echo(f"Edges: {len(artifact.edges)}")

--- a/src/archex/cli/onboard_cmd.py
+++ b/src/archex/cli/onboard_cmd.py
@@ -9,7 +9,7 @@ import click
 from archex.api import index_repository
 from archex.config import load_config, load_index_config
 from archex.exceptions import ArchexError
-from archex.graph_artifact import build_arch_graph_from_store
+from archex.graph_artifact import GraphArtifactError, build_arch_graph_from_store, load_arch_graph
 from archex.models import RepoSource
 from archex.onboarding import OnboardingError, render_onboarding_markdown
 
@@ -35,27 +35,38 @@ from archex.onboarding import OnboardingError, render_onboarding_markdown
     show_default=True,
     help="Maximum paths per capped section.",
 )
+@click.option(
+    "--graph",
+    "graph_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Read an exported graph artifact instead of indexing SOURCE.",
+)
 def onboard_cmd(
     source: str,
     output: Path | None,
     output_format: str,
     max_files: int,
+    graph_path: Path | None,
 ) -> None:
     """Generate a deterministic onboarding guide from graph/profile data."""
     if output_format != "markdown":
         raise click.ClickException(f"Unsupported onboarding output format: {output_format}")
-    repo_root = Path(source).expanduser().resolve()
-    repo_source = RepoSource(local_path=source)
-    config = load_config(repo_source)
-    index_config = load_index_config(repo_source)
     try:
-        store = index_repository(repo_source, config=config, index_config=index_config)
-        try:
-            graph = build_arch_graph_from_store(store, repo_root=repo_root)
-        finally:
-            store.close()
+        if graph_path is not None:
+            graph = load_arch_graph(graph_path)
+        else:
+            repo_root = Path(source).expanduser().resolve()
+            repo_source = RepoSource(local_path=source)
+            config = load_config(repo_source)
+            index_config = load_index_config(repo_source)
+            store = index_repository(repo_source, config=config, index_config=index_config)
+            try:
+                graph = build_arch_graph_from_store(store, repo_root=repo_root)
+            finally:
+                store.close()
         rendered = render_onboarding_markdown(graph, max_files=max_files)
-    except (ArchexError, OnboardingError) as exc:
+    except (ArchexError, GraphArtifactError, OnboardingError) as exc:
         raise click.ClickException(str(exc)) from exc
 
     if output is None:

--- a/src/archex/explain.py
+++ b/src/archex/explain.py
@@ -8,7 +8,14 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
-from archex.graph_artifact import node_id_for_path, symbol_node_id
+from archex.graph_artifact import (
+    ArchGraph,
+    GraphEdgeType,
+    GraphNode,
+    GraphNodeType,
+    node_id_for_path,
+    symbol_node_id,
+)
 
 if TYPE_CHECKING:
     from archex.index.store import IndexStore
@@ -199,6 +206,103 @@ def render_explain_context(context: ExplainContext, output_format: str) -> str:
     raise ExplainError(f"Unsupported explain output format: {output_format}")
 
 
+def explain_graph_file(graph: ArchGraph, file_path: str) -> ExplainContext:
+    node = _graph_node_by_path(graph, file_path)
+    if node is None:
+        raise ExplainError(f"Target file does not exist in graph: {file_path}")
+    imports, imported_by = _graph_edge_context(graph, node.id)
+    symbol_nodes = _graph_symbol_nodes_for_file(graph, file_path)
+    symbols = [_symbol_from_graph_node(symbol) for symbol in symbol_nodes]
+    public, internal = _partition_symbols(symbols)
+    module_files = _graph_module_files(graph, file_path)
+    return ExplainContext(
+        target_type=ExplainTargetType.FILE,
+        target=file_path,
+        graph_node_ids=[node.id],
+        files=[file_path],
+        public_interfaces=public,
+        internal_symbols=internal,
+        imports=imports,
+        imported_by=imported_by,
+        module_files=module_files,
+        direct_dependency_edges=_graph_direct_edges(graph, {node.id}),
+        complexity=ExplainComplexity(
+            file_count=1,
+            line_count=node.complexity.line_count,
+            token_count=node.complexity.token_count,
+            symbol_count=node.complexity.symbol_count,
+            import_fan_in=len(imported_by),
+            import_fan_out=len(imports),
+        ),
+    )
+
+
+def explain_graph_symbol(graph: ArchGraph, target: str) -> ExplainContext:
+    node = _graph_node_by_id_or_label(graph, target, GraphNodeType.SYMBOL)
+    if node is None:
+        raise ExplainError(f"Target symbol does not exist in graph: {target}")
+    file_path = node.path or ""
+    context = explain_graph_file(graph, file_path)
+    symbol = _symbol_from_graph_node(node)
+    return context.model_copy(
+        update={
+            "target_type": ExplainTargetType.SYMBOL,
+            "target": target,
+            "graph_node_ids": [node.id],
+            "public_interfaces": [symbol]
+            if node.symbol_kind in {"function", "class", "interface"}
+            else [],
+            "internal_symbols": []
+            if node.symbol_kind in {"function", "class", "interface"}
+            else [symbol],
+        }
+    )
+
+
+def explain_graph_module(graph: ArchGraph, module_name: str) -> ExplainContext:
+    files = [
+        node.path or node.label
+        for node in graph.nodes
+        if node.type in {GraphNodeType.FILE, GraphNodeType.TEST}
+        and _path_matches_module(node.path or node.label, module_name)
+    ]
+    files = sorted(files)
+    if not files:
+        raise ExplainError(f"Target module does not exist in graph: {module_name}")
+    file_node_ids = {
+        node.id
+        for node in graph.nodes
+        if node.type in {GraphNodeType.FILE, GraphNodeType.TEST}
+        and (node.path or node.label) in files
+    }
+    imports, imported_by = _graph_edge_context(graph, file_node_ids)
+    symbols = [
+        _symbol_from_graph_node(node)
+        for node in graph.nodes
+        if node.type == GraphNodeType.SYMBOL and node.path in files
+    ]
+    public, internal = _partition_symbols(symbols)
+    return ExplainContext(
+        target_type=ExplainTargetType.MODULE,
+        target=module_name,
+        graph_node_ids=sorted(file_node_ids),
+        files=files,
+        public_interfaces=public,
+        internal_symbols=internal,
+        imports=imports,
+        imported_by=imported_by,
+        module_files=files,
+        direct_dependency_edges=_graph_direct_edges(graph, file_node_ids),
+        complexity=ExplainComplexity(
+            file_count=len(files),
+            line_count=_graph_line_count(graph, files),
+            symbol_count=len(symbols),
+            import_fan_in=len(imported_by),
+            import_fan_out=len(imports),
+        ),
+    )
+
+
 def _symbol_from_chunk(chunk: CodeChunk) -> ExplainSymbol:
     name = chunk.symbol_name or chunk.qualified_name or chunk.id
     qualified_name = chunk.qualified_name or name
@@ -213,6 +317,97 @@ def _symbol_from_chunk(chunk: CodeChunk) -> ExplainSymbol:
         line_end=chunk.end_line,
         signature=chunk.signature,
     )
+
+
+def _symbol_from_graph_node(node: GraphNode) -> ExplainSymbol:
+    return ExplainSymbol(
+        id=node.id,
+        name=node.label,
+        qualified_name=node.label,
+        kind=node.symbol_kind or "symbol",
+        file_path=node.path or "",
+        line_start=node.line_start or 0,
+        line_end=node.line_end or 0,
+    )
+
+
+def _graph_node_by_path(graph: ArchGraph, file_path: str) -> GraphNode | None:
+    for node in graph.nodes:
+        if node.type in {GraphNodeType.FILE, GraphNodeType.TEST} and node.path == file_path:
+            return node
+    return None
+
+
+def _graph_node_by_id_or_label(
+    graph: ArchGraph,
+    target: str,
+    node_type: GraphNodeType,
+) -> GraphNode | None:
+    matches = [
+        node
+        for node in graph.nodes
+        if node.type == node_type and target in {node.id, node.label}
+    ]
+    return sorted(matches, key=lambda node: node.id)[0] if matches else None
+
+
+def _graph_symbol_nodes_for_file(graph: ArchGraph, file_path: str) -> list[GraphNode]:
+    return [
+        node
+        for node in graph.nodes
+        if node.type == GraphNodeType.SYMBOL and node.path == file_path
+    ]
+
+
+def _graph_module_files(graph: ArchGraph, file_path: str) -> list[str]:
+    if "/" not in file_path:
+        return [file_path]
+    module_prefix = file_path.rsplit("/", maxsplit=1)[0]
+    return sorted(
+        node.path or node.label
+        for node in graph.nodes
+        if node.type in {GraphNodeType.FILE, GraphNodeType.TEST}
+        and (node.path or node.label).startswith(f"{module_prefix}/")
+    )
+
+
+def _graph_edge_context(
+    graph: ArchGraph,
+    node_ids: str | set[str],
+) -> tuple[list[str], list[str]]:
+    ids = {node_ids} if isinstance(node_ids, str) else node_ids
+    path_by_id = {node.id: node.path or node.label for node in graph.nodes}
+    imports = sorted(
+        path_by_id.get(edge.target, edge.target)
+        for edge in graph.edges
+        if edge.type == GraphEdgeType.IMPORTS and edge.source in ids and edge.target not in ids
+    )
+    imported_by = sorted(
+        path_by_id.get(edge.source, edge.source)
+        for edge in graph.edges
+        if edge.type == GraphEdgeType.IMPORTS and edge.target in ids and edge.source not in ids
+    )
+    return imports, imported_by
+
+
+def _graph_direct_edges(graph: ArchGraph, node_ids: set[str]) -> list[tuple[str, str]]:
+    path_by_id = {node.id: node.path or node.label for node in graph.nodes}
+    return sorted(
+        {
+            (path_by_id.get(edge.source, edge.source), path_by_id.get(edge.target, edge.target))
+            for edge in graph.edges
+            if edge.source in node_ids or edge.target in node_ids
+        }
+    )
+
+
+def _graph_line_count(graph: ArchGraph, files: list[str]) -> int:
+    total = 0
+    for path in files:
+        node = _graph_node_by_path(graph, path)
+        if node is not None:
+            total += node.complexity.line_count
+    return total
 
 
 def _partition_symbols(

--- a/src/archex/explain.py
+++ b/src/archex/explain.py
@@ -344,18 +344,14 @@ def _graph_node_by_id_or_label(
     node_type: GraphNodeType,
 ) -> GraphNode | None:
     matches = [
-        node
-        for node in graph.nodes
-        if node.type == node_type and target in {node.id, node.label}
+        node for node in graph.nodes if node.type == node_type and target in {node.id, node.label}
     ]
     return sorted(matches, key=lambda node: node.id)[0] if matches else None
 
 
 def _graph_symbol_nodes_for_file(graph: ArchGraph, file_path: str) -> list[GraphNode]:
     return [
-        node
-        for node in graph.nodes
-        if node.type == GraphNodeType.SYMBOL and node.path == file_path
+        node for node in graph.nodes if node.type == GraphNodeType.SYMBOL and node.path == file_path
     ]
 
 

--- a/src/archex/graph_artifact.py
+++ b/src/archex/graph_artifact.py
@@ -9,7 +9,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from archex import __version__
 from archex.models import CodeChunk, Edge, EdgeKind
@@ -292,6 +292,19 @@ def assert_supported_schema_version(version: GraphSchemaVersion) -> None:
             f"Unsupported graph schema major version {version.major}; "
             f"supported major version is {SUPPORTED_GRAPH_SCHEMA_MAJOR}"
         )
+
+
+def load_arch_graph(path: Path) -> ArchGraph:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise GraphArtifactError(f"Failed to read graph artifact {path}: {exc}") from exc
+    try:
+        graph = ArchGraph.model_validate_json(raw)
+    except ValidationError as exc:
+        raise GraphArtifactError(f"Malformed graph artifact {path}: {exc}") from exc
+    assert_supported_schema_version(graph.schema_version)
+    return graph
 
 
 def _normalize_path(path: str) -> str:

--- a/tests/test_graph_load_cli.py
+++ b/tests/test_graph_load_cli.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+
+
+def _export_graph(runner: CliRunner, repo: Path, output_path: Path) -> None:
+    result = runner.invoke(
+        cli,
+        ["graph", "export", str(repo), "--output", str(output_path)],
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_graph_inspect_reads_exported_artifact(python_simple_repo: Path, tmp_path: Path) -> None:
+    runner = CliRunner()
+    graph_path = tmp_path / "archgraph.json"
+    _export_graph(runner, python_simple_repo, graph_path)
+
+    result = runner.invoke(cli, ["graph", "inspect", str(graph_path), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["schema_version"] == "1.0.0"
+    assert data["nodes"] > 0
+    assert data["edges"] > 0
+
+
+def test_explain_reads_graph_without_source_index(python_simple_repo: Path, tmp_path: Path) -> None:
+    runner = CliRunner()
+    graph_path = tmp_path / "archgraph.json"
+    _export_graph(runner, python_simple_repo, graph_path)
+
+    result = runner.invoke(
+        cli,
+        ["explain", "--graph", str(graph_path), "main.py", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["target_type"] == "file"
+    assert data["files"] == ["main.py"]
+    assert "utils.py" in data["imports"]
+
+
+def test_onboard_reads_graph_without_source_index(python_simple_repo: Path, tmp_path: Path) -> None:
+    runner = CliRunner()
+    graph_path = tmp_path / "archgraph.json"
+    _export_graph(runner, python_simple_repo, graph_path)
+
+    result = runner.invoke(cli, ["onboard", "--graph", str(graph_path), "--max-files", "3"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.startswith("# Onboarding:")
+    assert "## Configuration Surface" in result.output
+
+
+def test_graph_load_rejects_unknown_major_version(tmp_path: Path) -> None:
+    runner = CliRunner()
+    graph_path = tmp_path / "archgraph.json"
+    graph_path.write_text(
+        json.dumps(
+            {
+                "schema_version": {"value": "2.0.0"},
+                "project": {"name": "bad"},
+                "metadata": {"archex_version": "0.6.2"},
+                "nodes": [],
+                "edges": [],
+                "layers": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(cli, ["graph", "inspect", str(graph_path)])
+
+    assert result.exit_code != 0
+    assert "Unsupported graph schema major version 2" in result.output
+
+
+def test_graph_load_rejects_malformed_artifact(tmp_path: Path) -> None:
+    runner = CliRunner()
+    graph_path = tmp_path / "archgraph.json"
+    graph_path.write_text('{"schema_version": {"value": "1.0.0"}}', encoding="utf-8")
+
+    result = runner.invoke(cli, ["graph", "inspect", str(graph_path)])
+
+    assert result.exit_code != 0
+    assert "Malformed graph artifact" in result.output


### PR DESCRIPTION
## Summary
- add graph artifact loading with explicit malformed-artifact and unsupported-major-version errors
- add `archex graph inspect`
- add graph-backed `explain --graph` and `onboard --graph` paths that avoid re-indexing

## Stack
Base: `feat/onboarding-artifact`
Parent: #126

1. `feat/graph-artifact-model`
2. `feat/graph-export-cli`
3. `feat/explain-context`
4. `feat/impact-analysis`
5. `feat/onboarding-artifact`
6. `feat/graph-load` -> this PR

## Validation
- Passed: `uv run ruff check`
- Passed: `uv run ruff format --check .`
- Passed: `uv run pyright`
- Not run: `uv run mypy --strict`; no mypy configuration is present in `pyproject.toml` and mypy is not a configured project checker
- Passed: `uv run pytest`

## Optional work skipped
- dashboard UI
- hook auto-update workflow
- XML explain output
- semantic or LLM-generated summaries