### PR TITLE
Add architecture baseline lifecycle messaging

### DIFF
--- a/src/archex/benchmark/arch_quality.py
+++ b/src/archex/benchmark/arch_quality.py
@@ -18,6 +18,8 @@ from archex.benchmark.models import (
 from archex.exceptions import BenchmarkCloneError
 from archex.models import ArchProfile, Config, RepoSource
 
+DEFAULT_ARCHITECTURE_BASELINE_DIR = Path(".archex/arch-quality-baseline")
+
 
 def run_architecture_benchmark(task: ArchitectureBenchmarkTask) -> ArchitectureBenchmarkResult:
     """Run architecture analysis for a single labeled task and score it against its oracle."""
@@ -112,7 +114,12 @@ def score_architecture_profile(
     )
 
 
-def format_architecture_summary(results: list[ArchitectureBenchmarkResult]) -> str:
+def format_architecture_summary(
+    results: list[ArchitectureBenchmarkResult],
+    *,
+    baseline_dir: Path = DEFAULT_ARCHITECTURE_BASELINE_DIR,
+    baseline_results: list[ArchitectureBenchmarkResult] | None = None,
+) -> str:
     """Render per-dimension architecture-quality scores as Markdown."""
     lines = [
         "# Architecture Quality Benchmark",
@@ -130,6 +137,17 @@ def format_architecture_summary(results: list[ArchitectureBenchmarkResult]) -> s
         )
     lines.append("")
     lines.append("Architecture-quality gate mode: ADVISORY")
+    if baseline_results is None:
+        lines.append(
+            "Architecture baseline mode: FIRST RUN / seed candidate "
+            f"(no accepted baseline loaded from {baseline_dir})"
+        )
+        lines.append(
+            "Accepted baseline seeding remains an operator decision; "
+            f"copy reviewed result JSON files into {baseline_dir} to enable regression comparison."
+        )
+    else:
+        lines.append(f"Architecture baseline mode: REGRESSION COMPARISON ({baseline_dir})")
     return "\n".join(lines)
 
 

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import click
 
 from archex.benchmark.arch_quality import (
+    DEFAULT_ARCHITECTURE_BASELINE_DIR,
     architecture_gate_warnings,
     format_architecture_summary,
     load_architecture_results,
@@ -28,6 +29,7 @@ from archex.benchmark.gate import (
 )
 from archex.benchmark.loader import load_tasks
 from archex.benchmark.models import (
+    ArchitectureBenchmarkResult,
     BenchmarkReport,
     BenchmarkRetrievalOptions,
     DeltaBenchmarkResult,
@@ -557,6 +559,29 @@ def gate_cmd(
     click.echo("Quality gate passed.")
 
 
+def _load_architecture_baseline(
+    baseline_dir: str | None,
+) -> tuple[Path, list[ArchitectureBenchmarkResult] | None]:
+    baseline_path = Path(baseline_dir) if baseline_dir else DEFAULT_ARCHITECTURE_BASELINE_DIR
+    if not baseline_path.exists():
+        if baseline_dir is not None:
+            raise click.ClickException(
+                f"No architecture baseline directory found at {baseline_path}"
+            )
+        return baseline_path, None
+    if not baseline_path.is_dir():
+        raise click.ClickException(
+            f"Architecture baseline path is not a directory: {baseline_path}"
+        )
+
+    baseline_results = load_architecture_results(baseline_path)
+    if not baseline_results:
+        raise click.ClickException(
+            f"No architecture baseline result files found in {baseline_path}"
+        )
+    return baseline_path, baseline_results
+
+
 @benchmark_cmd.group("arch")
 def arch_cmd() -> None:
     """Architecture-quality benchmarks for analyze/explain outputs."""
@@ -598,12 +623,29 @@ def arch_run_cmd(output_dir: str, task_id: str | None, tasks_dir: str) -> None:
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
     help="Directory containing architecture-quality result JSON files.",
 )
-def arch_report_cmd(input_dir: str) -> None:
+@click.option(
+    "--baseline",
+    "baseline_dir",
+    default=None,
+    type=click.Path(file_okay=False, dir_okay=True),
+    help=(
+        "Optional accepted baseline directory. Defaults to "
+        ".archex/arch-quality-baseline when present; absent default means seed mode."
+    ),
+)
+def arch_report_cmd(input_dir: str, baseline_dir: str | None) -> None:
     """Generate a formatted architecture-quality report."""
     results = load_architecture_results(Path(input_dir))
     if not results:
         raise click.ClickException(f"No architecture result files found in {input_dir}")
-    click.echo(format_architecture_summary(results))
+    baseline_path, baseline_results = _load_architecture_baseline(baseline_dir)
+    click.echo(
+        format_architecture_summary(
+            results,
+            baseline_dir=baseline_path,
+            baseline_results=baseline_results,
+        )
+    )
 
 
 @arch_cmd.command("gate")
@@ -618,8 +660,11 @@ def arch_report_cmd(input_dir: str) -> None:
     "--baseline",
     "baseline_dir",
     default=None,
-    type=click.Path(exists=True, file_okay=False, dir_okay=True),
-    help="Optional baseline architecture result directory for advisory regression warnings.",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help=(
+        "Optional accepted baseline directory. Defaults to "
+        ".archex/arch-quality-baseline when present; absent default means seed mode."
+    ),
 )
 @click.option("--min-boundary-f1", default=0.80, type=float, help="Advisory boundary F1 floor.")
 @click.option(
@@ -649,9 +694,7 @@ def arch_gate_cmd(
     results = load_architecture_results(Path(input_dir))
     if not results:
         raise click.ClickException(f"No architecture result files found in {input_dir}")
-    baseline_results = load_architecture_results(Path(baseline_dir)) if baseline_dir else None
-    if baseline_dir is not None and not baseline_results:
-        raise click.ClickException(f"No architecture baseline result files found in {baseline_dir}")
+    baseline_path, baseline_results = _load_architecture_baseline(baseline_dir)
     warnings = architecture_gate_warnings(
         results,
         baseline_results=baseline_results,
@@ -660,6 +703,17 @@ def arch_gate_cmd(
         min_pattern_recall=min_pattern_recall,
         min_interface_completeness=min_interface_completeness,
     )
+    if baseline_results is None:
+        click.echo(
+            "Architecture baseline mode: FIRST RUN / seed candidate "
+            f"(no accepted baseline loaded from {baseline_path})"
+        )
+        click.echo(
+            "Accepted baseline seeding remains an operator decision; "
+            f"copy reviewed result JSON files into {baseline_path} to enable regression comparison."
+        )
+    else:
+        click.echo(f"Architecture baseline mode: REGRESSION COMPARISON ({baseline_path})")
     if warnings:
         click.echo(f"ARCHITECTURE QUALITY ADVISORY: {len(warnings)} warning(s)")
         for warning in warnings:

--- a/tests/benchmark/test_arch_quality.py
+++ b/tests/benchmark/test_arch_quality.py
@@ -234,6 +234,25 @@ def test_format_architecture_summary_includes_gate_mode() -> None:
 
     assert "| arch_fixture | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |" in summary
     assert "Architecture-quality gate mode: ADVISORY" in summary
+    assert "Architecture baseline mode: FIRST RUN / seed candidate" in summary
+    assert ".archex/arch-quality-baseline" in summary
+
+
+def test_format_architecture_summary_reports_baseline_comparison(tmp_path: Path) -> None:
+    result = ArchitectureBenchmarkResult(
+        task_id="arch_fixture",
+        repo=".",
+        commit="HEAD",
+        scores=ArchitectureDimensionScores(),
+    )
+
+    summary = format_architecture_summary(
+        [result],
+        baseline_dir=tmp_path,
+        baseline_results=[result],
+    )
+
+    assert f"Architecture baseline mode: REGRESSION COMPARISON ({tmp_path})" in summary
 
 
 def test_load_architecture_results(tmp_path: Path) -> None:
@@ -262,6 +281,8 @@ def test_arch_gate_cli_exits_zero_for_advisory_warning(tmp_path: Path) -> None:
     output = CliRunner().invoke(benchmark_cmd, ["arch", "gate", "--input", str(tmp_path)])
 
     assert output.exit_code == 0
+    assert "Architecture baseline mode: FIRST RUN / seed candidate" in output.output
+    assert ".archex/arch-quality-baseline" in output.output
     assert "ARCHITECTURE QUALITY ADVISORY" in output.output
 
 
@@ -292,6 +313,21 @@ def test_arch_gate_cli_accepts_baseline_results(tmp_path: Path) -> None:
 
     assert output.exit_code == 0
     assert "pattern_recall regressed" in output.output
+
+
+def test_arch_report_cli_defaults_to_seed_mode(tmp_path: Path) -> None:
+    result = ArchitectureBenchmarkResult(
+        task_id="arch_fixture",
+        repo=".",
+        commit="HEAD",
+        scores=ArchitectureDimensionScores(),
+    )
+    (tmp_path / "result.json").write_text(result.model_dump_json())
+
+    output = CliRunner().invoke(benchmark_cmd, ["arch", "report", "--input", str(tmp_path)])
+
+    assert output.exit_code == 0
+    assert "Architecture baseline mode: FIRST RUN / seed candidate" in output.output
 
 
 def test_run_architecture_benchmark_scores_fixture() -> None:


### PR DESCRIPTION
## Stack

Stack-Id: `arch-quality-g1`
Base: `main`
Position: 2/3

1. `feat/arch-cross-language-tasks` -> #174
2. `feat/arch-baseline-lifecycle` -> this PR
3. `feat/arch-extraction-hardening` -> #176

Depends on: #174
Upstack: #176

## Summary

- Adds `.archex/arch-quality-baseline` as the default accepted architecture baseline convention.
- Updates `archex benchmark arch report` and `arch gate` to distinguish first-run seed-candidate mode from regression comparison mode.
- Keeps architecture gate advisory and leaves accepted baseline seeding as an operator decision.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright && uv run pytest tests/analyze/ tests/benchmark/ -q` — passed
- `uv run archex benchmark arch report --input .archex/arch-quality-current && uv run archex benchmark arch gate --input .archex/arch-quality-current --min-boundary-f1 0.80 --min-pattern-precision 0.80 --min-pattern-recall 0.80 --min-interface-completeness 0.80` — seed mode shown; advisory warnings preserved for Go task before hardening.

## Review

- `pr-review` scope: 3 changed files; code/test/comment dimensions. No blocking findings.