### PR TITLE
feat(index): default reranker to jina v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Removed unused Personalized PageRank graph-expansion helpers. Measured candidate ordering showed no recall gain on `archex_graph_expansion` or the external-large benchmark bucket, and introduced a `rust_tokio_runtime` candidate-recall regression risk.
 - Corrected retrieval-pipeline documentation to describe the wired deterministic dependency expansion path instead of stale PPR wording.
 - Kept the fast vector benchmark default after a CodeRankEmbed full-suite run crossed six hours at task 19/35; CodeRankEmbed remains pinned and configurable as `embedder="coderank"` for targeted evaluation.
+- Switched the opt-in cross-encoder reranker default from `cross-encoder/ms-marco-MiniLM-L-6-v2` to pinned `jinaai/jina-reranker-v3`; the MiniLM model remains selectable via `IndexConfig(rerank_model=...)`.
 
 ## 0.6.2 (2026-05-25)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ archex is a Python library and CLI that transforms any Git repository into struc
 - **8 public APIs** — `analyze()`, `query()`, `compare()`, `file_tree()`, `file_outline()`, `search_symbols()`, `get_symbol()`, `get_symbols_batch()` + token counting utilities
 - **Hybrid retrieval** — BM25F weighted-field keyword search + optional vector embeddings, merged via confidence-weighted Reciprocal Rank Fusion and adaptive Relative Score Fusion behind an AvgIDF fusion gate
 - **Intent-aware ranking** — query intent classification (definition, architecture, usage, debugging, general) selects per-intent scoring-weight presets
-- **Cross-encoder reranking** — opt-in `cross-encoder/ms-marco-MiniLM` re-scoring of top candidates; local sentence-transformers, off by default, enabled via `IndexConfig(rerank=True)`
+- **Cross-encoder reranking** — opt-in `jinaai/jina-reranker-v3` re-scoring of top candidates; local sentence-transformers, off by default, enabled via `IndexConfig(rerank=True)`
 - **Token budget assembly** — AST-aware chunking, deterministic dependency-graph expansion, greedy bin-packing with configurable `ScoringWeights`
 - **Structural analysis** — module detection (Louvain), pattern recognition (extensible `PatternRegistry`), interface extraction
 - **Cross-repo comparison** — 6 architectural dimensions, no LLM required

--- a/src/archex/index/rerank.py
+++ b/src/archex/index/rerank.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 JINA_RERANKER_MODEL = "jinaai/jina-reranker-v3"
 JINA_RERANKER_REVISION = "10fb694fc21f7a710a563ff1eb977a460f3868e4"
-DEFAULT_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+DEFAULT_MODEL = JINA_RERANKER_MODEL
 MODEL_REVISIONS = {
     JINA_RERANKER_MODEL: JINA_RERANKER_REVISION,
 }

--- a/src/archex/index/rerank.py
+++ b/src/archex/index/rerank.py
@@ -13,7 +13,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+JINA_RERANKER_MODEL = "jinaai/jina-reranker-v3"
+JINA_RERANKER_REVISION = "10fb694fc21f7a710a563ff1eb977a460f3868e4"
 DEFAULT_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+MODEL_REVISIONS = {
+    JINA_RERANKER_MODEL: JINA_RERANKER_REVISION,
+}
 
 # Maximum content length passed to the cross-encoder per chunk.
 # MiniLM has a 512-token context window (~4 chars/token avg).
@@ -72,7 +77,11 @@ class CrossEncoderReranker:
             file=sys.stderr,
             flush=True,
         )
-        self._model = CrossEncoder(self._model_name, trust_remote_code=True)
+        self._model = CrossEncoder(
+            self._model_name,
+            revision=MODEL_REVISIONS.get(self._model_name),
+            trust_remote_code=True,
+        )
         _MODEL_CACHE[self._model_name] = self._model
         logger.info("Loaded cross-encoder reranker: %s", self._model_name)
 

--- a/tests/index/test_rerank.py
+++ b/tests/index/test_rerank.py
@@ -11,6 +11,7 @@ from archex.index import rerank as rerank_module
 from archex.index.rerank import (
     DEFAULT_MODEL,
     DEFAULT_TOP_K,
+    JINA_RERANKER_MODEL,
     MAX_CONTENT_CHARS,
     CrossEncoderReranker,
     is_available,
@@ -60,8 +61,8 @@ class TestConstants:
     def test_max_content_chars_is_4096(self) -> None:
         assert MAX_CONTENT_CHARS == 4096
 
-    def test_default_model_is_minilm(self) -> None:
-        assert DEFAULT_MODEL == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+    def test_default_model_is_jina_reranker(self) -> None:
+        assert DEFAULT_MODEL == JINA_RERANKER_MODEL
 
 
 class TestMaybeReranker:
@@ -99,7 +100,7 @@ class TestCrossEncoderReranker:
 
     def test_default_model_name(self) -> None:
         _ = CrossEncoderReranker()
-        assert DEFAULT_MODEL == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+        assert DEFAULT_MODEL == "jinaai/jina-reranker-v3"
 
     def test_custom_model_name(self) -> None:
         reranker = CrossEncoderReranker(model_name="custom/model")

--- a/tests/index/test_rerank.py
+++ b/tests/index/test_rerank.py
@@ -12,6 +12,7 @@ from archex.index.rerank import (
     DEFAULT_MODEL,
     DEFAULT_TOP_K,
     JINA_RERANKER_MODEL,
+    JINA_RERANKER_REVISION,
     MAX_CONTENT_CHARS,
     CrossEncoderReranker,
     is_available,
@@ -75,12 +76,13 @@ class TestMaybeReranker:
         assert result is None
 
     @pytest.mark.skipif(not _HAS_CROSS_ENCODER, reason="sentence-transformers not installed")
-    def test_explicit_rerank_true(self) -> None:
+    def test_explicit_rerank_true_uses_jina_default(self) -> None:
         from archex.api import _maybe_reranker  # pyright: ignore[reportPrivateUsage]
 
         config = IndexConfig(rerank=True)
         result = _maybe_reranker(config)
         assert isinstance(result, CrossEncoderReranker)
+        assert result._model_name == JINA_RERANKER_MODEL  # pyright: ignore[reportPrivateUsage]
 
     @pytest.mark.skipif(not _HAS_CROSS_ENCODER, reason="sentence-transformers not installed")
     def test_uses_custom_model(self) -> None:
@@ -105,6 +107,36 @@ class TestCrossEncoderReranker:
     def test_custom_model_name(self) -> None:
         reranker = CrossEncoderReranker(model_name="custom/model")
         assert reranker.rerank("query", []) == []
+
+    def test_default_load_passes_pinned_jina_revision(self) -> None:
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+        chunk = _make_chunk("a")
+
+        with patch("sentence_transformers.CrossEncoder") as cross_encoder:
+            cross_encoder.return_value.predict.return_value = np.array([1.0])
+            CrossEncoderReranker().rerank("query", [(chunk, 0.0)])
+
+        cross_encoder.assert_called_once_with(
+            JINA_RERANKER_MODEL,
+            revision=JINA_RERANKER_REVISION,
+            trust_remote_code=True,
+        )
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+
+    def test_custom_model_load_has_no_revision_pin(self) -> None:
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+        chunk = _make_chunk("a")
+
+        with patch("sentence_transformers.CrossEncoder") as cross_encoder:
+            cross_encoder.return_value.predict.return_value = np.array([1.0])
+            CrossEncoderReranker(model_name="custom/model").rerank("query", [(chunk, 0.0)])
+
+        cross_encoder.assert_called_once_with(
+            "custom/model",
+            revision=None,
+            trust_remote_code=True,
+        )
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
 
     def test_reuses_loaded_model_for_same_model_name(self) -> None:
         rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
## Stack

Base: `feat/bi-encoder-swap`

1. `fix/expanded-files-accounting` -> #128
2. `fix/benchmark-oracle-defects` -> #129
3. `fix/expansion-constants-and-docs` -> #130
4. `fix/dogfood-baseline-gate` -> #131
5. `chore/strategy-comparison-report` -> #132
6. `feat/cli-intent` -> #133
7. `feat/ppr-decision` -> #134
8. `feat/bi-encoder-swap` -> #135
9. `feat/cross-encoder-swap` -> this PR
10. `test/generalization-guard` -> #137
11. `chore/regression-contract` -> #138

## Summary

- Pins `jinaai/jina-reranker-v3` to revision `10fb694fc21f7a710a563ff1eb977a460f3868e4`.
- Switches the opt-in cross-encoder reranker default from `cross-encoder/ms-marco-MiniLM-L-6-v2` to `jinaai/jina-reranker-v3`.
- Keeps MiniLM and other rerankers reachable through `IndexConfig(rerank_model=...)`.
- Updates README and changelog default-reranker wording.
- Covers default model selection, pinned revision loading, and custom-model rollback behavior.

## Validation

- `uv run pytest tests/index/test_rerank.py -q --no-cov` -> 22 passed.
- Reranker default/legacy override smoke script -> `reranker defaults and legacy override ok`.
- Leaf gate after descendant rebase: `uv run ruff check`; `uv run ruff format --check .`; `uv run pyright`; `uv run pytest` -> all pass, `1959 passed, 4 deselected, 1 warning`.
- `! grep -rE 'task_id\s*==\s*"' src/archex` -> pass.

## Benchmark

- Attempted bounded smoke: `uv run archex benchmark run --query-fusion --rerank --tasks-dir benchmarks/tasks --output .archex/e2e-results-pr9-smoke --task archex_query_pipeline`.
- Result: stopped after roughly three minutes with 0 fresh JSON results. The process was still in vector-index warmup and had not reached cross-encoder reranking, so no readiness metrics are claimed here.
- Full-suite acceptance command remains too expensive in the current benchmark runner profile: `uv run archex benchmark run --query-fusion --rerank --tasks-dir benchmarks/tasks --output .archex/e2e-results`; readiness command: `uv run archex benchmark readiness --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown`.

## Review Notes

This PR changes only the opt-in reranker path. Callers that do not set `IndexConfig(rerank=True)` continue to skip cross-encoder loading entirely.
