### PR TITLE
fix: simplify benchmark pipeline entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,10 +314,10 @@ Release gates are intentionally tied to the product contract:
 Reproduce the full retrieval gate and dogfood delta locally:
 
 ```bash
-scripts/benchmark_pipeline.sh
+bash scripts/benchmark_pipeline.sh
 ```
 
-The script removes prior `.archex/e2e-tokens` output, writes a fresh `.docs/pipeline.log`, runs benchmark generation, runs the baseline-aware gate, and then runs dogfood even when the gate fails. It exits non-zero at the end if any step failed.
+The script resolves the repo root from its own location, removes prior `.archex/e2e-tokens` output, writes a fresh `.docs/pipeline.log`, streams the run to the terminal that started it, runs benchmark generation, runs the baseline-aware gate, and then runs dogfood even when the gate fails. It exits non-zero at the end if any step failed.
 
 ## Language support
 

--- a/README.md
+++ b/README.md
@@ -71,14 +71,13 @@ Ranked code chunks, the imports and type definitions they depend on, the depende
 
 ## Why it helps
 
-On the latest local 35-task benchmark, the product-default `archex query` improved on every axis against the previous accepted baseline:
+On the latest local 35-task benchmark, the product-default `archex query` reduced what the downstream agent had to read versus a raw-file crawl while keeping retrieval quality high:
 
-- **15% fewer returned tokens** — 7,110 → 6,037 mean tokens per query.
-- **71.3% saved versus reading raw files** — up 5.1 points.
-- **Recall 0.629 → 0.819** — the agent gets more of what it actually needed.
-- **Token efficiency 0.351 → 0.702** — `1 − returned_tokens / accessed_file_tokens`, higher is better.
+- **71.3% fewer returned tokens than reading raw files** — archex returns 6,037 mean tokens per query instead of making the agent read the full raw-file baseline.
+- **Recall 0.819** — the agent still gets most of what it actually needed.
+- **Token efficiency 0.702** — `1 − returned_tokens / accessed_file_tokens`, higher is better.
 
-Every number is measured and gated in CI, not asserted. Full tables and the gate rules live in [Performance and gates](#performance-and-gates).
+Every number is measured and gated in CI, not asserted. Full baseline-vs-current release tables and gate rules live in [Performance and gates](#performance-and-gates).
 
 ## Who it's for
 

--- a/scripts/benchmark_pipeline.sh
+++ b/scripts/benchmark_pipeline.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 set -Euo pipefail
 
-output_dir=".archex/e2e-tokens"
-baseline_dir=".archex/e2e-tier2"
-log_file=".docs/pipeline.log"
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
 
-mkdir -p .archex .docs
-rm -rf "$output_dir" "$log_file"
+output_dir_rel=".archex/e2e-tokens"
+baseline_dir_rel=".archex/e2e-tier2"
+log_file_rel=".docs/pipeline.log"
+
+output_dir="$repo_root/$output_dir_rel"
+baseline_dir="$repo_root/$baseline_dir_rel"
+log_file="$repo_root/$log_file_rel"
+
 
 format_duration() {
     local duration="$1"
@@ -15,6 +20,11 @@ format_duration() {
         "$((duration / 3600))" \
         "$(((duration % 3600) / 60))" \
         "$((duration % 60))"
+}
+
+prepare_run_artifacts() {
+    mkdir -p "$repo_root/.archex" "$repo_root/.docs"
+    rm -rf "$output_dir" "$log_file"
 }
 
 run_step() {
@@ -29,7 +39,7 @@ run_step() {
     fi
 
     echo
-    printf -- '=+%.0s' {1..25}
+    printf -- '=+%.0s' {1..25}; echo
     echo "===== $(date '+%Y-%m-%d %H:%M:%S') : Starting \"$label\" ====="
     echo "Command: $cmd"
 
@@ -49,7 +59,7 @@ run_step() {
         echo "===== $(date '+%Y-%m-%d %H:%M:%S') : FAILED \"$label\" (exit $status) ====="
     fi
     echo "===== Time taken: $(format_duration "$duration") ====="
-    printf -- '=+%.0s' {1..25}
+    printf -- '=+%.0s' {1..25}; echo
     echo
     return "$status"
 }
@@ -63,12 +73,12 @@ run_pipeline() {
         --rerank \
         --embedder jina-v2 \
         --tasks-dir benchmarks/tasks \
-        --output "$output_dir" || status=$?
+        --output "$output_dir_rel" || status=$?
 
     run_step "Benchmark Gate" \
         uv run archex benchmark gate \
-        --input "$output_dir" \
-        --baseline "$baseline_dir" \
+        --input "$output_dir_rel" \
+        --baseline "$baseline_dir_rel" \
         --warn-latency-ms 3000 || status=$?
 
     run_step "Dogfood Delta" \
@@ -80,26 +90,45 @@ run_pipeline() {
     return "$status"
 }
 
-{
-    pipeline_start=$(date +%s)
-    pipeline_status=0
+run_foreground() {
+    prepare_run_artifacts
+    cd "$repo_root"
 
-    echo "=================================================="
-    echo "Pipeline started at $(date '+%Y-%m-%d %H:%M:%S')"
-    echo "Output directory: $output_dir"
-    echo "Log file: $log_file"
-    echo "=================================================="
+    (
+        local pipeline_start pipeline_end pipeline_status total_duration
 
-    run_pipeline || pipeline_status=$?
+        pipeline_start=$(date +%s)
+        pipeline_status=0
 
-    pipeline_end=$(date +%s)
-    total_duration=$((pipeline_end - pipeline_start))
+        echo "=================================================="
+        echo "Pipeline started at $(date '+%Y-%m-%d %H:%M:%S')"
+        echo "Repository root: $repo_root"
+        echo "Output directory: $output_dir_rel"
+        echo "Log file: $log_file_rel"
+        echo "=================================================="
 
-    echo
-    echo "=================================================="
-    echo "Pipeline completed at $(date '+%Y-%m-%d %H:%M:%S')"
-    echo "Total time taken: $(format_duration "$total_duration")"
-    echo "Pipeline exit status: $pipeline_status"
-    echo "=================================================="
-    exit "$pipeline_status"
-} 2>&1 | tee "$log_file"
+        run_pipeline || pipeline_status=$?
+
+        pipeline_end=$(date +%s)
+        total_duration=$((pipeline_end - pipeline_start))
+
+        echo
+        echo "=================================================="
+        echo "Pipeline completed at $(date '+%Y-%m-%d %H:%M:%S')"
+        echo "Total time taken: $(format_duration "$total_duration")"
+        echo "Pipeline exit status: $pipeline_status"
+        echo "=================================================="
+        exit "$pipeline_status"
+    ) 2>&1 | tee "$log_file"
+}
+
+main() {
+    if (($# > 0)); then
+        echo "benchmark_pipeline.sh does not accept arguments; run it as: bash scripts/benchmark_pipeline.sh" >&2
+        return 2
+    fi
+
+    run_foreground
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- make `bash scripts/benchmark_pipeline.sh` work from any current working directory by resolving paths from the script location
- keep the existing foreground behavior: stream output to the invoking terminal and `.docs/pipeline.log`
- clarify the README benchmark framing to compare `archex_query` against raw-file reading, not against the previous accepted benchmark

## Validation
- `bash -n scripts/benchmark_pipeline.sh` -> pass
- `bash scripts/benchmark_pipeline.sh extra` -> exits 2 with the expected usage error, without starting the benchmark run
- reviewer -> no blocking or important findings
