### PR TITLE
feat(index): use MPS for reranking

### DIFF
--- a/src/archex/index/embeddings/coderank.py
+++ b/src/archex/index/embeddings/coderank.py
@@ -20,10 +20,10 @@ def _best_device() -> str:
     try:
         import torch  # type: ignore[import-untyped]
 
-        if torch.cuda.is_available():
-            return "cuda"
         if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
             return "mps"
+        if torch.cuda.is_available():
+            return "cuda"
     except ImportError:
         pass
     return "cpu"

--- a/src/archex/index/rerank.py
+++ b/src/archex/index/rerank.py
@@ -32,6 +32,18 @@ DEFAULT_TOP_K = 30
 _MODEL_CACHE: dict[str, Any] = {}
 
 
+def _best_device() -> str:
+    """Pick the best available torch device for cross-encoder reranking."""
+    try:
+        import torch  # type: ignore[import-untyped]
+
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+            return "mps"
+    except ImportError:
+        pass
+    return "cpu"
+
+
 def is_available() -> bool:
     """Return True if cross-encoder dependencies are installed."""
     try:
@@ -72,8 +84,10 @@ class CrossEncoderReranker:
                 "Install with: uv add 'archex[vector-torch]'"
             ) from e
 
+        device = _best_device()
         print(
-            f"Loading reranker model '{self._model_name}' (downloading if not cached)...",
+            f"Loading reranker model '{self._model_name}' on {device} "
+            "(downloading if not cached)...",
             file=sys.stderr,
             flush=True,
         )
@@ -81,9 +95,10 @@ class CrossEncoderReranker:
             self._model_name,
             revision=MODEL_REVISIONS.get(self._model_name),
             trust_remote_code=True,
+            device=device,
         )
         _MODEL_CACHE[self._model_name] = self._model
-        logger.info("Loaded cross-encoder reranker: %s", self._model_name)
+        logger.info("Loaded cross-encoder reranker: %s on %s", self._model_name, device)
 
     def rerank(
         self,

--- a/tests/index/embeddings/test_embeddings.py
+++ b/tests/index/embeddings/test_embeddings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
@@ -278,6 +279,36 @@ class TestFastEmbedder:
 
 
 class TestCodeRankEmbedder:
+    def test_coderank_best_device_prefers_mps(self) -> None:
+        from archex.index.embeddings.coderank import (
+            _best_device,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        torch_module = SimpleNamespace(
+            backends=SimpleNamespace(
+                mps=SimpleNamespace(is_available=lambda: True),
+            ),
+            cuda=SimpleNamespace(is_available=lambda: True),
+        )
+
+        with patch.dict("sys.modules", {"torch": torch_module}):
+            assert _best_device() == "mps"
+
+    def test_coderank_best_device_uses_cuda_when_mps_unavailable(self) -> None:
+        from archex.index.embeddings.coderank import (
+            _best_device,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        torch_module = SimpleNamespace(
+            backends=SimpleNamespace(
+                mps=SimpleNamespace(is_available=lambda: False),
+            ),
+            cuda=SimpleNamespace(is_available=lambda: True),
+        )
+
+        with patch.dict("sys.modules", {"torch": torch_module}):
+            assert _best_device() == "cuda"
+
     def test_coderank_embedder_init_lazy_loads(self) -> None:
         """CodeRankEmbedder can be instantiated without loading the model."""
         from archex.index.embeddings.coderank import CodeRankEmbedder

--- a/tests/index/test_rerank.py
+++ b/tests/index/test_rerank.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -15,6 +16,7 @@ from archex.index.rerank import (
     JINA_RERANKER_REVISION,
     MAX_CONTENT_CHARS,
     CrossEncoderReranker,
+    _best_device,  # pyright: ignore[reportPrivateUsage]
     is_available,
 )
 from archex.models import CodeChunk, IndexConfig, SymbolKind
@@ -53,6 +55,28 @@ class TestIsAvailable:
         with patch("archex.index.rerank.is_available", return_value=True):
             # Direct import bypasses mock; test the real function shape
             assert isinstance(is_available(), bool)
+
+
+class TestDeviceSelection:
+    def test_best_device_uses_mps_when_available(self) -> None:
+        torch_module = SimpleNamespace(
+            backends=SimpleNamespace(
+                mps=SimpleNamespace(is_available=lambda: True),
+            ),
+        )
+
+        with patch.dict("sys.modules", {"torch": torch_module}):
+            assert _best_device() == "mps"
+
+    def test_best_device_falls_back_to_cpu(self) -> None:
+        torch_module = SimpleNamespace(
+            backends=SimpleNamespace(
+                mps=SimpleNamespace(is_available=lambda: False),
+            ),
+        )
+
+        with patch.dict("sys.modules", {"torch": torch_module}):
+            assert _best_device() == "cpu"
 
 
 class TestConstants:
@@ -112,7 +136,10 @@ class TestCrossEncoderReranker:
         rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
         chunk = _make_chunk("a")
 
-        with patch("sentence_transformers.CrossEncoder") as cross_encoder:
+        with (
+            patch("archex.index.rerank._best_device", return_value="cpu"),
+            patch("sentence_transformers.CrossEncoder") as cross_encoder,
+        ):
             cross_encoder.return_value.predict.return_value = np.array([1.0])
             CrossEncoderReranker().rerank("query", [(chunk, 0.0)])
 
@@ -120,6 +147,7 @@ class TestCrossEncoderReranker:
             JINA_RERANKER_MODEL,
             revision=JINA_RERANKER_REVISION,
             trust_remote_code=True,
+            device="cpu",
         )
         rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
 
@@ -127,7 +155,10 @@ class TestCrossEncoderReranker:
         rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
         chunk = _make_chunk("a")
 
-        with patch("sentence_transformers.CrossEncoder") as cross_encoder:
+        with (
+            patch("archex.index.rerank._best_device", return_value="cpu"),
+            patch("sentence_transformers.CrossEncoder") as cross_encoder,
+        ):
             cross_encoder.return_value.predict.return_value = np.array([1.0])
             CrossEncoderReranker(model_name="custom/model").rerank("query", [(chunk, 0.0)])
 
@@ -135,6 +166,26 @@ class TestCrossEncoderReranker:
             "custom/model",
             revision=None,
             trust_remote_code=True,
+            device="cpu",
+        )
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+
+    def test_load_passes_mps_when_available(self) -> None:
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+        chunk = _make_chunk("a")
+
+        with (
+            patch("archex.index.rerank._best_device", return_value="mps"),
+            patch("sentence_transformers.CrossEncoder") as cross_encoder,
+        ):
+            cross_encoder.return_value.predict.return_value = np.array([1.0])
+            CrossEncoderReranker().rerank("query", [(chunk, 0.0)])
+
+        cross_encoder.assert_called_once_with(
+            JINA_RERANKER_MODEL,
+            revision=JINA_RERANKER_REVISION,
+            trust_remote_code=True,
+            device="mps",
         )
         rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
 


### PR DESCRIPTION
## Stack

Base: `main`

1. `feat/bench-stable-cache-key` -> #140
2. `feat/bench-self-only-tier` -> #141
3. `feat/mps-device` -> this PR

## Changes

- Adds MPS detection for cross-encoder reranking and passes `device=` into `CrossEncoder`.
- Keeps a clean CPU fallback when MPS is unavailable.
- Aligns CodeRankEmbed device selection with its `mps > cuda > cpu` policy.
- Adds unit coverage for reranker MPS/CPU paths and CodeRank MPS preference.

## Validation

- `uv run ruff check`: passed
- `uv run ruff format --check .`: passed
- `uv run pyright`: passed
- `uv run pytest tests/benchmark/ -q`: benchmark tests passed (`214 passed, 2 deselected`), command exits nonzero because repo-wide `--cov-fail-under=85` is enforced against scoped tests and reports 38.89% global coverage
- `uv run pytest tests/index/test_rerank.py tests/index/embeddings/test_embeddings.py -q --no-cov`: passed (`57 passed`)
- `uv run pytest -q`: passed (`1971 passed, 4 deselected`, 91.24% coverage)
- `pr-review`: no blocking findings

No `archex benchmark run` or `archex dogfood` was run.