### PR TITLE
fix(rerank): raise content scoring window

### DIFF
--- a/src/archex/index/rerank.py
+++ b/src/archex/index/rerank.py
@@ -21,8 +21,9 @@ MODEL_REVISIONS = {
 }
 
 # Maximum content length passed to the cross-encoder per chunk.
-# MiniLM has a 512-token context window (~4 chars/token avg).
-MAX_CONTENT_CHARS = 4096
+# jinaai/jina-reranker-v3 supports an 8192-token window; keep roughly
+# 4 chars/token budget for full code chunks while leaving room for the query.
+MAX_CONTENT_CHARS = 16384
 
 # Default number of top candidates to keep after reranking.
 # Sized to cover ~8-10 files x 3-4 chunks each, giving downstream

--- a/src/archex/index/rerank.py
+++ b/src/archex/index/rerank.py
@@ -33,6 +33,34 @@ DEFAULT_TOP_K = 30
 _MODEL_CACHE: dict[str, Any] = {}
 
 
+def _ensure_padding_token(cross_encoder: Any) -> None:
+    tokenizer = getattr(cross_encoder, "tokenizer", None)
+    if tokenizer is None:
+        raise ArchexIndexError(f"Cross-encoder model '{cross_encoder}' has no tokenizer.")
+
+    pad_token_id = getattr(tokenizer, "pad_token_id", None)
+    if getattr(tokenizer, "pad_token", None) is None:
+        eos_token = getattr(tokenizer, "eos_token", None)
+        eos_token_id = getattr(tokenizer, "eos_token_id", None)
+        if eos_token is None or eos_token_id is None:
+            raise ArchexIndexError(
+                f"Cross-encoder model '{cross_encoder}' has no padding token or EOS token."
+            )
+
+        tokenizer.pad_token = eos_token
+        tokenizer.pad_token_id = eos_token_id
+        pad_token_id = eos_token_id
+
+    if pad_token_id is None:
+        raise ArchexIndexError(f"Cross-encoder model '{cross_encoder}' has no padding token id.")
+
+    model = getattr(cross_encoder, "model", None)
+    config = getattr(model, "config", None)
+    if config is None:
+        raise ArchexIndexError(f"Cross-encoder model '{cross_encoder}' has no config.")
+    config.pad_token_id = pad_token_id
+
+
 def _best_device() -> str:
     """Pick the best available torch device for cross-encoder reranking."""
     try:
@@ -74,6 +102,7 @@ class CrossEncoderReranker:
 
         cached_model = _MODEL_CACHE.get(self._model_name)
         if cached_model is not None:
+            _ensure_padding_token(cached_model)
             self._model = cached_model
             return
 
@@ -98,6 +127,7 @@ class CrossEncoderReranker:
             trust_remote_code=True,
             device=device,
         )
+        _ensure_padding_token(self._model)
         _MODEL_CACHE[self._model_name] = self._model
         logger.info("Loaded cross-encoder reranker: %s on %s", self._model_name, device)
 

--- a/src/archex/index/rerank.py
+++ b/src/archex/index/rerank.py
@@ -21,8 +21,8 @@ MODEL_REVISIONS = {
 }
 
 # Maximum content length passed to the cross-encoder per chunk.
-# jinaai/jina-reranker-v3 supports an 8192-token window; keep roughly
-# 4 chars/token budget for full code chunks while leaving room for the query.
+# jinaai/jina-reranker-v3 supports an 8192-token window. Use a conservative
+# ~4096-token chunk slice so larger code chunks score while query overhead fits.
 MAX_CONTENT_CHARS = 16384
 
 # Default number of top candidates to keep after reranking.

--- a/src/archex/pipeline/chunker.py
+++ b/src/archex/pipeline/chunker.py
@@ -130,7 +130,7 @@ class Chunker(Protocol):
 
 
 def _count_tokens(encoder: tiktoken.Encoding, text: str) -> int:
-    return len(encoder.encode(text))
+    return len(encoder.encode(text, disallowed_special=()))
 
 
 def _format_import(imp: ImportStatement) -> str:

--- a/src/archex/reporting.py
+++ b/src/archex/reporting.py
@@ -13,7 +13,7 @@ _encoder = tiktoken.get_encoding("cl100k_base")
 
 def count_tokens(text: str) -> int:
     """Count tokens using the cl100k_base encoding."""
-    return len(_encoder.encode(text))
+    return len(_encoder.encode(text, disallowed_special=()))
 
 
 def compute_meta(

--- a/tests/index/test_chunker.py
+++ b/tests/index/test_chunker.py
@@ -192,6 +192,32 @@ def test_token_count_is_accurate() -> None:
         )
 
 
+def test_chunk_file_counts_literal_special_token_text() -> None:
+    source = b'def marker() -> str:\n    return "<|endoftext|>"\n'
+    parsed = ParsedFile(
+        path="special.py",
+        language="python",
+        symbols=[
+            Symbol(
+                name="marker",
+                qualified_name="marker",
+                kind=SymbolKind.FUNCTION,
+                file_path="special.py",
+                start_line=1,
+                end_line=2,
+            )
+        ],
+        imports=[],
+        lines=2,
+    )
+
+    chunks = _default_chunker().chunk_file(parsed, source)
+
+    assert len(chunks) == 1
+    assert chunks[0].content == 'def marker() -> str:\n    return "<|endoftext|>"'
+    assert chunks[0].token_count > 0
+
+
 def test_chunk_ids_are_unique() -> None:
     chunker = _default_chunker()
     chunks = chunker.chunk_file(PARSED_SIMPLE, SOURCE_SIMPLE)

--- a/tests/index/test_rerank.py
+++ b/tests/index/test_rerank.py
@@ -189,6 +189,94 @@ class TestCrossEncoderReranker:
         )
         rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
 
+    def test_load_sets_eos_as_padding_token_when_missing(self) -> None:
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+        chunk = _make_chunk("a")
+        fake_encoder = SimpleNamespace(
+            tokenizer=SimpleNamespace(
+                pad_token=None,
+                pad_token_id=None,
+                eos_token="<eos>",
+                eos_token_id=151645,
+            ),
+            model=SimpleNamespace(config=SimpleNamespace(pad_token_id=None)),
+            predict=MagicMock(return_value=np.array([1.0])),
+        )
+
+        with (
+            patch("archex.index.rerank._best_device", return_value="cpu"),
+            patch("sentence_transformers.CrossEncoder", return_value=fake_encoder),
+        ):
+            CrossEncoderReranker().rerank("query", [(chunk, 0.0)])
+
+        assert fake_encoder.tokenizer.pad_token == "<eos>"
+        assert fake_encoder.tokenizer.pad_token_id == 151645
+        assert fake_encoder.model.config.pad_token_id == 151645
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+
+    def test_load_sets_model_padding_id_when_tokenizer_has_pad(self) -> None:
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+        chunk = _make_chunk("a")
+        fake_encoder = SimpleNamespace(
+            tokenizer=SimpleNamespace(
+                pad_token="<|endoftext|>",
+                pad_token_id=151643,
+                eos_token="<|im_end|>",
+                eos_token_id=151645,
+            ),
+            model=SimpleNamespace(config=SimpleNamespace(pad_token_id=None)),
+            predict=MagicMock(return_value=np.array([1.0])),
+        )
+
+        with (
+            patch("archex.index.rerank._best_device", return_value="cpu"),
+            patch("sentence_transformers.CrossEncoder", return_value=fake_encoder),
+        ):
+            CrossEncoderReranker().rerank("query", [(chunk, 0.0)])
+
+        assert fake_encoder.tokenizer.pad_token == "<|endoftext|>"
+        assert fake_encoder.model.config.pad_token_id == 151643
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+
+    def test_cached_model_sets_model_padding_id(self) -> None:
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+        chunk = _make_chunk("a")
+        fake_encoder = SimpleNamespace(
+            tokenizer=SimpleNamespace(
+                pad_token="<|endoftext|>",
+                pad_token_id=151643,
+            ),
+            model=SimpleNamespace(config=SimpleNamespace(pad_token_id=None)),
+            predict=MagicMock(return_value=np.array([1.0])),
+        )
+        rerank_module._MODEL_CACHE["test/model"] = fake_encoder  # pyright: ignore[reportPrivateUsage]
+
+        CrossEncoderReranker(model_name="test/model").rerank("query", [(chunk, 0.0)])
+
+        assert fake_encoder.model.config.pad_token_id == 151643
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+
+    def test_load_aligns_model_padding_id_with_tokenizer(self) -> None:
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+        chunk = _make_chunk("a")
+        fake_encoder = SimpleNamespace(
+            tokenizer=SimpleNamespace(
+                pad_token="<|endoftext|>",
+                pad_token_id=151643,
+            ),
+            model=SimpleNamespace(config=SimpleNamespace(pad_token_id=151645)),
+            predict=MagicMock(return_value=np.array([1.0])),
+        )
+
+        with (
+            patch("archex.index.rerank._best_device", return_value="cpu"),
+            patch("sentence_transformers.CrossEncoder", return_value=fake_encoder),
+        ):
+            CrossEncoderReranker().rerank("query", [(chunk, 0.0)])
+
+        assert fake_encoder.model.config.pad_token_id == 151643
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+
     def test_reuses_loaded_model_for_same_model_name(self) -> None:
         rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
         chunk = _make_chunk("a")

--- a/tests/index/test_rerank.py
+++ b/tests/index/test_rerank.py
@@ -83,8 +83,8 @@ class TestConstants:
     def test_default_top_k_is_30(self) -> None:
         assert DEFAULT_TOP_K == 30
 
-    def test_max_content_chars_is_4096(self) -> None:
-        assert MAX_CONTENT_CHARS == 4096
+    def test_max_content_chars_matches_jina_window_budget(self) -> None:
+        assert MAX_CONTENT_CHARS == 16384
 
     def test_default_model_is_jina_reranker(self) -> None:
         assert DEFAULT_MODEL == JINA_RERANKER_MODEL

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -17,6 +17,12 @@ def test_count_tokens_empty_string() -> None:
     assert count_tokens("") == 0
 
 
+def test_count_tokens_treats_special_token_literals_as_text() -> None:
+    result = count_tokens('return "<|endoftext|>"')
+
+    assert result > 0
+
+
 def test_compute_meta_basic() -> None:
     meta = compute_meta(
         tool_name="test_tool",


### PR DESCRIPTION
## Stack

Base: `main`

1. `fix/fusion-normalization` -> #143
2. `fix/fusion-file-cutoff` -> #144
3. `feat/fusion-vector-topk` -> #145
4. `fix/rerank-topk-recall` -> #146
5. `fix/rerank-content-window` -> this PR

## Changes

- Raise reranker chunk content cap from `4096` to `16384` chars.
- Replace the stale MiniLM context-window comment with the current Jina reranker budget rationale.
- Configure the cross-encoder tokenizer/model padding invariant after load and on cache reuse so batched Jina rerank calls have a model `pad_token_id` aligned with the tokenizer.
- Count tiktoken special-token spellings in source code as normal text during chunk token counting so benchmark warm indexing does not fail on literal `<|endoftext|>` strings.
- Count tiktoken special-token spellings as normal text in reporting token accounting so `raw_grepped` raw-file token totals do not fail on the same source literals.
- Update reranker, chunker, and reporting tests to lock the Jina-sized window, CrossEncoder padding behavior, cached models, and source literals that match tokenizer special tokens.

## Operator benchmark notes

Three operator benchmark attempts were blocked before producing `archex_query_fusion_rerank` result rows:

1. `ValueError: Cannot handle batch sizes > 1 if no padding token is defined.`
   - Root cause: the Jina tokenizer had a pad token, but the underlying Qwen sequence-classification config still had `pad_token_id = None`.
   - Fix: set the model config pad id from the tokenizer pad id before batched prediction.
2. `ValueError: Encountered text corresponding to disallowed special token '<|endoftext|>'` during warm indexing.
   - Root cause: chunk token counting used tiktoken's default special-token rejection policy on source code.
   - Fix: count source text with `disallowed_special=()` so special-token spellings remain ordinary source text.
3. The same tiktoken error during `raw_grepped` token accounting.
   - Root cause: `archex.reporting.count_tokens()` still used default special-token rejection for raw file contents.
   - Fix: count reporting text with `disallowed_special=()` as well.

The pasted benchmark outputs are not Tier 1 quality verdicts because the fusion+rerank arm produced no result rows. The operator benchmark block needs to be rerun after pulling this branch.

## Validation

- `uv run ruff check` passed.
- `uv run ruff format --check .` passed.
- `uv run pyright` passed.
- `uv run pytest tests/index/test_rerank.py -q --no-cov` passed: 29 passed.
- `uv run pytest tests/index/test_chunker.py::test_chunk_file_counts_literal_special_token_text tests/index/test_chunker.py::test_token_count_is_accurate -q --no-cov` passed: 2 passed.
- `uv run pytest tests/test_reporting.py::test_count_tokens_treats_special_token_literals_as_text tests/test_reporting.py::test_count_tokens_known_string -q --no-cov` passed: 2 passed.
- `uv run pytest tests/test_reporting.py tests/benchmark/test_strategies.py tests/index/test_chunker.py tests/index/test_fusion.py tests/serve/ -q --no-cov` passed: 324 passed.
- `uv run pytest` passed: 1982 passed, 4 deselected, coverage 91.29%.
- Offline cached-Jina reranker smoke passed with batch size 2 under `HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1`.
- Exact requested narrow command `uv run pytest tests/index/test_fusion.py tests/serve/ -q` is coverage-invalid in this repo because coverage is measured globally against a subset.

## Review

- `pr-review` completed after commits and follow-up fixes: no blocking findings.
