### PR TITLE
Forbid unknown benchmark YAML fields

### DIFF
--- a/src/archex/benchmark/loader.py
+++ b/src/archex/benchmark/loader.py
@@ -2,23 +2,52 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar, cast
 
 import yaml
+from pydantic import BaseModel, ValidationError
 
 from archex.benchmark.models import ArchitectureBenchmarkTask, BenchmarkTask, DeltaBenchmarkTask
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+BenchmarkSpec = TypeVar("BenchmarkSpec", bound=BaseModel)
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, object]:
+    raw = path.read_text(encoding="utf-8")
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"Failed to parse YAML in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected a YAML mapping in {path}, got {type(data).__name__}")
+    return cast("dict[str, object]", data)
+
+
+def _format_validation_error(path: Path, exc: ValidationError) -> str:
+    messages: list[str] = []
+    for error in exc.errors():
+        loc = ".".join(str(part) for part in error["loc"])
+        field = loc or "<root>"
+        if error["type"] == "extra_forbidden":
+            messages.append(f"unknown field {field!r}: {error['msg']}")
+        else:
+            messages.append(f"{field}: {error['msg']}")
+    return f"Invalid benchmark YAML in {path}: " + "; ".join(messages)
+
+
+def _validate_yaml_model(path: Path, model: type[BenchmarkSpec]) -> BenchmarkSpec:
+    try:
+        return model.model_validate(_load_yaml_mapping(path))
+    except ValidationError as exc:
+        raise ValueError(_format_validation_error(path, exc)) from exc
+
 
 def load_task(path: Path) -> BenchmarkTask:
     """Parse a single YAML file into a BenchmarkTask."""
-    raw = path.read_text(encoding="utf-8")
-    data = yaml.safe_load(raw)
-    if not isinstance(data, dict):
-        raise ValueError(f"Expected a YAML mapping in {path}, got {type(data).__name__}")
-    return BenchmarkTask.model_validate(data)
+    return _validate_yaml_model(path, BenchmarkTask)
 
 
 def load_tasks(directory: Path) -> list[BenchmarkTask]:
@@ -33,11 +62,7 @@ def load_tasks(directory: Path) -> list[BenchmarkTask]:
 
 def load_arch_task(path: Path) -> ArchitectureBenchmarkTask:
     """Parse a single YAML file into an ArchitectureBenchmarkTask."""
-    raw = path.read_text(encoding="utf-8")
-    data = yaml.safe_load(raw)
-    if not isinstance(data, dict):
-        raise ValueError(f"Expected a YAML mapping in {path}, got {type(data).__name__}")
-    return ArchitectureBenchmarkTask.model_validate(data)
+    return _validate_yaml_model(path, ArchitectureBenchmarkTask)
 
 
 def load_arch_tasks(directory: Path) -> list[ArchitectureBenchmarkTask]:
@@ -52,11 +77,7 @@ def load_arch_tasks(directory: Path) -> list[ArchitectureBenchmarkTask]:
 
 def load_delta_task(path: Path) -> DeltaBenchmarkTask:
     """Parse a single YAML file into a DeltaBenchmarkTask."""
-    raw = path.read_text(encoding="utf-8")
-    data = yaml.safe_load(raw)
-    if not isinstance(data, dict):
-        raise ValueError(f"Expected a YAML mapping in {path}, got {type(data).__name__}")
-    return DeltaBenchmarkTask.model_validate(data)
+    return _validate_yaml_model(path, DeltaBenchmarkTask)
 
 
 def load_delta_tasks(directory: Path) -> list[DeltaBenchmarkTask]:

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from archex.models import (  # noqa: TCH001 — Pydantic needs at runtime
     DeltaMeta,
@@ -34,7 +34,11 @@ class TaskCategory(StrEnum):
     FRAMEWORK_SEMANTIC = "framework-semantic"
 
 
-class BenchmarkTask(BaseModel):
+class BenchmarkSpecModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class BenchmarkTask(BenchmarkSpecModel):
     task_id: str
     repo: str
     commit: str
@@ -56,36 +60,36 @@ class BenchmarkTask(BaseModel):
         return self
 
 
-class ArchitectureExpectedModule(BaseModel):
+class ArchitectureExpectedModule(BenchmarkSpecModel):
     name: str
     root_path: str
     files: list[str]
     responsibility_terms: list[str] = []
 
 
-class ArchitectureExpectedPattern(BaseModel):
+class ArchitectureExpectedPattern(BenchmarkSpecModel):
     name: str
     evidence_symbols: list[str] = []
 
 
-class ArchitectureExpectedInterface(BaseModel):
+class ArchitectureExpectedInterface(BenchmarkSpecModel):
     name: str
     file_path: str
     kind: SymbolKind | None = None
 
 
-class ArchitectureExpectedDecision(BaseModel):
+class ArchitectureExpectedDecision(BenchmarkSpecModel):
     decision_terms: list[str]
 
 
-class ArchitectureOracle(BaseModel):
+class ArchitectureOracle(BenchmarkSpecModel):
     modules: list[ArchitectureExpectedModule] = []
     patterns: list[ArchitectureExpectedPattern] = []
     interfaces: list[ArchitectureExpectedInterface] = []
     decisions: list[ArchitectureExpectedDecision] = []
 
 
-class ArchitectureBenchmarkTask(BaseModel):
+class ArchitectureBenchmarkTask(BenchmarkSpecModel):
     task_id: str
     repo: str
     commit: str
@@ -201,7 +205,7 @@ class DeltaStrategy(StrEnum):
     FULL_REINDEX = "full_reindex"
 
 
-class DeltaBenchmarkTask(BaseModel):
+class DeltaBenchmarkTask(BenchmarkSpecModel):
     task_id: str
     repo: str
     base_commit: str

--- a/tests/benchmark/test_loader.py
+++ b/tests/benchmark/test_loader.py
@@ -93,6 +93,21 @@ expected_files:
         with pytest.raises(Exception):  # noqa: B017 — Pydantic ValidationError
             load_task(p)
 
+    def test_load_rejects_unknown_field_with_path(self, tmp_path: Path) -> None:
+        p = tmp_path / "unknown.yaml"
+        p.write_text("""\
+task_id: unknown
+repo: owner/repo
+commit: abc
+question: "How?"
+expected_files:
+  - src/main.py
+unexpected: true
+""")
+
+        with pytest.raises(ValueError, match=r"unknown\.yaml.*unknown field 'unexpected'"):
+            load_task(p)
+
 
 class TestLoadArchTask:
     def test_load_valid_arch_yaml(self, tmp_path: Path) -> None:
@@ -125,6 +140,28 @@ arch_oracle:
         p.write_text("- just a list")
 
         with pytest.raises(ValueError, match="Expected a YAML mapping"):
+            load_arch_task(p)
+
+    def test_load_arch_rejects_unknown_nested_oracle_field(self, tmp_path: Path) -> None:
+        p = tmp_path / "arch_unknown.yaml"
+        p.write_text("""\
+task_id: arch_unknown
+repo: "."
+commit: HEAD
+question: "Which architectural patterns are present?"
+include_paths:
+  - tests/fixtures/python_patterns
+arch_oracle:
+  patterns:
+    - name: strategy
+      extra_pattern_field: nope
+""")
+
+        message = (
+            r"arch_unknown\.yaml.*unknown field "
+            r"'arch_oracle\.patterns\.0\.extra_pattern_field'"
+        )
+        with pytest.raises(ValueError, match=message):
             load_arch_task(p)
 
     def test_load_arch_tasks_directory(self, tmp_path: Path) -> None:
@@ -312,4 +349,22 @@ delta_commit: delta{i}
         p = tmp_path / "bad.yaml"
         p.write_text("- just a list")
         with pytest.raises(ValueError, match="Expected a YAML mapping"):
+            load_delta_task(p)
+
+    def test_load_delta_rejects_unknown_field_with_path(self, tmp_path: Path) -> None:
+        p = tmp_path / "delta_unknown.yaml"
+        p.write_text("""\
+task_id: delta_unknown
+repo: "."
+base_commit: abc123
+delta_commit: def456
+expected_delta:
+  - src/main.py
+extra_delta_field: nope
+""")
+
+        with pytest.raises(
+            ValueError,
+            match=r"delta_unknown\.yaml.*unknown field 'extra_delta_field'",
+        ):
             load_delta_task(p)


### PR DESCRIPTION
## Stack

Stack-Id: `benchmark-validation-g5`
Base: `main`
Position: 1/3

1. `fix/benchmark-strict-schema` -> this PR
2. `fix/benchmark-duplicate-ids` -> #183
3. `feat/benchmark-validate-command` -> #184

Depends on: none
Upstack: #183

## Validation

- Pass: `uv run ruff check && uv run ruff format --check . && uv run pyright && uv run pytest tests/benchmark/test_loader.py tests/benchmark/test_cli.py -q`
- PR review: no blocking findings from pr-review methodology.

## Scope

- Reject unknown fields on benchmark, architecture, delta, and nested architecture oracle YAML models.
- Wrap loader validation errors with the YAML path and offending field.