### PR TITLE
feat(benchmark): surface token economy in reports

### DIFF
--- a/src/archex/benchmark/readiness.py
+++ b/src/archex/benchmark/readiness.py
@@ -70,6 +70,9 @@ class ReadinessReport:
     mean_mrr: float
     median_latency_ms: float
     p95_latency_ms: float
+    tokens_total: int
+    token_efficiency: float
+    savings_vs_raw: float
     zero_recall_tasks: int
     low_f1_tasks: int
     low_precision_tasks: int
@@ -92,6 +95,9 @@ class ReadinessReport:
             "mean_mrr": self.mean_mrr,
             "median_latency_ms": self.median_latency_ms,
             "p95_latency_ms": self.p95_latency_ms,
+            "tokens_total": self.tokens_total,
+            "token_efficiency": self.token_efficiency,
+            "savings_vs_raw": self.savings_vs_raw,
             "zero_recall_tasks": self.zero_recall_tasks,
             "low_f1_tasks": self.low_f1_tasks,
             "low_precision_tasks": self.low_precision_tasks,
@@ -124,6 +130,9 @@ def build_readiness_report(
             mean_mrr=0.0,
             median_latency_ms=0.0,
             p95_latency_ms=0.0,
+            tokens_total=0,
+            token_efficiency=0.0,
+            savings_vs_raw=0.0,
             zero_recall_tasks=0,
             low_f1_tasks=0,
             low_precision_tasks=0,
@@ -139,6 +148,9 @@ def build_readiness_report(
     mean_mrr = _mean([result.mrr for result in metric_results])
     median_latency_ms = _percentile([result.wall_time_ms for result in metric_results], 0.50)
     p95_latency_ms = _percentile([result.wall_time_ms for result in metric_results], 0.95)
+    tokens_total = sum(result.tokens_total for result in metric_results)
+    token_efficiency = _mean([result.token_efficiency for result in metric_results])
+    savings_vs_raw = _mean([result.savings_vs_raw for result in metric_results])
     zero_recall_tasks = sum(1 for result in metric_results if result.recall <= 0.0)
     low_f1_tasks = sum(1 for result in metric_results if result.f1_score < LOW_F1_THRESHOLD)
     low_precision_tasks = sum(
@@ -185,6 +197,9 @@ def build_readiness_report(
         mean_mrr=mean_mrr,
         median_latency_ms=median_latency_ms,
         p95_latency_ms=p95_latency_ms,
+        tokens_total=tokens_total,
+        token_efficiency=token_efficiency,
+        savings_vs_raw=savings_vs_raw,
         zero_recall_tasks=zero_recall_tasks,
         low_f1_tasks=low_f1_tasks,
         low_precision_tasks=low_precision_tasks,
@@ -213,6 +228,20 @@ def format_readiness_markdown(report: ReadinessReport) -> str:
             f"| {target.comparator} {_format_number(target.target)} | {status} |"
         )
     lines.append("")
+    lines.append("## Strategy Metrics")
+    lines.append("")
+    lines.append(
+        "| Strategy | Tasks | Recall | F1 | Tokens Total | Token Efficiency "
+        "| Savings vs Raw | Median Latency | P95 Latency |"
+    )
+    lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|")
+    lines.append(
+        f"| `{report.strategy}` | {report.task_count} | {report.mean_recall:.3f} "
+        f"| {report.mean_f1_score:.3f} | {report.tokens_total:,} "
+        f"| {report.token_efficiency:.3f} | {report.savings_vs_raw:.1f}% "
+        f"| {report.median_latency_ms:.0f} ms | {report.p95_latency_ms:.0f} ms |"
+    )
+    lines.append("")
     lines.append("## Summary")
     lines.append("")
     lines.append(
@@ -222,6 +251,9 @@ def format_readiness_markdown(report: ReadinessReport) -> str:
         f"- Mean MRR: `{report.mean_mrr:.3f}`\n"
         f"- Median latency: `{report.median_latency_ms:.0f} ms`\n"
         f"- P95 latency: `{report.p95_latency_ms:.0f} ms`\n"
+        f"- Tokens total: `{report.tokens_total:,}`\n"
+        f"- Token efficiency: `{report.token_efficiency:.3f}`\n"
+        f"- Savings vs raw: `{report.savings_vs_raw:.1f}%`\n"
         f"- Zero-recall tasks: `{report.zero_recall_tasks}`\n"
         f"- Tasks below F1 {LOW_F1_THRESHOLD:.2f}: `{report.low_f1_tasks}`\n"
         f"- Tasks below precision {LOW_PRECISION_THRESHOLD:.2f}: `{report.low_precision_tasks}`"

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -233,16 +233,20 @@ def format_strategy_comparison(reports: list[BenchmarkReport]) -> str:
     for report in reports:
         lines.append(f"## {report.task_id}")
         lines.append("")
-        lines.append("| Strategy | Recall | Precision | F1 | MRR | nDCG | MAP | Tokens | Savings |")
         lines.append(
-            "|----------|--------|-----------|------|------|------|------|--------|---------|"
+            "| Strategy | Recall | Precision | F1 | MRR | nDCG | MAP | Tokens Total "
+            "| Token Efficiency | Savings vs Raw |"
+        )
+        lines.append(
+            "|----------|--------|-----------|------|------|------|------|-------------"
+            "|------------------|---------------|"
         )
         for r in report.results:
             lines.append(
                 f"| {r.strategy.value} | {r.recall:.2f} | {r.precision:.2f} "
                 f"| {r.f1_score:.2f} | {r.mrr:.2f} | {r.ndcg:.2f} "
-                f"| {r.map_score:.2f} "
-                f"| {r.tokens_total:,} | {r.savings_vs_raw:.1f}% |"
+                f"| {r.map_score:.2f} | {r.tokens_total:,} "
+                f"| {r.token_efficiency:.2f} | {r.savings_vs_raw:.1f}% |"
             )
         lines.append("")
 

--- a/src/archex/benchmark/triage.py
+++ b/src/archex/benchmark/triage.py
@@ -30,6 +30,9 @@ class TriageFinding:
     precision: float
     f1_score: float
     mrr: float
+    tokens_total: int
+    token_efficiency: float
+    savings_vs_raw: float
     seed_files: list[str]
     expanded_files: list[str]
     expansion_ratio: float
@@ -55,6 +58,9 @@ class TriageFinding:
                 "precision": self.precision,
                 "f1_score": self.f1_score,
                 "mrr": self.mrr,
+                "tokens_total": self.tokens_total,
+                "token_efficiency": self.token_efficiency,
+                "savings_vs_raw": self.savings_vs_raw,
             },
             "seed_files": self.seed_files,
             "expanded_files": self.expanded_files,
@@ -121,6 +127,9 @@ def triage_failures(
                 precision=result.precision,
                 f1_score=result.f1_score,
                 mrr=result.mrr,
+                tokens_total=result.tokens_total,
+                token_efficiency=result.token_efficiency,
+                savings_vs_raw=result.savings_vs_raw,
                 seed_files=result.seed_files,
                 expanded_files=result.expanded_files,
                 expansion_ratio=result.expansion_ratio,
@@ -141,13 +150,18 @@ def format_triage_markdown(findings: list[TriageFinding]) -> str:
         return "# Benchmark Failure Triage\n\nNo failures matched the triage thresholds."
 
     lines = ["# Benchmark Failure Triage", ""]
-    lines.append("| Rank | Task | Category | Bucket | Recall | Precision | F1 | Missing | Extra |")
-    lines.append("|---:|---|---|---|---:|---:|---:|---|---|")
+    lines.append(
+        "| Rank | Task | Category | Bucket | Recall | Precision | F1 | Tokens Total "
+        "| Token Efficiency | Savings vs Raw | Missing | Extra |"
+    )
+    lines.append("|---:|---|---|---|---:|---:|---:|---:|---:|---:|---|---|")
     for idx, finding in enumerate(findings, start=1):
         lines.append(
             f"| {idx} | `{finding.task_id}` | {finding.category} | {finding.failure_bucket} "
             f"| {finding.recall:.3f} | {finding.precision:.3f} | {finding.f1_score:.3f} "
-            f"| {_inline_files(finding.missing_files)} | {_inline_files(finding.extra_files)} |"
+            f"| {finding.tokens_total:,} | {finding.token_efficiency:.3f} "
+            f"| {finding.savings_vs_raw:.1f}% | {_inline_files(finding.missing_files)} "
+            f"| {_inline_files(finding.extra_files)} |"
         )
     lines.append("")
 
@@ -162,7 +176,10 @@ def format_triage_markdown(findings: list[TriageFinding]) -> str:
         lines.append(
             "- Metrics: "
             f"recall `{finding.recall:.3f}`, precision `{finding.precision:.3f}`, "
-            f"F1 `{finding.f1_score:.3f}`, MRR `{finding.mrr:.3f}`"
+            f"F1 `{finding.f1_score:.3f}`, MRR `{finding.mrr:.3f}`, "
+            f"tokens `{finding.tokens_total:,}`, "
+            f"token efficiency `{finding.token_efficiency:.3f}`, "
+            f"savings vs raw `{finding.savings_vs_raw:.1f}%`"
         )
         if finding.raw_grepped_f1_score is not None:
             lines.append(

--- a/tests/benchmark/test_readiness.py
+++ b/tests/benchmark/test_readiness.py
@@ -26,20 +26,24 @@ def _result(
     f1_score: float,
     mrr: float = 1.0,
     wall_time_ms: float = 10.0,
+    tokens_total: int = 100,
+    token_efficiency: float = 0.5,
+    savings_vs_raw: float = 25.0,
     category: TaskCategory | None = None,
     strategy: Strategy = Strategy.ARCHEX_QUERY,
 ) -> BenchmarkResult:
     return BenchmarkResult(
         task_id=task_id,
         strategy=strategy,
-        tokens_total=100,
+        tokens_total=tokens_total,
+        token_efficiency=token_efficiency,
         tool_calls=1,
         files_accessed=1,
         recall=recall,
         precision=precision,
         f1_score=f1_score,
         mrr=mrr,
-        savings_vs_raw=0.0,
+        savings_vs_raw=savings_vs_raw,
         wall_time_ms=wall_time_ms,
         cached=False,
         timestamp="2026-01-01T00:00:00Z",
@@ -110,6 +114,9 @@ def test_build_readiness_report_tracks_targets_and_counts() -> None:
     assert readiness.low_precision_tasks == 1
     assert readiness.median_latency_ms == 200.0
     assert readiness.p95_latency_ms == 290.0
+    assert readiness.tokens_total == 200
+    assert readiness.token_efficiency == 0.5
+    assert readiness.savings_vs_raw == 25.0
     assert readiness.ready is False
     assert [target.name for target in readiness.targets] == [
         "mean_recall",
@@ -173,6 +180,9 @@ def test_format_readiness_outputs_are_stable() -> None:
     assert "mean_recall" in markdown
     assert "P95 latency" in markdown
     assert "Top Blocking Tasks" in markdown
+    assert "Tokens Total" in markdown
+    assert "Token Efficiency" in markdown
+    assert "Savings vs Raw" in markdown
     assert "`miss`" in markdown
 
     payload = json.loads(format_readiness_json(readiness))
@@ -180,4 +190,7 @@ def test_format_readiness_outputs_are_stable() -> None:
     assert payload["ready"] is False
     assert payload["median_latency_ms"] == 10.0
     assert payload["p95_latency_ms"] == 10.0
+    assert payload["tokens_total"] == 100
+    assert payload["token_efficiency"] == 0.5
+    assert payload["savings_vs_raw"] == 25.0
     assert payload["blocking_tasks"][0]["task_id"] == "miss"

--- a/tests/benchmark/test_reporter.py
+++ b/tests/benchmark/test_reporter.py
@@ -143,6 +143,9 @@ class TestFormatStrategyComparison:
         assert "## test" in result
         assert "raw_files" in result
         assert "archex_query" in result
+        assert "Tokens Total" in result
+        assert "Token Efficiency" in result
+        assert "Savings vs Raw" in result
 
     def test_contains_head_to_head(self) -> None:
         report = _make_report()

--- a/tests/benchmark/test_triage.py
+++ b/tests/benchmark/test_triage.py
@@ -27,18 +27,22 @@ def _result(
     category: TaskCategory | None = None,
     seed_files: list[str] | None = None,
     expanded_files: list[str] | None = None,
+    tokens_total: int = 100,
+    token_efficiency: float = 0.5,
+    savings_vs_raw: float = 25.0,
 ) -> BenchmarkResult:
     return BenchmarkResult(
         task_id="task",
         strategy=strategy,
-        tokens_total=100,
+        tokens_total=tokens_total,
+        token_efficiency=token_efficiency,
         tool_calls=1,
         files_accessed=1,
         recall=recall,
         precision=precision,
         f1_score=f1_score,
         mrr=recall,
-        savings_vs_raw=0.0,
+        savings_vs_raw=savings_vs_raw,
         wall_time_ms=10.0,
         cached=False,
         timestamp="2026-01-01T00:00:00Z",
@@ -174,10 +178,16 @@ def test_format_triage_outputs_are_stable() -> None:
     assert "# Benchmark Failure Triage" in markdown
     assert "`zero_recall`" in markdown
     assert "`src/task.py`" in markdown
+    assert "Tokens Total" in markdown
+    assert "Token Efficiency" in markdown
+    assert "Savings vs Raw" in markdown
 
     payload = json.loads(format_triage_json(findings))
     assert payload[0]["task_id"] == "zero"
     assert payload[0]["failure_bucket"] == "zero_recall"
+    assert payload[0]["metrics"]["tokens_total"] == 100
+    assert payload[0]["metrics"]["token_efficiency"] == 0.5
+    assert payload[0]["metrics"]["savings_vs_raw"] == 25.0
 
 
 def test_format_triage_json_serializes_expansion_diagnostics() -> None:


### PR DESCRIPTION
## Stack

Stack-Id: `tier25-benchmark-integrity`
Base: `main`
Position: 2/2

1. `feat/bench-embedder-flag` -> #156
2. `feat/bench-token-latency-surface` -> this PR

Depends on: #156
Upstack: none

## Summary

- Surface `tokens_total`, `token_efficiency`, and `savings_vs_raw` in readiness output alongside recall and p95 latency.
- Add the same token economy columns to triage and strategy comparison tables.
- Leave all thresholds unchanged.

## Validation

- Passed: `uv run ruff check && uv run ruff format --check . && uv run pyright`
- Passed: `uv run pytest tests/benchmark/ -q` — 231 passed, 2 deselected
- Passed: `uv run pytest -q` — 2020 passed, 4 deselected, 90.91% coverage
- Verified stack-head Jina/scoping fixes: `transformers==4.57.6`, `find_pruneable_heads_and_indices` is present, `jina-v2` loads with `max_seq_length 1024`, and focused scoped-corpus validation produced graph candidates for 18/19 external tasks

## Handoff

Updated local `.docs/handoff.md` with defect-D status, token/p95 notes, Jina compatibility/runtime fixes, widened scoped external corpora, validation, and the operator command block. `.docs/` is gitignored, so the handoff remains local workspace state rather than a tracked PR file.

## Operator note

Discard partial `.archex/e2e-tier2` results produced before the latest root PR update; their corpus/cache identity differs. Re-run the Tier 2 verdict benchmark from a clean output directory in a separate terminal.