### PR TITLE
feat(benchmark): expose graph expansion diagnostics

### DIFF
--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -90,6 +90,13 @@ class BenchmarkResult(BaseModel):
     expansion_ratio: float = 0.0
     seed_recall: float = 0.0
     seed_precision: float = 0.0
+    expansion_eligible_seeds: int = 0
+    expansion_candidates_found: int = 0
+    expansion_import_neighbor_edges: int = 0
+    expansion_same_module_candidates: int = 0
+    expansion_hub_candidates: int = 0
+    expansion_test_candidates_skipped: int = 0
+    expansion_zero_candidate_reason: str = ""
     category: TaskCategory | None = None
     vector_mode: VectorMode = VectorMode.RAW
     surrogate_version: str | None = None

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -374,6 +374,13 @@ class _ArchexFields:
         "expansion_ratio",
         "seed_recall",
         "seed_precision",
+        "expansion_eligible_seeds",
+        "expansion_candidates_found",
+        "expansion_import_neighbor_edges",
+        "expansion_same_module_candidates",
+        "expansion_hub_candidates",
+        "expansion_test_candidates_skipped",
+        "expansion_zero_candidate_reason",
     )
 
     def __init__(
@@ -390,6 +397,13 @@ class _ArchexFields:
         expansion_ratio: float,
         seed_recall: float,
         seed_precision: float,
+        expansion_eligible_seeds: int,
+        expansion_candidates_found: int,
+        expansion_import_neighbor_edges: int,
+        expansion_same_module_candidates: int,
+        expansion_hub_candidates: int,
+        expansion_test_candidates_skipped: int,
+        expansion_zero_candidate_reason: str,
     ) -> None:
         self.tokens_input = tokens_input
         self.tokens_output = tokens_output
@@ -402,6 +416,13 @@ class _ArchexFields:
         self.expansion_ratio = expansion_ratio
         self.seed_recall = seed_recall
         self.seed_precision = seed_precision
+        self.expansion_eligible_seeds = expansion_eligible_seeds
+        self.expansion_candidates_found = expansion_candidates_found
+        self.expansion_import_neighbor_edges = expansion_import_neighbor_edges
+        self.expansion_same_module_candidates = expansion_same_module_candidates
+        self.expansion_hub_candidates = expansion_hub_candidates
+        self.expansion_test_candidates_skipped = expansion_test_candidates_skipped
+        self.expansion_zero_candidate_reason = expansion_zero_candidate_reason
 
 
 def _archex_fields(
@@ -444,6 +465,13 @@ def _archex_fields(
             expansion_ratio=expansion_ratio,
             seed_recall=seed_recall_val,
             seed_precision=seed_precision_val,
+            expansion_eligible_seeds=meta.expansion_eligible_seeds,
+            expansion_candidates_found=meta.expansion_candidates_found,
+            expansion_import_neighbor_edges=meta.expansion_import_neighbor_edges,
+            expansion_same_module_candidates=meta.expansion_same_module_candidates,
+            expansion_hub_candidates=meta.expansion_hub_candidates,
+            expansion_test_candidates_skipped=meta.expansion_test_candidates_skipped,
+            expansion_zero_candidate_reason=meta.expansion_zero_candidate_reason,
         )
 
     seed_file_count = meta.seed_files_found
@@ -485,6 +513,13 @@ def _archex_fields(
         expansion_ratio=expansion_ratio,
         seed_recall=seed_recall_val,
         seed_precision=seed_precision_val,
+        expansion_eligible_seeds=meta.expansion_eligible_seeds,
+        expansion_candidates_found=meta.expansion_candidates_found,
+        expansion_import_neighbor_edges=meta.expansion_import_neighbor_edges,
+        expansion_same_module_candidates=meta.expansion_same_module_candidates,
+        expansion_hub_candidates=meta.expansion_hub_candidates,
+        expansion_test_candidates_skipped=meta.expansion_test_candidates_skipped,
+        expansion_zero_candidate_reason=meta.expansion_zero_candidate_reason,
     )
 
 
@@ -641,6 +676,13 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         expansion_ratio=af.expansion_ratio,
         seed_recall=af.seed_recall,
         seed_precision=af.seed_precision,
+        expansion_eligible_seeds=af.expansion_eligible_seeds,
+        expansion_candidates_found=af.expansion_candidates_found,
+        expansion_import_neighbor_edges=af.expansion_import_neighbor_edges,
+        expansion_same_module_candidates=af.expansion_same_module_candidates,
+        expansion_hub_candidates=af.expansion_hub_candidates,
+        expansion_test_candidates_skipped=af.expansion_test_candidates_skipped,
+        expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -713,6 +755,13 @@ def run_archex_query_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
         expansion_ratio=af.expansion_ratio,
         seed_recall=af.seed_recall,
         seed_precision=af.seed_precision,
+        expansion_eligible_seeds=af.expansion_eligible_seeds,
+        expansion_candidates_found=af.expansion_candidates_found,
+        expansion_import_neighbor_edges=af.expansion_import_neighbor_edges,
+        expansion_same_module_candidates=af.expansion_same_module_candidates,
+        expansion_hub_candidates=af.expansion_hub_candidates,
+        expansion_test_candidates_skipped=af.expansion_test_candidates_skipped,
+        expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -786,6 +835,13 @@ def run_surrogate_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResul
         expansion_ratio=af.expansion_ratio,
         seed_recall=af.seed_recall,
         seed_precision=af.seed_precision,
+        expansion_eligible_seeds=af.expansion_eligible_seeds,
+        expansion_candidates_found=af.expansion_candidates_found,
+        expansion_import_neighbor_edges=af.expansion_import_neighbor_edges,
+        expansion_same_module_candidates=af.expansion_same_module_candidates,
+        expansion_hub_candidates=af.expansion_hub_candidates,
+        expansion_test_candidates_skipped=af.expansion_test_candidates_skipped,
+        expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         category=task.category,
         vector_mode=index_config.vector_mode,
         surrogate_version=index_config.surrogate_version,
@@ -859,6 +915,13 @@ def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
         expansion_ratio=af.expansion_ratio,
         seed_recall=af.seed_recall,
         seed_precision=af.seed_precision,
+        expansion_eligible_seeds=af.expansion_eligible_seeds,
+        expansion_candidates_found=af.expansion_candidates_found,
+        expansion_import_neighbor_edges=af.expansion_import_neighbor_edges,
+        expansion_same_module_candidates=af.expansion_same_module_candidates,
+        expansion_hub_candidates=af.expansion_hub_candidates,
+        expansion_test_candidates_skipped=af.expansion_test_candidates_skipped,
+        expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -924,6 +987,13 @@ def run_archex_query_fusion_rerank(task: BenchmarkTask, repo_path: Path) -> Benc
         expansion_ratio=af.expansion_ratio,
         seed_recall=af.seed_recall,
         seed_precision=af.seed_precision,
+        expansion_eligible_seeds=af.expansion_eligible_seeds,
+        expansion_candidates_found=af.expansion_candidates_found,
+        expansion_import_neighbor_edges=af.expansion_import_neighbor_edges,
+        expansion_same_module_candidates=af.expansion_same_module_candidates,
+        expansion_hub_candidates=af.expansion_hub_candidates,
+        expansion_test_candidates_skipped=af.expansion_test_candidates_skipped,
+        expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -996,6 +1066,13 @@ def run_cross_layer_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
         expansion_ratio=af.expansion_ratio,
         seed_recall=af.seed_recall,
         seed_precision=af.seed_precision,
+        expansion_eligible_seeds=af.expansion_eligible_seeds,
+        expansion_candidates_found=af.expansion_candidates_found,
+        expansion_import_neighbor_edges=af.expansion_import_neighbor_edges,
+        expansion_same_module_candidates=af.expansion_same_module_candidates,
+        expansion_hub_candidates=af.expansion_hub_candidates,
+        expansion_test_candidates_skipped=af.expansion_test_candidates_skipped,
+        expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         category=task.category,
         vector_mode=index_config.vector_mode,
         surrogate_version=index_config.surrogate_version,

--- a/src/archex/benchmark/triage.py
+++ b/src/archex/benchmark/triage.py
@@ -36,6 +36,13 @@ class TriageFinding:
     seed_files: list[str]
     expanded_files: list[str]
     expansion_ratio: float
+    expansion_eligible_seeds: int
+    expansion_candidates_found: int
+    expansion_import_neighbor_edges: int
+    expansion_same_module_candidates: int
+    expansion_hub_candidates: int
+    expansion_test_candidates_skipped: int
+    expansion_zero_candidate_reason: str
     raw_grepped_recall: float | None
     raw_grepped_precision: float | None
     raw_grepped_f1_score: float | None
@@ -65,6 +72,15 @@ class TriageFinding:
             "seed_files": self.seed_files,
             "expanded_files": self.expanded_files,
             "expansion_ratio": self.expansion_ratio,
+            "expansion_diagnostics": {
+                "eligible_seeds": self.expansion_eligible_seeds,
+                "candidates_found": self.expansion_candidates_found,
+                "import_neighbor_edges": self.expansion_import_neighbor_edges,
+                "same_module_candidates": self.expansion_same_module_candidates,
+                "hub_candidates": self.expansion_hub_candidates,
+                "test_candidates_skipped": self.expansion_test_candidates_skipped,
+                "zero_candidate_reason": self.expansion_zero_candidate_reason,
+            },
             "raw_grepped_metrics": {
                 "recall": self.raw_grepped_recall,
                 "precision": self.raw_grepped_precision,
@@ -133,6 +149,13 @@ def triage_failures(
                 seed_files=result.seed_files,
                 expanded_files=result.expanded_files,
                 expansion_ratio=result.expansion_ratio,
+                expansion_eligible_seeds=result.expansion_eligible_seeds,
+                expansion_candidates_found=result.expansion_candidates_found,
+                expansion_import_neighbor_edges=result.expansion_import_neighbor_edges,
+                expansion_same_module_candidates=result.expansion_same_module_candidates,
+                expansion_hub_candidates=result.expansion_hub_candidates,
+                expansion_test_candidates_skipped=result.expansion_test_candidates_skipped,
+                expansion_zero_candidate_reason=result.expansion_zero_candidate_reason,
                 raw_grepped_recall=raw_grepped.recall if raw_grepped is not None else None,
                 raw_grepped_precision=raw_grepped.precision if raw_grepped is not None else None,
                 raw_grepped_f1_score=raw_grepped.f1_score if raw_grepped is not None else None,
@@ -188,6 +211,17 @@ def format_triage_markdown(findings: list[TriageFinding]) -> str:
                 f"precision `{finding.raw_grepped_precision:.3f}`, "
                 f"F1 `{finding.raw_grepped_f1_score:.3f}`"
             )
+        lines.append(
+            "- Expansion: "
+            f"eligible seeds `{finding.expansion_eligible_seeds}`, "
+            f"candidates `{finding.expansion_candidates_found}`, "
+            f"import edges `{finding.expansion_import_neighbor_edges}`, "
+            f"same-module `{finding.expansion_same_module_candidates}`, "
+            f"hubs `{finding.expansion_hub_candidates}`, "
+            f"test skips `{finding.expansion_test_candidates_skipped}`"
+        )
+        if finding.expansion_zero_candidate_reason:
+            lines.append(f"- Zero expansion reason: `{finding.expansion_zero_candidate_reason}`")
         lines.append("- Expected files:")
         lines.extend(_file_bullets(finding.expected_files))
         lines.append("- Returned files:")

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -574,6 +574,11 @@ class RetrievalMetadata(BaseModel):
     expansion_eligible_seeds: int = 0
     expansion_candidates_found: int = 0
     expansion_files_added: int = 0
+    expansion_zero_candidate_reason: str = ""
+    expansion_import_neighbor_edges: int = 0
+    expansion_same_module_candidates: int = 0
+    expansion_hub_candidates: int = 0
+    expansion_test_candidates_skipped: int = 0
     # Fusion gating
     fusion_skipped: bool = False
     fusion_skip_reason: str = ""

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -447,13 +447,15 @@ def _hop2_expansion_priority(expansion: _Hop2Expansion) -> dict[str, float]:
     return hop2_priority
 
 
-def _add_hop2_expansion(expansion: _Hop2Expansion) -> list[str]:
+def _add_hop2_expansion(expansion: _Hop2Expansion) -> tuple[list[str], int]:
     hop2_priority = _hop2_expansion_priority(expansion)
     hop2_files_added: list[str] = []
+    test_candidates_skipped = 0
     for file_path in sorted(hop2_priority.keys(), key=lambda f: -hop2_priority[f]):
         if len(hop2_files_added) >= expansion.remaining_budget:
             break
         if _is_test_file(file_path):
+            test_candidates_skipped += 1
             continue
         added = _add_file_chunks(
             expansion.candidate_map,
@@ -469,7 +471,7 @@ def _add_hop2_expansion(expansion: _Hop2Expansion) -> list[str]:
         len(hop2_priority),
         len(hop2_files_added),
     )
-    return hop2_files_added
+    return hop2_files_added, test_candidates_skipped
 
 
 def _dependency_subgraph(
@@ -519,6 +521,30 @@ def _neighbor_boosts(
                 seed_score * NEIGHBOR_IMPORTER_DECAY,
             )
     return boosts
+
+
+def _file_to_module(modules: list[Module] | None) -> dict[str, Module]:
+    if not modules:
+        return {}
+    return {file_path: module for module in modules for file_path in module.files}
+
+
+def _zero_expansion_reason(
+    *,
+    seed_files: set[str],
+    expansion_eligible_seeds: int,
+    total_expansion_candidates: int,
+    expansion_files_added: int,
+) -> str:
+    if not seed_files:
+        return "no_seed_files"
+    if expansion_eligible_seeds == 0:
+        return "no_eligible_seeds"
+    if total_expansion_candidates == 0:
+        return "no_import_neighbors"
+    if expansion_files_added == 0:
+        return "candidates_filtered_or_missing_chunks"
+    return ""
 
 
 def assemble_context(
@@ -673,6 +699,8 @@ def assemble_context(
     norm_seed_scores = {fp: s / max_seed_score for fp, s in seed_file_scores.items()}
 
     # Extract query terms for path-aware import prioritization
+    file_to_module = _file_to_module(modules)
+
     q_terms = _query_terms(question)
     alignment_terms = {QueryIntent.CLI.value} if intent == QueryIntent.CLI else q_terms
 
@@ -700,17 +728,25 @@ def assemble_context(
             imports_of_count,
             imported_by_count,
         )
-
     expansion_priority: dict[str, float] = {}
     expansion_source_count: dict[str, int] = {}
+    import_neighbor_edges = 0
+    same_module_candidates: set[str] = set()
+    hub_candidates: set[str] = set()
     for file_path in seed_files:
         # Only expand from seeds above the confidence threshold
         if norm_seed_scores.get(file_path, 0.0) < effective_expansion_min:
             continue
         seed_score = seed_file_scores.get(file_path, 0.0)
+        seed_module = file_to_module.get(file_path)
         # Direct imports get full seed score — they're in the same call chain
         for dep in graph.imports_of(file_path):
             if dep not in seed_files:
+                import_neighbor_edges += 1
+                if seed_module is not None and file_to_module.get(dep) == seed_module:
+                    same_module_candidates.add(dep)
+                if len(graph.imports_of(dep)) + len(graph.imported_by(dep)) >= 4:
+                    hub_candidates.add(dep)
                 # Boost imports whose file path matches a query term
                 path_lower = dep.lower()
                 path_match = any(t in path_lower for t in q_terms)
@@ -720,12 +756,16 @@ def assemble_context(
         # Importers get half seed score — they're consumers, not dependencies
         for imp in graph.imported_by(file_path):
             if imp not in seed_files:
+                import_neighbor_edges += 1
+                if seed_module is not None and file_to_module.get(imp) == seed_module:
+                    same_module_candidates.add(imp)
+                if len(graph.imports_of(imp)) + len(graph.imported_by(imp)) >= 4:
+                    hub_candidates.add(imp)
                 path_lower = imp.lower()
                 path_match = any(t in path_lower for t in q_terms)
                 priority = seed_score * (0.75 if path_match else 0.5)
                 expansion_priority[imp] = expansion_priority.get(imp, 0.0) + priority
                 expansion_source_count[imp] = expansion_source_count.get(imp, 0) + 1
-
     # Convergence bonus: files reached by multiple independent seeds are structurally
     # corroborated — more likely to be genuinely relevant than files from a single seed.
     for dep in expansion_priority:
@@ -734,7 +774,7 @@ def assemble_context(
 
     total_expansion_candidates = len(expansion_priority)
     if total_expansion_candidates == 0:
-        logger.warning(
+        logger.debug(
             "graph_expansion: zero candidates found. seed_files=%s norm_scores=%s",
             list(seed_files),
             {fp: f"{norm_seed_scores.get(fp, 0.0):.3f}" for fp in seed_files},
@@ -758,10 +798,12 @@ def assemble_context(
     # for that file.
     candidate_map = _initial_candidate_map(search_results, effective_vector, effective_splade)
     expansion_files_added = 0
+    expansion_test_candidates_skipped = 0
     hop1_files_added: list[str] = []
     expanded_file_paths: list[str] = []
     for file_path in sorted_expansion:
         if _is_test_file(file_path):
+            expansion_test_candidates_skipped += 1
             continue
         added = _add_file_chunks(
             candidate_map,
@@ -776,11 +818,18 @@ def assemble_context(
         if expansion_files_added >= MAX_EXPANSION_FILES:
             break
 
+    expansion_zero_candidate_reason = _zero_expansion_reason(
+        seed_files=seed_files,
+        expansion_eligible_seeds=expansion_eligible_seeds,
+        total_expansion_candidates=total_expansion_candidates,
+        expansion_files_added=expansion_files_added,
+    )
+
     # 2-hop expansion for architecture queries: follow imports_of for top hop-1 candidates
     if is_arch_query and hop1_files_added:
         remaining_budget = MAX_EXPANSION_FILES - expansion_files_added
         if remaining_budget > 0:
-            hop2_files_added = _add_hop2_expansion(
+            hop2_files_added, hop2_test_candidates_skipped = _add_hop2_expansion(
                 _Hop2Expansion(
                     graph=graph,
                     candidate_map=candidate_map,
@@ -793,9 +842,9 @@ def assemble_context(
                     max_per_file=max_per_file,
                 )
             )
+            expansion_test_candidates_skipped += hop2_test_candidates_skipped
             expansion_files_added += len(hop2_files_added)
             expanded_file_paths.extend(hop2_files_added)
-
     candidates_after_expansion = len(candidate_map)
 
     if trace is not None:
@@ -808,6 +857,13 @@ def assemble_context(
                     "seed_files": len(seed_files),
                     "expansion_files_added": expansion_files_added,
                     "candidates_after_expansion": candidates_after_expansion,
+                    "expansion_eligible_seeds": expansion_eligible_seeds,
+                    "expansion_candidates_found": total_expansion_candidates,
+                    "expansion_import_neighbor_edges": import_neighbor_edges,
+                    "expansion_same_module_candidates": len(same_module_candidates),
+                    "expansion_hub_candidates": len(hub_candidates),
+                    "expansion_test_candidates_skipped": expansion_test_candidates_skipped,
+                    "expansion_zero_candidate_reason": expansion_zero_candidate_reason,
                 },
             )
         )
@@ -860,13 +916,6 @@ def assemble_context(
 
     # Get structural centrality scores
     centrality = graph.structural_centrality()
-
-    # Build file-to-module mapping for cohesion signal
-    file_to_module: dict[str, Module] = {}
-    if modules:
-        for mod in modules:
-            for fp in mod.files:
-                file_to_module[fp] = mod
 
     # Signal agreement was computed pre-fusion; carry it forward for metadata
     signal_agreement: float | None = signal_agreement_pre if vector_results else None
@@ -1045,6 +1094,11 @@ def assemble_context(
         expansion_files_added=expansion_files_added,
         fusion_skipped=fusion_skipped,
         fusion_skip_reason=fusion_skip_reason,
+        expansion_zero_candidate_reason=expansion_zero_candidate_reason,
+        expansion_import_neighbor_edges=import_neighbor_edges,
+        expansion_same_module_candidates=len(same_module_candidates),
+        expansion_hub_candidates=len(hub_candidates),
+        expansion_test_candidates_skipped=expansion_test_candidates_skipped,
         bm25_cv=bm25_cv_val,
         splade_results=len(splade_results or []),
         splade_used=bool(effective_splade),

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -424,6 +424,13 @@ class TestRunArchexQuery:
                 candidates_after_expansion=5,
                 seed_files_found=2,
                 expansion_files_added=2,
+                expansion_eligible_seeds=2,
+                expansion_candidates_found=3,
+                expansion_import_neighbor_edges=3,
+                expansion_same_module_candidates=1,
+                expansion_hub_candidates=1,
+                expansion_test_candidates_skipped=1,
+                expansion_zero_candidate_reason="",
             ),
         )
         task = BenchmarkTask(
@@ -440,6 +447,13 @@ class TestRunArchexQuery:
         assert fields.expanded_files == ["expanded_a.py", "expanded_b.py"]
         assert fields.expansion_ratio == 1.0
         assert fields.seed_recall == 0.0
+        assert fields.expansion_eligible_seeds == 2
+        assert fields.expansion_candidates_found == 3
+        assert fields.expansion_import_neighbor_edges == 3
+        assert fields.expansion_same_module_candidates == 1
+        assert fields.expansion_hub_candidates == 1
+        assert fields.expansion_test_candidates_skipped == 1
+        assert fields.expansion_zero_candidate_reason == ""
 
     def test_expanded_files_uses_metadata_paths_when_expansion_is_not_included(
         self,
@@ -462,6 +476,13 @@ class TestRunArchexQuery:
                 seed_file_paths=["seed_a.py", "seed_b.py"],
                 expanded_file_paths=["expanded_a.py", "expanded_b.py"],
                 expansion_files_added=2,
+                expansion_eligible_seeds=2,
+                expansion_candidates_found=0,
+                expansion_import_neighbor_edges=0,
+                expansion_same_module_candidates=0,
+                expansion_hub_candidates=0,
+                expansion_test_candidates_skipped=0,
+                expansion_zero_candidate_reason="no_import_neighbors",
             ),
         )
         task = BenchmarkTask(
@@ -477,6 +498,8 @@ class TestRunArchexQuery:
         assert fields.seed_files == ["seed_a.py", "seed_b.py"]
         assert fields.expanded_files == ["expanded_a.py", "expanded_b.py"]
         assert fields.expansion_ratio == 1.0
+
+        assert fields.expansion_zero_candidate_reason == "no_import_neighbors"
 
 
 class _StubEmbedder:

--- a/tests/benchmark/test_triage.py
+++ b/tests/benchmark/test_triage.py
@@ -30,6 +30,9 @@ def _result(
     tokens_total: int = 100,
     token_efficiency: float = 0.5,
     savings_vs_raw: float = 25.0,
+    expansion_eligible_seeds: int = 0,
+    expansion_candidates_found: int = 0,
+    expansion_zero_candidate_reason: str = "",
 ) -> BenchmarkResult:
     return BenchmarkResult(
         task_id="task",
@@ -49,6 +52,9 @@ def _result(
         seed_files=seed_files or [],
         expanded_files=expanded_files or [],
         expansion_ratio=0.5,
+        expansion_eligible_seeds=expansion_eligible_seeds,
+        expansion_candidates_found=expansion_candidates_found,
+        expansion_zero_candidate_reason=expansion_zero_candidate_reason,
         category=category,
     )
 
@@ -181,6 +187,7 @@ def test_format_triage_outputs_are_stable() -> None:
     assert "Tokens Total" in markdown
     assert "Token Efficiency" in markdown
     assert "Savings vs Raw" in markdown
+    assert "Expansion:" in markdown
 
     payload = json.loads(format_triage_json(findings))
     assert payload[0]["task_id"] == "zero"
@@ -188,6 +195,7 @@ def test_format_triage_outputs_are_stable() -> None:
     assert payload[0]["metrics"]["tokens_total"] == 100
     assert payload[0]["metrics"]["token_efficiency"] == 0.5
     assert payload[0]["metrics"]["savings_vs_raw"] == 25.0
+    assert payload[0]["expansion_diagnostics"]["eligible_seeds"] == 0
 
 
 def test_format_triage_json_serializes_expansion_diagnostics() -> None:
@@ -198,6 +206,9 @@ def test_format_triage_json_serializes_expansion_diagnostics() -> None:
         f1_score=0.33,
         seed_files=["src/task.py"],
         expanded_files=["src/worker.py", "src/noise.py"],
+        expansion_eligible_seeds=1,
+        expansion_candidates_found=2,
+        expansion_zero_candidate_reason="",
     )
     findings = triage_failures([_report("expanded", result)], {"expanded": _task("expanded")})
 
@@ -209,3 +220,5 @@ def test_format_triage_json_serializes_expansion_diagnostics() -> None:
     assert payload[0]["seed_files"] == ["src/task.py"]
     assert payload[0]["expanded_files"] == ["src/worker.py", "src/noise.py"]
     assert payload[0]["expansion_ratio"] == 0.5
+    assert payload[0]["expansion_diagnostics"]["eligible_seeds"] == 1
+    assert payload[0]["expansion_diagnostics"]["candidates_found"] == 2

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -416,6 +416,31 @@ def test_expansion_metadata_records_seed_and_expanded_file_paths() -> None:
     assert meta.seed_file_paths == ["seed.py"]
     assert meta.expanded_file_paths == ["expanded.py"]
     assert meta.expansion_files_added == 1
+    assert meta.expansion_eligible_seeds == 1
+    assert meta.expansion_candidates_found == 1
+    assert meta.expansion_import_neighbor_edges == 1
+    assert meta.expansion_zero_candidate_reason == ""
+
+
+def test_expansion_metadata_records_zero_candidate_reason() -> None:
+    graph = DependencyGraph()
+    graph.add_file_node("seed.py")
+    seed_chunk = make_chunk("seed", "seed.py", token_count=10)
+
+    bundle = assemble_context(
+        [(seed_chunk, 5.0)],
+        graph,
+        [seed_chunk],
+        "graph expansion",
+        token_budget=1000,
+    )
+
+    meta = bundle.retrieval_metadata
+    assert meta.seed_files_found == 1
+    assert meta.expansion_eligible_seeds == 1
+    assert meta.expansion_candidates_found == 0
+    assert meta.expansion_import_neighbor_edges == 0
+    assert meta.expansion_zero_candidate_reason == "no_import_neighbors"
 
 
 def test_ranked_chunk_carries_cohesion_score() -> None:


### PR DESCRIPTION
## Stack

Stack-Id: `tier25-benchmark-integrity`
Base: `main`
Position: 3/3

1. `feat/bench-embedder-flag` -> #156
2. `feat/bench-token-latency-surface` -> #157
3. `feat/bench-expansion-diagnostics` -> this PR

Depends on: #157
Upstack: none

## Summary

- Add structured graph-expansion diagnostics to `RetrievalMetadata` and `BenchmarkResult`.
- Surface expansion diagnostics in benchmark triage JSON and Markdown.
- Demote `graph_expansion: zero candidates found` from warning to debug so benchmark logs keep failures readable.
- Keep retrieval behavior unchanged; this PR is diagnostic-only.

## Validation

- Passed: `uv run ruff check && uv run ruff format --check . && uv run pyright`
- Passed: `uv run pytest tests/benchmark/ -q` — 231 passed, 2 deselected
- Passed: `uv run pytest -q` — 2021 passed, 4 deselected, 90.89% coverage
- Passed targeted diagnostics tests: `uv run pytest tests/serve/test_context.py tests/benchmark/test_strategies.py tests/benchmark/test_triage.py -q --no-cov`

## Review notes

- Structured diagnostics now include eligible seeds, unique candidate files, import-neighbor edge count, same-module candidate count, hub candidate count, test-file skips, and zero-candidate reason.
- Review feedback addressed: no extra full `file_edges()` pass on the query hot path, and the import-neighbor metric now counts edges rather than duplicating unique candidate files.
