### PR TITLE
fix(serve): relax file cutoff after fusion

### DIFF
--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -81,12 +81,17 @@ SEED_EXPANSION_MIN = 0.05
 
 # Files below this fraction of the top file's aggregate score are excluded.
 FILE_SCORE_CUTOFF = 0.10
+FUSION_FILE_SCORE_CUTOFF = 0.05
 
 
 def estimate_tokens(chunk: CodeChunk) -> int:
     if chunk.token_count > 0:
         return chunk.token_count
     return int(len(chunk.content.split()) * 1.3)
+
+
+def _file_score_cutoff_ratio(*, fusion_applied: bool) -> float:
+    return FUSION_FILE_SCORE_CUTOFF if fusion_applied else FILE_SCORE_CUTOFF
 
 
 def _is_test_file(file_path: str) -> bool:

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -856,7 +856,9 @@ def assemble_context(
         file_agg[fp] = file_agg.get(fp, 0.0) + rc.final_score
     sorted_files = sorted(file_agg.items(), key=lambda x: -x[1])
     top_file_score = sorted_files[0][1] if sorted_files else 0.0
-    score_cutoff = top_file_score * FILE_SCORE_CUTOFF
+    score_cutoff = top_file_score * _file_score_cutoff_ratio(
+        fusion_applied=fusion_bm25_weight is not None
+    )
     top_files: set[str] = set()
     adaptive_max = _adaptive_max_files(sorted_files)
     if intent == QueryIntent.CLI or q_terms & {

--- a/tests/serve/test_context_recall.py
+++ b/tests/serve/test_context_recall.py
@@ -211,3 +211,11 @@ def test_file_score_cutoff_is_0_10() -> None:
     from archex.serve.context import FILE_SCORE_CUTOFF
 
     assert FILE_SCORE_CUTOFF == 0.10
+
+
+def test_file_score_cutoff_relaxes_when_fusion_applies() -> None:
+    """Fusion uses a lower file cutoff because RSF flattens aggregate scores."""
+    from archex.serve.context import _file_score_cutoff_ratio  # pyright: ignore[reportPrivateUsage]
+
+    assert _file_score_cutoff_ratio(fusion_applied=False) == 0.10
+    assert _file_score_cutoff_ratio(fusion_applied=True) == 0.05


### PR DESCRIPTION
## Stack

Base: `main`

1. `fix/fusion-normalization` -> #143
2. `fix/fusion-file-cutoff` -> this PR
3. `feat/fusion-vector-topk` -> depends on this PR
4. `fix/rerank-topk-recall` -> depends on `feat/fusion-vector-topk`
5. `fix/rerank-content-window` -> depends on `fix/rerank-topk-recall`

## Changes

- Add explicit BM25-only and fusion-applied file cutoff contracts.
- Keep BM25-only file cutoff at `0.10`.
- Use `0.05` when fusion applies so flattened RSF file scores are not filtered by the BM25-only ratio.

## Validation

- `uv run ruff check` passed.
- `uv run ruff format --check .` passed.
- `uv run pyright` passed.
- `uv run pytest tests/index/test_fusion.py tests/serve/ -q --no-cov` passed: 221 passed.
- `uv run pytest` passed: 1973 passed, 4 deselected, coverage 91.23%.
- Exact requested narrow command `uv run pytest tests/index/test_fusion.py tests/serve/ -q` is coverage-invalid in this repo because coverage is measured globally against a subset.

## Review

- `pr-review` completed after commits: no blocking findings.
