### PR TITLE
Normalize framework semantic query terms

### DIFF
--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -195,24 +195,97 @@ _QUERY_STOP = frozenset(
     }
 )
 
-# Architecture-intent synonyms: map each architectural keyword to code-level equivalents.
-# These expand BM25 misses caused by vocabulary gaps between natural-language queries
-# and the actual identifiers/comments in source files.
+# Architecture-intent synonyms: map broad architectural keywords to code-level
+# equivalents. These keywords still control architecture-specific expansion.
 _ARCH_SYNONYMS: dict[str, list[str]] = {
     "pipeline": ["workflow", "chain", "process", "pipe", "stage", "assembly", "context"],
-    "middleware": ["handler", "interceptor", "filter", "hook"],
+    "middleware": ["handler", "interceptor", "filter", "hook", "router", "route", "layer", "stack"],
     "registry": ["register", "catalog", "factory", "provider"],
     "adapter": ["plugin", "connector", "driver", "bridge"],
-    "injection": ["inject", "resolve", "depend", "wire"],
-    "routing": ["route", "router", "dispatch", "endpoint", "path"],
+    "injection": [
+        "inject",
+        "resolve",
+        "depend",
+        "depends",
+        "dependant",
+        "wire",
+        "provider",
+        "resolver",
+    ],
+    "routing": ["route", "router", "dispatch", "endpoint", "path", "handler", "register", "mount"],
     "index": ["indexing", "indexed", "cache", "config", "project", "store", "build"],
     "indexing": ["index", "indexed", "delta", "catalog", "cache", "store"],
-    "dependency": ["depend", "resolve", "inject", "require"],
+    "dependency": [
+        "depend",
+        "depends",
+        "dependant",
+        "resolve",
+        "inject",
+        "require",
+        "provider",
+        "resolver",
+    ],
     "session": ["connection", "pool", "client", "transport"],
-    "hook": ["callback", "listener", "subscriber", "event"],
-    "orm": ["model", "schema", "mapper", "table", "entity"],
+    "hook": ["callback", "listener", "subscriber", "event", "state", "effect"],
+    "orm": [
+        "model",
+        "schema",
+        "mapper",
+        "table",
+        "entity",
+        "queryset",
+        "sql",
+        "compiler",
+        "expression",
+        "where",
+    ],
     "task": ["job", "worker", "celery", "dispatch", "execute"],
     "runtime": ["scheduler", "executor", "loop", "spawn"],
+}
+
+# Framework-semantic synonyms improve lexical and path alignment without making
+# every framework implementation question trigger architecture-only expansion.
+_FRAMEWORK_SYNONYMS: dict[str, list[str]] = {
+    "validator": [
+        "validate",
+        "validation",
+        "field_validator",
+        "model_validator",
+        "functional_validators",
+        "validate_call",
+    ],
+    "validators": [
+        "validate",
+        "validation",
+        "field_validator",
+        "model_validator",
+        "functional_validators",
+        "validate_call",
+    ],
+    "decorator": [
+        "decorators",
+        "decoration",
+        "parameter",
+        "option",
+        "argument",
+        "command",
+        "callback",
+        "wrapper",
+    ],
+    "decorators": [
+        "decorator",
+        "decoration",
+        "parameter",
+        "option",
+        "argument",
+        "command",
+        "callback",
+        "wrapper",
+    ],
+    "parameter": ["param", "option", "argument", "decorator"],
+    "parameters": ["param", "option", "argument", "decorator"],
+    "route": ["router", "routing", "endpoint", "handler", "register", "mount"],
+    "routes": ["router", "routing", "endpoint", "handler", "register", "mount"],
 }
 
 # Architecture keywords that trigger 2-hop expansion.
@@ -297,16 +370,16 @@ def _query_terms(question: str) -> set[str]:
     if {"benchmark", "dogfood", "gate"} <= expanded:
         expanded.update({"baseline", "benchmark_cmd", "report", "reporter"})
     if "middleware" in expanded:
-        expanded.update({"common", "wsgi"})
+        expanded.update({"common", "wsgi", "asgi"})
     if "pooling" in expanded or "keep_alive" in expanded:
         expanded.update({"client", "config"})
-    if "validators" in expanded or "validator" in expanded:
-        expanded.update({"functional_validators", "validate_call"})
 
-    # Architecture-intent synonym expansion
+    # Semantic synonym expansion
     for term in list(expanded):
         if term in _ARCH_SYNONYMS:
             expanded.update(_ARCH_SYNONYMS[term])
+        if term in _FRAMEWORK_SYNONYMS:
+            expanded.update(_FRAMEWORK_SYNONYMS[term])
 
     return expanded
 

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -1116,6 +1116,35 @@ def test_path_alignment_matches_private_module_stem_without_underscore() -> None
     assert _path_alignment_boost("pydantic/_internal/_validators.py", {"validators"}) == 2.0
 
 
+def test_query_terms_expand_framework_semantics_without_path_hacks() -> None:
+    from archex.serve.context import _query_terms  # pyright: ignore[reportPrivateUsage]
+
+    middleware_terms = _query_terms("How does express implement the middleware chain?")
+    assert {"router", "route", "layer", "stack", "handler"} <= middleware_terms
+
+    dependency_terms = _query_terms("How does FastAPI implement dependency injection?")
+    assert {"depends", "dependant", "provider", "resolver"} <= dependency_terms
+
+    validator_terms = _query_terms("How does Pydantic chain and apply field validators?")
+    assert {"validate", "validation", "field_validator", "functional_validators"} <= validator_terms
+
+    decorator_terms = _query_terms("How does click implement command decorators?")
+    assert {"decorator", "parameter", "option", "argument", "wrapper"} <= decorator_terms
+
+    orm_terms = _query_terms("How does Django's ORM build and execute SQL queries?")
+    assert {"queryset", "compiler", "expression", "where"} <= orm_terms
+
+
+def test_framework_semantic_terms_boost_router_and_layer_paths() -> None:
+    from archex.serve.context import _path_alignment_boost  # pyright: ignore[reportPrivateUsage]
+    from archex.serve.context import _query_terms  # pyright: ignore[reportPrivateUsage]
+
+    terms = _query_terms("How does express implement the middleware chain and next function?")
+    assert _path_alignment_boost("lib/router/layer.js", terms) > 1.0
+    assert _path_alignment_boost("lib/router/route.js", terms) > 1.0
+    assert _path_alignment_boost("lib/view.js", terms) == 1.0
+
+
 def test_type_alignment_requires_query_overlap_for_general_queries() -> None:
     from archex.serve.context import _type_alignment_score  # pyright: ignore[reportPrivateUsage]
 


### PR DESCRIPTION
## Stack

Stack-Id: `g2-precision-f1`
Base: `main`
Position: 2/5

1. `chore/retrieval-blocker-triage` -> #177
2. `feat/framework-semantic-normalization` -> this PR
3. `feat/self-lifecycle-ranking` -> #179
4. `feat/expansion-diagnostics`
5. `fix/expansion-selectivity`

Depends on: #177
Upstack: #179

## Summary

- Adds characterization coverage for framework-semantic query terms before changing ranking behavior.
- Expands general semantic normalization for middleware, dependency injection, validators, decorators, ORM query construction, hooks, and route registration without framework-specific file-name rules.
- Keeps `archex_query` as the product default and adds no hosted or generative inference.

## Validation

- Characterization pre-change: new framework semantic tests failed before implementation, then passed after implementation.
- `uv run ruff check && uv run ruff format --check . && uv run pyright` — passed
- `uv run pytest tests/serve/ tests/benchmark/ -q` — 476 passed, 2 deselected
- PR review — no blocking findings on the normalization/test diff
