### PR TITLE
feat(serve): add CLI lifecycle intent

### DIFF
--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -330,6 +330,8 @@ def _directory_alignment_boost(file_path: str, query_terms: set[str]) -> float:
     dir_path = parts[0]
     dir_segments = {seg for seg in dir_path.split("/") if len(seg) >= 3}
     if dir_segments & query_terms:
+        if "cli" in dir_segments and "cli" in query_terms:
+            return 1.6
         return 1.2
     return 1.0
 
@@ -518,12 +520,10 @@ def assemble_context(
     assembly_start = time.perf_counter()
     # Intent-based weight routing: when no explicit weights are provided,
     # classify the query intent and select optimized weight presets.
-    if scoring_weights is None:
-        from archex.serve.intent import weights_for_query
+    from archex.serve.intent import INTENT_WEIGHTS, QueryIntent, classify_intent
 
-        weights = weights_for_query(question)
-    else:
-        weights = scoring_weights
+    intent = classify_intent(question)
+    weights = INTENT_WEIGHTS[intent] if scoring_weights is None else scoring_weights
 
     strategy = "hybrid+graph" if vector_results else "bm25+graph"
 
@@ -604,6 +604,7 @@ def assemble_context(
 
     # Extract query terms for path-aware import prioritization
     q_terms = _query_terms(question)
+    alignment_terms = {QueryIntent.CLI.value} if intent == QueryIntent.CLI else q_terms
 
     # Determine whether this is an architecture query (enables 2-hop expansion)
     is_arch_query = _is_architecture_query(question)
@@ -682,7 +683,7 @@ def assemble_context(
     # Collect candidate chunks (seed + file-capped expansion), dedup by id
     # Cap per-file to prevent one large file from monopolizing the expansion budget.
     # Skip test files in expansion — they add noise without improving relevance.
-    max_per_file = 3
+    max_per_file = 1 if intent == QueryIntent.CLI else 3
     # Vector-only seeds participate in scoring even when BM25 returned nothing
     # for that file.
     candidate_map = _initial_candidate_map(search_results, vector_results)
@@ -812,7 +813,7 @@ def assemble_context(
         entry_boost = _ENTRY_POINT_BOOST if _is_entry_point(chunk.file_path) else 1.0
 
         # Directory-path alignment: files under directories matching query terms
-        dir_boost = _directory_alignment_boost(chunk.file_path, q_terms)
+        dir_boost = _directory_alignment_boost(chunk.file_path, alignment_terms)
 
         final = (
             (
@@ -853,6 +854,8 @@ def assemble_context(
     score_cutoff = top_file_score * FILE_SCORE_CUTOFF
     top_files: set[str] = set()
     adaptive_max = _adaptive_max_files(sorted_files)
+    if intent == QueryIntent.CLI:
+        adaptive_max = min(adaptive_max, 4)
     for fp, score in sorted_files[:adaptive_max]:
         if score < score_cutoff:
             break

--- a/src/archex/serve/intent.py
+++ b/src/archex/serve/intent.py
@@ -15,6 +15,7 @@ class QueryIntent(StrEnum):
     ARCHITECTURE_BROAD = "architecture_broad"
     USAGE_SEARCH = "usage_search"
     DEBUGGING = "debugging"
+    CLI = "cli"
     GENERAL = "general"
 
 
@@ -35,6 +36,10 @@ INTENT_WEIGHTS: dict[QueryIntent, ScoringWeights] = {
     # Debugging: relevance-heavy but structural helps trace error propagation
     QueryIntent.DEBUGGING: ScoringWeights(
         relevance=0.80, structural=0.10, type_coverage=0.05, cohesion=0.05
+    ),
+    # CLI lifecycle: favor direct command modules while preserving graph context
+    QueryIntent.CLI: ScoringWeights(
+        relevance=0.75, structural=0.10, type_coverage=0.05, cohesion=0.10
     ),
     # General: default balanced weights (same as current defaults)
     QueryIntent.GENERAL: ScoringWeights(
@@ -98,13 +103,17 @@ _DEBUGGING_PATTERNS = [
     re.compile(r"\bstack\s*trace\b"),  # "stack trace"
 ]
 
+_CLI_PATTERNS = [
+    re.compile(r"\barchex\s+(?:init|reset|status|index|config|cache|delta)\b"),
+]
+
 
 def classify_intent(question: str) -> QueryIntent:
     """Classify a search query into an intent bucket for scoring weight routing.
 
     Uses pattern matching against the lowercased query. The classification
     priority order is: definition_lookup (explicit patterns) > debugging >
-    usage_search > definition_lookup (identifier heuristic) >
+    usage_search > cli > definition_lookup (identifier heuristic) >
     architecture_broad > general.
 
     Explicit definition patterns (e.g. "where is X defined") take highest
@@ -136,6 +145,11 @@ def classify_intent(question: str) -> QueryIntent:
     for pat in _USAGE_PATTERNS:
         if pat.search(q):
             return QueryIntent.USAGE_SEARCH
+
+    # CLI lifecycle: repo-local command lifecycle verbs such as reset/status/cache
+    for pat in _CLI_PATTERNS:
+        if pat.search(q):
+            return QueryIntent.CLI
 
     # Identifier heuristic: classify as definition lookup when query is dominated
     # by CamelCase/snake_case/dotted identifiers (symbol-targeted queries with no

--- a/tests/serve/test_intent.py
+++ b/tests/serve/test_intent.py
@@ -85,6 +85,15 @@ def test_classify_lifecycle() -> None:
     assert result == QueryIntent.ARCHITECTURE_BROAD
 
 
+def test_classify_archex_reset_as_cli_command() -> None:
+    # Arrange
+    query = "archex reset"
+    # Act
+    result = classify_intent(query)
+    # Assert
+    assert result == QueryIntent.CLI
+
+
 # ---------------------------------------------------------------------------
 # Usage search tests
 # ---------------------------------------------------------------------------
@@ -243,6 +252,7 @@ def test_definition_weights_higher_relevance() -> None:
         ("Find references to dispatch", QueryIntent.USAGE_SEARCH),
         ("NullPointerException in getData", QueryIntent.DEBUGGING),
         ("Tests failing after migration", QueryIntent.DEBUGGING),
+        ("archex reset", QueryIntent.CLI),
         ("Show me the user model", QueryIntent.GENERAL),
     ],
 )


### PR DESCRIPTION
## Summary

- add `QueryIntent.CLI` for explicit `archex <lifecycle-command>` queries
- route CLI intent through directory alignment using the existing scoring path
- cap CLI expansion/file selection to keep command-surface context focused

## Stack

Base: `main`

1. #128 `fix/expanded-files-accounting`
2. #129 `fix/benchmark-oracle-defects`
3. #130 `fix/expansion-constants-and-docs`
4. #131 `fix/dogfood-baseline-gate`
5. #132 `chore/strategy-comparison-report`
6. `feat/cli-intent` -> this PR
7. `feat/ppr-decision`
8. `feat/bi-encoder-swap`
9. `feat/cross-encoder-swap`
10. `test/generalization-guard`
11. `chore/regression-contract`

## Validation

- `uv run pytest tests/serve/ -q --no-cov` -> 182 passed
- `uv run archex dogfood . --task archex_project_reset --baseline benchmarks/dogfood_baseline.json --format json` -> no regressions; `archex_query` recall 0.667, F1 0.571
- `uv run archex dogfood . --all --baseline benchmarks/dogfood_baseline.json --format json` -> 16 tasks, no regressions
- `uv run ruff check` -> passed
- `uv run ruff format --check .` -> passed
- `uv run pyright` -> passed
- `uv run pytest` -> 1956 passed, 4 deselected, 1 warning
- `rg -n 'task_id\s*==\s*"' src/archex || true` -> no matches

## Notes

CLI intent is intentionally restricted to explicit command-form input like `archex reset`. Broader mechanism phrases such as delta indexing or cache lifecycle remain on the existing non-CLI routing path to avoid product-query regressions.
