### PR TITLE
Explain graph expansion diagnostics

### DIFF
--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -177,6 +177,8 @@ class BenchmarkResult(BaseModel):
     vector_mode: VectorMode = VectorMode.RAW
     surrogate_version: str | None = None
     cache_state: str = "cold"
+    expansion_reason_counts: dict[str, int] = {}
+    expanded_file_reasons: dict[str, list[str]] = {}
 
 
 class BenchmarkReport(BaseModel):

--- a/src/archex/benchmark/readiness.py
+++ b/src/archex/benchmark/readiness.py
@@ -275,13 +275,20 @@ def format_readiness_markdown(report: ReadinessReport) -> str:
     if not report.blocking_tasks:
         lines.append("No blocking tasks matched the triage thresholds.")
     else:
-        lines.append("| Rank | Task | Category | Bucket | Recall | Precision | F1 |")
-        lines.append("|---:|---|---|---|---:|---:|---:|")
+        lines.append(
+            "| Rank | Task | Category | Bucket | Recall | Precision | F1 | Expansion Reasons |"
+        )
+        lines.append("|---:|---|---|---|---:|---:|---:|---|")
         for index, finding in enumerate(report.blocking_tasks, start=1):
+            reason_summary = ", ".join(
+                f"{reason}:{count}"
+                for reason, count in sorted(finding.expansion_reason_counts.items())
+            )
             lines.append(
                 f"| {index} | `{finding.task_id}` | {finding.category} "
                 f"| {finding.failure_bucket} | {finding.recall:.3f} "
-                f"| {finding.precision:.3f} | {finding.f1_score:.3f} |"
+                f"| {finding.precision:.3f} | {finding.f1_score:.3f} "
+                f"| {reason_summary or 'none'} |"
             )
     return "\n".join(lines)
 

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -389,6 +389,8 @@ class _ArchexFields:
         "expansion_hub_candidates",
         "expansion_test_candidates_skipped",
         "expansion_zero_candidate_reason",
+        "expansion_reason_counts",
+        "expanded_file_reasons",
     )
 
     def __init__(
@@ -412,6 +414,8 @@ class _ArchexFields:
         expansion_hub_candidates: int,
         expansion_test_candidates_skipped: int,
         expansion_zero_candidate_reason: str,
+        expansion_reason_counts: dict[str, int],
+        expanded_file_reasons: dict[str, list[str]],
     ) -> None:
         self.tokens_input = tokens_input
         self.tokens_output = tokens_output
@@ -431,6 +435,8 @@ class _ArchexFields:
         self.expansion_hub_candidates = expansion_hub_candidates
         self.expansion_test_candidates_skipped = expansion_test_candidates_skipped
         self.expansion_zero_candidate_reason = expansion_zero_candidate_reason
+        self.expansion_reason_counts = expansion_reason_counts
+        self.expanded_file_reasons = expanded_file_reasons
 
 
 def _archex_fields(
@@ -480,6 +486,10 @@ def _archex_fields(
             expansion_hub_candidates=meta.expansion_hub_candidates,
             expansion_test_candidates_skipped=meta.expansion_test_candidates_skipped,
             expansion_zero_candidate_reason=meta.expansion_zero_candidate_reason,
+            expansion_reason_counts=dict(meta.expansion_reason_counts),
+            expanded_file_reasons={
+                path: list(reasons) for path, reasons in meta.expanded_file_reasons.items()
+            },
         )
 
     seed_file_count = meta.seed_files_found
@@ -528,6 +538,10 @@ def _archex_fields(
         expansion_hub_candidates=meta.expansion_hub_candidates,
         expansion_test_candidates_skipped=meta.expansion_test_candidates_skipped,
         expansion_zero_candidate_reason=meta.expansion_zero_candidate_reason,
+        expansion_reason_counts=dict(meta.expansion_reason_counts),
+        expanded_file_reasons={
+            path: list(reasons) for path, reasons in meta.expanded_file_reasons.items()
+        },
     )
 
 
@@ -694,6 +708,8 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         expansion_hub_candidates=af.expansion_hub_candidates,
         expansion_test_candidates_skipped=af.expansion_test_candidates_skipped,
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
+        expansion_reason_counts=af.expansion_reason_counts,
+        expanded_file_reasons=af.expanded_file_reasons,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -774,6 +790,8 @@ def run_archex_query_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
         expansion_hub_candidates=af.expansion_hub_candidates,
         expansion_test_candidates_skipped=af.expansion_test_candidates_skipped,
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
+        expansion_reason_counts=af.expansion_reason_counts,
+        expanded_file_reasons=af.expanded_file_reasons,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -855,6 +873,8 @@ def run_surrogate_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResul
         expansion_hub_candidates=af.expansion_hub_candidates,
         expansion_test_candidates_skipped=af.expansion_test_candidates_skipped,
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
+        expansion_reason_counts=af.expansion_reason_counts,
+        expanded_file_reasons=af.expanded_file_reasons,
         category=task.category,
         vector_mode=index_config.vector_mode,
         surrogate_version=index_config.surrogate_version,
@@ -936,6 +956,8 @@ def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
         expansion_hub_candidates=af.expansion_hub_candidates,
         expansion_test_candidates_skipped=af.expansion_test_candidates_skipped,
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
+        expansion_reason_counts=af.expansion_reason_counts,
+        expanded_file_reasons=af.expanded_file_reasons,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -1009,6 +1031,8 @@ def run_archex_query_fusion_rerank(task: BenchmarkTask, repo_path: Path) -> Benc
         expansion_hub_candidates=af.expansion_hub_candidates,
         expansion_test_candidates_skipped=af.expansion_test_candidates_skipped,
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
+        expansion_reason_counts=af.expansion_reason_counts,
+        expanded_file_reasons=af.expanded_file_reasons,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -1089,6 +1113,8 @@ def run_cross_layer_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
         expansion_hub_candidates=af.expansion_hub_candidates,
         expansion_test_candidates_skipped=af.expansion_test_candidates_skipped,
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
+        expansion_reason_counts=af.expansion_reason_counts,
+        expanded_file_reasons=af.expanded_file_reasons,
         category=task.category,
         vector_mode=index_config.vector_mode,
         surrogate_version=index_config.surrogate_version,

--- a/src/archex/benchmark/triage.py
+++ b/src/archex/benchmark/triage.py
@@ -43,6 +43,8 @@ class TriageFinding:
     expansion_hub_candidates: int
     expansion_test_candidates_skipped: int
     expansion_zero_candidate_reason: str
+    expansion_reason_counts: dict[str, int]
+    expanded_file_reasons: dict[str, list[str]]
     raw_grepped_recall: float | None
     raw_grepped_precision: float | None
     raw_grepped_f1_score: float | None
@@ -80,6 +82,8 @@ class TriageFinding:
                 "hub_candidates": self.expansion_hub_candidates,
                 "test_candidates_skipped": self.expansion_test_candidates_skipped,
                 "zero_candidate_reason": self.expansion_zero_candidate_reason,
+                "reason_counts": self.expansion_reason_counts,
+                "file_reasons": self.expanded_file_reasons,
             },
             "raw_grepped_metrics": {
                 "recall": self.raw_grepped_recall,
@@ -156,6 +160,8 @@ def triage_failures(
                 expansion_hub_candidates=result.expansion_hub_candidates,
                 expansion_test_candidates_skipped=result.expansion_test_candidates_skipped,
                 expansion_zero_candidate_reason=result.expansion_zero_candidate_reason,
+                expansion_reason_counts=result.expansion_reason_counts,
+                expanded_file_reasons=result.expanded_file_reasons,
                 raw_grepped_recall=raw_grepped.recall if raw_grepped is not None else None,
                 raw_grepped_precision=raw_grepped.precision if raw_grepped is not None else None,
                 raw_grepped_f1_score=raw_grepped.f1_score if raw_grepped is not None else None,
@@ -220,6 +226,12 @@ def format_triage_markdown(findings: list[TriageFinding]) -> str:
             f"hubs `{finding.expansion_hub_candidates}`, "
             f"test skips `{finding.expansion_test_candidates_skipped}`"
         )
+        if finding.expansion_reason_counts:
+            reason_summary = ", ".join(
+                f"`{reason}` `{count}`"
+                for reason, count in sorted(finding.expansion_reason_counts.items())
+            )
+            lines.append(f"- Expansion reasons: {reason_summary}")
         if finding.expansion_zero_candidate_reason:
             lines.append(f"- Zero expansion reason: `{finding.expansion_zero_candidate_reason}`")
         lines.append("- Expected files:")

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -590,6 +590,8 @@ class RetrievalMetadata(BaseModel):
     lexical_confidence: str = ""  # "high", "medium", "low"
     vector_mode: VectorMode = VectorMode.RAW
     surrogate_version: str | None = None
+    expansion_reason_counts: dict[str, int] = {}
+    expanded_file_reasons: dict[str, list[str]] = {}
 
 
 class ContextBundle(BaseModel):

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -683,6 +683,19 @@ def _unique_file_paths(results: list[tuple[CodeChunk, float]]) -> list[str]:
     return paths
 
 
+def _record_expansion_reason(
+    reasons_by_file: dict[str, set[str]],
+    reason_counts: dict[str, int],
+    file_path: str,
+    reason: str,
+) -> None:
+    file_reasons = reasons_by_file.setdefault(file_path, set())
+    if reason in file_reasons:
+        return
+    file_reasons.add(reason)
+    reason_counts[reason] = reason_counts.get(reason, 0) + 1
+
+
 def _hop2_expansion_priority(expansion: _Hop2Expansion) -> dict[str, float]:
     hop1_files = set(expansion.hop1_files_added)
     hop2_priority: dict[str, float] = {}
@@ -991,6 +1004,8 @@ def assemble_context(
             imported_by_count,
         )
     expansion_priority: dict[str, float] = {}
+    expansion_reasons_by_file: dict[str, set[str]] = {}
+    expansion_reason_counts: dict[str, int] = {}
     expansion_source_count: dict[str, int] = {}
     import_neighbor_edges = 0
     same_module_candidates: set[str] = set()
@@ -1009,12 +1024,40 @@ def assemble_context(
                     same_module_candidates.add(dep)
                 if len(graph.imports_of(dep)) + len(graph.imported_by(dep)) >= 4:
                     hub_candidates.add(dep)
+                    _record_expansion_reason(
+                        expansion_reasons_by_file,
+                        expansion_reason_counts,
+                        dep,
+                        "hub",
+                    )
                 # Boost imports whose file path matches a query term
                 path_lower = dep.lower()
                 path_match = any(t in path_lower for t in q_terms)
                 priority = seed_score * (1.5 if path_match else 1.0)
                 expansion_priority[dep] = expansion_priority.get(dep, 0.0) + priority
                 expansion_source_count[dep] = expansion_source_count.get(dep, 0) + 1
+                _record_expansion_reason(
+                    expansion_reasons_by_file,
+                    expansion_reason_counts,
+                    dep,
+                    "import_target",
+                )
+                dep_module = file_to_module.get(dep)
+                if seed_module is not None and dep_module is not None:
+                    module_reason = "same_module" if dep_module == seed_module else "cross_module"
+                    _record_expansion_reason(
+                        expansion_reasons_by_file,
+                        expansion_reason_counts,
+                        dep,
+                        module_reason,
+                    )
+                if _is_entry_point(dep):
+                    _record_expansion_reason(
+                        expansion_reasons_by_file,
+                        expansion_reason_counts,
+                        dep,
+                        "entry_point",
+                    )
         # Importers get half seed score — they're consumers, not dependencies
         for imp in graph.imported_by(file_path):
             if imp not in seed_files:
@@ -1023,11 +1066,39 @@ def assemble_context(
                     same_module_candidates.add(imp)
                 if len(graph.imports_of(imp)) + len(graph.imported_by(imp)) >= 4:
                     hub_candidates.add(imp)
+                    _record_expansion_reason(
+                        expansion_reasons_by_file,
+                        expansion_reason_counts,
+                        imp,
+                        "hub",
+                    )
                 path_lower = imp.lower()
                 path_match = any(t in path_lower for t in q_terms)
                 priority = seed_score * (0.75 if path_match else 0.5)
                 expansion_priority[imp] = expansion_priority.get(imp, 0.0) + priority
                 expansion_source_count[imp] = expansion_source_count.get(imp, 0) + 1
+                _record_expansion_reason(
+                    expansion_reasons_by_file,
+                    expansion_reason_counts,
+                    imp,
+                    "importer",
+                )
+                imp_module = file_to_module.get(imp)
+                if seed_module is not None and imp_module is not None:
+                    module_reason = "same_module" if imp_module == seed_module else "cross_module"
+                    _record_expansion_reason(
+                        expansion_reasons_by_file,
+                        expansion_reason_counts,
+                        imp,
+                        module_reason,
+                    )
+                if _is_entry_point(imp):
+                    _record_expansion_reason(
+                        expansion_reasons_by_file,
+                        expansion_reason_counts,
+                        imp,
+                        "entry_point",
+                    )
     # Convergence bonus: files reached by multiple independent seeds are structurally
     # corroborated — more likely to be genuinely relevant than files from a single seed.
     for dep in expansion_priority:
@@ -1066,6 +1137,12 @@ def assemble_context(
     for file_path in sorted_expansion:
         if _is_test_file(file_path):
             expansion_test_candidates_skipped += 1
+            _record_expansion_reason(
+                expansion_reasons_by_file,
+                expansion_reason_counts,
+                file_path,
+                "test_file",
+            )
             continue
         added = _add_file_chunks(
             candidate_map,
@@ -1073,6 +1150,13 @@ def assemble_context(
             file_path,
             max_per_file=max_per_file,
         )
+        if added == 0:
+            _record_expansion_reason(
+                expansion_reasons_by_file,
+                expansion_reason_counts,
+                file_path,
+                "skipped",
+            )
         if added > 0:
             expansion_files_added += 1
             hop1_files_added.append(file_path)
@@ -1107,6 +1191,23 @@ def assemble_context(
             expansion_test_candidates_skipped += hop2_test_candidates_skipped
             expansion_files_added += len(hop2_files_added)
             expanded_file_paths.extend(hop2_files_added)
+            for file_path in hop2_files_added:
+                _record_expansion_reason(
+                    expansion_reasons_by_file,
+                    expansion_reason_counts,
+                    file_path,
+                    "import_target",
+                )
+            if hop2_test_candidates_skipped:
+                expansion_reason_counts["test_file"] = (
+                    expansion_reason_counts.get("test_file", 0) + hop2_test_candidates_skipped
+                )
+    expanded_file_reasons = {
+        file_path: sorted(expansion_reasons_by_file[file_path])
+        for file_path in expanded_file_paths
+        if file_path in expansion_reasons_by_file
+    }
+
     candidates_after_expansion = len(candidate_map)
 
     if trace is not None:
@@ -1126,6 +1227,11 @@ def assemble_context(
                     "expansion_hub_candidates": len(hub_candidates),
                     "expansion_test_candidates_skipped": expansion_test_candidates_skipped,
                     "expansion_zero_candidate_reason": expansion_zero_candidate_reason,
+                    "expansion_reason_counts": ",".join(
+                        f"{reason}:{count}"
+                        for reason, count in sorted(expansion_reason_counts.items())
+                    ),
+                    "expanded_file_reasons": len(expanded_file_reasons),
                 },
             )
         )
@@ -1372,6 +1478,8 @@ def assemble_context(
         expansion_same_module_candidates=len(same_module_candidates),
         expansion_hub_candidates=len(hub_candidates),
         expansion_test_candidates_skipped=expansion_test_candidates_skipped,
+        expansion_reason_counts=dict(expansion_reason_counts),
+        expanded_file_reasons=expanded_file_reasons,
         bm25_cv=bm25_cv_val,
         splade_results=len(splade_results or []),
         splade_used=bool(effective_splade),

--- a/tests/benchmark/test_readiness.py
+++ b/tests/benchmark/test_readiness.py
@@ -184,6 +184,7 @@ def test_format_readiness_outputs_are_stable() -> None:
     assert "Token Efficiency" in markdown
     assert "Savings vs Raw" in markdown
     assert "`miss`" in markdown
+    assert "Expansion Reasons" in markdown
 
     payload = json.loads(format_readiness_json(readiness))
     assert payload["strategy"] == "archex_query"

--- a/tests/benchmark/test_triage.py
+++ b/tests/benchmark/test_triage.py
@@ -33,6 +33,8 @@ def _result(
     expansion_eligible_seeds: int = 0,
     expansion_candidates_found: int = 0,
     expansion_zero_candidate_reason: str = "",
+    expansion_reason_counts: dict[str, int] | None = None,
+    expanded_file_reasons: dict[str, list[str]] | None = None,
 ) -> BenchmarkResult:
     return BenchmarkResult(
         task_id="task",
@@ -55,6 +57,8 @@ def _result(
         expansion_eligible_seeds=expansion_eligible_seeds,
         expansion_candidates_found=expansion_candidates_found,
         expansion_zero_candidate_reason=expansion_zero_candidate_reason,
+        expansion_reason_counts=expansion_reason_counts or {},
+        expanded_file_reasons=expanded_file_reasons or {},
         category=category,
     )
 
@@ -205,6 +209,8 @@ def test_format_triage_json_serializes_expansion_diagnostics() -> None:
         precision=0.2,
         f1_score=0.33,
         seed_files=["src/task.py"],
+        expansion_reason_counts={"import_target": 2, "test_file": 1},
+        expanded_file_reasons={"src/worker.py": ["import_target"]},
         expanded_files=["src/worker.py", "src/noise.py"],
         expansion_eligible_seeds=1,
         expansion_candidates_found=2,
@@ -216,6 +222,13 @@ def test_format_triage_json_serializes_expansion_diagnostics() -> None:
 
     assert payload[0]["task_id"] == "expanded"
     assert payload[0]["returned_files"] == ["src/task.py", "src/worker.py", "src/noise.py"]
+    assert payload[0]["expansion_diagnostics"]["reason_counts"] == {
+        "import_target": 2,
+        "test_file": 1,
+    }
+    assert payload[0]["expansion_diagnostics"]["file_reasons"] == {
+        "src/worker.py": ["import_target"]
+    }
     assert payload[0]["extra_files"] == ["src/noise.py"]
     assert payload[0]["seed_files"] == ["src/task.py"]
     assert payload[0]["expanded_files"] == ["src/worker.py", "src/noise.py"]

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -561,6 +561,46 @@ def test_expansion_metadata_records_seed_and_expanded_file_paths() -> None:
     assert meta.expansion_zero_candidate_reason == ""
 
 
+def test_expansion_metadata_records_file_reasons_without_changing_output() -> None:
+    graph = DependencyGraph()
+    for file_path in (
+        "src/app/main.py",
+        "src/app/dep.py",
+        "src/lib/helper.py",
+        "tests/test_dep.py",
+    ):
+        graph.add_file_node(file_path)
+    graph.add_file_edge("src/app/main.py", "src/app/dep.py", kind="imports")
+    graph.add_file_edge("src/app/main.py", "src/lib/helper.py", kind="imports")
+    graph.add_file_edge("src/app/main.py", "tests/test_dep.py", kind="imports")
+    seed_chunk = make_chunk("seed", "src/app/main.py", token_count=10)
+    same_module_chunk = make_chunk("dep", "src/app/dep.py", token_count=10)
+    cross_module_chunk = make_chunk("helper", "src/lib/helper.py", token_count=10)
+    test_chunk = make_chunk("test", "tests/test_dep.py", token_count=10)
+
+    bundle = assemble_context(
+        [(seed_chunk, 5.0)],
+        graph,
+        [seed_chunk, same_module_chunk, cross_module_chunk, test_chunk],
+        "graph expansion",
+        token_budget=1000,
+        modules=[
+            Module(name="app", root_path="src/app", files=["src/app/main.py", "src/app/dep.py"]),
+            Module(name="lib", root_path="src/lib", files=["src/lib/helper.py"]),
+        ],
+    )
+
+    included_files = {rc.chunk.file_path for rc in bundle.chunks}
+    assert included_files == {"src/app/main.py", "src/app/dep.py", "src/lib/helper.py"}
+    meta = bundle.retrieval_metadata
+    assert meta.expanded_file_reasons["src/app/dep.py"] == ["import_target", "same_module"]
+    assert meta.expanded_file_reasons["src/lib/helper.py"] == ["cross_module", "import_target"]
+    assert meta.expansion_reason_counts["import_target"] == 3
+    assert meta.expansion_reason_counts["same_module"] == 1
+    assert meta.expansion_reason_counts["cross_module"] == 1
+    assert meta.expansion_reason_counts["test_file"] == 1
+
+
 def test_expansion_metadata_records_zero_candidate_reason() -> None:
     graph = DependencyGraph()
     graph.add_file_node("seed.py")


### PR DESCRIPTION
## Stack

Stack-Id: `g2-precision-f1`
Base: `main`
Position: 4/5

1. `chore/retrieval-blocker-triage` -> #177
2. `feat/framework-semantic-normalization` -> #178
3. `feat/self-lifecycle-ranking` -> #179
4. `feat/expansion-diagnostics` -> this PR
5. `fix/expansion-selectivity` -> #181

Depends on: #179
Upstack: #181

## Summary

- Adds expansion reason metadata for import targets, importers, same-module, cross-module, entry points, hubs, test-file skips, and skipped candidates.
- Carries diagnostics through retrieval metadata, benchmark result JSON, triage JSON/markdown, and readiness top-blocker output.
- Adds a no-output-change characterization test: expanded files remain unchanged while reason metadata is populated.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright` — passed
- `uv run pytest tests/serve/ tests/benchmark/ -q` — 483 passed, 2 deselected
- PR review — no blocking findings on diagnostics/reporting diff
