### PR TITLE
Classify retrieval precision blockers

### DIFF
--- a/.docs/handoff.md
+++ b/.docs/handoff.md
@@ -1,0 +1,32 @@
+# Handoff — archex
+
+**Last touched:** 2026-06-10T21:45:00Z · **branch:** `chore/retrieval-blocker-triage` · **HEAD:** pending · **session:** openai-codex/gpt-5.5
+
+> Authority: this file owns *transient session state*. Persistent facts live in `~/.claude/projects/<project>/memory/`. Static setup lives in `CLAUDE.md`. Strategic roadmap lives in `.docs/2026-06-09-system-improvements-enhancement-plan.md`. Committed history lives in `git log`.
+
+## Status
+- Working tree: active G2 precision/F1 stack work on `chore/retrieval-blocker-triage`.
+- Baseline evidence: `.archex/benchmark-current` readiness for `archex_query` reports recall `0.819`, precision `0.480`, F1 `0.589`, token efficiency `0.704`, p95 `2059 ms`, zero-recall tasks `0`.
+- Tests: pending for G2.1.
+
+## What changed this session
+- G2.1 blocker classification recorded in `.docs/retrieval-blocker-triage.md` using existing `.archex/benchmark-current` readiness and triage outputs.
+
+## Decisions
+1. **No model-default change** (2026-06-10) — Keep `archex_query` as the product default; improve ranking, normalization, path alignment, and expansion selectivity only.
+2. **No hosted/generative inference** (2026-06-10) — G2 remains local-only and deterministic.
+3. **Top blockers are ranking/packing problems, not oracle defects** (2026-06-10) — The top ten all return oracle files; precision/F1 bottlenecks come from semantic gaps, path-alignment misses, expansion noise, and large-repo ambiguity.
+
+## Blockers / open questions
+- [ ] Operator verdict still required after the stack: full retrieval gate plus dogfood command block from Goal G2.
+
+## Resume checklist
+1. Continue stack order: `chore/retrieval-blocker-triage` → `feat/framework-semantic-normalization` → `feat/self-lifecycle-ranking` → `feat/expansion-diagnostics` → `fix/expansion-selectivity`.
+2. For each PR slice, run `uv run ruff check && uv run ruff format --check . && uv run pyright` and `uv run pytest tests/serve/ tests/benchmark/ -q`.
+3. Do not run `archex benchmark run` or `archex dogfood` in-session.
+4. Print the operator verdict block at final handoff.
+
+## Refs
+- Plan: `.docs/2026-06-09-system-improvements-enhancement-plan.md` Goal G2
+- Baseline report: `.archex/benchmark-current`
+- Triage report: `.docs/retrieval-blocker-triage.md`

--- a/.docs/retrieval-blocker-triage.md
+++ b/.docs/retrieval-blocker-triage.md
@@ -1,0 +1,26 @@
+# G2 Retrieval Blocker Triage
+
+Source evidence: `uv run archex benchmark readiness --input .archex/benchmark-current --tasks-dir benchmarks/tasks --strategy archex_query --format markdown` and `uv run archex benchmark triage --input .archex/benchmark-current --tasks-dir benchmarks/tasks --strategy archex_query --format markdown` on 2026-06-10.
+
+Baseline for this work: `archex_query` recall `0.819`, precision `0.480`, F1 `0.589`, token efficiency `0.704`, p95 `2059 ms`; zero-recall tasks `0`.
+
+| Task | Classification | Evidence | Expected movement |
+|---|---|---|---|
+| `express_middleware` | semantic gap + path-alignment miss | Expected router files are present, but broad middleware vocabulary admits application/request/response/view utilities; raw grepped has full recall. | Framework synonym and route/middleware path evidence should rank `lib/router/*` above generic Express support files. |
+| `django_orm_queries` | large-repo ambiguity | Full recall with 18 extra files; large Django ORM/backends surface and low MRR indicate broad query terms across many SQL-adjacent modules. | ORM query construction terms should prefer `models/query.py` and `models/sql/{query,compiler}.py`; selectivity diagnostics should identify expansion noise separately. |
+| `fastapi_dependency_injection` | semantic gap + expansion noise | Seeds hit all three oracle files; six security/exception files arrive through expansion. | Dependency-injection terms should keep `fastapi/dependencies/*` and `routing.py` dominant; expansion diagnostics should make the noisy import-target additions attributable. |
+| `archex_project_init` | path-alignment miss + expansion noise | Oracle files are returned, but low precision comes from status/test/cache/delta/reporting extras; CLI lifecycle vocabulary is not treated as command/path evidence early enough. | Lifecycle ranking should prioritize `cli/init_cmd.py`, `cli/main.py`, `project.py`, and `config.py`; low-signal tests and lifecycle neighbors should be demoted. |
+| `archex_project_status` | path-alignment miss + expansion noise | Oracle files are returned, but very broad seed and expansion sets include cache/index/query/test files; p95/token baseline is already acceptable. | Status/fresh/stale/dirty/corrupt terms should focus `status.py`, `project.py`, `index/delta.py`, and `cli/status_cmd.py`. |
+| `pydantic_validators` | semantic gap + expansion noise | Oracle files are present; `_generate_schema`, decorators, fields, metadata, and utility modules dilute precision. | Validator/decorator synonym normalization should lift `_validators.py`, `functional_validators.py`, and `_validate_call.py`; diagnostics should expose expansion sources. |
+| `click_decorators` | semantic gap + expansion noise | Oracle files are present; expansion adds compatibility, globals, formatting, termui, exceptions, parser, completion. | Decorator/parameter/command lifecycle terms should rank `decorators.py`, `core.py`, and `types.py` above support modules. |
+| `django_middleware` | semantic gap + expansion noise | Oracle files are present; middleware package breadth pulls many concrete middleware and HTTP/cache/log helpers. | Middleware lifecycle terms should prefer handler chain files and `middleware/common.py`; expansion diagnostics should identify generic import-target/helper additions. |
+| `archex_project_config_resolution` | path-alignment miss + large-repo ambiguity | Oracle files are returned with many parser/index/test/comparison extras; query mixes settings/runtime/config vocabulary across the repo. | Config/settings/runtime terms should prioritize `project.py`, `config.py`, `models.py`, and `cache.py`, with lifecycle path evidence over incidental parser/config mentions. |
+| `archex_project_index` | path-alignment miss + expansion noise | Expected files are present, but many tests/reporting/graph/index internals are packed; token efficiency is low (`0.429`). | Index/build/refresh lifecycle ranking should keep CLI/API/cache/project/config files before tests and low-signal internals. |
+
+## Failure mechanisms
+
+- Semantic gap: framework terms such as middleware, validators, decorators, ORM query construction, dependency injection, hooks, route registration, and lifecycle do not yet consistently expand to code-level identifiers and path terms that match implementation files.
+- Path-alignment miss: self-repo lifecycle questions need command names (`init`, `status`, `index`, `reset`), project-state concepts (`fresh`, `stale`, `dirty`, `corrupt`), and config path concepts treated as first-class ranking evidence.
+- Expansion noise: several blockers already include all oracle files in seeds; precision falls when import-target/importer expansion admits low-signal helpers, tests, or broad support modules.
+- Large-repo ambiguity: Django ORM and self config/index questions have many true-adjacent files; ranking must reduce tail files without trading away recall.
+- Oracle/task-spec issue: none identified in the top ten. Each top blocker has returned oracle files and actionable ranking/packing noise rather than an invalid expected set.


### PR DESCRIPTION
## Stack

Stack-Id: `g2-precision-f1`
Base: `main`
Position: 1/5

1. `chore/retrieval-blocker-triage` -> this PR
2. `feat/framework-semantic-normalization` -> #178
3. `feat/self-lifecycle-ranking`
4. `feat/expansion-diagnostics`
5. `fix/expansion-selectivity`

Depends on: (none - root)
Upstack: #178

## Summary

- Classifies the top ten `archex_query` precision/F1 blockers from `.archex/benchmark-current` readiness and triage evidence.
- Records failure mechanisms and expected metric movement in `.docs/retrieval-blocker-triage.md` and refreshes `.docs/handoff.md` for G2.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright` — passed
- `uv run pytest tests/serve/ tests/benchmark/ -q` — 474 passed, 2 deselected
- PR review — no blocking findings on documentation-only diff
