### PR TITLE
fix(index): reuse embedders and record retrieval defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ archex gives AI agents structural priors about codebases they have not seen. A p
 ## Performance and gates
 
 archex optimizes the amount of context the downstream agent must read, not recall alone. Benchmark reports track recall, precision, F1, MRR, NDCG, MAP, latency, returned tokens, raw-file baselines, and token efficiency (`1 − returned_tokens / accessed_file_tokens`, higher is better).
-Default embedder, reranker, and strategy switches are evidence-gated in `docs/RETRIEVAL_DEFAULT_DECISIONS.md`; the product default stays unchanged until the clean warm-cache frontier satisfies those rules.
+Default embedder, reranker, and strategy switches are evidence-gated in `docs/RETRIEVAL_DEFAULT_DECISIONS.md`; the 2026-06-09 retrieval-default run kept `archex_query` as the product default and did not refresh `benchmarks/dogfood_baseline.json`.
 
 Latest local 35-task benchmark, compared with the previous accepted baseline:
 

--- a/docs/RETRIEVAL_DEFAULT_DECISIONS.md
+++ b/docs/RETRIEVAL_DEFAULT_DECISIONS.md
@@ -1,13 +1,13 @@
 # Retrieval Default Decision Protocol
 
-Tier 3 decisions stay pending until the operator provides clean warm-cache benchmark evidence. Product defaults remain unchanged until the switch rules in this document pass and the operator approves the change.
+Operator evidence from the 2026-06-09 retrieval-default benchmark keeps `archex_query` as the product default. CodeRankEmbed and reranker default changes remain blocked until a clean full run clears the recall/F1, token-efficiency, and p95 latency rules.
 
 ## Invariants
 
 - Run benchmarks locally only; no network or generative LLM inference.
 - Pin exactly one embedder per benchmark run with `--embedder`.
 - Compare candidates on recall, F1, token efficiency, median latency, and p95 latency. Recall/F1 alone is not sufficient.
-- Keep `archex_query` as the product default until the final strategy switch rule passes.
+- Keep `archex_query` as the product default; the 2026-06-09 run did not satisfy the strategy switch rule.
 - Do not refresh `benchmarks/dogfood_baseline.json` without explicit approval after a proven improvement.
 
 ## Embedder decision
@@ -20,6 +20,8 @@ Candidate embedders:
 | CodeRankEmbed | `--embedder coderank` | Registered as `coderank`; no product default flip before approval |
 
 Switch from Jina v2 to CodeRankEmbed only when a warm full run shows `archex_query_fusion_rerank` recall and F1 improve, token efficiency is not worse, and p95 latency does not regress.
+
+2026-06-09 result: do not switch. The CodeRank run completed only `28/35` tasks because seven GitHub clones failed DNS resolution, so it is invalid as final A/B evidence. Even on the partial set, CodeRank fusion rerank underperformed Jina fusion rerank on recall (`0.774` vs `0.818`), F1 (`0.590` vs `0.594`), token efficiency (`0.597` vs `0.612`), and p95 latency (`253658 ms` vs `16588 ms`).
 
 Operator commands:
 
@@ -38,8 +40,11 @@ Candidate rerankers:
 | --- | --- | --- |
 | Jina reranker v3 on detected device | omit `--rerank-model` | Current default reranker |
 | MiniLM cross-encoder | `--rerank-model cross-encoder/ms-marco-MiniLM-L-6-v2` | Lighter fallback if Jina exceeds the p95 budget |
+| TinyBERT cross-encoder | `--rerank-model cross-encoder/ms-marco-TinyBERT-L-2-v2` | Lighter candidate to test after MiniLM missed p95 |
 
-Keep the highest-quality reranker that holds p95 latency at or below `3000 ms` on the operator's hardware. Evaluate Jina first with MPS device selection; use the MiniLM fallback only if Jina remains over budget.
+Keep the highest-quality reranker that holds p95 latency at or below `3000 ms` on the operator's hardware. Evaluate Jina first with MPS device selection, then MiniLM, then TinyBERT only if heavier candidates remain over budget.
+
+2026-06-09 result: do not change the reranker default. Jina reranker p95 was `16522 ms`, and MiniLM p95 was `3924 ms`; both miss the `<= 3000 ms` budget. MiniLM is the better latency candidate observed so far, but it still needs further tuning or a lighter local reranker before it can be selected. The next local candidate is TinyBERT.
 
 Before comparing reranker p95, run the Jina command once as a cache warm-up and discard that output, then rerun both candidates against the warmed index cache.
 
@@ -52,6 +57,9 @@ uv run archex benchmark gate --input .archex/e2e-rerank-jina --warn-latency-ms 3
 uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --rerank-model cross-encoder/ms-marco-MiniLM-L-6-v2 --tasks-dir benchmarks/tasks --output .archex/e2e-rerank-minilm
 uv run archex benchmark readiness --input .archex/e2e-rerank-minilm --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
 uv run archex benchmark gate --input .archex/e2e-rerank-minilm --warn-latency-ms 3000
+uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --rerank-model cross-encoder/ms-marco-TinyBERT-L-2-v2 --tasks-dir benchmarks/tasks --output .archex/e2e-rerank-tinybert
+uv run archex benchmark readiness --input .archex/e2e-rerank-tinybert --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
+uv run archex benchmark gate --input .archex/e2e-rerank-tinybert --warn-latency-ms 3000
 ```
 
 ## Product strategy decision
@@ -64,6 +72,8 @@ Candidate product defaults:
 | `archex_query_fusion_rerank` | BM25 + vector fusion + cross-encoder rerank | Candidate only if quality and latency both clear the rule |
 
 Switch to `archex_query_fusion_rerank` only if the clean warm run shows mean F1 at least `0.05` higher than `archex_query`, token efficiency at least as high as `archex_query`, and p95 latency at or below `3000 ms`. If the rule does not pass, keep `archex_query` as the product default.
+
+2026-06-09 result: keep `archex_query`. On the clean Jina run, `archex_query` had F1 `0.589`, token efficiency `0.701`, and p95 `2186 ms`; `archex_query_fusion_rerank` had F1 `0.594`, token efficiency `0.612`, and p95 `16588 ms`. The F1 delta was only `+0.005`, token efficiency regressed, and p95 exceeded the `3000 ms` limit.
 
 Operator commands:
 

--- a/docs/adr/001-retrieval-default-evidence-gate.md
+++ b/docs/adr/001-retrieval-default-evidence-gate.md
@@ -1,28 +1,33 @@
 # ADR-001: Gate Retrieval Default Changes On Recall, Tokens, And P95
 
-**Status:** Proposed
-**Date:** 2026-06-08
+**Status:** Accepted
+**Date:** 2026-06-09
 **Author:** archex maintainers
 
 ## Context
 
-Tier 3 settles the deferred default embedder, reranker, and product strategy decisions. Earlier strategy evidence was confounded by mixed embedders and missing token/p95 gates, so a recall-only switch can optimize the benchmark while worsening the product contract: fewer tokens per retrieval/explanation query with interactive p95 latency.
+The retrieval-default evaluation settles the deferred default embedder, reranker, and product strategy decisions. Earlier strategy evidence was confounded by mixed embedders and missing token/p95 gates, so a recall-only switch can optimize the benchmark while worsening the product contract: fewer tokens per retrieval/explanation query with interactive p95 latency.
 
 ## Decision
 
-Keep the current product default until clean warm-cache operator evidence satisfies the documented recall/token/p95 switch rules. Do not refresh `benchmarks/dogfood_baseline.json` or flip defaults without explicit approval after the evidence is reviewed.
+Keep `archex_query` as the product default. The 2026-06-09 operator run did not satisfy the default switch rule: `archex_query_fusion_rerank` improved F1 by only `0.005`, regressed token efficiency from `0.701` to `0.612`, and exceeded the p95 budget at `16588 ms`.
 
 ## Alternatives Considered
 
-### Switch to `archex_query_fusion_rerank` immediately
-- **Pros:** Uses the highest-precision candidate path and may reduce returned context when rerank is effective.
-- **Cons:** Current accepted evidence does not prove p95 <= 3000 ms on the clean single-embedder frontier.
-- **Rejected because:** The Tier 3 rule requires operator-run median and p95 latency plus token efficiency before changing the product default.
+### Switch to `archex_query_fusion_rerank`
+- **Pros:** Highest observed MRR on the Jina run (`0.938`) and a small F1 lift (`0.594` vs `0.589`).
+- **Cons:** Token efficiency regressed (`0.612` vs `0.701`) and p95 latency was `16588 ms`, far above the `3000 ms` budget.
+- **Rejected because:** It failed all non-F1 switch constraints and did not clear the required `+0.05` mean F1 delta.
 
-### Keep `archex_query` permanently
-- **Pros:** Preserves the known product default and rollback path.
-- **Cons:** Could reject a better frontier point if CodeRankEmbed or a tuned reranker improves quality without token or p95 regression.
-- **Rejected because:** Tier 3 exists to decide from clean evidence, not freeze the old default without measuring the candidates.
+### Switch the benchmark embedder to CodeRankEmbed
+- **Pros:** CodeRankEmbed remains a plausible code-specialized embedder after fixing query-prefix and repeated-load issues.
+- **Cons:** The 2026-06-09 CodeRank run completed only `28/35` tasks due clone DNS failures and had extreme partial-run p95 latency (`253658 ms` for fusion rerank).
+- **Rejected because:** The evidence is not clean full-run evidence, and the partial frontier was worse than Jina on recall, F1, token efficiency, and p95 latency.
+
+### Select MiniLM as the reranker default
+- **Pros:** Much faster than Jina reranker v3 on the same 35-task run (`3924 ms` p95 vs `16522 ms` p95).
+- **Cons:** Still misses the `<= 3000 ms` p95 budget and slightly lowers F1 (`0.586` vs `0.594`).
+- **Rejected because:** The reranker decision rule requires the selected model to hold p95 at or below `3000 ms` on the operator hardware.
 
 ## Consequences
 
@@ -34,8 +39,8 @@ Keep the current product default until clean warm-cache operator evidence satisf
 
 ### Negative
 
-- The final default remains pending until the operator runs the long benchmark block.
-- Reviewers must inspect the evidence table before accepting any default flip.
+- Rerank remains optional and not product-defaulted until a local reranker holds p95 `<= 3000 ms`.
+- CodeRankEmbed needs a separate clean re-run after the query-prefix and model-reuse fixes before it can be reconsidered.
 
 ### Neutral
 
@@ -44,4 +49,4 @@ Keep the current product default until clean warm-cache operator evidence satisf
 ## References
 
 - `docs/RETRIEVAL_DEFAULT_DECISIONS.md`
-- `.docs/2026-05-29-retrieval-recall-enhancement-plan.md` Tier 3
+- 2026-06-09 retrieval-default benchmark run and readiness summaries

--- a/scripts/benchmark_pipeline.sh
+++ b/scripts/benchmark_pipeline.sh
@@ -29,6 +29,7 @@ run_step() {
     fi
 
     echo
+    printf -- '=+%.0s' {1..25}
     echo "===== $(date '+%Y-%m-%d %H:%M:%S') : Starting \"$label\" ====="
     echo "Command: $cmd"
 
@@ -48,6 +49,8 @@ run_step() {
         echo "===== $(date '+%Y-%m-%d %H:%M:%S') : FAILED \"$label\" (exit $status) ====="
     fi
     echo "===== Time taken: $(format_duration "$duration") ====="
+    printf -- '=+%.0s' {1..25}
+    echo
     return "$status"
 }
 

--- a/src/archex/benchmark/preflight.py
+++ b/src/archex/benchmark/preflight.py
@@ -35,7 +35,11 @@ def warm_benchmark_models(
         if embedder is None:
             msg = "Benchmark vector strategy requires a configured embedder"
             raise ValueError(msg)
-        _ = embedder.dimension
+        warm = getattr(embedder, "warm", None)
+        if callable(warm):
+            warm()
+        else:
+            _ = embedder.dimension
         warmed.append(retrieval_options.embedder)
 
     if retrieval_options.splade:

--- a/src/archex/index/embeddings/__init__.py
+++ b/src/archex/index/embeddings/__init__.py
@@ -72,28 +72,35 @@ class EmbedderRegistry:
     def __init__(self) -> None:
         self._factories: dict[str, EmbedderFactory] = {}
         self._entry_points_loaded: bool = False
+        self._instances: dict[str, Embedder] = {}
         self._entry_points_strict: bool = False
 
     def register(self, name: str, factory: EmbedderFactory) -> None:
         """Register an embedder factory by name."""
         self._factories[name] = factory
+        self._instances.pop(name, None)
 
     def get(self, name: str) -> EmbedderFactory | None:
         """Return the factory for an embedder name, or None."""
         return self._factories.get(name)
 
     def create(self, index_config: IndexConfig) -> Embedder | None:
-        """Create an embedder from index_config.
+        """Return a cached embedder for index_config.
 
         Returns None when no embedder is configured.
         Raises ConfigError for unknown embedder names.
         """
         if not index_config.embedder:
             return None
+        cached = self._instances.get(index_config.embedder)
+        if cached is not None:
+            return cached
         factory = self._factories.get(index_config.embedder)
         if factory is None:
             raise ConfigError(f"Unknown embedder: {index_config.embedder!r}")
-        return factory()
+        embedder = factory()
+        self._instances[index_config.embedder] = embedder
+        return embedder
 
     def load_entry_points(
         self,
@@ -108,6 +115,7 @@ class EmbedderRegistry:
             try:
                 factory = ep.load()
                 self._factories[ep.name] = factory
+                self._instances.pop(ep.name, None)
                 logger.info("Loaded embedder %s from entry point", ep.name)
             except (ImportError, AttributeError, TypeError, ValueError) as exc:
                 if strict:

--- a/src/archex/index/embeddings/fast.py
+++ b/src/archex/index/embeddings/fast.py
@@ -12,6 +12,9 @@ from archex.exceptions import ArchexIndexError
 logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "BAAI/bge-small-en-v1.5"
+_MODEL_DIMENSIONS = {
+    _DEFAULT_MODEL: 384,
+}
 
 
 class FastEmbedder:
@@ -31,7 +34,7 @@ class FastEmbedder:
         self._model_name = model_name
         self._batch_size = batch_size
         self._model: Any = None
-        self._dimension: int | None = None
+        self._dimension: int | None = _MODEL_DIMENSIONS.get(model_name)
 
     def _load_model(self) -> None:
         if self._model is not None:
@@ -53,6 +56,10 @@ class FastEmbedder:
             self._model_name,
             self._dimension,
         )
+
+    def warm(self) -> None:
+        """Load the fastembed model before latency-sensitive work starts."""
+        self._load_model()
 
     def encode(self, texts: list[str]) -> list[list[float]]:
         self._load_model()

--- a/src/archex/index/vector.py
+++ b/src/archex/index/vector.py
@@ -29,6 +29,13 @@ def _chunk_embedding_text(chunk: CodeChunk) -> str:
     return chunk.content
 
 
+def _encode_query(embedder: Embedder, query: str) -> list[float]:
+    encode_queries = getattr(embedder, "encode_queries", None)
+    if encode_queries is not None:
+        return encode_queries([query])[0]
+    return embedder.encode([query])[0]
+
+
 class VectorIndex:
     """Dense vector index for semantic search over CodeChunks.
 
@@ -120,7 +127,7 @@ class VectorIndex:
         if self._vectors is None and self._quantized_codes is None:
             return []
 
-        query_vec = np.array(embedder.encode([query])[0], dtype=np.float32)
+        query_vec = np.array(_encode_query(embedder, query), dtype=np.float32)
         norm = np.linalg.norm(query_vec)
         if norm < 1e-9:
             return []
@@ -310,7 +317,7 @@ class VectorIndex:
         if not candidates:
             return []
 
-        texts = [query] + [
+        candidate_texts = [
             surrogates_by_chunk_id[c.id].surrogate_text
             if (
                 vector_mode == VectorMode.SURROGATE
@@ -320,11 +327,13 @@ class VectorIndex:
             else _chunk_embedding_text(c)
             for c in candidates
         ]
+        query_vec_raw = np.array(_encode_query(embedder, query), dtype=np.float32)
         encode_np = getattr(embedder, "encode_ndarray", None)
         if encode_np is not None:
-            vecs = encode_np(texts)
+            candidate_vecs_raw = encode_np(candidate_texts)
         else:
-            vecs = np.array(embedder.encode(texts), dtype=np.float32)
+            candidate_vecs_raw = np.array(embedder.encode(candidate_texts), dtype=np.float32)
+        vecs = np.vstack([query_vec_raw, candidate_vecs_raw])
 
         norms = np.linalg.norm(vecs, axis=1, keepdims=True)
         norms = np.maximum(norms, 1e-9)

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -73,6 +73,35 @@ class TestBenchmarkPreflight:
         assert warmed_models == ["cross-encoder/ms-marco-MiniLM-L-6-v2"]
         assert warmed == ["jina-v2", "cross-encoder/ms-marco-MiniLM-L-6-v2"]
 
+    def test_warms_embedder_with_explicit_warm_method(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from archex.benchmark.preflight import warm_benchmark_models
+
+        warmed_embedders: list[str] = []
+
+        class RecordingEmbedder:
+            dimension = 768
+
+            def warm(self) -> None:
+                warmed_embedders.append("coderank")
+
+        def create_embedder(_index_config: object) -> RecordingEmbedder:
+            return RecordingEmbedder()
+
+        from archex.index.embeddings import default_embedder_registry
+
+        monkeypatch.setattr(default_embedder_registry, "load_entry_points", lambda: None)
+        monkeypatch.setattr(default_embedder_registry, "create", create_embedder)
+
+        warmed = warm_benchmark_models(
+            [Strategy.ARCHEX_QUERY_FUSION],
+            BenchmarkRetrievalOptions(embedder="coderank"),
+        )
+
+        assert warmed_embedders == ["coderank"]
+        assert warmed == ["coderank"]
+
 
 class TestRunBenchmark:
     def test_run_with_fixture_repo(

--- a/tests/index/test_embedder_registry.py
+++ b/tests/index/test_embedder_registry.py
@@ -34,6 +34,35 @@ class TestEmbedderRegistry:
         assert emb is not None
         assert isinstance(emb, Embedder)
 
+    def test_create_reuses_embedder_instance(self) -> None:
+        call_count = 0
+
+        def factory() -> Embedder:
+            nonlocal call_count
+            call_count += 1
+            return _fake_factory()
+
+        reg = EmbedderRegistry()
+        reg.register("test_emb", factory)
+        config = IndexConfig(vector=True, embedder="test_emb")
+
+        first = reg.create(config)
+        second = reg.create(config)
+
+        assert first is second
+        assert call_count == 1
+
+    def test_register_replaces_cached_embedder_instance(self) -> None:
+        reg = EmbedderRegistry()
+        reg.register("test_emb", _fake_factory)
+        config = IndexConfig(vector=True, embedder="test_emb")
+        first = reg.create(config)
+
+        reg.register("test_emb", _fake_factory)
+        second = reg.create(config)
+
+        assert first is not second
+
     def test_create_unknown_raises_config_error(self) -> None:
         reg = EmbedderRegistry()
         config = IndexConfig(vector=True, embedder="unknown")

--- a/tests/index/test_vector.py
+++ b/tests/index/test_vector.py
@@ -45,6 +45,53 @@ class FakeEmbedder:
         return self._dim
 
 
+class QueryPrefixEmbedder:
+    dimension = 2
+
+    def __init__(self) -> None:
+        self.encoded_documents: list[str] = []
+        self.encoded_queries: list[str] = []
+
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        self.encoded_documents.extend(texts)
+        return [self._vector(text) for text in texts]
+
+    def encode_queries(self, queries: list[str]) -> list[list[float]]:
+        self.encoded_queries.extend(queries)
+        return [self._vector(f"query:{query}") for query in queries]
+
+    def _vector(self, text: str) -> list[float]:
+        if text in {"target", "query:target"}:
+            return [1.0, 0.0]
+        return [0.0, 1.0]
+
+
+QUERY_PREFIX_CHUNKS = [
+    CodeChunk(
+        id="target.py:target:1",
+        content="target",
+        file_path="target.py",
+        start_line=1,
+        end_line=1,
+        symbol_name="target",
+        symbol_kind=SymbolKind.FUNCTION,
+        language="python",
+        token_count=1,
+    ),
+    CodeChunk(
+        id="other.py:other:1",
+        content="other",
+        file_path="other.py",
+        start_line=1,
+        end_line=1,
+        symbol_name="other",
+        symbol_kind=SymbolKind.FUNCTION,
+        language="python",
+        token_count=1,
+    ),
+]
+
+
 SAMPLE_CHUNKS = [
     CodeChunk(
         id="utils.py:calculate_sum:5",
@@ -176,6 +223,29 @@ class TestVectorIndexSearch:
         )
         assert len(results) > 0
         assert results[0][0].id == "utils.py:calculate_sum:5"
+
+    def test_search_uses_embedder_query_encoder(self) -> None:
+        embedder = QueryPrefixEmbedder()
+        index = VectorIndex()
+        index.build(QUERY_PREFIX_CHUNKS, embedder)
+
+        results = index.search("target", embedder, top_k=1)
+
+        assert results[0][0].id == "target.py:target:1"
+        assert embedder.encoded_queries == ["target"]
+        assert embedder.encoded_documents == ["target", "other"]
+
+
+class TestVectorIndexRerank:
+    def test_rerank_uses_embedder_query_encoder(self) -> None:
+        embedder = QueryPrefixEmbedder()
+        index = VectorIndex()
+
+        results = index.rerank("target", list(reversed(QUERY_PREFIX_CHUNKS)), embedder)
+
+        assert results[0][0].id == "target.py:target:1"
+        assert embedder.encoded_queries == ["target"]
+        assert embedder.encoded_documents == ["other", "target"]
 
 
 class TestVectorIndexPersistence:


### PR DESCRIPTION
## Summary

This PR records the retrieval-default evaluation outcome and keeps the product default unchanged.

It includes three logical commits:

1. Benchmark pipeline log readability: adds visible separators around timed steps.
2. Retrieval-default decision records: documents why defaults stay unchanged.
3. Index/runtime fixes: reuses heavy embedders and applies query-specific encoding correctly.

## Decisions recorded

- Keep `archex_query` as the product default.
- Do not switch the default embedder to CodeRankEmbed.
- Do not select Jina reranker v3 or MiniLM as the default reranker; both miss p95 `<= 3000 ms`.
- Do not refresh `benchmarks/dogfood_baseline.json`.

Evidence from the operator-run pipeline:

| Candidate | Outcome |
| --- | --- |
| `archex_query` on Jina | Kept as default: F1 `0.589`, token efficiency `0.701`, p95 `2186 ms` |
| `archex_query_fusion_rerank` on Jina | Rejected: F1 delta only `+0.005`, token efficiency `0.612`, p95 `16588 ms` |
| CodeRankEmbed | Not selected: run was incomplete (`28/35` tasks) and partial results regressed recall/F1/token efficiency/p95 |
| MiniLM reranker | Not selected: p95 `3924 ms`, still above `3000 ms` budget |

## Documentation changes

- Updates `README.md` to state that the 2026-06-09 retrieval-default run kept `archex_query` and did not refresh the dogfood baseline.
- Updates `docs/RETRIEVAL_DEFAULT_DECISIONS.md` with the final retrieval-default outcomes and next candidate reranker command.
- Marks `docs/adr/001-retrieval-default-evidence-gate.md` as Accepted and records why the default strategy, CodeRankEmbed, and MiniLM were rejected.

## Benchmark script change

- Adds visible step separators to `scripts/benchmark_pipeline.sh` log output around each timed step.

## Index/runtime fixes

- Caches embedder instances by embedder name in `EmbedderRegistry.create()`.
  - This avoids reconstructing heavy embedders repeatedly inside one process.
  - Cache entries are invalidated when factories are re-registered or replaced by entry points.
- Makes vector search and vector rerank use `encode_queries()` when an embedder exposes it.
  - This preserves CodeRankEmbed's query prefix behavior while keeping document/candidate encoding on `encode()` / `encode_ndarray()`.
- Adds `FastEmbedder.warm()` and a known default dimension for BGE-small.
  - Runtime protocol checks no longer load a missing/corrupt ONNX cache just to read `dimension`.
  - Benchmark preflight calls explicit embedder `warm()` methods when available, so timed benchmark tasks do not absorb the model-load cost.

## Tests added

- Embedder registry instance reuse and cache invalidation.
- Vector search uses query-specific encoding.
- Vector rerank uses query-specific encoding.
- Benchmark preflight calls explicit embedder warm methods.

## Validation

Full implementation gate passed locally:

```bash
uv run ruff check && uv run ruff format --check . && uv run pyright && uv run pytest
```

Observed result:

- Ruff check: passed
- Ruff format check: passed
- Pyright: `0 errors, 0 warnings, 0 informations`
- Pytest: `2068 passed, 4 deselected`
- Coverage: `91.18%`

## Notes

- No `archex benchmark run` or `archex dogfood` command was run while preparing this PR.
- `benchmarks/dogfood_baseline.json` is unchanged.
- Product defaults are unchanged.