### PR TITLE
feat(benchmark): wire rich progress into benchmark run

### DIFF
--- a/.docs/handoff.md
+++ b/.docs/handoff.md
@@ -1,0 +1,64 @@
+# Handoff — archex
+
+**Last touched:** 2026-05-30T07:40:42+05:30 · **branch:** `feat/bench-progress-integration` · **HEAD:** `6cddab2` · **session:** codex-gpt-5
+
+> Authority: this file owns *transient session state*. Persistent facts live in Codex memory. Static setup lives in `AGENTS.md` / repo instructions. Strategic roadmap lives in `.docs/2026-05-29-retrieval-recall-enhancement-plan.md`. Committed history lives in `git log`.
+
+## Status
+- Working tree: clean on `feat/bench-progress-integration` before this handoff rewrite; this file is the only expected post-validation edit until committed.
+- Active stack for Tier 1.5 benchmark progress visibility:
+  1. `build/rich-direct-dep` on `main` at `03ba28e`.
+  2. `feat/bench-progress-controller` on `build/rich-direct-dep` at `dc15f1e`.
+  3. `feat/bench-progress-integration` on `feat/bench-progress-controller` at `6cddab2`, with this handoff update to commit next.
+- G1 code has merged, but the decisive G1 operator benchmark has not been run yet. Tier 1.5 lands before that run so the long comparison is legible.
+- No `archex benchmark run` and no `archex dogfood` command was run in this session.
+- Validation completed on each implementation slice:
+  - `uv run ruff check && uv run ruff format --check . && uv run pyright` -> pass on all three branches.
+  - `uv run pytest tests/benchmark/test_progress.py tests/benchmark/ -q` -> selected benchmark tests passed on controller/integration slices, but the command exits nonzero because scoped pytest triggers repo-wide coverage fail-under. Latest integration run: `218 passed, 2 deselected`, coverage 39.32% vs 85%.
+  - `uv run pytest -q` -> pass on each branch. Latest integration run: `1986 passed, 4 deselected`, coverage 91.24%.
+- `pr-review` ran after each committed PR slice:
+  - `build/rich-direct-dep`: no issues.
+  - `feat/bench-progress-controller`: no blocking or important issues.
+  - `feat/bench-progress-integration`: no blocking or important issues.
+- PRs still need to be pushed/created if this handoff is being read before publish.
+
+## What changed this session
+- Synced local `main` with `origin/main` before starting the stack.
+- Added direct pinned dependency `rich==14.3.3` via `uv add "rich==14.3.3"` in `pyproject.toml` and `uv.lock`; resolved version did not change.
+- Added `src/archex/benchmark/progress.py`, a context-manager benchmark progress controller owning one stderr `Console`, one optional `Live`, and two `Progress` instances:
+  - Overall determinate row: task label, bar, `MofNCompleteColumn`, elapsed, remaining.
+  - Active-task row: spinner first, task label, bar, percent, elapsed, activity text.
+  - Warm-up starts indeterminate with `warming vector index…`, then flips to `len(strategies)`.
+  - Non-TTY or `--no-progress` disables Live/progress rendering.
+- Added `tests/benchmark/test_progress.py` to verify rendered task/counter/strategy/warm-up text, warm-up indeterminate-to-determinate state, and non-TTY disable behavior.
+- Wired one shared controller from `benchmark run` CLI through `run_all` into `run_benchmark`.
+- Removed `click.progressbar` from benchmark strategy execution.
+- Routed warming, skipped, and wrote messages through `progress.console.log(...)` when a controller is present, or plain stderr otherwise.
+- Added `--no-progress` to `archex benchmark run`; final `Completed ...` still emits after the Live context closes.
+- Added `load_selected_tasks(...)` so `run_cmd` can create the controller after applying task filters while `run_all` preserves direct-call behavior.
+
+## Decisions
+1. **Implementation gate only** (2026-05-30) — Tier 1.5 changes terminal rendering only, so it lands on lint/type/tests plus rendering tests. It does not run or add any operator benchmark.
+2. **Single shared Live owned by CLI path** (2026-05-30) — `run_cmd` creates one controller and keeps it open around `run_all`; `run_benchmark` only updates the active row.
+3. **Plain redirected output over escape spam** (2026-05-30) — Non-TTY and `--no-progress` disable Live/progress rows while preserving clean stderr log lines.
+
+## Blockers / open questions
+- [ ] Push the three branches and create the linear PR stack if not already published.
+- [ ] Visual confirmation is still pending on the next G1 decisive operator run. That run should confirm a coherent two-line Live view: overall `[n/N]`/ETA row plus active spinner row, with warm/wrote/skip lines scrolling above.
+- [ ] Redirected run behavior still needs operator-side confirmation with a real benchmark invocation such as `... 2> bench.log`; this session intentionally did not run benchmarks.
+
+## Resume checklist
+1. Confirm branch and tree: `git status --short --branch`.
+2. If `.docs/handoff.md` is uncommitted, commit it on `feat/bench-progress-integration` with `docs: update benchmark progress handoff`.
+3. Publish stack in order:
+   - `build/rich-direct-dep` -> base `main`.
+   - `feat/bench-progress-controller` -> base `build/rich-direct-dep`.
+   - `feat/bench-progress-integration` -> base `feat/bench-progress-controller`.
+4. Include validation notes in each PR body. Mention the scoped benchmark pytest coverage caveat explicitly.
+5. Do not run `archex benchmark run` or `archex dogfood` in-agent. The next visual check belongs to the operator's already-queued G1 decisive benchmark.
+
+## Refs
+- Plan: `.docs/2026-05-29-retrieval-recall-enhancement-plan.md` Tier 1.5.
+- Related PRs: pending publish for `build/rich-direct-dep`, `feat/bench-progress-controller`, `feat/bench-progress-integration`.
+- Memory: `MEMORY.md` archex stacked-PR workflow notes used for stack discipline and scoped pytest coverage caveat.
+- Conversation: current `/goal Implement Tier 1.5 (benchmark progress visibility)` thread.

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -8,13 +8,15 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-
-import click
+from typing import TYPE_CHECKING
 
 from archex.benchmark.loader import load_tasks
 from archex.benchmark.models import BenchmarkReport, BenchmarkResult, BenchmarkTask, Strategy
 from archex.benchmark.strategies import default_strategy_registry
 from archex.exceptions import ArchexIndexError, BenchmarkCloneError
+
+if TYPE_CHECKING:
+    from archex.benchmark.progress import BenchmarkProgress
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +136,7 @@ def run_benchmark(
     task: BenchmarkTask,
     strategies: list[Strategy] | None = None,
     repo_path: Path | None = None,
+    progress: BenchmarkProgress | None = None,
 ) -> BenchmarkReport:
     """Run a benchmark task across strategies. Clones repo if repo_path not provided."""
     if strategies is None:
@@ -149,34 +152,39 @@ def run_benchmark(
             repo_path, needs_cleanup = clone_at_commit(task.repo, task.commit)
 
     try:
-        if _check_vector_available() and any(s in _VECTOR_STRATEGIES for s in strategies):
-            print(f"  warming vector index for {task.task_id}...", file=sys.stderr, flush=True)
+        should_warm = _check_vector_available() and any(s in _VECTOR_STRATEGIES for s in strategies)
+        if should_warm:
+            _log_progress(progress, f"  warming vector index for {task.task_id}...")
+            if progress is not None:
+                progress.start_warmup()
             _warm_repo_index(task, repo_path)
+        if progress is not None:
+            progress.finish_warmup(strategies)
 
         results: list[BenchmarkResult] = []
-        with click.progressbar(
-            strategies,
-            label=f"  {task.task_id}",
-            item_show_func=lambda s: s.value if s is not None else "",
-            file=sys.stderr,
-        ) as bar:
-            for strategy in bar:
-                runner = default_strategy_registry.get(strategy)
-                if runner is None:
-                    logger.warning("No runner for strategy %s, skipping", strategy)
-                    continue
-                try:
-                    result = runner(task, repo_path)
-                    results.append(result)
-                    logger.info(
-                        "%s: %d tokens, recall=%.2f, %.0fms",
-                        strategy.value,
-                        result.tokens_total,
-                        result.recall,
-                        result.wall_time_ms,
-                    )
-                except (NotImplementedError, ArchexIndexError) as exc:
-                    logger.info("Skipping %s: %s", strategy.value, exc)
+        for strategy in strategies:
+            if progress is not None:
+                progress.start_strategy(strategy)
+            runner = default_strategy_registry.get(strategy)
+            if runner is None:
+                logger.warning("No runner for strategy %s, skipping", strategy)
+                if progress is not None:
+                    progress.finish_strategy()
+                continue
+            try:
+                result = runner(task, repo_path)
+                results.append(result)
+                logger.info(
+                    "%s: %d tokens, recall=%.2f, %.0fms",
+                    strategy.value,
+                    result.tokens_total,
+                    result.recall,
+                    result.wall_time_ms,
+                )
+            except (NotImplementedError, ArchexIndexError) as exc:
+                logger.info("Skipping %s: %s", strategy.value, exc)
+            if progress is not None:
+                progress.finish_strategy()
 
         # Compute baseline and backfill savings_vs_raw
         baseline_tokens = 0
@@ -218,17 +226,12 @@ def run_all(
     strategies: list[Strategy] | None = None,
     task_filter: str | None = None,
     self_only: bool = False,
+    progress: BenchmarkProgress | None = None,
+    tasks: list[BenchmarkTask] | None = None,
 ) -> list[BenchmarkReport]:
     """Load all tasks, run benchmarks, write results to output_dir."""
-    tasks = load_tasks(tasks_dir)
-    if self_only:
-        tasks = [t for t in tasks if t.repo == "."]
-        if not tasks:
-            raise ValueError(f"No self-only tasks found in {tasks_dir}")
-    if task_filter:
-        tasks = [t for t in tasks if t.task_id == task_filter]
-        if not tasks:
-            raise ValueError(f"No task found with id '{task_filter}'")
+    if tasks is None:
+        tasks = load_selected_tasks(tasks_dir, task_filter=task_filter, self_only=self_only)
 
     output_dir.mkdir(parents=True, exist_ok=True)
     reports: list[BenchmarkReport] = []
@@ -238,32 +241,65 @@ def run_all(
 
     try:
         for i, task in enumerate(tasks, 1):
-            print(f"[{i}/{len(tasks)}] {task.task_id} ({task.repo})", file=sys.stderr)
+            if progress is not None:
+                progress.start_task(task)
+                if not progress.live_display_enabled:
+                    progress.console.log(f"[{i}/{len(tasks)}] {task.task_id} ({task.repo})")
+            else:
+                print(f"[{i}/{len(tasks)}] {task.task_id} ({task.repo})", file=sys.stderr)
             try:
                 task_repo_path = _repo_path_for_task(task, repo_cache, cleanup_paths)
-                report = run_benchmark(task, strategies=strategies, repo_path=task_repo_path)
+                report = run_benchmark(
+                    task,
+                    strategies=strategies,
+                    repo_path=task_repo_path,
+                    progress=progress,
+                )
             except BenchmarkCloneError as exc:
                 # Isolate per-task clone failures (network, rate limit, bad ref) so one
                 # bad repo does not abort the whole batch.
                 logger.warning("Skipping task %s: %s", task.task_id, exc)
-                print(f"  SKIPPED {task.task_id}: {exc}", file=sys.stderr)
+                _log_progress(progress, f"  SKIPPED {task.task_id}: {exc}")
                 failures.append((task.task_id, str(exc)))
+                if progress is not None:
+                    progress.finish_task()
                 continue
             reports.append(report)
 
             result_path = output_dir / f"{task.task_id}.json"
             result_path.write_text(report.model_dump_json(indent=2), encoding="utf-8")
-            print(f"  → Wrote {result_path}", file=sys.stderr)
+            _log_progress(progress, f"  → Wrote {result_path}")
+            if progress is not None:
+                progress.finish_task()
 
         if failures:
-            print(f"\n{len(failures)} task(s) skipped due to clone failures:", file=sys.stderr)
+            _log_progress(progress, f"{len(failures)} task(s) skipped due to clone failures:")
             for task_id, detail in failures:
-                print(f"  - {task_id}: {detail}", file=sys.stderr)
+                _log_progress(progress, f"  - {task_id}: {detail}")
 
         return reports
     finally:
         for path in cleanup_paths:
             shutil.rmtree(path, ignore_errors=True)
+
+
+def load_selected_tasks(
+    tasks_dir: Path,
+    *,
+    task_filter: str | None = None,
+    self_only: bool = False,
+) -> list[BenchmarkTask]:
+    """Load benchmark tasks after applying run filters."""
+    tasks = load_tasks(tasks_dir)
+    if self_only:
+        tasks = [t for t in tasks if t.repo == "."]
+        if not tasks:
+            raise ValueError(f"No self-only tasks found in {tasks_dir}")
+    if task_filter:
+        tasks = [t for t in tasks if t.task_id == task_filter]
+        if not tasks:
+            raise ValueError(f"No task found with id '{task_filter}'")
+    return tasks
 
 
 def _repo_path_for_task(
@@ -285,6 +321,13 @@ def _repo_path_for_task(
     if needs_cleanup:
         cleanup_paths.append(repo_path)
     return repo_path
+
+
+def _log_progress(progress: BenchmarkProgress | None, message: str) -> None:
+    if progress is not None:
+        progress.console.log(message)
+    else:
+        print(message, file=sys.stderr)
 
 
 def _percentile(values: list[float], quantile: float) -> float:

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -19,6 +19,7 @@ from archex.benchmark.gate import (
 )
 from archex.benchmark.loader import load_tasks
 from archex.benchmark.models import BenchmarkReport, DeltaBenchmarkResult, Strategy
+from archex.benchmark.progress import BenchmarkProgress
 from archex.benchmark.readiness import (
     build_readiness_report,
     format_readiness_json,
@@ -31,7 +32,7 @@ from archex.benchmark.reporter import (
     format_markdown,
     format_summary,
 )
-from archex.benchmark.runner import DEFAULT_STRATEGIES, run_all
+from archex.benchmark.runner import DEFAULT_STRATEGIES, load_selected_tasks, run_all
 from archex.benchmark.triage import (
     format_triage_json,
     format_triage_markdown,
@@ -92,6 +93,12 @@ def benchmark_cmd() -> None:
     default=False,
     help='Run only benchmark tasks whose repo is ".".',
 )
+@click.option(
+    "--no-progress",
+    is_flag=True,
+    default=False,
+    help="Disable the live progress display.",
+)
 def run_cmd(
     output_dir: str,
     task_id: str | None,
@@ -101,6 +108,7 @@ def run_cmd(
     cross_layer_fusion: bool,
     rerank: bool,
     self_only: bool,
+    no_progress: bool,
 ) -> None:
     """Run benchmarks across strategies."""
     strategies: list[Strategy] = list(DEFAULT_STRATEGIES)
@@ -118,13 +126,18 @@ def run_cmd(
         if Strategy.ARCHEX_QUERY_FUSION_RERANK not in strategies:
             strategies.append(Strategy.ARCHEX_QUERY_FUSION_RERANK)
 
-    reports = run_all(
-        tasks_dir=Path(tasks_dir),
-        output_dir=Path(output_dir),
-        strategies=strategies,
-        task_filter=task_id,
-        self_only=self_only,
-    )
+    tasks_path = Path(tasks_dir)
+    tasks = load_selected_tasks(tasks_path, task_filter=task_id, self_only=self_only)
+    with BenchmarkProgress(tasks, force_disable=no_progress) as progress:
+        reports = run_all(
+            tasks_dir=tasks_path,
+            output_dir=Path(output_dir),
+            strategies=strategies,
+            task_filter=task_id,
+            self_only=self_only,
+            progress=progress,
+            tasks=tasks,
+        )
 
     click.echo(f"\nCompleted {len(reports)} benchmark(s).", err=True)
 

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -4,16 +4,18 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from click.testing import CliRunner
 
-from archex.benchmark.models import BenchmarkReport, BenchmarkResult, Strategy
+from archex.benchmark.models import BenchmarkReport, BenchmarkResult, BenchmarkTask, Strategy
 from archex.cli.benchmark_cmd import benchmark_cmd
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from archex.benchmark.progress import BenchmarkProgress
 
 
 @pytest.fixture
@@ -65,6 +67,16 @@ expected_files:
   - src/main.py
 """)
     return tasks
+
+
+def _empty_tasks(
+    tasks_dir: Path,
+    *,
+    task_filter: str | None = None,
+    self_only: bool = False,
+) -> list[BenchmarkTask]:
+    del tasks_dir, task_filter, self_only
+    return []
 
 
 class TestReportCommand:
@@ -228,6 +240,7 @@ class TestRunCommand:
         assert "--cross_layer_fusion" in result.output
         assert "--rerank" in result.output
         assert "--self-only" in result.output
+        assert "--no-progress" in result.output
 
     def test_run_uses_default_strategies_without_flags(
         self,
@@ -242,11 +255,14 @@ class TestRunCommand:
             strategies: list[Strategy] | None = None,
             task_filter: str | None = None,
             self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
         ) -> list[BenchmarkReport]:
-            del tasks_dir, output_dir, task_filter, self_only
+            del tasks_dir, output_dir, task_filter, self_only, progress, tasks
             captured["strategies"] = strategies
             return []
 
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
         monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
         result = runner.invoke(benchmark_cmd, ["run"])
         assert result.exit_code == 0
@@ -269,11 +285,14 @@ class TestRunCommand:
             strategies: list[Strategy] | None = None,
             task_filter: str | None = None,
             self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
         ) -> list[BenchmarkReport]:
-            del tasks_dir, output_dir, task_filter, self_only
+            del tasks_dir, output_dir, task_filter, self_only, progress, tasks
             captured["strategies"] = strategies
             return []
 
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
         monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
         result = runner.invoke(
             benchmark_cmd,
@@ -301,11 +320,14 @@ class TestRunCommand:
             strategies: list[Strategy] | None = None,
             task_filter: str | None = None,
             self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
         ) -> list[BenchmarkReport]:
-            del tasks_dir, output_dir, task_filter, self_only
+            del tasks_dir, output_dir, task_filter, self_only, progress, tasks
             captured["strategies"] = strategies
             return []
 
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
         monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
         result = runner.invoke(benchmark_cmd, ["run", "--rerank"])
         assert result.exit_code == 0
@@ -330,12 +352,42 @@ class TestRunCommand:
             strategies: list[Strategy] | None = None,
             task_filter: str | None = None,
             self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
         ) -> list[BenchmarkReport]:
-            del tasks_dir, output_dir, strategies, task_filter
+            del tasks_dir, output_dir, strategies, task_filter, progress, tasks
             captured["self_only"] = self_only
             return []
 
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
         monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
         result = runner.invoke(benchmark_cmd, ["run", "--self-only"])
         assert result.exit_code == 0
         assert captured["self_only"] is True
+
+    def test_run_no_progress_forces_disabled_controller(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, tasks
+            assert progress is not None
+            captured["progress_enabled"] = cast("BenchmarkProgress", progress).live_display_enabled
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(benchmark_cmd, ["run", "--no-progress"])
+        assert result.exit_code == 0
+        assert captured["progress_enabled"] is False


### PR DESCRIPTION
## Stack

Base: `main`

1. `build/rich-direct-dep` -> parent PR #148
2. `feat/bench-progress-controller` -> parent PR #149
3. `feat/bench-progress-integration` -> this PR

## Summary

- Create one benchmark progress controller in `benchmark run` and thread it through `run_all` into `run_benchmark`.
- Replace the per-task `click.progressbar` strategy loop with controller updates.
- Route warming, skipped, and wrote messages through `progress.console.log(...)` above the Live display.
- Add `--no-progress` to force disabled progress rendering.
- Keep final `Completed ...` output after the Live context closes.
- Update `.docs/handoff.md` with Tier 1.5 status and pending operator visual confirmation.

## Validation

- PASS: `uv run ruff check && uv run ruff format --check . && uv run pyright`
- SELECTED TESTS PASS: `uv run pytest tests/benchmark/test_progress.py tests/benchmark/ -q` -> 218 passed, 2 deselected; command exits nonzero only because scoped pytest triggers repo-wide coverage fail-under.
- PASS: `uv run pytest -q` -> 1986 passed, 4 deselected, coverage 91.24%.
- PR review: no blocking or important issues found.

## Benchmark Policy

- No `archex benchmark run` or `archex dogfood` command was run.
- The new display awaits visual confirmation during the already-queued G1 decisive operator benchmark.