### PR TITLE
feat(api): widen vector fusion candidate pool

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -494,6 +494,11 @@ def _compute_top_k(total_chunks: int) -> int:
     return 150
 
 
+def _compute_vector_top_k(*, bm25_top_k: int, total_chunks: int) -> int:
+    """Use a deeper independent vector pool for fusion candidate union."""
+    return min(total_chunks, bm25_top_k * 2)
+
+
 _PATH_NOISE = frozenset(
     {
         "how",

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1065,6 +1065,10 @@ def query(
                     )
 
                 top_k = _compute_top_k(chunk_count)
+                vector_top_k = _compute_vector_top_k(
+                    bm25_top_k=top_k,
+                    total_chunks=chunk_count,
+                )
                 # Pre-load all chunks into memory before parallel search so the
                 # vector thread has no dependency on the SQLite store connection.
                 all_chunks_cached = store.get_chunks()
@@ -1087,7 +1091,7 @@ def query(
                         all_chunks_cached,
                         question,
                         index_config,
-                        top_k,
+                        vector_top_k,
                     )
                     if index_config.bm25:
                         _bm25_raw, path_boost, symbol_seeds = _bm25_search_with_boosts(
@@ -1119,7 +1123,7 @@ def query(
                             all_chunks_cached,
                             index_config,
                             timing,
-                            top_k=top_k,
+                            top_k=vector_top_k,
                             surrogates_by_chunk_id=surrogate_lookup,
                         )
 
@@ -1146,6 +1150,7 @@ def query(
                                 "path_boost": len(path_boost),
                                 "symbol_seeds": len(symbol_seeds),
                                 "top_k": top_k,
+                                "vector_top_k": vector_top_k,
                             },
                         )
                     )
@@ -1336,6 +1341,10 @@ def query(
                 )
 
             top_k = _compute_top_k(len(all_chunks))
+            vector_top_k = _compute_vector_top_k(
+                bm25_top_k=top_k,
+                total_chunks=len(all_chunks),
+            )
 
             # Persist corpus stats for fast warm-query access
             store.set_metadata("repo_total_tokens", str(total_repo_tokens))
@@ -1389,7 +1398,7 @@ def query(
                     all_chunks,
                     question,
                     index_config,
-                    top_k,
+                    vector_top_k,
                 )
                 if index_config.bm25:
                     _bm25_raw, path_boost, symbol_seeds_miss = _bm25_search_with_boosts(
@@ -1421,7 +1430,7 @@ def query(
                         all_chunks,
                         index_config,
                         timing,
-                        top_k=top_k,
+                        top_k=vector_top_k,
                         surrogates_by_chunk_id=surrogate_lookup,
                     )
 
@@ -1447,6 +1456,7 @@ def query(
                             "path_boost": len(path_boost),
                             "symbol_seeds": len(symbol_seeds_miss),
                             "top_k": top_k,
+                            "vector_top_k": vector_top_k,
                         },
                     )
                 )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,6 +9,7 @@ import pytest
 
 from archex.api import (
     _compute_top_k,  # pyright: ignore[reportPrivateUsage]
+    _compute_vector_top_k,  # pyright: ignore[reportPrivateUsage]
     analyze,
     compare,
     query,
@@ -53,6 +54,15 @@ def test_compute_top_k_thresholds() -> None:
     assert _compute_top_k(1000) == 100
     assert _compute_top_k(2000) == 100
     assert _compute_top_k(5000) == 150
+
+
+def test_compute_vector_top_k_widens_bm25_pool() -> None:
+    assert _compute_vector_top_k(bm25_top_k=50, total_chunks=500) == 100
+    assert _compute_vector_top_k(bm25_top_k=100, total_chunks=2000) == 200
+
+
+def test_compute_vector_top_k_caps_at_chunk_count() -> None:
+    assert _compute_vector_top_k(bm25_top_k=30, total_chunks=40) == 40
 
 
 class TestAnalyzeEndToEnd:


### PR DESCRIPTION
## Stack

Base: `main`

1. `fix/fusion-normalization` -> #143
2. `fix/fusion-file-cutoff` -> #144
3. `feat/fusion-vector-topk` -> this PR
4. `fix/rerank-topk-recall` -> depends on this PR
5. `fix/rerank-content-window` -> depends on `fix/rerank-topk-recall`

## Changes

- Add `_compute_vector_top_k()` with a 2x vector candidate pool capped by chunk count.
- Keep BM25 `top_k` unchanged while passing the widened pool to precomputed and in-memory vector search.
- Record `vector_top_k` in search trace metadata.

## Validation

- `uv run ruff check` passed.
- `uv run ruff format --check .` passed.
- `uv run pyright` passed.
- `uv run pytest tests/index/test_fusion.py tests/serve/ -q --no-cov` passed: 221 passed.
- `uv run pytest` passed: 1975 passed, 4 deselected, coverage 91.22%.
- Exact requested narrow command `uv run pytest tests/index/test_fusion.py tests/serve/ -q` is coverage-invalid in this repo because coverage is measured globally against a subset.

## Review

- `pr-review` completed after commits: no blocking findings.
