### PR TITLE
chore(benchmark): record strategy comparison decision

### DIFF
--- a/.docs/strategy-comparison.md
+++ b/.docs/strategy-comparison.md
@@ -7,14 +7,23 @@ Compare the current product default, `archex_query`, against `archex_query_fusio
 ## Commands
 
 - Benchmark run: `uv run archex benchmark run --query-fusion --rerank --tasks-dir benchmarks/tasks --output .archex/e2e-results`
-- Readiness report: `uv run archex benchmark readiness --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown`
+- Current-default readiness: `uv run archex benchmark readiness --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query --format markdown`
+- Fusion-rerank readiness: `uv run archex benchmark readiness --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown`
+
+The full benchmark command was run directly twice during this PR. The first run
+completed 18 of 35 result files before repeated cross-encoder loads made the run
+impractical. After adding process-level reranker model reuse and run-level
+external-repo reuse, the command again completed 18 of 35 result files and then
+became CPU-bound on the first `django/django` task. The measurements below use
+the 18 fresh artifacts produced by the direct run because they are already
+decisive against the default-switch rule.
 
 ## Measurements
 
 | Strategy | Mean recall | Mean precision | Mean F1 | Mean MRR | Median latency | P95 latency | Zero-recall tasks |
 |---|---:|---:|---:|---:|---:|---:|---:|
-| `archex_query` | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
-| `archex_query_fusion_rerank` | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| `archex_query` | 0.602 | 0.442 | 0.494 | 0.903 | 1876 ms | 2222 ms | 0 |
+| `archex_query_fusion_rerank` | 0.282 | 0.392 | 0.309 | 0.593 | 3204 ms | 5525 ms | 6 |
 
 ## Decision Rule
 
@@ -25,12 +34,20 @@ Switch the product default to `archex_query_fusion_rerank` only if:
 
 ## Recommendation
 
-TBD.
+Keep `archex_query` as the product default.
 
 ## Chosen Path
 
-TBD.
+Decision B: do not switch the product default in this PR.
+
+`archex_query_fusion_rerank` fails both switch criteria on the measured artifact
+set. Its mean F1 is `0.185` below `archex_query`, not `0.05` above it, and its
+P95 latency is `5525 ms`, above the `3000 ms` threshold.
 
 ## Notes
 
-TBD.
+- Artifact set: 18 tasks from `.archex/e2e-results`.
+- Categories covered: 16 self tasks, 1 external-framework task, 1 external-large task.
+- `archex_query_fusion_rerank` produced 6 zero-recall tasks in the measured set.
+- The full 35-task fusion-rerank run remains too expensive for this PR's local
+  validation loop under the current benchmark harness.

--- a/.docs/strategy-comparison.md
+++ b/.docs/strategy-comparison.md
@@ -1,0 +1,36 @@
+# Strategy Comparison
+
+## Context
+
+Compare the current product default, `archex_query`, against `archex_query_fusion_rerank` on the corrected benchmark oracle.
+
+## Commands
+
+- Benchmark run: `uv run archex benchmark run --query-fusion --rerank --tasks-dir benchmarks/tasks --output .archex/e2e-results`
+- Readiness report: `uv run archex benchmark readiness --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown`
+
+## Measurements
+
+| Strategy | Mean recall | Mean precision | Mean F1 | Mean MRR | Median latency | P95 latency | Zero-recall tasks |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `archex_query` | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+| `archex_query_fusion_rerank` | TBD | TBD | TBD | TBD | TBD | TBD | TBD |
+
+## Decision Rule
+
+Switch the product default to `archex_query_fusion_rerank` only if:
+
+- `archex_query_fusion_rerank` mean F1 is at least `archex_query` mean F1 plus `0.05`.
+- `archex_query_fusion_rerank` P95 latency is at most `3000 ms` per task.
+
+## Recommendation
+
+TBD.
+
+## Chosen Path
+
+TBD.
+
+## Notes
+
+TBD.

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -87,6 +87,8 @@ class BenchmarkReport(BaseModel):
     question: str
     results: list[BenchmarkResult]
     baseline_tokens: int
+    median_latency_ms: float = 0.0
+    p95_latency_ms: float = 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/src/archex/benchmark/readiness.py
+++ b/src/archex/benchmark/readiness.py
@@ -68,6 +68,8 @@ class ReadinessReport:
     mean_precision: float
     mean_f1_score: float
     mean_mrr: float
+    median_latency_ms: float
+    p95_latency_ms: float
     zero_recall_tasks: int
     low_f1_tasks: int
     low_precision_tasks: int
@@ -88,6 +90,8 @@ class ReadinessReport:
             "mean_precision": self.mean_precision,
             "mean_f1_score": self.mean_f1_score,
             "mean_mrr": self.mean_mrr,
+            "median_latency_ms": self.median_latency_ms,
+            "p95_latency_ms": self.p95_latency_ms,
             "zero_recall_tasks": self.zero_recall_tasks,
             "low_f1_tasks": self.low_f1_tasks,
             "low_precision_tasks": self.low_precision_tasks,
@@ -118,6 +122,8 @@ def build_readiness_report(
             mean_precision=0.0,
             mean_f1_score=0.0,
             mean_mrr=0.0,
+            median_latency_ms=0.0,
+            p95_latency_ms=0.0,
             zero_recall_tasks=0,
             low_f1_tasks=0,
             low_precision_tasks=0,
@@ -131,6 +137,8 @@ def build_readiness_report(
     mean_precision = _mean([result.precision for result in metric_results])
     mean_f1 = _mean([result.f1_score for result in metric_results])
     mean_mrr = _mean([result.mrr for result in metric_results])
+    median_latency_ms = _percentile([result.wall_time_ms for result in metric_results], 0.50)
+    p95_latency_ms = _percentile([result.wall_time_ms for result in metric_results], 0.95)
     zero_recall_tasks = sum(1 for result in metric_results if result.recall <= 0.0)
     low_f1_tasks = sum(1 for result in metric_results if result.f1_score < LOW_F1_THRESHOLD)
     low_precision_tasks = sum(
@@ -175,6 +183,8 @@ def build_readiness_report(
         mean_precision=mean_precision,
         mean_f1_score=mean_f1,
         mean_mrr=mean_mrr,
+        median_latency_ms=median_latency_ms,
+        p95_latency_ms=p95_latency_ms,
         zero_recall_tasks=zero_recall_tasks,
         low_f1_tasks=low_f1_tasks,
         low_precision_tasks=low_precision_tasks,
@@ -210,6 +220,8 @@ def format_readiness_markdown(report: ReadinessReport) -> str:
         f"- Mean precision: `{report.mean_precision:.3f}`\n"
         f"- Mean F1: `{report.mean_f1_score:.3f}`\n"
         f"- Mean MRR: `{report.mean_mrr:.3f}`\n"
+        f"- Median latency: `{report.median_latency_ms:.0f} ms`\n"
+        f"- P95 latency: `{report.p95_latency_ms:.0f} ms`\n"
         f"- Zero-recall tasks: `{report.zero_recall_tasks}`\n"
         f"- Tasks below F1 {LOW_F1_THRESHOLD:.2f}: `{report.low_f1_tasks}`\n"
         f"- Tasks below precision {LOW_PRECISION_THRESHOLD:.2f}: `{report.low_precision_tasks}`"
@@ -293,6 +305,19 @@ def _category(
 
 def _mean(values: list[float]) -> float:
     return sum(values) / len(values) if values else 0.0
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
 
 
 def _format_number(value: float | int) -> str:

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -198,6 +198,14 @@ def run_benchmark(
             question=task.question,
             results=results,
             baseline_tokens=baseline_tokens,
+            median_latency_ms=_percentile(
+                [result.wall_time_ms for result in results],
+                0.50,
+            ),
+            p95_latency_ms=_percentile(
+                [result.wall_time_ms for result in results],
+                0.95,
+            ),
         )
     finally:
         if needs_cleanup:
@@ -247,3 +255,16 @@ def run_all(
             print(f"  - {task_id}: {detail}", file=sys.stderr)
 
     return reports
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -228,33 +228,58 @@ def run_all(
     output_dir.mkdir(parents=True, exist_ok=True)
     reports: list[BenchmarkReport] = []
     failures: list[tuple[str, str]] = []
+    repo_cache: dict[tuple[str, str], Path] = {}
+    cleanup_paths: list[Path] = []
 
-    for i, task in enumerate(tasks, 1):
-        print(f"[{i}/{len(tasks)}] {task.task_id} ({task.repo})", file=sys.stderr)
-        task_repo_path: Path | None = None
-        if task.repo == ".":
-            task_repo_path = Path.cwd()
-        try:
-            report = run_benchmark(task, strategies=strategies, repo_path=task_repo_path)
-        except BenchmarkCloneError as exc:
-            # Isolate per-task clone failures (network, rate limit, bad ref) so one
-            # bad repo does not abort the whole batch.
-            logger.warning("Skipping task %s: %s", task.task_id, exc)
-            print(f"  SKIPPED {task.task_id}: {exc}", file=sys.stderr)
-            failures.append((task.task_id, str(exc)))
-            continue
-        reports.append(report)
+    try:
+        for i, task in enumerate(tasks, 1):
+            print(f"[{i}/{len(tasks)}] {task.task_id} ({task.repo})", file=sys.stderr)
+            try:
+                task_repo_path = _repo_path_for_task(task, repo_cache, cleanup_paths)
+                report = run_benchmark(task, strategies=strategies, repo_path=task_repo_path)
+            except BenchmarkCloneError as exc:
+                # Isolate per-task clone failures (network, rate limit, bad ref) so one
+                # bad repo does not abort the whole batch.
+                logger.warning("Skipping task %s: %s", task.task_id, exc)
+                print(f"  SKIPPED {task.task_id}: {exc}", file=sys.stderr)
+                failures.append((task.task_id, str(exc)))
+                continue
+            reports.append(report)
 
-        result_path = output_dir / f"{task.task_id}.json"
-        result_path.write_text(report.model_dump_json(indent=2), encoding="utf-8")
-        print(f"  → Wrote {result_path}", file=sys.stderr)
+            result_path = output_dir / f"{task.task_id}.json"
+            result_path.write_text(report.model_dump_json(indent=2), encoding="utf-8")
+            print(f"  → Wrote {result_path}", file=sys.stderr)
 
-    if failures:
-        print(f"\n{len(failures)} task(s) skipped due to clone failures:", file=sys.stderr)
-        for task_id, detail in failures:
-            print(f"  - {task_id}: {detail}", file=sys.stderr)
+        if failures:
+            print(f"\n{len(failures)} task(s) skipped due to clone failures:", file=sys.stderr)
+            for task_id, detail in failures:
+                print(f"  - {task_id}: {detail}", file=sys.stderr)
 
-    return reports
+        return reports
+    finally:
+        for path in cleanup_paths:
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def _repo_path_for_task(
+    task: BenchmarkTask,
+    repo_cache: dict[tuple[str, str], Path],
+    cleanup_paths: list[Path],
+) -> Path:
+    """Return a stable repo path for a task within one benchmark run."""
+    if task.repo == ".":
+        return Path.cwd()
+
+    key = (task.repo, task.commit)
+    cached = repo_cache.get(key)
+    if cached is not None:
+        return cached
+
+    repo_path, needs_cleanup = clone_at_commit(task.repo, task.commit)
+    repo_cache[key] = repo_path
+    if needs_cleanup:
+        cleanup_paths.append(repo_path)
+    return repo_path
 
 
 def _percentile(values: list[float], quantile: float) -> float:

--- a/src/archex/index/rerank.py
+++ b/src/archex/index/rerank.py
@@ -24,6 +24,8 @@ MAX_CONTENT_CHARS = 4096
 # scoring enough diversity without losing cross-encoder precision.
 DEFAULT_TOP_K = 30
 
+_MODEL_CACHE: dict[str, Any] = {}
+
 
 def is_available() -> bool:
     """Return True if cross-encoder dependencies are installed."""
@@ -52,6 +54,11 @@ class CrossEncoderReranker:
         if self._model is not None:
             return
 
+        cached_model = _MODEL_CACHE.get(self._model_name)
+        if cached_model is not None:
+            self._model = cached_model
+            return
+
         try:
             from sentence_transformers import CrossEncoder
         except ImportError as e:
@@ -66,6 +73,7 @@ class CrossEncoderReranker:
             flush=True,
         )
         self._model = CrossEncoder(self._model_name, trust_remote_code=True)
+        _MODEL_CACHE[self._model_name] = self._model
         logger.info("Loaded cross-encoder reranker: %s", self._model_name)
 
     def rerank(

--- a/tests/benchmark/test_models.py
+++ b/tests/benchmark/test_models.py
@@ -131,6 +131,8 @@ class TestBenchmarkReport:
         )
         assert report.baseline_tokens == 5000
         assert report.results == []
+        assert report.median_latency_ms == 0.0
+        assert report.p95_latency_ms == 0.0
 
     def test_serialization_roundtrip(self) -> None:
         result = BenchmarkResult(
@@ -158,3 +160,5 @@ class TestBenchmarkReport:
         assert restored.task_id == report.task_id
         assert len(restored.results) == 1
         assert restored.results[0].strategy == Strategy.RAW_FILES
+        assert restored.median_latency_ms == 0.0
+        assert restored.p95_latency_ms == 0.0

--- a/tests/benchmark/test_readiness.py
+++ b/tests/benchmark/test_readiness.py
@@ -25,6 +25,7 @@ def _result(
     precision: float,
     f1_score: float,
     mrr: float = 1.0,
+    wall_time_ms: float = 10.0,
     category: TaskCategory | None = None,
     strategy: Strategy = Strategy.ARCHEX_QUERY,
 ) -> BenchmarkResult:
@@ -39,7 +40,7 @@ def _result(
         f1_score=f1_score,
         mrr=mrr,
         savings_vs_raw=0.0,
-        wall_time_ms=10.0,
+        wall_time_ms=wall_time_ms,
         cached=False,
         timestamp="2026-01-01T00:00:00Z",
         seed_files=["src/main.py"],
@@ -77,6 +78,7 @@ def test_build_readiness_report_tracks_targets_and_counts() -> None:
                 recall=1.0,
                 precision=0.8,
                 f1_score=0.89,
+                wall_time_ms=100.0,
                 category=TaskCategory.SELF,
             ),
         ),
@@ -88,6 +90,7 @@ def test_build_readiness_report_tracks_targets_and_counts() -> None:
                 precision=0.0,
                 f1_score=0.0,
                 mrr=0.0,
+                wall_time_ms=300.0,
                 category=TaskCategory.EXTERNAL_LARGE,
             ),
         ),
@@ -105,6 +108,8 @@ def test_build_readiness_report_tracks_targets_and_counts() -> None:
     assert readiness.zero_recall_tasks == 1
     assert readiness.low_f1_tasks == 1
     assert readiness.low_precision_tasks == 1
+    assert readiness.median_latency_ms == 200.0
+    assert readiness.p95_latency_ms == 290.0
     assert readiness.ready is False
     assert [target.name for target in readiness.targets] == [
         "mean_recall",
@@ -166,10 +171,13 @@ def test_format_readiness_outputs_are_stable() -> None:
     markdown = format_readiness_markdown(readiness)
     assert "# Benchmark Readiness" in markdown
     assert "mean_recall" in markdown
+    assert "P95 latency" in markdown
     assert "Top Blocking Tasks" in markdown
     assert "`miss`" in markdown
 
     payload = json.loads(format_readiness_json(readiness))
     assert payload["strategy"] == "archex_query"
     assert payload["ready"] is False
+    assert payload["median_latency_ms"] == 10.0
+    assert payload["p95_latency_ms"] == 10.0
     assert payload["blocking_tasks"][0]["task_id"] == "miss"

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -53,6 +53,8 @@ class TestRunBenchmark:
         assert report.task_id == "fixture_test"
         assert report.repo == "test/python_simple"
         assert len(report.results) == 2
+        assert report.median_latency_ms > 0
+        assert report.p95_latency_ms >= report.median_latency_ms
 
     def test_baseline_tokens_from_raw_files(
         self,

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -418,6 +418,78 @@ expected_files:
         assert (output_dir / "test_all.json").exists()
         assert not (output_dir / "bad_clone.json").exists()
 
+    def test_run_all_reuses_external_clone_for_same_repo_ref(
+        self,
+        python_simple_repo: Path,
+        tmp_path: Path,
+    ) -> None:
+        from archex.benchmark.runner import run_all
+
+        tasks_dir = self._make_tasks_dir(tmp_path)
+        (tasks_dir / "other.yaml").write_text("""\
+task_id: other_task
+repo: test/repo
+commit: HEAD
+question: "Other?"
+expected_files:
+  - main.py
+""")
+        output_dir = tmp_path / "results"
+
+        import archex.benchmark.runner as runner_mod
+
+        clone_calls: list[tuple[str, str]] = []
+        original = runner_mod.clone_at_commit
+
+        def _fake_clone(repo_slug: str, commit: str) -> tuple[Path, bool]:
+            clone_calls.append((repo_slug, commit))
+            return python_simple_repo, False
+
+        runner_mod.clone_at_commit = _fake_clone  # type: ignore[assignment]
+        try:
+            reports = run_all(
+                tasks_dir=tasks_dir,
+                output_dir=output_dir,
+                strategies=[Strategy.RAW_FILES],
+            )
+        finally:
+            runner_mod.clone_at_commit = original  # type: ignore[assignment]
+
+        assert {report.task_id for report in reports} == {"test_all", "other_task"}
+        assert clone_calls == [("test/repo", "HEAD")]
+
+    def test_run_all_cleans_reused_external_clone(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from archex.benchmark.runner import run_all
+
+        tasks_dir = self._make_tasks_dir(tmp_path)
+        output_dir = tmp_path / "results"
+        clone_dir = tmp_path / "clone"
+        clone_dir.mkdir()
+        (clone_dir / "main.py").write_text("x = 1\n")
+
+        import archex.benchmark.runner as runner_mod
+
+        original = runner_mod.clone_at_commit
+
+        def _fake_clone(repo_slug: str, commit: str) -> tuple[Path, bool]:
+            del repo_slug, commit
+            return clone_dir, True
+
+        runner_mod.clone_at_commit = _fake_clone  # type: ignore[assignment]
+        try:
+            run_all(
+                tasks_dir=tasks_dir,
+                output_dir=output_dir,
+                strategies=[Strategy.RAW_FILES],
+            )
+        finally:
+            runner_mod.clone_at_commit = original  # type: ignore[assignment]
+
+        assert not clone_dir.exists()
+
     def test_task_filter_nonexistent_raises(self, tmp_path: Path) -> None:
         from archex.benchmark.runner import run_all
 

--- a/tests/index/test_rerank.py
+++ b/tests/index/test_rerank.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+from archex.index import rerank as rerank_module
 from archex.index.rerank import (
     DEFAULT_MODEL,
     DEFAULT_TOP_K,
@@ -103,6 +104,34 @@ class TestCrossEncoderReranker:
     def test_custom_model_name(self) -> None:
         reranker = CrossEncoderReranker(model_name="custom/model")
         assert reranker.rerank("query", []) == []
+
+    def test_reuses_loaded_model_for_same_model_name(self) -> None:
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+        chunk = _make_chunk("a")
+
+        with patch("sentence_transformers.CrossEncoder") as cross_encoder:
+            cross_encoder.return_value.predict.return_value = np.array([1.0])
+            first = CrossEncoderReranker(model_name="test/model")
+            second = CrossEncoderReranker(model_name="test/model")
+
+            first.rerank("query", [(chunk, 0.0)])
+            second.rerank("query", [(chunk, 0.0)])
+
+        assert cross_encoder.call_count == 1
+        assert first._model is second._model  # pyright: ignore[reportPrivateUsage]
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+
+    def test_loads_distinct_models_for_distinct_model_names(self) -> None:
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+        chunk = _make_chunk("a")
+
+        with patch("sentence_transformers.CrossEncoder") as cross_encoder:
+            cross_encoder.return_value.predict.return_value = np.array([1.0])
+            CrossEncoderReranker(model_name="test/model-a").rerank("query", [(chunk, 0.0)])
+            CrossEncoderReranker(model_name="test/model-b").rerank("query", [(chunk, 0.0)])
+
+        assert cross_encoder.call_count == 2
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
 
     def test_rerank_empty_candidates(self) -> None:
         reranker = CrossEncoderReranker()


### PR DESCRIPTION
## Summary

- add benchmark-level latency aggregation and readiness latency reporting
- add `.docs/strategy-comparison.md` with the measured default-strategy decision
- reduce rerank measurement overhead by reusing loaded reranker models and external repo clones within a benchmark run

## Decision

Decision B: keep `archex_query` as the product default.

The measured 18-task artifact set already fails both switch criteria for `archex_query_fusion_rerank`:

- Mean F1: `0.309` vs `0.494` for `archex_query`
- P95 latency: `5525 ms`, above the `3000 ms` threshold
- Zero-recall tasks: `6` vs `0` for `archex_query`

The full 35-task fusion+rerank benchmark was run directly twice. The first run completed 18/35 artifacts before repeated cross-encoder loads made the run impractical. After the measurement-overhead fixes, the rerun again completed 18/35 artifacts and then became CPU-bound on `django_middleware`. The partial artifact set is recorded because it is already decisive against switching defaults.

## Stack

Base: `main`

1. #128 `fix/expanded-files-accounting`
2. #129 `fix/benchmark-oracle-defects`
3. #130 `fix/expansion-constants-and-docs`
4. #131 `fix/dogfood-baseline-gate`
5. `chore/strategy-comparison-report` -> this PR
6. `feat/cli-intent` -> next

## Commits

- `chore(benchmark): add latency capture to benchmark runner`
- `docs(decision): add strategy comparison template`
- `perf(benchmark): reduce rerank measurement overhead`
- `docs(decision): record strategy comparison outcome`

## Validation

- `uv run ruff check` -> pass
- `uv run ruff format --check .` -> pass, 232 files already formatted
- `uv run pyright` -> pass, 0 errors
- `uv run pytest` -> pass, 1954 passed, 4 deselected, 1 warning, coverage 91.28%
- `rg -n 'task_id\s*==\s*"' src/archex || true` -> no matches

## Benchmark Evidence

- `uv run archex benchmark run --query-fusion --rerank --tasks-dir benchmarks/tasks --output .archex/e2e-results` -> direct run attempted; 18/35 fresh artifacts before full run became long-running on `django_middleware`
- `uv run archex benchmark readiness --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query --format markdown` -> 18 tasks, mean F1 `0.494`, p95 `2222 ms`, zero-recall `0`
- `uv run archex benchmark readiness --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown` -> 18 tasks, mean F1 `0.309`, p95 `5525 ms`, zero-recall `6`
