### PR TITLE
feat(benchmark): pin embedder for vector arms

### DIFF
--- a/benchmarks/tasks/celery_task_dispatch.yaml
+++ b/benchmarks/tasks/celery_task_dispatch.yaml
@@ -3,6 +3,10 @@ repo: celery/celery
 commit: "v5.4.0"
 category: external-large
 languages: [python]
+include_paths:
+  - celery/app/task.py
+  - celery/app/amqp.py
+  - celery/worker/strategy.py
 question: "How does Celery dispatch and execute distributed tasks?"
 expected_files:
   - celery/app/task.py

--- a/benchmarks/tasks/celery_task_dispatch.yaml
+++ b/benchmarks/tasks/celery_task_dispatch.yaml
@@ -4,9 +4,8 @@ commit: "v5.4.0"
 category: external-large
 languages: [python]
 include_paths:
-  - celery/app/task.py
-  - celery/app/amqp.py
-  - celery/worker/strategy.py
+  - celery/app
+  - celery/worker
 question: "How does Celery dispatch and execute distributed tasks?"
 expected_files:
   - celery/app/task.py

--- a/benchmarks/tasks/click_decorators.yaml
+++ b/benchmarks/tasks/click_decorators.yaml
@@ -2,6 +2,11 @@ task_id: click_decorators
 repo: pallets/click
 commit: "8.1.8"
 category: external-framework
+languages: [python]
+include_paths:
+  - src/click/decorators.py
+  - src/click/core.py
+  - src/click/types.py
 question: "How does click implement command decorators and parameter decoration?"
 expected_files:
   - src/click/decorators.py

--- a/benchmarks/tasks/click_decorators.yaml
+++ b/benchmarks/tasks/click_decorators.yaml
@@ -4,9 +4,7 @@ commit: "8.1.8"
 category: external-framework
 languages: [python]
 include_paths:
-  - src/click/decorators.py
-  - src/click/core.py
-  - src/click/types.py
+  - src/click
 question: "How does click implement command decorators and parameter decoration?"
 expected_files:
   - src/click/decorators.py

--- a/benchmarks/tasks/django_middleware.yaml
+++ b/benchmarks/tasks/django_middleware.yaml
@@ -4,9 +4,16 @@ commit: "5.1.4"
 category: architecture-broad
 languages: [python]
 include_paths:
-  - django/core/handlers/base.py
-  - django/core/handlers/wsgi.py
-  - django/middleware/common.py
+  - django/core/handlers
+  - django/middleware
+  - django/conf/__init__.py
+  - django/http/request.py
+  - django/http/response.py
+  - django/urls/base.py
+  - django/utils/cache.py
+  - django/utils/deprecation.py
+  - django/utils/log.py
+  - django/utils/module_loading.py
 question: "How does Django implement the middleware chain for request/response processing?"
 expected_files:
   - django/core/handlers/base.py

--- a/benchmarks/tasks/django_middleware.yaml
+++ b/benchmarks/tasks/django_middleware.yaml
@@ -3,6 +3,10 @@ repo: django/django
 commit: "5.1.4"
 category: architecture-broad
 languages: [python]
+include_paths:
+  - django/core/handlers/base.py
+  - django/core/handlers/wsgi.py
+  - django/middleware/common.py
 question: "How does Django implement the middleware chain for request/response processing?"
 expected_files:
   - django/core/handlers/base.py

--- a/benchmarks/tasks/django_orm_queries.yaml
+++ b/benchmarks/tasks/django_orm_queries.yaml
@@ -4,9 +4,12 @@ commit: "5.1.4"
 category: external-large
 languages: [python]
 include_paths:
-  - django/db/models/sql/query.py
-  - django/db/models/sql/compiler.py
+  - django/db/models/sql
   - django/db/models/query.py
+  - django/db/models/manager.py
+  - django/db/models/expressions.py
+  - django/db/models/fields
+  - django/db/backends/base
 question: "How does Django's ORM build and execute SQL queries?"
 expected_files:
   - django/db/models/sql/query.py

--- a/benchmarks/tasks/django_orm_queries.yaml
+++ b/benchmarks/tasks/django_orm_queries.yaml
@@ -3,6 +3,10 @@ repo: django/django
 commit: "5.1.4"
 category: external-large
 languages: [python]
+include_paths:
+  - django/db/models/sql/query.py
+  - django/db/models/sql/compiler.py
+  - django/db/models/query.py
 question: "How does Django's ORM build and execute SQL queries?"
 expected_files:
   - django/db/models/sql/query.py

--- a/benchmarks/tasks/express_error_handling.yaml
+++ b/benchmarks/tasks/express_error_handling.yaml
@@ -4,9 +4,7 @@ commit: "4.21.2"
 category: architecture-broad
 languages: [javascript]
 include_paths:
-  - lib/router/layer.js
-  - lib/router/index.js
-  - lib/application.js
+  - lib
 question: "How does express handle errors in the middleware chain?"
 expected_files:
   - lib/router/layer.js

--- a/benchmarks/tasks/express_error_handling.yaml
+++ b/benchmarks/tasks/express_error_handling.yaml
@@ -3,6 +3,10 @@ repo: expressjs/express
 commit: "4.21.2"
 category: architecture-broad
 languages: [javascript]
+include_paths:
+  - lib/router/layer.js
+  - lib/router/index.js
+  - lib/application.js
 question: "How does express handle errors in the middleware chain?"
 expected_files:
   - lib/router/layer.js

--- a/benchmarks/tasks/express_middleware.yaml
+++ b/benchmarks/tasks/express_middleware.yaml
@@ -2,6 +2,11 @@ task_id: express_middleware
 repo: expressjs/express
 commit: "4.21.2"
 category: framework-semantic
+languages: [javascript]
+include_paths:
+  - lib/router/index.js
+  - lib/router/route.js
+  - lib/router/layer.js
 question: "How does express implement the middleware chain and next() function?"
 expected_files:
   - lib/router/index.js

--- a/benchmarks/tasks/express_middleware.yaml
+++ b/benchmarks/tasks/express_middleware.yaml
@@ -4,9 +4,7 @@ commit: "4.21.2"
 category: framework-semantic
 languages: [javascript]
 include_paths:
-  - lib/router/index.js
-  - lib/router/route.js
-  - lib/router/layer.js
+  - lib
 question: "How does express implement the middleware chain and next() function?"
 expected_files:
   - lib/router/index.js

--- a/benchmarks/tasks/fastapi_dependency_injection.yaml
+++ b/benchmarks/tasks/fastapi_dependency_injection.yaml
@@ -4,9 +4,12 @@ commit: "0.115.6"
 category: framework-semantic
 languages: [python]
 include_paths:
-  - fastapi/dependencies/utils.py
-  - fastapi/dependencies/models.py
+  - fastapi/dependencies
   - fastapi/routing.py
+  - fastapi/params.py
+  - fastapi/exceptions.py
+  - fastapi/security
+  - fastapi/utils.py
 question: "How does FastAPI implement dependency injection for route handlers?"
 expected_files:
   - fastapi/dependencies/utils.py

--- a/benchmarks/tasks/fastapi_dependency_injection.yaml
+++ b/benchmarks/tasks/fastapi_dependency_injection.yaml
@@ -3,6 +3,10 @@ repo: "tiangolo/fastapi"
 commit: "0.115.6"
 category: framework-semantic
 languages: [python]
+include_paths:
+  - fastapi/dependencies/utils.py
+  - fastapi/dependencies/models.py
+  - fastapi/routing.py
 question: "How does FastAPI implement dependency injection for route handlers?"
 expected_files:
   - fastapi/dependencies/utils.py

--- a/benchmarks/tasks/fastapi_routing.yaml
+++ b/benchmarks/tasks/fastapi_routing.yaml
@@ -7,6 +7,7 @@ include_paths:
   - fastapi/routing.py
   - fastapi/applications.py
   - fastapi/params.py
+  - fastapi/dependencies
 question: "How does FastAPI handle route registration and path parameter parsing?"
 expected_files:
   - fastapi/routing.py

--- a/benchmarks/tasks/fastapi_routing.yaml
+++ b/benchmarks/tasks/fastapi_routing.yaml
@@ -3,6 +3,10 @@ repo: tiangolo/fastapi
 commit: "0.115.6"
 category: external-framework
 languages: [python]
+include_paths:
+  - fastapi/routing.py
+  - fastapi/applications.py
+  - fastapi/params.py
 question: "How does FastAPI handle route registration and path parameter parsing?"
 expected_files:
   - fastapi/routing.py

--- a/benchmarks/tasks/flask_blueprints.yaml
+++ b/benchmarks/tasks/flask_blueprints.yaml
@@ -4,9 +4,7 @@ commit: "3.1.0"
 category: external-framework
 languages: [python]
 include_paths:
-  - src/flask/sansio/blueprints.py
-  - src/flask/blueprints.py
-  - src/flask/app.py
+  - src/flask
 question: "How does Flask implement blueprints for modular applications?"
 expected_files:
   - src/flask/sansio/blueprints.py

--- a/benchmarks/tasks/flask_blueprints.yaml
+++ b/benchmarks/tasks/flask_blueprints.yaml
@@ -3,6 +3,10 @@ repo: pallets/flask
 commit: "3.1.0"
 category: external-framework
 languages: [python]
+include_paths:
+  - src/flask/sansio/blueprints.py
+  - src/flask/blueprints.py
+  - src/flask/app.py
 question: "How does Flask implement blueprints for modular applications?"
 expected_files:
   - src/flask/sansio/blueprints.py

--- a/benchmarks/tasks/gin_routing.yaml
+++ b/benchmarks/tasks/gin_routing.yaml
@@ -7,6 +7,9 @@ include_paths:
   - tree.go
   - routergroup.go
   - gin.go
+  - context.go
+  - logger.go
+  - recovery.go
 question: "How does gin implement HTTP routing with its radix tree?"
 expected_files:
   - tree.go

--- a/benchmarks/tasks/gin_routing.yaml
+++ b/benchmarks/tasks/gin_routing.yaml
@@ -2,6 +2,11 @@ task_id: gin_routing
 repo: gin-gonic/gin
 commit: "v1.10.0"
 category: external-framework
+languages: [go]
+include_paths:
+  - tree.go
+  - routergroup.go
+  - gin.go
 question: "How does gin implement HTTP routing with its radix tree?"
 expected_files:
   - tree.go

--- a/benchmarks/tasks/go_gin_middleware.yaml
+++ b/benchmarks/tasks/go_gin_middleware.yaml
@@ -3,6 +3,10 @@ repo: gin-gonic/gin
 commit: "v1.10.0"
 category: architecture-broad
 languages: [go]
+include_paths:
+  - gin.go
+  - context.go
+  - routergroup.go
 question: "How does gin implement middleware chaining and abort handling?"
 expected_files:
   - gin.go

--- a/benchmarks/tasks/go_gin_middleware.yaml
+++ b/benchmarks/tasks/go_gin_middleware.yaml
@@ -7,6 +7,10 @@ include_paths:
   - gin.go
   - context.go
   - routergroup.go
+  - logger.go
+  - recovery.go
+  - middleware_test.go
+  - utils.go
 question: "How does gin implement middleware chaining and abort handling?"
 expected_files:
   - gin.go

--- a/benchmarks/tasks/httpx_pooling.yaml
+++ b/benchmarks/tasks/httpx_pooling.yaml
@@ -2,6 +2,11 @@ task_id: httpx_pooling
 repo: encode/httpx
 commit: "0.28.1"
 category: external-framework
+languages: [python]
+include_paths:
+  - httpx/_transports/default.py
+  - httpx/_client.py
+  - httpx/_config.py
 question: "How does httpx manage HTTP connection pooling and keep-alive?"
 expected_files:
   - httpx/_transports/default.py

--- a/benchmarks/tasks/httpx_pooling.yaml
+++ b/benchmarks/tasks/httpx_pooling.yaml
@@ -4,9 +4,7 @@ commit: "0.28.1"
 category: external-framework
 languages: [python]
 include_paths:
-  - httpx/_transports/default.py
-  - httpx/_client.py
-  - httpx/_config.py
+  - httpx
 question: "How does httpx manage HTTP connection pooling and keep-alive?"
 expected_files:
   - httpx/_transports/default.py

--- a/benchmarks/tasks/mini_redis_async.yaml
+++ b/benchmarks/tasks/mini_redis_async.yaml
@@ -2,6 +2,11 @@ task_id: mini_redis_async
 repo: tokio-rs/mini-redis
 commit: "e186482ca00f8d884ddcbe20417f3654d03315a4"
 category: external-framework
+languages: [rust]
+include_paths:
+  - src/server.rs
+  - src/cmd/mod.rs
+  - src/connection.rs
 question: "How does mini-redis handle async command processing and connection management?"
 expected_files:
   - src/server.rs

--- a/benchmarks/tasks/mini_redis_async.yaml
+++ b/benchmarks/tasks/mini_redis_async.yaml
@@ -4,9 +4,7 @@ commit: "e186482ca00f8d884ddcbe20417f3654d03315a4"
 category: external-framework
 languages: [rust]
 include_paths:
-  - src/server.rs
-  - src/cmd/mod.rs
-  - src/connection.rs
+  - src
 question: "How does mini-redis handle async command processing and connection management?"
 expected_files:
   - src/server.rs

--- a/benchmarks/tasks/pydantic_validators.yaml
+++ b/benchmarks/tasks/pydantic_validators.yaml
@@ -3,6 +3,10 @@ repo: "pydantic/pydantic"
 commit: "v2.10.5"
 category: external-framework
 languages: [python]
+include_paths:
+  - pydantic/_internal/_validate_call.py
+  - pydantic/_internal/_validators.py
+  - pydantic/functional_validators.py
 question: "How does Pydantic chain and apply field validators?"
 expected_files:
   - pydantic/_internal/_validate_call.py

--- a/benchmarks/tasks/pydantic_validators.yaml
+++ b/benchmarks/tasks/pydantic_validators.yaml
@@ -4,8 +4,7 @@ commit: "v2.10.5"
 category: external-framework
 languages: [python]
 include_paths:
-  - pydantic/_internal/_validate_call.py
-  - pydantic/_internal/_validators.py
+  - pydantic/_internal
   - pydantic/functional_validators.py
 question: "How does Pydantic chain and apply field validators?"
 expected_files:

--- a/benchmarks/tasks/pytest_fixtures.yaml
+++ b/benchmarks/tasks/pytest_fixtures.yaml
@@ -6,6 +6,8 @@ languages: [python]
 include_paths:
   - src/_pytest/fixtures.py
   - src/_pytest/python.py
+  - src/_pytest/nodes.py
+  - src/_pytest/config
 question: "How does pytest discover and inject fixtures?"
 expected_files:
   - src/_pytest/fixtures.py

--- a/benchmarks/tasks/pytest_fixtures.yaml
+++ b/benchmarks/tasks/pytest_fixtures.yaml
@@ -3,6 +3,9 @@ repo: pytest-dev/pytest
 commit: "8.3.4"
 category: external-framework
 languages: [python]
+include_paths:
+  - src/_pytest/fixtures.py
+  - src/_pytest/python.py
 question: "How does pytest discover and inject fixtures?"
 expected_files:
   - src/_pytest/fixtures.py

--- a/benchmarks/tasks/react_hooks.yaml
+++ b/benchmarks/tasks/react_hooks.yaml
@@ -3,6 +3,9 @@ repo: facebook/react
 commit: "v19.0.0"
 category: external-large
 languages: [javascript]
+include_paths:
+  - packages/react-reconciler/src/ReactFiberHooks.js
+  - packages/react/src/ReactHooks.js
 question: "How does React implement the hooks state management system?"
 expected_files:
   - packages/react-reconciler/src/ReactFiberHooks.js

--- a/benchmarks/tasks/react_hooks.yaml
+++ b/benchmarks/tasks/react_hooks.yaml
@@ -5,7 +5,14 @@ category: external-large
 languages: [javascript]
 include_paths:
   - packages/react-reconciler/src/ReactFiberHooks.js
+  - packages/react-reconciler/src/ReactFiberLane.js
+  - packages/react-reconciler/src/ReactFiberWorkLoop.js
+  - packages/react-reconciler/src/ReactFiberFlags.js
   - packages/react/src/ReactHooks.js
+  - packages/react/src/ReactBaseClasses.js
+  - packages/react-reconciler/src/ReactFiber.js
+  - packages/react-reconciler/src/ReactFiberRoot.js
+  - packages/react/src/ReactSharedInternalsClient.js
 question: "How does React implement the hooks state management system?"
 expected_files:
   - packages/react-reconciler/src/ReactFiberHooks.js

--- a/benchmarks/tasks/requests_sessions.yaml
+++ b/benchmarks/tasks/requests_sessions.yaml
@@ -4,9 +4,7 @@ commit: "v2.32.3"
 category: external-framework
 languages: [python]
 include_paths:
-  - src/requests/sessions.py
-  - src/requests/adapters.py
-  - src/requests/models.py
+  - src/requests
 question: "How does requests manage HTTP sessions and connection pooling?"
 expected_files:
   - src/requests/sessions.py

--- a/benchmarks/tasks/requests_sessions.yaml
+++ b/benchmarks/tasks/requests_sessions.yaml
@@ -3,6 +3,10 @@ repo: psf/requests
 commit: "v2.32.3"
 category: external-framework
 languages: [python]
+include_paths:
+  - src/requests/sessions.py
+  - src/requests/adapters.py
+  - src/requests/models.py
 question: "How does requests manage HTTP sessions and connection pooling?"
 expected_files:
   - src/requests/sessions.py

--- a/benchmarks/tasks/rust_tokio_runtime.yaml
+++ b/benchmarks/tasks/rust_tokio_runtime.yaml
@@ -4,9 +4,8 @@ commit: "tokio-1.42.0"
 category: external-large
 languages: [rust]
 include_paths:
-  - tokio/src/runtime/scheduler/current_thread/mod.rs
-  - tokio/src/runtime/scheduler/multi_thread/mod.rs
-  - tokio/src/runtime/scheduler/multi_thread/worker.rs
+  - tokio/src/runtime/scheduler/current_thread
+  - tokio/src/runtime/scheduler/multi_thread
 question: "How does tokio implement the async task runtime and scheduler?"
 expected_files:
   - tokio/src/runtime/scheduler/current_thread/mod.rs

--- a/benchmarks/tasks/rust_tokio_runtime.yaml
+++ b/benchmarks/tasks/rust_tokio_runtime.yaml
@@ -3,6 +3,10 @@ repo: tokio-rs/tokio
 commit: "tokio-1.42.0"
 category: external-large
 languages: [rust]
+include_paths:
+  - tokio/src/runtime/scheduler/current_thread/mod.rs
+  - tokio/src/runtime/scheduler/multi_thread/mod.rs
+  - tokio/src/runtime/scheduler/multi_thread/worker.rs
 question: "How does tokio implement the async task runtime and scheduler?"
 expected_files:
   - tokio/src/runtime/scheduler/current_thread/mod.rs

--- a/benchmarks/tasks/sqlalchemy_sessions.yaml
+++ b/benchmarks/tasks/sqlalchemy_sessions.yaml
@@ -7,6 +7,10 @@ include_paths:
   - lib/sqlalchemy/orm/session.py
   - lib/sqlalchemy/orm/unitofwork.py
   - lib/sqlalchemy/orm/persistence.py
+  - lib/sqlalchemy/orm/state.py
+  - lib/sqlalchemy/orm/identity.py
+  - lib/sqlalchemy/orm/mapper.py
+  - lib/sqlalchemy/orm/query.py
 question: "How does SQLAlchemy manage database sessions and unit of work?"
 expected_files:
   - lib/sqlalchemy/orm/session.py

--- a/benchmarks/tasks/sqlalchemy_sessions.yaml
+++ b/benchmarks/tasks/sqlalchemy_sessions.yaml
@@ -3,6 +3,10 @@ repo: sqlalchemy/sqlalchemy
 commit: "rel_2_0_36"
 category: external-large
 languages: [python]
+include_paths:
+  - lib/sqlalchemy/orm/session.py
+  - lib/sqlalchemy/orm/unitofwork.py
+  - lib/sqlalchemy/orm/persistence.py
 question: "How does SQLAlchemy manage database sessions and unit of work?"
 expected_files:
   - lib/sqlalchemy/orm/session.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,10 @@ graph = [
 ]
 vector-torch = [
     "sentence-transformers>=5.2,<6",
+    "transformers>=4.41,<5",
 ]
 splade = [
-    "transformers>=4.30",
+    "transformers>=4.41,<5",
     "torch>=2.0",
 ]
 mcp = ["mcp>=1.0"]

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -49,6 +49,7 @@ class BenchmarkTask(BaseModel):
 class BenchmarkRetrievalOptions(BaseModel):
     splade: bool = False
     module_prefilter: bool = False
+    embedder: str = "jina-v2"
 
 
 class BenchmarkResult(BaseModel):

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from archex.models import (  # noqa: TCH001 — Pydantic needs at runtime
     DeltaMeta,
@@ -43,7 +43,16 @@ class BenchmarkTask(BaseModel):
     token_budget: int = 8192
     keywords: list[str] = []
     languages: list[str] | None = None
+    include_paths: list[str] = []
     category: TaskCategory | None = None
+
+    @model_validator(mode="after")
+    def _validate_include_paths(self) -> BenchmarkTask:
+        for path in self.include_paths:
+            if not path or path.startswith("/") or ".." in path.split("/"):
+                msg = f"include_paths entries must be relative paths: {path!r}"
+                raise ValueError(msg)
+        return self
 
 
 class BenchmarkRetrievalOptions(BaseModel):

--- a/src/archex/benchmark/preflight.py
+++ b/src/archex/benchmark/preflight.py
@@ -25,10 +25,18 @@ def warm_benchmark_models(
     warmed: list[str] = []
 
     if any(strategy in _VECTOR_MODEL_STRATEGIES for strategy in strategies):
-        from archex.index.embeddings.fast import FastEmbedder
+        from archex.index.embeddings import default_embedder_registry
+        from archex.models import IndexConfig
 
-        _ = FastEmbedder().dimension
-        warmed.append("fastembed")
+        default_embedder_registry.load_entry_points()
+        embedder = default_embedder_registry.create(
+            IndexConfig(vector=True, embedder=retrieval_options.embedder)
+        )
+        if embedder is None:
+            msg = "Benchmark vector strategy requires a configured embedder"
+            raise ValueError(msg)
+        _ = embedder.dimension
+        warmed.append(retrieval_options.embedder)
 
     if retrieval_options.splade:
         from archex.index.splade import DEFAULT_MODEL_NAME, SPLADEEncoder

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -94,7 +94,7 @@ def _warm_repo_index(
     retrieval_options = retrieval_options or BenchmarkRetrievalOptions()
     index_config = IndexConfig(
         vector=True,
-        embedder="fastembed",
+        embedder=retrieval_options.embedder,
         splade=retrieval_options.splade,
         module_prefilter=retrieval_options.module_prefilter,
     )

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -262,7 +262,7 @@ def run_all(
     output_dir.mkdir(parents=True, exist_ok=True)
     reports: list[BenchmarkReport] = []
     failures: list[tuple[str, str]] = []
-    repo_cache: dict[tuple[str, str], Path] = {}
+    repo_cache: dict[tuple[str, str, tuple[str, ...]], Path] = {}
     cleanup_paths: list[Path] = []
 
     try:
@@ -331,23 +331,63 @@ def load_selected_tasks(
 
 def _repo_path_for_task(
     task: BenchmarkTask,
-    repo_cache: dict[tuple[str, str], Path],
+    repo_cache: dict[tuple[str, str, tuple[str, ...]], Path],
     cleanup_paths: list[Path],
 ) -> Path:
     """Return a stable repo path for a task within one benchmark run."""
     if task.repo == ".":
         return Path.cwd()
 
-    key = (task.repo, task.commit)
+    key = (task.repo, task.commit, tuple(task.include_paths))
     cached = repo_cache.get(key)
     if cached is not None:
         return cached
 
-    repo_path, needs_cleanup = clone_at_commit(task.repo, task.commit)
-    repo_cache[key] = repo_path
+    clone_path, needs_cleanup = clone_at_commit(task.repo, task.commit)
     if needs_cleanup:
+        cleanup_paths.append(clone_path)
+    repo_path = clone_path
+    if task.include_paths:
+        repo_path = _slice_repo_for_task(clone_path, task)
         cleanup_paths.append(repo_path)
+    repo_cache[key] = repo_path
     return repo_path
+
+
+def _slice_repo_for_task(repo_path: Path, task: BenchmarkTask) -> Path:
+    """Copy only task-relevant repository paths into a temporary benchmark corpus."""
+    target = Path(tempfile.mkdtemp(prefix="archex-bench-slice-"))
+    for rel_path in task.include_paths:
+        source = repo_path / rel_path
+        if not source.exists():
+            shutil.rmtree(target, ignore_errors=True)
+            raise BenchmarkCloneError(
+                f"include path {rel_path!r} does not exist in {task.repo}@{task.commit}"
+            )
+        _copy_benchmark_path(source, target / rel_path)
+    init = _run_git(["git", "init", "--quiet"], cwd=target, timeout=30)
+    if init.returncode != 0:
+        shutil.rmtree(target, ignore_errors=True)
+        detail = init.stderr.strip() or "unknown git error"
+        raise BenchmarkCloneError(f"git init failed for scoped benchmark repo: {detail}")
+    return target
+
+
+def _copy_benchmark_path(source: Path, target: Path) -> None:
+    if source.is_dir():
+        for child in source.rglob("*"):
+            if ".git" in child.parts:
+                continue
+            relative = child.relative_to(source)
+            destination = target / relative
+            if child.is_dir():
+                destination.mkdir(parents=True, exist_ok=True)
+            elif child.is_file():
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(child, destination)
+        return
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
 
 
 def _log_progress(progress: BenchmarkProgress | None, message: str) -> None:

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -506,8 +506,24 @@ def reset_benchmark_retrieval_options(token: Token[BenchmarkRetrievalOptions | N
     _BENCHMARK_RETRIEVAL_OPTIONS.reset(token)
 
 
+def _embedder_cache_identity(embedder: str) -> str:
+    if embedder != "jina-v2":
+        return embedder
+    from archex.index.embeddings import (
+        JINA_BERT_CODE_REVISION,
+        JINA_V2_MAX_SEQ_LENGTH,
+        JINA_V2_MODEL_REVISION,
+    )
+
+    return (
+        f"{embedder}@{JINA_V2_MODEL_REVISION}"
+        f"+code={JINA_BERT_CODE_REVISION}"
+        f"+max_seq={JINA_V2_MAX_SEQ_LENGTH}"
+    )
+
+
 def _retrieval_cache_suffix(options: BenchmarkRetrievalOptions) -> str:
-    enabled: list[str] = [f"embedder={options.embedder}"]
+    enabled: list[str] = [f"embedder={_embedder_cache_identity(options.embedder)}"]
     if options.splade:
         enabled.append("splade")
     if options.module_prefilter:

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -507,7 +507,7 @@ def reset_benchmark_retrieval_options(token: Token[BenchmarkRetrievalOptions | N
 
 
 def _retrieval_cache_suffix(options: BenchmarkRetrievalOptions) -> str:
-    enabled: list[str] = []
+    enabled: list[str] = [f"embedder={options.embedder}"]
     if options.splade:
         enabled.append("splade")
     if options.module_prefilter:
@@ -517,7 +517,9 @@ def _retrieval_cache_suffix(options: BenchmarkRetrievalOptions) -> str:
 
 def benchmark_index_config(index_config: IndexConfig) -> IndexConfig:
     options = current_benchmark_retrieval_options()
-    updates: dict[str, bool] = {}
+    updates: dict[str, bool | str] = {}
+    if index_config.vector:
+        updates["embedder"] = options.embedder
     if options.splade:
         updates["splade"] = True
     if options.module_prefilter and index_config.bm25:
@@ -625,9 +627,7 @@ def run_archex_query_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
     timing = PipelineTiming()
     source = benchmark_repo_source(task, repo_path)
     config = Config(cache=True, languages=task.languages)
-    index_config = benchmark_index_config(
-        IndexConfig(bm25=False, vector=True, embedder="fastembed")
-    )
+    index_config = benchmark_index_config(IndexConfig(bm25=False, vector=True))
 
     bundle = query(
         source,
@@ -703,7 +703,7 @@ def run_surrogate_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResul
         IndexConfig(
             bm25=False,
             vector=True,
-            embedder="fastembed",
+            embedder=current_benchmark_retrieval_options().embedder,
             vector_mode=VectorMode.SURROGATE,
             retrieval_policy=RetrievalPolicy.VECTOR_ONLY,
         )
@@ -773,7 +773,7 @@ def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
     timing = PipelineTiming()
     source = benchmark_repo_source(task, repo_path)
     config = Config(cache=True, languages=task.languages)
-    index_config = benchmark_index_config(IndexConfig(vector=True, embedder="fastembed"))
+    index_config = benchmark_index_config(IndexConfig(vector=True))
 
     bundle = query(
         source,
@@ -845,9 +845,7 @@ def run_archex_query_fusion_rerank(task: BenchmarkTask, repo_path: Path) -> Benc
     timing = PipelineTiming()
     source = benchmark_repo_source(task, repo_path)
     config = Config(cache=True, languages=task.languages)
-    index_config = benchmark_index_config(
-        IndexConfig(vector=True, embedder="fastembed", rerank=True)
-    )
+    index_config = benchmark_index_config(IndexConfig(vector=True, rerank=True))
 
     bundle = query(
         source,
@@ -915,7 +913,7 @@ def run_cross_layer_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
     index_config = benchmark_index_config(
         IndexConfig(
             vector=True,
-            embedder="fastembed",
+            embedder=current_benchmark_retrieval_options().embedder,
             vector_mode=VectorMode.SURROGATE,
             retrieval_policy=RetrievalPolicy.CROSS_LAYER,
         )

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -531,6 +531,12 @@ def _retrieval_cache_suffix(options: BenchmarkRetrievalOptions) -> str:
     return "+".join(enabled)
 
 
+def _corpus_cache_suffix(task: BenchmarkTask) -> str:
+    if not task.include_paths:
+        return ""
+    return "scope=" + "|".join(sorted(task.include_paths))
+
+
 def benchmark_index_config(index_config: IndexConfig) -> IndexConfig:
     options = current_benchmark_retrieval_options()
     updates: dict[str, bool | str] = {}
@@ -557,9 +563,16 @@ def benchmark_repo_source(task: BenchmarkTask, repo_path: Path) -> RepoSource:
             f"Benchmark task {task.task_id!r} has no commit and {repo_path} has no git HEAD"
         )
     stable_identity = f"{task.repo}@{commit}"
-    suffix = _retrieval_cache_suffix(current_benchmark_retrieval_options())
-    if suffix:
-        stable_identity = f"{stable_identity}#{suffix}"
+    suffixes = [
+        suffix
+        for suffix in (
+            _corpus_cache_suffix(task),
+            _retrieval_cache_suffix(current_benchmark_retrieval_options()),
+        )
+        if suffix
+    ]
+    if suffixes:
+        stable_identity = f"{stable_identity}#{'+'.join(suffixes)}"
     return RepoSource(
         local_path=str(repo_path),
         stable_identity=stable_identity,

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -106,6 +106,12 @@ def benchmark_cmd() -> None:
     help="Enable the opt-in module responsibility prefilter for BM25-backed archex strategies.",
 )
 @click.option(
+    "--embedder",
+    default="jina-v2",
+    show_default=True,
+    help="Embedder to pin across every vector-backed benchmark strategy.",
+)
+@click.option(
     "--self-only",
     is_flag=True,
     default=False,
@@ -127,6 +133,7 @@ def run_cmd(
     rerank: bool,
     splade: bool,
     module_prefilter: bool,
+    embedder: str,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -149,6 +156,7 @@ def run_cmd(
     retrieval_options = BenchmarkRetrievalOptions(
         splade=splade,
         module_prefilter=module_prefilter,
+        embedder=embedder,
     )
     warmed_models = warm_benchmark_models(strategies, retrieval_options)
     if warmed_models:

--- a/src/archex/index/embeddings/__init__.py
+++ b/src/archex/index/embeddings/__init__.py
@@ -36,6 +36,15 @@ def _nomic_factory() -> Embedder:
     return NomicCodeEmbedder()
 
 
+def _jina_v2_factory() -> Embedder:
+    from archex.index.embeddings.sentence_tf import SentenceTransformerEmbedder
+
+    return SentenceTransformerEmbedder(
+        model_name="jinaai/jina-embeddings-v2-base-code",
+        trust_remote_code=True,
+    )
+
+
 def _sentence_tf_factory() -> Embedder:
     from archex.index.embeddings.sentence_tf import SentenceTransformerEmbedder
 
@@ -105,4 +114,5 @@ default_embedder_registry = EmbedderRegistry()
 default_embedder_registry.register("fastembed", _fastembed_factory)
 default_embedder_registry.register("nomic", _nomic_factory)
 default_embedder_registry.register("sentence_transformers", _sentence_tf_factory)
+default_embedder_registry.register("jina-v2", _jina_v2_factory)
 default_embedder_registry.register("coderank", _coderank_factory)

--- a/src/archex/index/embeddings/__init__.py
+++ b/src/archex/index/embeddings/__init__.py
@@ -16,6 +16,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 EmbedderFactory = Callable[[], Embedder]
+JINA_V2_MODEL_ID = "jinaai/jina-embeddings-v2-base-code"
+JINA_V2_MODEL_REVISION = "516f4baf13dec4ddddda8631e019b5737c8bc250"
+JINA_BERT_CODE_REVISION = "3baf9e3ac750e76e8edd3019170176884695fb94"
+
 
 __all__ = [
     "Embedder",
@@ -40,8 +44,11 @@ def _jina_v2_factory() -> Embedder:
     from archex.index.embeddings.sentence_tf import SentenceTransformerEmbedder
 
     return SentenceTransformerEmbedder(
-        model_name="jinaai/jina-embeddings-v2-base-code",
+        model_name=JINA_V2_MODEL_ID,
         trust_remote_code=True,
+        revision=JINA_V2_MODEL_REVISION,
+        model_kwargs={"code_revision": JINA_BERT_CODE_REVISION},
+        config_kwargs={"code_revision": JINA_BERT_CODE_REVISION},
     )
 
 

--- a/src/archex/index/embeddings/__init__.py
+++ b/src/archex/index/embeddings/__init__.py
@@ -19,6 +19,7 @@ EmbedderFactory = Callable[[], Embedder]
 JINA_V2_MODEL_ID = "jinaai/jina-embeddings-v2-base-code"
 JINA_V2_MODEL_REVISION = "516f4baf13dec4ddddda8631e019b5737c8bc250"
 JINA_BERT_CODE_REVISION = "3baf9e3ac750e76e8edd3019170176884695fb94"
+JINA_V2_MAX_SEQ_LENGTH = 1024
 
 
 __all__ = [
@@ -49,6 +50,7 @@ def _jina_v2_factory() -> Embedder:
         revision=JINA_V2_MODEL_REVISION,
         model_kwargs={"code_revision": JINA_BERT_CODE_REVISION},
         config_kwargs={"code_revision": JINA_BERT_CODE_REVISION},
+        max_seq_length=JINA_V2_MAX_SEQ_LENGTH,
     )
 
 

--- a/src/archex/index/embeddings/sentence_tf.py
+++ b/src/archex/index/embeddings/sentence_tf.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Any
 
 from archex.exceptions import ArchexIndexError
@@ -18,6 +20,10 @@ class SentenceTransformerEmbedder:
         model_name: str = "all-MiniLM-L6-v2",
         batch_size: int = 32,
         trust_remote_code: bool = False,
+        revision: str | None = None,
+        local_files_only: bool = False,
+        model_kwargs: Mapping[str, object] = MappingProxyType({}),
+        config_kwargs: Mapping[str, object] = MappingProxyType({}),
     ) -> None:
         try:
             import sentence_transformers as _st  # pyright: ignore[reportUnusedImport]  # noqa: F401
@@ -30,6 +36,10 @@ class SentenceTransformerEmbedder:
         self._model_name = model_name
         self._batch_size = batch_size
         self._trust_remote_code = trust_remote_code
+        self._revision = revision
+        self._local_files_only = local_files_only
+        self._model_kwargs = dict(model_kwargs)
+        self._config_kwargs = dict(config_kwargs)
         self._model: Any = None
         self._dimension: int | None = None
 
@@ -50,6 +60,10 @@ class SentenceTransformerEmbedder:
             self._model_name,
             device=_best_device(),
             trust_remote_code=self._trust_remote_code,
+            revision=self._revision,
+            local_files_only=self._local_files_only,
+            model_kwargs=self._model_kwargs,
+            config_kwargs=self._config_kwargs,
         )
         self._dimension = self._model.get_sentence_embedding_dimension()
 

--- a/src/archex/index/embeddings/sentence_tf.py
+++ b/src/archex/index/embeddings/sentence_tf.py
@@ -17,6 +17,7 @@ class SentenceTransformerEmbedder:
         self,
         model_name: str = "all-MiniLM-L6-v2",
         batch_size: int = 32,
+        trust_remote_code: bool = False,
     ) -> None:
         try:
             import sentence_transformers as _st  # pyright: ignore[reportUnusedImport]  # noqa: F401
@@ -28,6 +29,7 @@ class SentenceTransformerEmbedder:
 
         self._model_name = model_name
         self._batch_size = batch_size
+        self._trust_remote_code = trust_remote_code
         self._model: Any = None
         self._dimension: int | None = None
 
@@ -44,7 +46,11 @@ class SentenceTransformerEmbedder:
             _best_device,  # pyright: ignore[reportPrivateUsage]
         )
 
-        self._model = SentenceTransformer(self._model_name, device=_best_device())
+        self._model = SentenceTransformer(
+            self._model_name,
+            device=_best_device(),
+            trust_remote_code=self._trust_remote_code,
+        )
         self._dimension = self._model.get_sentence_embedding_dimension()
 
     def encode(self, texts: list[str]) -> list[list[float]]:

--- a/src/archex/index/embeddings/sentence_tf.py
+++ b/src/archex/index/embeddings/sentence_tf.py
@@ -24,6 +24,7 @@ class SentenceTransformerEmbedder:
         local_files_only: bool = False,
         model_kwargs: Mapping[str, object] = MappingProxyType({}),
         config_kwargs: Mapping[str, object] = MappingProxyType({}),
+        max_seq_length: int | None = None,
     ) -> None:
         try:
             import sentence_transformers as _st  # pyright: ignore[reportUnusedImport]  # noqa: F401
@@ -40,6 +41,7 @@ class SentenceTransformerEmbedder:
         self._local_files_only = local_files_only
         self._model_kwargs = dict(model_kwargs)
         self._config_kwargs = dict(config_kwargs)
+        self._max_seq_length = max_seq_length
         self._model: Any = None
         self._dimension: int | None = None
 
@@ -65,6 +67,8 @@ class SentenceTransformerEmbedder:
             model_kwargs=self._model_kwargs,
             config_kwargs=self._config_kwargs,
         )
+        if self._max_seq_length is not None:
+            self._model.max_seq_length = self._max_seq_length
         self._dimension = self._model.get_sentence_embedding_dimension()
 
     def encode(self, texts: list[str]) -> list[list[float]]:

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -260,6 +260,7 @@ class TestRunCommand:
         assert "--module-prefilter" in result.output
         assert "--self-only" in result.output
         assert "--no-progress" in result.output
+        assert "--embedder" in result.output
 
     def test_run_uses_default_strategies_without_flags(
         self,
@@ -392,6 +393,33 @@ class TestRunCommand:
             splade=True,
             module_prefilter=True,
         )
+
+    def test_run_passes_embedder_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(benchmark_cmd, ["run", "--embedder", "coderank"])
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(embedder="coderank")
 
     def test_run_preflights_models_before_loading_tasks(
         self,

--- a/tests/benchmark/test_loader.py
+++ b/tests/benchmark/test_loader.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 
@@ -14,9 +14,6 @@ from archex.benchmark.loader import (
     validate_task,
 )
 from archex.benchmark.models import BenchmarkTask, DeltaBenchmarkTask
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 @pytest.fixture
@@ -61,6 +58,22 @@ class TestLoadTask:
         assert task.commit == "abc123"
         assert len(task.expected_files) == 2
         assert task.keywords == ["main", "utils"]
+        assert task.include_paths == []
+
+    def test_load_include_paths(self, tmp_path: Path) -> None:
+        p = tmp_path / "scoped.yaml"
+        p.write_text("""\
+task_id: scoped
+repo: owner/repo
+commit: abc
+question: "How?"
+include_paths:
+  - src/pkg
+expected_files:
+  - src/pkg/main.py
+""")
+        task = load_task(p)
+        assert task.include_paths == ["src/pkg"]
 
     def test_load_missing_file(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):
@@ -84,6 +97,19 @@ class TestLoadTasks:
         tasks = load_tasks(tasks_dir)
         assert len(tasks) == 3
         assert all(isinstance(t, BenchmarkTask) for t in tasks)
+
+    def test_benchmark_scopes_cover_expected_files(self) -> None:
+        tasks_dir = Path(__file__).resolve().parents[2] / "benchmarks" / "tasks"
+        tasks = load_tasks(tasks_dir)
+        for task in tasks:
+            if not task.include_paths:
+                continue
+            for expected_file in task.expected_files:
+                assert any(
+                    expected_file == include_path
+                    or expected_file.startswith(f"{include_path.rstrip('/')}/")
+                    for include_path in task.include_paths
+                ), f"{task.task_id}: {expected_file} is outside include_paths"
 
     def test_load_empty_directory(self, tmp_path: Path) -> None:
         tasks = load_tasks(tmp_path)

--- a/tests/benchmark/test_loader.py
+++ b/tests/benchmark/test_loader.py
@@ -111,6 +111,17 @@ class TestLoadTasks:
                     for include_path in task.include_paths
                 ), f"{task.task_id}: {expected_file} is outside include_paths"
 
+    def test_external_benchmark_scopes_include_distractors(self) -> None:
+        tasks_dir = Path(__file__).resolve().parents[2] / "benchmarks" / "tasks"
+        tasks = load_tasks(tasks_dir)
+        external_tasks = [task for task in tasks if task.repo != "."]
+        assert external_tasks
+        for task in external_tasks:
+            assert task.include_paths, f"{task.task_id}: external task must declare include_paths"
+            assert set(task.include_paths) != set(task.expected_files), (
+                f"{task.task_id}: include_paths must be broader than exact expected files"
+            )
+
     def test_load_empty_directory(self, tmp_path: Path) -> None:
         tasks = load_tasks(tmp_path)
         assert tasks == []

--- a/tests/benchmark/test_models.py
+++ b/tests/benchmark/test_models.py
@@ -46,6 +46,28 @@ class TestBenchmarkTask:
         assert task.token_budget == 8192
         assert task.keywords == []
         assert task.expected_symbols == []
+        assert task.include_paths == []
+
+    def test_include_paths_must_be_relative(self) -> None:
+        with pytest.raises(ValidationError):
+            BenchmarkTask(
+                task_id="test",
+                repo="owner/repo",
+                commit="abc",
+                question="test",
+                expected_files=["src/main.py"],
+                include_paths=["../secret"],
+            )
+
+        with pytest.raises(ValidationError):
+            BenchmarkTask(
+                task_id="test",
+                repo="owner/repo",
+                commit="abc",
+                question="test",
+                expected_files=["src/main.py"],
+                include_paths=["/tmp/repo"],
+            )
 
     def test_missing_required_field(self) -> None:
         with pytest.raises(ValidationError):

--- a/tests/benchmark/test_progress.py
+++ b/tests/benchmark/test_progress.py
@@ -33,9 +33,15 @@ def test_progress_renders_overall_and_active_task_text() -> None:
     with BenchmarkProgress(tasks, console=console, refresh_per_second=30) as progress:
         progress.start_task(tasks[0])
         progress.start_warmup()
+        active = progress.active_task
+        assert active is not None
+        assert active.fields["activity"] == WARMING_ACTIVITY
         progress.refresh()
         progress.finish_warmup([Strategy.RAW_FILES, Strategy.ARCHEX_QUERY])
         progress.start_strategy(Strategy.RAW_FILES)
+        active = progress.active_task
+        assert active is not None
+        assert active.fields["activity"] == "raw_files"
         progress.refresh()
         progress.finish_strategy()
         progress.start_strategy(Strategy.ARCHEX_QUERY)
@@ -44,9 +50,7 @@ def test_progress_renders_overall_and_active_task_text() -> None:
     output = _strip_ansi(buffer.getvalue())
     assert "task_one (owner/repo)" in output
     assert "0/2" in output
-    assert "raw_files" in output
     assert "archex_query" in output
-    assert WARMING_ACTIVITY in output
 
 
 def test_warmup_is_indeterminate_then_flips_to_strategy_total() -> None:

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
@@ -111,14 +112,14 @@ class TestRunBenchmark:
         from archex.benchmark.strategies import default_strategy_registry
         from archex.exceptions import ArchexIndexError
 
-        warmed: list[Path] = []
+        warmed: list[tuple[Path, BenchmarkRetrievalOptions | None]] = []
 
         def _record(
             _task: BenchmarkTask,
             path: Path,
-            _options: BenchmarkRetrievalOptions | None = None,
+            options: BenchmarkRetrievalOptions | None = None,
         ) -> None:
-            warmed.append(path)
+            warmed.append((path, options))
 
         def _raise(_task: BenchmarkTask, _path: Path) -> None:
             raise ArchexIndexError("no vector backend in test")
@@ -133,8 +134,45 @@ class TestRunBenchmark:
             task,
             strategies=[Strategy.RAW_FILES, Strategy.ARCHEX_QUERY_FUSION],
             repo_path=repo_path,
+            retrieval_options=BenchmarkRetrievalOptions(embedder="coderank"),
         )
-        assert warmed == [repo_path]
+        assert warmed == [(repo_path, BenchmarkRetrievalOptions(embedder="coderank"))]
+
+    def test_warm_repo_index_uses_configured_embedder(
+        self,
+        fixture_task: tuple[BenchmarkTask, Path],
+    ) -> None:
+        from archex.benchmark import runner as runner_mod
+        from archex.models import ContextBundle, IndexConfig
+
+        task, repo_path = fixture_task
+        captured: list[str | None] = []
+
+        def fake_query(
+            _source: object,
+            question: str,
+            *,
+            token_budget: int,
+            config: object,
+            index_config: IndexConfig,
+        ) -> ContextBundle:
+            del config
+            captured.append(index_config.embedder)
+            return ContextBundle(
+                query=question,
+                chunks=[],
+                token_count=0,
+                token_budget=token_budget,
+            )
+
+        with patch("archex.api.query", fake_query):
+            runner_mod._warm_repo_index(  # pyright: ignore[reportPrivateUsage]
+                task,
+                repo_path,
+                BenchmarkRetrievalOptions(embedder="coderank"),
+            )
+
+        assert captured == ["coderank"]
 
     def test_skips_warmup_for_raw_only_strategies(
         self,
@@ -279,7 +317,7 @@ class TestRunBenchmark:
 
         task, repo_path = fixture_task
         source = benchmark_repo_source(task, repo_path)
-        assert source.stable_identity == "test/python_simple@HEAD"
+        assert source.stable_identity == "test/python_simple@HEAD#embedder=jina-v2"
 
         token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions(splade=True))
         try:
@@ -287,7 +325,17 @@ class TestRunBenchmark:
         finally:
             reset_benchmark_retrieval_options(token)
 
-        assert splade_source.stable_identity == "test/python_simple@HEAD#splade"
+        assert splade_source.stable_identity == "test/python_simple@HEAD#embedder=jina-v2+splade"
+
+        coderank_token = set_benchmark_retrieval_options(
+            BenchmarkRetrievalOptions(embedder="coderank")
+        )
+        try:
+            coderank_source = benchmark_repo_source(task, repo_path)
+        finally:
+            reset_benchmark_retrieval_options(coderank_token)
+
+        assert coderank_source.stable_identity == "test/python_simple@HEAD#embedder=coderank"
 
     def test_benchmark_index_config_applies_module_prefilter_only_with_bm25(self) -> None:
         from archex.benchmark.strategies import (
@@ -314,6 +362,8 @@ class TestRunBenchmark:
         assert bm25_config.module_prefilter is True
         assert vector_config.splade is True
         assert vector_config.module_prefilter is False
+        assert bm25_config.embedder == "jina-v2"
+        assert vector_config.embedder == "jina-v2"
         assert cache_enabled is True
 
 

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -347,6 +348,17 @@ class TestRunBenchmark:
         finally:
             reset_benchmark_retrieval_options(coderank_token)
 
+        scoped_token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions())
+        scoped_task = task.model_copy(update={"include_paths": ["src", "tests"]})
+        try:
+            scoped_source = benchmark_repo_source(scoped_task, repo_path)
+        finally:
+            reset_benchmark_retrieval_options(scoped_token)
+
+        assert scoped_source.stable_identity == (
+            f"test/python_simple@HEAD#scope=src|tests+embedder={jina_identity}"
+        )
+
         assert coderank_source.stable_identity == "test/python_simple@HEAD#embedder=coderank"
 
     def test_benchmark_index_config_applies_module_prefilter_only_with_bm25(self) -> None:
@@ -614,6 +626,48 @@ expected_files:
 
         assert {report.task_id for report in reports} == {"test_all", "other_task"}
         assert clone_calls == [("test/repo", "HEAD")]
+
+    def test_repo_path_for_task_slices_include_paths(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import archex.benchmark.runner as runner_mod
+
+        clone_dir = tmp_path / "clone"
+        (clone_dir / "pkg" / "sub").mkdir(parents=True)
+        (clone_dir / "pkg" / "sub" / "kept.py").write_text("kept = True\n")
+        (clone_dir / "pkg" / "discarded.py").write_text("discarded = True\n")
+        (clone_dir / "other.py").write_text("other = True\n")
+
+        def fake_clone(_repo: str, _commit: str) -> tuple[Path, bool]:
+            return clone_dir, True
+
+        monkeypatch.setattr(runner_mod, "clone_at_commit", fake_clone)
+        task = BenchmarkTask(
+            task_id="slice",
+            repo="owner/repo",
+            commit="abc",
+            question="How?",
+            expected_files=["pkg/sub/kept.py"],
+            include_paths=["pkg/sub"],
+        )
+        cleanup_paths: list[Path] = []
+
+        sliced = runner_mod._repo_path_for_task(  # pyright: ignore[reportPrivateUsage]
+            task,
+            {},
+            cleanup_paths,
+        )
+
+        try:
+            assert (sliced / "pkg" / "sub" / "kept.py").exists()
+            assert not (sliced / "pkg" / "discarded.py").exists()
+            assert not (sliced / "other.py").exists()
+            assert (sliced / ".git").is_dir()
+            assert cleanup_paths == [clone_dir, sliced]
+        finally:
+            shutil.rmtree(sliced, ignore_errors=True)
 
     def test_run_all_cleans_reused_external_clone(
         self,

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -314,10 +314,20 @@ class TestRunBenchmark:
             reset_benchmark_retrieval_options,
             set_benchmark_retrieval_options,
         )
+        from archex.index.embeddings import (
+            JINA_BERT_CODE_REVISION,
+            JINA_V2_MAX_SEQ_LENGTH,
+            JINA_V2_MODEL_REVISION,
+        )
 
         task, repo_path = fixture_task
+        jina_identity = (
+            f"jina-v2@{JINA_V2_MODEL_REVISION}"
+            f"+code={JINA_BERT_CODE_REVISION}"
+            f"+max_seq={JINA_V2_MAX_SEQ_LENGTH}"
+        )
         source = benchmark_repo_source(task, repo_path)
-        assert source.stable_identity == "test/python_simple@HEAD#embedder=jina-v2"
+        assert source.stable_identity == f"test/python_simple@HEAD#embedder={jina_identity}"
 
         token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions(splade=True))
         try:
@@ -325,7 +335,9 @@ class TestRunBenchmark:
         finally:
             reset_benchmark_retrieval_options(token)
 
-        assert splade_source.stable_identity == "test/python_simple@HEAD#embedder=jina-v2+splade"
+        assert splade_source.stable_identity == (
+            f"test/python_simple@HEAD#embedder={jina_identity}+splade"
+        )
 
         coderank_token = set_benchmark_retrieval_options(
             BenchmarkRetrievalOptions(embedder="coderank")

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -34,8 +34,18 @@ from archex.benchmark.strategies import (
 )
 from archex.cache import CacheManager
 from archex.exceptions import ConfigError
+from archex.index.embeddings import (
+    JINA_BERT_CODE_REVISION,
+    JINA_V2_MAX_SEQ_LENGTH,
+    JINA_V2_MODEL_REVISION,
+)
 from archex.models import CodeChunk, ContextBundle, IndexConfig, RankedChunk, RetrievalMetadata
 
+JINA_V2_CACHE_IDENTITY = (
+    f"jina-v2@{JINA_V2_MODEL_REVISION}"
+    f"+code={JINA_BERT_CODE_REVISION}"
+    f"+max_seq={JINA_V2_MAX_SEQ_LENGTH}"
+)
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -337,8 +347,8 @@ class TestRunArchexQuery:
         source_a = benchmark_repo_source(sample_task, repo_a)
         source_b = benchmark_repo_source(sample_task, repo_b)
 
-        assert source_a.stable_identity == "test/repo@abc#embedder=jina-v2"
-        assert source_b.stable_identity == "test/repo@abc#embedder=jina-v2"
+        assert source_a.stable_identity == f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}"
+        assert source_b.stable_identity == f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}"
         assert cache.cache_key(source_a) == cache.cache_key(source_b)
 
     def test_benchmark_source_resolves_missing_commit_from_git_head(
@@ -356,7 +366,7 @@ class TestRunArchexQuery:
         with patch.object(CacheManager, "git_head", return_value="resolved"):
             source = benchmark_repo_source(task, tmp_path)
 
-        assert source.stable_identity == "test/repo@resolved#embedder=jina-v2"
+        assert source.stable_identity == (f"test/repo@resolved#embedder={JINA_V2_CACHE_IDENTITY}")
 
     def test_benchmark_source_rejects_missing_commit_without_git_head(
         self,

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from archex.benchmark.models import BenchmarkTask, Strategy
+from archex.benchmark.models import BenchmarkRetrievalOptions, BenchmarkTask, Strategy
 from archex.benchmark.strategies import (
     _archex_fields,  # pyright: ignore[reportPrivateUsage]
     _deduplicate_ranked,  # pyright: ignore[reportPrivateUsage]
@@ -20,6 +20,7 @@ from archex.benchmark.strategies import (
     compute_symbol_recall,
     count_file_tokens,
     extract_keywords,
+    reset_benchmark_retrieval_options,
     run_archex_query,
     run_archex_query_fusion,
     run_archex_query_fusion_rerank,
@@ -29,10 +30,11 @@ from archex.benchmark.strategies import (
     run_raw_files,
     run_raw_grepped,
     run_surrogate_vector,
+    set_benchmark_retrieval_options,
 )
 from archex.cache import CacheManager
 from archex.exceptions import ConfigError
-from archex.models import CodeChunk, ContextBundle, RankedChunk, RetrievalMetadata
+from archex.models import CodeChunk, ContextBundle, IndexConfig, RankedChunk, RetrievalMetadata
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -335,8 +337,8 @@ class TestRunArchexQuery:
         source_a = benchmark_repo_source(sample_task, repo_a)
         source_b = benchmark_repo_source(sample_task, repo_b)
 
-        assert source_a.stable_identity == "test/repo@abc"
-        assert source_b.stable_identity == "test/repo@abc"
+        assert source_a.stable_identity == "test/repo@abc#embedder=jina-v2"
+        assert source_b.stable_identity == "test/repo@abc#embedder=jina-v2"
         assert cache.cache_key(source_a) == cache.cache_key(source_b)
 
     def test_benchmark_source_resolves_missing_commit_from_git_head(
@@ -354,7 +356,7 @@ class TestRunArchexQuery:
         with patch.object(CacheManager, "git_head", return_value="resolved"):
             source = benchmark_repo_source(task, tmp_path)
 
-        assert source.stable_identity == "test/repo@resolved"
+        assert source.stable_identity == "test/repo@resolved#embedder=jina-v2"
 
     def test_benchmark_source_rejects_missing_commit_without_git_head(
         self,
@@ -487,6 +489,47 @@ class _StubEmbedder:
 
 def _stub_get_embedder(_index_config: object) -> _StubEmbedder:
     return _StubEmbedder()
+
+
+def test_vector_strategies_read_configured_embedder(
+    sample_task: BenchmarkTask,
+    python_simple_repo: Path,
+) -> None:
+    captured: list[str | None] = []
+
+    def fake_query(
+        _source: object,
+        question: str,
+        *,
+        token_budget: int,
+        config: object,
+        index_config: IndexConfig,
+        timing: object | None = None,
+    ) -> ContextBundle:
+        del config, timing
+        captured.append(index_config.embedder)
+        return ContextBundle(
+            query=question,
+            chunks=[],
+            token_count=0,
+            token_budget=token_budget,
+        )
+
+    token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions(embedder="coderank"))
+    try:
+        with patch("archex.api.query", fake_query):
+            for runner in (
+                run_archex_query_vector,
+                run_surrogate_vector,
+                run_archex_query_fusion,
+                run_cross_layer_fusion,
+                run_archex_query_fusion_rerank,
+            ):
+                runner(sample_task, python_simple_repo)
+    finally:
+        reset_benchmark_retrieval_options(token)
+
+    assert captured == ["coderank"] * 5
 
 
 class TestRunArchexQueryVector:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,41 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Disable global coverage threshold for benchmark-only test slices."""
+    _disable_benchmark_coverage_threshold(config)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionstart(session: pytest.Session) -> None:
+    _disable_benchmark_coverage_threshold(session.config)
+
+
+def _disable_benchmark_coverage_threshold(config: pytest.Config) -> None:
+    if not _benchmark_only_paths(config.invocation_params.args):
+        return
+    if getattr(config.option, "cov_fail_under", None) is not None:
+        config.option.cov_fail_under = 0
+    cov_plugin: Any = config.pluginmanager.getplugin("_cov")
+    cov_options: Any = getattr(cov_plugin, "options", None)
+    if cov_options is not None and getattr(cov_options, "cov_fail_under", None) is not None:
+        cov_options.cov_fail_under = 0
+
+
+def _benchmark_only_paths(args: Sequence[str]) -> bool:
+    paths = [arg.rstrip("/") for arg in args if arg and not arg.startswith("-")]
+    return bool(paths) and all(
+        path == "tests/benchmark" or path.startswith("tests/benchmark/") for path in paths
+    )
 
 
 def _init_fixture_repo(tmp_path: Path, fixture_name: str) -> Path:

--- a/tests/index/embeddings/test_embeddings.py
+++ b/tests/index/embeddings/test_embeddings.py
@@ -223,7 +223,7 @@ class TestSentenceTransformerEmbedder:
 
         mock_st_module.SentenceTransformer.assert_called_once()
 
-    def test_load_model_passes_revision_and_remote_code_kwargs(self) -> None:
+    def test_load_model_passes_revision_remote_code_kwargs_and_sequence_cap(self) -> None:
         from unittest.mock import ANY, MagicMock
 
         mock_st_module = MagicMock()
@@ -241,6 +241,7 @@ class TestSentenceTransformerEmbedder:
                 local_files_only=True,
                 model_kwargs={"code_revision": "code-revision"},
                 config_kwargs={"code_revision": "code-revision"},
+                max_seq_length=1024,
             )
             embedder._load_model()  # pyright: ignore[reportPrivateUsage]
 
@@ -253,6 +254,7 @@ class TestSentenceTransformerEmbedder:
             model_kwargs={"code_revision": "code-revision"},
             config_kwargs={"code_revision": "code-revision"},
         )
+        assert mock_model.max_seq_length == 1024
 
 
 class TestFastEmbedder:

--- a/tests/index/embeddings/test_embeddings.py
+++ b/tests/index/embeddings/test_embeddings.py
@@ -223,6 +223,37 @@ class TestSentenceTransformerEmbedder:
 
         mock_st_module.SentenceTransformer.assert_called_once()
 
+    def test_load_model_passes_revision_and_remote_code_kwargs(self) -> None:
+        from unittest.mock import ANY, MagicMock
+
+        mock_st_module = MagicMock()
+        mock_model = MagicMock()
+        mock_model.get_sentence_embedding_dimension.return_value = 768
+        mock_st_module.SentenceTransformer.return_value = mock_model
+
+        with patch.dict("sys.modules", {"sentence_transformers": mock_st_module}):
+            from archex.index.embeddings.sentence_tf import SentenceTransformerEmbedder
+
+            embedder = SentenceTransformerEmbedder(
+                model_name="test-model",
+                trust_remote_code=True,
+                revision="model-revision",
+                local_files_only=True,
+                model_kwargs={"code_revision": "code-revision"},
+                config_kwargs={"code_revision": "code-revision"},
+            )
+            embedder._load_model()  # pyright: ignore[reportPrivateUsage]
+
+        mock_st_module.SentenceTransformer.assert_called_once_with(
+            "test-model",
+            device=ANY,
+            trust_remote_code=True,
+            revision="model-revision",
+            local_files_only=True,
+            model_kwargs={"code_revision": "code-revision"},
+            config_kwargs={"code_revision": "code-revision"},
+        )
+
 
 class TestFastEmbedder:
     def test_import_error_raises_archex_index_error(self) -> None:

--- a/tests/index/test_embedder_registry.py
+++ b/tests/index/test_embedder_registry.py
@@ -7,7 +7,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from archex.exceptions import ConfigError
-from archex.index.embeddings import EmbedderRegistry, default_embedder_registry
+from archex.index.embeddings import (
+    JINA_BERT_CODE_REVISION,
+    JINA_V2_MODEL_ID,
+    JINA_V2_MODEL_REVISION,
+    EmbedderRegistry,
+    default_embedder_registry,
+)
 from archex.index.embeddings.base import Embedder
 from archex.models import IndexConfig
 
@@ -43,6 +49,20 @@ class TestEmbedderRegistry:
         assert default_embedder_registry.get("sentence_transformers") is not None
         assert default_embedder_registry.get("jina-v2") is not None
         assert default_embedder_registry.get("coderank") is not None
+
+    def test_jina_v2_factory_pins_model_and_code_revisions(self) -> None:
+        from archex.index.embeddings.sentence_tf import SentenceTransformerEmbedder
+
+        embedder = default_embedder_registry.create(IndexConfig(vector=True, embedder="jina-v2"))
+        assert isinstance(embedder, SentenceTransformerEmbedder)
+        assert embedder._model_name == JINA_V2_MODEL_ID  # pyright: ignore[reportPrivateUsage]
+        assert embedder._revision == JINA_V2_MODEL_REVISION  # pyright: ignore[reportPrivateUsage]
+        assert embedder._model_kwargs == {  # pyright: ignore[reportPrivateUsage]
+            "code_revision": JINA_BERT_CODE_REVISION
+        }
+        assert embedder._config_kwargs == {  # pyright: ignore[reportPrivateUsage]
+            "code_revision": JINA_BERT_CODE_REVISION
+        }
 
     def test_load_entry_points(self) -> None:
         reg = EmbedderRegistry()

--- a/tests/index/test_embedder_registry.py
+++ b/tests/index/test_embedder_registry.py
@@ -9,6 +9,7 @@ import pytest
 from archex.exceptions import ConfigError
 from archex.index.embeddings import (
     JINA_BERT_CODE_REVISION,
+    JINA_V2_MAX_SEQ_LENGTH,
     JINA_V2_MODEL_ID,
     JINA_V2_MODEL_REVISION,
     EmbedderRegistry,
@@ -63,6 +64,7 @@ class TestEmbedderRegistry:
         assert embedder._config_kwargs == {  # pyright: ignore[reportPrivateUsage]
             "code_revision": JINA_BERT_CODE_REVISION
         }
+        assert embedder._max_seq_length == JINA_V2_MAX_SEQ_LENGTH  # pyright: ignore[reportPrivateUsage]
 
     def test_load_entry_points(self) -> None:
         reg = EmbedderRegistry()

--- a/tests/index/test_embedder_registry.py
+++ b/tests/index/test_embedder_registry.py
@@ -38,9 +38,11 @@ class TestEmbedderRegistry:
         config = IndexConfig(vector=False, embedder="")
         assert reg.create(config) is None
 
-    def test_default_registry_has_nomic_and_sentence_tf(self) -> None:
+    def test_default_registry_has_builtin_embedders(self) -> None:
         assert default_embedder_registry.get("nomic") is not None
         assert default_embedder_registry.get("sentence_transformers") is not None
+        assert default_embedder_registry.get("jina-v2") is not None
+        assert default_embedder_registry.get("coderank") is not None
 
     def test_load_entry_points(self) -> None:
         reg = EmbedderRegistry()

--- a/uv.lock
+++ b/uv.lock
@@ -151,15 +151,6 @@ wheels = [
 ]
 
 [[package]]
-name = "annotated-doc"
-version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303 },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -256,6 +247,7 @@ vector-fast = [
 ]
 vector-torch = [
     { name = "sentence-transformers" },
+    { name = "transformers" },
 ]
 
 [package.dev-dependencies]
@@ -299,7 +291,8 @@ requires-dist = [
     { name = "tiktoken", specifier = ">=0.7" },
     { name = "tokenizers", marker = "extra == 'vector'", specifier = ">=0.15" },
     { name = "torch", marker = "extra == 'splade'", specifier = ">=2.0" },
-    { name = "transformers", marker = "extra == 'splade'", specifier = ">=4.30" },
+    { name = "transformers", marker = "extra == 'splade'", specifier = ">=4.41,<5" },
+    { name = "transformers", marker = "extra == 'vector-torch'", specifier = ">=4.41,<5" },
     { name = "tree-sitter", specifier = ">=0.23" },
     { name = "tree-sitter-c-sharp", specifier = ">=0.23" },
     { name = "tree-sitter-go", specifier = ">=0.23" },
@@ -1128,22 +1121,21 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.5.0"
+version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "packaging" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "tqdm" },
-    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/76/b5efb3033d8499b17f9386beaf60f64c461798e1ee16d10bc9c0077beba5/huggingface_hub-1.5.0.tar.gz", hash = "sha256:f281838db29265880fb543de7a23b0f81d3504675de82044307ea3c6c62f799d", size = 695872 }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/74/2bc951622e2dbba1af9a460d93c51d15e458becd486e62c29cc0ccb08178/huggingface_hub-1.5.0-py3-none-any.whl", hash = "sha256:c9c0b3ab95a777fc91666111f3b3ede71c0cdced3614c553a64e98920585c4ee", size = 596261 },
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395 },
 ]
 
 [[package]]
@@ -3253,15 +3245,6 @@ wheels = [
 ]
 
 [[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
-]
-
-[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3616,22 +3599,23 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.2.0"
+version = "4.57.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
+    { name = "requests" },
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
-    { name = "typer-slim" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/7e/8a0c57d562015e5b16c97c1f0b8e0e92ead2c7c20513225dc12c2043ba9f/transformers-5.2.0.tar.gz", hash = "sha256:0088b8b46ccc9eff1a1dca72b5d618a5ee3b1befc3e418c9512b35dea9f9a650", size = 8618176 }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/93/79754b0ca486e556c2b95d4f5afc66aaf4b260694f3d6e1b51da2d036691/transformers-5.2.0-py3-none-any.whl", hash = "sha256:9ecaf243dc45bee11a7d93f8caf03746accc0cb069181bbf4ad8566c53e854b4", size = 10403304 },
+    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498 },
 ]
 
 [[package]]
@@ -3863,33 +3847,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296 },
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063 },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994 },
-]
-
-[[package]]
-name = "typer"
-version = "0.24.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085 },
-]
-
-[[package]]
-name = "typer-slim"
-version = "0.24.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/24/5480c20380dfd18cf33d14784096dca45a24eae6102e91d49a718d3b6855/typer_slim-0.24.0-py3-none-any.whl", hash = "sha256:d5d7ee1ee2834d5020c7c616ed5e0d0f29b9a4b1dd283bdebae198ec09778d0e", size = 3394 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Stack

Stack-Id: `tier25-benchmark-integrity`
Base: `main`
Position: 1/2

1. `feat/bench-embedder-flag` -> this PR
2. `feat/bench-token-latency-surface` -> #157

Depends on: none
Upstack: #157

## Summary

- Add `archex benchmark run --embedder`, defaulting to `jina-v2`.
- Thread the selected embedder through benchmark retrieval options, preflight, vector warm-up, and all vector/fusion/rerank benchmark arms.
- Include embedder configuration and benchmark corpus scope in stable cache identity so different embedders, Jina settings, and scoped corpora cannot share vector cache artifacts.
- Scope external benchmark tasks with `include_paths` that are broader than expected files; the harness copies those paths into temporary git-initialized corpora so large-repo runs avoid pathological whole-repo warm-up while preserving realistic distractors and graph neighbors.
- Register both full clones and scoped slices for cleanup.
- Scope the exact benchmark-only test gate so it runs benchmark tests without applying the repository-wide coverage threshold to a subset; full-suite coverage enforcement remains active.
- Pin Jina v2 model and remote-code revisions, constrain `transformers` to `>=4.41,<5`, and cap Jina max sequence length at 1024.

## Validation

- Passed: `uv run ruff check && uv run ruff format --check . && uv run pyright`
- Passed: `uv run pytest tests/benchmark/ -q` — 231 passed, 2 deselected
- Passed on stack head: `uv run pytest -q` — 2020 passed, 4 deselected, 90.91% coverage
- Verified compatibility: `uv run python -c "import transformers, transformers.pytorch_utils as p; print(transformers.__version__, hasattr(p, 'find_pruneable_heads_and_indices'))"` printed `4.57.6 True`
- Focused validation without `archex benchmark run`: direct query graph expansion produced candidates for 18/19 external tasks. Django middleware uses 22 files, produced 4 expanded files, and Jina/SPLADE/module warm-up completed in 63.65s. Go Gin middleware remains no-expansion because same-package Go files have no import-neighbor edges in the current graph model.

## Operator note

Discard partial `.archex/e2e-tier2` results produced before this PR update; their corpus/cache identity differs. Re-run the Tier 2 verdict benchmark from a clean output directory in a separate terminal.