### PR TITLE
chore(benchmark): document regression contract

### DIFF
--- a/.docs/E2E_verification.md
+++ b/.docs/E2E_verification.md
@@ -1,0 +1,80 @@
+# E2E Verification
+
+Use this contract for release-quality verification in this stack. It separates
+implementation health, dogfood regression behavior, and benchmark readiness so a
+slow or incomplete benchmark cannot be reported as a product-quality pass.
+
+## Implementation Gate
+
+Run from the repository root:
+
+```bash
+uv run ruff check
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+grep -rE 'task_id\s*==\s*"' src/archex; test $? -eq 1
+```
+
+Pass means the implementation is lint-clean, formatted, typed, covered by the
+test suite, and free of direct task-ID-keyed source branches.
+
+## Dogfood Regression Gate
+
+Run product-default dogfood comparisons against an explicit baseline:
+
+```bash
+uv run archex dogfood . --all --baseline benchmarks/dogfood_baseline.json --format dogfood-delta
+uv run archex dogfood . --all --baseline benchmarks/dogfood_baseline.json --format json
+```
+
+Pass means product-default comparisons show no regressions against the baseline.
+Diagnostic strategies are excluded from the compact delta summary. Do not refresh
+`benchmarks/dogfood_baseline.json` to hide a regression; refresh it only after an
+explicit quality improvement and explicit approval.
+
+## Benchmark Readiness
+
+Validate benchmark task definitions before using benchmark outputs:
+
+```bash
+uv run archex benchmark validate
+```
+
+Run the full benchmark and readiness reports only when runtime is acceptable for
+the current slice:
+
+```bash
+uv run archex benchmark run --tasks-dir benchmarks/tasks --output .archex/e2e-results
+uv run archex benchmark readiness --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query --format markdown
+uv run archex benchmark triage --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query --format markdown
+```
+
+Pass means the readiness report meets the documented quality thresholds for the
+selected strategy. If a run is interrupted or empirically long-running, record
+elapsed time, task progress, and output location, then report benchmark readiness
+as unmeasured rather than passed.
+
+## Current Runtime Evidence
+
+- Benchmark task validation passes when `uv run archex benchmark validate`
+  reports all 35 task files valid.
+- PR8 CodeRankEmbed benchmarking was stopped after more than 6 hours at 19 of 35
+  tasks; `django_middleware` was still warming its vector index at 103 of 1338
+  batches. Treat those outputs as partial evidence only.
+- PR9 reranker smoke benchmarking was stopped during vector warmup before any
+  fresh task JSON was written. It does not prove benchmark readiness.
+- Dogfood regression status must be reported from the explicit baseline command
+  above, with compact deltas and full JSON kept separate.
+
+## Reporting Contract
+
+Every release-quality summary must state these independently:
+
+- Implementation pass/fail: lint, format, type check, unit tests, source grep.
+- Dogfood regression pass/fail: product-default deltas against the explicit
+  baseline.
+- Benchmark readiness: measured pass/fail, or explicitly unmeasured with runtime
+  evidence.
+
+For the full local sequence, see `.docs/release-quality.md`.

--- a/.docs/release-quality.md
+++ b/.docs/release-quality.md
@@ -1,0 +1,48 @@
+# Release Quality
+
+Run this sequence before publishing retrieval-sensitive changes.
+
+## Implementation Gate
+
+```bash
+uv run ruff check
+uv run ruff format --check .
+uv run pyright
+uv run pytest
+grep -rE 'task_id\s*==\s*"' src/archex; test $? -eq 1
+```
+
+Pass means the implementation is formatted, typed, tested, and has no direct
+task-ID-keyed source branches.
+
+## Dogfood Regression Gate
+
+```bash
+uv run archex dogfood . --all --baseline benchmarks/dogfood_baseline.json --format dogfood-delta
+uv run archex dogfood . --all --baseline benchmarks/dogfood_baseline.json --format json
+```
+
+Pass means product-default dogfood comparisons show no regressions. Refresh
+`benchmarks/dogfood_baseline.json` only after an explicit quality improvement
+and explicit approval; never refresh it to bless a regression.
+
+## Benchmark Readiness
+
+```bash
+uv run archex benchmark validate
+uv run archex benchmark run --tasks-dir benchmarks/tasks --output .archex/e2e-results
+uv run archex benchmark readiness --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query --format markdown
+uv run archex benchmark triage --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query --format markdown
+```
+
+Run the full benchmark only when runtime is acceptable for the current slice.
+When it is empirically long-running, stop it, record elapsed time and task
+progress, and treat readiness as unmeasured rather than passed.
+
+## Reporting Contract
+
+Final PR summaries must separate:
+
+- Implementation pass/fail: lint, format, type, unit tests, source grep.
+- Dogfood regression pass/fail: product-default deltas against the explicit baseline.
+- Benchmark readiness: measured pass/fail or explicitly unmeasured with runtime evidence.

--- a/src/archex/cli/dogfood_cmd.py
+++ b/src/archex/cli/dogfood_cmd.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import click
 
-from archex.dogfood import run_dogfood
+from archex.dogfood import format_product_default_delta, run_dogfood
 
 
 @click.command("dogfood")
@@ -40,7 +40,7 @@ from archex.dogfood import run_dogfood
     "--format",
     "output_format",
     default="text",
-    type=click.Choice(["text", "json"]),
+    type=click.Choice(["text", "json", "dogfood-delta"]),
     help="Output format.",
 )
 def dogfood_cmd(
@@ -67,6 +67,8 @@ def dogfood_cmd(
 
     if output_format == "json":
         click.echo(result.latest_json_path.read_text(encoding="utf-8").rstrip())
+    elif output_format == "dogfood-delta":
+        click.echo(format_product_default_delta(result))
     else:
         click.echo(f"Dogfood tasks:      {len(result.tasks)}")
         click.echo(f"Reports:            {result.latest_json_path}")

--- a/src/archex/dogfood.py
+++ b/src/archex/dogfood.py
@@ -27,6 +27,7 @@ DEFAULT_TASKS_DIR = Path("benchmarks/tasks")
 DEFAULT_OUTPUT_DIR = Path(".archex/dogfood")
 DEFAULT_TASK_PREFIX = "archex_"
 DOGFOOD_DIAGNOSTIC_STRATEGIES = frozenset({Strategy.RAW_FILES.value, Strategy.RAW_GREPPED.value})
+DOGFOOD_PRODUCT_DEFAULT_STRATEGY = Strategy.ARCHEX_QUERY.value
 
 
 @dataclass(frozen=True)
@@ -404,6 +405,39 @@ def _markdown_report(
     lines.append("")
     for report in reports:
         lines.append(format_markdown(report))
+    return "\n".join(lines)
+
+
+def format_product_default_delta(result: DogfoodRunResult) -> str:
+    """Render compact product-default dogfood baseline deltas."""
+    comparisons = [
+        comparison
+        for comparison in result.comparisons
+        if comparison.strategy == DOGFOOD_PRODUCT_DEFAULT_STRATEGY
+    ]
+    lines: list[str] = ["# Dogfood Product-Default Deltas", ""]
+    lines.append(f"Strategy: `{DOGFOOD_PRODUCT_DEFAULT_STRATEGY}`")
+    if result.baseline_path is None:
+        lines.append("Baseline: none")
+    else:
+        lines.append(f"Baseline: `{result.baseline_path}`")
+    lines.append("")
+    if not comparisons:
+        lines.append("No product-default baseline comparisons were run.")
+        return "\n".join(lines)
+
+    regression_count = sum(1 for comparison in comparisons if comparison.regression)
+    lines.append(f"Regressions: {regression_count}")
+    lines.append("")
+    lines.append("| Task | Metric | Baseline | Current | Delta | Status |")
+    lines.append("|------|--------|----------|---------|-------|--------|")
+    for comparison in comparisons:
+        status = "regression" if comparison.regression else "ok"
+        lines.append(
+            f"| {comparison.task_id} | {comparison.metric} "
+            f"| {comparison.baseline_value:.3f} | {comparison.current_value:.3f} "
+            f"| {comparison.delta:+.3f} | {status} |"
+        )
     return "\n".join(lines)
 
 

--- a/tests/benchmark/test_dogfood.py
+++ b/tests/benchmark/test_dogfood.py
@@ -12,7 +12,7 @@ from click.testing import CliRunner
 from archex.benchmark.baseline import Baseline, BaselineEntry
 from archex.benchmark.models import BenchmarkReport, BenchmarkResult, BenchmarkTask, Strategy
 from archex.cli.main import cli
-from archex.dogfood import run_dogfood
+from archex.dogfood import format_product_default_delta, run_dogfood
 
 if TYPE_CHECKING:
     import pytest
@@ -373,6 +373,55 @@ def test_dogfood_command_json_outputs_latest_payload(
     payload = json.loads(result.output)
     assert payload["tasks"] == ["archex_query_pipeline"]
     assert payload["regressions"] == []
+
+
+def test_product_default_delta_summary_excludes_diagnostic_strategies(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_tasks(tmp_path)
+    baseline_path = _write_baseline(tmp_path, include_diagnostics=True)
+    monkeypatch.setattr("archex.dogfood.run_benchmark", _diagnostic_regressing_report)
+
+    result = run_dogfood(tmp_path, task_id="archex_query_pipeline", baseline_path=baseline_path)
+    summary = format_product_default_delta(result)
+
+    assert "Strategy: `archex_query`" in summary
+    assert "raw_files" not in summary
+    assert "raw_grepped" not in summary
+    assert "| archex_query_pipeline | recall |" in summary
+
+
+def test_dogfood_command_outputs_product_default_delta_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_tasks(tmp_path)
+    baseline_path = _write_baseline(tmp_path)
+    monkeypatch.setattr("archex.dogfood.run_benchmark", _passing_report)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "dogfood",
+            str(tmp_path),
+            "--task",
+            "archex_query_pipeline",
+            "--baseline",
+            str(baseline_path),
+            "--format",
+            "dogfood-delta",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "# Dogfood Product-Default Deltas" in result.output
+    assert "Strategy: `archex_query`" in result.output
+    assert "Regressions: 0" in result.output
+    assert "| archex_query_pipeline | recall |" in result.output
 
 
 def test_dogfood_requires_explicit_baseline(


### PR DESCRIPTION
## Summary

- Adds the local release-quality command sequence under `.docs/release-quality.md`.
- Adds a compact product-default dogfood delta format for regression reporting.
- Refreshes `.docs/E2E_verification.md` with separate implementation, dogfood, and benchmark readiness interpretation.

## Stack

Base: `main`

1. `fix/expanded-files-accounting` -> #128
2. `fix/benchmark-oracle-defects` -> #129
3. `fix/expansion-constants-and-docs` -> #130
4. `fix/dogfood-baseline-gate` -> #131
5. `chore/strategy-comparison-report` -> #132
6. `feat/cli-intent` -> #133
7. `feat/ppr-decision` -> #134
8. `feat/bi-encoder-swap` -> #135
9. `feat/cross-encoder-swap` -> #136
10. `test/generalization-guard` -> #137
11. `chore/regression-contract` -> this PR

## Commits

- `docs: add release-quality command sequence`
- `feat(benchmark): add compact dogfood delta summary`
- `docs: refresh E2E verification contract`

## Implementation Validation

Pass.

- `uv run ruff check` -> pass.
- `uv run ruff format --check .` -> pass, `233 files already formatted`.
- `uv run pyright` -> pass, `0 errors, 0 warnings, 0 informations`.
- `uv run pytest` -> pass, `1959 passed, 4 deselected, 1 warning`, coverage `91.27%`.
- `! grep -rE 'task_id\s*==\s*"' src/archex` -> pass.
- `uv run archex benchmark validate` -> pass, all 35 task files valid.

## Dogfood Regression Validation

Pass.

Command:

```bash
uv run archex dogfood . --all --baseline benchmarks/dogfood_baseline.json --format dogfood-delta
```

Result: `Regressions: 0`.

Key recovered tasks:

- `archex_graph_expansion`: recall `0.667 -> 1.000`, precision `0.500 -> 0.500`, F1 `0.571 -> 0.667`.
- `archex_query_cache_lifecycle`: recall `0.600 -> 0.600`, precision `0.600 -> 0.600`, F1 `0.600 -> 0.600`.
- `archex_project_reset`: recall `0.667 -> 0.667`, precision `0.500 -> 1.000`, F1 `0.571 -> 0.800`.

## Benchmark Readiness

Task validation passed:

```bash
uv run archex benchmark validate
```

Result: all 35 task files valid.

Full vector benchmark readiness remains operationally constrained. The PR8 CodeRankEmbed benchmark execution reached task 19/35 after more than 6 hours and was still warming `django_middleware`; readiness generated from the available `.archex/e2e-results` artifacts had 18 `archex_query_fusion` task results, ready `no`, mean recall `0.614`, mean precision `0.475`, mean F1 `0.520`, and zero-recall tasks `0`.
