### PR TITLE
Add external MCP benchmark adapter

### DIFF
--- a/src/archex/benchmark/__init__.py
+++ b/src/archex/benchmark/__init__.py
@@ -9,6 +9,8 @@ from archex.benchmark.models import (
     DeltaBenchmarkResult,
     DeltaBenchmarkTask,
     DeltaStrategy,
+    ExternalToolBenchmarkConfig,
+    ExternalToolCommandConfig,
     Strategy,
     TaskCategory,
 )
@@ -20,6 +22,8 @@ __all__ = [
     "DeltaBenchmarkResult",
     "DeltaBenchmarkTask",
     "DeltaStrategy",
+    "ExternalToolBenchmarkConfig",
+    "ExternalToolCommandConfig",
     "Strategy",
     "TaskCategory",
 ]

--- a/src/archex/benchmark/external_mcp.py
+++ b/src/archex/benchmark/external_mcp.py
@@ -1,0 +1,328 @@
+"""External MCP-backed benchmark strategy."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import subprocess
+import time
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from archex.benchmark.models import (
+    BenchmarkResult,
+    BenchmarkTask,
+    ExternalToolBenchmarkConfig,
+    Strategy,
+)
+from archex.benchmark.strategies import (
+    compute_f1,
+    compute_map,
+    compute_mrr,
+    compute_ndcg,
+    compute_precision,
+    compute_recall,
+    compute_token_efficiency,
+    count_file_tokens,
+    now_iso,
+)
+from archex.reporting import count_tokens
+
+_EXTERNAL_TOOL_CONFIG: ContextVar[ExternalToolBenchmarkConfig | None] = ContextVar(
+    "external_tool_config", default=None
+)
+
+_CODE_PATH_RE = re.compile(
+    r"(?P<path>(?:[A-Za-z0-9_.@+-]+/)*[A-Za-z0-9_.@+-]+\."
+    r"(?:py|js|jsx|ts|tsx|go|rs|java|kt|cs|swift|md|yaml|yml|toml|json))"
+)
+
+
+class ExternalToolBenchmarkError(RuntimeError):
+    """Raised when an external MCP benchmark lane cannot produce a valid result."""
+
+
+@dataclass(frozen=True)
+class ExternalSearchHit:
+    """Normalized file-scoped result returned by an external MCP search tool."""
+
+    file_path: str
+    text: str
+
+
+def _deduplicate_paths(paths: list[str]) -> list[str]:
+    return list(dict.fromkeys(paths))
+
+
+def set_external_tool_config(
+    config: ExternalToolBenchmarkConfig,
+) -> Token[ExternalToolBenchmarkConfig | None]:
+    return _EXTERNAL_TOOL_CONFIG.set(config)
+
+
+def reset_external_tool_config(token: Token[ExternalToolBenchmarkConfig | None]) -> None:
+    _EXTERNAL_TOOL_CONFIG.reset(token)
+
+
+def current_external_tool_config() -> ExternalToolBenchmarkConfig:
+    config = _EXTERNAL_TOOL_CONFIG.get()
+    if config is None:
+        raise NotImplementedError("external_mcp requires an ExternalToolBenchmarkConfig")
+    return config
+
+
+def _run_bootstrap_commands(config: ExternalToolBenchmarkConfig, repo_path: Path) -> float:
+    if not config.bootstrap_commands:
+        return 0.0
+
+    total_elapsed_ms = 0.0
+    for step in config.bootstrap_commands:
+        command = [step.command, *step.args]
+        started = time.perf_counter()
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=repo_path,
+                env={**os.environ, **config.env} if config.env else None,
+                capture_output=True,
+                text=True,
+                timeout=step.timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise ExternalToolBenchmarkError(
+                f"bootstrap command timed out after {step.timeout_seconds}s: {command}"
+            ) from exc
+
+        total_elapsed_ms += (time.perf_counter() - started) * 1000
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip() or "no output"
+            raise ExternalToolBenchmarkError(
+                f"bootstrap command failed with exit {completed.returncode}: {detail}"
+            )
+    return total_elapsed_ms
+
+
+def _search_arguments(
+    config: ExternalToolBenchmarkConfig, task: BenchmarkTask
+) -> dict[str, object]:
+    arguments: dict[str, object] = {config.query_argument: task.question}
+    if config.limit_argument:
+        arguments[config.limit_argument] = config.limit
+    if config.path_argument and task.include_paths:
+        arguments[config.path_argument] = list(task.include_paths)
+    if config.language_argument and task.languages:
+        arguments[config.language_argument] = list(task.languages)
+    if config.extra_arguments:
+        arguments.update(config.extra_arguments)
+    return arguments
+
+
+async def _call_mcp_search(
+    config: ExternalToolBenchmarkConfig,
+    task: BenchmarkTask,
+    repo_path: Path,
+) -> tuple[object, float]:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    cwd = Path(config.cwd) if config.cwd else repo_path
+    server_params = StdioServerParameters(
+        command=config.command,
+        args=list(config.args),
+        env={**config.env} if config.env else None,
+        cwd=cwd,
+    )
+    try:
+        async with (
+            stdio_client(server_params) as (read_stream, write_stream),
+            ClientSession(read_stream, write_stream) as session,
+        ):
+            await asyncio.wait_for(session.initialize(), timeout=config.timeout_seconds)
+            started = time.perf_counter()
+            result = await asyncio.wait_for(
+                session.call_tool(config.search_tool, _search_arguments(config, task)),
+                timeout=config.timeout_seconds,
+            )
+            warm_ms = (time.perf_counter() - started) * 1000
+            return result, warm_ms
+    except TimeoutError as exc:
+        raise ExternalToolBenchmarkError(
+            f"MCP tool {config.search_tool!r} timed out after {config.timeout_seconds}s"
+        ) from exc
+
+
+def _relative_existing_path(repo_path: Path, value: str) -> str | None:
+    candidate = value.strip().strip("`'\" ,;()[]{}")
+    if "#L" in candidate:
+        candidate = candidate.split("#L", 1)[0]
+    if ":" in candidate:
+        prefix = candidate.split(":", 1)[0]
+        if (repo_path / prefix).is_file() or Path(prefix).is_file():
+            candidate = prefix
+    path = Path(candidate)
+    if path.is_absolute():
+        try:
+            path = path.resolve().relative_to(repo_path.resolve())
+        except ValueError:
+            return None
+    if path.is_absolute() or ".." in path.parts:
+        return None
+    normalized = path.as_posix().lstrip("./")
+    return normalized if (repo_path / normalized).is_file() else None
+
+
+def _string_value(mapping: dict[str, Any], keys: tuple[str, ...]) -> str:
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _hits_from_json_value(repo_path: Path, value: object) -> list[ExternalSearchHit]:
+    hits: list[ExternalSearchHit] = []
+    if isinstance(value, list):
+        for item in cast("list[object]", value):
+            hits.extend(_hits_from_json_value(repo_path, item))
+        return hits
+    if not isinstance(value, dict):
+        return hits
+
+    mapping = cast("dict[str, Any]", value)
+    path_value = _string_value(mapping, ("file_path", "filepath", "path", "file", "filename"))
+    normalized = _relative_existing_path(repo_path, path_value) if path_value else None
+    if normalized is not None:
+        text = _string_value(mapping, ("content", "code", "text", "snippet", "chunk"))
+        hits.append(ExternalSearchHit(file_path=normalized, text=text))
+        return hits
+
+    for child in mapping.values():
+        hits.extend(_hits_from_json_value(repo_path, child))
+    return hits
+
+
+def _hits_from_text(repo_path: Path, text: str) -> list[ExternalSearchHit]:
+    stripped = text.strip()
+    if stripped:
+        try:
+            decoded = json.loads(stripped)
+        except json.JSONDecodeError:
+            decoded = None
+        if decoded is not None:
+            hits = _hits_from_json_value(repo_path, decoded)
+            if hits:
+                return hits
+
+    hits: list[ExternalSearchHit] = []
+    seen: set[str] = set()
+    for match in _CODE_PATH_RE.finditer(text):
+        normalized = _relative_existing_path(repo_path, match.group("path"))
+        if normalized is not None and normalized not in seen:
+            seen.add(normalized)
+            hits.append(ExternalSearchHit(file_path=normalized, text=""))
+    return hits
+
+
+def _content_texts(result: object) -> list[str]:
+    content = getattr(result, "content", None)
+    if content is None:
+        return [str(result)]
+    texts: list[str] = []
+    for item in content:
+        text = getattr(item, "text", None)
+        if isinstance(text, str):
+            texts.append(text)
+        elif isinstance(item, str):
+            texts.append(item)
+        elif hasattr(item, "model_dump"):
+            texts.append(json.dumps(item.model_dump(mode="json")))
+        else:
+            texts.append(str(item))
+    return texts
+
+
+def normalize_external_search_result(repo_path: Path, result: object) -> list[ExternalSearchHit]:
+    """Normalize MCP search output into ordered, file-scoped hits."""
+    hits: list[ExternalSearchHit] = []
+    for text in _content_texts(result):
+        hits.extend(_hits_from_text(repo_path, text))
+    return hits
+
+
+def _external_output_tokens(repo_path: Path, hits: list[ExternalSearchHit]) -> tuple[int, str]:
+    total = 0
+    token_mode = "chunk_text"
+    full_file_paths: list[str] = []
+    for hit in hits:
+        if hit.text:
+            total += count_tokens(hit.text)
+        else:
+            token_mode = "chunk_text_with_full_file_fallback"
+            full_file_paths.append(hit.file_path)
+    if full_file_paths:
+        total += count_file_tokens(repo_path, _deduplicate_paths(full_file_paths))
+    return total, token_mode
+
+
+def run_external_mcp(
+    task: BenchmarkTask,
+    repo_path: Path,
+    config: ExternalToolBenchmarkConfig | None = None,
+) -> BenchmarkResult:
+    """Run a configured external MCP search tool and score file-scoped results."""
+    config = config or current_external_tool_config()
+    total_started = time.perf_counter()
+    cold_start_ms = _run_bootstrap_commands(config, repo_path)
+    result, warm_latency_ms = asyncio.run(_call_mcp_search(config, task, repo_path))
+    hits = normalize_external_search_result(repo_path, result)
+    ranked_files = [hit.file_path for hit in hits]
+    unique_files = _deduplicate_paths(ranked_files)
+    result_files = set(unique_files)
+    tokens_input = count_file_tokens(repo_path, unique_files)
+    tokens_output, token_mode = _external_output_tokens(repo_path, hits)
+    recall = compute_recall(result_files, task.expected_files)
+    precision = compute_precision(result_files, task.expected_files)
+    wall_ms = (time.perf_counter() - total_started) * 1000
+
+    return BenchmarkResult(
+        task_id=task.task_id,
+        strategy=Strategy.EXTERNAL_MCP,
+        strategy_label=config.name,
+        tokens_total=tokens_output,
+        tokens_input=tokens_input,
+        tokens_output=tokens_output,
+        token_efficiency=compute_token_efficiency(tokens_output, tokens_input),
+        tokens_raw_baseline=count_file_tokens(repo_path, task.expected_files),
+        tool_calls=1 + len(config.bootstrap_commands),
+        files_accessed=len(result_files),
+        recall=recall,
+        precision=precision,
+        f1_score=compute_f1(recall, precision),
+        mrr=compute_mrr(ranked_files, task.expected_files),
+        ndcg=compute_ndcg(ranked_files, task.expected_files),
+        map_score=compute_map(ranked_files, task.expected_files),
+        savings_vs_raw=0.0,
+        wall_time_ms=wall_ms,
+        cached=not bool(config.bootstrap_commands),
+        timestamp=now_iso(),
+        unique_ranked_files=len(unique_files),
+        seed_files=unique_files,
+        result_files=unique_files,
+        cold_start_ms=cold_start_ms,
+        warm_latency_ms=warm_latency_ms,
+        cache_state="cold" if config.bootstrap_commands else "warm",
+        provenance={
+            "external_tool": config.name,
+            "external_tool_version": config.version,
+            "external_tool_embedder": config.embedder,
+            "external_tool_command": " ".join([config.command, *config.args]),
+            "external_tool_search_tool": config.search_tool,
+            "external_tool_token_mode": token_mode,
+            "external_tool_result_count": str(len(hits)),
+            "external_tool_bootstrap_count": str(len(config.bootstrap_commands)),
+        },
+    )

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -24,6 +24,7 @@ class Strategy(StrEnum):
     CROSS_LAYER_FUSION = "cross_layer_fusion"
     ARCHEX_QUERY_FUSION_RERANK = "archex_query_fusion_rerank"
     ARCHEX_SYMBOL_LOOKUP = "archex_symbol_lookup"
+    EXTERNAL_MCP = "external_mcp"
 
 
 class TaskCategory(StrEnum):
@@ -141,9 +142,35 @@ class BenchmarkRetrievalOptions(BaseModel):
     rerank_model: str | None = None
 
 
+class ExternalToolCommandConfig(BenchmarkSpecModel):
+    command: str
+    args: list[str] = []
+    timeout_seconds: float = 600.0
+
+
+class ExternalToolBenchmarkConfig(BenchmarkSpecModel):
+    name: str
+    version: str
+    command: str
+    args: list[str] = []
+    embedder: str
+    cwd: str | None = None
+    env: dict[str, str] = {}
+    search_tool: str = "search"
+    query_argument: str = "query"
+    path_argument: str | None = "paths"
+    language_argument: str | None = "languages"
+    limit_argument: str | None = "limit"
+    limit: int = 10
+    extra_arguments: dict[str, object] = {}
+    timeout_seconds: float = 120.0
+    bootstrap_commands: list[ExternalToolCommandConfig] = []
+
+
 class BenchmarkResult(BaseModel):
     task_id: str
     strategy: Strategy
+    strategy_label: str | None = None
     tokens_total: int
     tool_calls: int
     files_accessed: int
@@ -183,6 +210,10 @@ class BenchmarkResult(BaseModel):
     cache_state: str = "cold"
     expansion_reason_counts: dict[str, int] = {}
     expanded_file_reasons: dict[str, list[str]] = {}
+    result_files: list[str] = []
+    cold_start_ms: float = 0.0
+    warm_latency_ms: float = 0.0
+    provenance: dict[str, str] = {}
 
 
 class BenchmarkReport(BaseModel):

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -1176,6 +1176,12 @@ class StrategyRegistry:
         self._entry_points_strict = strict
 
 
+def _run_external_mcp_strategy(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
+    from archex.benchmark.external_mcp import run_external_mcp
+
+    return run_external_mcp(task, repo_path)
+
+
 default_strategy_registry = StrategyRegistry()
 default_strategy_registry.register(Strategy.RAW_FILES.value, run_raw_files)
 default_strategy_registry.register(Strategy.RAW_GREPPED.value, run_raw_grepped)
@@ -1188,3 +1194,4 @@ default_strategy_registry.register(
 )
 default_strategy_registry.register(Strategy.CROSS_LAYER_FUSION.value, run_cross_layer_fusion)
 default_strategy_registry.register(Strategy.ARCHEX_SYMBOL_LOOKUP.value, run_archex_symbol_lookup)
+default_strategy_registry.register(Strategy.EXTERNAL_MCP.value, _run_external_mcp_strategy)

--- a/tests/benchmark/test_external_mcp.py
+++ b/tests/benchmark/test_external_mcp.py
@@ -1,0 +1,150 @@
+"""Tests for external MCP benchmark strategy."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from archex.benchmark.external_mcp import normalize_external_search_result, run_external_mcp
+from archex.benchmark.models import (
+    BenchmarkTask,
+    ExternalToolBenchmarkConfig,
+    ExternalToolCommandConfig,
+    Strategy,
+)
+
+
+def _write_fixture_repo(path: Path) -> None:
+    source = path / "src"
+    source.mkdir()
+    (source / "main.py").write_text("def target() -> None:\n    pass\n", encoding="utf-8")
+    (source / "support.py").write_text("class Helper:\n    pass\n", encoding="utf-8")
+
+
+def test_normalize_external_json_result_keeps_existing_files(tmp_path: Path) -> None:
+    _write_fixture_repo(tmp_path)
+    result = SimpleNamespace(
+        content=[
+            SimpleNamespace(
+                text='{"results": [{"file_path": "src/main.py", "content": "def target"}]}'
+            )
+        ]
+    )
+
+    hits = normalize_external_search_result(tmp_path, result)
+
+    assert [(hit.file_path, hit.text) for hit in hits] == [("src/main.py", "def target")]
+
+
+def test_run_external_mcp_runs_bootstrap_commands(tmp_path: Path) -> None:
+    _write_fixture_repo(tmp_path)
+    bootstrap_marker = tmp_path / "bootstrap.txt"
+    server = tmp_path / "server.py"
+    server.write_text(
+        """\
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("benchmark-fixture", json_response=True)
+
+
+@mcp.tool()
+def search(query: str, limit: int = 10, paths: list[str] | None = None) -> list[dict[str, str]]:
+    del query, limit, paths
+    return [{"file_path": "src/main.py", "content": "def target() -> None:"}]
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")
+""",
+        encoding="utf-8",
+    )
+    task = BenchmarkTask(
+        task_id="external_fixture_bootstrap",
+        repo="owner/repo",
+        commit="abc123",
+        question="Where is target defined?",
+        expected_files=["src/main.py"],
+        include_paths=["src"],
+        languages=["python"],
+    )
+    bootstrap_script = (
+        "from pathlib import Path; "
+        f"Path({str(bootstrap_marker)!r}).write_text('ok', encoding='utf-8')"
+    )
+    config = ExternalToolBenchmarkConfig(
+        name="fixture-mcp",
+        version="1.0.0",
+        command=sys.executable,
+        args=[str(server)],
+        embedder="fixture-local",
+        timeout_seconds=20,
+        bootstrap_commands=[
+            ExternalToolCommandConfig(
+                command=sys.executable,
+                args=["-c", bootstrap_script],
+                timeout_seconds=5,
+            )
+        ],
+    )
+
+    result = run_external_mcp(task, tmp_path, config)
+
+    assert bootstrap_marker.read_text(encoding="utf-8") == "ok"
+    assert result.tool_calls == 2
+    assert result.cold_start_ms >= 0.0
+    assert result.provenance["external_tool_bootstrap_count"] == "1"
+
+
+def test_run_external_mcp_scores_fixture_server(tmp_path: Path) -> None:
+    _write_fixture_repo(tmp_path)
+    server = tmp_path / "server.py"
+    server.write_text(
+        """\
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("benchmark-fixture", json_response=True)
+
+
+@mcp.tool()
+def search(query: str, limit: int = 10, paths: list[str] | None = None) -> list[dict[str, str]]:
+    del query, limit, paths
+    return [
+        {"file_path": "src/main.py", "content": "def target() -> None:"},
+        {"file_path": "src/support.py", "content": "class Helper:"},
+    ]
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")
+""",
+        encoding="utf-8",
+    )
+    task = BenchmarkTask(
+        task_id="external_fixture",
+        repo="owner/repo",
+        commit="abc123",
+        question="Where is target defined?",
+        expected_files=["src/main.py"],
+        include_paths=["src"],
+        languages=["python"],
+    )
+    config = ExternalToolBenchmarkConfig(
+        name="fixture-mcp",
+        version="1.0.0",
+        command=sys.executable,
+        args=[str(server)],
+        embedder="fixture-local",
+        timeout_seconds=20,
+    )
+
+    result = run_external_mcp(task, tmp_path, config)
+
+    assert result.strategy is Strategy.EXTERNAL_MCP
+    assert result.strategy_label == "fixture-mcp"
+    assert result.result_files == ["src/main.py", "src/support.py"]
+    assert result.recall == 1.0
+    assert result.precision == 0.5
+    assert result.tool_calls == 1
+    assert result.warm_latency_ms >= 0.0
+    assert result.provenance["external_tool_version"] == "1.0.0"

--- a/tests/benchmark/test_models.py
+++ b/tests/benchmark/test_models.py
@@ -29,6 +29,7 @@ class TestStrategy:
         assert Strategy.CROSS_LAYER_FUSION == "cross_layer_fusion"
         assert Strategy.ARCHEX_QUERY_FUSION_RERANK == "archex_query_fusion_rerank"
         assert Strategy.ARCHEX_SYMBOL_LOOKUP == "archex_symbol_lookup"
+        assert Strategy.EXTERNAL_MCP == "external_mcp"
 
     def test_enum_from_value(self) -> None:
         assert Strategy("raw_files") is Strategy.RAW_FILES

--- a/tests/integrations/test_lsap.py
+++ b/tests/integrations/test_lsap.py
@@ -102,7 +102,7 @@ class TestHoverEnrichment:
 
         client = _mock_client()
         lookup = LSAPEnrichedLookup(lsp_client=client)
-        hover = asyncio.get_event_loop().run_until_complete(lookup.get_hover("src/repo.py", 10))
+        hover = asyncio.run(lookup.get_hover("src/repo.py", 10))
         assert isinstance(hover, HoverInfo)
         assert "get_user" in hover.type_signature
         assert hover.documentation == "Fetch a user by ID."
@@ -114,7 +114,7 @@ class TestHoverEnrichment:
         client = _mock_client()
         client.request_hover = AsyncMock(return_value=None)
         lookup = LSAPEnrichedLookup(lsp_client=client)
-        hover = asyncio.get_event_loop().run_until_complete(lookup.get_hover("src/repo.py", 10))
+        hover = asyncio.run(lookup.get_hover("src/repo.py", 10))
         assert hover.type_signature == ""
         assert hover.raw_content == ""
 
@@ -125,7 +125,7 @@ class TestReferences:
 
         client = _mock_client()
         lookup = LSAPEnrichedLookup(lsp_client=client)
-        refs = asyncio.get_event_loop().run_until_complete(lookup.get_references("src/repo.py", 10))
+        refs = asyncio.run(lookup.get_references("src/repo.py", 10))
         assert len(refs) == 2
         assert all(isinstance(r, ReferenceLocation) for r in refs)
         assert refs[0].file_path == "src/service.py"
@@ -138,7 +138,7 @@ class TestReferences:
         client = _mock_client()
         client.request_references = AsyncMock(return_value=None)
         lookup = LSAPEnrichedLookup(lsp_client=client)
-        refs = asyncio.get_event_loop().run_until_complete(lookup.get_references("src/repo.py", 10))
+        refs = asyncio.run(lookup.get_references("src/repo.py", 10))
         assert refs == []
 
 
@@ -148,7 +148,7 @@ class TestDefinition:
 
         client = _mock_client()
         lookup = LSAPEnrichedLookup(lsp_client=client)
-        defn = asyncio.get_event_loop().run_until_complete(lookup.get_definition("src/repo.py", 10))
+        defn = asyncio.run(lookup.get_definition("src/repo.py", 10))
         assert isinstance(defn, DefinitionLocation)
         assert defn.file_path == "src/repo.py"
         assert defn.line == 10
@@ -159,7 +159,7 @@ class TestDefinition:
         client = _mock_client()
         client.request_definition = AsyncMock(return_value=None)
         lookup = LSAPEnrichedLookup(lsp_client=client)
-        defn = asyncio.get_event_loop().run_until_complete(lookup.get_definition("src/repo.py", 10))
+        defn = asyncio.run(lookup.get_definition("src/repo.py", 10))
         assert defn is None
 
 
@@ -170,7 +170,7 @@ class TestEnrichSymbol:
         client = _mock_client()
         lookup = LSAPEnrichedLookup(lsp_client=client)
         symbol = _make_symbol()
-        enriched = asyncio.get_event_loop().run_until_complete(lookup.enrich_symbol(symbol))
+        enriched = asyncio.run(lookup.enrich_symbol(symbol))
         assert enriched.lsap_enrichment is not None
         enr = enriched.lsap_enrichment
         assert enr.hover is not None
@@ -189,7 +189,7 @@ class TestEnrichSymbol:
         client.request_hover = AsyncMock(side_effect=RuntimeError("server error"))
         lookup = LSAPEnrichedLookup(lsp_client=client)
         symbol = _make_symbol()
-        enriched = asyncio.get_event_loop().run_until_complete(lookup.enrich_symbol(symbol))
+        enriched = asyncio.run(lookup.enrich_symbol(symbol))
         assert enriched.lsap_enrichment is not None
         enr = enriched.lsap_enrichment
         assert enr.hover is None  # failed
@@ -207,9 +207,7 @@ class TestBatchConcurrency:
             _make_symbol(name=f"method_{i}", sid=f"src/repo.py::method_{i}#method")
             for i in range(10)
         ]
-        enriched = asyncio.get_event_loop().run_until_complete(
-            lookup.enrich_symbols_batch(symbols, concurrency=3)
-        )
+        enriched = asyncio.run(lookup.enrich_symbols_batch(symbols, concurrency=3))
         assert len(enriched) == 10
         assert all(s.lsap_enrichment is not None for s in enriched)
         # Verify hover was called for each symbol.
@@ -269,9 +267,7 @@ class TestPatternVerifier:
         pattern = self._make_repository_pattern()
         parsed_files = [self._make_parsed_file()]
 
-        adjusted = asyncio.get_event_loop().run_until_complete(
-            verify_repository_pattern(lookup, pattern, parsed_files)
-        )
+        adjusted = asyncio.run(verify_repository_pattern(lookup, pattern, parsed_files))
         assert adjusted is not None
         assert adjusted > pattern.confidence  # boosted
 
@@ -289,9 +285,7 @@ class TestPatternVerifier:
         pattern = self._make_repository_pattern()
         parsed_files = [self._make_parsed_file()]
 
-        adjusted = asyncio.get_event_loop().run_until_complete(
-            verify_repository_pattern(lookup, pattern, parsed_files)
-        )
+        adjusted = asyncio.run(verify_repository_pattern(lookup, pattern, parsed_files))
         assert adjusted is not None
         assert adjusted < pattern.confidence  # reduced
 
@@ -308,7 +302,5 @@ class TestPatternVerifier:
             confidence=0.85,
             evidence=[],
         )
-        result = asyncio.get_event_loop().run_until_complete(
-            verify_repository_pattern(lookup, pattern, [])
-        )
+        result = asyncio.run(verify_repository_pattern(lookup, pattern, []))
         assert result is None


### PR DESCRIPTION
## Stack

Stack-Id: `headtohead-c1-20260611`
Base: `main`
Position: 1/4

1. `feat/headtohead-adapter` -> this PR
2. `feat/headtohead-manifest`
3. `feat/headtohead-token-parity`
4. `feat/headtohead-report`

Depends on: (none - root)
Upstack: `feat/headtohead-manifest`

## Summary

- Adds the `external_mcp` benchmark strategy and config model.
- Launches a configured MCP stdio server, calls its `search` tool per task, normalizes file-scoped hits, records cold-start/warm timings, and preserves provenance.
- Covers the MCP contract with a fixture server test.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright` — passed on this branch.
- `uv run pytest tests/benchmark/ -q` — passed on this branch (281 passed, 2 deselected).
- pr-review: manual diff review completed; no blocking findings after formatting fix.