### PR TITLE
fix(benchmark): account for expanded files by file boundary

### DIFF
--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -412,6 +412,28 @@ def _archex_fields(
     # Seed vs expansion: candidates_found is a chunk count, while
     # seed_files_found is the file boundary for graph expansion diagnostics.
     meta = bundle.retrieval_metadata
+    if meta.seed_file_paths or meta.expanded_file_paths:
+        seed_files = list(meta.seed_file_paths)
+        expanded_files = list(meta.expanded_file_paths)
+        expansion_ratio = (
+            len(expanded_files) / len(seed_files) if seed_files else float(bool(expanded_files))
+        )
+        seed_recall_val = compute_recall(set(seed_files), task.expected_files)
+        seed_precision_val = compute_precision(set(seed_files), task.expected_files)
+        return _ArchexFields(
+            tokens_input=tokens_input,
+            tokens_output=tokens_output,
+            token_efficiency=token_efficiency,
+            tokens_raw_baseline=tokens_raw_baseline,
+            symbol_recall=symbol_recall,
+            unique_ranked_files=len(unique_files),
+            seed_files=seed_files,
+            expanded_files=expanded_files,
+            expansion_ratio=expansion_ratio,
+            seed_recall=seed_recall_val,
+            seed_precision=seed_precision_val,
+        )
+
     seed_file_count = meta.seed_files_found
 
     # Build seed file list from first `seed_file_count` unique chunk file paths.

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -409,23 +409,23 @@ def _archex_fields(
     result_symbols = {c.chunk.symbol_name for c in bundle.chunks if c.chunk.symbol_name}
     symbol_recall = compute_symbol_recall(result_symbols, task.expected_symbols)
 
-    # Seed vs expansion: candidates_found is the BM25 seed count,
-    # candidates_after_expansion includes graph-expanded chunks.
+    # Seed vs expansion: candidates_found is a chunk count, while
+    # seed_files_found is the file boundary for graph expansion diagnostics.
     meta = bundle.retrieval_metadata
-    seed_count = meta.candidates_found
+    seed_file_count = meta.seed_files_found
 
-    # Build seed file list from first `seed_count` unique chunk file paths
+    # Build seed file list from first `seed_file_count` unique chunk file paths.
     all_chunk_files = [c.chunk.file_path for c in bundle.chunks]
     seen: set[str] = set()
     seed_files: list[str] = []
     expanded_files: list[str] = []
-    # Chunks are ordered by score; first seed_count entries in candidate_map
-    # correspond to BM25 seeds. We use unique_files order as proxy.
+    # Chunks are ordered by score; unique file order is the observable boundary
+    # preserved in benchmark results.
     seed_file_set: set[str] = set()
     for fp in all_chunk_files:
         if fp not in seen:
             seen.add(fp)
-            if len(seed_file_set) < seed_count:
+            if len(seed_file_set) < seed_file_count:
                 seed_files.append(fp)
                 seed_file_set.add(fp)
             else:

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -562,6 +562,8 @@ class RetrievalMetadata(BaseModel):
     fusion_vector_weight: float | None = None
     # Expansion diagnostics
     seed_files_found: int = 0
+    seed_file_paths: list[str] = []
+    expanded_file_paths: list[str] = []
     expansion_eligible_seeds: int = 0
     expansion_candidates_found: int = 0
     expansion_files_added: int = 0

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -561,6 +561,7 @@ class RetrievalMetadata(BaseModel):
     fusion_bm25_weight: float | None = None
     fusion_vector_weight: float | None = None
     # Expansion diagnostics
+    seed_files_found: int = 0
     expansion_eligible_seeds: int = 0
     expansion_candidates_found: int = 0
     expansion_files_added: int = 0

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -911,6 +911,7 @@ def assemble_context(
         signal_agreement=signal_agreement,
         fusion_bm25_weight=fusion_bm25_weight,
         fusion_vector_weight=fusion_vector_weight,
+        seed_files_found=len(seed_files),
         expansion_eligible_seeds=expansion_eligible_seeds,
         expansion_candidates_found=len(expansion_priority),
         expansion_files_added=expansion_files_added,

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -392,6 +392,17 @@ def _initial_candidate_map(
     return candidate_map
 
 
+def _unique_file_paths(results: list[tuple[CodeChunk, float]]) -> list[str]:
+    seen: set[str] = set()
+    paths: list[str] = []
+    for chunk, _ in results:
+        if chunk.file_path in seen:
+            continue
+        seen.add(chunk.file_path)
+        paths.append(chunk.file_path)
+    return paths
+
+
 def _hop2_expansion_priority(expansion: _Hop2Expansion) -> dict[str, float]:
     hop1_files = set(expansion.hop1_files_added)
     hop2_priority: dict[str, float] = {}
@@ -406,11 +417,11 @@ def _hop2_expansion_priority(expansion: _Hop2Expansion) -> dict[str, float]:
     return hop2_priority
 
 
-def _add_hop2_expansion(expansion: _Hop2Expansion) -> int:
+def _add_hop2_expansion(expansion: _Hop2Expansion) -> list[str]:
     hop2_priority = _hop2_expansion_priority(expansion)
-    hop2_added = 0
+    hop2_files_added: list[str] = []
     for file_path in sorted(hop2_priority.keys(), key=lambda f: -hop2_priority[f]):
-        if hop2_added >= expansion.remaining_budget:
+        if len(hop2_files_added) >= expansion.remaining_budget:
             break
         if _is_test_file(file_path):
             continue
@@ -421,14 +432,14 @@ def _add_hop2_expansion(expansion: _Hop2Expansion) -> int:
             max_per_file=expansion.max_per_file,
         )
         if added > 0:
-            hop2_added += 1
+            hop2_files_added.append(file_path)
 
     logger.debug(
         "graph_expansion 2-hop: arch_query=True, hop2_candidates=%d, hop2_added=%d",
         len(hop2_priority),
-        hop2_added,
+        len(hop2_files_added),
     )
-    return hop2_added
+    return hop2_files_added
 
 
 def _dependency_subgraph(
@@ -566,7 +577,8 @@ def assemble_context(
     # When fusion is skipped, exclude vector results from seeds to avoid noise
     effective_vector = vector_results if (vector_results and not fusion_skipped) else []
     all_results = search_results + effective_vector
-    seed_files: set[str] = {chunk.file_path for chunk, _ in all_results}
+    seed_file_paths = _unique_file_paths(all_results)
+    seed_files: set[str] = set(seed_file_paths)
 
     candidates_found = len(search_results)
 
@@ -673,6 +685,7 @@ def assemble_context(
     candidate_map = _initial_candidate_map(search_results, vector_results)
     expansion_files_added = 0
     hop1_files_added: list[str] = []
+    expanded_file_paths: list[str] = []
     for file_path in sorted_expansion:
         if _is_test_file(file_path):
             continue
@@ -685,6 +698,7 @@ def assemble_context(
         if added > 0:
             expansion_files_added += 1
             hop1_files_added.append(file_path)
+            expanded_file_paths.append(file_path)
         if expansion_files_added >= MAX_EXPANSION_FILES:
             break
 
@@ -692,7 +706,7 @@ def assemble_context(
     if is_arch_query and hop1_files_added:
         remaining_budget = MAX_EXPANSION_FILES - expansion_files_added
         if remaining_budget > 0:
-            expansion_files_added += _add_hop2_expansion(
+            hop2_files_added = _add_hop2_expansion(
                 _Hop2Expansion(
                     graph=graph,
                     candidate_map=candidate_map,
@@ -705,6 +719,8 @@ def assemble_context(
                     max_per_file=max_per_file,
                 )
             )
+            expansion_files_added += len(hop2_files_added)
+            expanded_file_paths.extend(hop2_files_added)
 
     candidates_after_expansion = len(candidate_map)
 
@@ -911,7 +927,9 @@ def assemble_context(
         signal_agreement=signal_agreement,
         fusion_bm25_weight=fusion_bm25_weight,
         fusion_vector_weight=fusion_vector_weight,
-        seed_files_found=len(seed_files),
+        seed_files_found=len(seed_file_paths),
+        seed_file_paths=seed_file_paths,
+        expanded_file_paths=expanded_file_paths,
         expansion_eligible_seeds=expansion_eligible_seeds,
         expansion_candidates_found=len(expansion_priority),
         expansion_files_added=expansion_files_added,

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -9,6 +9,7 @@ import pytest
 
 from archex.benchmark.models import BenchmarkTask, Strategy
 from archex.benchmark.strategies import (
+    _archex_fields,  # pyright: ignore[reportPrivateUsage]
     _deduplicate_ranked,  # pyright: ignore[reportPrivateUsage]
     compute_map,
     compute_mrr,
@@ -28,6 +29,7 @@ from archex.benchmark.strategies import (
     run_raw_grepped,
     run_surrogate_vector,
 )
+from archex.models import CodeChunk, ContextBundle, RankedChunk, RetrievalMetadata
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -43,6 +45,19 @@ def sample_task() -> BenchmarkTask:
         expected_files=["main.py", "services/auth.py"],
         keywords=["auth", "login"],
     )
+
+
+def _ranked_chunk(chunk_id: str, file_path: str, *, score: float) -> RankedChunk:
+    chunk = CodeChunk(
+        id=chunk_id,
+        content=f"content for {file_path}",
+        file_path=file_path,
+        start_line=1,
+        end_line=1,
+        language="python",
+        token_count=4,
+    )
+    return RankedChunk(chunk=chunk, final_score=score)
 
 
 class TestComputeRecall:
@@ -321,6 +336,42 @@ class TestRunArchexQuery:
         assert result.tokens_input >= 0
         assert result.tokens_output >= 0
         assert result.tokens_raw_baseline >= 0
+
+    def test_expanded_files_split_uses_file_count_boundary(self, tmp_path: Path) -> None:
+        for file_path in ("seed_a.py", "seed_b.py", "expanded_a.py", "expanded_b.py"):
+            (tmp_path / file_path).write_text("print('x')\n", encoding="utf-8")
+        bundle = ContextBundle(
+            query="How does graph expansion work?",
+            chunks=[
+                _ranked_chunk("seed-a-1", "seed_a.py", score=1.0),
+                _ranked_chunk("seed-a-2", "seed_a.py", score=0.9),
+                _ranked_chunk("seed-b-1", "seed_b.py", score=0.8),
+                _ranked_chunk("expanded-a-1", "expanded_a.py", score=0.7),
+                _ranked_chunk("expanded-b-1", "expanded_b.py", score=0.6),
+            ],
+            token_count=20,
+            token_budget=100,
+            retrieval_metadata=RetrievalMetadata(
+                candidates_found=3,
+                candidates_after_expansion=5,
+                seed_files_found=2,
+                expansion_files_added=2,
+            ),
+        )
+        task = BenchmarkTask(
+            task_id="archex_graph_expansion",
+            repo="Mathews-Tom/archex",
+            commit="abc",
+            question="How does graph expansion work?",
+            expected_files=["expanded_a.py"],
+        )
+
+        fields = _archex_fields(bundle, task, tmp_path)
+
+        assert fields.seed_files == ["seed_a.py", "seed_b.py"]
+        assert fields.expanded_files == ["expanded_a.py", "expanded_b.py"]
+        assert fields.expansion_ratio == 1.0
+        assert fields.seed_recall == 0.0
 
 
 class _StubEmbedder:

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -373,6 +373,43 @@ class TestRunArchexQuery:
         assert fields.expansion_ratio == 1.0
         assert fields.seed_recall == 0.0
 
+    def test_expanded_files_uses_metadata_paths_when_expansion_is_not_included(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        for file_path in ("seed_a.py", "seed_b.py", "expanded_a.py", "expanded_b.py"):
+            (tmp_path / file_path).write_text("print('x')\n", encoding="utf-8")
+        bundle = ContextBundle(
+            query="How does graph expansion work?",
+            chunks=[
+                _ranked_chunk("seed-a-1", "seed_a.py", score=1.0),
+                _ranked_chunk("seed-b-1", "seed_b.py", score=0.8),
+            ],
+            token_count=8,
+            token_budget=100,
+            retrieval_metadata=RetrievalMetadata(
+                candidates_found=2,
+                candidates_after_expansion=4,
+                seed_files_found=2,
+                seed_file_paths=["seed_a.py", "seed_b.py"],
+                expanded_file_paths=["expanded_a.py", "expanded_b.py"],
+                expansion_files_added=2,
+            ),
+        )
+        task = BenchmarkTask(
+            task_id="archex_graph_expansion",
+            repo="Mathews-Tom/archex",
+            commit="abc",
+            question="How does graph expansion work?",
+            expected_files=["expanded_a.py"],
+        )
+
+        fields = _archex_fields(bundle, task, tmp_path)
+
+        assert fields.seed_files == ["seed_a.py", "seed_b.py"]
+        assert fields.expanded_files == ["expanded_a.py", "expanded_b.py"]
+        assert fields.expansion_ratio == 1.0
+
 
 class _StubEmbedder:
     """Deterministic stub embedder for vector/fusion tests without onnxruntime."""

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -377,6 +377,29 @@ def test_signal_agreement_none_without_vector() -> None:
     assert bundle.retrieval_metadata.signal_agreement is None
 
 
+def test_expansion_metadata_records_seed_and_expanded_file_paths() -> None:
+    graph = DependencyGraph()
+    graph.add_file_node("seed.py")
+    graph.add_file_node("expanded.py")
+    graph.add_file_edge("seed.py", "expanded.py", kind="imports")
+    seed_chunk = make_chunk("seed", "seed.py", token_count=10)
+    expanded_chunk = make_chunk("expanded", "expanded.py", token_count=10)
+
+    bundle = assemble_context(
+        [(seed_chunk, 5.0)],
+        graph,
+        [seed_chunk, expanded_chunk],
+        "graph expansion",
+        token_budget=1000,
+    )
+
+    meta = bundle.retrieval_metadata
+    assert meta.seed_files_found == 1
+    assert meta.seed_file_paths == ["seed.py"]
+    assert meta.expanded_file_paths == ["expanded.py"]
+    assert meta.expansion_files_added == 1
+
+
 def test_ranked_chunk_carries_cohesion_score() -> None:
     """RankedChunk has cohesion_score field."""
     from archex.models import RankedChunk


### PR DESCRIPTION
## Summary

- Adds seed and expansion file-path diagnostics to retrieval metadata so benchmark output can explain graph expansion independently from final token-budget assembly.
- Splits `seed_files` and `expanded_files` from metadata path lists, with a file-count fallback for older bundles.
- Covers graph-expansion accounting with deterministic `ContextBundle` and `assemble_context` tests.

## Stack

Base: `main`

1. `fix/expanded-files-accounting` -> this PR
2. `fix/benchmark-oracle-defects` -> depends on this PR
3. `fix/expansion-constants-and-docs` -> depends on `fix/benchmark-oracle-defects`
4. `fix/dogfood-baseline-gate` -> depends on `fix/expansion-constants-and-docs`
5. `chore/strategy-comparison-report` -> depends on `fix/dogfood-baseline-gate`
6. `feat/cli-intent` -> depends on `chore/strategy-comparison-report`
7. `feat/ppr-decision` -> depends on `feat/cli-intent`
8. `feat/bi-encoder-swap` -> depends on `feat/ppr-decision`
9. `feat/cross-encoder-swap` -> depends on `feat/bi-encoder-swap`
10. `test/generalization-guard` -> depends on `feat/cross-encoder-swap`
11. `chore/regression-contract` -> depends on `test/generalization-guard`

## Validation

- `uv run ruff check` -> pass
- `uv run ruff format --check .` -> pass
- `uv run pyright` -> pass
- `uv run pytest` -> pass (`1945 passed, 4 deselected`, coverage `91.18%`)
- `uv run pytest tests/serve/test_context.py tests/benchmark/test_strategies.py -q --no-cov` -> pass (`105 passed`)
- `rg -n 'task_id\\s*==\\s*"' src/archex` -> pass, no matches

## Pending Manual Benchmark

Do not run this in CI for this PR. User should run:

```bash
uv run archex benchmark run --tasks-dir benchmarks/tasks --output .archex/e2e-results --task archex_graph_expansion
```

Expected: `expanded_files` is non-empty and length is consistent with `expansion_ratio`.