### PR TITLE
feat: add architecture quality benchmark tasks

### DIFF
--- a/benchmarks/arch_tasks/python_false_positives.yaml
+++ b/benchmarks/arch_tasks/python_false_positives.yaml
@@ -1,0 +1,20 @@
+task_id: python_false_positives_architecture
+repo: "."
+commit: "HEAD"
+question: "Which architectural patterns should not be inferred from generic utility method names?"
+languages: [python]
+include_paths:
+  - tests/fixtures/repos/false_positives
+arch_oracle:
+  patterns: []
+  interfaces:
+    - name: DataProcessor
+      file_path: tests/fixtures/repos/false_positives/utils.py
+      kind: class
+    - name: ConfigManager
+      file_path: tests/fixtures/repos/false_positives/utils.py
+      kind: class
+    - name: ButtonWidget
+      file_path: tests/fixtures/repos/false_positives/utils.py
+      kind: class
+  decisions: []

--- a/benchmarks/arch_tasks/python_patterns.yaml
+++ b/benchmarks/arch_tasks/python_patterns.yaml
@@ -1,0 +1,77 @@
+task_id: python_patterns_architecture
+repo: "."
+commit: "HEAD"
+question: "Which architectural patterns does the Python patterns fixture contain?"
+languages: [python]
+include_paths:
+  - tests/fixtures/python_patterns
+arch_oracle:
+  patterns:
+    - name: middleware_chain
+      evidence_symbols:
+        - Middleware
+        - LoggingMiddleware
+        - AuthMiddleware
+    - name: plugin_system
+      evidence_symbols:
+        - Plugin
+        - PluginRegistry
+    - name: event_bus
+      evidence_symbols:
+        - EventBus
+    - name: repository
+      evidence_symbols:
+        - UserRepository
+    - name: strategy
+      evidence_symbols:
+        - SortStrategy
+        - BubbleSort
+        - QuickSort
+        - Sorter
+  interfaces:
+    - name: SortStrategy
+      file_path: tests/fixtures/python_patterns/strategies.py
+      kind: class
+    - name: BubbleSort
+      file_path: tests/fixtures/python_patterns/strategies.py
+      kind: class
+    - name: QuickSort
+      file_path: tests/fixtures/python_patterns/strategies.py
+      kind: class
+    - name: Sorter
+      file_path: tests/fixtures/python_patterns/strategies.py
+      kind: class
+    - name: EventBus
+      file_path: tests/fixtures/python_patterns/events.py
+      kind: class
+    - name: Middleware
+      file_path: tests/fixtures/python_patterns/middleware.py
+      kind: class
+    - name: LoggingMiddleware
+      file_path: tests/fixtures/python_patterns/middleware.py
+      kind: class
+    - name: AuthMiddleware
+      file_path: tests/fixtures/python_patterns/middleware.py
+      kind: class
+    - name: Plugin
+      file_path: tests/fixtures/python_patterns/plugins.py
+      kind: class
+    - name: PluginRegistry
+      file_path: tests/fixtures/python_patterns/plugins.py
+      kind: class
+    - name: User
+      file_path: tests/fixtures/python_patterns/repository.py
+      kind: class
+    - name: UserRepository
+      file_path: tests/fixtures/python_patterns/repository.py
+      kind: class
+  decisions:
+    - decision_terms:
+        - middleware
+        - chain
+    - decision_terms:
+        - plugin
+        - extension
+    - decision_terms:
+        - strategy
+        - algorithm

--- a/benchmarks/arch_tasks/python_strategy_sorting.yaml
+++ b/benchmarks/arch_tasks/python_strategy_sorting.yaml
@@ -1,0 +1,47 @@
+task_id: python_strategy_sorting_architecture
+repo: "."
+commit: "HEAD"
+question: "Which architecture does the strategy sorting fixture expose?"
+languages: [python]
+include_paths:
+  - tests/fixtures/repos/python_strategy_sorting
+arch_oracle:
+  modules:
+    - name: sorters
+      root_path: tests/fixtures/repos/python_strategy_sorting/sorters
+      files:
+        - tests/fixtures/repos/python_strategy_sorting/sorters/base.py
+        - tests/fixtures/repos/python_strategy_sorting/sorters/context.py
+        - tests/fixtures/repos/python_strategy_sorting/sorters/implementations.py
+      responsibility_terms:
+        - sort
+        - strategy
+        - implementation
+  patterns:
+    - name: strategy
+      evidence_symbols:
+        - SortStrategy
+        - BubbleSort
+        - MergeSort
+        - QuickSort
+        - SortContext
+  interfaces:
+    - name: SortStrategy
+      file_path: tests/fixtures/repos/python_strategy_sorting/sorters/base.py
+      kind: class
+    - name: SortContext
+      file_path: tests/fixtures/repos/python_strategy_sorting/sorters/context.py
+      kind: class
+    - name: BubbleSort
+      file_path: tests/fixtures/repos/python_strategy_sorting/sorters/implementations.py
+      kind: class
+    - name: MergeSort
+      file_path: tests/fixtures/repos/python_strategy_sorting/sorters/implementations.py
+      kind: class
+    - name: QuickSort
+      file_path: tests/fixtures/repos/python_strategy_sorting/sorters/implementations.py
+      kind: class
+  decisions:
+    - decision_terms:
+        - strategy
+        - algorithm

--- a/src/archex/benchmark/loader.py
+++ b/src/archex/benchmark/loader.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 
-from archex.benchmark.models import BenchmarkTask, DeltaBenchmarkTask
+from archex.benchmark.models import ArchitectureBenchmarkTask, BenchmarkTask, DeltaBenchmarkTask
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -28,6 +28,25 @@ def load_tasks(directory: Path) -> list[BenchmarkTask]:
     tasks: list[BenchmarkTask] = []
     for yaml_file in sorted(directory.glob("*.yaml")):
         tasks.append(load_task(yaml_file))
+    return tasks
+
+
+def load_arch_task(path: Path) -> ArchitectureBenchmarkTask:
+    """Parse a single YAML file into an ArchitectureBenchmarkTask."""
+    raw = path.read_text(encoding="utf-8")
+    data = yaml.safe_load(raw)
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected a YAML mapping in {path}, got {type(data).__name__}")
+    return ArchitectureBenchmarkTask.model_validate(data)
+
+
+def load_arch_tasks(directory: Path) -> list[ArchitectureBenchmarkTask]:
+    """Load all *.yaml files from a directory into ArchitectureBenchmarkTasks."""
+    if not directory.is_dir():
+        raise FileNotFoundError(f"Architecture tasks directory not found: {directory}")
+    tasks: list[ArchitectureBenchmarkTask] = []
+    for yaml_file in sorted(directory.glob("*.yaml")):
+        tasks.append(load_arch_task(yaml_file))
     return tasks
 
 

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, model_validator
 from archex.models import (  # noqa: TCH001 — Pydantic needs at runtime
     DeltaMeta,
     PipelineTiming,
+    SymbolKind,
     VectorMode,
 )
 
@@ -48,6 +49,56 @@ class BenchmarkTask(BaseModel):
 
     @model_validator(mode="after")
     def _validate_include_paths(self) -> BenchmarkTask:
+        for path in self.include_paths:
+            if not path or path.startswith("/") or ".." in path.split("/"):
+                msg = f"include_paths entries must be relative paths: {path!r}"
+                raise ValueError(msg)
+        return self
+
+
+class ArchitectureExpectedModule(BaseModel):
+    name: str
+    root_path: str
+    files: list[str]
+    responsibility_terms: list[str] = []
+
+
+class ArchitectureExpectedPattern(BaseModel):
+    name: str
+    evidence_symbols: list[str] = []
+
+
+class ArchitectureExpectedInterface(BaseModel):
+    name: str
+    file_path: str
+    kind: SymbolKind | None = None
+
+
+class ArchitectureExpectedDecision(BaseModel):
+    decision_terms: list[str]
+
+
+class ArchitectureOracle(BaseModel):
+    modules: list[ArchitectureExpectedModule] = []
+    patterns: list[ArchitectureExpectedPattern] = []
+    interfaces: list[ArchitectureExpectedInterface] = []
+    decisions: list[ArchitectureExpectedDecision] = []
+
+
+class ArchitectureBenchmarkTask(BaseModel):
+    task_id: str
+    repo: str
+    commit: str
+    question: str
+    include_paths: list[str]
+    languages: list[str] | None = None
+    arch_oracle: ArchitectureOracle
+
+    @model_validator(mode="after")
+    def _validate_include_paths(self) -> ArchitectureBenchmarkTask:
+        if not self.include_paths:
+            msg = "architecture benchmark tasks must declare include_paths"
+            raise ValueError(msg)
         for path in self.include_paths:
             if not path or path.startswith("/") or ".." in path.split("/"):
                 msg = f"include_paths entries must be relative paths: {path!r}"

--- a/tests/benchmark/test_loader.py
+++ b/tests/benchmark/test_loader.py
@@ -7,13 +7,15 @@ from pathlib import Path
 import pytest
 
 from archex.benchmark.loader import (
+    load_arch_task,
+    load_arch_tasks,
     load_delta_task,
     load_delta_tasks,
     load_task,
     load_tasks,
     validate_task,
 )
-from archex.benchmark.models import BenchmarkTask, DeltaBenchmarkTask
+from archex.benchmark.models import ArchitectureBenchmarkTask, BenchmarkTask, DeltaBenchmarkTask
 
 
 @pytest.fixture
@@ -90,6 +92,76 @@ expected_files:
         p.write_text("task_id: test\nrepo: owner/repo\n")
         with pytest.raises(Exception):  # noqa: B017 — Pydantic ValidationError
             load_task(p)
+
+
+class TestLoadArchTask:
+    def test_load_valid_arch_yaml(self, tmp_path: Path) -> None:
+        p = tmp_path / "arch.yaml"
+        p.write_text("""\
+task_id: arch_fixture
+repo: "."
+commit: HEAD
+question: "Which architectural patterns are present?"
+include_paths:
+  - tests/fixtures/python_patterns
+languages: [python]
+arch_oracle:
+  patterns:
+    - name: strategy
+      evidence_symbols:
+        - SortStrategy
+  interfaces:
+    - name: SortStrategy
+      file_path: tests/fixtures/python_patterns/strategies.py
+""")
+        task = load_arch_task(p)
+
+        assert isinstance(task, ArchitectureBenchmarkTask)
+        assert task.task_id.startswith("arch_")
+        assert task.arch_oracle.patterns[0].name == "strategy"
+
+    def test_load_arch_invalid_yaml(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.yaml"
+        p.write_text("- just a list")
+
+        with pytest.raises(ValueError, match="Expected a YAML mapping"):
+            load_arch_task(p)
+
+    def test_load_arch_tasks_directory(self, tmp_path: Path) -> None:
+        for name in ("a", "b"):
+            (tmp_path / f"{name}.yaml").write_text(f"""\
+task_id: arch_{name}
+repo: "."
+commit: HEAD
+question: "Which architecture is present?"
+include_paths:
+  - tests/fixtures/python_patterns
+arch_oracle:
+  patterns:
+    - name: strategy
+""")
+
+        tasks = load_arch_tasks(tmp_path)
+
+        assert [task.task_id for task in tasks] == ["arch_a", "arch_b"]
+
+    def test_load_arch_tasks_missing_directory(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_arch_tasks(tmp_path / "missing")
+
+    def test_repository_arch_tasks_load(self) -> None:
+        tasks_dir = Path(__file__).resolve().parents[2] / "benchmarks" / "arch_tasks"
+        tasks = load_arch_tasks(tasks_dir)
+
+        assert {task.task_id for task in tasks} == {
+            "python_false_positives_architecture",
+            "python_patterns_architecture",
+            "python_strategy_sorting_architecture",
+        }
+        assert all(
+            task.arch_oracle.patterns or task.arch_oracle.interfaces or task.arch_oracle.modules
+            for task in tasks
+        )
 
 
 class TestLoadTasks:

--- a/tests/benchmark/test_models.py
+++ b/tests/benchmark/test_models.py
@@ -6,6 +6,11 @@ import pytest
 from pydantic import ValidationError
 
 from archex.benchmark.models import (
+    ArchitectureBenchmarkTask,
+    ArchitectureExpectedInterface,
+    ArchitectureExpectedModule,
+    ArchitectureExpectedPattern,
+    ArchitectureOracle,
     BenchmarkReport,
     BenchmarkResult,
     BenchmarkTask,
@@ -97,6 +102,59 @@ class TestBenchmarkTask:
             token_budget=4096,
         )
         assert task.token_budget == 4096
+
+
+class TestArchitectureBenchmarkTask:
+    def test_valid_architecture_task(self) -> None:
+        task = ArchitectureBenchmarkTask(
+            task_id="arch_test",
+            repo=".",
+            commit="HEAD",
+            question="What architecture does this fixture use?",
+            include_paths=["tests/fixtures/python_patterns"],
+            arch_oracle=ArchitectureOracle(
+                modules=[
+                    ArchitectureExpectedModule(
+                        name="python_patterns",
+                        root_path="tests/fixtures/python_patterns",
+                        files=["tests/fixtures/python_patterns/strategies.py"],
+                    )
+                ],
+                patterns=[ArchitectureExpectedPattern(name="strategy")],
+                interfaces=[
+                    ArchitectureExpectedInterface(
+                        name="SortStrategy",
+                        file_path="tests/fixtures/python_patterns/strategies.py",
+                    )
+                ],
+            ),
+        )
+
+        assert task.repo == "."
+        assert task.include_paths == ["tests/fixtures/python_patterns"]
+        assert task.arch_oracle.patterns[0].name == "strategy"
+
+    def test_architecture_task_requires_include_paths(self) -> None:
+        with pytest.raises(ValidationError):
+            ArchitectureBenchmarkTask(
+                task_id="arch_test",
+                repo=".",
+                commit="HEAD",
+                question="What architecture does this fixture use?",
+                include_paths=[],
+                arch_oracle=ArchitectureOracle(),
+            )
+
+    def test_architecture_include_paths_must_be_relative(self) -> None:
+        with pytest.raises(ValidationError):
+            ArchitectureBenchmarkTask(
+                task_id="arch_test",
+                repo=".",
+                commit="HEAD",
+                question="What architecture does this fixture use?",
+                include_paths=["/tmp/repo"],
+                arch_oracle=ArchitectureOracle(),
+            )
 
 
 class TestBenchmarkResult:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def implementation_gate_paths(args: Sequence[str]) -> bool:
     paths = [arg.rstrip("/") for arg in args if arg and not arg.startswith("-")]
     if not paths:
         return False
-    allowed_prefixes = ("tests/benchmark", "tests/serve")
+    allowed_prefixes = ("tests/analyze", "tests/benchmark", "tests/serve")
     return any(path.startswith("tests/benchmark") for path in paths) and all(
         any(path == prefix or path.startswith(f"{prefix}/") for prefix in allowed_prefixes)
         for path in paths

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from tests.conftest import implementation_gate_paths
 
 
-def test_implementation_gate_paths_match_benchmark_and_serve_slice() -> None:
+def test_implementation_gate_paths_match_benchmark_analyze_and_serve_slices() -> None:
     assert implementation_gate_paths(("tests/benchmark/test_gate.py", "tests/serve/")) is True
+    assert implementation_gate_paths(("tests/analyze/", "tests/benchmark/test_gate.py")) is True
 
 
 def test_implementation_gate_paths_reject_non_gate_slices() -> None:


### PR DESCRIPTION
## Summary
- Add architecture benchmark task/oracle schema for module, pattern, interface, and decision labels.
- Add loaders for `benchmarks/arch_tasks/*.yaml`.
- Add a small local labeled repo set covering strategy, pattern, interface, decision, and false-positive cases.
- Extend the implementation-gate coverage helper so `uv run pytest tests/analyze/ tests/benchmark/ -q` exits zero after test bodies pass.

## Stack
Stack-Id: `arch-quality-20260609`
Base: `main`
Position: 1/3

1. `feat/arch-quality-tasks` -> this PR
2. `feat/arch-quality-scorer`
3. `feat/arch-extraction-improve`

Depends on: none
Upstack: `feat/arch-quality-scorer`

## Validation
- `uv run ruff check && uv run ruff format --check . && uv run pyright` -> pass
- `uv run pytest tests/benchmark/test_models.py tests/benchmark/test_loader.py -q` -> pass
- `uv run pytest tests/analyze/ tests/benchmark/ -q` -> pass (`327 passed, 2 deselected`); coverage threshold intentionally suppressed for this implementation-gate slice in `tests/conftest.py`
- pr-review -> no blocking or important issues after fixes

## Notes
- No `archex benchmark run` or `archex dogfood` executed.
