### PR TITLE
fix(fusion): preserve positive normalized scores

### DIFF
--- a/src/archex/index/fusion.py
+++ b/src/archex/index/fusion.py
@@ -155,15 +155,14 @@ def confidence_weighted_rrf(
 def normalize_scores(
     results: list[tuple[CodeChunk, float]],
 ) -> dict[str, float]:
-    """Min-max normalize scores to [0, 1], preserving within-signal distances."""
+    """Normalize scores by the maximum score, preserving retrieved positive evidence."""
     if not results:
         return {}
     scores = [s for _, s in results]
-    min_s, max_s = min(scores), max(scores)
-    rng = max_s - min_s
-    if rng < 1e-9:
-        return {c.id: 0.5 for c, _ in results}
-    return {c.id: (s - min_s) / rng for c, s in results}
+    max_s = max(scores)
+    if max_s < 1e-9:
+        return {c.id: 0.0 for c, _ in results}
+    return {c.id: s / max_s for c, s in results}
 
 
 def adaptive_rsf_weights(

--- a/tests/index/test_fusion.py
+++ b/tests/index/test_fusion.py
@@ -161,11 +161,18 @@ class TestNormalizeScores:
         assert norm["b"] == pytest.approx(0.5)  # pyright: ignore[reportUnknownMemberType]
         assert norm["c"] == pytest.approx(0.0)  # pyright: ignore[reportUnknownMemberType]
 
+    def test_lowest_positive_score_remains_positive(self) -> None:
+        results = _results([("a", "a.py", 10.0), ("b", "b.py", 5.0), ("c", "c.py", 1.0)])
+        norm = normalize_scores(results)
+        assert norm["a"] == pytest.approx(1.0)  # pyright: ignore[reportUnknownMemberType]
+        assert norm["b"] == pytest.approx(0.5)  # pyright: ignore[reportUnknownMemberType]
+        assert norm["c"] == pytest.approx(0.1)  # pyright: ignore[reportUnknownMemberType]
+
     def test_normalize_flat_scores(self) -> None:
         results = _results([("a", "a.py", 5.0), ("b", "b.py", 5.0)])
         norm = normalize_scores(results)
-        assert norm["a"] == pytest.approx(0.5)  # pyright: ignore[reportUnknownMemberType]
-        assert norm["b"] == pytest.approx(0.5)  # pyright: ignore[reportUnknownMemberType]
+        assert norm["a"] == pytest.approx(1.0)  # pyright: ignore[reportUnknownMemberType]
+        assert norm["b"] == pytest.approx(1.0)  # pyright: ignore[reportUnknownMemberType]
 
     def test_normalize_empty(self) -> None:
         assert normalize_scores([]) == {}

--- a/tests/index/test_vector.py
+++ b/tests/index/test_vector.py
@@ -816,8 +816,8 @@ class TestRelativeScoreFusion:
         assert len(fused) == 1
         assert fused[0][0].id == chunk_a.id
 
-    def test_rsf_flat_scores_normalize_to_half(self) -> None:
-        # Arrange: all equal scores → normalized to 0.5 per signal
+    def test_rsf_flat_scores_normalize_to_full_signal(self) -> None:
+        # Arrange: all equal positive scores → normalized to 1.0 per signal
         chunks = [
             CodeChunk(
                 id=f"f{i}.py:fn:{i}",
@@ -836,6 +836,6 @@ class TestRelativeScoreFusion:
         vector_results: list[tuple[CodeChunk, float]] = [(c, 1.0) for c in chunks]
 
         fused = relative_score_fusion(bm25_results, vector_results)
-        # All chunks get 0.5*0.5 + 0.5*0.5 = 0.5 each
+        # All chunks get 0.5*1.0 + 0.5*1.0 = 1.0 each
         for _, score in fused:
-            assert abs(score - 0.5) < 1e-9
+            assert abs(score - 1.0) < 1e-9

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -629,6 +629,8 @@ def test_vector_only_seed_surfaces_via_assemble_context() -> None:
     is a BM25 seed.  With vector_results supplying B directly, B also acts as
     its own seed regardless of graph structure.
     Provides >= 3 results per signal to satisfy should_fuse min_results.
+    The query avoids dependency keywords so this test isolates fusion seed union
+    from dependency-query file capping.
     """
     graph = DependencyGraph()
     for name in ("a.py", "b.py", "c.py", "d.py", "e.py"):
@@ -653,7 +655,7 @@ def test_vector_only_seed_surfaces_via_assemble_context() -> None:
         search_results=bm25_results,
         graph=graph,
         all_chunks=all_chunks,
-        question="how does a import b?",
+        question="how does a use b?",
         token_budget=1000,
         vector_results=vec_results,
     )


### PR DESCRIPTION
## Stack

Base: `main`

1. `fix/fusion-normalization` -> this PR
2. `fix/fusion-file-cutoff` -> depends on this PR
3. `feat/fusion-vector-topk` -> depends on `fix/fusion-file-cutoff`
4. `fix/rerank-topk-recall` -> depends on `feat/fusion-vector-topk`
5. `fix/rerank-content-window` -> depends on `fix/rerank-topk-recall`

## Changes

- Switch RSF score normalization from min-max to max-only so the lowest positive retrieved score keeps positive evidence.
- Characterize the positive-bottom-score contract in fusion tests.
- Update duplicate RSF flat-score expectations and isolate vector-seed union coverage from dependency-query file capping.

## Validation

- `uv run ruff check` passed.
- `uv run ruff format --check .` passed.
- `uv run pyright` passed.
- `uv run pytest tests/index/test_fusion.py tests/serve/ -q --no-cov` passed: 220 passed.
- `uv run pytest` passed: 1972 passed, 4 deselected, coverage 91.23%.
- Exact requested narrow command `uv run pytest tests/index/test_fusion.py tests/serve/ -q` executes 220 passing tests but fails the repo-wide coverage threshold because coverage is measured against a subset.

## Review

- `pr-review` completed after commits: no blocking findings.
