### PR TITLE
Add cross-language architecture benchmark tasks

### DIFF
--- a/benchmarks/arch_tasks/go_middleware_interfaces.yaml
+++ b/benchmarks/arch_tasks/go_middleware_interfaces.yaml
@@ -1,0 +1,30 @@
+task_id: go_middleware_interfaces_architecture
+repo: "."
+commit: "HEAD"
+question: "Which middleware chain and public interface boundaries does the Go handler fixture expose?"
+languages: [go]
+include_paths:
+  - tests/fixtures/go_handler.go
+arch_oracle:
+  modules:
+    - name: fixtures
+      root_path: tests/fixtures
+      files:
+        - tests/fixtures/go_handler.go
+      responsibility_terms:
+        - handler
+        - interface
+  patterns:
+    - name: middleware_chain
+      evidence_symbols:
+        - Handler
+        - BaseHandler
+        - AuthHandler
+  interfaces:
+    - name: Handler
+      file_path: tests/fixtures/go_handler.go
+      kind: interface
+  decisions:
+    - decision_terms:
+        - middleware
+        - chain

--- a/benchmarks/arch_tasks/mixed_language_false_positives.yaml
+++ b/benchmarks/arch_tasks/mixed_language_false_positives.yaml
@@ -1,0 +1,36 @@
+task_id: mixed_language_false_positives_architecture
+repo: "."
+commit: "HEAD"
+question: "Which public boundaries are present without inferring architectural patterns across unrelated TypeScript and Go utilities?"
+languages: [typescript, go]
+include_paths:
+  - tests/fixtures/repos/mixed_false_positives
+arch_oracle:
+  modules:
+    - name: web
+      root_path: tests/fixtures/repos/mixed_false_positives/web
+      files:
+        - tests/fixtures/repos/mixed_false_positives/web/toolbar.ts
+      responsibility_terms:
+        - toolbar
+        - state
+        - render
+    - name: worker
+      root_path: tests/fixtures/repos/mixed_false_positives/worker
+      files:
+        - tests/fixtures/repos/mixed_false_positives/worker/collector.go
+      responsibility_terms:
+        - metrics
+        - collector
+  patterns: []
+  interfaces:
+    - name: ToolbarState
+      file_path: tests/fixtures/repos/mixed_false_positives/web/toolbar.ts
+      kind: class
+    - name: renderToolbar
+      file_path: tests/fixtures/repos/mixed_false_positives/web/toolbar.ts
+      kind: function
+    - name: NewMetricsCollector
+      file_path: tests/fixtures/repos/mixed_false_positives/worker/collector.go
+      kind: function
+  decisions: []

--- a/benchmarks/arch_tasks/rust_traits_async.yaml
+++ b/benchmarks/arch_tasks/rust_traits_async.yaml
@@ -1,0 +1,31 @@
+task_id: rust_traits_async_architecture
+repo: "."
+commit: "HEAD"
+question: "Which trait and async request boundaries does the Rust async fixture expose?"
+languages: [rust]
+include_paths:
+  - tests/fixtures/repos/rust_async_boundaries
+arch_oracle:
+  modules:
+    - name: src
+      root_path: tests/fixtures/repos/rust_async_boundaries/src
+      files:
+        - tests/fixtures/repos/rust_async_boundaries/src/auth.rs
+        - tests/fixtures/repos/rust_async_boundaries/src/server.rs
+      responsibility_terms:
+        - token
+        - verifier
+        - authenticate
+        - authorize
+  patterns: []
+  interfaces:
+    - name: TokenVerifier
+      file_path: tests/fixtures/repos/rust_async_boundaries/src/auth.rs
+      kind: interface
+    - name: authenticate
+      file_path: tests/fixtures/repos/rust_async_boundaries/src/auth.rs
+      kind: function
+    - name: authorize_request
+      file_path: tests/fixtures/repos/rust_async_boundaries/src/server.rs
+      kind: function
+  decisions: []

--- a/benchmarks/arch_tasks/typescript_react_hooks.yaml
+++ b/benchmarks/arch_tasks/typescript_react_hooks.yaml
@@ -1,0 +1,32 @@
+task_id: typescript_react_hooks_architecture
+repo: "."
+commit: "HEAD"
+question: "Which public hook and component boundaries does the React hooks fixture expose?"
+languages: [typescript]
+include_paths:
+  - tests/fixtures/repos/react_hooks_state
+arch_oracle:
+  modules:
+    - name: src
+      root_path: tests/fixtures/repos/react_hooks_state/src
+      files:
+        - tests/fixtures/repos/react_hooks_state/src/components/Login.tsx
+        - tests/fixtures/repos/react_hooks_state/src/hooks/useAuth.ts
+        - tests/fixtures/repos/react_hooks_state/src/hooks/useLocalStorage.ts
+      responsibility_terms:
+        - auth
+        - hook
+        - storage
+        - login
+  patterns: []
+  interfaces:
+    - name: Login
+      file_path: tests/fixtures/repos/react_hooks_state/src/components/Login.tsx
+      kind: function
+    - name: useAuth
+      file_path: tests/fixtures/repos/react_hooks_state/src/hooks/useAuth.ts
+      kind: function
+    - name: useLocalStorage
+      file_path: tests/fixtures/repos/react_hooks_state/src/hooks/useLocalStorage.ts
+      kind: function
+  decisions: []

--- a/tests/benchmark/test_loader.py
+++ b/tests/benchmark/test_loader.py
@@ -154,9 +154,13 @@ arch_oracle:
         tasks = load_arch_tasks(tasks_dir)
 
         assert {task.task_id for task in tasks} == {
+            "go_middleware_interfaces_architecture",
+            "mixed_language_false_positives_architecture",
             "python_false_positives_architecture",
             "python_patterns_architecture",
             "python_strategy_sorting_architecture",
+            "rust_traits_async_architecture",
+            "typescript_react_hooks_architecture",
         }
         assert all(
             task.arch_oracle.patterns or task.arch_oracle.interfaces or task.arch_oracle.modules

--- a/tests/fixtures/repos/mixed_false_positives/web/toolbar.ts
+++ b/tests/fixtures/repos/mixed_false_positives/web/toolbar.ts
@@ -1,0 +1,17 @@
+export type ToolbarAction = "save" | "cancel";
+
+export class ToolbarState {
+  private selectedAction: ToolbarAction | null = null;
+
+  select(action: ToolbarAction): void {
+    this.selectedAction = action;
+  }
+
+  current(): ToolbarAction | null {
+    return this.selectedAction;
+  }
+}
+
+export function renderToolbar(actions: ToolbarAction[]): string {
+  return actions.map((action) => `<button>${action}</button>`).join("");
+}

--- a/tests/fixtures/repos/mixed_false_positives/worker/collector.go
+++ b/tests/fixtures/repos/mixed_false_positives/worker/collector.go
@@ -1,0 +1,29 @@
+package worker
+
+import "sync"
+
+type MetricsCollector struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+func NewMetricsCollector() *MetricsCollector {
+	return &MetricsCollector{counts: map[string]int{}}
+}
+
+func (c *MetricsCollector) Add(name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.counts[name]++
+}
+
+func (c *MetricsCollector) Snapshot() map[string]int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	copy := make(map[string]int, len(c.counts))
+	for key, value := range c.counts {
+		copy[key] = value
+	}
+	return copy
+}

--- a/tests/fixtures/repos/rust_async_boundaries/src/auth.rs
+++ b/tests/fixtures/repos/rust_async_boundaries/src/auth.rs
@@ -1,0 +1,23 @@
+pub trait TokenVerifier {
+    fn verify(&self, token: &str) -> bool;
+}
+
+pub struct StaticTokenVerifier {
+    expected: String,
+}
+
+impl StaticTokenVerifier {
+    pub fn new(expected: String) -> Self {
+        Self { expected }
+    }
+}
+
+impl TokenVerifier for StaticTokenVerifier {
+    fn verify(&self, token: &str) -> bool {
+        token == self.expected
+    }
+}
+
+pub async fn authenticate(token: String, verifier: &dyn TokenVerifier) -> bool {
+    verifier.verify(&token)
+}

--- a/tests/fixtures/repos/rust_async_boundaries/src/lib.rs
+++ b/tests/fixtures/repos/rust_async_boundaries/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod auth;
+pub mod server;

--- a/tests/fixtures/repos/rust_async_boundaries/src/server.rs
+++ b/tests/fixtures/repos/rust_async_boundaries/src/server.rs
@@ -1,0 +1,16 @@
+use crate::auth::{authenticate, TokenVerifier};
+
+pub struct RequestContext {
+    pub bearer_token: String,
+}
+
+pub async fn authorize_request(
+    request: RequestContext,
+    verifier: &dyn TokenVerifier,
+) -> Result<(), &'static str> {
+    if authenticate(request.bearer_token, verifier).await {
+        Ok(())
+    } else {
+        Err("unauthorized")
+    }
+}


### PR DESCRIPTION
## Stack

Stack-Id: `arch-quality-g1`
Base: `main`
Position: 1/3

1. `feat/arch-cross-language-tasks` -> this PR
2. `feat/arch-baseline-lifecycle` -> #175
3. `feat/arch-extraction-hardening` -> #176

Depends on: none
Upstack: #175

## Summary

- Adds TypeScript React hooks, Go middleware/interface, Rust trait/async, and mixed-language negative architecture-quality benchmark tasks.
- Reuses existing React/Go fixtures where possible and adds minimal Rust async and mixed-language false-positive fixtures.
- Updates repository arch-task loader coverage for the expanded task set.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright && uv run pytest tests/analyze/ tests/benchmark/ -q` — passed
- `uv run archex benchmark arch run --tasks-dir benchmarks/arch_tasks --output .archex/arch-quality-current && uv run archex benchmark arch report --input .archex/arch-quality-current` — completed 7 tasks; Go middleware task exposes measured pattern/decision failure for later hardening.

## Review

- `pr-review` scope: 10 changed files; code/test dimensions. No blocking findings.