### PR TITLE
feat(benchmark): add retrieval leg measurement flags

### DIFF
--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -46,6 +46,11 @@ class BenchmarkTask(BaseModel):
     category: TaskCategory | None = None
 
 
+class BenchmarkRetrievalOptions(BaseModel):
+    splade: bool = False
+    module_prefilter: bool = False
+
+
 class BenchmarkResult(BaseModel):
     task_id: str
     strategy: Strategy

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -11,8 +11,19 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from archex.benchmark.loader import load_tasks
-from archex.benchmark.models import BenchmarkReport, BenchmarkResult, BenchmarkTask, Strategy
-from archex.benchmark.strategies import default_strategy_registry
+from archex.benchmark.models import (
+    BenchmarkReport,
+    BenchmarkResult,
+    BenchmarkRetrievalOptions,
+    BenchmarkTask,
+    Strategy,
+)
+from archex.benchmark.strategies import (
+    benchmark_repo_source,
+    default_strategy_registry,
+    reset_benchmark_retrieval_options,
+    set_benchmark_retrieval_options,
+)
 from archex.exceptions import ArchexIndexError, BenchmarkCloneError
 
 if TYPE_CHECKING:
@@ -60,7 +71,11 @@ def _check_vector_available() -> bool:
         return False
 
 
-def _warm_repo_index(task: BenchmarkTask, repo_path: Path) -> None:
+def _warm_repo_index(
+    task: BenchmarkTask,
+    repo_path: Path,
+    retrieval_options: BenchmarkRetrievalOptions | None = None,
+) -> None:
     """Pre-build the shared vector index so every vector strategy runs warm.
 
     The first vector strategy to execute otherwise absorbs the full embedding
@@ -72,11 +87,17 @@ def _warm_repo_index(task: BenchmarkTask, repo_path: Path) -> None:
     not surrogate-mode strategies.
     """
     from archex.api import query
-    from archex.models import Config, IndexConfig, RepoSource
+    from archex.models import Config, IndexConfig
 
-    source = RepoSource(local_path=str(repo_path))
+    source = benchmark_repo_source(task, repo_path)
     config = Config(cache=True, languages=task.languages)
-    index_config = IndexConfig(vector=True, embedder="fastembed")
+    retrieval_options = retrieval_options or BenchmarkRetrievalOptions()
+    index_config = IndexConfig(
+        vector=True,
+        embedder="fastembed",
+        splade=retrieval_options.splade,
+        module_prefilter=retrieval_options.module_prefilter,
+    )
     query(
         source,
         task.question,
@@ -137,6 +158,7 @@ def run_benchmark(
     strategies: list[Strategy] | None = None,
     repo_path: Path | None = None,
     progress: BenchmarkProgress | None = None,
+    retrieval_options: BenchmarkRetrievalOptions | None = None,
 ) -> BenchmarkReport:
     """Run a benchmark task across strategies. Clones repo if repo_path not provided."""
     if strategies is None:
@@ -151,13 +173,15 @@ def run_benchmark(
         else:
             repo_path, needs_cleanup = clone_at_commit(task.repo, task.commit)
 
+    retrieval_options = retrieval_options or BenchmarkRetrievalOptions()
+    token = set_benchmark_retrieval_options(retrieval_options)
     try:
         should_warm = _check_vector_available() and any(s in _VECTOR_STRATEGIES for s in strategies)
         if should_warm:
             _log_progress(progress, f"  warming vector index for {task.task_id}...")
             if progress is not None:
                 progress.start_warmup()
-            _warm_repo_index(task, repo_path)
+            _warm_repo_index(task, repo_path, retrieval_options)
         if progress is not None:
             progress.finish_warmup(strategies)
 
@@ -216,6 +240,7 @@ def run_benchmark(
             ),
         )
     finally:
+        reset_benchmark_retrieval_options(token)
         if needs_cleanup:
             shutil.rmtree(repo_path, ignore_errors=True)
 
@@ -228,6 +253,7 @@ def run_all(
     self_only: bool = False,
     progress: BenchmarkProgress | None = None,
     tasks: list[BenchmarkTask] | None = None,
+    retrieval_options: BenchmarkRetrievalOptions | None = None,
 ) -> list[BenchmarkReport]:
     """Load all tasks, run benchmarks, write results to output_dir."""
     if tasks is None:
@@ -254,6 +280,7 @@ def run_all(
                     strategies=strategies,
                     repo_path=task_repo_path,
                     progress=progress,
+                    retrieval_options=retrieval_options,
                 )
             except BenchmarkCloneError as exc:
                 # Isolate per-task clone failures (network, rate limit, bad ref) so one

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -9,18 +9,29 @@ import re
 import subprocess
 import time
 from collections.abc import Callable
+from contextvars import ContextVar, Token
 from datetime import UTC, datetime
 from pathlib import Path
 
-from archex.benchmark.models import BenchmarkResult, BenchmarkTask, Strategy
+from archex.benchmark.models import (
+    BenchmarkResult,
+    BenchmarkRetrievalOptions,
+    BenchmarkTask,
+    Strategy,
+)
 from archex.cache import CacheManager
 from archex.exceptions import ConfigError
-from archex.models import PipelineTiming, RepoSource
+from archex.models import IndexConfig, PipelineTiming, RepoSource
 from archex.reporting import count_tokens
 
 logger = logging.getLogger(__name__)
 
 StrategyRunner = Callable[[BenchmarkTask, Path], BenchmarkResult]
+
+_BENCHMARK_RETRIEVAL_OPTIONS: ContextVar[BenchmarkRetrievalOptions | None] = ContextVar(
+    "benchmark_retrieval_options",
+    default=None,
+)
 
 _STOPWORDS = frozenset(
     {
@@ -481,28 +492,67 @@ def _cache_state(timing: PipelineTiming) -> str:
     return "warm" if timing.cached else "cold"
 
 
-def _benchmark_repo_source(task: BenchmarkTask, repo_path: Path) -> RepoSource:
+def current_benchmark_retrieval_options() -> BenchmarkRetrievalOptions:
+    return _BENCHMARK_RETRIEVAL_OPTIONS.get() or BenchmarkRetrievalOptions()
+
+
+def set_benchmark_retrieval_options(
+    options: BenchmarkRetrievalOptions,
+) -> Token[BenchmarkRetrievalOptions | None]:
+    return _BENCHMARK_RETRIEVAL_OPTIONS.set(options)
+
+
+def reset_benchmark_retrieval_options(token: Token[BenchmarkRetrievalOptions | None]) -> None:
+    _BENCHMARK_RETRIEVAL_OPTIONS.reset(token)
+
+
+def _retrieval_cache_suffix(options: BenchmarkRetrievalOptions) -> str:
+    enabled: list[str] = []
+    if options.splade:
+        enabled.append("splade")
+    if options.module_prefilter:
+        enabled.append("module-prefilter")
+    return "+".join(enabled)
+
+
+def benchmark_index_config(index_config: IndexConfig) -> IndexConfig:
+    options = current_benchmark_retrieval_options()
+    updates: dict[str, bool] = {}
+    if options.splade:
+        updates["splade"] = True
+    if options.module_prefilter and index_config.bm25:
+        updates["module_prefilter"] = True
+    if not updates:
+        return index_config
+    return index_config.model_copy(update=updates)
+
+
+def benchmark_repo_source(task: BenchmarkTask, repo_path: Path) -> RepoSource:
     commit = task.commit or CacheManager.git_head(str(repo_path))
     if not commit:
         raise ConfigError(
             f"Benchmark task {task.task_id!r} has no commit and {repo_path} has no git HEAD"
         )
+    stable_identity = f"{task.repo}@{commit}"
+    suffix = _retrieval_cache_suffix(current_benchmark_retrieval_options())
+    if suffix:
+        stable_identity = f"{stable_identity}#{suffix}"
     return RepoSource(
         local_path=str(repo_path),
-        stable_identity=f"{task.repo}@{commit}",
+        stable_identity=stable_identity,
     )
 
 
 def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """archex query strategy: use BM25-based retrieval."""
     from archex.api import query
-    from archex.models import Config, IndexConfig
+    from archex.models import Config
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = _benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path)
     config = Config(cache=False, languages=task.languages)
-    index_config = IndexConfig(vector=False)
+    index_config = benchmark_index_config(IndexConfig(vector=False))
 
     bundle = query(
         source,
@@ -561,13 +611,15 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
 def run_archex_query_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Pure vector retrieval strategy: vector search without BM25."""
     from archex.api import query
-    from archex.models import Config, IndexConfig
+    from archex.models import Config
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = _benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path)
     config = Config(cache=True, languages=task.languages)
-    index_config = IndexConfig(bm25=False, vector=True, embedder="fastembed")
+    index_config = benchmark_index_config(
+        IndexConfig(bm25=False, vector=True, embedder="fastembed")
+    )
 
     bundle = query(
         source,
@@ -633,18 +685,20 @@ def run_archex_query_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
 def run_surrogate_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Pure surrogate-vector retrieval strategy."""
     from archex.api import query
-    from archex.models import Config, IndexConfig, RetrievalPolicy, VectorMode
+    from archex.models import Config, RetrievalPolicy, VectorMode
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = _benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path)
     config = Config(cache=True, languages=task.languages)
-    index_config = IndexConfig(
-        bm25=False,
-        vector=True,
-        embedder="fastembed",
-        vector_mode=VectorMode.SURROGATE,
-        retrieval_policy=RetrievalPolicy.VECTOR_ONLY,
+    index_config = benchmark_index_config(
+        IndexConfig(
+            bm25=False,
+            vector=True,
+            embedder="fastembed",
+            vector_mode=VectorMode.SURROGATE,
+            retrieval_policy=RetrievalPolicy.VECTOR_ONLY,
+        )
     )
 
     bundle = query(
@@ -705,13 +759,13 @@ def run_surrogate_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResul
 def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Full fusion strategy: BM25 + independent vector + confidence-aware RRF."""
     from archex.api import query
-    from archex.models import Config, IndexConfig
+    from archex.models import Config
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = _benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path)
     config = Config(cache=True, languages=task.languages)
-    index_config = IndexConfig(vector=True, embedder="fastembed")
+    index_config = benchmark_index_config(IndexConfig(vector=True, embedder="fastembed"))
 
     bundle = query(
         source,
@@ -777,13 +831,15 @@ def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
 def run_archex_query_fusion_rerank(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Fusion strategy with cross-encoder reranking: BM25 + vector + rerank."""
     from archex.api import query
-    from archex.models import Config, IndexConfig
+    from archex.models import Config
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = _benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path)
     config = Config(cache=True, languages=task.languages)
-    index_config = IndexConfig(vector=True, embedder="fastembed", rerank=True)
+    index_config = benchmark_index_config(
+        IndexConfig(vector=True, embedder="fastembed", rerank=True)
+    )
 
     bundle = query(
         source,
@@ -842,17 +898,19 @@ def run_archex_query_fusion_rerank(task: BenchmarkTask, repo_path: Path) -> Benc
 def run_cross_layer_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """BM25 over raw chunks plus vector retrieval over surrogates."""
     from archex.api import query
-    from archex.models import Config, IndexConfig, RetrievalPolicy, VectorMode
+    from archex.models import Config, RetrievalPolicy, VectorMode
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = _benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path)
     config = Config(cache=True, languages=task.languages)
-    index_config = IndexConfig(
-        vector=True,
-        embedder="fastembed",
-        vector_mode=VectorMode.SURROGATE,
-        retrieval_policy=RetrievalPolicy.CROSS_LAYER,
+    index_config = benchmark_index_config(
+        IndexConfig(
+            vector=True,
+            embedder="fastembed",
+            vector_mode=VectorMode.SURROGATE,
+            retrieval_policy=RetrievalPolicy.CROSS_LAYER,
+        )
     )
 
     bundle = query(

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -18,7 +18,12 @@ from archex.benchmark.gate import (
     check_latency_warnings,
 )
 from archex.benchmark.loader import load_tasks
-from archex.benchmark.models import BenchmarkReport, DeltaBenchmarkResult, Strategy
+from archex.benchmark.models import (
+    BenchmarkReport,
+    BenchmarkRetrievalOptions,
+    DeltaBenchmarkResult,
+    Strategy,
+)
 from archex.benchmark.progress import BenchmarkProgress
 from archex.benchmark.readiness import (
     build_readiness_report,
@@ -88,6 +93,18 @@ def benchmark_cmd() -> None:
     help="Include the fusion+rerank strategy (archex_query_fusion_rerank).",
 )
 @click.option(
+    "--splade",
+    is_flag=True,
+    default=False,
+    help="Enable the opt-in SPLADE retrieval leg for archex benchmark strategies.",
+)
+@click.option(
+    "--module-prefilter",
+    is_flag=True,
+    default=False,
+    help="Enable the opt-in module responsibility prefilter for BM25-backed archex strategies.",
+)
+@click.option(
     "--self-only",
     is_flag=True,
     default=False,
@@ -107,6 +124,8 @@ def run_cmd(
     query_fusion: bool,
     cross_layer_fusion: bool,
     rerank: bool,
+    splade: bool,
+    module_prefilter: bool,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -137,6 +156,10 @@ def run_cmd(
             self_only=self_only,
             progress=progress,
             tasks=tasks,
+            retrieval_options=BenchmarkRetrievalOptions(
+                splade=splade,
+                module_prefilter=module_prefilter,
+            ),
         )
 
     click.echo(f"\nCompleted {len(reports)} benchmark(s).", err=True)

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -9,7 +9,13 @@ from typing import TYPE_CHECKING, cast
 import pytest
 from click.testing import CliRunner
 
-from archex.benchmark.models import BenchmarkReport, BenchmarkResult, BenchmarkTask, Strategy
+from archex.benchmark.models import (
+    BenchmarkReport,
+    BenchmarkResult,
+    BenchmarkRetrievalOptions,
+    BenchmarkTask,
+    Strategy,
+)
 from archex.cli.benchmark_cmd import benchmark_cmd
 
 if TYPE_CHECKING:
@@ -239,6 +245,8 @@ class TestRunCommand:
         assert "--query-fusion" in result.output
         assert "--cross_layer_fusion" in result.output
         assert "--rerank" in result.output
+        assert "--splade" in result.output
+        assert "--module-prefilter" in result.output
         assert "--self-only" in result.output
         assert "--no-progress" in result.output
 
@@ -257,9 +265,11 @@ class TestRunCommand:
             self_only: bool = False,
             progress: object | None = None,
             tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
         ) -> list[BenchmarkReport]:
             del tasks_dir, output_dir, task_filter, self_only, progress, tasks
             captured["strategies"] = strategies
+            captured["retrieval_options"] = retrieval_options
             return []
 
         monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
@@ -271,6 +281,7 @@ class TestRunCommand:
             Strategy.RAW_GREPPED,
             Strategy.ARCHEX_QUERY,
         ]
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions()
 
     def test_run_adds_experimental_flags(
         self,
@@ -287,8 +298,9 @@ class TestRunCommand:
             self_only: bool = False,
             progress: object | None = None,
             tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
         ) -> list[BenchmarkReport]:
-            del tasks_dir, output_dir, task_filter, self_only, progress, tasks
+            del tasks_dir, output_dir, task_filter, self_only, progress, tasks, retrieval_options
             captured["strategies"] = strategies
             return []
 
@@ -322,8 +334,9 @@ class TestRunCommand:
             self_only: bool = False,
             progress: object | None = None,
             tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
         ) -> list[BenchmarkReport]:
-            del tasks_dir, output_dir, task_filter, self_only, progress, tasks
+            del tasks_dir, output_dir, task_filter, self_only, progress, tasks, retrieval_options
             captured["strategies"] = strategies
             return []
 
@@ -338,6 +351,36 @@ class TestRunCommand:
             Strategy.ARCHEX_QUERY_FUSION,
             Strategy.ARCHEX_QUERY_FUSION_RERANK,
         ]
+
+    def test_run_passes_retrieval_measurement_flags(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(benchmark_cmd, ["run", "--splade", "--module-prefilter"])
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(
+            splade=True,
+            module_prefilter=True,
+        )
 
     def test_run_self_only_flag_filters_tasks(
         self,
@@ -354,8 +397,9 @@ class TestRunCommand:
             self_only: bool = False,
             progress: object | None = None,
             tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
         ) -> list[BenchmarkReport]:
-            del tasks_dir, output_dir, strategies, task_filter, progress, tasks
+            del tasks_dir, output_dir, strategies, task_filter, progress, tasks, retrieval_options
             captured["self_only"] = self_only
             return []
 
@@ -380,8 +424,9 @@ class TestRunCommand:
             self_only: bool = False,
             progress: object | None = None,
             tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
         ) -> list[BenchmarkReport]:
-            del tasks_dir, output_dir, strategies, task_filter, self_only, tasks
+            del tasks_dir, output_dir, strategies, task_filter, self_only, tasks, retrieval_options
             assert progress is not None
             captured["progress_enabled"] = cast("BenchmarkProgress", progress).live_display_enabled
             return []

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from archex.benchmark.models import BenchmarkTask, Strategy
+from archex.benchmark.models import BenchmarkRetrievalOptions, BenchmarkTask, Strategy
 from archex.benchmark.runner import AVAILABLE_STRATEGIES, DEFAULT_STRATEGIES, run_benchmark
 
 if TYPE_CHECKING:
@@ -113,7 +113,11 @@ class TestRunBenchmark:
 
         warmed: list[Path] = []
 
-        def _record(_task: BenchmarkTask, path: Path) -> None:
+        def _record(
+            _task: BenchmarkTask,
+            path: Path,
+            _options: BenchmarkRetrievalOptions | None = None,
+        ) -> None:
             warmed.append(path)
 
         def _raise(_task: BenchmarkTask, _path: Path) -> None:
@@ -220,6 +224,92 @@ class TestRunBenchmark:
         # RAW_GREPPED was skipped; only RAW_FILES ran
         assert len(report.results) == 1
         assert report.results[0].strategy == Strategy.RAW_FILES
+
+    def test_retrieval_options_are_scoped_to_strategy_runner(
+        self,
+        fixture_task: tuple[BenchmarkTask, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from archex.benchmark.models import BenchmarkResult
+        from archex.benchmark.strategies import (
+            current_benchmark_retrieval_options,
+            default_strategy_registry,
+        )
+
+        task, repo_path = fixture_task
+        captured: list[BenchmarkRetrievalOptions] = []
+
+        def _record_options(_task: BenchmarkTask, _path: Path) -> BenchmarkResult:
+            captured.append(current_benchmark_retrieval_options())
+            return BenchmarkResult(
+                task_id=task.task_id,
+                strategy=Strategy.RAW_GREPPED,
+                tokens_total=1,
+                tool_calls=1,
+                files_accessed=1,
+                recall=0.0,
+                precision=0.0,
+                savings_vs_raw=0.0,
+                wall_time_ms=1.0,
+                cached=False,
+                timestamp="2026-01-01T00:00:00Z",
+            )
+
+        key = Strategy.RAW_GREPPED.value
+        monkeypatch.setitem(default_strategy_registry._runners, key, _record_options)  # pyright: ignore[reportPrivateUsage]
+
+        run_benchmark(
+            task,
+            strategies=[Strategy.RAW_GREPPED],
+            repo_path=repo_path,
+            retrieval_options=BenchmarkRetrievalOptions(splade=True, module_prefilter=True),
+        )
+
+        assert captured == [BenchmarkRetrievalOptions(splade=True, module_prefilter=True)]
+
+    def test_benchmark_repo_source_isolates_opt_in_cache_keys(
+        self,
+        fixture_task: tuple[BenchmarkTask, Path],
+    ) -> None:
+        from archex.benchmark.strategies import (
+            benchmark_repo_source,
+            reset_benchmark_retrieval_options,
+            set_benchmark_retrieval_options,
+        )
+
+        task, repo_path = fixture_task
+        source = benchmark_repo_source(task, repo_path)
+        assert source.stable_identity == "test/python_simple@HEAD"
+
+        token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions(splade=True))
+        try:
+            splade_source = benchmark_repo_source(task, repo_path)
+        finally:
+            reset_benchmark_retrieval_options(token)
+
+        assert splade_source.stable_identity == "test/python_simple@HEAD#splade"
+
+    def test_benchmark_index_config_applies_module_prefilter_only_with_bm25(self) -> None:
+        from archex.benchmark.strategies import (
+            benchmark_index_config,
+            reset_benchmark_retrieval_options,
+            set_benchmark_retrieval_options,
+        )
+        from archex.models import IndexConfig
+
+        token = set_benchmark_retrieval_options(
+            BenchmarkRetrievalOptions(splade=True, module_prefilter=True)
+        )
+        try:
+            bm25_config = benchmark_index_config(IndexConfig(vector=True))
+            vector_config = benchmark_index_config(IndexConfig(bm25=False, vector=True))
+        finally:
+            reset_benchmark_retrieval_options(token)
+
+        assert bm25_config.splade is True
+        assert bm25_config.module_prefilter is True
+        assert vector_config.splade is True
+        assert vector_config.module_prefilter is False
 
 
 class TestCloneAtCommit:

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -10,8 +10,8 @@ import pytest
 from archex.benchmark.models import BenchmarkTask, Strategy
 from archex.benchmark.strategies import (
     _archex_fields,  # pyright: ignore[reportPrivateUsage]
-    _benchmark_repo_source,  # pyright: ignore[reportPrivateUsage]
     _deduplicate_ranked,  # pyright: ignore[reportPrivateUsage]
+    benchmark_repo_source,
     compute_map,
     compute_mrr,
     compute_ndcg,
@@ -332,8 +332,8 @@ class TestRunArchexQuery:
         repo_a.mkdir()
         repo_b.mkdir()
 
-        source_a = _benchmark_repo_source(sample_task, repo_a)
-        source_b = _benchmark_repo_source(sample_task, repo_b)
+        source_a = benchmark_repo_source(sample_task, repo_a)
+        source_b = benchmark_repo_source(sample_task, repo_b)
 
         assert source_a.stable_identity == "test/repo@abc"
         assert source_b.stable_identity == "test/repo@abc"
@@ -352,7 +352,7 @@ class TestRunArchexQuery:
         )
 
         with patch.object(CacheManager, "git_head", return_value="resolved"):
-            source = _benchmark_repo_source(task, tmp_path)
+            source = benchmark_repo_source(task, tmp_path)
 
         assert source.stable_identity == "test/repo@resolved"
 
@@ -372,7 +372,7 @@ class TestRunArchexQuery:
             patch.object(CacheManager, "git_head", return_value=None),
             pytest.raises(ConfigError, match="has no commit"),
         ):
-            _benchmark_repo_source(task, tmp_path)
+            benchmark_repo_source(task, tmp_path)
 
     def test_archex_query_strategy(self, python_simple_repo: Path) -> None:
         task = BenchmarkTask(


### PR DESCRIPTION
## Summary
- add `archex benchmark run --splade` and `--module-prefilter` flags
- thread retrieval measurement options through the benchmark runner without changing default behavior
- isolate opt-in benchmark cache keys so default cached indexes do not mask missing SPLADE/module artifacts

## Validation
- `uv run ruff check`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest tests/benchmark/test_cli.py tests/benchmark/test_runner.py tests/benchmark/test_strategies.py -q --no-cov`
- `uv run pytest -q`

## Operator benchmark commands
Do not run these in-agent. Use a separate terminal:

```bash
uv run archex benchmark run --query-fusion --rerank --splade --tasks-dir benchmarks/tasks --output .archex/e2e-results-splade
uv run archex benchmark triage --input .archex/e2e-results-splade --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
```

For the combined Tier 2 opt-in measurement:

```bash
uv run archex benchmark run --query-fusion --rerank --splade --module-prefilter --tasks-dir benchmarks/tasks --output .archex/e2e-results-tier2-optin
uv run archex benchmark triage --input .archex/e2e-results-tier2-optin --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
```
