### PR TITLE
feat(benchmark): add rich progress controller

### DIFF
--- a/src/archex/benchmark/progress.py
+++ b/src/archex/benchmark/progress.py
@@ -1,0 +1,195 @@
+"""Terminal progress rendering for benchmark runs."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from enum import StrEnum
+from types import TracebackType
+from typing import Protocol
+
+from rich.console import Console, Group
+from rich.live import Live
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    Task,
+    TaskID,
+    TaskProgressColumn,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+
+WARMING_ACTIVITY = "warming vector index…"
+
+
+class _BenchmarkTaskLike(Protocol):
+    @property
+    def task_id(self) -> str: ...
+
+    @property
+    def repo(self) -> str: ...
+
+
+class BenchmarkProgress:
+    """Own the benchmark live display and its two progress rows."""
+
+    def __init__(
+        self,
+        tasks: Sequence[_BenchmarkTaskLike],
+        *,
+        console: Console | None = None,
+        force_disable: bool = False,
+        refresh_per_second: float = 8.0,
+    ) -> None:
+        self.console = console or Console(stderr=True)
+        self._tasks = tasks
+        self._refresh_per_second = refresh_per_second
+        self._disable = force_disable or not self.console.is_terminal
+        self._overall_task_id: TaskID | None = None
+        self._active_task_id: TaskID | None = None
+        self._group: Group | None = None
+        self._live: Live | None = None
+        self.overall_progress = self._make_overall_progress()
+        self.active_progress = self._make_active_progress()
+
+    @property
+    def live_display_enabled(self) -> bool:
+        return not self._disable
+
+    @property
+    def active_task(self) -> Task | None:
+        if self._active_task_id is None:
+            return None
+        return self.active_progress.tasks[self._active_task_id]
+
+    def __enter__(self) -> BenchmarkProgress:
+        self._overall_task_id = self.overall_progress.add_task(
+            "",
+            total=len(self._tasks),
+            visible=bool(self._tasks),
+        )
+        self._active_task_id = self.active_progress.add_task(
+            "",
+            total=None,
+            activity="",
+            visible=False,
+        )
+        self._group = Group(self.overall_progress, self.active_progress)
+        if self.live_display_enabled:
+            self._live = Live(
+                self._group,
+                console=self.console,
+                refresh_per_second=self._refresh_per_second,
+                redirect_stdout=False,
+                redirect_stderr=False,
+            )
+            self._live.start(refresh=True)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del exc_type, exc_value, traceback
+        if self._live is not None:
+            self._live.stop()
+            self._live = None
+
+    def start_task(self, task: _BenchmarkTaskLike) -> None:
+        self._require_started()
+        self.overall_progress.update(
+            self._overall_id(),
+            description=f"{task.task_id} ({task.repo})",
+        )
+        self.active_progress.update(
+            self._active_id(),
+            description=f"  {task.task_id}",
+            total=None,
+            completed=0,
+            activity="",
+            visible=True,
+        )
+
+    def start_warmup(self) -> None:
+        self._require_started()
+        self.active_progress.update(
+            self._active_id(),
+            total=None,
+            completed=0,
+            activity=WARMING_ACTIVITY,
+            visible=True,
+        )
+
+    def finish_warmup(self, strategies: Sequence[object]) -> None:
+        self._require_started()
+        self.active_progress.update(
+            self._active_id(),
+            total=len(strategies),
+            completed=0,
+            activity="",
+            visible=True,
+        )
+
+    def start_strategy(self, strategy: StrEnum) -> None:
+        self._require_started()
+        self.active_progress.update(
+            self._active_id(),
+            activity=strategy.value,
+            visible=True,
+        )
+
+    def finish_strategy(self) -> None:
+        self._require_started()
+        self.active_progress.advance(self._active_id())
+
+    def finish_task(self) -> None:
+        self._require_started()
+        self.overall_progress.advance(self._overall_id())
+
+    def refresh(self) -> None:
+        if self._live is not None:
+            self._live.refresh()
+
+    def _make_overall_progress(self) -> Progress:
+        return Progress(
+            TextColumn("{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            TimeRemainingColumn(),
+            console=self.console,
+            disable=self._disable,
+            refresh_per_second=self._refresh_per_second,
+        )
+
+    def _make_active_progress(self) -> Progress:
+        return Progress(
+            SpinnerColumn(),
+            TextColumn("{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            TimeElapsedColumn(),
+            TextColumn("{task.fields[activity]}"),
+            console=self.console,
+            disable=self._disable,
+            refresh_per_second=self._refresh_per_second,
+        )
+
+    def _require_started(self) -> None:
+        if self._overall_task_id is None or self._active_task_id is None:
+            raise RuntimeError("BenchmarkProgress must be used as a context manager")
+
+    def _overall_id(self) -> TaskID:
+        self._require_started()
+        assert self._overall_task_id is not None
+        return self._overall_task_id
+
+    def _active_id(self) -> TaskID:
+        self._require_started()
+        assert self._active_task_id is not None
+        return self._active_task_id

--- a/tests/benchmark/test_progress.py
+++ b/tests/benchmark/test_progress.py
@@ -1,0 +1,86 @@
+"""Tests for benchmark progress rendering."""
+
+from __future__ import annotations
+
+import re
+from io import StringIO
+
+from rich.console import Console
+
+from archex.benchmark.models import BenchmarkTask, Strategy
+from archex.benchmark.progress import WARMING_ACTIVITY, BenchmarkProgress
+
+
+def _task(task_id: str, repo: str = ".") -> BenchmarkTask:
+    return BenchmarkTask(
+        task_id=task_id,
+        repo=repo,
+        commit="HEAD",
+        question="How does this work?",
+        expected_files=["main.py"],
+    )
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", text)
+
+
+def test_progress_renders_overall_and_active_task_text() -> None:
+    buffer = StringIO()
+    console = Console(file=buffer, force_terminal=True, color_system=None, width=140)
+    tasks = [_task("task_one", "owner/repo"), _task("task_two")]
+
+    with BenchmarkProgress(tasks, console=console, refresh_per_second=30) as progress:
+        progress.start_task(tasks[0])
+        progress.start_warmup()
+        progress.refresh()
+        progress.finish_warmup([Strategy.RAW_FILES, Strategy.ARCHEX_QUERY])
+        progress.start_strategy(Strategy.RAW_FILES)
+        progress.refresh()
+        progress.finish_strategy()
+        progress.start_strategy(Strategy.ARCHEX_QUERY)
+        progress.refresh()
+
+    output = _strip_ansi(buffer.getvalue())
+    assert "task_one (owner/repo)" in output
+    assert "0/2" in output
+    assert "raw_files" in output
+    assert "archex_query" in output
+    assert WARMING_ACTIVITY in output
+
+
+def test_warmup_is_indeterminate_then_flips_to_strategy_total() -> None:
+    buffer = StringIO()
+    console = Console(file=buffer, force_terminal=True, color_system=None, width=120)
+    task = _task("vector_task")
+    strategies = [Strategy.RAW_FILES, Strategy.ARCHEX_QUERY, Strategy.ARCHEX_QUERY_FUSION]
+
+    with BenchmarkProgress([task], console=console) as progress:
+        progress.start_task(task)
+        progress.start_warmup()
+        active = progress.active_task
+        assert active is not None
+        assert active.total is None
+        assert active.fields["activity"] == WARMING_ACTIVITY
+
+        progress.finish_warmup(strategies)
+        active = progress.active_task
+        assert active is not None
+        assert active.total == len(strategies)
+        assert active.completed == 0
+
+
+def test_non_tty_disables_live_display_and_progress_rows() -> None:
+    buffer = StringIO()
+    console = Console(file=buffer, force_terminal=False)
+    task = _task("plain_task")
+
+    with BenchmarkProgress([task], console=console) as progress:
+        assert progress.live_display_enabled is False
+        assert progress.overall_progress.disable is True
+        assert progress.active_progress.disable is True
+        progress.start_task(task)
+        progress.console.log("plain log line")
+
+    assert "plain log line" in buffer.getvalue()
+    assert "plain_task" not in buffer.getvalue()


### PR DESCRIPTION
## Stack

Base: `main`

1. `build/rich-direct-dep` -> parent PR #148
2. `feat/bench-progress-controller` -> this PR
3. `feat/bench-progress-integration` -> depends on this PR

## Summary

- Add `src/archex/benchmark/progress.py` with a context-manager Rich benchmark progress controller.
- Render two Progress instances in one Live group: overall task progress and active task progress.
- Keep warm-up indeterminate before flipping to `len(strategies)`.
- Disable Live/progress rendering for non-TTY output.
- Add rendering/state tests in `tests/benchmark/test_progress.py`.

## Validation

- PASS: `uv run ruff check && uv run ruff format --check . && uv run pyright`
- SELECTED TESTS PASS: `uv run pytest tests/benchmark/test_progress.py tests/benchmark/ -q` -> 217 passed, 2 deselected; command exits nonzero only because scoped pytest triggers repo-wide coverage fail-under.
- PASS: `uv run pytest -q` -> 1985 passed, 4 deselected, coverage 91.32%.
- PR review: no blocking or important issues found.

## Benchmark Policy

- No `archex benchmark run` or `archex dogfood` command was run.