### PR TITLE
fix(benchmark): enforce dogfood baseline gate

### DIFF
--- a/src/archex/benchmark/baseline.py
+++ b/src/archex/benchmark/baseline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
 from datetime import UTC, datetime
 
 from pydantic import BaseModel
@@ -78,6 +79,7 @@ def compare_baseline(
     reports: list[BenchmarkReport],
     baseline: Baseline,
     tolerance: float = _DEFAULT_TOLERANCE,
+    excluded_strategies: Collection[str] = (),
 ) -> list[BaselineComparison]:
     """Compare current reports against a baseline. Flag regressions beyond tolerance."""
     baseline_lookup: dict[tuple[str, str], BaselineEntry] = {
@@ -86,6 +88,9 @@ def compare_baseline(
     comparisons: list[BaselineComparison] = []
     for report in reports:
         for r in report.results:
+            strategy = r.strategy.value
+            if strategy in excluded_strategies:
+                continue
             key = (r.task_id, r.strategy.value)
             entry = baseline_lookup.get(key)
             if entry is None:

--- a/src/archex/cli/dogfood_cmd.py
+++ b/src/archex/cli/dogfood_cmd.py
@@ -34,7 +34,7 @@ from archex.dogfood import run_dogfood
     "baseline_path",
     default=None,
     type=click.Path(),
-    help="Baseline JSON path. Defaults to local dogfood baseline, or committed CI baseline.",
+    help="Required baseline JSON path for regression gating.",
 )
 @click.option(
     "--format",

--- a/src/archex/dogfood.py
+++ b/src/archex/dogfood.py
@@ -26,6 +26,7 @@ DOGFOOD_BASELINE_PATH = Path("benchmarks/dogfood_baseline.json")
 DEFAULT_TASKS_DIR = Path("benchmarks/tasks")
 DEFAULT_OUTPUT_DIR = Path(".archex/dogfood")
 DEFAULT_TASK_PREFIX = "archex_"
+DOGFOOD_DIAGNOSTIC_STRATEGIES = frozenset({Strategy.RAW_FILES.value, Strategy.RAW_GREPPED.value})
 
 
 @dataclass(frozen=True)
@@ -225,7 +226,11 @@ def _compare_to_baseline(
         return []
     baseline_data = json.loads(baseline_path.read_text(encoding="utf-8"))
     baseline = load_baseline(baseline_data)
-    return compare_baseline(reports, baseline)
+    return compare_baseline(
+        reports,
+        baseline,
+        excluded_strategies=DOGFOOD_DIAGNOSTIC_STRATEGIES,
+    )
 
 
 def _write_reports(

--- a/src/archex/dogfood.py
+++ b/src/archex/dogfood.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import tomllib
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -206,6 +205,7 @@ def _resolve_baseline_path(
     explicit_baseline: str | Path | None,
     output_dir: Path,
 ) -> Path | None:
+    del output_dir
     if explicit_baseline is not None:
         path = Path(explicit_baseline).expanduser()
         if not path.is_absolute():
@@ -214,12 +214,7 @@ def _resolve_baseline_path(
             raise ValueError(f"Dogfood baseline not found: {path}")
         return path
 
-    if os.environ.get("CI"):
-        ci_baseline = state.repo_root / DOGFOOD_BASELINE_PATH
-        return ci_baseline if ci_baseline.is_file() else None
-
-    local_baseline = output_dir / "baseline.json"
-    return local_baseline if local_baseline.is_file() else None
+    raise ValueError("Dogfood requires an explicit --baseline path")
 
 
 def _compare_to_baseline(

--- a/tests/benchmark/test_baseline.py
+++ b/tests/benchmark/test_baseline.py
@@ -14,6 +14,7 @@ from archex.benchmark.models import BenchmarkReport, BenchmarkResult, Strategy
 
 def _make_report(
     task_id: str = "test_task",
+    strategy: Strategy = Strategy.ARCHEX_QUERY,
     recall: float = 0.8,
     precision: float = 0.6,
     f1_score: float = 0.685,
@@ -23,7 +24,7 @@ def _make_report(
 ) -> BenchmarkReport:
     result = BenchmarkResult(
         task_id=task_id,
-        strategy=Strategy.ARCHEX_QUERY,
+        strategy=strategy,
         tokens_total=1000,
         tool_calls=1,
         files_accessed=3,
@@ -130,3 +131,39 @@ def test_compare_baseline_no_regression() -> None:
     comparisons = compare_baseline(reports, baseline)
     regressions = [c for c in comparisons if c.regression]
     assert len(regressions) == 0
+
+
+def test_compare_baseline_excludes_diagnostic_strategies() -> None:
+    baseline = Baseline(
+        entries=[
+            BaselineEntry(
+                task_id="test_task",
+                strategy="raw_grepped",
+                recall=1.0,
+                precision=1.0,
+                f1_score=1.0,
+                mrr=1.0,
+            ),
+            BaselineEntry(
+                task_id="test_task",
+                strategy="archex_query",
+                recall=0.8,
+                precision=0.6,
+                f1_score=0.685,
+                mrr=0.5,
+            ),
+        ]
+    )
+    reports = [
+        _make_report(strategy=Strategy.RAW_GREPPED, recall=0.0),
+        _make_report(strategy=Strategy.ARCHEX_QUERY, recall=0.85),
+    ]
+
+    comparisons = compare_baseline(
+        reports,
+        baseline,
+        excluded_strategies={Strategy.RAW_GREPPED.value},
+    )
+
+    assert {comparison.strategy for comparison in comparisons} == {Strategy.ARCHEX_QUERY.value}
+    assert [comparison for comparison in comparisons if comparison.regression] == []

--- a/tests/benchmark/test_dogfood.py
+++ b/tests/benchmark/test_dogfood.py
@@ -54,23 +54,48 @@ expected_symbols: []
     return tasks_dir
 
 
-def _write_baseline(path: Path, *, recall: float = 1.0) -> Path:
+def _write_baseline(
+    path: Path,
+    *,
+    recall: float = 1.0,
+    include_diagnostics: bool = False,
+) -> Path:
     baseline_path = path / "baseline.json"
-    baseline = Baseline(
-        entries=[
-            BaselineEntry(
-                task_id="archex_query_pipeline",
-                strategy=Strategy.ARCHEX_QUERY.value,
-                recall=recall,
-                precision=1.0,
-                f1_score=recall,
-                mrr=recall,
-                ndcg=recall,
-                map_score=recall,
-                token_efficiency=recall,
-            )
-        ]
-    )
+    entries = [
+        BaselineEntry(
+            task_id="archex_query_pipeline",
+            strategy=Strategy.ARCHEX_QUERY.value,
+            recall=recall,
+            precision=1.0,
+            f1_score=recall,
+            mrr=recall,
+            ndcg=recall,
+            map_score=recall,
+            token_efficiency=recall,
+        )
+    ]
+    if include_diagnostics:
+        entries.extend(
+            [
+                BaselineEntry(
+                    task_id="archex_query_pipeline",
+                    strategy=Strategy.RAW_FILES.value,
+                    recall=1.0,
+                    precision=1.0,
+                    f1_score=1.0,
+                    mrr=1.0,
+                ),
+                BaselineEntry(
+                    task_id="archex_query_pipeline",
+                    strategy=Strategy.RAW_GREPPED.value,
+                    recall=1.0,
+                    precision=1.0,
+                    f1_score=1.0,
+                    mrr=1.0,
+                ),
+            ]
+        )
+    baseline = Baseline(entries=entries)
     baseline_path.write_text(baseline.model_dump_json(indent=2), encoding="utf-8")
     return baseline_path
 
@@ -121,6 +146,28 @@ def _passing_report(
 ) -> BenchmarkReport:
     del strategies, repo_path
     return _report(task)
+
+
+def _diagnostic_regressing_report(
+    task: BenchmarkTask,
+    strategies: list[Strategy] | None = None,
+    repo_path: Path | None = None,
+) -> BenchmarkReport:
+    del strategies, repo_path
+    report = _report(task)
+    diagnostic_result = report.results[0].model_copy(
+        update={
+            "strategy": Strategy.RAW_GREPPED,
+            "recall": 0.0,
+            "precision": 0.0,
+            "f1_score": 0.0,
+            "mrr": 0.0,
+            "ndcg": 0.0,
+            "map_score": 0.0,
+            "token_efficiency": 0.0,
+        }
+    )
+    return report.model_copy(update={"results": [diagnostic_result, *report.results]})
 
 
 def test_dogfood_runs_self_tasks_and_writes_reports(
@@ -229,6 +276,28 @@ def test_dogfood_compares_explicit_baseline(
     assert result.baseline_path == baseline_path
     assert result.regressions
     assert {regression.metric for regression in result.regressions} >= {"recall", "f1_score", "mrr"}
+
+
+def test_dogfood_filters_diagnostic_strategy_regressions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_tasks(tmp_path)
+    baseline_path = _write_baseline(tmp_path, include_diagnostics=True)
+    monkeypatch.setattr("archex.dogfood.run_benchmark", _diagnostic_regressing_report)
+
+    result = run_dogfood(tmp_path, task_id="archex_query_pipeline", baseline_path=baseline_path)
+
+    assert result.regressions == []
+    assert {comparison.strategy for comparison in result.comparisons} == {
+        Strategy.ARCHEX_QUERY.value
+    }
+    payload = json.loads(result.latest_json_path.read_text(encoding="utf-8"))
+    assert payload["regressions"] == []
+    assert {comparison["strategy"] for comparison in payload["comparisons"]} == {
+        Strategy.ARCHEX_QUERY.value
+    }
 
 
 def test_dogfood_command_exits_nonzero_on_regression(

--- a/tests/benchmark/test_dogfood.py
+++ b/tests/benchmark/test_dogfood.py
@@ -54,6 +54,27 @@ expected_symbols: []
     return tasks_dir
 
 
+def _write_baseline(path: Path, *, recall: float = 1.0) -> Path:
+    baseline_path = path / "baseline.json"
+    baseline = Baseline(
+        entries=[
+            BaselineEntry(
+                task_id="archex_query_pipeline",
+                strategy=Strategy.ARCHEX_QUERY.value,
+                recall=recall,
+                precision=1.0,
+                f1_score=recall,
+                mrr=recall,
+                ndcg=recall,
+                map_score=recall,
+                token_efficiency=recall,
+            )
+        ]
+    )
+    baseline_path.write_text(baseline.model_dump_json(indent=2), encoding="utf-8")
+    return baseline_path
+
+
 def _report(task: BenchmarkTask, recall: float = 1.0) -> BenchmarkReport:
     result = BenchmarkResult(
         task_id=task.task_id,
@@ -121,8 +142,9 @@ def test_dogfood_runs_self_tasks_and_writes_reports(
         return _report(task)
 
     monkeypatch.setattr("archex.dogfood.run_benchmark", fake_run_benchmark)
+    baseline_path = _write_baseline(tmp_path)
 
-    result = run_dogfood(tmp_path)
+    result = run_dogfood(tmp_path, baseline_path=baseline_path)
 
     assert captured == ["archex_query_pipeline"]
     assert result.latest_json_path == tmp_path / ".archex" / "dogfood" / "latest.json"
@@ -178,8 +200,9 @@ def test_dogfood_reports_failure_classes(
         )
 
     monkeypatch.setattr("archex.dogfood.run_benchmark", partial_report)
+    baseline_path = _write_baseline(tmp_path, recall=0.5)
 
-    result = run_dogfood(tmp_path, task_id="archex_query_pipeline")
+    result = run_dogfood(tmp_path, task_id="archex_query_pipeline", baseline_path=baseline_path)
     payload = json.loads(result.latest_json_path.read_text(encoding="utf-8"))
     diagnostic = payload["retrieval_diagnostics"][0]
 
@@ -197,23 +220,7 @@ def test_dogfood_compares_explicit_baseline(
 ) -> None:
     _init_git_repo(tmp_path)
     _write_tasks(tmp_path)
-    baseline_path = tmp_path / "baseline.json"
-    baseline = Baseline(
-        entries=[
-            BaselineEntry(
-                task_id="archex_query_pipeline",
-                strategy=Strategy.ARCHEX_QUERY.value,
-                recall=1.0,
-                precision=1.0,
-                f1_score=1.0,
-                mrr=1.0,
-                ndcg=1.0,
-                map_score=1.0,
-                token_efficiency=1.0,
-            )
-        ]
-    )
-    baseline_path.write_text(baseline.model_dump_json(indent=2), encoding="utf-8")
+    baseline_path = _write_baseline(tmp_path)
 
     monkeypatch.setattr("archex.dogfood.run_benchmark", _regressing_report)
 
@@ -230,22 +237,7 @@ def test_dogfood_command_exits_nonzero_on_regression(
 ) -> None:
     _init_git_repo(tmp_path)
     _write_tasks(tmp_path)
-    baseline_path = tmp_path / "baseline.json"
-    baseline_path.write_text(
-        Baseline(
-            entries=[
-                BaselineEntry(
-                    task_id="archex_query_pipeline",
-                    strategy=Strategy.ARCHEX_QUERY.value,
-                    recall=1.0,
-                    precision=1.0,
-                    f1_score=1.0,
-                    mrr=1.0,
-                )
-            ]
-        ).model_dump_json(indent=2),
-        encoding="utf-8",
-    )
+    baseline_path = _write_baseline(tmp_path)
     monkeypatch.setattr("archex.dogfood.run_benchmark", _regressing_report)
 
     runner = CliRunner()
@@ -272,15 +264,43 @@ def test_dogfood_command_json_outputs_latest_payload(
 ) -> None:
     _init_git_repo(tmp_path)
     _write_tasks(tmp_path)
+    baseline_path = _write_baseline(tmp_path)
     monkeypatch.setattr("archex.dogfood.run_benchmark", _passing_report)
 
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["dogfood", str(tmp_path), "--task", "archex_query_pipeline", "--format", "json"],
+        [
+            "dogfood",
+            str(tmp_path),
+            "--task",
+            "archex_query_pipeline",
+            "--baseline",
+            str(baseline_path),
+            "--format",
+            "json",
+        ],
     )
 
     assert result.exit_code == 0
     payload = json.loads(result.output)
     assert payload["tasks"] == ["archex_query_pipeline"]
     assert payload["regressions"] == []
+
+
+def test_dogfood_requires_explicit_baseline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_tasks(tmp_path)
+    monkeypatch.setattr("archex.dogfood.run_benchmark", _passing_report)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["dogfood", str(tmp_path), "--task", "archex_query_pipeline"],
+    )
+
+    assert result.exit_code == 1
+    assert "Dogfood requires an explicit --baseline path" in result.output

--- a/tests/benchmark/test_dogfood.py
+++ b/tests/benchmark/test_dogfood.py
@@ -278,6 +278,24 @@ def test_dogfood_compares_explicit_baseline(
     assert {regression.metric for regression in result.regressions} >= {"recall", "f1_score", "mrr"}
 
 
+def test_dogfood_resolves_relative_baseline_from_repo_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_tasks(tmp_path)
+    baseline_path = _write_baseline(tmp_path)
+    monkeypatch.setattr("archex.dogfood.run_benchmark", _passing_report)
+
+    result = run_dogfood(
+        tmp_path,
+        task_id="archex_query_pipeline",
+        baseline_path=baseline_path.name,
+    )
+
+    assert result.baseline_path == baseline_path
+
+
 def test_dogfood_filters_diagnostic_strategy_regressions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/benchmark/test_triage.py
+++ b/tests/benchmark/test_triage.py
@@ -178,3 +178,24 @@ def test_format_triage_outputs_are_stable() -> None:
     payload = json.loads(format_triage_json(findings))
     assert payload[0]["task_id"] == "zero"
     assert payload[0]["failure_bucket"] == "zero_recall"
+
+
+def test_format_triage_json_serializes_expansion_diagnostics() -> None:
+    result = _result(
+        Strategy.ARCHEX_QUERY,
+        recall=1.0,
+        precision=0.2,
+        f1_score=0.33,
+        seed_files=["src/task.py"],
+        expanded_files=["src/worker.py", "src/noise.py"],
+    )
+    findings = triage_failures([_report("expanded", result)], {"expanded": _task("expanded")})
+
+    payload = json.loads(format_triage_json(findings))
+
+    assert payload[0]["task_id"] == "expanded"
+    assert payload[0]["returned_files"] == ["src/task.py", "src/worker.py", "src/noise.py"]
+    assert payload[0]["extra_files"] == ["src/noise.py"]
+    assert payload[0]["seed_files"] == ["src/task.py"]
+    assert payload[0]["expanded_files"] == ["src/worker.py", "src/noise.py"]
+    assert payload[0]["expansion_ratio"] == 0.5


### PR DESCRIPTION
## Stack

Base: `main`

1. `fix/expanded-files-accounting` -> PR #128
2. `fix/benchmark-oracle-defects` -> PR #129
3. `fix/expansion-constants-and-docs` -> PR #130
4. `fix/dogfood-baseline-gate` -> this PR
5. `chore/strategy-comparison-report` -> next
6. `feat/cli-intent`
7. `feat/ppr-decision`
8. `feat/bi-encoder-swap`
9. `feat/cross-encoder-swap`
10. `test/generalization-guard`
11. `chore/regression-contract`

## Changes

- Require dogfood callers to pass an explicit `--baseline` path instead of silently skipping or auto-discovering baseline comparisons.
- Filter diagnostic strategies, `raw_files` and `raw_grepped`, out of the dogfood regression gate while leaving them in benchmark reports and diagnostics.
- Add focused tests for baseline path resolution, diagnostic-regression filtering, and triage JSON serialization for expansion diagnostics.

## Validation

- `uv run pytest tests/benchmark/test_dogfood.py tests/benchmark/test_baseline.py tests/benchmark/test_triage.py --no-cov`: passed, 18 passed
- `uv run pytest tests/benchmark/test_dogfood.py tests/benchmark/test_baseline.py tests/benchmark/test_triage.py`: tests passed, coverage threshold fails because the target is intentionally narrow
- `uv run ruff check`: passed
- `uv run ruff format --check .`: passed
- `uv run pyright`: passed
- `uv run pytest`: passed, 1950 passed, 4 deselected
- `uv run archex dogfood . --task archex_query_pipeline --baseline benchmarks/dogfood_baseline.json --format json`: passed; comparisons contain `archex_query` only and `regressions` is empty
- `rg -n 'task_id\s*==\s*"' src/archex`: no matches
