### PR TITLE
feat(benchmark): add self-only run tier

### DIFF
--- a/.docs/release-quality.md
+++ b/.docs/release-quality.md
@@ -39,6 +39,12 @@ Run the full benchmark only when runtime is acceptable for the current slice.
 When it is empirically long-running, stop it, record elapsed time and task
 progress, and treat readiness as unmeasured rather than passed.
 
+For fast local iteration over the self-task tier only:
+
+```bash
+uv run archex benchmark run --self-only --tasks-dir benchmarks/tasks --output .archex/e2e-self
+```
+
 ## Reporting Contract
 
 Final PR summaries must separate:

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -217,9 +217,14 @@ def run_all(
     output_dir: Path,
     strategies: list[Strategy] | None = None,
     task_filter: str | None = None,
+    self_only: bool = False,
 ) -> list[BenchmarkReport]:
     """Load all tasks, run benchmarks, write results to output_dir."""
     tasks = load_tasks(tasks_dir)
+    if self_only:
+        tasks = [t for t in tasks if t.repo == "."]
+        if not tasks:
+            raise ValueError(f"No self-only tasks found in {tasks_dir}")
     if task_filter:
         tasks = [t for t in tasks if t.task_id == task_filter]
         if not tasks:

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -86,6 +86,12 @@ def benchmark_cmd() -> None:
     default=False,
     help="Include the fusion+rerank strategy (archex_query_fusion_rerank).",
 )
+@click.option(
+    "--self-only",
+    is_flag=True,
+    default=False,
+    help='Run only benchmark tasks whose repo is ".".',
+)
 def run_cmd(
     output_dir: str,
     task_id: str | None,
@@ -94,6 +100,7 @@ def run_cmd(
     query_fusion: bool,
     cross_layer_fusion: bool,
     rerank: bool,
+    self_only: bool,
 ) -> None:
     """Run benchmarks across strategies."""
     strategies: list[Strategy] = list(DEFAULT_STRATEGIES)
@@ -116,6 +123,7 @@ def run_cmd(
         output_dir=Path(output_dir),
         strategies=strategies,
         task_filter=task_id,
+        self_only=self_only,
     )
 
     click.echo(f"\nCompleted {len(reports)} benchmark(s).", err=True)

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -227,6 +227,7 @@ class TestRunCommand:
         assert "--query-fusion" in result.output
         assert "--cross_layer_fusion" in result.output
         assert "--rerank" in result.output
+        assert "--self-only" in result.output
 
     def test_run_uses_default_strategies_without_flags(
         self,
@@ -240,7 +241,9 @@ class TestRunCommand:
             output_dir: Path,
             strategies: list[Strategy] | None = None,
             task_filter: str | None = None,
+            self_only: bool = False,
         ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, task_filter, self_only
             captured["strategies"] = strategies
             return []
 
@@ -265,7 +268,9 @@ class TestRunCommand:
             output_dir: Path,
             strategies: list[Strategy] | None = None,
             task_filter: str | None = None,
+            self_only: bool = False,
         ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, task_filter, self_only
             captured["strategies"] = strategies
             return []
 
@@ -295,7 +300,9 @@ class TestRunCommand:
             output_dir: Path,
             strategies: list[Strategy] | None = None,
             task_filter: str | None = None,
+            self_only: bool = False,
         ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, task_filter, self_only
             captured["strategies"] = strategies
             return []
 
@@ -309,3 +316,26 @@ class TestRunCommand:
             Strategy.ARCHEX_QUERY_FUSION,
             Strategy.ARCHEX_QUERY_FUSION_RERANK,
         ]
+
+    def test_run_self_only_flag_filters_tasks(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter
+            captured["self_only"] = self_only
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(benchmark_cmd, ["run", "--self-only"])
+        assert result.exit_code == 0
+        assert captured["self_only"] is True

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -542,3 +542,60 @@ expected_files:
 
         assert len(reports) == 1
         assert reports[0].task_id == "test_all"
+
+    def test_self_only_filters_to_local_repo_tasks(
+        self,
+        python_simple_repo: Path,
+        tmp_path: Path,
+    ) -> None:
+        from archex.benchmark.runner import run_all
+
+        tasks_dir = self._make_tasks_dir(tmp_path)
+        (tasks_dir / "self.yaml").write_text("""\
+task_id: self_task
+repo: "."
+commit: HEAD
+question: "Self?"
+expected_files:
+  - main.py
+""")
+        output_dir = tmp_path / "results"
+
+        import archex.benchmark.runner as runner_mod
+
+        clone_calls: list[tuple[str, str]] = []
+        original = runner_mod.clone_at_commit
+
+        def _fake_clone(repo_slug: str, commit: str) -> tuple[Path, bool]:
+            clone_calls.append((repo_slug, commit))
+            return python_simple_repo, False
+
+        runner_mod.clone_at_commit = _fake_clone  # type: ignore[assignment]
+        try:
+            reports = run_all(
+                tasks_dir=tasks_dir,
+                output_dir=output_dir,
+                strategies=[Strategy.RAW_FILES],
+                self_only=True,
+            )
+        finally:
+            runner_mod.clone_at_commit = original  # type: ignore[assignment]
+
+        assert [report.task_id for report in reports] == ["self_task"]
+        assert clone_calls == []
+        assert (output_dir / "self_task.json").exists()
+        assert not (output_dir / "test_all.json").exists()
+
+    def test_self_only_requires_local_repo_tasks(self, tmp_path: Path) -> None:
+        from archex.benchmark.runner import run_all
+
+        tasks_dir = self._make_tasks_dir(tmp_path)
+        output_dir = tmp_path / "results"
+
+        with pytest.raises(ValueError, match="No self-only tasks"):
+            run_all(
+                tasks_dir=tasks_dir,
+                output_dir=output_dir,
+                strategies=[Strategy.RAW_FILES],
+                self_only=True,
+            )


### PR DESCRIPTION
## Stack

Base: `main`

1. `feat/bench-stable-cache-key` -> #140
2. `feat/bench-self-only-tier` -> this PR
3. `feat/mps-device` -> depends on this PR

## Changes

- Adds `--self-only` to `archex benchmark run`.
- Filters benchmark task execution to tasks whose `repo == "."` before cloning.
- Documents the fast self-only benchmark command in `.docs/release-quality.md`.

## Validation

- `uv run ruff check`: passed
- `uv run ruff format --check .`: passed
- `uv run pyright`: passed
- `uv run pytest tests/benchmark/ -q`: benchmark tests passed (`214 passed, 2 deselected`), command exits nonzero because repo-wide `--cov-fail-under=85` is enforced against scoped tests and reports 38.92% global coverage
- `uv run pytest -q`: passed (`1966 passed, 4 deselected`, 91.24% coverage)
- `pr-review`: no blocking findings

No `archex benchmark run` or `archex dogfood` was run.