### PR TITLE
fix(mcp): report honest token savings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,41 +6,63 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Coverage](https://codecov.io/gh/Mathews-Tom/archex/graph/badge.svg)](https://codecov.io/gh/Mathews-Tom/archex)
 
-**Local codebase intelligence and token-budgeted context bundles for AI agents.**
+**archex gives AI agents the right code context with fewer tokens.**
 
-archex indexes a repository once, then answers codebase questions with compact, structured context: ranked code chunks, symbol metadata, dependency expansion, and retrieval provenance. It does not run a generative model. The downstream agent or MCP client uses the emitted bundle to explain, edit, or navigate the code.
+Agents waste context windows by crawling files one at a time. archex indexes a repository locally, ranks the relevant code, expands the dependency/type context, and emits a compact XML/JSON/Markdown bundle for the downstream agent or MCP client to explain. It does not call a hosted LLM, generate prose, or require API keys.
 
-- **Local-first retrieval** — BM25, optional local embeddings, optional local reranking; no hosted LLM inference or API keys required.
-- **Intent-aware budgets** — definition lookups stay small; broad architecture questions keep a larger budget.
-- **Structured output** — XML, JSON, and Markdown bundles designed for agent prompts and MCP clients.
-- **8 languages** out of the box — Python, TypeScript/JavaScript, Go, Rust, Java, Kotlin, C#, Swift.
-- **Deterministic architecture views** — modules, symbols, patterns, dependency graph, file tree, and cross-repo comparisons.
+Latest local 35-task benchmark, product-default `archex_query` vs the previous accepted baseline:
+
+| Product-default metric | Previous baseline | Current | Delta |
+| --- | ---: | ---: | ---: |
+| Mean returned tokens | 7,110 | 6,037 | -15.1% |
+| Weighted raw-baseline savings | 66.2% | 71.3% | +5.1 pts |
+| Mean recall | 0.629 | 0.819 | +0.190 |
+| Mean token efficiency | 0.351 | 0.702 | +0.351 |
+| Dogfood regressions | — | 0 | pass |
 
 > Your agent reads files. archex reads codebases. See [Why archex](docs/WHY_ARCHEX.md).
 
-## Quick Start
+## How archex works
+
+```text
+Repository → local index → intent classifier → hybrid retrieval → dependency/type expansion → token-budgeted bundle → agent / MCP client
+```
+
+archex optimizes the bundle the agent reads, not a generated answer. Explanation queries run outside archex: the CLI, Python API, LangChain/LlamaIndex retrievers, or MCP server emits structured context; the caller decides which model, prompt, or editing workflow consumes it.
+
+Core properties:
+
+- **Local first** — BM25F, optional local embeddings, optional local reranking. No hosted LLM inference.
+- **Token-budgeted by design** — definition lookups stay small; broad architecture questions get larger budgets; explicit `--budget` still overrides.
+- **Structured for agents** — XML, JSON, and Markdown bundles include ranked chunks, symbol metadata, imports, type context, dependency expansion, and provenance.
+- **Language-aware** — Python, TypeScript/JavaScript, Go, Rust, Java, Kotlin, C#, and Swift through tree-sitter adapters.
+- **Deterministic architecture views** — modules, symbols, patterns, dependency graph, file tree, impact analysis, onboarding, and cross-repo comparisons.
+
+## Quick start
 
 ```bash
 # Install the CLI
 uv tool install archex
 
-# Ask a question against any local repo or GitHub URL
+# Query any local repository
 archex query ./my-project "How does authentication work?"
-archex query https://github.com/encode/httpx "Where is connection pooling implemented?" --format xml
 
-# Override the adaptive budget when you need a hard cap
+# Emit XML for an agent prompt or MCP-style workflow
+archex query ./my-project "Where is connection pooling implemented?" --format xml
+
+# Override the adaptive budget only when the caller needs a hard cap
 archex query ./my-project "Explain the architecture" --budget 12000
 ```
 
-No init step, language config, hosted model, or API key is required for ad-hoc queries.
+No init step, language config, hosted model, or API key is required for ad-hoc local queries. GitHub URLs are also supported when network access is available:
 
-## Choose Your Path
+```bash
+archex query https://github.com/encode/httpx "Where is connection pooling implemented?" --format xml
+```
 
-archex meets agents and humans where they are. Pick the integration that fits:
+## Choose your integration
 
-### 1 — CLI (any agent, any shell)
-
-Drop archex into any agent that can run shell commands (Cursor, Claude Code, Copilot, custom):
+### CLI: any agent, any shell
 
 ```bash
 archex query ./repo "Where is cache invalidation handled?" --format xml
@@ -48,7 +70,7 @@ archex tree ./repo --depth 3
 archex symbol ./repo "src/auth/middleware.py::authenticate#function"
 ```
 
-### 2 — MCP server (Claude Code / Claude Desktop)
+### MCP server: Claude Code, Claude Desktop, and MCP clients
 
 ```json
 {
@@ -58,9 +80,9 @@ archex symbol ./repo "src/auth/middleware.py::authenticate#function"
 }
 ```
 
-Eight tools register automatically: `analyze_repo`, `query_repo`, `compare_repos`, `get_file_tree`, `get_file_outline`, `search_symbols`, `get_symbol`, `get_symbols_batch`.
+Eight tools register automatically: `analyze_repo`, `query_repo`, `compare_repos`, `get_file_tree`, `get_file_outline`, `search_symbols`, `get_symbol`, and `get_symbols_batch`.
 
-### 3 — Python API (your framework)
+### Python API: applications and retrieval frameworks
 
 ```python
 from archex import analyze, query
@@ -69,32 +91,36 @@ from archex.models import RepoSource
 source = RepoSource(local_path="./my-project")
 profile = analyze(source)
 print(f"{len(profile.module_map)} modules")
+
 bundle = query(source, "How does authentication work?")
 print(bundle.to_prompt(format="xml"))
 ```
 
 LangChain and LlamaIndex retrievers ship in the `[langchain]` and `[llamaindex]` extras.
 
-## What You Get
+## What archex gives you
 
-| | |
+| Outcome | Capabilities |
 | --- | --- |
-| **Hybrid retrieval** | BM25F weighted-field search plus optional local vector retrieval, confidence-weighted RRF, and adaptive score fusion. |
-| **Intent-aware budgets** | Query intent classification picks scoring weights and a default token cap: symbol/definition lookups stay small, broad architecture queries stay larger. |
-| **Context assembly** | AST-aware chunking, dependency-graph expansion, type definitions, imports, and greedy packing into XML/JSON/Markdown bundles. |
-| **Honest token accounting** | Benchmark gates track returned context, raw file baselines, token efficiency, latency, and MCP envelope overhead. |
-| **Structural analysis** | Module detection, pattern recognition, interface extraction, architecture graph export, deterministic onboarding, and blast-radius impact analysis. |
-| **Surgical lookups** | `tree`, `outline`, `symbols`, `symbol`, and MCP equivalents for narrow reads that replace whole-file loading. |
-| **Cross-repo comparison** | Deterministic comparison across API surface, state management, error handling, concurrency, testing, and configuration. |
-| **Local reranking** | Opt-in `jinaai/jina-reranker-v3` cross-encoder reranking for top retrieval candidates. |
-| **Repo-local mode** | `.archex/` stores generated indexes, vector artifacts, graph artifacts, cache metadata, and dogfood reports outside source control. |
-| **Agent integrations** | CLI, MCP server, Python API, LangChain retriever, and LlamaIndex retriever. |
+| **Find the right files** | BM25F weighted-field search, optional local vector retrieval, confidence-weighted RRF, local cross-encoder reranking, path/symbol boosts, dependency expansion. |
+| **Spend fewer tokens** | Intent-routed budgets, file-diverse packing, nested-range suppression, raw-file baselines, token-efficiency gates, honest MCP envelope accounting. |
+| **Give agents structured context** | XML, JSON, and Markdown context bundles with ranked chunks, provenance, imports, type definitions, and stable symbol IDs. |
+| **Understand architecture deterministically** | Module detection, pattern recognition, interface extraction, architecture graph export, onboarding, impact analysis, and cross-repo comparison. |
+| **Stay local and CI-friendly** | Repo-local `.archex/` indexes, generated artifacts outside source control, no hosted model dependency, deterministic gates. |
 
 Full pipeline anatomy lives in [docs/SYSTEM_DESIGN.md](docs/SYSTEM_DESIGN.md).
 
+## What archex is not
+
+- **Not a chatbot** — it emits context bundles; another agent or LLM explains.
+- **Not a hosted RAG service** — indexes and retrieval run locally unless you explicitly query a remote Git URL.
+- **Not a vector database** — vector search is optional; BM25 and structural signals are first-class.
+- **Not an LSP replacement** — use LSAP/LSP where compiler-backed type resolution matters; archex packages repository-scale context for agents.
+- **Not a prompt template library** — output is structured retrieval evidence, not prompt prose.
+
 ## Installation
 
-The core package handles all 8 languages, structural analysis, and BM25 retrieval with zero API calls. Extras are opt-in:
+The core package handles the supported languages, structural analysis, and BM25 retrieval with zero API calls. Extras are opt-in:
 
 ```bash
 uv tool install archex                    # CLI, system-wide
@@ -106,10 +132,11 @@ uv add "archex[langchain]"                # LangChain retriever
 uv add "archex[llamaindex]"               # LlamaIndex retriever
 uv add "archex[lsap]"                     # LSP type enrichment
 
-# Vector retrieval (any one)
-uv add "archex[vector]"                   # ONNX local embeddings (no GPU)
-uv add "archex[vector-fast]"              # FastEmbed (no GPU)
-uv add "archex[vector-torch]"             # sentence-transformers (GPU)
+# Vector retrieval
+uv add "archex[vector]"                   # ONNX local embeddings
+uv add "archex[vector-fast]"              # FastEmbed
+uv add "archex[vector-torch]"             # sentence-transformers / torch
+uv add "archex[splade]"                   # SPLADE sparse retrieval
 
 # Everything
 uv add "archex[all]"                      # vector + graph + mcp + langchain + llamaindex + language-pack
@@ -147,21 +174,21 @@ print(bundle.to_prompt(format="xml"))
 
 `query()` returns a `ContextBundle`, not a generated explanation. Feed that bundle to your agent, MCP client, or downstream LLM. Pass `token_budget=...` when the caller needs an explicit override; otherwise archex uses the intent-routed budget.
 
-### Surgical lookups (skip whole-file reads)
+### Surgical lookups that replace whole-file reads
 
 ```python
-from archex.api import file_tree, file_outline, search_symbols, get_symbol
+from archex.api import file_outline, file_tree, get_symbol, search_symbols
 from archex.models import RepoSource
 
 source = RepoSource(local_path="./my-project")
 
-tree = file_tree(source, max_depth=3, language="python")              # ~2K tokens vs 200K+
-outline = file_outline(source, "src/auth/middleware.py")              # ~180 tokens vs 4,800
+tree = file_tree(source, max_depth=3, language="python")
+outline = file_outline(source, "src/auth/middleware.py")
 matches = search_symbols(source, "authenticate", kind="function")
 symbol = get_symbol(source, "src/auth/middleware.py::authenticate#function")
 ```
 
-### Compare two repositories
+### Compare repositories
 
 ```python
 from archex import compare
@@ -174,20 +201,21 @@ result = compare(
 )
 ```
 
-## CLI at a Glance
+## CLI at a glance
 
 ```bash
-archex analyze ./repo --format markdown          # architecture profile
-archex query ./repo "How does auth work?"        # intent-budgeted context bundle
-archex compare ./repo-a ./repo-b                 # cross-repo architectural diff
-archex tree ./repo --depth 3                     # annotated file tree
-archex outline ./repo src/auth/middleware.py     # symbol outline for one file
-archex symbols ./repo "authenticate"             # symbol search
-archex symbol ./repo "src/auth.py::login#function"  # full source by stable ID
-archex explain ./repo src/auth.py                # deterministic structural explanation
-archex graph export ./repo --format json         # architecture graph artifact
-archex impact ./repo src/auth.py                 # deterministic blast-radius analysis
-archex onboard ./repo                            # deterministic onboarding guide
+archex analyze ./repo --format markdown              # architecture profile
+archex query ./repo "How does auth work?"            # intent-budgeted context bundle
+archex query ./repo "Find the query pipeline" --format xml
+archex compare ./repo-a ./repo-b                     # cross-repo architectural diff
+archex tree ./repo --depth 3                         # annotated file tree
+archex outline ./repo src/auth/middleware.py         # symbol outline for one file
+archex symbols ./repo "authenticate"                 # symbol search
+archex symbol ./repo "src/auth.py::login#function"   # full source by stable ID
+archex explain ./repo src/auth.py                    # deterministic structural explanation
+archex graph export ./repo --format json             # architecture graph artifact
+archex impact ./repo src/auth.py                     # deterministic blast-radius analysis
+archex onboard ./repo                                # deterministic onboarding guide
 
 # Repo-local lifecycle
 archex init && archex index && archex status
@@ -197,12 +225,12 @@ archex reset --force
 # Cache and benchmarks
 archex cache list | clean --max-age 168 | info
 archex benchmark run --query-fusion --rerank --embedder jina-v2 --tasks-dir benchmarks/tasks --output .archex/e2e
-archex benchmark gate --input .archex/e2e --warn-latency-ms 3000
+archex benchmark gate --input .archex/e2e --baseline .archex/e2e-baseline --warn-latency-ms 3000
 ```
 
 Run `archex --help` or any subcommand with `--help` for the full option list.
 
-## Repo-Local Mode
+## Repo-local mode
 
 For agent or maintainer workflows tied to a single checked-out repo:
 
@@ -214,34 +242,40 @@ archex status   # is the index fresh? does HEAD match? is the tree dirty?
 archex query "Where is cache invalidation handled?"
 ```
 
-The entire `.archex/` directory is generated state — SQLite index, vector artifacts, dogfood reports — and stays out of source control. `archex status --strict` fails on stale or dirty state, which is useful in CI gates.
+The entire `.archex/` directory is generated state — SQLite index, vector artifacts, graph artifacts, cache metadata, and dogfood reports — and stays out of source control. `archex status --strict` fails on stale or dirty state, which is useful in CI gates.
 
-## When To Use archex
+## When to use archex
 
-archex gives AI agents structural priors about codebases they've never seen. Pre-computed map → cheap, fast, complete. File-by-file exploration → expensive, slow, incomplete.
+archex gives AI agents structural priors about codebases they have not seen. Pre-computed map → cheap, fast, complete. File-by-file exploration → expensive, slow, incomplete.
 
-| Capability                        | archex                          | archex + LSAP                       | Claude Code         | LSP                |
-| --------------------------------- | ------------------------------- | ----------------------------------- | ------------------- | ------------------ |
-| Cold-start codebase understanding | **Yes** — pre-computed map      | **Yes** — structural + semantic     | Slow — sequential   | No — needs session |
-| Semantic type resolution          | Syntactic (tree-sitter)         | **Yes** — LSP hover/refs/defs       | Via LLM reasoning   | **Yes** — compiler |
-| Token-budget context assembly     | **Yes** — ranked, packed        | **Yes** — type-enriched             | Manual selection    | Not designed for it |
-| Cross-repo structural comparison  | **Yes** — 6 dimensions, no LLM  | **Yes**                             | No                  | No                 |
-| Offline / CI-embeddable           | **Yes**                         | Partial — needs language server     | No                  | Partial            |
-| Works with any agent framework    | **Yes** — CLI, MCP, Python API  | **Yes** — async Python API          | Claude-specific     | Editor-specific    |
+| Capability | archex | archex + LSAP | Claude Code | LSP |
+| --- | --- | --- | --- | --- |
+| Cold-start codebase understanding | **Yes** — pre-computed map | **Yes** — structural + semantic | Slow — sequential | No — needs session |
+| Semantic type resolution | Syntactic tree-sitter signals | **Yes** — LSP hover/refs/defs | Via LLM reasoning | **Yes** — compiler-backed |
+| Token-budget context assembly | **Yes** — ranked, packed | **Yes** — type-enriched | Manual selection | Not designed for it |
+| Cross-repo structural comparison | **Yes** — deterministic dimensions | **Yes** | No | No |
+| Offline / CI embeddable | **Yes** | Partial — needs language server | No | Partial |
+| Works with any agent framework | **Yes** — CLI, MCP, Python API | **Yes** — async Python API | Claude-specific | Editor-specific |
 
-## Performance and Gates
+## Performance and gates
 
-archex optimizes for the amount of context the downstream agent must read, not recall alone. Benchmark reports track recall, precision, F1, MRR, NDCG, MAP, latency, returned tokens, raw-file baselines, and token efficiency. Token efficiency is higher-is-better: `1 - returned_tokens / accessed_file_tokens`.
+archex optimizes the amount of context the downstream agent must read, not recall alone. Benchmark reports track recall, precision, F1, MRR, NDCG, MAP, latency, returned tokens, raw-file baselines, and token efficiency. Token efficiency is higher-is-better: `1 - returned_tokens / accessed_file_tokens`.
 
-Latest 35-task local benchmark counts for the product-default `archex_query` strategy, compared with the accepted Tier 2.5 run:
+Latest local 35-task benchmark, compared with the previous accepted baseline:
 
-| Metric | Tier 2.5 | Latest run | Delta |
-| --- | ---: | ---: | ---: |
-| Mean returned tokens | 7,110 | 5,527 | -22.3% |
-| Mean recall | 0.629 | 0.694 | +0.065 |
-| Mean token efficiency | 0.649 | 0.701 | +0.052 |
+| Strategy | Returned tokens | Weighted raw-baseline savings | Recall | Token efficiency |
+| --- | ---: | ---: | ---: | ---: |
+| `archex_query` | 7,110 → 6,037 (-15.1%) | 66.2% → 71.3% | 0.629 → 0.819 | 0.351 → 0.702 |
+| `archex_query_fusion` | 7,173 → 7,293 (+1.7%) | 65.9% → 65.4% | 0.627 → 0.809 | 0.307 → 0.612 |
+| `archex_query_fusion_rerank` | 7,178 → 7,307 (+1.8%) | 65.9% → 65.3% | 0.627 → 0.818 | 0.307 → 0.612 |
 
-Fusion and rerank currently reduce mean returned tokens by roughly 11% while improving mean recall from 0.627 to 0.640. Gate thresholds are intentionally stricter than averages: a run fails if individual tasks regress recall or fall below the product-default token-efficiency floor. Treat the gate output, not the aggregate table, as the release signal.
+Release gates are intentionally tied to the product contract:
+
+- hard fail if product-default token efficiency falls below the measured floor (`0.08`);
+- hard fail if any gated strategy regresses recall against the accepted baseline when `--baseline` is supplied;
+- hard fail if a baseline row is missing;
+- warn, but do not fail, on absolute non-token rows such as rank-2 MRR or low recall rows already accepted in the baseline;
+- dogfood must report zero regressions.
 
 Reproduce the full retrieval gate and dogfood delta locally:
 
@@ -249,26 +283,26 @@ Reproduce the full retrieval gate and dogfood delta locally:
 scripts/benchmark_pipeline.sh
 ```
 
-The script removes prior `.archex/e2e-tokens` output, writes a fresh `.docs/pipeline.log`, runs benchmark generation, runs the gate, and then runs dogfood even when the gate fails. It exits non-zero at the end if any step failed.
+The script removes prior `.archex/e2e-tokens` output, writes a fresh `.docs/pipeline.log`, runs benchmark generation, runs the baseline-aware gate, and then runs dogfood even when the gate fails. It exits non-zero at the end if any step failed.
 
-## Language Support
+## Language support
 
-| Language                    | Extensions                   | Symbols                                                          |
-| --------------------------- | ---------------------------- | ---------------------------------------------------------------- |
-| **Python**                  | `.py`                        | Functions, classes, methods, types, constants, decorators        |
+| Language | Extensions | Symbols |
+| --- | --- | --- |
+| **Python** | `.py` | Functions, classes, methods, types, constants, decorators |
 | **TypeScript / JavaScript** | `.ts`, `.tsx`, `.js`, `.jsx` | Functions, classes, methods, types, interfaces, enums, constants |
-| **Go**                      | `.go`                        | Functions, methods, structs, interfaces, constants               |
-| **Rust**                    | `.rs`                        | Functions, structs, enums, traits, impl blocks, macros           |
-| **Java**                    | `.java`                      | Classes, interfaces, enums, methods, fields, annotations         |
-| **Kotlin**                  | `.kt`, `.kts`                | Classes, objects, functions, properties, extensions              |
-| **C#**                      | `.cs`                        | Classes, structs, interfaces, enums, methods, properties         |
-| **Swift**                   | `.swift`                     | Classes, structs, enums, protocols, actors, extensions           |
+| **Go** | `.go` | Functions, methods, structs, interfaces, constants |
+| **Rust** | `.rs` | Functions, structs, enums, traits, impl blocks, macros |
+| **Java** | `.java` | Classes, interfaces, enums, methods, fields, annotations |
+| **Kotlin** | `.kt`, `.kts` | Classes, objects, functions, properties, extensions |
+| **C#** | `.cs` | Classes, structs, interfaces, enums, methods, properties |
+| **Swift** | `.swift` | Classes, structs, enums, protocols, actors, extensions |
 
 Need another language? Register an adapter via Python entry points — no core changes required.
 
 ## Configuration
 
-Configuration cascades from defaults through `~/.archex/config.toml`, repo-local `.archex/settings.toml`, `ARCHEX_*` environment variables, and explicit CLI/API arguments — later sources override earlier ones.
+Configuration cascades from defaults through `~/.archex/config.toml`, repo-local `.archex/settings.toml`, `ARCHEX_*` environment variables, and explicit CLI/API arguments. Later sources override earlier ones.
 
 ```toml
 # ~/.archex/config.toml
@@ -280,7 +314,7 @@ parallel = true
 delta_threshold = 0.5
 ```
 
-Repo-local settings (`archex init` creates this):
+Repo-local settings created by `archex init`:
 
 ```toml
 # .archex/settings.toml
@@ -295,7 +329,7 @@ delta_threshold = 0.5
 
 ## Extending archex
 
-archex exposes four plugin surfaces via Python entry points and protocols — language adapters, pattern detectors, chunkers, and scoring weights. Register an adapter in your own package:
+archex exposes plugin surfaces via Python entry points and protocols: language adapters, pattern detectors, chunkers, scoring weights, benchmark strategies, and embedders. Register an adapter in your own package:
 
 ```toml
 [project.entry-points."archex.language_adapters"]
@@ -318,13 +352,13 @@ uv run pyright                   # strict mode
 
 Contribution guidelines and the dogfood gate workflow live in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Learn More
+## Learn more
 
 - [Why archex](docs/WHY_ARCHEX.md) — the agent token problem this solves
-- [System Overview](docs/OVERVIEW.md) — what archex is and isn't
-- [System Design](docs/SYSTEM_DESIGN.md) — pipeline anatomy, extensibility surfaces
-- [Benchmark Readiness](docs/BENCHMARK_READINESS.md) — full retrieval quality results
-- [Roadmap](docs/ROADMAP.md) — what's next
+- [System Overview](docs/OVERVIEW.md) — what archex is and is not
+- [System Design](docs/SYSTEM_DESIGN.md) — pipeline anatomy and extensibility surfaces
+- [Benchmark Readiness](docs/BENCHMARK_READINESS.md) — retrieval quality history
+- [Roadmap](docs/ROADMAP.md) — what is next
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -231,15 +231,15 @@ archex gives AI agents structural priors about codebases they've never seen. Pre
 
 ## Performance and Gates
 
-archex optimizes for the amount of context the downstream agent must read, not recall alone. Benchmark reports track recall, precision, F1, MRR, NDCG, MAP, latency, returned tokens, raw-file baselines, and token efficiency.
+archex optimizes for the amount of context the downstream agent must read, not recall alone. Benchmark reports track recall, precision, F1, MRR, NDCG, MAP, latency, returned tokens, raw-file baselines, and token efficiency. Token efficiency is higher-is-better: `1 - returned_tokens / accessed_file_tokens`.
 
-Current 35-task local benchmark snapshot for the product-default `archex_query` strategy, compared with the accepted Tier 2.5 run:
+Latest 35-task local benchmark counts for the product-default `archex_query` strategy, compared with the accepted Tier 2.5 run:
 
-| Metric | Tier 2.5 | Current | Delta |
+| Metric | Tier 2.5 | Latest run | Delta |
 | --- | ---: | ---: | ---: |
-| Mean returned tokens | 7,110 | 5,528 | -22.3% |
+| Mean returned tokens | 7,110 | 5,527 | -22.3% |
 | Mean recall | 0.629 | 0.694 | +0.065 |
-| Mean token efficiency | 0.351 | 0.296 | -0.056 |
+| Mean token efficiency | 0.649 | 0.701 | +0.052 |
 
 Fusion and rerank currently reduce mean returned tokens by roughly 11% while improving mean recall from 0.627 to 0.640. Gate thresholds are intentionally stricter than averages: a run fails if individual tasks regress recall or fall below the product-default token-efficiency floor. Treat the gate output, not the aggregate table, as the release signal.
 

--- a/README.md
+++ b/README.md
@@ -243,12 +243,13 @@ Current 35-task local benchmark snapshot for the product-default `archex_query` 
 
 Fusion and rerank currently reduce mean returned tokens by roughly 11% while improving mean recall from 0.627 to 0.640. Gate thresholds are intentionally stricter than averages: a run fails if individual tasks regress recall or fall below the product-default token-efficiency floor. Treat the gate output, not the aggregate table, as the release signal.
 
-Reproduce the full retrieval gate locally:
+Reproduce the full retrieval gate and dogfood delta locally:
 
 ```bash
-uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --tasks-dir benchmarks/tasks --output .archex/e2e
-uv run archex benchmark gate --input .archex/e2e --warn-latency-ms 3000
+scripts/benchmark_pipeline.sh
 ```
+
+The script removes prior `.archex/e2e-tokens` output, writes a fresh `.docs/pipeline.log`, runs benchmark generation, runs the gate, and then runs dogfood even when the gate fails. It exits non-zero at the end if any step failed.
 
 ## Language Support
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![Coverage](https://codecov.io/gh/Mathews-Tom/archex/graph/badge.svg)](https://codecov.io/gh/Mathews-Tom/archex)
 
-**Architectural intelligence for code, with no LLM bill.**
+**Local codebase intelligence and token-budgeted context bundles for AI agents.**
 
-archex turns any Git repository into structured architectural intelligence and token-budget-aware code context — fully local, fully deterministic, no API keys. It's the pre-computed map your AI agent reaches for *before* it starts opening files.
+archex indexes a repository once, then answers codebase questions with compact, structured context: ranked code chunks, symbol metadata, dependency expansion, and retrieval provenance. It does not run a generative model. The downstream agent or MCP client uses the emitted bundle to explain, edit, or navigate the code.
 
-- **~91% fewer tokens** sent to your agent vs. raw file loading (median across 10 OSS repos)
-- **<150 ms** warm queries against cached indexes
-- **8 languages** out of the box — Python, TypeScript/JavaScript, Go, Rust, Java, Kotlin, C#, Swift
-- **Zero API cost** — every pipeline stage runs on your machine
+- **Local-first retrieval** — BM25, optional local embeddings, optional local reranking; no hosted LLM inference or API keys required.
+- **Intent-aware budgets** — definition lookups stay small; broad architecture questions keep a larger budget.
+- **Structured output** — XML, JSON, and Markdown bundles designed for agent prompts and MCP clients.
+- **8 languages** out of the box — Python, TypeScript/JavaScript, Go, Rust, Java, Kotlin, C#, Swift.
+- **Deterministic architecture views** — modules, symbols, patterns, dependency graph, file tree, and cross-repo comparisons.
 
 > Your agent reads files. archex reads codebases. See [Why archex](docs/WHY_ARCHEX.md).
 
@@ -24,11 +25,14 @@ archex turns any Git repository into structured architectural intelligence and t
 uv tool install archex
 
 # Ask a question against any local repo or GitHub URL
-archex query ./my-project "How does authentication work?" --budget 8192
-archex query https://github.com/encode/httpx "connection pooling" --format xml
+archex query ./my-project "How does authentication work?"
+archex query https://github.com/encode/httpx "Where is connection pooling implemented?" --format xml
+
+# Override the adaptive budget when you need a hard cap
+archex query ./my-project "Explain the architecture" --budget 12000
 ```
 
-That's it. No init step, no language config, no API keys.
+No init step, language config, hosted model, or API key is required for ad-hoc queries.
 
 ## Choose Your Path
 
@@ -39,7 +43,7 @@ archex meets agents and humans where they are. Pick the integration that fits:
 Drop archex into any agent that can run shell commands (Cursor, Claude Code, Copilot, custom):
 
 ```bash
-archex query ./repo "Where is cache invalidation handled?" --budget 8192 --format xml
+archex query ./repo "Where is cache invalidation handled?" --format xml
 archex tree ./repo --depth 3
 archex symbol ./repo "src/auth/middleware.py::authenticate#function"
 ```
@@ -59,14 +63,13 @@ Eight tools register automatically: `analyze_repo`, `query_repo`, `compare_repos
 ### 3 — Python API (your framework)
 
 ```python
-from archex import analyze, query, compare
+from archex import analyze, query
 from archex.models import RepoSource
 
-bundle = query(
-    RepoSource(local_path="./my-project"),
-    "How does authentication work?",
-    token_budget=8192,
-)
+source = RepoSource(local_path="./my-project")
+profile = analyze(source)
+print(f"{len(profile.module_map)} modules")
+bundle = query(source, "How does authentication work?")
 print(bundle.to_prompt(format="xml"))
 ```
 
@@ -76,18 +79,16 @@ LangChain and LlamaIndex retrievers ship in the `[langchain]` and `[llamaindex]`
 
 | | |
 | --- | --- |
-| **Hybrid retrieval** | BM25F weighted-field search + optional vector embeddings, fused via confidence-weighted RRF and adaptive RSF behind an AvgIDF gate |
-| **Intent-aware ranking** | Query intent classifier (definition, architecture, usage, debugging, CLI, general) picks per-intent scoring presets |
-| **Token-budget assembly** | AST-aware chunking, deterministic dependency-graph expansion, greedy bin-packing under a configurable budget |
-| **Structural analysis** | Module detection (Leiden with Louvain fallback), pattern recognition via an extensible `PatternRegistry`, interface extraction |
-| **Cross-repo comparison** | Diff two repos across 6 architectural dimensions — no LLM in the loop |
-| **Surgical lookups** | `file_tree`, `file_outline`, `search_symbols`, `get_symbol(s)` — narrow reads that replace whole-file loads |
-| **Cross-encoder reranking** | Opt-in `jinaai/jina-reranker-v3` re-scoring of top candidates, local-only, off by default |
-| **Delta indexing** | Git-diff-driven incremental reindex when only a few files changed; mtime fallback for non-git sources |
-| **Cache-first queries** | Skip parse on cache hit, parallel parsing and comparison, git-aware cache keys |
-| **Pipeline observability** | Opt-in `PipelineTrace` with step-level timing for retrieve, expand, score, assemble |
-| **LSP enrichment** | Opt-in `[lsap]` extra layers compiler-grade type info onto archex symbols |
-| **Extensible** | Language adapters, pattern detectors, chunkers, and scoring weights register via Python entry points |
+| **Hybrid retrieval** | BM25F weighted-field search plus optional local vector retrieval, confidence-weighted RRF, and adaptive score fusion. |
+| **Intent-aware budgets** | Query intent classification picks scoring weights and a default token cap: symbol/definition lookups stay small, broad architecture queries stay larger. |
+| **Context assembly** | AST-aware chunking, dependency-graph expansion, type definitions, imports, and greedy packing into XML/JSON/Markdown bundles. |
+| **Honest token accounting** | Benchmark gates track returned context, raw file baselines, token efficiency, latency, and MCP envelope overhead. |
+| **Structural analysis** | Module detection, pattern recognition, interface extraction, architecture graph export, deterministic onboarding, and blast-radius impact analysis. |
+| **Surgical lookups** | `tree`, `outline`, `symbols`, `symbol`, and MCP equivalents for narrow reads that replace whole-file loading. |
+| **Cross-repo comparison** | Deterministic comparison across API surface, state management, error handling, concurrency, testing, and configuration. |
+| **Local reranking** | Opt-in `jinaai/jina-reranker-v3` cross-encoder reranking for top retrieval candidates. |
+| **Repo-local mode** | `.archex/` stores generated indexes, vector artifacts, graph artifacts, cache metadata, and dogfood reports outside source control. |
+| **Agent integrations** | CLI, MCP server, Python API, LangChain retriever, and LlamaIndex retriever. |
 
 Full pipeline anatomy lives in [docs/SYSTEM_DESIGN.md](docs/SYSTEM_DESIGN.md).
 
@@ -134,16 +135,17 @@ for pattern in profile.pattern_catalog:
 
 ```python
 from archex import query
-from archex.models import RepoSource, ScoringWeights
+from archex.models import RepoSource
 
 bundle = query(
     RepoSource(local_path="./my-project"),
-    "database connection pooling",
-    token_budget=8192,
-    scoring_weights=ScoringWeights(relevance=0.8, structural=0.1, type_coverage=0.1),
+    "Where is database connection pooling implemented?",
 )
+
 print(bundle.to_prompt(format="xml"))
 ```
+
+`query()` returns a `ContextBundle`, not a generated explanation. Feed that bundle to your agent, MCP client, or downstream LLM. Pass `token_budget=...` when the caller needs an explicit override; otherwise archex uses the intent-routed budget.
 
 ### Surgical lookups (skip whole-file reads)
 
@@ -175,22 +177,27 @@ result = compare(
 ## CLI at a Glance
 
 ```bash
-archex analyze ./repo --format markdown          # architectural profile
-archex query ./repo "How does auth work?"        # context bundle (defaults to cwd if omitted)
-archex compare ./repo-a ./repo-b                 # cross-repo diff
+archex analyze ./repo --format markdown          # architecture profile
+archex query ./repo "How does auth work?"        # intent-budgeted context bundle
+archex compare ./repo-a ./repo-b                 # cross-repo architectural diff
 archex tree ./repo --depth 3                     # annotated file tree
 archex outline ./repo src/auth/middleware.py     # symbol outline for one file
 archex symbols ./repo "authenticate"             # symbol search
 archex symbol ./repo "src/auth.py::login#function"  # full source by stable ID
+archex explain ./repo src/auth.py                # deterministic structural explanation
+archex graph export ./repo --format json         # architecture graph artifact
+archex impact ./repo src/auth.py                 # deterministic blast-radius analysis
+archex onboard ./repo                            # deterministic onboarding guide
 
-# Repo-local lifecycle (inside a checked-out repo)
+# Repo-local lifecycle
 archex init && archex index && archex status
-archex dogfood --task archex_query_pipeline
+archex dogfood . --all --baseline benchmarks/dogfood_baseline.json --format dogfood-delta
 archex reset --force
 
 # Cache and benchmarks
 archex cache list | clean --max-age 168 | info
-archex benchmark run tasks.yaml --strategies bm25,hybrid
+archex benchmark run --query-fusion --rerank --embedder jina-v2 --tasks-dir benchmarks/tasks --output .archex/e2e
+archex benchmark gate --input .archex/e2e --warn-latency-ms 3000
 ```
 
 Run `archex --help` or any subcommand with `--help` for the full option list.
@@ -204,7 +211,7 @@ cd ./my-project
 archex init     # creates .archex/, adds it to .gitignore
 archex index    # build or refresh
 archex status   # is the index fresh? does HEAD match? is the tree dirty?
-archex query "Where is cache invalidation handled?" --budget 8192
+archex query "Where is cache invalidation handled?"
 ```
 
 The entire `.archex/` directory is generated state — SQLite index, vector artifacts, dogfood reports — and stays out of source control. `archex status --strict` fails on stale or dirty state, which is useful in CI gates.
@@ -222,30 +229,26 @@ archex gives AI agents structural priors about codebases they've never seen. Pre
 | Offline / CI-embeddable           | **Yes**                         | Partial — needs language server     | No                  | Partial            |
 | Works with any agent framework    | **Yes** — CLI, MCP, Python API  | **Yes** — async Python API          | Claude-specific     | Editor-specific    |
 
-## Performance
+## Performance and Gates
 
-**Token efficiency** (median across 10 OSS repos spanning Python, JS/TS, Go, Rust — 35 to 2,332 files):
+archex optimizes for the amount of context the downstream agent must read, not recall alone. Benchmark reports track recall, precision, F1, MRR, NDCG, MAP, latency, returned tokens, raw-file baselines, and token efficiency.
 
-| Operation          | Median savings | Replaces                                            |
-| ------------------ | -------------: | --------------------------------------------------- |
-| `file_tree()`      |          98.3% | Reading the repo to understand structure            |
-| `compare()`        |          97.8% | Reading both repos end-to-end                       |
-| `analyze()`        |          96.7% | Manual exploration of modules, patterns, interfaces |
-| `search_symbols()` |          91.0% | Grepping + reading every matching file              |
-| `query()`          |          90.8% | Multi-file search and backtracking                  |
-| `get_symbol()`     |          61.7% | Reading the entire file to grab one function        |
+Current 35-task local benchmark snapshot for the product-default `archex_query` strategy, compared with the accepted Tier 2.5 run:
 
-**Retrieval quality** (BM25 baseline, 25-task benchmark corpus, 8K-token budget):
+| Metric | Tier 2.5 | Current | Delta |
+| --- | ---: | ---: | ---: |
+| Mean returned tokens | 7,110 | 5,528 | -22.3% |
+| Mean recall | 0.629 | 0.694 | +0.065 |
+| Mean token efficiency | 0.351 | 0.296 | -0.056 |
 
-| Category           | Tasks | Recall | Precision |   F1 |  MRR |
-| ------------------ | ----: | -----: | --------: | ---: | ---: |
-| external-framework |     9 |   0.80 |      0.36 | 0.50 | 0.80 |
-| architecture-broad |     3 |   0.67 |      0.26 | 0.38 | 0.83 |
-| self-referential   |     6 |   0.56 |      0.20 | 0.29 | 0.83 |
-| framework-semantic |     2 |   0.33 |      0.19 | 0.23 | 0.62 |
-| external-large     |     5 |   0.27 |      0.11 | 0.16 | 0.25 |
+Fusion and rerank currently reduce mean returned tokens by roughly 11% while improving mean recall from 0.627 to 0.640. Gate thresholds are intentionally stricter than averages: a run fails if individual tasks regress recall or fall below the product-default token-efficiency floor. Treat the gate output, not the aggregate table, as the release signal.
 
-archex excels on mid-size framework repos where keyword vocabulary aligns with code. Very large codebases (django, react, sqlalchemy) need hybrid retrieval and reranking to push past BM25's vocabulary ceiling. Full per-task tables and reproduction steps live in [docs/BENCHMARK_READINESS.md](docs/BENCHMARK_READINESS.md).
+Reproduce the full retrieval gate locally:
+
+```bash
+uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --tasks-dir benchmarks/tasks --output .archex/e2e
+uv run archex benchmark gate --input .archex/e2e --warn-latency-ms 3000
+```
 
 ## Language Support
 
@@ -307,8 +310,8 @@ git clone https://github.com/Mathews-Tom/archex.git
 cd archex
 uv sync --all-extras
 
-uv run pytest                    # ~1,960 tests, 85% minimum coverage
-uv run ruff check . && uv run ruff format .
+uv run pytest                    # full test suite, 85% minimum coverage
+uv run ruff check && uv run ruff format --check .
 uv run pyright                   # strict mode
 ```
 

--- a/scripts/benchmark_pipeline.sh
+++ b/scripts/benchmark_pipeline.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -Euo pipefail
+
+output_dir=".archex/e2e-tokens"
+log_file=".docs/pipeline.log"
+
+mkdir -p .archex .docs
+rm -rf "$output_dir" "$log_file"
+
+format_duration() {
+    local duration="$1"
+
+    printf '%02dh:%02dm:%02ds' \
+        "$((duration / 3600))" \
+        "$(((duration % 3600) / 60))" \
+        "$((duration % 60))"
+}
+
+run_step() {
+    local label="$1"
+    shift
+
+    local cmd="$*"
+    local start end duration status
+
+    if [[ -z "$label" ]]; then
+        label="$cmd"
+    fi
+
+    echo
+    echo "===== $(date '+%Y-%m-%d %H:%M:%S') : Starting \"$label\" ====="
+    echo "Command: $cmd"
+
+    start=$(date +%s)
+    if "$@"; then
+        status=0
+    else
+        status=$?
+    fi
+    end=$(date +%s)
+
+    duration=$((end - start))
+
+    if [[ "$status" -eq 0 ]]; then
+        echo "===== $(date '+%Y-%m-%d %H:%M:%S') : Completed \"$label\" ====="
+    else
+        echo "===== $(date '+%Y-%m-%d %H:%M:%S') : FAILED \"$label\" (exit $status) ====="
+    fi
+    echo "===== Time taken: $(format_duration "$duration") ====="
+    return "$status"
+}
+
+run_pipeline() {
+    local status=0
+
+    run_step "Benchmark Run" \
+        uv run archex benchmark run \
+        --query-fusion \
+        --rerank \
+        --embedder jina-v2 \
+        --tasks-dir benchmarks/tasks \
+        --output "$output_dir" || status=$?
+
+    run_step "Benchmark Gate" \
+        uv run archex benchmark gate \
+        --input "$output_dir" \
+        --warn-latency-ms 3000 || status=$?
+
+    run_step "Dogfood Delta" \
+        uv run archex dogfood . \
+        --all \
+        --baseline benchmarks/dogfood_baseline.json \
+        --format dogfood-delta || status=$?
+
+    return "$status"
+}
+
+{
+    pipeline_start=$(date +%s)
+    pipeline_status=0
+
+    echo "=================================================="
+    echo "Pipeline started at $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "Output directory: $output_dir"
+    echo "Log file: $log_file"
+    echo "=================================================="
+
+    run_pipeline || pipeline_status=$?
+
+    pipeline_end=$(date +%s)
+    total_duration=$((pipeline_end - pipeline_start))
+
+    echo
+    echo "=================================================="
+    echo "Pipeline completed at $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "Total time taken: $(format_duration "$total_duration")"
+    echo "Pipeline exit status: $pipeline_status"
+    echo "=================================================="
+    exit "$pipeline_status"
+} 2>&1 | tee "$log_file"

--- a/scripts/benchmark_pipeline.sh
+++ b/scripts/benchmark_pipeline.sh
@@ -2,6 +2,7 @@
 set -Euo pipefail
 
 output_dir=".archex/e2e-tokens"
+baseline_dir=".archex/e2e-tier2"
 log_file=".docs/pipeline.log"
 
 mkdir -p .archex .docs
@@ -64,6 +65,7 @@ run_pipeline() {
     run_step "Benchmark Gate" \
         uv run archex benchmark gate \
         --input "$output_dir" \
+        --baseline "$baseline_dir" \
         --warn-latency-ms 3000 || status=$?
 
     run_step "Dogfood Delta" \

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -22,7 +22,7 @@ from archex.api import (
     search_symbols,
 )
 from archex.models import PipelineTiming
-from archex.reporting import compute_meta
+from archex.reporting import compute_meta, count_tokens
 from archex.serve.compare import validate_dimensions
 from archex.serve.intent import DEFAULT_TOKEN_BUDGET
 from archex.utils import resolve_source
@@ -95,12 +95,21 @@ def handle_query_repo(repo_url: str, question: str, budget: int | None = None) -
     )
 
     content = bundle.to_prompt(format="xml")
-    unique_files = list({c.chunk.file_path for c in bundle.chunks})
-    raw_tokens = get_files_token_count(source, unique_files)
+    metadata = bundle.retrieval_metadata
+    raw_file_paths = sorted(
+        {
+            *metadata.seed_file_paths,
+            *metadata.expanded_file_paths,
+            *(c.chunk.file_path for c in bundle.chunks),
+        }
+    )
+    raw_tokens = get_files_token_count(source, raw_file_paths)
+    envelope_overhead = max(count_tokens(content) - bundle.token_count, 0)
     meta = compute_meta(
         tool_name="query_repo",
         response_text=content,
         raw_file_tokens=max(raw_tokens, 1),
+        envelope_overhead_tokens=envelope_overhead,
         strategy="bm25+graph",
         cached=pt.cached,
         index_time_ms=pt.index_ms,

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -25,6 +25,7 @@ from archex.models import PipelineTiming
 from archex.reporting import compute_meta, count_tokens
 from archex.serve.compare import validate_dimensions
 from archex.serve.intent import DEFAULT_TOKEN_BUDGET
+from archex.serve.renderers.xml import render_xml, render_xml_envelope
 from archex.utils import resolve_source
 
 logger = logging.getLogger(__name__)
@@ -94,7 +95,7 @@ def handle_query_repo(repo_url: str, question: str, budget: int | None = None) -
         explicit_token_budget=budget is not None,
     )
 
-    content = bundle.to_prompt(format="xml")
+    content = render_xml(bundle)
     metadata = bundle.retrieval_metadata
     raw_file_paths = sorted(
         {
@@ -104,7 +105,7 @@ def handle_query_repo(repo_url: str, question: str, budget: int | None = None) -
         }
     )
     raw_tokens = get_files_token_count(source, raw_file_paths)
-    envelope_overhead = max(count_tokens(content) - bundle.token_count, 0)
+    envelope_overhead = count_tokens(render_xml_envelope(bundle))
     meta = compute_meta(
         tool_name="query_repo",
         response_text=content,

--- a/src/archex/reporting.py
+++ b/src/archex/reporting.py
@@ -22,6 +22,7 @@ def compute_meta(
     response_text: str,
     raw_file_tokens: int,
     strategy: str,
+    envelope_overhead_tokens: int = 0,
     cached: bool = False,
     index_time_ms: float = 0.0,
     query_time_ms: float = 0.0,
@@ -29,9 +30,10 @@ def compute_meta(
 ) -> TokenMeta:
     """Compute token efficiency metrics for a tool response."""
     returned = count_tokens(response_text)
-    savings = (1 - returned / raw_file_tokens) * 100 if raw_file_tokens > 0 else 0.0
+    payload_tokens = max(returned - envelope_overhead_tokens, 0)
+    savings = (1 - payload_tokens / raw_file_tokens) * 100 if raw_file_tokens > 0 else 0.0
     return TokenMeta(
-        tokens_returned=returned,
+        tokens_returned=payload_tokens,
         tokens_raw_equivalent=raw_file_tokens,
         savings_pct=round(savings, 1),
         strategy=strategy,

--- a/src/archex/serve/renderers/xml.py
+++ b/src/archex/serve/renderers/xml.py
@@ -67,6 +67,53 @@ def render_xml(bundle: ContextBundle) -> str:
     return "\n".join(lines)
 
 
+def render_xml_envelope(bundle: ContextBundle) -> str:
+    """Render only the XML wrapper structure for token-overhead accounting."""
+    lines: list[str] = []
+    lines.append('<context query="">')
+
+    sc = bundle.structural_context
+    lines.append("  <structural-context>")
+    if sc.file_tree:
+        lines.append("    <file-tree><![CDATA[\n\n    ]]></file-tree>")
+    lines.append("  </structural-context>")
+
+    lines.append("  <chunks>")
+    for rc in bundle.chunks:
+        chunk = rc.chunk
+        attrs = ' file="" lines=""'
+        if chunk.symbol_name:
+            attrs += ' symbol=""'
+        attrs += ' score=""'
+        attrs += ' tokens=""'
+        lines.append(f"    <chunk{attrs}>")
+        if chunk.imports_context:
+            lines.append("      <imports><![CDATA[]]></imports>")
+        lines.append("      <code><![CDATA[\n\n      ]]></code>")
+        lines.append("    </chunk>")
+    lines.append("  </chunks>")
+
+    if bundle.type_definitions:
+        lines.append("  <type-definitions>")
+        for _ in bundle.type_definitions:
+            lines.append('    <type-def file="" symbol="" lines="">')
+            lines.append("      <![CDATA[]]>")
+            lines.append("    </type-def>")
+        lines.append("  </type-definitions>")
+
+    dep = bundle.dependency_summary
+    if dep.internal or dep.external:
+        lines.append("  <dependencies>")
+        for _ in dep.internal:
+            lines.append("    <internal></internal>")
+        for _ in dep.external:
+            lines.append("    <external></external>")
+        lines.append("  </dependencies>")
+
+    lines.append("</context>")
+    return "\n".join(lines)
+
+
 def _attr(value: str) -> str:
     """Return a double-quoted XML attribute value with escaping."""
     return f'"{escape(value, {chr(34): "&quot;"})}"'

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -18,9 +18,12 @@ from archex.integrations.mcp import (
 )
 from archex.models import (
     ArchProfile,
+    CodeChunk,
     ComparisonResult,
     ContextBundle,
+    RankedChunk,
     RepoMetadata,
+    RetrievalMetadata,
 )
 
 # ---------------------------------------------------------------------------
@@ -157,6 +160,41 @@ class TestHandleQueryRepo:
             handle_query_repo("/fake/repo", "what is the entry point?", budget=4000)
         assert mock_query.call_args.kwargs["token_budget"] == 4000
         assert mock_query.call_args.kwargs["explicit_token_budget"] is True
+
+    def test_query_savings_use_candidate_files_and_payload_tokens(self) -> None:
+        chunk = CodeChunk(
+            id="c1",
+            content="def selected(): pass",
+            file_path="selected.py",
+            start_line=1,
+            end_line=1,
+            language="python",
+            token_count=5,
+        )
+        bundle = ContextBundle(
+            query="Where is selected defined?",
+            chunks=[RankedChunk(chunk=chunk, final_score=1.0)],
+            token_count=5,
+            token_budget=2048,
+            retrieval_metadata=RetrievalMetadata(
+                seed_file_paths=["selected.py", "candidate.py"],
+                expanded_file_paths=["neighbor.py"],
+            ),
+        )
+        with (
+            patch("archex.integrations.mcp.query", return_value=bundle),
+            patch("archex.integrations.mcp.get_files_token_count", return_value=100) as raw_mock,
+        ):
+            output = handle_query_repo("/fake/repo", "Where is selected defined?")
+
+        raw_mock.assert_called_once()
+        assert raw_mock.call_args.args[1] == ["candidate.py", "neighbor.py", "selected.py"]
+
+        import json
+
+        parsed = json.loads(output)
+        assert parsed["_meta"]["tokens_returned"] == 5
+        assert parsed["_meta"]["savings_pct"] == 95.0
 
     def test_rejects_empty_question(self) -> None:
         with pytest.raises(ValueError, match="question must not be empty"):

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -24,7 +25,10 @@ from archex.models import (
     RankedChunk,
     RepoMetadata,
     RetrievalMetadata,
+    TypeDefinition,
 )
+from archex.reporting import count_tokens
+from archex.serve.renderers.xml import render_xml, render_xml_envelope
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -189,12 +193,51 @@ class TestHandleQueryRepo:
 
         raw_mock.assert_called_once()
         assert raw_mock.call_args.args[1] == ["candidate.py", "neighbor.py", "selected.py"]
+        parsed = json.loads(output)
+        expected_tokens = count_tokens(render_xml(bundle)) - count_tokens(
+            render_xml_envelope(bundle)
+        )
+        assert parsed["_meta"]["tokens_returned"] == expected_tokens
+        assert parsed["_meta"]["savings_pct"] == round((1 - expected_tokens / 100) * 100, 1)
+
+    def test_query_savings_keep_type_definition_payload(self) -> None:
+        content = "class Selected:\n    pass"
+        chunk = CodeChunk(
+            id="c1",
+            content=content,
+            file_path="selected.py",
+            start_line=1,
+            end_line=2,
+            language="python",
+            token_count=5,
+            symbol_name="Selected",
+        )
+        bundle = ContextBundle(
+            query="Where is Selected defined?",
+            chunks=[RankedChunk(chunk=chunk, final_score=1.0)],
+            type_definitions=[
+                TypeDefinition(
+                    symbol="Selected",
+                    file_path="selected.py",
+                    start_line=1,
+                    end_line=2,
+                    content=content,
+                )
+            ],
+            token_count=5,
+            token_budget=2048,
+            retrieval_metadata=RetrievalMetadata(seed_file_paths=["selected.py"]),
+        )
+        with (
+            patch("archex.integrations.mcp.query", return_value=bundle),
+            patch("archex.integrations.mcp.get_files_token_count", return_value=100),
+        ):
+            output = handle_query_repo("/fake/repo", "Where is Selected defined?")
 
         import json
 
         parsed = json.loads(output)
-        assert parsed["_meta"]["tokens_returned"] == 5
-        assert parsed["_meta"]["savings_pct"] == 95.0
+        assert parsed["_meta"]["tokens_returned"] > bundle.token_count
 
     def test_rejects_empty_question(self) -> None:
         with pytest.raises(ValueError, match="question must not be empty"):

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -41,6 +41,21 @@ def test_compute_meta_basic() -> None:
     assert meta.query_time_ms == 0.0
 
 
+def test_compute_meta_subtracts_envelope_overhead_from_savings() -> None:
+    response_text = "wrapper tokens around payload"
+    returned = count_tokens(response_text)
+    meta = compute_meta(
+        tool_name="query_repo",
+        response_text=response_text,
+        raw_file_tokens=10,
+        envelope_overhead_tokens=returned - 1,
+        strategy="bm25+graph",
+    )
+
+    assert meta.tokens_returned == 1
+    assert meta.savings_pct == 90.0
+
+
 def test_compute_meta_zero_raw() -> None:
     meta = compute_meta(
         tool_name="t",


### PR DESCRIPTION
## Stack

Stack-Id: `token-economy-20260606`
Base: `feat/adaptive-intent-budget`
Position: 3/3

1. `feat/gate-token-floor` -> #159
2. `feat/adaptive-intent-budget` -> #160
3. `feat/mcp-honest-savings` -> this PR

Depends on: #160
Upstack: none

## Summary

- Computes MCP `query_repo` raw-equivalent tokens from seed, expanded, and returned candidate files instead of only files surviving final bundle assembly.
- Subtracts only XML scaffolding overhead before calculating `_meta.savings_pct`, so duplicated payload such as type-definition bodies still counts as returned context.
- Adds tests for honest savings math, candidate-file denominator usage, and preserved type-definition payload.
- Refreshes `README.md` to describe the current retrieval pipeline, intent-routed budgets, context-bundle model, higher-is-better token efficiency, benchmark gates, current benchmark snapshot, and committed benchmark runner.
- Adds `scripts/benchmark_pipeline.sh` as the standardized long-running benchmark/gate/dogfood runner. It deletes prior `.archex/e2e-tokens`, writes `.docs/pipeline.log`, continues to dogfood after gate failure, and exits non-zero if any step failed.
- Updates the runner to pass `--baseline .archex/e2e-tier2` to the benchmark gate so it uses the approved baseline-aware policy from #159.
- Rebases on the updated adaptive-budget branch that restores self-query oracle files, fixes query-pipeline packing, preserves file-priority order, and ranks production files ahead of tests.

## Validation

- `scripts/benchmark_pipeline.sh` passed end-to-end with `Pipeline exit status: 0`.
- `bash -n scripts/benchmark_pipeline.sh` passed.
- `uv run archex benchmark gate --input .archex/e2e-tokens --baseline .archex/e2e-tier2 --warn-latency-ms 3000` passed in the pipeline, printing 40 non-token absolute-threshold warnings and no hard violations.
- `uv run ruff check && uv run ruff format --check . && uv run pyright` passed on the stack tip.
- `uv run pytest tests/benchmark/test_gate.py tests/serve/ -q` passed on the stack tip with 223 tests.
- `uv run pytest -q` passed on the stack tip with 2061 tests, 4 deselected, and 90.92% coverage.
- PR review: no blocking or important issues remain after the pipeline baseline wiring.

## Final operator result

- Benchmark run completed 35/35 tasks in `00h:28m:17s`.
- Benchmark gate passed with no hard violations; 40 non-token absolute-threshold rows were reported as warnings.
- Dogfood completed with `Regressions: 0`.
- Pipeline exit status: `0`.
- Product-default mean returned tokens improved `7110 -> 6037` (`-15.1%`).
- Product-default weighted raw-baseline savings improved `66.2% -> 71.3%`.
- Product-default mean recall improved `0.629 -> 0.819`.