### PR TITLE
Detect architecture patterns on typed containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,13 +310,13 @@ Release gates are intentionally tied to the product contract:
 - warn, but do not fail, on absolute non-token rows such as rank-2 MRR or low recall rows already accepted in the baseline;
 - dogfood must report zero regressions.
 
-Reproduce the full retrieval gate and dogfood delta locally:
+Reproduce the architecture-quality smoke, retrieval benchmark/report/gate, and dogfood run locally:
 
 ```bash
 bash scripts/benchmark_pipeline.sh
 ```
 
-The script resolves the repo root from its own location, removes prior `.archex/e2e-tokens` output, writes a fresh `.docs/pipeline.log`, streams the run to the terminal that started it, runs benchmark generation, runs the baseline-aware gate, and then runs dogfood even when the gate fails. It exits non-zero at the end if any step failed.
+The script resolves the repo root from its own location, writes a fresh `logs/benchmark_pipeline.log`, streams output to the terminal that started it, and keeps running later steps so failures are reported together. Defaults are intentionally generic: architecture results go to `.archex/arch-quality-current`, retrieval results go to `.archex/benchmark-current`, retrieval baseline comparison is enabled only when `ARCHEX_BENCHMARK_BASELINE_DIR` is supplied, and dogfood uses `benchmarks/dogfood_baseline.json`. Override paths, thresholds, and extra benchmark flags with `ARCHEX_*` environment variables in `scripts/benchmark_pipeline.sh`; set `ARCHEX_RUN_ARCH_BENCHMARK=0`, `ARCHEX_RUN_RETRIEVAL_BENCHMARK=0`, or `ARCHEX_RUN_DOGFOOD=0` to skip a stage.
 
 ## Language support
 

--- a/scripts/benchmark_pipeline.sh
+++ b/scripts/benchmark_pipeline.sh
@@ -2,15 +2,54 @@
 set -Euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+resolve_repo_path() {
+    local path="$1"
+
+    case "$path" in
+        /*) printf '%s\n' "$path" ;;
+        *) printf '%s/%s\n' "$repo_root" "$path" ;;
+    esac
+}
+
+
 repo_root="$(cd -- "$script_dir/.." && pwd)"
 
-output_dir_rel=".archex/e2e-tokens"
-baseline_dir_rel=".archex/e2e-tier2"
-log_file_rel=".docs/pipeline.log"
+# Architecture-quality smoke settings. These defaults are short and local; set
+# ARCHEX_ARCH_BASELINE_DIR only after an operator has accepted baseline results.
 
-output_dir="$repo_root/$output_dir_rel"
-baseline_dir="$repo_root/$baseline_dir_rel"
-log_file="$repo_root/$log_file_rel"
+arch_tasks_dir_rel="${ARCHEX_ARCH_TASKS_DIR:-benchmarks/arch_tasks}"
+arch_output_dir_rel="${ARCHEX_ARCH_OUTPUT_DIR:-.archex/arch-quality-current}"
+arch_baseline_dir_rel="${ARCHEX_ARCH_BASELINE_DIR:-}"
+arch_min_boundary_f1="${ARCHEX_ARCH_MIN_BOUNDARY_F1:-0.80}"
+arch_min_pattern_precision="${ARCHEX_ARCH_MIN_PATTERN_PRECISION:-0.80}"
+arch_min_pattern_recall="${ARCHEX_ARCH_MIN_PATTERN_RECALL:-0.80}"
+arch_min_interface_completeness="${ARCHEX_ARCH_MIN_INTERFACE_COMPLETENESS:-0.80}"
+
+# Retrieval benchmark settings. Baseline and latency gates stay opt-in so the
+# same script works for first runs, local experiments, and release checks.
+benchmark_tasks_dir_rel="${ARCHEX_BENCHMARK_TASKS_DIR:-benchmarks/tasks}"
+benchmark_output_dir_rel="${ARCHEX_BENCHMARK_OUTPUT_DIR:-.archex/benchmark-current}"
+benchmark_baseline_dir_rel="${ARCHEX_BENCHMARK_BASELINE_DIR:-}"
+benchmark_warn_latency_ms="${ARCHEX_BENCHMARK_WARN_LATENCY_MS:-}"
+
+# Dogfood settings. The default baseline is the checked-in accepted dogfood
+# baseline; ARCHEX_DOGFOOD_ARGS can add command-specific flags.
+dogfood_source="${ARCHEX_DOGFOOD_SOURCE:-.}"
+dogfood_baseline_rel="${ARCHEX_DOGFOOD_BASELINE:-benchmarks/dogfood_baseline.json}"
+dogfood_format="${ARCHEX_DOGFOOD_FORMAT:-text}"
+
+# Log under logs/ rather than documentation; callers can override this path.
+log_file_rel="${ARCHEX_BENCHMARK_LOG_FILE:-logs/benchmark_pipeline.log}"
+
+# Stage toggles accept 1/0, true/false, yes/no, or on/off.
+run_arch_benchmark="${ARCHEX_RUN_ARCH_BENCHMARK:-1}"
+run_retrieval_benchmark="${ARCHEX_RUN_RETRIEVAL_BENCHMARK:-1}"
+run_dogfood="${ARCHEX_RUN_DOGFOOD:-1}"
+
+arch_output_dir="$(resolve_repo_path "$arch_output_dir_rel")"
+benchmark_output_dir="$(resolve_repo_path "$benchmark_output_dir_rel")"
+log_file="$(resolve_repo_path "$log_file_rel")"
 
 
 format_duration() {
@@ -23,8 +62,13 @@ format_duration() {
 }
 
 prepare_run_artifacts() {
-    mkdir -p "$repo_root/.archex" "$repo_root/.docs"
-    rm -rf "$output_dir" "$log_file"
+    # Clear only artifacts this script owns so each invocation starts clean
+    # without touching accepted baselines or unrelated local cache files.
+    mkdir -p \
+        "$(dirname -- "$log_file")" \
+        "$(dirname -- "$arch_output_dir")" \
+        "$(dirname -- "$benchmark_output_dir")"
+    rm -rf "$arch_output_dir" "$benchmark_output_dir" "$log_file"
 }
 
 run_step() {
@@ -64,28 +108,113 @@ run_step() {
     return "$status"
 }
 
+is_enabled() {
+    case "$1" in
+        1 | true | TRUE | yes | YES | on | ON) return 0 ;;
+        0 | false | FALSE | no | NO | off | OFF) return 1 ;;
+        *)
+            echo "Invalid boolean value: $1" >&2
+            exit 2
+            ;;
+    esac
+}
+
+
+
+
+
 run_pipeline() {
     local status=0
+    local -a arch_gate_cmd arch_report_cmd
+    local -a benchmark_gate_cmd benchmark_report_cmd benchmark_run_cmd
+    local -a dogfood_cmd
+    local -a benchmark_gate_extra_args benchmark_run_extra_args dogfood_extra_args
 
-    run_step "Benchmark Run" \
-        uv run archex benchmark run \
-        --query-fusion \
-        --rerank \
-        --embedder jina-v2 \
-        --tasks-dir benchmarks/tasks \
-        --output "$output_dir_rel" || status=$?
+    # Keep the architecture stage independent from retrieval/dogfood so it can
+    # run as a quick smoke or as the first stage of the full local pipeline.
+    if is_enabled "$run_arch_benchmark"; then
+        run_step "Architecture Benchmark Run" \
+            uv run archex benchmark arch run \
+            --tasks-dir "$arch_tasks_dir_rel" \
+            --output "$arch_output_dir_rel" || status=$?
 
-    run_step "Benchmark Gate" \
-        uv run archex benchmark gate \
-        --input "$output_dir_rel" \
-        --baseline "$baseline_dir_rel" \
-        --warn-latency-ms 3000 || status=$?
+        arch_report_cmd=(
+            uv run archex benchmark arch report
+            --input "$arch_output_dir_rel"
+        )
+        if [[ -n "$arch_baseline_dir_rel" ]]; then
+            arch_report_cmd+=(--baseline "$arch_baseline_dir_rel")
+        fi
+        run_step "Architecture Benchmark Report" "${arch_report_cmd[@]}" || status=$?
 
-    run_step "Dogfood Delta" \
-        uv run archex dogfood . \
-        --all \
-        --baseline benchmarks/dogfood_baseline.json \
-        --format dogfood-delta || status=$?
+        arch_gate_cmd=(
+            uv run archex benchmark arch gate
+            --input "$arch_output_dir_rel"
+            --min-boundary-f1 "$arch_min_boundary_f1"
+            --min-pattern-precision "$arch_min_pattern_precision"
+            --min-pattern-recall "$arch_min_pattern_recall"
+            --min-interface-completeness "$arch_min_interface_completeness"
+        )
+        if [[ -n "$arch_baseline_dir_rel" ]]; then
+            arch_gate_cmd+=(--baseline "$arch_baseline_dir_rel")
+        fi
+        run_step "Architecture Benchmark Gate" "${arch_gate_cmd[@]}" || status=$?
+    fi
+
+    # Retrieval defaults are intentionally plain. Use ARCHEX_BENCHMARK_RUN_ARGS
+    # for opt-in strategies such as query fusion, rerankers, or custom embedders.
+    if is_enabled "$run_retrieval_benchmark"; then
+        benchmark_run_cmd=(
+            uv run archex benchmark run
+            --tasks-dir "$benchmark_tasks_dir_rel"
+            --output "$benchmark_output_dir_rel"
+            --no-progress
+        )
+        if [[ -n "${ARCHEX_BENCHMARK_RUN_ARGS:-}" ]]; then
+            IFS=' ' read -r -a benchmark_run_extra_args <<< "$ARCHEX_BENCHMARK_RUN_ARGS"
+            benchmark_run_cmd+=("${benchmark_run_extra_args[@]}")
+        fi
+        run_step "Benchmark Run" "${benchmark_run_cmd[@]}" || status=$?
+
+        benchmark_report_cmd=(
+            uv run archex benchmark report
+            --input "$benchmark_output_dir_rel"
+            --format markdown
+        )
+        run_step "Benchmark Report" "${benchmark_report_cmd[@]}" || status=$?
+
+        benchmark_gate_cmd=(
+            uv run archex benchmark gate
+            --input "$benchmark_output_dir_rel"
+        )
+        if [[ -n "$benchmark_baseline_dir_rel" ]]; then
+            benchmark_gate_cmd+=(--baseline "$benchmark_baseline_dir_rel")
+        fi
+        if [[ -n "$benchmark_warn_latency_ms" ]]; then
+            benchmark_gate_cmd+=(--warn-latency-ms "$benchmark_warn_latency_ms")
+        fi
+        if [[ -n "${ARCHEX_BENCHMARK_GATE_ARGS:-}" ]]; then
+            IFS=' ' read -r -a benchmark_gate_extra_args <<< "$ARCHEX_BENCHMARK_GATE_ARGS"
+            benchmark_gate_cmd+=("${benchmark_gate_extra_args[@]}")
+        fi
+        run_step "Benchmark Gate" "${benchmark_gate_cmd[@]}" || status=$?
+    fi
+
+    # Dogfood runs last and still executes after prior failures so one run
+    # reports every failing stage before returning a non-zero status.
+    if is_enabled "$run_dogfood"; then
+        dogfood_cmd=(
+            uv run archex dogfood "$dogfood_source"
+            --all
+            --baseline "$dogfood_baseline_rel"
+            --format "$dogfood_format"
+        )
+        if [[ -n "${ARCHEX_DOGFOOD_ARGS:-}" ]]; then
+            IFS=' ' read -r -a dogfood_extra_args <<< "$ARCHEX_DOGFOOD_ARGS"
+            dogfood_cmd+=("${dogfood_extra_args[@]}")
+        fi
+        run_step "Dogfood" "${dogfood_cmd[@]}" || status=$?
+    fi
 
     return "$status"
 }
@@ -103,7 +232,8 @@ run_foreground() {
         echo "=================================================="
         echo "Pipeline started at $(date '+%Y-%m-%d %H:%M:%S')"
         echo "Repository root: $repo_root"
-        echo "Output directory: $output_dir_rel"
+        echo "Architecture output directory: $arch_output_dir_rel"
+        echo "Benchmark output directory: $benchmark_output_dir_rel"
         echo "Log file: $log_file_rel"
         echo "=================================================="
 

--- a/src/archex/analyze/patterns.py
+++ b/src/archex/analyze/patterns.py
@@ -81,23 +81,26 @@ default_registry = PatternRegistry()
 # ---------------------------------------------------------------------------
 
 
-def _public_methods_of(class_name: str, symbols: list[Symbol]) -> list[Symbol]:
-    """Return public method symbols belonging to a class."""
+_PATTERN_CONTAINER_KINDS = {SymbolKind.CLASS, SymbolKind.TYPE, SymbolKind.INTERFACE}
+
+
+def _public_methods_of(container_name: str, symbols: list[Symbol]) -> list[Symbol]:
+    """Return public method symbols belonging to a class, type, or interface."""
     return [
         s
         for s in symbols
         if s.kind == SymbolKind.METHOD
-        and s.parent == class_name
+        and s.parent == container_name
         and s.visibility == Visibility.PUBLIC
     ]
 
 
-def _method_names(class_name: str, symbols: list[Symbol]) -> set[str]:
-    return {s.name.lower() for s in _public_methods_of(class_name, symbols)}
+def _method_names(container_name: str, symbols: list[Symbol]) -> set[str]:
+    return {s.name.lower() for s in _public_methods_of(container_name, symbols)}
 
 
 def _classes(symbols: list[Symbol]) -> list[Symbol]:
-    return [s for s in symbols if s.kind == SymbolKind.CLASS]
+    return [s for s in symbols if s.kind in _PATTERN_CONTAINER_KINDS]
 
 
 def _confidence(evidence_count: int) -> float:
@@ -126,7 +129,7 @@ def _detect_middleware(
         classes = _classes(pf.symbols)
         full_chain_found = False
 
-        # First pass: find full chain classes
+        # First pass: find full chain containers
         for cls in classes:
             methods = _method_names(cls.name, pf.symbols)
             has_next = "set_next" in methods or "next" in methods
@@ -141,7 +144,7 @@ def _detect_middleware(
                         end_line=cls.end_line,
                         symbol=cls.name,
                         explanation=(
-                            f"Class '{cls.name}' has set_next/next + process/handle methods"
+                            f"Container '{cls.name}' has set_next/next + process/handle methods"
                         ),
                     )
                 )
@@ -168,7 +171,8 @@ def _detect_middleware(
                             end_line=cls.end_line,
                             symbol=cls.name,
                             explanation=(
-                                f"Class '{cls.name}' overrides process/handle (chain participant)"
+                                f"Container '{cls.name}' overrides process/handle "
+                                "(chain participant)"
                             ),
                         )
                     )
@@ -349,7 +353,7 @@ def _detect_repository(
                         end_line=cls.end_line,
                         symbol=cls.name,
                         explanation=(
-                            f"Class '{cls.name}' has CRUD-like methods: "
+                            f"Container '{cls.name}' has CRUD-like methods: "
                             f"{', '.join(sorted(crud_hits))}"
                         ),
                     )

--- a/tests/analyze/test_patterns.py
+++ b/tests/analyze/test_patterns.py
@@ -335,6 +335,22 @@ def test_middleware_detects_pascalcase_methods() -> None:
     assert "middleware_chain" in names
 
 
+def test_middleware_detects_go_struct_receivers() -> None:
+    file_path = "handler.go"
+    symbols = [
+        _make_symbol("BaseHandler", SymbolKind.TYPE, file_path, 1, 10),
+        _make_symbol("SetNext", SymbolKind.METHOD, file_path, 2, 4, parent="BaseHandler"),
+        _make_symbol("Handle", SymbolKind.METHOD, file_path, 5, 8, parent="BaseHandler"),
+        _make_symbol("AuthHandler", SymbolKind.TYPE, file_path, 12, 20),
+        _make_symbol("Handle", SymbolKind.METHOD, file_path, 13, 18, parent="AuthHandler"),
+    ]
+    pf = ParsedFile(path=file_path, language="go", symbols=symbols)
+
+    names = _pattern_names([pf])
+
+    assert "middleware_chain" in names
+
+
 def test_repository_detects_camelcase_methods() -> None:
     """Java-style camelCase CRUD methods should trigger repository detection."""
     file_path = "UserRepository.java"


### PR DESCRIPTION
## Stack

Stack-Id: `arch-quality-g1`
Base: `main`
Position: 3/3

1. `feat/arch-cross-language-tasks` -> #174
2. `feat/arch-baseline-lifecycle` -> #175
3. `feat/arch-extraction-hardening` -> this PR

Depends on: #175
Upstack: none

## Summary

- Generalizes architecture pattern detection from class-only containers to class/type/interface containers.
- Fixes the measured Go middleware/interface regression exposed by the expanded architecture harness without task-id or fixture-name branches.
- Adds a unit test for Go struct receiver middleware detection.
- Makes `scripts/benchmark_pipeline.sh` generic and configurable for architecture, retrieval, and dogfood stages via `ARCHEX_*` environment variables.
- Moves benchmark pipeline logs to `logs/benchmark_pipeline.log`, removes `.docs` references from the script/README pipeline docs, and documents stage behavior with comments.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright && uv run pytest tests/analyze/ tests/benchmark/ -q` — passed before the benchmark script update
- `bash -n scripts/benchmark_pipeline.sh` — passed
- `ARCHEX_RUN_ARCH_BENCHMARK=0 ARCHEX_RUN_RETRIEVAL_BENCHMARK=0 ARCHEX_RUN_DOGFOOD=0 ARCHEX_BENCHMARK_LOG_FILE=/tmp/archex-benchmark-pipeline-smoke.log bash scripts/benchmark_pipeline.sh` — passed; temporary smoke log removed
- `ARCHEX_BENCHMARK_BASELINE_DIR=.archex/e2e-tier2 ARCHEX_BENCHMARK_WARN_LATENCY_MS=3000 bash scripts/benchmark_pipeline.sh` — passed; completed architecture smoke, 35 retrieval benchmarks, baseline-aware retrieval gate, and dogfood with pipeline exit status 0
- Latest pipeline log: `logs/benchmark_pipeline.log`; total time 00h:29m:22s; dogfood regressions 0; architecture advisory gate passed with 7 tasks at 1.000 across every dimension

## Review

- `pr-review` scope: 2 changed files; code/test dimensions. No blocking findings for extraction hardening.
- Follow-up review agent invocation for script update failed due a tool/model strict-tools compatibility error; script changes were manually checked and smoke-tested.