### PR TITLE
fix(serve): honor reranker default top k

### DIFF
--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -752,13 +752,13 @@ def assemble_context(
     # query-chunk attention. This replaces BM25/fusion scores with
     # cross-encoder relevance scores for downstream ranking.
     if reranker is not None:
-        from archex.index.rerank import CrossEncoderReranker
+        from archex.index.rerank import DEFAULT_TOP_K, CrossEncoderReranker
 
         if isinstance(reranker, CrossEncoderReranker):
             candidate_list = [
                 (chunk, bm25_by_id.get(chunk.id, 0.0)) for chunk in candidate_map.values()
             ]
-            reranked = reranker.rerank(question, candidate_list, top_k=20)
+            reranked = reranker.rerank(question, candidate_list, top_k=DEFAULT_TOP_K)
             candidate_map = {chunk.id: chunk for chunk, _ in reranked}
             max_rerank = max((s for _, s in reranked), default=1.0) or 1.0
             bm25_by_id = {chunk.id: score / max_rerank for chunk, score in reranked}

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import xml.etree.ElementTree as ET
 
+from archex.index.rerank import DEFAULT_TOP_K, CrossEncoderReranker
 from archex.index.graph import DependencyGraph
 from archex.models import CodeChunk, ContextBundle, Module, SymbolKind
 from archex.serve.context import assemble_context
@@ -49,6 +50,21 @@ def make_graph_with_edges() -> DependencyGraph:
     graph.add_file_edge("auth.py", "models.py", kind="imports")
     graph.add_file_edge("utils.py", "auth.py", kind="imports")
     return graph
+
+
+class RecordingReranker(CrossEncoderReranker):
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen_top_k: int | None = None
+
+    def rerank(
+        self,
+        query: str,
+        candidates: list[tuple[CodeChunk, float]],
+        top_k: int = DEFAULT_TOP_K,
+    ) -> list[tuple[CodeChunk, float]]:
+        self.seen_top_k = top_k
+        return candidates[:top_k]
 
 
 # ---------------------------------------------------------------------------
@@ -663,6 +679,26 @@ def test_vector_only_seed_surfaces_via_assemble_context() -> None:
     included = {rc.chunk.file_path for rc in bundle.chunks}
     assert "a.py" in included, "BM25 seed a.py must be in bundle"
     assert "b.py" in included, "vector seed b.py must be in bundle"
+
+
+def test_assemble_context_honors_reranker_default_top_k() -> None:
+    graph = DependencyGraph()
+    chunks = [make_chunk(f"c{i}", f"f{i}.py", token_count=10) for i in range(DEFAULT_TOP_K + 5)]
+    for chunk in chunks:
+        graph.add_file_node(chunk.file_path)
+    search_results = [(chunk, float(DEFAULT_TOP_K + 5 - i)) for i, chunk in enumerate(chunks)]
+    reranker = RecordingReranker()
+
+    assemble_context(
+        search_results=search_results,
+        graph=graph,
+        all_chunks=chunks,
+        question="query",
+        token_budget=1000,
+        reranker=reranker,
+    )
+
+    assert reranker.seen_top_k == DEFAULT_TOP_K
 
 
 def test_vector_only_recovery_when_bm25_empty() -> None:


### PR DESCRIPTION
## Stack

Base: `main`

1. `fix/fusion-normalization` -> #143
2. `fix/fusion-file-cutoff` -> #144
3. `feat/fusion-vector-topk` -> #145
4. `fix/rerank-topk-recall` -> this PR
5. `fix/rerank-content-window` -> depends on this PR

## Changes

- Add a serve-level characterization proving `assemble_context()` forwards the reranker default candidate limit.
- Replace the hardcoded `top_k=20` override with `index.rerank.DEFAULT_TOP_K`.
- Keep reranking opt-in and model loading untouched.

## Validation

- `uv run ruff check` passed.
- `uv run ruff format --check .` passed.
- `uv run pyright` passed.
- `uv run pytest tests/index/test_fusion.py tests/serve/ -q --no-cov` passed: 222 passed.
- `uv run pytest` passed: 1976 passed, 4 deselected, coverage 91.31%.
- Exact requested narrow command `uv run pytest tests/index/test_fusion.py tests/serve/ -q` is coverage-invalid in this repo because coverage is measured globally against a subset.

## Review

- `pr-review` completed after commits: no blocking findings.
