### PR TITLE
fix(benchmark): correct benchmark oracle defects

### DIFF
--- a/benchmarks/tasks/archex_delta_index_lifecycle.yaml
+++ b/benchmarks/tasks/archex_delta_index_lifecycle.yaml
@@ -3,16 +3,14 @@ repo: "."
 commit: "HEAD"
 category: self
 languages: [python]
-question: "How does archex decide between delta indexing and a full reindex during project lifecycle operations?"
-# Expected files cover the API decision point, delta computation/application,
-# cache metadata, and status freshness checks.
+question: "How does archex compute delta indexing changes and report project freshness during lifecycle operations?"
+# Expected files cover delta computation/application, cache metadata, and
+# status freshness checks.
 expected_files:
-  - src/archex/api.py
   - src/archex/index/delta.py
   - src/archex/cache.py
   - src/archex/status.py
 expected_symbols:
-  - _try_delta_index
   - compute_delta
   - apply_delta
   - inspect_project_status

--- a/benchmarks/tasks/archex_delta_indexing.yaml
+++ b/benchmarks/tasks/archex_delta_indexing.yaml
@@ -7,7 +7,6 @@ question: "How does delta indexing detect and apply changes?"
 expected_files:
   - src/archex/index/delta.py
   - src/archex/cache.py
-  - src/archex/api.py
 expected_symbols:
   - compute_delta
   - apply_delta

--- a/benchmarks/tasks/archex_graph_expansion.yaml
+++ b/benchmarks/tasks/archex_graph_expansion.yaml
@@ -7,11 +7,9 @@ question: "How does archex expand search results using the dependency graph?"
 expected_files:
   - src/archex/index/graph.py
   - src/archex/serve/context.py
-  - src/archex/parse/imports.py
 expected_symbols:
-  - build_import_graph
+  - DependencyGraph.from_parsed_files
   - assemble_context
-  - build_file_map
 token_budget: 8192
 keywords:
   - graph

--- a/benchmarks/tasks/react_hooks.yaml
+++ b/benchmarks/tasks/react_hooks.yaml
@@ -7,7 +7,6 @@ question: "How does React implement the hooks state management system?"
 expected_files:
   - packages/react-reconciler/src/ReactFiberHooks.js
   - packages/react/src/ReactHooks.js
-  - packages/react-reconciler/src/ReactFiberWorkLoop.js
 expected_symbols: []
 token_budget: 8192
 keywords:

--- a/benchmarks/tasks/rust_tokio_runtime.yaml
+++ b/benchmarks/tasks/rust_tokio_runtime.yaml
@@ -5,9 +5,9 @@ category: external-large
 languages: [rust]
 question: "How does tokio implement the async task runtime and scheduler?"
 expected_files:
-  - tokio/src/runtime/mod.rs
-  - tokio/src/runtime/scheduler/mod.rs
-  - tokio/src/runtime/task/mod.rs
+  - tokio/src/runtime/scheduler/current_thread/mod.rs
+  - tokio/src/runtime/scheduler/multi_thread/mod.rs
+  - tokio/src/runtime/scheduler/multi_thread/worker.rs
 expected_symbols: []
 token_budget: 8192
 keywords:


### PR DESCRIPTION
## Summary

- Corrects the graph-expansion self-task oracle by removing the index-time imports file and replacing the phantom symbol with `DependencyGraph.from_parsed_files`.
- Scopes delta-indexing self-task oracles to mechanism files instead of broad API orchestration.
- Replaces Tokio runtime re-export stubs with concrete scheduler implementation files at the pinned `tokio-1.42.0` tag.
- Removes React work-loop scheduling from the hooks-state oracle at the pinned `v19.0.0` tag.

## Stack

Base: `main`

1. `fix/expanded-files-accounting` -> #128
2. `fix/benchmark-oracle-defects` -> this PR
3. `fix/expansion-constants-and-docs` -> depends on this PR
4. `fix/dogfood-baseline-gate` -> depends on `fix/expansion-constants-and-docs`
5. `chore/strategy-comparison-report` -> depends on `fix/dogfood-baseline-gate`
6. `feat/cli-intent` -> depends on `chore/strategy-comparison-report`
7. `feat/ppr-decision` -> depends on `feat/cli-intent`
8. `feat/bi-encoder-swap` -> depends on `feat/ppr-decision`
9. `feat/cross-encoder-swap` -> depends on `feat/bi-encoder-swap`
10. `test/generalization-guard` -> depends on `feat/cross-encoder-swap`
11. `chore/regression-contract` -> depends on `test/generalization-guard`

## Validation

- `uv run archex benchmark validate --tasks-dir benchmarks/tasks` -> pass (`All 35 task(s) valid.`)
- `uv run pytest tests/benchmark/ --no-cov` -> pass (`196 passed, 2 deselected`)
- `uv run ruff check` -> pass
- `uv run ruff format --check .` -> pass
- `uv run pyright` -> pass
- `uv run pytest` -> pass (`1945 passed, 4 deselected`, coverage `91.18%`)
- `rg -n 'task_id\\s*==\\s*"' src/archex` -> pass, no matches