### PR TITLE
Add strict benchmark validation command

### DIFF
--- a/src/archex/benchmark/loader.py
+++ b/src/archex/benchmark/loader.py
@@ -62,9 +62,52 @@ def _append_unique_task(
     tasks.append(task)
 
 
+def _raise_spec_error(path: Path, field: str, message: str) -> None:
+    raise ValueError(f"Invalid benchmark YAML in {path}: {field}: {message}")
+
+
+def _validate_text_field(path: Path, field: str, value: str) -> None:
+    if not value.strip():
+        _raise_spec_error(path, field, "must not be empty")
+
+
+def _validate_list_field(path: Path, field: str, value: list[str]) -> None:
+    if not value:
+        _raise_spec_error(path, field, "must define at least one entry")
+    for index, entry in enumerate(value):
+        if not entry.strip():
+            _raise_spec_error(path, f"{field}.{index}", "must not be empty")
+
+
+def _validate_benchmark_task(path: Path, task: BenchmarkTask) -> None:
+    _validate_text_field(path, "question", task.question)
+    _validate_text_field(path, "commit", task.commit)
+    _validate_list_field(path, "expected_files", task.expected_files)
+
+
+def _validate_architecture_task(path: Path, task: ArchitectureBenchmarkTask) -> None:
+    _validate_text_field(path, "question", task.question)
+    _validate_text_field(path, "commit", task.commit)
+    if not (
+        task.arch_oracle.modules
+        or task.arch_oracle.patterns
+        or task.arch_oracle.interfaces
+        or task.arch_oracle.decisions
+    ):
+        _raise_spec_error(path, "arch_oracle", "must define at least one expectation")
+
+
+def _validate_delta_task(path: Path, task: DeltaBenchmarkTask) -> None:
+    _validate_text_field(path, "base_commit", task.base_commit)
+    _validate_text_field(path, "delta_commit", task.delta_commit)
+    _validate_list_field(path, "expected_delta", task.expected_delta)
+
+
 def load_task(path: Path) -> BenchmarkTask:
     """Parse a single YAML file into a BenchmarkTask."""
-    return _validate_yaml_model(path, BenchmarkTask)
+    task = _validate_yaml_model(path, BenchmarkTask)
+    _validate_benchmark_task(path, task)
+    return task
 
 
 def load_tasks(directory: Path) -> list[BenchmarkTask]:
@@ -80,7 +123,9 @@ def load_tasks(directory: Path) -> list[BenchmarkTask]:
 
 def load_arch_task(path: Path) -> ArchitectureBenchmarkTask:
     """Parse a single YAML file into an ArchitectureBenchmarkTask."""
-    return _validate_yaml_model(path, ArchitectureBenchmarkTask)
+    task = _validate_yaml_model(path, ArchitectureBenchmarkTask)
+    _validate_architecture_task(path, task)
+    return task
 
 
 def load_arch_tasks(directory: Path) -> list[ArchitectureBenchmarkTask]:
@@ -96,7 +141,9 @@ def load_arch_tasks(directory: Path) -> list[ArchitectureBenchmarkTask]:
 
 def load_delta_task(path: Path) -> DeltaBenchmarkTask:
     """Parse a single YAML file into a DeltaBenchmarkTask."""
-    return _validate_yaml_model(path, DeltaBenchmarkTask)
+    task = _validate_yaml_model(path, DeltaBenchmarkTask)
+    _validate_delta_task(path, task)
+    return task
 
 
 def load_delta_tasks(directory: Path) -> list[DeltaBenchmarkTask]:

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -27,7 +27,7 @@ from archex.benchmark.gate import (
     non_token_quality_warnings,
     token_efficiency_violations,
 )
-from archex.benchmark.loader import load_tasks
+from archex.benchmark.loader import load_arch_tasks, load_delta_tasks, load_tasks
 from archex.benchmark.models import (
     ArchitectureBenchmarkResult,
     BenchmarkReport,
@@ -325,38 +325,90 @@ def readiness_cmd(input_dir: str, tasks_dir: str, strategy_name: str, output_for
 @click.option(
     "--tasks-dir",
     default="benchmarks/tasks",
-    type=click.Path(exists=True),
-    help="Directory containing task YAML files.",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Directory containing benchmark task YAML files.",
 )
-def validate_cmd(tasks_dir: str) -> None:
+@click.option(
+    "--arch-tasks-dir",
+    default="benchmarks/arch_tasks",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Directory containing architecture task YAML files.",
+)
+@click.option(
+    "--delta-tasks-dir",
+    default="benchmarks/delta_tasks",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Directory containing delta task YAML files.",
+)
+@click.option(
+    "--kind",
+    default="tasks",
+    type=click.Choice(["tasks", "arch", "delta", "all"]),
+    show_default=True,
+    help="Task definition family to validate.",
+)
+def validate_cmd(tasks_dir: str, arch_tasks_dir: str, delta_tasks_dir: str, kind: str) -> None:
     """Validate benchmark task definitions."""
-    tasks = load_tasks(Path(tasks_dir))
+    repo_root = Path.cwd()
+    validated_counts: list[tuple[str, int]] = []
 
-    if not tasks:
-        raise click.ClickException(f"No task files found in {tasks_dir}")
+    if kind in {"tasks", "all"}:
+        try:
+            tasks = load_tasks(Path(tasks_dir))
+        except (FileNotFoundError, ValueError) as exc:
+            raise click.ClickException(str(exc)) from exc
 
-    has_errors = False
-    for task in tasks:
-        click.echo(f"Validating: {task.task_id} ({task.repo})")
-        # Structural validation only (no clone) — check fields are reasonable
-        errors: list[str] = []
-        if not task.expected_files:
-            errors.append("No expected_files defined")
-        if not task.question.strip():
-            errors.append("Empty question")
-        if not task.commit:
-            errors.append("No commit hash")
+        if not tasks:
+            raise click.ClickException(f"No task files found in {tasks_dir}")
 
-        if errors:
-            has_errors = True
-            for err in errors:
-                click.echo(f"  ERROR: {err}", err=True)
-        else:
-            click.echo(f"  OK ({len(task.expected_files)} expected files)")
+        has_errors = False
+        for task in tasks:
+            click.echo(f"Validating: {task.task_id} ({task.repo})")
+            errors: list[str] = []
+            if task.repo == ".":
+                for expected in task.expected_files:
+                    if not (repo_root / expected).is_file():
+                        errors.append(f"Expected file not found: {expected}")
 
-    if has_errors:
-        raise SystemExit(1)
-    click.echo(f"\nAll {len(tasks)} task(s) valid.")
+            if errors:
+                has_errors = True
+                for err in errors:
+                    click.echo(f"  ERROR: {err}", err=True)
+            else:
+                click.echo(f"  OK ({len(task.expected_files)} expected files)")
+
+        if has_errors:
+            raise SystemExit(1)
+        validated_counts.append(("task", len(tasks)))
+
+    if kind in {"arch", "all"}:
+        try:
+            arch_tasks = load_arch_tasks(Path(arch_tasks_dir))
+        except (FileNotFoundError, ValueError) as exc:
+            raise click.ClickException(str(exc)) from exc
+
+        if not arch_tasks:
+            raise click.ClickException(f"No architecture task files found in {arch_tasks_dir}")
+        validated_counts.append(("architecture task", len(arch_tasks)))
+
+    if kind in {"delta", "all"}:
+        try:
+            delta_tasks = load_delta_tasks(Path(delta_tasks_dir))
+        except (FileNotFoundError, ValueError) as exc:
+            raise click.ClickException(str(exc)) from exc
+
+        if not delta_tasks:
+            raise click.ClickException(f"No delta task files found in {delta_tasks_dir}")
+        validated_counts.append(("delta task", len(delta_tasks)))
+
+    if validated_counts == [("task", 1)]:
+        click.echo("\nAll 1 task(s) valid.")
+        return
+
+    summary = ", ".join(
+        f"{count} {label}{'' if count == 1 else 's'}" for label, count in validated_counts
+    )
+    click.echo(f"\nAll {summary} valid.")
 
 
 @benchmark_cmd.group("baseline")

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -227,12 +227,100 @@ class TestValidateCommand:
         (tasks / "bad.yaml").write_text("""\
 task_id: bad_task
 repo: owner/repo
-commit: ""
-question: "  "
+commit: abc
+question: "How?"
 expected_files: []
 """)
         result = runner.invoke(benchmark_cmd, ["validate", "--tasks-dir", str(tasks)])
         assert result.exit_code != 0
+        assert "bad.yaml" in result.output
+        assert "expected_files" in result.output
+
+    def test_validate_rejects_missing_local_expected_file(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        tasks = tmp_path / "tasks"
+        tasks.mkdir()
+        (tasks / "bad.yaml").write_text("""\
+task_id: missing_local_file
+repo: "."
+commit: HEAD
+question: "How?"
+expected_files:
+  - missing.py
+""")
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(benchmark_cmd, ["validate", "--tasks-dir", str(tasks)])
+
+        assert result.exit_code != 0
+        assert "Expected file not found: missing.py" in result.output
+
+    def test_validate_all_task_families(self, runner: CliRunner, tmp_path: Path) -> None:
+        tasks = tmp_path / "tasks"
+        arch_tasks = tmp_path / "arch_tasks"
+        delta_tasks = tmp_path / "delta_tasks"
+        tasks.mkdir()
+        arch_tasks.mkdir()
+        delta_tasks.mkdir()
+        (tasks / "task.yaml").write_text("""\
+task_id: task
+repo: owner/repo
+commit: abc
+question: "How?"
+expected_files:
+  - src/main.py
+""")
+        (arch_tasks / "arch.yaml").write_text("""\
+task_id: arch
+repo: "."
+commit: HEAD
+question: "Which architecture is present?"
+include_paths:
+  - src
+arch_oracle:
+  patterns:
+    - name: pattern
+""")
+        (delta_tasks / "delta.yaml").write_text("""\
+task_id: delta
+repo: "."
+base_commit: base
+delta_commit: delta
+expected_delta:
+  - src/main.py
+""")
+
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "validate",
+                "--kind",
+                "all",
+                "--tasks-dir",
+                str(tasks),
+                "--arch-tasks-dir",
+                str(arch_tasks),
+                "--delta-tasks-dir",
+                str(delta_tasks),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "1 task" in result.output
+        assert "1 architecture task" in result.output
+        assert "1 delta task" in result.output
+
+    def test_validate_reports_malformed_yaml(self, runner: CliRunner, tmp_path: Path) -> None:
+        tasks = tmp_path / "tasks"
+        tasks.mkdir()
+        (tasks / "bad.yaml").write_text("task_id: [unterminated")
+
+        result = runner.invoke(benchmark_cmd, ["validate", "--tasks-dir", str(tasks)])
+        assert result.exit_code != 0
+        assert "Failed to parse YAML" in result.output
 
 
 class TestRunCommand:

--- a/tests/benchmark/test_loader.py
+++ b/tests/benchmark/test_loader.py
@@ -87,10 +87,17 @@ expected_files:
         with pytest.raises(ValueError, match="Expected a YAML mapping"):
             load_task(p)
 
+    def test_load_malformed_yaml_includes_path(self, tmp_path: Path) -> None:
+        p = tmp_path / "malformed.yaml"
+        p.write_text("task_id: [unterminated")
+
+        with pytest.raises(ValueError, match=r"Failed to parse YAML in .*malformed\.yaml"):
+            load_task(p)
+
     def test_load_missing_fields(self, tmp_path: Path) -> None:
         p = tmp_path / "incomplete.yaml"
         p.write_text("task_id: test\nrepo: owner/repo\n")
-        with pytest.raises(Exception):  # noqa: B017 — Pydantic ValidationError
+        with pytest.raises(ValueError, match=r"incomplete\.yaml.*question"):
             load_task(p)
 
     def test_load_rejects_unknown_field_with_path(self, tmp_path: Path) -> None:
@@ -106,6 +113,64 @@ unexpected: true
 """)
 
         with pytest.raises(ValueError, match=r"unknown\.yaml.*unknown field 'unexpected'"):
+            load_task(p)
+
+    def test_load_rejects_empty_expected_files_with_path(self, tmp_path: Path) -> None:
+        p = tmp_path / "empty_expected.yaml"
+        p.write_text("""\
+task_id: empty_expected
+repo: owner/repo
+commit: abc
+question: "How?"
+expected_files: []
+""")
+
+        with pytest.raises(ValueError, match=r"empty_expected\.yaml.*expected_files"):
+            load_task(p)
+
+    def test_load_rejects_empty_question_with_path(self, tmp_path: Path) -> None:
+        p = tmp_path / "empty_question.yaml"
+        p.write_text("""\
+task_id: empty_question
+repo: owner/repo
+commit: abc
+question: "  "
+expected_files:
+  - src/main.py
+""")
+
+        with pytest.raises(ValueError, match=r"empty_question\.yaml.*question"):
+            load_task(p)
+
+    def test_load_rejects_invalid_category_with_path(self, tmp_path: Path) -> None:
+        p = tmp_path / "invalid_category.yaml"
+        p.write_text("""\
+task_id: invalid_category
+repo: owner/repo
+commit: abc
+category: invalid
+question: "How?"
+expected_files:
+  - src/main.py
+""")
+
+        with pytest.raises(ValueError, match=r"invalid_category\.yaml.*category"):
+            load_task(p)
+
+    def test_load_rejects_invalid_include_path_with_path(self, tmp_path: Path) -> None:
+        p = tmp_path / "invalid_include.yaml"
+        p.write_text("""\
+task_id: invalid_include
+repo: owner/repo
+commit: abc
+question: "How?"
+include_paths:
+  - ../src
+expected_files:
+  - src/main.py
+""")
+
+        with pytest.raises(ValueError, match=r"invalid_include\.yaml.*include_paths"):
             load_task(p)
 
 
@@ -367,6 +432,8 @@ task_id: delta_{i}
 repo: "."
 base_commit: base{i}
 delta_commit: delta{i}
+expected_delta:
+  - src/file_{i}.py
 """
             (tmp_path / f"delta_{i}.yaml").write_text(content)
         tasks = load_delta_tasks(tmp_path)
@@ -381,6 +448,8 @@ task_id: delta_duplicate
 repo: "."
 base_commit: base
 delta_commit: delta
+expected_delta:
+  - src/main.py
 """)
 
         with pytest.raises(


### PR DESCRIPTION
## Stack

Stack-Id: `benchmark-validation-g5`
Base: `main`
Position: 3/3

1. `fix/benchmark-strict-schema` -> #182
2. `fix/benchmark-duplicate-ids` -> #183
3. `feat/benchmark-validate-command` -> this PR

Depends on: #183
Upstack: none

## Validation

- Pass: `uv run ruff check && uv run ruff format --check . && uv run pyright && uv run pytest tests/benchmark/test_loader.py tests/benchmark/test_cli.py -q`
- Pass: `uv run archex benchmark validate --kind all`
- PR review: no blocking findings from pr-review methodology.

## Scope

- Add `archex benchmark validate --kind all` across benchmark, architecture, and delta task directories.
- Fail fast for malformed YAML, scalar YAML, unknown fields, duplicate IDs, empty required specs, invalid categories, invalid include paths, and missing local expected files before execution.