### PR TITLE
docs(benchmark): add coderank default evaluation protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ archex gives AI agents structural priors about codebases they have not seen. A p
 ## Performance and gates
 
 archex optimizes the amount of context the downstream agent must read, not recall alone. Benchmark reports track recall, precision, F1, MRR, NDCG, MAP, latency, returned tokens, raw-file baselines, and token efficiency (`1 − returned_tokens / accessed_file_tokens`, higher is better).
+Default embedder and strategy switches are evidence-gated in `docs/RETRIEVAL_DEFAULT_DECISIONS.md`; the product default stays unchanged until the clean warm-cache frontier satisfies those rules.
 
 Latest local 35-task benchmark, compared with the previous accepted baseline:
 

--- a/docs/RETRIEVAL_DEFAULT_DECISIONS.md
+++ b/docs/RETRIEVAL_DEFAULT_DECISIONS.md
@@ -1,0 +1,31 @@
+# Retrieval Default Decision Protocol
+
+Tier 3 decisions stay pending until the operator provides clean warm-cache benchmark evidence. Product defaults remain unchanged until the switch rules in this document pass and the operator approves the change.
+
+## Invariants
+
+- Run benchmarks locally only; no network or generative LLM inference.
+- Pin exactly one embedder per benchmark run with `--embedder`.
+- Compare candidates on recall, F1, token efficiency, median latency, and p95 latency. Recall/F1 alone is not sufficient.
+- Keep `archex_query` as the product default until the final strategy switch rule passes.
+- Do not refresh `benchmarks/dogfood_baseline.json` without explicit approval after a proven improvement.
+
+## Embedder decision
+
+Candidate embedders:
+
+| Candidate | Benchmark flag | Rollback path |
+| --- | --- | --- |
+| Jina v2 code embeddings | `--embedder jina-v2` | Current benchmark default |
+| CodeRankEmbed | `--embedder coderank` | Registered as `coderank`; no product default flip before approval |
+
+Switch from Jina v2 to CodeRankEmbed only when a warm full run shows `archex_query_fusion_rerank` recall and F1 improve, token efficiency is not worse, and p95 latency does not regress.
+
+Operator commands:
+
+```bash
+uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --tasks-dir benchmarks/tasks --output .archex/e2e-jina
+uv run archex benchmark run --query-fusion --rerank --embedder coderank --tasks-dir benchmarks/tasks --output .archex/e2e-coderank
+uv run archex benchmark readiness --input .archex/e2e-jina --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
+uv run archex benchmark readiness --input .archex/e2e-coderank --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
+```


### PR DESCRIPTION
## Stack

Stack-Id: `retrieval-defaults-20260608`
Base: `main`
Position: 1/3

1. `feat/coderank-default-eval` -> this PR
2. `feat/reranker-latency-tune` -> #165
3. `chore/default-strategy-decision` -> #166

Depends on: none
Upstack: #165

## Summary

- Adds `docs/RETRIEVAL_DEFAULT_DECISIONS.md` with the CodeRankEmbed vs Jina v2 A/B protocol.
- Keeps product defaults unchanged pending operator evidence.
- Links the evidence gate from README.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright && uv run pytest` — passed
- pr-review — passed after README wording fix; no critical/important findings remain

## Benchmark policy

No `archex benchmark run` or `archex dogfood` executed in this session. Operator commands are documented only.