### PR TITLE
Reject duplicate benchmark task ids

### DIFF
--- a/src/archex/benchmark/loader.py
+++ b/src/archex/benchmark/loader.py
@@ -45,6 +45,23 @@ def _validate_yaml_model(path: Path, model: type[BenchmarkSpec]) -> BenchmarkSpe
         raise ValueError(_format_validation_error(path, exc)) from exc
 
 
+LoadedTask = TypeVar("LoadedTask", BenchmarkTask, ArchitectureBenchmarkTask, DeltaBenchmarkTask)
+
+
+def _append_unique_task(
+    tasks: list[LoadedTask],
+    task: LoadedTask,
+    path: Path,
+    seen_paths: dict[str, Path],
+) -> None:
+    previous_path = seen_paths.get(task.task_id)
+    if previous_path is not None:
+        msg = f"Duplicate task_id {task.task_id!r} in {previous_path} and {path}"
+        raise ValueError(msg)
+    seen_paths[task.task_id] = path
+    tasks.append(task)
+
+
 def load_task(path: Path) -> BenchmarkTask:
     """Parse a single YAML file into a BenchmarkTask."""
     return _validate_yaml_model(path, BenchmarkTask)
@@ -55,8 +72,9 @@ def load_tasks(directory: Path) -> list[BenchmarkTask]:
     if not directory.is_dir():
         raise FileNotFoundError(f"Tasks directory not found: {directory}")
     tasks: list[BenchmarkTask] = []
+    seen_paths: dict[str, Path] = {}
     for yaml_file in sorted(directory.glob("*.yaml")):
-        tasks.append(load_task(yaml_file))
+        _append_unique_task(tasks, load_task(yaml_file), yaml_file, seen_paths)
     return tasks
 
 
@@ -70,8 +88,9 @@ def load_arch_tasks(directory: Path) -> list[ArchitectureBenchmarkTask]:
     if not directory.is_dir():
         raise FileNotFoundError(f"Architecture tasks directory not found: {directory}")
     tasks: list[ArchitectureBenchmarkTask] = []
+    seen_paths: dict[str, Path] = {}
     for yaml_file in sorted(directory.glob("*.yaml")):
-        tasks.append(load_arch_task(yaml_file))
+        _append_unique_task(tasks, load_arch_task(yaml_file), yaml_file, seen_paths)
     return tasks
 
 
@@ -85,8 +104,9 @@ def load_delta_tasks(directory: Path) -> list[DeltaBenchmarkTask]:
     if not directory.is_dir():
         raise FileNotFoundError(f"Tasks directory not found: {directory}")
     tasks: list[DeltaBenchmarkTask] = []
+    seen_paths: dict[str, Path] = {}
     for yaml_file in sorted(directory.glob("*.yaml")):
-        tasks.append(load_delta_task(yaml_file))
+        _append_unique_task(tasks, load_delta_task(yaml_file), yaml_file, seen_paths)
     return tasks
 
 

--- a/tests/benchmark/test_loader.py
+++ b/tests/benchmark/test_loader.py
@@ -182,6 +182,24 @@ arch_oracle:
 
         assert [task.task_id for task in tasks] == ["arch_a", "arch_b"]
 
+    def test_load_arch_tasks_rejects_duplicate_ids_with_paths(self, tmp_path: Path) -> None:
+        for name in ("a", "b"):
+            (tmp_path / f"{name}.yaml").write_text("""\
+task_id: arch_duplicate
+repo: "."
+commit: HEAD
+question: "Which architecture is present?"
+include_paths:
+  - tests/fixtures/python_patterns
+arch_oracle:
+  patterns:
+    - name: strategy
+""")
+
+        message = r"Duplicate task_id 'arch_duplicate'.*a\.yaml.*b\.yaml"
+        with pytest.raises(ValueError, match=message):
+            load_arch_tasks(tmp_path)
+
     def test_load_arch_tasks_missing_directory(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):
             load_arch_tasks(tmp_path / "missing")
@@ -247,6 +265,21 @@ class TestLoadTasks:
         tasks = load_tasks(tasks_dir)
         ids = [t.task_id for t in tasks]
         assert ids == ["task_0", "task_1", "task_2"]
+
+    def test_load_directory_rejects_duplicate_ids_with_paths(self, tmp_path: Path) -> None:
+        for name in ("a", "b"):
+            (tmp_path / f"{name}.yaml").write_text("""\
+task_id: duplicate
+repo: owner/repo
+commit: abc
+question: "How?"
+expected_files:
+  - src/main.py
+""")
+
+        message = r"Duplicate task_id 'duplicate'.*a\.yaml.*b\.yaml"
+        with pytest.raises(ValueError, match=message):
+            load_tasks(tmp_path)
 
 
 class TestValidateTask:
@@ -340,6 +373,21 @@ delta_commit: delta{i}
         assert len(tasks) == 2
         assert all(isinstance(t, DeltaBenchmarkTask) for t in tasks)
         assert [t.task_id for t in tasks] == ["delta_0", "delta_1"]
+
+    def test_load_delta_tasks_rejects_duplicate_ids_with_paths(self, tmp_path: Path) -> None:
+        for name in ("a", "b"):
+            (tmp_path / f"{name}.yaml").write_text("""\
+task_id: delta_duplicate
+repo: "."
+base_commit: base
+delta_commit: delta
+""")
+
+        with pytest.raises(
+            ValueError,
+            match=r"Duplicate task_id 'delta_duplicate'.*a\.yaml.*b\.yaml",
+        ):
+            load_delta_tasks(tmp_path)
 
     def test_load_delta_missing_directory(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
## Stack

Stack-Id: `benchmark-validation-g5`
Base: `main`
Position: 2/3

1. `fix/benchmark-strict-schema` -> #182
2. `fix/benchmark-duplicate-ids` -> this PR
3. `feat/benchmark-validate-command` -> #184

Depends on: #182
Upstack: #184

## Validation

- Pass: `uv run ruff check && uv run ruff format --check . && uv run pyright && uv run pytest tests/benchmark/test_loader.py tests/benchmark/test_cli.py -q`
- PR review: no blocking findings from pr-review methodology.

## Scope

- Reject duplicate task IDs across benchmark, architecture, and delta task directories.
- Error messages list both YAML paths that define the duplicate ID.