### PR TITLE
feat(retrieval): add opt-in splade candidate leg

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -171,6 +171,7 @@ def _full_index(
         )
         edges = graph.file_edges()
         store.insert_edges(edges)
+        _build_splade_index(store, all_chunks, effective_index_config)
 
         if config.cache:
             commit = cloned_head or cache.git_head(source.local_path) or source.commit or ""
@@ -497,6 +498,43 @@ def _compute_top_k(total_chunks: int) -> int:
 def _compute_vector_top_k(*, bm25_top_k: int, total_chunks: int) -> int:
     """Use a deeper independent vector pool for fusion candidate union."""
     return min(total_chunks, bm25_top_k * 2)
+
+
+def _compute_splade_top_k(*, bm25_top_k: int, total_chunks: int) -> int:
+    """Use SPLADE as a recall leg with the same depth as vector fusion."""
+    return min(total_chunks, bm25_top_k * 2)
+
+
+def _build_splade_index(
+    store: IndexStore,
+    chunks: list[CodeChunk],
+    index_config: IndexConfig,
+) -> None:
+    if not index_config.splade:
+        return
+    from archex.index.splade import SPLADEIndex
+
+    splade = SPLADEIndex(store)
+    splade.build(chunks)
+
+
+def _splade_search_or_raise(
+    store: IndexStore,
+    question: str,
+    index_config: IndexConfig,
+    top_k: int,
+) -> list[tuple[CodeChunk, float]] | None:
+    if not index_config.splade:
+        return None
+    from archex.index.splade import SPLADEIndex
+
+    splade = SPLADEIndex(store)
+    if not splade.has_data:
+        raise ArchexIndexError(
+            "SPLADE requested but the cached index has no SPLADE rows; "
+            "refresh it with `archex index --splade`."
+        )
+    return splade.search(question, top_k=top_k)
 
 
 _PATH_NOISE = frozenset(
@@ -1069,6 +1107,10 @@ def query(
                     bm25_top_k=top_k,
                     total_chunks=chunk_count,
                 )
+                splade_top_k = _compute_splade_top_k(
+                    bm25_top_k=top_k,
+                    total_chunks=chunk_count,
+                )
                 # Pre-load all chunks into memory before parallel search so the
                 # vector thread has no dependency on the SQLite store connection.
                 all_chunks_cached = store.get_chunks()
@@ -1105,6 +1147,12 @@ def query(
                         search_results = []
                         path_boost = []
                         symbol_seeds = []
+                    splade_results = _splade_search_or_raise(
+                        store,
+                        question,
+                        index_config,
+                        splade_top_k,
+                    )
                     vector_results: list[tuple[CodeChunk, float]] | None = _vec_future.result()
 
                 # Fall back to rerank when pre-computed .npz is absent
@@ -1149,12 +1197,18 @@ def query(
                                 "bm25_results": len(search_results),
                                 "path_boost": len(path_boost),
                                 "symbol_seeds": len(symbol_seeds),
+                                "splade_results": len(splade_results or []),
                                 "top_k": top_k,
                                 "vector_top_k": vector_top_k,
+                                "splade_top_k": splade_top_k,
                             },
                         )
                     )
-                query_avg_idf = bm25.avg_idf(question) if vector_results is not None else None
+                query_avg_idf = (
+                    bm25.avg_idf(question)
+                    if vector_results is not None or splade_results is not None
+                    else None
+                )
                 # Cross-encoder reranker: enabled only when index_config.rerank is set.
                 _reranker = _maybe_reranker(index_config)
                 bundle = assemble_context(
@@ -1164,6 +1218,7 @@ def query(
                     question=question,
                     token_budget=effective_budget,
                     vector_results=vector_results,  # type: ignore[arg-type]
+                    splade_results=splade_results,
                     scoring_weights=scoring_weights,
                     trace=trace,
                     avg_idf=query_avg_idf,
@@ -1280,6 +1335,7 @@ def query(
             edges = graph.file_edges()
             store.insert_edges(edges)
             bm25.build(all_chunks)
+            _build_splade_index(store, all_chunks, index_config)
 
             # Pre-compute vector embeddings at index time when vector mode is enabled
             _precomputed_vector_path: Path | None = None
@@ -1342,6 +1398,10 @@ def query(
 
             top_k = _compute_top_k(len(all_chunks))
             vector_top_k = _compute_vector_top_k(
+                bm25_top_k=top_k,
+                total_chunks=len(all_chunks),
+            )
+            splade_top_k = _compute_splade_top_k(
                 bm25_top_k=top_k,
                 total_chunks=len(all_chunks),
             )
@@ -1412,6 +1472,12 @@ def query(
                     search_results = []
                     path_boost = []
                     symbol_seeds_miss = []
+                splade_results_miss = _splade_search_or_raise(
+                    store,
+                    question,
+                    index_config,
+                    splade_top_k,
+                )
                 vector_results_miss: list[tuple[CodeChunk, float]] | None = _vec_future.result()
 
             # Fall back to rerank when pre-computed .npz is absent
@@ -1455,12 +1521,18 @@ def query(
                             "bm25_results": len(search_results),
                             "path_boost": len(path_boost),
                             "symbol_seeds": len(symbol_seeds_miss),
+                            "splade_results": len(splade_results_miss or []),
                             "top_k": top_k,
                             "vector_top_k": vector_top_k,
+                            "splade_top_k": splade_top_k,
                         },
                     )
                 )
-            query_avg_idf_miss = bm25.avg_idf(question) if vector_results_miss is not None else None
+            query_avg_idf_miss = (
+                bm25.avg_idf(question)
+                if vector_results_miss is not None or splade_results_miss is not None
+                else None
+            )
             _reranker_miss = _maybe_reranker(index_config)
             bundle = assemble_context(
                 search_results=search_results,
@@ -1469,6 +1541,7 @@ def query(
                 question=question,
                 token_budget=effective_budget,
                 vector_results=vector_results_miss,  # type: ignore[arg-type]
+                splade_results=splade_results_miss,
                 scoring_weights=scoring_weights,
                 trace=trace,
                 avg_idf=query_avg_idf_miss,

--- a/src/archex/cli/index_cmd.py
+++ b/src/archex/cli/index_cmd.py
@@ -33,12 +33,15 @@ def _language_counts(file_metadata: list[dict[str, str | int]]) -> dict[str, int
     type=click.Choice(["text", "json"]),
     help="Output format.",
 )
-def index_cmd(source: str, output_format: str) -> None:
+@click.option("--splade", is_flag=True, default=False, help="Build the opt-in SPLADE index.")
+def index_cmd(source: str, output_format: str, splade: bool) -> None:
     """Build or refresh the index for SOURCE without running a query."""
     repo_source = RepoSource(local_path=source)
     repo_root = Path(source).expanduser().resolve()
     config = load_config(repo_source)
     index_config = load_index_config(repo_source)
+    if splade:
+        index_config = index_config.model_copy(update={"splade": True})
     timing = PipelineTiming()
     started = time.perf_counter()
     try:

--- a/src/archex/cli/query_cmd.py
+++ b/src/archex/cli/query_cmd.py
@@ -29,6 +29,7 @@ from archex.utils import resolve_source
 )
 @click.option("--timing", is_flag=True, default=False, help="Print timing breakdown.")
 @click.option("--metrics", is_flag=True, default=False, help="Print timing metrics as JSON.")
+@click.option("--splade", is_flag=True, default=False, help="Use the opt-in SPLADE retrieval leg.")
 def query_cmd(
     args: tuple[str, ...],
     budget: int,
@@ -37,6 +38,7 @@ def query_cmd(
     strategy: str | None,
     timing: bool,
     metrics: bool,
+    splade: bool,
 ) -> None:
     """Query a repository and return a context bundle."""
     from archex.config import load_config, load_index_config
@@ -50,6 +52,8 @@ def query_cmd(
     index_config = load_index_config(repo_source)
     if strategy is not None:
         index_config = index_config.model_copy(update={"vector": strategy == "hybrid"})
+    if splade:
+        index_config = index_config.model_copy(update={"splade": True})
 
     pt = PipelineTiming() if (timing or metrics) else None
     try:

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -138,6 +138,7 @@ class Config(BaseModel):
 class IndexConfig(BaseModel):
     bm25: bool = True
     vector: bool = False
+    splade: bool = False
     embedder: str | None = None
     vector_mode: VectorMode = VectorMode.RAW
     surrogate_version: str = "v1"
@@ -150,8 +151,8 @@ class IndexConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_index_config(self) -> IndexConfig:
-        if not self.bm25 and not self.vector:
-            raise ValueError("At least one of bm25 or vector must be enabled")
+        if not self.bm25 and not self.vector and not self.splade:
+            raise ValueError("At least one of bm25, vector, or splade must be enabled")
         if self.chunk_max_tokens <= 0:
             raise ValueError("chunk_max_tokens must be > 0")
         if self.chunk_min_tokens < 0:
@@ -574,6 +575,10 @@ class RetrievalMetadata(BaseModel):
     fusion_skipped: bool = False
     fusion_skip_reason: str = ""
     bm25_cv: float | None = None
+    splade_results: int = 0
+    splade_used: bool = False
+    splade_fusion_skipped: bool = False
+    splade_fusion_skip_reason: str = ""
     lexical_confidence: str = ""  # "high", "medium", "low"
     vector_mode: VectorMode = VectorMode.RAW
     surrogate_version: str | None = None

--- a/src/archex/project.py
+++ b/src/archex/project.py
@@ -21,6 +21,7 @@ mode = "local"
 cache_dir = ".archex"
 languages = []
 vector = false
+splade = false
 delta_threshold = 0.5
 
 [dogfood]

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -626,6 +626,7 @@ def assemble_context(
             base_results = merged
             bm25_by_id = _normalized_scores(merged)
             effective_splade = splade_results
+            strategy = "hybrid+splade+graph" if effective_vector else "bm25+splade+graph"
             logger.debug("SPLADE fusion applied (RSF): %s", splade_reason)
         else:
             splade_fusion_skipped = True
@@ -651,7 +652,7 @@ def assemble_context(
     # Expand: follow directed imports from seed files, prioritized by seed score.
     # imports_of(file) = files this file depends on (high relevance — same call chain)
     # imported_by(file) = files that depend on this file (moderate relevance — consumers)
-    seed_file_scores = _seed_file_scores(search_results, vector_results, effective_splade)
+    seed_file_scores = _seed_file_scores(search_results, effective_vector, effective_splade)
 
     # Normalize seed file scores to [0, 1] for expansion gating
     max_seed_score = max(seed_file_scores.values()) if seed_file_scores else 1.0
@@ -907,7 +908,7 @@ def assemble_context(
     sorted_files = sorted(file_agg.items(), key=lambda x: -x[1])
     top_file_score = sorted_files[0][1] if sorted_files else 0.0
     score_cutoff = top_file_score * _file_score_cutoff_ratio(
-        fusion_applied=fusion_bm25_weight is not None
+        fusion_applied=fusion_bm25_weight is not None or bool(effective_splade)
     )
     top_files: set[str] = set()
     adaptive_max = _adaptive_max_files(sorted_files)

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -349,6 +349,7 @@ def _normalized_scores(results: list[tuple[CodeChunk, float]]) -> dict[str, floa
 def _seed_file_scores(
     search_results: list[tuple[CodeChunk, float]],
     vector_results: list[tuple[CodeChunk, float]] | None,
+    splade_results: list[tuple[CodeChunk, float]] | None,
 ) -> dict[str, float]:
     scores: dict[str, float] = {}
     for chunk, score in search_results:
@@ -360,6 +361,10 @@ def _seed_file_scores(
                 continue
             effective = score * (0.6 if _is_test_file(chunk.file_path) else 1.0)
             scores[chunk.file_path] = effective
+    if splade_results:
+        for chunk, score in splade_results:
+            effective = score * (0.6 if _is_test_file(chunk.file_path) else 1.0)
+            scores[chunk.file_path] = max(scores.get(chunk.file_path, 0.0), effective)
     return scores
 
 
@@ -391,10 +396,14 @@ def _add_file_chunks(
 def _initial_candidate_map(
     search_results: list[tuple[CodeChunk, float]],
     vector_results: list[tuple[CodeChunk, float]] | None,
+    splade_results: list[tuple[CodeChunk, float]] | None,
 ) -> dict[str, CodeChunk]:
     candidate_map = {chunk.id: chunk for chunk, _ in search_results}
     if vector_results:
         for chunk, _ in vector_results:
+            candidate_map.setdefault(chunk.id, chunk)
+    if splade_results:
+        for chunk, _ in splade_results:
             candidate_map.setdefault(chunk.id, chunk)
     return candidate_map
 
@@ -505,6 +514,7 @@ def assemble_context(
     question: str,
     token_budget: int = 8192,
     vector_results: list[tuple[CodeChunk, float]] | None = None,
+    splade_results: list[tuple[CodeChunk, float]] | None = None,
     scoring_weights: ScoringWeights | None = None,
     modules: list[Module] | None = None,
     trace: PipelineTrace | None = None,
@@ -514,8 +524,8 @@ def assemble_context(
 ) -> ContextBundle:
     """Assemble a token-budgeted ContextBundle from search results and a dependency graph.
 
-    When vector_results is provided, uses Reciprocal Rank Fusion to merge BM25 and
-    vector results before scoring.
+    When vector_results or splade_results are provided, uses score fusion to merge
+    opt-in retrieval legs before scoring.
     When modules is provided, computes cohesion signal per chunk.
     When trace is provided, records step-level timings for graph_expansion, scoring,
     and assembly phases.
@@ -531,8 +541,10 @@ def assemble_context(
     weights = INTENT_WEIGHTS[intent] if scoring_weights is None else scoring_weights
 
     strategy = "hybrid+graph" if vector_results else "bm25+graph"
+    if splade_results:
+        strategy = "hybrid+splade+graph" if vector_results else "bm25+splade+graph"
 
-    if not search_results and not vector_results:
+    if not search_results and not vector_results and not splade_results:
         return ContextBundle(
             query=question,
             token_budget=token_budget,
@@ -544,7 +556,12 @@ def assemble_context(
     fusion_vector_weight: float | None = None
     fusion_skipped = False
     fusion_skip_reason = ""
+    splade_fusion_skipped = False
+    splade_fusion_skip_reason = ""
     bm25_cv_val: float | None = None
+    effective_vector: list[tuple[CodeChunk, float]] = []
+    effective_splade: list[tuple[CodeChunk, float]] = []
+    base_results = search_results
     if vector_results:
         from archex.index.fusion import adaptive_rsf, bm25_score_cv, should_fuse
 
@@ -569,7 +586,9 @@ def assemble_context(
             merged, fusion_bm25_weight, fusion_vector_weight = adaptive_rsf(
                 search_results, vector_results, signal_agreement_pre, bm25_cv_val
             )
+            base_results = merged
             bm25_by_id = _normalized_scores(merged)
+            effective_vector = vector_results
             logger.debug("Fusion applied (RSF): %s", fuse_reason)
         else:
             # BM25 is confident — skip fusion, use BM25 results only
@@ -582,9 +601,40 @@ def assemble_context(
     else:
         signal_agreement_pre = 0.0
         bm25_by_id = _normalized_scores(search_results)
-    # When fusion is skipped, exclude vector results from seeds to avoid noise
-    effective_vector = vector_results if (vector_results and not fusion_skipped) else []
-    all_results = search_results + effective_vector
+
+    if splade_results:
+        from archex.index.fusion import adaptive_rsf, bm25_score_cv, should_fuse
+
+        splade_cv = bm25_cv_val if bm25_cv_val is not None else bm25_score_cv(search_results)
+        splade_fuse, splade_reason = should_fuse(
+            search_results,
+            splade_results,
+            avg_idf=avg_idf,
+        )
+        if splade_fuse or not search_results:
+            _k_agree = 20
+            _bm25_top_k = {chunk.file_path for chunk, _ in search_results[:_k_agree]}
+            _splade_top_k = {chunk.file_path for chunk, _ in splade_results[:_k_agree]}
+            _union = _bm25_top_k | _splade_top_k
+            splade_agreement = len(_bm25_top_k & _splade_top_k) / len(_union) if _union else 0.0
+            merged, _, _ = adaptive_rsf(
+                base_results,
+                splade_results,
+                splade_agreement,
+                splade_cv,
+            )
+            base_results = merged
+            bm25_by_id = _normalized_scores(merged)
+            effective_splade = splade_results
+            logger.debug("SPLADE fusion applied (RSF): %s", splade_reason)
+        else:
+            splade_fusion_skipped = True
+            splade_fusion_skip_reason = splade_reason
+            if not vector_results:
+                strategy = "bm25+graph"
+            logger.debug("SPLADE fusion skipped: %s", splade_reason)
+
+    all_results = search_results + effective_vector + effective_splade
     seed_file_paths = _unique_file_paths(all_results)
     seed_files: set[str] = set(seed_file_paths)
 
@@ -601,7 +651,7 @@ def assemble_context(
     # Expand: follow directed imports from seed files, prioritized by seed score.
     # imports_of(file) = files this file depends on (high relevance — same call chain)
     # imported_by(file) = files that depend on this file (moderate relevance — consumers)
-    seed_file_scores = _seed_file_scores(search_results, vector_results)
+    seed_file_scores = _seed_file_scores(search_results, vector_results, effective_splade)
 
     # Normalize seed file scores to [0, 1] for expansion gating
     max_seed_score = max(seed_file_scores.values()) if seed_file_scores else 1.0
@@ -691,7 +741,7 @@ def assemble_context(
     max_per_file = 1 if intent == QueryIntent.CLI else 3
     # Vector-only seeds participate in scoring even when BM25 returned nothing
     # for that file.
-    candidate_map = _initial_candidate_map(search_results, vector_results)
+    candidate_map = _initial_candidate_map(search_results, effective_vector, effective_splade)
     expansion_files_added = 0
     hop1_files_added: list[str] = []
     expanded_file_paths: list[str] = []
@@ -956,6 +1006,10 @@ def assemble_context(
         fusion_skipped=fusion_skipped,
         fusion_skip_reason=fusion_skip_reason,
         bm25_cv=bm25_cv_val,
+        splade_results=len(splade_results or []),
+        splade_used=bool(effective_splade),
+        splade_fusion_skipped=splade_fusion_skipped,
+        splade_fusion_skip_reason=splade_fusion_skip_reason,
     )
 
     return ContextBundle(

--- a/tests/index/test_splade.py
+++ b/tests/index/test_splade.py
@@ -11,9 +11,11 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from archex.exceptions import ArchexIndexError
+from archex.index.graph import DependencyGraph
 from archex.index.splade import SPLADEEncoder, SPLADEIndex
 from archex.index.store import IndexStore
 from archex.models import CodeChunk, SymbolKind
+from archex.serve.context import assemble_context
 
 SAMPLE_CHUNKS = [
     CodeChunk(
@@ -201,6 +203,71 @@ def test_search_scores_descending(store_and_index: tuple[IndexStore, SPLADEIndex
     results = idx.search("session manager")
     scores = [s for _, s in results]
     assert scores == sorted(scores, reverse=True)
+
+
+def test_search_return_contract_matches_bm25(
+    store_and_index: tuple[IndexStore, SPLADEIndex],
+) -> None:
+    _, idx = store_and_index
+    results = idx.search("authenticate", top_k=2)
+
+    assert len(results) <= 2
+    for chunk, score in results:
+        assert isinstance(chunk, CodeChunk)
+        assert isinstance(score, float)
+        assert score > 0
+
+
+def test_build_then_query_vocabulary_mismatch_candidate(
+    tmp_path: Path,
+    fake_encoder: FakeSPLADEEncoder,
+) -> None:
+    db = tmp_path / "vocab_mismatch.db"
+    store = IndexStore(db)
+    chunk = CodeChunk(
+        id="tasks.py:celery_task_dispatch:1",
+        content=(
+            "def celery_task_dispatch(payload: dict[str, str]) -> None:\n    worker.send(payload)"
+        ),
+        file_path="tasks.py",
+        start_line=1,
+        end_line=2,
+        symbol_name="celery_task_dispatch",
+        symbol_kind=SymbolKind.FUNCTION,
+        language="python",
+        token_count=24,
+    )
+    store.insert_chunks([chunk])
+    idx = SPLADEIndex(store, encoder=fake_encoder)
+
+    idx.build([chunk])
+    results = idx.search("dispatch worker", top_k=5)
+
+    assert [result_chunk.id for result_chunk, _ in results] == [chunk.id]
+    store.close()
+
+
+def test_assemble_context_uses_splade_candidate_when_opted_in(
+    store_and_index: tuple[IndexStore, SPLADEIndex],
+) -> None:
+    _, idx = store_and_index
+    splade_results = idx.search("session commit database", top_k=5)
+    graph = DependencyGraph()
+    for chunk, _ in splade_results:
+        graph.add_file_node(chunk.file_path)
+
+    bundle = assemble_context(
+        search_results=[],
+        graph=graph,
+        all_chunks=[chunk for chunk, _ in splade_results],
+        question="session lifecycle",
+        token_budget=1000,
+        splade_results=splade_results,
+    )
+
+    assert bundle.retrieval_metadata.splade_used is True
+    assert bundle.retrieval_metadata.splade_results == len(splade_results)
+    assert {rc.chunk.id for rc in bundle.chunks} == {chunk.id for chunk, _ in splade_results}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,7 +110,20 @@ def test_index_command_uses_project_config(python_simple_repo: Path) -> None:
     index_config = index_mock.call_args.kwargs["index_config"]
     assert config.cache_dir == str(python_simple_repo / ".archex")
     assert index_config.vector is False
+    assert index_config.splade is False
     assert store.closed is True
+
+
+def test_index_command_splade_flag_enables_splade(python_simple_repo: Path) -> None:
+    store = FakeIndexStore()
+    runner = CliRunner()
+
+    with patch("archex.cli.index_cmd.index_repository", return_value=store) as index_mock:
+        result = runner.invoke(cli, ["index", str(python_simple_repo), "--splade"])
+
+    assert result.exit_code == 0, result.output
+    index_config = index_mock.call_args.kwargs["index_config"]
+    assert index_config.splade is True
 
 
 def test_index_command_json_output(python_simple_repo: Path) -> None:
@@ -423,6 +436,7 @@ def test_query_uses_project_config_when_cli_args_omitted(python_simple_repo: Pat
     assert config.cache_dir == str(python_simple_repo / ".archex")
     assert config.languages is None
     assert index_config.vector is False
+    assert index_config.splade is False
 
 
 def test_query_cli_options_override_project_config(python_simple_repo: Path) -> None:
@@ -449,6 +463,7 @@ def test_query_cli_options_override_project_config(python_simple_repo: Path) -> 
                 "python",
                 "--strategy",
                 "hybrid",
+                "--splade",
             ],
         )
 
@@ -457,6 +472,7 @@ def test_query_cli_options_override_project_config(python_simple_repo: Path) -> 
     index_config = query_mock.call_args.kwargs["index_config"]
     assert config.languages == ["python"]
     assert index_config.vector is True
+    assert index_config.splade is True
 
 
 def test_query_timing_flag(python_simple_repo: Path) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -514,8 +514,11 @@ class TestIndexConfigValidation:
         assert config.chunk_min_tokens == 0
 
     def test_both_disabled_raises(self) -> None:
-        with pytest.raises(ValueError, match="At least one of bm25 or vector must be enabled"):
-            IndexConfig(bm25=False, vector=False)
+        with pytest.raises(
+            ValueError,
+            match="At least one of bm25, vector, or splade must be enabled",
+        ):
+            IndexConfig(bm25=False, vector=False, splade=False)
 
     def test_bm25_only_valid(self) -> None:
         config = IndexConfig(bm25=True, vector=False)
@@ -526,6 +529,12 @@ class TestIndexConfigValidation:
         config = IndexConfig(bm25=False, vector=True)
         assert config.bm25 is False
         assert config.vector is True
+
+    def test_splade_only_valid(self) -> None:
+        config = IndexConfig(bm25=False, vector=False, splade=True)
+        assert config.bm25 is False
+        assert config.vector is False
+        assert config.splade is True
 
     def test_both_enabled_valid(self) -> None:
         config = IndexConfig(bm25=True, vector=True)

--- a/tests/test_query_pipeline.py
+++ b/tests/test_query_pipeline.py
@@ -171,5 +171,8 @@ class TestIndexConfigQueryPaths:
     def test_bm25_false_vector_false_raises(self) -> None:
         from pydantic import ValidationError
 
-        with pytest.raises(ValidationError, match="At least one of bm25 or vector must be enabled"):
+        with pytest.raises(
+            ValidationError,
+            match="At least one of bm25, vector, or splade must be enabled",
+        ):
             IndexConfig(bm25=False, vector=False)


### PR DESCRIPTION
## Stack

Stack-Id: `tier2-candidate-pool-20260530`
Base: `main`
Position: 1/2

1. `feat/splade-leg` -> this PR
2. `feat/module-summary-prefilter` -> pending

Depends on: none
Upstack: pending

## Summary

- Adds opt-in `IndexConfig.splade`, `archex index --splade`, and `archex query --splade` without changing default retrieval behavior.
- Builds SPLADE rows during cache-miss indexing or explicit indexing when opted in.
- Fails fast when `--splade` is requested against a cached index without SPLADE rows.
- Fuses SPLADE as a third candidate source behind the existing confidence gate and records SPLADE metadata.
- Adds local deterministic SPLADE build/query and candidate-assembly coverage.

## Validation

- Passed: `uv run ruff check && uv run ruff format --check . && uv run pyright`
- Passed: `uv run pytest tests/index/test_splade.py tests/analyze/test_modules.py -q --no-cov`
- Ran requested exact pytest command: `uv run pytest tests/index/test_splade.py tests/analyze/test_modules.py -q`; tests passed functionally, command failed only on existing repo-wide coverage fail-under (`23.22% < 85%`) because the scoped command still applies global coverage.
- pr-review: completed; fixed SPLADE fusion seed/cutoff consistency before publishing.
