### PR TITLE
feat(retrieval): add module summary prefilter

### DIFF
--- a/.docs/handoff.md
+++ b/.docs/handoff.md
@@ -1,64 +1,65 @@
 # Handoff — archex
 
-**Last touched:** 2026-05-30T07:40:42+05:30 · **branch:** `feat/bench-progress-integration` · **HEAD:** `6cddab2` · **session:** codex-gpt-5
+**Last touched:** 2026-05-30T18:54:39+05:30 · **branch:** `feat/module-summary-prefilter` · **HEAD:** `2d17349` · **session:** codex-gpt-5
 
 > Authority: this file owns *transient session state*. Persistent facts live in Codex memory. Static setup lives in `AGENTS.md` / repo instructions. Strategic roadmap lives in `.docs/2026-05-29-retrieval-recall-enhancement-plan.md`. Committed history lives in `git log`.
 
 ## Status
-- Working tree: clean on `feat/bench-progress-integration` before this handoff rewrite; this file is the only expected post-validation edit until committed.
-- Active stack for Tier 1.5 benchmark progress visibility:
-  1. `build/rich-direct-dep` on `main` at `03ba28e`.
-  2. `feat/bench-progress-controller` on `build/rich-direct-dep` at `dc15f1e`.
-  3. `feat/bench-progress-integration` on `feat/bench-progress-controller` at `6cddab2`, with this handoff update to commit next.
-- G1 code has merged, but the decisive G1 operator benchmark has not been run yet. Tier 1.5 lands before that run so the long comparison is legible.
+- Working tree: clean before this handoff rewrite; `.docs/handoff.md` is the only expected uncommitted edit and must be force-added because `.docs/` is ignored.
+- Active Tier 2 candidate-pool stack:
+  1. `feat/splade-leg` on `main` at `f5580cd`; PR #151, base `main`.
+  2. `feat/module-summary-prefilter` on `feat/splade-leg` at `2d17349`; PR #152, base `feat/splade-leg`.
 - No `archex benchmark run` and no `archex dogfood` command was run in this session.
+- T2.3 is measurement only. Graph expansion instrumentation was left untouched; the operator block below includes expansion contribution triage and `MAX_EXPANSION_FILES` review.
 - Validation completed on each implementation slice:
-  - `uv run ruff check && uv run ruff format --check . && uv run pyright` -> pass on all three branches.
-  - `uv run pytest tests/benchmark/test_progress.py tests/benchmark/ -q` -> selected benchmark tests passed on controller/integration slices, but the command exits nonzero because scoped pytest triggers repo-wide coverage fail-under. Latest integration run: `218 passed, 2 deselected`, coverage 39.32% vs 85%.
-  - `uv run pytest -q` -> pass on each branch. Latest integration run: `1986 passed, 4 deselected`, coverage 91.24%.
+  - `uv run ruff check && uv run ruff format --check . && uv run pyright` -> pass on both branches.
+  - `uv run pytest tests/index/test_splade.py tests/analyze/test_modules.py -q --no-cov` -> pass; latest leaf run `44 passed, 2 deselected`.
+  - Requested exact scoped pytest command was run: `uv run pytest tests/index/test_splade.py tests/analyze/test_modules.py -q`. Tests passed functionally but command exits nonzero because repo-wide coverage fail-under still applies to scoped pytest; latest leaf run `44 passed, 2 deselected`, coverage `23.71% < 85%`.
 - `pr-review` ran after each committed PR slice:
-  - `build/rich-direct-dep`: no issues.
-  - `feat/bench-progress-controller`: no blocking or important issues.
-  - `feat/bench-progress-integration`: no blocking or important issues.
-- PRs still need to be pushed/created if this handoff is being read before publish.
+  - `feat/splade-leg`: fixed SPLADE fusion seed/cutoff consistency before publishing.
+  - `feat/module-summary-prefilter`: fixed invalid `module_prefilter=True, bm25=False` no-op by enforcing a config invariant before publishing.
 
 ## What changed this session
-- Synced local `main` with `origin/main` before starting the stack.
-- Added direct pinned dependency `rich==14.3.3` via `uv add "rich==14.3.3"` in `pyproject.toml` and `uv.lock`; resolved version did not change.
-- Added `src/archex/benchmark/progress.py`, a context-manager benchmark progress controller owning one stderr `Console`, one optional `Live`, and two `Progress` instances:
-  - Overall determinate row: task label, bar, `MofNCompleteColumn`, elapsed, remaining.
-  - Active-task row: spinner first, task label, bar, percent, elapsed, activity text.
-  - Warm-up starts indeterminate with `warming vector index…`, then flips to `len(strategies)`.
-  - Non-TTY or `--no-progress` disables Live/progress rendering.
-- Added `tests/benchmark/test_progress.py` to verify rendered task/counter/strategy/warm-up text, warm-up indeterminate-to-determinate state, and non-TTY disable behavior.
-- Wired one shared controller from `benchmark run` CLI through `run_all` into `run_benchmark`.
-- Removed `click.progressbar` from benchmark strategy execution.
-- Routed warming, skipped, and wrote messages through `progress.console.log(...)` when a controller is present, or plain stderr otherwise.
-- Added `--no-progress` to `archex benchmark run`; final `Completed ...` still emits after the Live context closes.
-- Added `load_selected_tasks(...)` so `run_cmd` can create the controller after applying task filters while `run_all` preserves direct-call behavior.
+- Synced local `main` with `origin/main` before starting Tier 2.
+- PR #151 (`feat/splade-leg`) adds opt-in SPLADE retrieval:
+  - `IndexConfig.splade`, `.archex/settings.toml` default `splade = false`, and CLI flags `archex index --splade` / `archex query --splade`.
+  - Cache-miss and explicit indexing build SPLADE rows only when opted in.
+  - Query-time SPLADE fails fast against cached indexes without SPLADE rows instead of silently dropping the leg.
+  - `assemble_context(...)` accepts `splade_results`, gates SPLADE via existing fusion confidence logic, contributes SPLADE candidates only when fused, and records SPLADE metadata.
+  - Tests verify SPLADE search contract, deterministic build/query, and SPLADE candidate assembly without loading the real model.
+- PR #152 (`feat/module-summary-prefilter`) adds opt-in module responsibility prefiltering:
+  - `analyze/modules.py` now populates `Module.responsibility` deterministically from module names, paths, exports, and external dependencies.
+  - `IndexStore` persists module summaries as JSON in a `modules` table.
+  - `IndexConfig.module_prefilter`, `.archex/settings.toml` default `module_prefilter = false`, and CLI flags `archex index --module-prefilter` / `archex query --module-prefilter` keep behavior opt-in.
+  - Cached query fails fast when module prefiltering is requested without persisted module summaries.
+  - Query path runs BM25 over module responsibility strings and contributes capped chunks from matched modules into the candidate pool.
+  - Tests verify responsibility population and candidate boosting for lifecycle-style queries.
 
 ## Decisions
-1. **Implementation gate only** (2026-05-30) — Tier 1.5 changes terminal rendering only, so it lands on lint/type/tests plus rendering tests. It does not run or add any operator benchmark.
-2. **Single shared Live owned by CLI path** (2026-05-30) — `run_cmd` creates one controller and keeps it open around `run_all`; `run_benchmark` only updates the active row.
-3. **Plain redirected output over escape spam** (2026-05-30) — Non-TTY and `--no-progress` disable Live/progress rows while preserving clean stderr log lines.
+1. **Opt-in only** (2026-05-30) — SPLADE and module prefiltering are both gated by explicit config/CLI flags. Product-default BM25 behavior remains unchanged until measured.
+2. **Fail fast on missing opt-in artifacts** (2026-05-30) — Querying with `--splade` or `--module-prefilter` against an old cached index raises `ArchexIndexError` with the refresh command. Silent fallback would corrupt benchmark interpretation.
+3. **Module prefilter requires BM25** (2026-05-30) — The prefilter is a BM25 responsibility pass that biases BM25 candidate assembly. `module_prefilter=True` with `bm25=False` is invalid instead of being accepted as a no-op.
 
 ## Blockers / open questions
-- [ ] Push the three branches and create the linear PR stack if not already published.
-- [ ] Visual confirmation is still pending on the next G1 decisive operator run. That run should confirm a coherent two-line Live view: overall `[n/N]`/ETA row plus active spinner row, with warm/wrote/skip lines scrolling above.
-- [ ] Redirected run behavior still needs operator-side confirmation with a real benchmark invocation such as `... 2> bench.log`; this session intentionally did not run benchmarks.
+- [ ] GitHub checks for PR #151 and PR #152 still need to complete if CI is enabled.
+- [ ] The decisive Tier 2 benchmark has not been run. The operator must run it outside this session.
+- [ ] After benchmark results are pasted back, record per-leg deltas and graph-expansion contribution in this file.
 
 ## Resume checklist
 1. Confirm branch and tree: `git status --short --branch`.
-2. If `.docs/handoff.md` is uncommitted, commit it on `feat/bench-progress-integration` with `docs: update benchmark progress handoff`.
-3. Publish stack in order:
-   - `build/rich-direct-dep` -> base `main`.
-   - `feat/bench-progress-controller` -> base `build/rich-direct-dep`.
-   - `feat/bench-progress-integration` -> base `feat/bench-progress-controller`.
-4. Include validation notes in each PR body. Mention the scoped benchmark pytest coverage caveat explicitly.
-5. Do not run `archex benchmark run` or `archex dogfood` in-agent. The next visual check belongs to the operator's already-queued G1 decisive benchmark.
+2. Confirm PR topology: `gh pr view 151 --json headRefName,baseRefName,state,url` and `gh pr view 152 --json headRefName,baseRefName,state,url`.
+3. Watch or inspect CI if available. Do not delete `feat/splade-leg` while PR #152 still targets it.
+4. Operator run, separate terminal:
+   ```bash
+   uv run archex benchmark run --query-fusion --rerank --tasks-dir benchmarks/tasks --output .archex/e2e-results
+   uv run archex benchmark triage --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
+   ```
+5. Pass criterion: vocabulary-mismatch / external-large recall improves; no regression on self or framework-semantic buckets.
+6. T2.3 measurement triage: quantify graph expansion recall contribution using `meta.seed_file_paths` / `meta.expanded_file_paths`, then decide whether `MAX_EXPANSION_FILES` should widen beyond 8. Do not change graph expansion constants unless measurement justifies it.
+7. If operator results are pasted back, update `.docs/handoff.md` with per-leg deltas and the expansion verdict. Do not start Tier 3.
 
 ## Refs
-- Plan: `.docs/2026-05-29-retrieval-recall-enhancement-plan.md` Tier 1.5.
-- Related PRs: pending publish for `build/rich-direct-dep`, `feat/bench-progress-controller`, `feat/bench-progress-integration`.
+- Plan: `.docs/2026-05-29-retrieval-recall-enhancement-plan.md` Tier 2.
+- Related PRs: #151 (`feat/splade-leg`), #152 (`feat/module-summary-prefilter`).
 - Memory: `MEMORY.md` archex stacked-PR workflow notes used for stack discipline and scoped pytest coverage caveat.
-- Conversation: current `/goal Implement Tier 1.5 (benchmark progress visibility)` thread.
+- Conversation: current `/goal Implement Tier 2 (candidate pool expansion)` thread.

--- a/.docs/handoff.md
+++ b/.docs/handoff.md
@@ -1,16 +1,17 @@
 # Handoff — archex
 
-**Last touched:** 2026-05-30T18:54:39+05:30 · **branch:** `feat/module-summary-prefilter` · **HEAD:** `2d17349` · **session:** codex-gpt-5
+**Last touched:** 2026-05-31T00:19:09+05:30 · **branch:** `feat/module-summary-prefilter` · **HEAD:** `current leaf` · **session:** codex-gpt-5
 
 > Authority: this file owns *transient session state*. Persistent facts live in Codex memory. Static setup lives in `AGENTS.md` / repo instructions. Strategic roadmap lives in `.docs/2026-05-29-retrieval-recall-enhancement-plan.md`. Committed history lives in `git log`.
 
 ## Status
-- Working tree: clean before this handoff rewrite; `.docs/handoff.md` is the only expected uncommitted edit and must be force-added because `.docs/` is ignored.
+- Working tree: `.docs/handoff.md` records the completed operator benchmark verdict and is force-added because `.docs/` is ignored.
 - Active Tier 2 candidate-pool stack:
   1. `feat/splade-leg` on `main` at `f5580cd`; PR #151, base `main`.
-  2. `feat/module-summary-prefilter` on `feat/splade-leg` at `2d17349`; PR #152, base `feat/splade-leg`.
-- No `archex benchmark run` and no `archex dogfood` command was run in this session.
-- T2.3 is measurement only. Graph expansion instrumentation was left untouched; the operator block below includes expansion contribution triage and `MAX_EXPANSION_FILES` review.
+  2. `feat/module-summary-prefilter` on `feat/splade-leg`; PR #152, base `feat/splade-leg`.
+- Operator benchmark completed from `.docs/benchmark-log.md` using the requested commands. This session did not run `archex benchmark run` or `archex dogfood`.
+- Tier 2 pass criterion was not met for the requested final strategy `archex_query_fusion_rerank`: vocabulary-mismatch / external-large did not improve versus `archex_query`, and self / architecture-broad regressed.
+- Important measurement caveat: the operator commands did not pass `--splade` or `--module-prefilter`, and both new Tier 2 legs default off. The run measured existing query/fusion/rerank behavior on this branch, not the opt-in SPLADE/module-prefilter legs. No SPLADE/module-prefilter per-leg deltas are available from this run.
 - Validation completed on each implementation slice:
   - `uv run ruff check && uv run ruff format --check . && uv run pyright` -> pass on both branches.
   - `uv run pytest tests/index/test_splade.py tests/analyze/test_modules.py -q --no-cov` -> pass; latest leaf run `44 passed, 2 deselected`.
@@ -18,6 +19,36 @@
 - `pr-review` ran after each committed PR slice:
   - `feat/splade-leg`: fixed SPLADE fusion seed/cutoff consistency before publishing.
   - `feat/module-summary-prefilter`: fixed invalid `module_prefilter=True, bm25=False` no-op by enforcing a config invariant before publishing.
+
+## Benchmark verdict
+- Commands recorded in `.docs/benchmark-log.md`:
+  ```bash
+  uv run archex benchmark run --query-fusion --rerank --tasks-dir benchmarks/tasks --output .archex/e2e-results
+  uv run archex benchmark triage --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
+  ```
+- Aggregate recall / F1 by bucket:
+  | Bucket | n | query recall | fusion recall | fusion+rerank recall | rerank delta vs query | query F1 | fusion+rerank F1 | F1 delta |
+  |---|---:|---:|---:|---:|---:|---:|---:|---:|
+  | architecture-broad | 3 | 0.556 | 0.444 | 0.222 | -0.333 | 0.444 | 0.167 | -0.278 |
+  | external-framework | 9 | 0.685 | 0.667 | 0.537 | -0.148 | 0.522 | 0.402 | -0.120 |
+  | external-large | 5 | 0.367 | 0.500 | 0.333 | -0.033 | 0.279 | 0.228 | -0.051 |
+  | framework-semantic | 2 | 0.333 | 0.333 | 0.500 | +0.167 | 0.325 | 0.393 | +0.068 |
+  | self | 16 | 0.590 | 0.618 | 0.252 | -0.338 | 0.495 | 0.177 | -0.317 |
+- Zero-recall count by bucket:
+  | Bucket | query | fusion | fusion+rerank |
+  |---|---:|---:|---:|
+  | architecture-broad | 0/3 | 0/3 | 2/3 |
+  | external-framework | 0/9 | 0/9 | 0/9 |
+  | external-large | 1/5 | 0/5 | 2/5 |
+  | framework-semantic | 0/2 | 0/2 | 0/2 |
+  | self | 0/16 | 0/16 | 3/16 |
+- Latency: fusion+rerank is ~107-168s average per bucket versus query at ~1.4-13.8s. The quality regression plus latency makes `archex_query_fusion_rerank` non-mergeable as a default decision.
+- Fusion alone is more promising than rerank: external-large recall improves from 0.367 to 0.500 and self improves from 0.590 to 0.618, but architecture-broad and external-framework still regress.
+- Graph expansion T2.3:
+  - `archex_graph_expansion` under `archex_query`: final recall 1.0, seed recall 0.5, expansion contribution +0.5, 8 expanded files. Expansion helped the non-rerank query path.
+  - `archex_graph_expansion` under fusion: final recall 1.0, seed recall 1.0, expansion contribution 0.0, 8 expanded files. Seeds already covered expected files.
+  - `archex_graph_expansion` under fusion+rerank: final recall 0.0, seed recall 1.0, expansion contribution -1.0, 8 expanded files. Rerank dropped the relevant graph-expanded/seed candidates.
+  - `MAX_EXPANSION_FILES=8` was hit often, but widening it is not the next move while rerank is eliminating already-present relevant candidates. Fix or disable rerank before tuning expansion width.
 
 ## What changed this session
 - Synced local `main` with `origin/main` before starting Tier 2.
@@ -42,21 +73,17 @@
 
 ## Blockers / open questions
 - [ ] GitHub checks for PR #151 and PR #152 still need to complete if CI is enabled.
-- [ ] The decisive Tier 2 benchmark has not been run. The operator must run it outside this session.
-- [ ] After benchmark results are pasted back, record per-leg deltas and graph-expansion contribution in this file.
+- [ ] Decide whether to merge the opt-in Tier 2 plumbing despite the benchmark caveat. The run did not exercise `--splade` or `--module-prefilter`, so it does not validate those legs.
+- [ ] Do not start Tier 3. The default/rerank decision is not justified by this benchmark.
 
 ## Resume checklist
 1. Confirm branch and tree: `git status --short --branch`.
 2. Confirm PR topology: `gh pr view 151 --json headRefName,baseRefName,state,url` and `gh pr view 152 --json headRefName,baseRefName,state,url`.
 3. Watch or inspect CI if available. Do not delete `feat/splade-leg` while PR #152 still targets it.
-4. Operator run, separate terminal:
-   ```bash
-   uv run archex benchmark run --query-fusion --rerank --tasks-dir benchmarks/tasks --output .archex/e2e-results
-   uv run archex benchmark triage --input .archex/e2e-results --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
-   ```
-5. Pass criterion: vocabulary-mismatch / external-large recall improves; no regression on self or framework-semantic buckets.
-6. T2.3 measurement triage: quantify graph expansion recall contribution using `meta.seed_file_paths` / `meta.expanded_file_paths`, then decide whether `MAX_EXPANSION_FILES` should widen beyond 8. Do not change graph expansion constants unless measurement justifies it.
-7. If operator results are pasted back, update `.docs/handoff.md` with per-leg deltas and the expansion verdict. Do not start Tier 3.
+4. If measuring the actual new opt-in Tier 2 legs, add benchmark support or a controlled command path that passes `splade=True` and `module_prefilter=True`; the recorded operator command does not enable them.
+5. Keep product defaults unchanged. `archex_query_fusion_rerank` failed the Tier 2 pass criterion.
+6. Do not widen `MAX_EXPANSION_FILES` yet. Rerank candidate elimination, not graph expansion width, is the measured failure mode for `archex_graph_expansion`.
+7. Do not start Tier 3.
 
 ## Refs
 - Plan: `.docs/2026-05-29-retrieval-recall-enhancement-plan.md` Tier 2.

--- a/src/archex/analyze/modules.py
+++ b/src/archex/analyze/modules.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import TYPE_CHECKING, Any, cast
 
 import networkx as nx
@@ -94,6 +95,41 @@ def _cohesion_score(community: set[str], g: Any) -> float:
     return round(internal / max_possible, 4)
 
 
+def _identifier_terms(value: str) -> list[str]:
+    raw = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", value.replace("_", " "))
+    return [term.lower() for term in re.findall(r"[a-zA-Z][a-zA-Z0-9]{2,}", raw)]
+
+
+def _module_responsibility(
+    name: str,
+    root_path: str,
+    files: list[str],
+    exports: list[SymbolRef],
+    external_deps: list[str],
+) -> str:
+    terms: list[str] = []
+    terms.extend(_identifier_terms(name))
+    terms.extend(_identifier_terms(root_path))
+    for file_path in files:
+        stem = os.path.splitext(os.path.basename(file_path))[0]
+        terms.extend(_identifier_terms(stem))
+        terms.extend(_identifier_terms(os.path.dirname(file_path)))
+    for export in exports:
+        terms.extend(_identifier_terms(export.name))
+        terms.append(str(export.kind))
+    for dep in external_deps:
+        terms.extend(_identifier_terms(dep))
+
+    seen: set[str] = set()
+    unique_terms: list[str] = []
+    for term in terms:
+        if term in seen:
+            continue
+        seen.add(term)
+        unique_terms.append(term)
+    return " ".join(unique_terms)
+
+
 def _build_module_from_community(
     community: set[str],
     g: Any,
@@ -149,6 +185,7 @@ def _build_module_from_community(
     external_deps = sorted(external_dep_set)
 
     cohesion = _cohesion_score(community, g)
+    responsibility = _module_responsibility(name, root_path, files, exports, external_deps)
 
     return Module(
         name=name,
@@ -157,6 +194,7 @@ def _build_module_from_community(
         exports=exports,
         internal_deps=internal_deps,
         external_deps=external_deps,
+        responsibility=responsibility,
         cohesion_score=cohesion,
         file_count=len(files),
         line_count=line_count,

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -68,6 +68,8 @@ from archex.models import (
     FileOutline,
     FileTree,
     IndexConfig,
+    Module,
+    ParsedFile,
     PipelineTiming,
     RepoMetadata,
     RepoSource,
@@ -172,6 +174,7 @@ def _full_index(
         edges = graph.file_edges()
         store.insert_edges(edges)
         _build_splade_index(store, all_chunks, effective_index_config)
+        _build_module_summaries(store, graph, parsed_files, effective_index_config)
 
         if config.cache:
             commit = cloned_head or cache.git_head(source.local_path) or source.commit or ""
@@ -518,6 +521,19 @@ def _build_splade_index(
     splade.build(chunks)
 
 
+def _build_module_summaries(
+    store: IndexStore,
+    graph: DependencyGraph,
+    parsed_files: list[ParsedFile],
+    index_config: IndexConfig,
+) -> list[Module]:
+    if not index_config.module_prefilter:
+        return []
+    modules = detect_modules(graph, parsed_files)
+    store.insert_modules(modules)
+    return modules
+
+
 def _splade_search_or_raise(
     store: IndexStore,
     question: str,
@@ -535,6 +551,18 @@ def _splade_search_or_raise(
             "refresh it with `archex index --splade`."
         )
     return splade.search(question, top_k=top_k)
+
+
+def _modules_or_raise(store: IndexStore, index_config: IndexConfig) -> list[Module]:
+    if not index_config.module_prefilter:
+        return []
+    modules = store.get_modules()
+    if not modules:
+        raise ArchexIndexError(
+            "Module prefilter requested but the cached index has no module summaries; "
+            "refresh it with `archex index --module-prefilter`."
+        )
+    return modules
 
 
 _PATH_NOISE = frozenset(
@@ -793,19 +821,102 @@ def _symbol_search_seeds(
     return seeds
 
 
+def _module_prefilter_boosts(
+    modules: list[Module],
+    all_chunks: list[CodeChunk],
+    question: str,
+    existing_ids: set[str],
+    max_bm25_score: float,
+    *,
+    max_modules: int = 3,
+    max_chunks_per_module: int = 8,
+) -> list[tuple[CodeChunk, float]]:
+    if not modules:
+        return []
+
+    import sqlite3
+
+    from archex.index.bm25 import escape_fts_query
+
+    escaped = escape_fts_query(question)
+    if not escaped:
+        return []
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute(
+            "CREATE VIRTUAL TABLE module_fts USING fts5("
+            "ordinal UNINDEXED, name, responsibility, tokenize='porter unicode61')"
+        )
+        conn.executemany(
+            "INSERT INTO module_fts (ordinal, name, responsibility) VALUES (?, ?, ?)",
+            [
+                (idx, module.name, module.responsibility or "")
+                for idx, module in enumerate(modules)
+                if module.responsibility
+            ],
+        )
+        rows = conn.execute(
+            "SELECT ordinal, bm25(module_fts, 2.0, 8.0) AS score "
+            "FROM module_fts WHERE module_fts MATCH ? ORDER BY score LIMIT ?",
+            (escaped, max_modules),
+        ).fetchall()
+        if not rows and " AND " in escaped:
+            rows = conn.execute(
+                "SELECT ordinal, bm25(module_fts, 2.0, 8.0) AS score "
+                "FROM module_fts WHERE module_fts MATCH ? ORDER BY score LIMIT ?",
+                (escaped.replace(" AND ", " OR "), max_modules),
+            ).fetchall()
+    finally:
+        conn.close()
+
+    if not rows:
+        return []
+
+    chunks_by_file: dict[str, list[CodeChunk]] = {}
+    for chunk in all_chunks:
+        chunks_by_file.setdefault(chunk.file_path, []).append(chunk)
+
+    seen = set(existing_ids)
+    boosts: list[tuple[CodeChunk, float]] = []
+    for rank, (ordinal, raw_score) in enumerate(rows):
+        module = modules[int(ordinal)]
+        score = max_bm25_score * (0.45 / (rank + 1))
+        if float(raw_score) == 0.0:
+            score *= 0.5
+        added_for_module = 0
+        for file_path in module.files:
+            for chunk in chunks_by_file.get(file_path, []):
+                if chunk.id in seen:
+                    continue
+                seen.add(chunk.id)
+                boosts.append((chunk, score))
+                added_for_module += 1
+                if added_for_module >= max_chunks_per_module:
+                    break
+            if added_for_module >= max_chunks_per_module:
+                break
+
+    return boosts
+
+
 def _bm25_search_with_boosts(
     bm25: BM25Index,
     store: IndexStore,
     question: str,
     top_k: int,
+    all_chunks: list[CodeChunk],
+    modules: list[Module],
+    index_config: IndexConfig,
 ) -> tuple[
     list[tuple[CodeChunk, float]],
     list[tuple[CodeChunk, float]],
     list[tuple[CodeChunk, float]],
+    list[tuple[CodeChunk, float]],
 ]:
-    """Run BM25 search plus file-path and symbol-seed boosts.
+    """Run BM25 search plus candidate-pool boosts.
 
-    Returns (search_results, path_boost, symbol_seeds) as separate lists so
+    Returns retrieval legs as separate lists so
     callers can record individual counts for observability, then combine them.
     """
     expanded_question = _expand_retrieval_question(question)
@@ -824,7 +935,14 @@ def _bm25_search_with_boosts(
         for c, s in _symbol_search_seeds(store, expanded_question, max_bm25_score=max_bm25)
         if c.id not in all_existing
     ]
-    return results, path_boost, symbol_seeds
+    module_boost = _module_prefilter_boosts(
+        modules if index_config.module_prefilter else [],
+        all_chunks,
+        expanded_question,
+        all_existing | {c.id for c, _ in symbol_seeds},
+        max_bm25_score=max_bm25,
+    )
+    return results, path_boost, symbol_seeds, module_boost
 
 
 def _vector_search_precomputed(
@@ -1115,6 +1233,7 @@ def query(
                 # vector thread has no dependency on the SQLite store connection.
                 all_chunks_cached = store.get_chunks()
                 surrogate_lookup = _surrogate_lookup(store, all_chunks_cached, index_config)
+                modules_cached = _modules_or_raise(store, index_config)
 
                 t_search = time.perf_counter()
                 cached_npz = cache.vector_path(
@@ -1136,17 +1255,26 @@ def query(
                         vector_top_k,
                     )
                     if index_config.bm25:
-                        _bm25_raw, path_boost, symbol_seeds = _bm25_search_with_boosts(
+                        (
+                            _bm25_raw,
+                            path_boost,
+                            symbol_seeds,
+                            module_boost,
+                        ) = _bm25_search_with_boosts(
                             bm25,
                             store,
                             question,
                             top_k,
+                            all_chunks_cached,
+                            modules_cached,
+                            index_config,
                         )
-                        search_results = _bm25_raw + path_boost + symbol_seeds
+                        search_results = _bm25_raw + path_boost + symbol_seeds + module_boost
                     else:
                         search_results = []
                         path_boost = []
                         symbol_seeds = []
+                        module_boost = []
                     splade_results = _splade_search_or_raise(
                         store,
                         question,
@@ -1197,6 +1325,7 @@ def query(
                                 "bm25_results": len(search_results),
                                 "path_boost": len(path_boost),
                                 "symbol_seeds": len(symbol_seeds),
+                                "module_boost": len(module_boost),
                                 "splade_results": len(splade_results or []),
                                 "top_k": top_k,
                                 "vector_top_k": vector_top_k,
@@ -1336,6 +1465,7 @@ def query(
             store.insert_edges(edges)
             bm25.build(all_chunks)
             _build_splade_index(store, all_chunks, index_config)
+            modules_miss = _build_module_summaries(store, graph, parsed_files, index_config)
 
             # Pre-compute vector embeddings at index time when vector mode is enabled
             _precomputed_vector_path: Path | None = None
@@ -1461,17 +1591,26 @@ def query(
                     vector_top_k,
                 )
                 if index_config.bm25:
-                    _bm25_raw, path_boost, symbol_seeds_miss = _bm25_search_with_boosts(
+                    (
+                        _bm25_raw,
+                        path_boost,
+                        symbol_seeds_miss,
+                        module_boost_miss,
+                    ) = _bm25_search_with_boosts(
                         bm25,
                         store,
                         question,
                         top_k,
+                        all_chunks,
+                        modules_miss,
+                        index_config,
                     )
-                    search_results = _bm25_raw + path_boost + symbol_seeds_miss
+                    search_results = _bm25_raw + path_boost + symbol_seeds_miss + module_boost_miss
                 else:
                     search_results = []
                     path_boost = []
                     symbol_seeds_miss = []
+                    module_boost_miss = []
                 splade_results_miss = _splade_search_or_raise(
                     store,
                     question,
@@ -1521,6 +1660,7 @@ def query(
                             "bm25_results": len(search_results),
                             "path_boost": len(path_boost),
                             "symbol_seeds": len(symbol_seeds_miss),
+                            "module_boost": len(module_boost_miss),
                             "splade_results": len(splade_results_miss or []),
                             "top_k": top_k,
                             "vector_top_k": vector_top_k,

--- a/src/archex/cli/index_cmd.py
+++ b/src/archex/cli/index_cmd.py
@@ -34,7 +34,13 @@ def _language_counts(file_metadata: list[dict[str, str | int]]) -> dict[str, int
     help="Output format.",
 )
 @click.option("--splade", is_flag=True, default=False, help="Build the opt-in SPLADE index.")
-def index_cmd(source: str, output_format: str, splade: bool) -> None:
+@click.option(
+    "--module-prefilter",
+    is_flag=True,
+    default=False,
+    help="Build opt-in module responsibility summaries.",
+)
+def index_cmd(source: str, output_format: str, splade: bool, module_prefilter: bool) -> None:
     """Build or refresh the index for SOURCE without running a query."""
     repo_source = RepoSource(local_path=source)
     repo_root = Path(source).expanduser().resolve()
@@ -42,6 +48,8 @@ def index_cmd(source: str, output_format: str, splade: bool) -> None:
     index_config = load_index_config(repo_source)
     if splade:
         index_config = index_config.model_copy(update={"splade": True})
+    if module_prefilter:
+        index_config = index_config.model_copy(update={"module_prefilter": True})
     timing = PipelineTiming()
     started = time.perf_counter()
     try:

--- a/src/archex/cli/query_cmd.py
+++ b/src/archex/cli/query_cmd.py
@@ -30,6 +30,12 @@ from archex.utils import resolve_source
 @click.option("--timing", is_flag=True, default=False, help="Print timing breakdown.")
 @click.option("--metrics", is_flag=True, default=False, help="Print timing metrics as JSON.")
 @click.option("--splade", is_flag=True, default=False, help="Use the opt-in SPLADE retrieval leg.")
+@click.option(
+    "--module-prefilter",
+    is_flag=True,
+    default=False,
+    help="Use opt-in module responsibility prefiltering.",
+)
 def query_cmd(
     args: tuple[str, ...],
     budget: int,
@@ -39,6 +45,7 @@ def query_cmd(
     timing: bool,
     metrics: bool,
     splade: bool,
+    module_prefilter: bool,
 ) -> None:
     """Query a repository and return a context bundle."""
     from archex.config import load_config, load_index_config
@@ -54,6 +61,8 @@ def query_cmd(
         index_config = index_config.model_copy(update={"vector": strategy == "hybrid"})
     if splade:
         index_config = index_config.model_copy(update={"splade": True})
+    if module_prefilter:
+        index_config = index_config.model_copy(update={"module_prefilter": True})
 
     pt = PipelineTiming() if (timing or metrics) else None
     try:

--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -6,7 +6,7 @@ import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from archex.models import ChunkSurrogate, CodeChunk, Edge, EdgeKind, SymbolKind
+from archex.models import ChunkSurrogate, CodeChunk, Edge, EdgeKind, Module, SymbolKind
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -57,6 +57,16 @@ CREATE TABLE IF NOT EXISTS chunk_surrogates (
 );
 """
 
+_CREATE_MODULES = """
+CREATE TABLE IF NOT EXISTS modules (
+    ordinal INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    root_path TEXT NOT NULL,
+    responsibility TEXT NOT NULL,
+    module_json TEXT NOT NULL
+);
+"""
+
 _CREATE_IDX_CHUNKS_FILE = "CREATE INDEX IF NOT EXISTS idx_chunks_file ON chunks(file_path);"
 _CREATE_IDX_CHUNKS_SYMBOL_ID = (
     "CREATE INDEX IF NOT EXISTS idx_chunks_symbol_id ON chunks(symbol_id);"
@@ -76,6 +86,7 @@ _CREATE_IDX_EDGES_TARGET = "CREATE INDEX IF NOT EXISTS idx_edges_target ON edges
 _CREATE_IDX_CHUNK_SURROGATES_FILE = (
     "CREATE INDEX IF NOT EXISTS idx_chunk_surrogates_file ON chunk_surrogates(file_path);"
 )
+_CREATE_IDX_MODULES_NAME = "CREATE INDEX IF NOT EXISTS idx_modules_name ON modules(name);"
 
 _CREATE_SYMBOLS_FTS = """
 CREATE VIRTUAL TABLE IF NOT EXISTS symbols_fts USING fts5(
@@ -146,10 +157,12 @@ class IndexStore:
             + _CREATE_EDGES
             + _CREATE_METADATA
             + _CREATE_CHUNK_SURROGATES
+            + _CREATE_MODULES
             + _CREATE_IDX_CHUNKS_FILE
             + _CREATE_IDX_EDGES_SOURCE
             + _CREATE_IDX_EDGES_TARGET
             + _CREATE_IDX_CHUNK_SURROGATES_FILE
+            + _CREATE_IDX_MODULES_NAME
         )
         # Create BM25 FTS table so delete operations are safe without prior BM25Index init
         cur.executescript("""
@@ -238,6 +251,26 @@ class IndexStore:
 
     def insert_edges(self, edges: list[Edge]) -> None:
         self._insert_edges_no_commit(edges)
+        self._conn.commit()
+
+    def insert_modules(self, modules: list[Module]) -> None:
+        self._conn.execute("DELETE FROM modules")
+        if modules:
+            self._conn.executemany(
+                "INSERT INTO modules "
+                "(ordinal, name, root_path, responsibility, module_json) "
+                "VALUES (?, ?, ?, ?, ?)",
+                [
+                    (
+                        idx,
+                        module.name,
+                        module.root_path,
+                        module.responsibility or "",
+                        module.model_dump_json(),
+                    )
+                    for idx, module in enumerate(modules)
+                ],
+            )
         self._conn.commit()
 
     def delete_chunks_for_files(self, file_paths: list[str]) -> int:
@@ -539,6 +572,10 @@ class IndexStore:
         cur = self._conn.execute(f"{_CHUNK_SELECT} WHERE file_path IN ({placeholders})", file_paths)
         return [_row_to_chunk(row) for row in cur.fetchall()]
 
+    def get_modules(self) -> list[Module]:
+        cur = self._conn.execute("SELECT module_json FROM modules ORDER BY ordinal")
+        return [Module.model_validate_json(str(row[0])) for row in cur.fetchall()]
+
     def get_chunk_count(self) -> int:
         """Return total number of chunks in the store."""
         row = self._conn.execute("SELECT COUNT(*) FROM chunks").fetchone()
@@ -591,6 +628,8 @@ class IndexStore:
             + _CREATE_IDX_CHUNKS_VISIBILITY
             + _CREATE_CHUNK_SURROGATES
             + _CREATE_IDX_CHUNK_SURROGATES_FILE
+            + _CREATE_MODULES
+            + _CREATE_IDX_MODULES_NAME
             + _CREATE_SYMBOLS_FTS
         )
         # Set schema version and detect stale data needing re-index

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -139,6 +139,7 @@ class IndexConfig(BaseModel):
     bm25: bool = True
     vector: bool = False
     splade: bool = False
+    module_prefilter: bool = False
     embedder: str | None = None
     vector_mode: VectorMode = VectorMode.RAW
     surrogate_version: str = "v1"
@@ -153,6 +154,8 @@ class IndexConfig(BaseModel):
     def _validate_index_config(self) -> IndexConfig:
         if not self.bm25 and not self.vector and not self.splade:
             raise ValueError("At least one of bm25, vector, or splade must be enabled")
+        if self.module_prefilter and not self.bm25:
+            raise ValueError("module_prefilter requires bm25 retrieval")
         if self.chunk_max_tokens <= 0:
             raise ValueError("chunk_max_tokens must be > 0")
         if self.chunk_min_tokens < 0:

--- a/src/archex/project.py
+++ b/src/archex/project.py
@@ -22,6 +22,7 @@ cache_dir = ".archex"
 languages = []
 vector = false
 splade = false
+module_prefilter = false
 delta_threshold = 0.5
 
 [dogfood]

--- a/tests/analyze/test_modules.py
+++ b/tests/analyze/test_modules.py
@@ -8,7 +8,7 @@ import pytest
 
 from archex.analyze.modules import detect_modules
 from archex.index.graph import DependencyGraph
-from archex.models import ParsedFile
+from archex.models import CodeChunk, Module, ParsedFile, Symbol, SymbolKind
 from archex.parse import (
     TreeSitterEngine,
     build_file_map,
@@ -95,6 +95,82 @@ def test_detect_modules_name_inferred(python_simple_repo: Path) -> None:
     for module in modules:
         assert module.name, "Module name should not be empty"
         assert isinstance(module.name, str)
+
+
+def test_detect_modules_populates_responsibility() -> None:
+    pf = ParsedFile(
+        path="lifecycle/status.py",
+        language="python",
+        lines=20,
+        symbols=[
+            Symbol(
+                name="project_reset_status",
+                qualified_name="project_reset_status",
+                kind=SymbolKind.FUNCTION,
+                file_path="lifecycle/status.py",
+                start_line=1,
+                end_line=5,
+            )
+        ],
+    )
+    graph = DependencyGraph()
+    graph.add_file_node("lifecycle/status.py")
+
+    module = detect_modules(graph, [pf])[0]
+
+    assert module.responsibility is not None
+    assert "lifecycle" in module.responsibility
+    assert "project" in module.responsibility
+    assert "reset" in module.responsibility
+    assert "status" in module.responsibility
+
+
+def test_module_prefilter_boosts_chunks_by_responsibility() -> None:
+    from archex.api import _module_prefilter_boosts  # pyright: ignore[reportPrivateUsage]
+
+    module = Module(
+        name="lifecycle",
+        root_path="pkg",
+        files=["pkg/__init__.py", "pkg/status.py"],
+        responsibility="project reset init status lifecycle",
+    )
+    chunks = [
+        CodeChunk(
+            id="init",
+            content="def init_project(): pass",
+            file_path="pkg/__init__.py",
+            start_line=1,
+            end_line=2,
+            language="python",
+        ),
+        CodeChunk(
+            id="status",
+            content="def status(): pass",
+            file_path="pkg/status.py",
+            start_line=1,
+            end_line=2,
+            language="python",
+        ),
+        CodeChunk(
+            id="other",
+            content="def unrelated(): pass",
+            file_path="other.py",
+            start_line=1,
+            end_line=2,
+            language="python",
+        ),
+    ]
+
+    boosts = _module_prefilter_boosts(
+        [module],
+        chunks,
+        "how does project reset report status",
+        existing_ids=set(),
+        max_bm25_score=10.0,
+    )
+
+    assert {chunk.id for chunk, _ in boosts} == {"init", "status"}
+    assert all(score > 0 for _, score in boosts)
 
 
 def test_detect_modules_single_file() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -111,6 +111,7 @@ def test_index_command_uses_project_config(python_simple_repo: Path) -> None:
     assert config.cache_dir == str(python_simple_repo / ".archex")
     assert index_config.vector is False
     assert index_config.splade is False
+    assert index_config.module_prefilter is False
     assert store.closed is True
 
 
@@ -124,6 +125,20 @@ def test_index_command_splade_flag_enables_splade(python_simple_repo: Path) -> N
     assert result.exit_code == 0, result.output
     index_config = index_mock.call_args.kwargs["index_config"]
     assert index_config.splade is True
+
+
+def test_index_command_module_prefilter_flag_enables_prefilter(
+    python_simple_repo: Path,
+) -> None:
+    store = FakeIndexStore()
+    runner = CliRunner()
+
+    with patch("archex.cli.index_cmd.index_repository", return_value=store) as index_mock:
+        result = runner.invoke(cli, ["index", str(python_simple_repo), "--module-prefilter"])
+
+    assert result.exit_code == 0, result.output
+    index_config = index_mock.call_args.kwargs["index_config"]
+    assert index_config.module_prefilter is True
 
 
 def test_index_command_json_output(python_simple_repo: Path) -> None:
@@ -437,6 +452,7 @@ def test_query_uses_project_config_when_cli_args_omitted(python_simple_repo: Pat
     assert config.languages is None
     assert index_config.vector is False
     assert index_config.splade is False
+    assert index_config.module_prefilter is False
 
 
 def test_query_cli_options_override_project_config(python_simple_repo: Path) -> None:
@@ -464,6 +480,7 @@ def test_query_cli_options_override_project_config(python_simple_repo: Path) -> 
                 "--strategy",
                 "hybrid",
                 "--splade",
+                "--module-prefilter",
             ],
         )
 
@@ -473,6 +490,7 @@ def test_query_cli_options_override_project_config(python_simple_repo: Path) -> 
     assert config.languages == ["python"]
     assert index_config.vector is True
     assert index_config.splade is True
+    assert index_config.module_prefilter is True
 
 
 def test_query_timing_flag(python_simple_repo: Path) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -536,6 +536,10 @@ class TestIndexConfigValidation:
         assert config.vector is False
         assert config.splade is True
 
+    def test_module_prefilter_requires_bm25(self) -> None:
+        with pytest.raises(ValueError, match="module_prefilter requires bm25 retrieval"):
+            IndexConfig(bm25=False, vector=True, module_prefilter=True)
+
     def test_both_enabled_valid(self) -> None:
         config = IndexConfig(bm25=True, vector=True)
         assert config.bm25 is True


### PR DESCRIPTION
## Stack

Stack-Id: `tier2-candidate-pool-20260530`
Base: `main`
Position: 2/2

1. `feat/splade-leg` -> #151
2. `feat/module-summary-prefilter` -> this PR

Depends on: #151
Upstack: none

## Summary

- Populates `Module.responsibility` deterministically from module names, paths, exports, and dependencies.
- Persists module summaries in the SQLite index for query-time reuse.
- Adds opt-in `module_prefilter` config plus `archex index --module-prefilter` and `archex query --module-prefilter`.
- Adds a BM25 responsibility pass that selects matching modules and contributes capped member chunks to the candidate pool.
- Fails fast when query-time prefiltering is requested against a cached index without module summaries.

## Validation

- Passed: `uv run ruff check && uv run ruff format --check . && uv run pyright`
- Passed: `uv run pytest tests/index/test_splade.py tests/analyze/test_modules.py -q --no-cov`
- Ran requested exact pytest command: `uv run pytest tests/index/test_splade.py tests/analyze/test_modules.py -q`; tests passed functionally, command failed only on existing repo-wide coverage fail-under (`23.71% < 85%`) because the scoped command still applies global coverage.
- pr-review: completed; fixed invalid `module_prefilter=True, bm25=False` no-op by enforcing a config invariant.
