### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+
+## 0.8.0 (2026-06-09)
+
+### Added
+
+- Added architecture-quality benchmark tasks under `benchmarks/arch_tasks/` with hand-labeled module, pattern, interface, and decision oracles.
+- Added `archex benchmark arch run`, `archex benchmark arch report`, and advisory `archex benchmark arch gate` commands for scoring analyze/explain output quality against labeled fixtures.
+
+### Changed
+
+- Improved Strategy pattern detection to aggregate protocol, concrete, and context evidence across files while rejecting unrelated shared-method false positives.
+- Updated the benchmark pipeline entrypoint so `bash scripts/benchmark_pipeline.sh` works from any current working directory and still mirrors output to `.docs/pipeline.log`.
+- Reframed the README benchmark pitch around `with archex` versus raw-file reading instead of previous-benchmark versus current-benchmark deltas.
+
+### Fixed
+
+- Fixed the implementation-gate pytest slice so `uv run pytest tests/analyze/ tests/benchmark/ -q` no longer fails on the repository-wide coverage floor after test bodies pass.
+
 ## 0.7.0 (2026-06-08)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archex"
-version = "0.7.0"
+version = "0.8.0"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "archex"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump the package version from `0.7.0` to `0.8.0`
- add `0.8.0` release notes to `CHANGELOG.md`
- refresh `uv.lock` package metadata for the new release version

## Validation
- `uv run ruff check` -> pass
- `uv run ruff format --check .` -> pass
- `uv run pyright` -> pass
- `uv run pytest` -> pass (`2091 passed, 4 deselected`, `91.13%` coverage)
- `uv build` -> pass
- `uv publish` -> published `archex 0.8.0` to PyPI

## Notes
- local release tag prepared as `v0.8`
- remote tag push will follow after this PR lands on `main`
