### PR TITLE
feat(benchmark): stabilize cache identity

### DIFF
--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from archex.benchmark.models import BenchmarkResult, BenchmarkTask, Strategy
+from archex.cache import CacheManager
 from archex.exceptions import ConfigError
 from archex.models import PipelineTiming, RepoSource
 from archex.reporting import count_tokens
@@ -480,6 +481,18 @@ def _cache_state(timing: PipelineTiming) -> str:
     return "warm" if timing.cached else "cold"
 
 
+def _benchmark_repo_source(task: BenchmarkTask, repo_path: Path) -> RepoSource:
+    commit = task.commit or CacheManager.git_head(str(repo_path))
+    if not commit:
+        raise ConfigError(
+            f"Benchmark task {task.task_id!r} has no commit and {repo_path} has no git HEAD"
+        )
+    return RepoSource(
+        local_path=str(repo_path),
+        stable_identity=f"{task.repo}@{commit}",
+    )
+
+
 def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """archex query strategy: use BM25-based retrieval."""
     from archex.api import query
@@ -487,7 +500,7 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = RepoSource(local_path=str(repo_path))
+    source = _benchmark_repo_source(task, repo_path)
     config = Config(cache=False, languages=task.languages)
     index_config = IndexConfig(vector=False)
 
@@ -552,7 +565,7 @@ def run_archex_query_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = RepoSource(local_path=str(repo_path))
+    source = _benchmark_repo_source(task, repo_path)
     config = Config(cache=True, languages=task.languages)
     index_config = IndexConfig(bm25=False, vector=True, embedder="fastembed")
 
@@ -624,7 +637,7 @@ def run_surrogate_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResul
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = RepoSource(local_path=str(repo_path))
+    source = _benchmark_repo_source(task, repo_path)
     config = Config(cache=True, languages=task.languages)
     index_config = IndexConfig(
         bm25=False,
@@ -696,7 +709,7 @@ def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = RepoSource(local_path=str(repo_path))
+    source = _benchmark_repo_source(task, repo_path)
     config = Config(cache=True, languages=task.languages)
     index_config = IndexConfig(vector=True, embedder="fastembed")
 
@@ -768,7 +781,7 @@ def run_archex_query_fusion_rerank(task: BenchmarkTask, repo_path: Path) -> Benc
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = RepoSource(local_path=str(repo_path))
+    source = _benchmark_repo_source(task, repo_path)
     config = Config(cache=True, languages=task.languages)
     index_config = IndexConfig(vector=True, embedder="fastembed", rerank=True)
 
@@ -833,7 +846,7 @@ def run_cross_layer_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = RepoSource(local_path=str(repo_path))
+    source = _benchmark_repo_source(task, repo_path)
     config = Config(cache=True, languages=task.languages)
     index_config = IndexConfig(
         vector=True,

--- a/src/archex/cache.py
+++ b/src/archex/cache.py
@@ -45,16 +45,22 @@ class CacheManager:
     ) -> str:
         """Derive a stable SHA256 cache key from the source identity and resolved ref.
 
-        When stable_identity is provided, it overrides the default identity derived
-        from source.url or source.local_path. This is used by benchmarks to ensure
-        that the same upstream repo always maps to the same cache key, regardless
-        of which temp directory it was cloned into.
+        When stable_identity is provided as an argument, it overrides the default
+        identity derived from source.url or source.local_path before appending the
+        resolved ref. When source.stable_identity is set, it is already the complete
+        stable cache identity. Benchmarks use that path to ensure the same upstream
+        repo maps to the same cache key, regardless of temp clone directory.
 
         For local repos: resolves HEAD via git rev-parse.
         For remote URLs with explicit commit: uses the pinned commit.
         For remote URLs without commit: resolves HEAD via git ls-remote.
         """
-        identity = stable_identity or source.url or source.local_path or ""
+        source_stable_identity = source.stable_identity
+        identity = (
+            stable_identity or source_stable_identity or source.url or source.local_path or ""
+        )
+        if source_stable_identity and stable_identity is None:
+            return hashlib.sha256(identity.encode()).hexdigest()
         commit = (
             source.commit
             or head_override

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -101,6 +101,7 @@ class RepoSource(BaseModel):
     local_path: str | None = None
     target: str | None = None
     commit: str | None = None
+    stable_identity: str | None = None
 
     @model_validator(mode="after")
     def _require_source(self) -> RepoSource:
@@ -108,6 +109,8 @@ class RepoSource(BaseModel):
             raise ValueError("url must not be empty")
         if self.local_path is not None and not self.local_path.strip():
             raise ValueError("local_path must not be empty")
+        if self.stable_identity is not None and not self.stable_identity.strip():
+            raise ValueError("stable_identity must not be empty")
         if not self.url and not self.local_path:
             raise ValueError("RepoSource requires either 'url' or 'local_path'")
         return self

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -10,6 +10,7 @@ import pytest
 from archex.benchmark.models import BenchmarkTask, Strategy
 from archex.benchmark.strategies import (
     _archex_fields,  # pyright: ignore[reportPrivateUsage]
+    _benchmark_repo_source,  # pyright: ignore[reportPrivateUsage]
     _deduplicate_ranked,  # pyright: ignore[reportPrivateUsage]
     compute_map,
     compute_mrr,
@@ -29,6 +30,8 @@ from archex.benchmark.strategies import (
     run_raw_grepped,
     run_surrogate_vector,
 )
+from archex.cache import CacheManager
+from archex.exceptions import ConfigError
 from archex.models import CodeChunk, ContextBundle, RankedChunk, RetrievalMetadata
 
 if TYPE_CHECKING:
@@ -318,6 +321,59 @@ class TestRunRawGrepped:
 
 
 class TestRunArchexQuery:
+    def test_benchmark_source_uses_stable_repo_commit_identity(
+        self,
+        sample_task: BenchmarkTask,
+        tmp_path: Path,
+    ) -> None:
+        cache = CacheManager(cache_dir=str(tmp_path / "cache"))
+        repo_a = tmp_path / "clone-a"
+        repo_b = tmp_path / "clone-b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+
+        source_a = _benchmark_repo_source(sample_task, repo_a)
+        source_b = _benchmark_repo_source(sample_task, repo_b)
+
+        assert source_a.stable_identity == "test/repo@abc"
+        assert source_b.stable_identity == "test/repo@abc"
+        assert cache.cache_key(source_a) == cache.cache_key(source_b)
+
+    def test_benchmark_source_resolves_missing_commit_from_git_head(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        task = BenchmarkTask(
+            task_id="test",
+            repo="test/repo",
+            commit="",
+            question="How?",
+            expected_files=["main.py"],
+        )
+
+        with patch.object(CacheManager, "git_head", return_value="resolved"):
+            source = _benchmark_repo_source(task, tmp_path)
+
+        assert source.stable_identity == "test/repo@resolved"
+
+    def test_benchmark_source_rejects_missing_commit_without_git_head(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        task = BenchmarkTask(
+            task_id="test",
+            repo="test/repo",
+            commit="",
+            question="How?",
+            expected_files=["main.py"],
+        )
+
+        with (
+            patch.object(CacheManager, "git_head", return_value=None),
+            pytest.raises(ConfigError, match="has no commit"),
+        ):
+            _benchmark_repo_source(task, tmp_path)
+
     def test_archex_query_strategy(self, python_simple_repo: Path) -> None:
         task = BenchmarkTask(
             task_id="test",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -605,6 +605,21 @@ class TestStableIdentity:
         expected = hashlib.sha256(stable.encode()).hexdigest()
         assert key_stable == expected
 
+    def test_source_stable_identity_is_complete_cache_identity(self, tmp_path: Path) -> None:
+        """RepoSource.stable_identity is already the complete cache identity."""
+        cm = CacheManager(cache_dir=str(tmp_path))
+        source = RepoSource(
+            local_path="/tmp/bench_run/repo",
+            stable_identity="owner/repo@abc123",
+        )
+
+        with patch.object(CacheManager, "git_head") as git_head:
+            key = cm.cache_key(source)
+
+        git_head.assert_not_called()
+        expected = hashlib.sha256(b"owner/repo@abc123").hexdigest()
+        assert key == expected
+
     def test_local_path_only_source_still_works(self, tmp_path: Path) -> None:
         """Backward compat: RepoSource with only local_path produces a valid key."""
         cm = CacheManager(cache_dir=str(tmp_path))


### PR DESCRIPTION
## Stack

Base: `main`

1. `feat/bench-stable-cache-key` -> this PR
2. `feat/bench-self-only-tier` -> depends on this PR
3. `feat/mps-device` -> depends on `feat/bench-self-only-tier`

## Changes

- Adds `RepoSource.stable_identity` as a complete cache identity for benchmark clones.
- Builds benchmark strategy sources with `stable_identity=f"{task.repo}@{commit}"`.
- Falls back to the clone git HEAD when a benchmark task has no commit.
- Covers path-independent cache keys across temp clone paths.

## Validation

- `uv run ruff check`: passed
- `uv run ruff format --check .`: passed
- `uv run pyright`: passed
- `uv run pytest tests/benchmark/ -q`: benchmark tests passed (`211 passed, 2 deselected`), command exits nonzero because repo-wide `--cov-fail-under=85` is enforced against scoped tests and reports 38.89% global coverage
- `uv run pytest -q`: passed (`1962 passed, 4 deselected`, 91.23% coverage)
- `pr-review`: no blocking findings

No `archex benchmark run` or `archex dogfood` was run.