### PR TITLE
Rank self lifecycle query paths

### DIFF
--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -288,6 +288,9 @@ _FRAMEWORK_SYNONYMS: dict[str, list[str]] = {
     "routes": ["router", "routing", "endpoint", "handler", "register", "mount"],
 }
 
+_CLI_LIFECYCLE_COMMAND_TERMS = frozenset({"cache", "config", "index", "init", "reset", "status"})
+
+
 # Architecture keywords that trigger 2-hop expansion.
 _ARCH_KEYWORDS = frozenset(_ARCH_SYNONYMS.keys())
 
@@ -361,6 +364,17 @@ def _query_terms(question: str) -> set[str]:
         expanded.update(
             {"api", "search", "retrieve", "retrieval", "lookup", "bm25", "rank", "score"}
         )
+    if "initialize" in expanded or "initialise" in expanded:
+        expanded.update({"init", "cli", "main", "project", "config"})
+    if {"project", "state"} <= expanded:
+        expanded.update({"cli", "project", "config"})
+    state_lifecycle_query = bool({"fresh", "stale", "dirty", "corrupt"} & expanded)
+    if state_lifecycle_query:
+        expanded.update({"status", "fresh", "stale", "dirty", "corrupt", "delta", "project"})
+    if {"build", "refresh"} & expanded and "index" in expanded:
+        expanded.update({"index", "cli", "api", "cache", "project", "config"})
+    if {"settings", "configuration"} & expanded or "runtime_configuration" in expanded:
+        expanded.update({"config", "settings", "runtime", "models", "cache", "project"})
     if "mcp" in expanded:
         expanded.update({"api", "context", "mcp_cmd", "model", "models"})
     if "query" in expanded and "cache" in expanded:
@@ -380,6 +394,9 @@ def _query_terms(question: str) -> set[str]:
             expanded.update(_ARCH_SYNONYMS[term])
         if term in _FRAMEWORK_SYNONYMS:
             expanded.update(_FRAMEWORK_SYNONYMS[term])
+
+    if state_lifecycle_query:
+        expanded.difference_update({"build", "cache", "config", "store"})
 
     return expanded
 
@@ -436,9 +453,14 @@ def _path_alignment_boost(file_path: str, query_terms: set[str]) -> float:
     normalized_stem = stem.lower().lstrip("_")
     if stem.lower() in query_terms or normalized_stem in query_terms:
         return 2.0
-    if not (path_terms & query_terms):
+    matched_terms = path_terms & query_terms
+    if not matched_terms:
         return 1.0
+    if "cli" in path_terms and matched_terms & _CLI_LIFECYCLE_COMMAND_TERMS:
+        return 2.2
     if "cli" in path_terms and "cli" in query_terms:
+        return 1.6
+    if matched_terms & _CLI_LIFECYCLE_COMMAND_TERMS:
         return 1.6
     return 1.35
 

--- a/src/archex/serve/intent.py
+++ b/src/archex/serve/intent.py
@@ -118,6 +118,14 @@ _DEBUGGING_PATTERNS = [
 
 _CLI_PATTERNS = [
     re.compile(r"\barchex\s+(?:init|reset|status|index|config|cache|delta)\b"),
+    re.compile(
+        r"\barchex\b.*\b(?:"
+        r"initialize|initialise|repo-local\s+project\s+state|"
+        r"fresh|stale|dirty|corrupt|"
+        r"(?:build|refresh)\b.*\bindex|"
+        r"(?:settings|configuration)\b.*\b(?:runtime|project)"
+        r")\b"
+    ),
 ]
 
 

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -1063,7 +1063,9 @@ def test_path_alignment_matches_query_term_in_directory() -> None:
 def test_path_alignment_matches_query_term_in_filename() -> None:
     from archex.serve.context import _path_alignment_boost  # pyright: ignore[reportPrivateUsage]
 
-    assert _path_alignment_boost("src/archex/cli/index_cmd.py", {"index"}) == 1.35
+    assert _path_alignment_boost("src/archex/cli/index_cmd.py", {"index"}) > _path_alignment_boost(
+        "src/archex/index/store.py", {"index"}
+    )
 
 
 def test_query_terms_expand_query_pipeline_to_bm25_context_signals() -> None:
@@ -1086,6 +1088,40 @@ def test_query_terms_expand_index_to_cache_project_signals() -> None:
 
     terms = _query_terms("How does archex explicitly build or refresh a repo-local index?")
     assert {"cache", "config", "project", "store"} <= terms
+
+
+def test_query_terms_expand_self_lifecycle_concepts() -> None:
+    from archex.serve.context import _query_terms  # pyright: ignore[reportPrivateUsage]
+
+    init_terms = _query_terms("How does archex initialize repo-local project state?")
+    assert {"init", "cli", "main", "project", "config"} <= init_terms
+
+    status_terms = _query_terms(
+        "How does archex inspect whether a repo-local index is fresh, stale, dirty, or corrupt?"
+    )
+    assert {"status", "fresh", "stale", "dirty", "corrupt", "delta"} <= status_terms
+
+    config_terms = _query_terms(
+        "How does archex resolve project settings into runtime configuration?"
+    )
+    assert {"config", "settings", "runtime", "models", "cache"} <= config_terms
+
+
+def test_self_lifecycle_terms_boost_command_paths() -> None:
+    from archex.serve.context import _path_alignment_boost  # pyright: ignore[reportPrivateUsage]
+    from archex.serve.context import _query_terms  # pyright: ignore[reportPrivateUsage]
+
+    init_terms = _query_terms("How does archex initialize repo-local project state?")
+    assert _path_alignment_boost("src/archex/cli/init_cmd.py", init_terms) > _path_alignment_boost(
+        "src/archex/status.py", init_terms
+    )
+
+    status_terms = _query_terms(
+        "How does archex inspect whether a repo-local index is fresh, stale, dirty, or corrupt?"
+    )
+    assert _path_alignment_boost(
+        "src/archex/cli/status_cmd.py", status_terms
+    ) > _path_alignment_boost("src/archex/cli/cache_cmd.py", status_terms)
 
 
 def test_query_terms_drop_repo_name_noise() -> None:

--- a/tests/serve/test_intent.py
+++ b/tests/serve/test_intent.py
@@ -97,6 +97,19 @@ def test_classify_archex_reset_as_cli_command() -> None:
     assert result == QueryIntent.CLI
 
 
+@pytest.mark.parametrize(
+    "query",
+    [
+        "How does archex initialize repo-local project state?",
+        "How does archex inspect whether a repo-local index is fresh, stale, dirty, or corrupt?",
+        "How does archex explicitly build or refresh a repo-local index?",
+        "How does archex resolve project settings into runtime configuration?",
+    ],
+)
+def test_classify_archex_lifecycle_questions_as_cli(query: str) -> None:
+    assert classify_intent(query) == QueryIntent.CLI
+
+
 # ---------------------------------------------------------------------------
 # Usage search tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stack

Stack-Id: `g2-precision-f1`
Base: `main`
Position: 3/5

1. `chore/retrieval-blocker-triage` -> #177
2. `feat/framework-semantic-normalization` -> #178
3. `feat/self-lifecycle-ranking` -> this PR
4. `feat/expansion-diagnostics` -> #180
5. `fix/expansion-selectivity`

Depends on: #178
Upstack: #180

## Summary

- Adds characterization coverage for self-repo lifecycle questions before changing ranking behavior.
- Classifies init/status/index/config-resolution questions as CLI intent when phrased as lifecycle questions rather than literal `archex <command>` commands.
- Promotes command names, project-state terms, config/runtime terms, and CLI command paths as first-class ranking evidence.

## Validation

- Characterization pre-change: new self lifecycle tests failed before implementation, then passed after implementation.
- `uv run ruff check && uv run ruff format --check . && uv run pyright` — passed
- `uv run pytest tests/serve/ tests/benchmark/ -q` — 482 passed, 2 deselected
- PR review — no blocking findings on the lifecycle ranking/test diff
