### PR TITLE
feat(benchmark): parameterize reranker model

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ archex gives AI agents structural priors about codebases they have not seen. A p
 ## Performance and gates
 
 archex optimizes the amount of context the downstream agent must read, not recall alone. Benchmark reports track recall, precision, F1, MRR, NDCG, MAP, latency, returned tokens, raw-file baselines, and token efficiency (`1 − returned_tokens / accessed_file_tokens`, higher is better).
-Default embedder and strategy switches are evidence-gated in `docs/RETRIEVAL_DEFAULT_DECISIONS.md`; the product default stays unchanged until the clean warm-cache frontier satisfies those rules.
+Default embedder, reranker, and strategy switches are evidence-gated in `docs/RETRIEVAL_DEFAULT_DECISIONS.md`; the product default stays unchanged until the clean warm-cache frontier satisfies those rules.
 
 Latest local 35-task benchmark, compared with the previous accepted baseline:
 

--- a/docs/RETRIEVAL_DEFAULT_DECISIONS.md
+++ b/docs/RETRIEVAL_DEFAULT_DECISIONS.md
@@ -29,3 +29,27 @@ uv run archex benchmark run --query-fusion --rerank --embedder coderank --tasks-
 uv run archex benchmark readiness --input .archex/e2e-jina --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
 uv run archex benchmark readiness --input .archex/e2e-coderank --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
 ```
+
+## Reranker decision
+
+Candidate rerankers:
+
+| Candidate | Benchmark flag | Decision role |
+| --- | --- | --- |
+| Jina reranker v3 on detected device | omit `--rerank-model` | Current default reranker |
+| MiniLM cross-encoder | `--rerank-model cross-encoder/ms-marco-MiniLM-L-6-v2` | Lighter fallback if Jina exceeds the p95 budget |
+
+Keep the highest-quality reranker that holds p95 latency at or below `3000 ms` on the operator's hardware. Evaluate Jina first with MPS device selection; use the MiniLM fallback only if Jina remains over budget.
+
+Before comparing reranker p95, run the Jina command once as a cache warm-up and discard that output, then rerun both candidates against the warmed index cache.
+
+Operator commands:
+
+```bash
+uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --tasks-dir benchmarks/tasks --output .archex/e2e-rerank-jina
+uv run archex benchmark readiness --input .archex/e2e-rerank-jina --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
+uv run archex benchmark gate --input .archex/e2e-rerank-jina --warn-latency-ms 3000
+uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --rerank-model cross-encoder/ms-marco-MiniLM-L-6-v2 --tasks-dir benchmarks/tasks --output .archex/e2e-rerank-minilm
+uv run archex benchmark readiness --input .archex/e2e-rerank-minilm --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
+uv run archex benchmark gate --input .archex/e2e-rerank-minilm --warn-latency-ms 3000
+```

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -59,6 +59,7 @@ class BenchmarkRetrievalOptions(BaseModel):
     splade: bool = False
     module_prefilter: bool = False
     embedder: str = "jina-v2"
+    rerank_model: str | None = None
 
 
 class BenchmarkResult(BaseModel):

--- a/src/archex/benchmark/preflight.py
+++ b/src/archex/benchmark/preflight.py
@@ -47,7 +47,8 @@ def warm_benchmark_models(
     if Strategy.ARCHEX_QUERY_FUSION_RERANK in strategies:
         from archex.index.rerank import DEFAULT_MODEL, CrossEncoderReranker
 
-        CrossEncoderReranker().warm()
-        warmed.append(DEFAULT_MODEL)
+        rerank_model = retrieval_options.rerank_model or DEFAULT_MODEL
+        CrossEncoderReranker(model_name=rerank_model).warm()
+        warmed.append(rerank_model)
 
     return warmed

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -589,6 +589,8 @@ def benchmark_index_config(index_config: IndexConfig) -> IndexConfig:
         updates["splade"] = True
     if options.module_prefilter and index_config.bm25:
         updates["module_prefilter"] = True
+    if index_config.rerank and options.rerank_model is not None:
+        updates["rerank_model"] = options.rerank_model
     if not updates:
         return index_config
     return index_config.model_copy(update=updates)

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -115,6 +115,11 @@ def benchmark_cmd() -> None:
     help="Embedder to pin across every vector-backed benchmark strategy.",
 )
 @click.option(
+    "--rerank-model",
+    default=None,
+    help="Cross-encoder model to use for the fusion+rerank benchmark strategy.",
+)
+@click.option(
     "--self-only",
     is_flag=True,
     default=False,
@@ -137,6 +142,7 @@ def run_cmd(
     splade: bool,
     module_prefilter: bool,
     embedder: str,
+    rerank_model: str | None,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -160,6 +166,7 @@ def run_cmd(
         splade=splade,
         module_prefilter=module_prefilter,
         embedder=embedder,
+        rerank_model=rerank_model,
     )
     warmed_models = warm_benchmark_models(strategies, retrieval_options)
     if warmed_models:

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -261,6 +261,7 @@ class TestRunCommand:
         assert "--self-only" in result.output
         assert "--no-progress" in result.output
         assert "--embedder" in result.output
+        assert "--rerank-model" in result.output
 
     def test_run_uses_default_strategies_without_flags(
         self,
@@ -420,6 +421,38 @@ class TestRunCommand:
         result = runner.invoke(benchmark_cmd, ["run", "--embedder", "coderank"])
         assert result.exit_code == 0
         assert captured["retrieval_options"] == BenchmarkRetrievalOptions(embedder="coderank")
+
+    def test_run_passes_rerank_model_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(
+            benchmark_cmd,
+            ["run", "--rerank-model", "cross-encoder/ms-marco-MiniLM-L-6-v2"],
+        )
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(
+            rerank_model="cross-encoder/ms-marco-MiniLM-L-6-v2"
+        )
 
     def test_run_preflights_models_before_loading_tasks(
         self,

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -41,6 +41,39 @@ class TestAvailableStrategies:
         assert Strategy.ARCHEX_SYMBOL_LOOKUP not in AVAILABLE_STRATEGIES
 
 
+class TestBenchmarkPreflight:
+    def test_warms_configured_rerank_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from archex.benchmark.preflight import warm_benchmark_models
+
+        warmed_models: list[str] = []
+
+        class RecordingEmbedder:
+            dimension = 768
+
+        class RecordingReranker:
+            def __init__(self, model_name: str) -> None:
+                self._model_name = model_name
+
+            def warm(self) -> None:
+                warmed_models.append(self._model_name)
+
+        def create_embedder(_index_config: object) -> RecordingEmbedder:
+            return RecordingEmbedder()
+
+        from archex.index.embeddings import default_embedder_registry
+
+        monkeypatch.setattr(default_embedder_registry, "load_entry_points", lambda: None)
+        monkeypatch.setattr(default_embedder_registry, "create", create_embedder)
+        monkeypatch.setattr("archex.index.rerank.CrossEncoderReranker", RecordingReranker)
+        warmed = warm_benchmark_models(
+            [Strategy.ARCHEX_QUERY_FUSION_RERANK],
+            BenchmarkRetrievalOptions(rerank_model="cross-encoder/ms-marco-MiniLM-L-6-v2"),
+        )
+
+        assert warmed_models == ["cross-encoder/ms-marco-MiniLM-L-6-v2"]
+        assert warmed == ["jina-v2", "cross-encoder/ms-marco-MiniLM-L-6-v2"]
+
+
 class TestRunBenchmark:
     def test_run_with_fixture_repo(
         self,
@@ -375,11 +408,16 @@ class TestRunBenchmark:
         assert benchmark_cache_enabled(default=False) is False
 
         token = set_benchmark_retrieval_options(
-            BenchmarkRetrievalOptions(splade=True, module_prefilter=True)
+            BenchmarkRetrievalOptions(
+                splade=True,
+                module_prefilter=True,
+                rerank_model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+            )
         )
         try:
             bm25_config = benchmark_index_config(IndexConfig(vector=True))
             vector_config = benchmark_index_config(IndexConfig(bm25=False, vector=True))
+            rerank_config = benchmark_index_config(IndexConfig(vector=True, rerank=True))
             cache_enabled = benchmark_cache_enabled(default=False)
         finally:
             reset_benchmark_retrieval_options(token)
@@ -389,7 +427,10 @@ class TestRunBenchmark:
         assert vector_config.splade is True
         assert vector_config.module_prefilter is False
         assert bm25_config.embedder == "jina-v2"
+        assert bm25_config.rerank_model is None
         assert vector_config.embedder == "jina-v2"
+        assert vector_config.rerank_model is None
+        assert rerank_config.rerank_model == "cross-encoder/ms-marco-MiniLM-L-6-v2"
         assert cache_enabled is True
 
 


### PR DESCRIPTION
## Stack

Stack-Id: `retrieval-defaults-20260608`
Base: `main`
Position: 2/3

1. `feat/coderank-default-eval` -> #164
2. `feat/reranker-latency-tune` -> this PR
3. `chore/default-strategy-decision` -> #166

Depends on: #164
Upstack: #166

## Summary

- Adds benchmark `--rerank-model` so Tier 3 can measure a lighter cross-encoder without changing product defaults.
- Threads `rerank_model` through `BenchmarkRetrievalOptions`, preflight warm-up, and benchmark `IndexConfig` for rerank strategies.
- Adds reranker p95 decision commands and warm-cache note to `docs/RETRIEVAL_DEFAULT_DECISIONS.md`.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright && uv run pytest` — passed
- pr-review — passed after warm-cache documentation fix; no critical/important findings remain

## Benchmark policy

No `archex benchmark run` or `archex dogfood` executed in this session. Operator commands are documented only.