### PR TITLE
fix(serve): align expansion constants and path docs

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -668,8 +668,9 @@ def _file_path_boost(
 
     Terms are searched longest-first (from _extract_path_terms) so specific terms
     like "validators" get priority over generic ones like "pydantic". Boost score
-    is 0.5× max BM25 so path-matched chunks compete without dominating. Per-file
-    caps prevent one matching directory from flooding file-level aggregation.
+    is max BM25 multiplied by _path_match_multiplier: 0.85 for stem/basename
+    matches, 0.70 for path segment matches, and 0.45 for substring matches.
+    Per-file caps prevent one matching directory from flooding file-level aggregation.
     """
     terms = _extract_path_terms(question)
     boosted: list[tuple[CodeChunk, float]] = []

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -41,11 +41,11 @@ logger = logging.getLogger(__name__)
 
 _TYPE_LIKE = {SymbolKind.CLASS, SymbolKind.TYPE, SymbolKind.INTERFACE}
 
-# Direct imports (files the seed depends on) get a strong boost — same call chain.
-IMPORT_TARGET_DECAY = 0.65
+# Propagated relevance for imported files that were already admitted as expansion candidates.
+NEIGHBOR_IMPORT_TARGET_DECAY = 0.65
 
-# Importers (files that depend on the seed) get a weaker boost — consumers, not deps.
-IMPORTER_DECAY = 0.35
+# Propagated relevance for importer files that were already admitted as expansion candidates.
+NEIGHBOR_IMPORTER_DECAY = 0.35
 
 MIN_SCORE_RATIO = 0.30
 
@@ -479,12 +479,15 @@ def _neighbor_boosts(
             if dep in seed_files:
                 continue
             path_match = any(term in dep.lower() for term in query_terms)
-            decay = IMPORT_TARGET_DECAY * (1.3 if path_match else 1.0)
+            decay = NEIGHBOR_IMPORT_TARGET_DECAY * (1.3 if path_match else 1.0)
             boosts[dep] = max(boosts.get(dep, 0.0), seed_score * decay)
         for importer in graph.imported_by(file_path):
             if importer in seed_files:
                 continue
-            boosts[importer] = max(boosts.get(importer, 0.0), seed_score * IMPORTER_DECAY)
+            boosts[importer] = max(
+                boosts.get(importer, 0.0),
+                seed_score * NEIGHBOR_IMPORTER_DECAY,
+            )
     return boosts
 
 

--- a/tests/serve/test_context_recall.py
+++ b/tests/serve/test_context_recall.py
@@ -126,7 +126,7 @@ def test_adaptive_max_files_returns_6_for_moderate_separation() -> None:
 
 
 def test_importer_file_included_with_higher_decay() -> None:
-    """Importer (consumer) files with IMPORTER_DECAY=0.35 survive cutoff."""
+    """Importer (consumer) files with NEIGHBOR_IMPORTER_DECAY=0.35 survive cutoff."""
     graph = DependencyGraph()
     graph.add_file_node("core.py")
     graph.add_file_node("consumer.py")
@@ -142,8 +142,8 @@ def test_importer_file_included_with_higher_decay() -> None:
 
 
 def test_importer_relevance_score_reflects_decay() -> None:
-    """Importer chunk gets relevance proportional to IMPORTER_DECAY."""
-    from archex.serve.context import IMPORTER_DECAY
+    """Importer chunk gets relevance proportional to NEIGHBOR_IMPORTER_DECAY."""
+    from archex.serve.context import NEIGHBOR_IMPORTER_DECAY
 
     graph = DependencyGraph()
     graph.add_file_node("seed.py")
@@ -154,8 +154,8 @@ def test_importer_relevance_score_reflects_decay() -> None:
     results = [(seed_chunk, 5.0)]
     bundle = assemble_context(results, graph, [seed_chunk, imp_chunk], "q", token_budget=1000)
     imp_rc = next(rc for rc in bundle.chunks if rc.chunk.file_path == "importer.py")
-    # Relevance should be seed_normalized * IMPORTER_DECAY = 1.0 * 0.35
-    assert abs(imp_rc.relevance_score - IMPORTER_DECAY) < 0.01
+    # Relevance should be seed_normalized * NEIGHBOR_IMPORTER_DECAY = 1.0 * 0.35
+    assert abs(imp_rc.relevance_score - NEIGHBOR_IMPORTER_DECAY) < 0.01
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stack

Base: `main`

1. `fix/expanded-files-accounting` -> PR #128
2. `fix/benchmark-oracle-defects` -> PR #129
3. `fix/expansion-constants-and-docs` -> this PR
4. `fix/dogfood-baseline-gate` -> next
5. `chore/strategy-comparison-report`
6. `feat/cli-intent`
7. `feat/ppr-decision`
8. `feat/bi-encoder-swap`
9. `feat/cross-encoder-swap`
10. `test/generalization-guard`
11. `chore/regression-contract`

## Changes

- Rename the import neighbor decay constants so they match their actual use in neighbor boost scoring.
- Keep expansion behavior unchanged: the expansion loop uses different inline multipliers, so routing the renamed constants into that path would change ranking behavior.
- Correct the `_file_path_boost` docstring to the current `_path_match_multiplier` values: 0.85, 0.70, and 0.45.
- Updated retrieval-pipeline memory out of band at `~/.claude/projects/-Users-druk-WorkSpace-AetherForge-determ-ai-archex/memory/retrieval_pipeline.md`.

## Validation

- `uv run pytest tests/serve/test_context_recall.py -q --no-cov`: passed
- `uv run pytest tests/serve/test_query_normalization.py -q --no-cov`: passed
- `uv run ruff check`: passed
- `uv run ruff format --check .`: passed
- `uv run pyright`: passed
- `uv run pytest`: passed, 1945 passed, 4 deselected
