### PR TITLE
docs(retrieval): record default strategy decision gate

### DIFF
--- a/docs/RETRIEVAL_DEFAULT_DECISIONS.md
+++ b/docs/RETRIEVAL_DEFAULT_DECISIONS.md
@@ -53,3 +53,22 @@ uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --rerank-
 uv run archex benchmark readiness --input .archex/e2e-rerank-minilm --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
 uv run archex benchmark gate --input .archex/e2e-rerank-minilm --warn-latency-ms 3000
 ```
+
+## Product strategy decision
+
+Candidate product defaults:
+
+| Candidate | Meaning | Decision role |
+| --- | --- | --- |
+| `archex_query` | Current BM25 + graph product path | Default to keep unless beaten on the full frontier |
+| `archex_query_fusion_rerank` | BM25 + vector fusion + cross-encoder rerank | Candidate only if quality and latency both clear the rule |
+
+Switch to `archex_query_fusion_rerank` only if the clean warm run shows mean F1 at least `0.05` higher than `archex_query`, token efficiency at least as high as `archex_query`, and p95 latency at or below `3000 ms`. If the rule does not pass, keep `archex_query` as the product default.
+
+Operator commands:
+
+```bash
+uv run archex benchmark readiness --input .archex/e2e-jina --tasks-dir benchmarks/tasks --strategy archex_query --format markdown
+uv run archex benchmark readiness --input .archex/e2e-jina --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
+uv run archex benchmark gate --input .archex/e2e-jina --baseline .archex/e2e-tier2 --warn-latency-ms 3000
+```

--- a/docs/adr/001-retrieval-default-evidence-gate.md
+++ b/docs/adr/001-retrieval-default-evidence-gate.md
@@ -1,0 +1,47 @@
+# ADR-001: Gate Retrieval Default Changes On Recall, Tokens, And P95
+
+**Status:** Proposed
+**Date:** 2026-06-08
+**Author:** archex maintainers
+
+## Context
+
+Tier 3 settles the deferred default embedder, reranker, and product strategy decisions. Earlier strategy evidence was confounded by mixed embedders and missing token/p95 gates, so a recall-only switch can optimize the benchmark while worsening the product contract: fewer tokens per retrieval/explanation query with interactive p95 latency.
+
+## Decision
+
+Keep the current product default until clean warm-cache operator evidence satisfies the documented recall/token/p95 switch rules. Do not refresh `benchmarks/dogfood_baseline.json` or flip defaults without explicit approval after the evidence is reviewed.
+
+## Alternatives Considered
+
+### Switch to `archex_query_fusion_rerank` immediately
+- **Pros:** Uses the highest-precision candidate path and may reduce returned context when rerank is effective.
+- **Cons:** Current accepted evidence does not prove p95 <= 3000 ms on the clean single-embedder frontier.
+- **Rejected because:** The Tier 3 rule requires operator-run median and p95 latency plus token efficiency before changing the product default.
+
+### Keep `archex_query` permanently
+- **Pros:** Preserves the known product default and rollback path.
+- **Cons:** Could reject a better frontier point if CodeRankEmbed or a tuned reranker improves quality without token or p95 regression.
+- **Rejected because:** Tier 3 exists to decide from clean evidence, not freeze the old default without measuring the candidates.
+
+## Consequences
+
+### Positive
+
+- Default changes require evidence across quality, token economy, and latency.
+- Baseline refresh cannot bless regressions because it remains approval-gated.
+- Jina v2 and `archex_query` stay reachable as rollback paths.
+
+### Negative
+
+- The final default remains pending until the operator runs the long benchmark block.
+- Reviewers must inspect the evidence table before accepting any default flip.
+
+### Neutral
+
+- Benchmark-only knobs, such as `--embedder` and `--rerank-model`, do not change product behavior by themselves.
+
+## References
+
+- `docs/RETRIEVAL_DEFAULT_DECISIONS.md`
+- `.docs/2026-05-29-retrieval-recall-enhancement-plan.md` Tier 3


### PR DESCRIPTION
## Stack

Stack-Id: `retrieval-defaults-20260608`
Base: `main`
Position: 3/3

1. `feat/coderank-default-eval` -> #164
2. `feat/reranker-latency-tune` -> #165
3. `chore/default-strategy-decision` -> this PR

Depends on: #165
Upstack: none

## Summary

- Documents the product default strategy switch rule: F1 delta, token efficiency, and p95 latency must all pass.
- Adds ADR-001 in Proposed status to keep retrieval default changes evidence-gated.
- Leaves `serve/profile.py`, product defaults, and `benchmarks/dogfood_baseline.json` unchanged.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright && uv run pytest` — passed
- pr-review — passed; no critical/important findings remain

## Benchmark policy

No `archex benchmark run` or `archex dogfood` executed in this session. Operator commands are documented only.