### PR TITLE
test(benchmark): add generalization guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Type check
         run: uv run pyright .
 
+      - name: Reject task-ID-keyed retrieval code
+        run: |
+          ! grep -rE 'task_id\s*==\s*"' src/archex
+
       - name: Test
         run: uv run pytest --junitxml=results.xml --cov-report=xml
 

--- a/benchmarks/held_out.txt
+++ b/benchmarks/held_out.txt
@@ -1,0 +1,5 @@
+archex_project_status
+archex_query_pipeline
+fastapi_dependency_injection
+react_hooks
+rust_tokio_runtime

--- a/scripts/benchmark_replay_smoke.sh
+++ b/scripts/benchmark_replay_smoke.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uv run pytest tests/benchmark/test_strategies.py --no-cov
+uv run pytest tests/benchmark/test_dogfood.py tests/benchmark/test_baseline.py tests/benchmark/test_triage.py --no-cov
+uv run pytest tests/serve/ --no-cov
+uv run pytest tests/index/test_rerank.py --no-cov
+! grep -rE 'task_id\s*==\s*"' src/archex

--- a/tests/benchmark/test_generalization.py
+++ b/tests/benchmark/test_generalization.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from archex.benchmark.loader import load_tasks
 
-
 ROOT = Path(__file__).resolve().parents[2]
 TASKS_DIR = ROOT / "benchmarks" / "tasks"
 HELD_OUT_PATH = ROOT / "benchmarks" / "held_out.txt"

--- a/tests/benchmark/test_generalization.py
+++ b/tests/benchmark/test_generalization.py
@@ -1,0 +1,37 @@
+"""Generalization guards for retrieval-quality changes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from archex.benchmark.loader import load_tasks
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TASKS_DIR = ROOT / "benchmarks" / "tasks"
+HELD_OUT_PATH = ROOT / "benchmarks" / "held_out.txt"
+
+
+def _held_out_ids() -> list[str]:
+    return [
+        line.strip()
+        for line in HELD_OUT_PATH.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    ]
+
+
+def test_held_out_set_has_five_existing_tasks() -> None:
+    held_out = _held_out_ids()
+    tasks_by_id = {task.task_id: task for task in load_tasks(TASKS_DIR)}
+
+    assert len(held_out) == 5
+    assert len(set(held_out)) == len(held_out)
+    assert set(held_out) <= set(tasks_by_id)
+
+
+def test_held_out_set_mixes_self_and_external_tasks() -> None:
+    tasks_by_id = {task.task_id: task for task in load_tasks(TASKS_DIR)}
+    held_out_tasks = [tasks_by_id[task_id] for task_id in _held_out_ids()]
+
+    assert any(task.repo == "." for task in held_out_tasks)
+    assert any(task.repo != "." for task in held_out_tasks)

--- a/tests/benchmark/test_generalization.py
+++ b/tests/benchmark/test_generalization.py
@@ -10,6 +10,7 @@ from archex.benchmark.loader import load_tasks
 ROOT = Path(__file__).resolve().parents[2]
 TASKS_DIR = ROOT / "benchmarks" / "tasks"
 HELD_OUT_PATH = ROOT / "benchmarks" / "held_out.txt"
+CI_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "ci.yml"
 
 
 def _held_out_ids() -> list[str]:
@@ -35,3 +36,12 @@ def test_held_out_set_mixes_self_and_external_tasks() -> None:
 
     assert any(task.repo == "." for task in held_out_tasks)
     assert any(task.repo != "." for task in held_out_tasks)
+
+
+def test_ci_rejects_task_id_keyed_source_branches() -> None:
+    workflow = CI_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "Reject task-ID-keyed retrieval code" in workflow
+    assert "grep -rE" in workflow
+    assert r'task_id\s*==\s*"' in workflow
+    assert "src/archex" in workflow


### PR DESCRIPTION
## Stack

Base: `feat/cross-encoder-swap`

1. `fix/expanded-files-accounting` -> #128
2. `fix/benchmark-oracle-defects` -> #129
3. `fix/expansion-constants-and-docs` -> #130
4. `fix/dogfood-baseline-gate` -> #131
5. `chore/strategy-comparison-report` -> #132
6. `feat/cli-intent` -> #133
7. `feat/ppr-decision` -> #134
8. `feat/bi-encoder-swap` -> #135
9. `feat/cross-encoder-swap` -> #136
10. `test/generalization-guard` -> this PR
11. `chore/regression-contract` -> #138

## Summary

- Adds `benchmarks/held_out.txt` with five held-out tasks spanning self and external repositories.
- Adds CI enforcement against task-ID-keyed retrieval code using `grep -rE 'task_id\\s*==\\s*"' src/archex`.
- Adds `scripts/benchmark_replay_smoke.sh` as the cross-slice smoke harness for prior acceptance surfaces.
- Keeps the replay harness out of Python source so benchmark self-retrieval is not perturbed by acceptance-command vocabulary.
- Covers held-out integrity and CI grep wiring in `tests/benchmark/test_generalization.py`.

## Validation

- `uv run pytest tests/benchmark/test_generalization.py tests/benchmark/test_cli.py -q --no-cov` -> 16 passed.
- `bash scripts/benchmark_replay_smoke.sh` -> passed.
- Leaf gate after descendant rebase: `uv run ruff check`; `uv run ruff format --check .`; `uv run pyright`; `uv run pytest` -> all pass, `1959 passed, 4 deselected, 1 warning`.
- `! grep -rE 'task_id\s*==\s*"' src/archex` -> pass.

## Benchmark

No full benchmark run is required for this guard slice. The replay harness intentionally uses prior pytest and grep acceptance surfaces, not full benchmark execution, because PR8 documented benchmark-runner stalls in vector warmup.
