### PR TITLE
chore(index): pin CodeRankEmbed runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Removed unused Personalized PageRank graph-expansion helpers. Measured candidate ordering showed no recall gain on `archex_graph_expansion` or the external-large benchmark bucket, and introduced a `rust_tokio_runtime` candidate-recall regression risk.
 - Corrected retrieval-pipeline documentation to describe the wired deterministic dependency expansion path instead of stale PPR wording.
+- Kept the fast vector benchmark default after a CodeRankEmbed full-suite run crossed six hours at task 19/35; CodeRankEmbed remains pinned and configurable as `embedder="coderank"` for targeted evaluation.
 
 ## 0.6.2 (2026-05-25)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ graph = [
     "leidenalg>=0.10",
 ]
 vector-torch = [
-    "sentence-transformers>=2.6",
+    "sentence-transformers>=5.2,<6",
 ]
 splade = [
     "transformers>=4.30",

--- a/src/archex/index/embeddings/coderank.py
+++ b/src/archex/index/embeddings/coderank.py
@@ -11,6 +11,7 @@ from archex.exceptions import ArchexIndexError
 logger = logging.getLogger(__name__)
 
 HF_MODEL_ID = "nomic-ai/CodeRankEmbed"
+HF_MODEL_REVISION = "3c4b60807d71f79b43f3c4363786d9493691f8b1"
 QUERY_PREFIX = "Represent this query for searching relevant code: "
 
 
@@ -69,7 +70,12 @@ class CodeRankEmbedder:
             file=sys.stderr,
             flush=True,
         )
-        self._model = SentenceTransformer(self._model_name, trust_remote_code=True, device=device)
+        self._model = SentenceTransformer(
+            self._model_name,
+            revision=HF_MODEL_REVISION if self._model_name == HF_MODEL_ID else None,
+            trust_remote_code=True,
+            device=device,
+        )
         self._dimension = self._model.get_sentence_embedding_dimension()
         logger.info(
             "Loaded %s via sentence-transformers on %s (dim=%d)",

--- a/tests/index/embeddings/test_embeddings.py
+++ b/tests/index/embeddings/test_embeddings.py
@@ -300,6 +300,8 @@ class TestCodeRankEmbedder:
         import numpy as np
 
         from archex.index.embeddings.coderank import (
+            HF_MODEL_ID,
+            HF_MODEL_REVISION,
             QUERY_PREFIX,
             CodeRankEmbedder,
         )
@@ -310,10 +312,19 @@ class TestCodeRankEmbedder:
         mock_model.encode.return_value = np.array([[0.1] * 768])
         mock_st_module.SentenceTransformer.return_value = mock_model
 
-        with patch.dict("sys.modules", {"sentence_transformers": mock_st_module}):
+        with (
+            patch.dict("sys.modules", {"sentence_transformers": mock_st_module}),
+            patch("archex.index.embeddings.coderank._best_device", return_value="cpu"),
+        ):
             embedder = CodeRankEmbedder()
             embedder._load_model()  # pyright: ignore[reportPrivateUsage]
 
+        mock_st_module.SentenceTransformer.assert_called_once_with(
+            HF_MODEL_ID,
+            revision=HF_MODEL_REVISION,
+            trust_remote_code=True,
+            device="cpu",
+        )
         query = "find authentication function"
         embedder.encode_queries([query])
 

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ requires-dist = [
     { name = "python-igraph", marker = "extra == 'graph'", specifier = ">=0.11" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
-    { name = "sentence-transformers", marker = "extra == 'vector-torch'", specifier = ">=2.6" },
+    { name = "sentence-transformers", marker = "extra == 'vector-torch'", specifier = ">=5.2,<6" },
     { name = "tiktoken", specifier = ">=0.7" },
     { name = "tokenizers", marker = "extra == 'vector'", specifier = ">=0.15" },
     { name = "torch", marker = "extra == 'splade'", specifier = ">=2.0" },


### PR DESCRIPTION
## Stack

Base: `feat/ppr-decision`

1. `fix/expanded-files-accounting` -> #128
2. `fix/benchmark-oracle-defects` -> #129
3. `fix/expansion-constants-and-docs` -> #130
4. `fix/dogfood-baseline-gate` -> #131
5. `chore/strategy-comparison-report` -> #132
6. `feat/cli-intent` -> #133
7. `feat/ppr-decision` -> #134
8. `feat/bi-encoder-swap` -> this PR
9. `feat/cross-encoder-swap` -> #136
10. `test/generalization-guard` -> #137
11. `chore/regression-contract` -> #138

## Summary

- Pins the CodeRankEmbed runtime path to `sentence-transformers>=5.2,<6`.
- Pins `nomic-ai/CodeRankEmbed` to revision `3c4b60807d71f79b43f3c4363786d9493691f8b1` when the default model id is used.
- Covers the revision pin in the CodeRank embedder tests.
- Records the measured decision to keep the fast vector default after the CodeRank full-suite benchmark crossed six hours at task 19/35.

## Benchmark Decision

The planned default switch was rejected for this slice. The user-run CodeRank full-suite command reached task 19/35 after more than six hours, with `django_middleware` at 103/1338 batches and an estimated 52+ hours remaining. CodeRank remains available through `embedder="coderank"` for targeted evaluation, but this PR does not switch benchmark or product defaults.

Readiness from the available `.archex/e2e-results` artifacts was generated without rerunning the benchmark:

```bash
uv run archex benchmark readiness --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query_fusion --format markdown
```

Result: 18 `archex_query_fusion` task results present, ready `no`, mean recall `0.614`, mean precision `0.475`, mean F1 `0.520`, zero-recall tasks `0`, median latency `10608 ms`, p95 latency `23042 ms`.

## Validation

- `uv run pytest tests/index/ tests/benchmark/test_strategies.py -q --no-cov` -> passed during slice validation.
- Leaf gate after descendant rebase: `uv run ruff check`; `uv run ruff format --check .`; `uv run pyright`; `uv run pytest` -> all pass, `1959 passed, 4 deselected, 1 warning`.
- `! grep -rE 'task_id\s*==\s*"' src/archex` -> pass.
