### PR TITLE
Add head-to-head comparison manifest loader

### DIFF
--- a/src/archex/benchmark/__init__.py
+++ b/src/archex/benchmark/__init__.py
@@ -11,6 +11,8 @@ from archex.benchmark.models import (
     DeltaStrategy,
     ExternalToolBenchmarkConfig,
     ExternalToolCommandConfig,
+    HeadToHeadArchexConfig,
+    HeadToHeadManifest,
     Strategy,
     TaskCategory,
 )
@@ -24,6 +26,8 @@ __all__ = [
     "DeltaStrategy",
     "ExternalToolBenchmarkConfig",
     "ExternalToolCommandConfig",
+    "HeadToHeadArchexConfig",
+    "HeadToHeadManifest",
     "Strategy",
     "TaskCategory",
 ]

--- a/src/archex/benchmark/headtohead.py
+++ b/src/archex/benchmark/headtohead.py
@@ -1,0 +1,146 @@
+"""Head-to-head benchmark manifest loading and task selection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypeVar, cast
+
+import yaml
+from pydantic import BaseModel, ValidationError
+
+from archex.benchmark.loader import load_tasks
+from archex.benchmark.models import BenchmarkTask, HeadToHeadManifest, Strategy, TaskCategory
+
+ManifestModel = TypeVar("ManifestModel", bound=BaseModel)
+
+
+class HeadToHeadManifestError(ValueError):
+    """Raised when the public comparison manifest is invalid."""
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, object]:
+    raw = path.read_text(encoding="utf-8")
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise HeadToHeadManifestError(f"Failed to parse YAML in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise HeadToHeadManifestError(
+            f"Expected a YAML mapping in {path}, got {type(data).__name__}"
+        )
+    return cast("dict[str, object]", data)
+
+
+def _format_manifest_validation_error(path: Path, exc: ValidationError) -> str:
+    messages: list[str] = []
+    for error in exc.errors():
+        loc = ".".join(str(part) for part in error["loc"])
+        field = loc or "<root>"
+        if error["type"] == "extra_forbidden":
+            messages.append(f"unknown field {field!r}: {error['msg']}")
+        else:
+            messages.append(f"{field}: {error['msg']}")
+    return f"Invalid head-to-head manifest in {path}: " + "; ".join(messages)
+
+
+def _validate_yaml_model(path: Path, model: type[ManifestModel]) -> ManifestModel:
+    try:
+        return model.model_validate(_load_yaml_mapping(path))
+    except ValidationError as exc:
+        raise HeadToHeadManifestError(_format_manifest_validation_error(path, exc)) from exc
+
+
+def _reject_empty_text(path: Path, field: str, value: str) -> None:
+    if not value.strip():
+        raise HeadToHeadManifestError(f"Invalid head-to-head manifest in {path}: {field}: empty")
+
+
+def _reject_unpinned_version(path: Path, tool_name: str, version: str) -> None:
+    normalized = version.strip().lower()
+    if normalized in {"", "latest", "head", "main", "operator-pinned"}:
+        raise HeadToHeadManifestError(
+            f"Invalid head-to-head manifest in {path}: external_tools.{tool_name}.version "
+            "must pin an exact released version"
+        )
+
+
+def _validate_manifest_shape(path: Path, manifest: HeadToHeadManifest) -> None:
+    if manifest.manifest_version != 1:
+        raise HeadToHeadManifestError(
+            f"Invalid head-to-head manifest in {path}: manifest_version must be 1"
+        )
+    _reject_empty_text(path, "name", manifest.name)
+    _reject_empty_text(path, "hardware_notes", manifest.hardware_notes)
+    if not manifest.task_subset:
+        raise HeadToHeadManifestError(
+            f"Invalid head-to-head manifest in {path}: task_subset must not be empty"
+        )
+    if len(set(manifest.task_subset)) != len(manifest.task_subset):
+        raise HeadToHeadManifestError(
+            f"Invalid head-to-head manifest in {path}: task_subset contains duplicate task ids"
+        )
+    if not manifest.archex.local_models_only:
+        raise HeadToHeadManifestError(
+            f"Invalid head-to-head manifest in {path}: archex.local_models_only must be true"
+        )
+    if manifest.archex.strategy is not Strategy.ARCHEX_QUERY:
+        raise HeadToHeadManifestError(
+            f"Invalid head-to-head manifest in {path}: archex.strategy must be archex_query"
+        )
+    if manifest.raw_read_strategy is not Strategy.RAW_GREPPED:
+        raise HeadToHeadManifestError(
+            f"Invalid head-to-head manifest in {path}: raw_read_strategy must be raw_grepped"
+        )
+    if not manifest.external_tools:
+        raise HeadToHeadManifestError(
+            f"Invalid head-to-head manifest in {path}: external_tools must not be empty"
+        )
+    seen_tools: set[str] = set()
+    for tool in manifest.external_tools:
+        _reject_empty_text(path, f"external_tools.{tool.name}.name", tool.name)
+        _reject_empty_text(path, f"external_tools.{tool.name}.command", tool.command)
+        _reject_empty_text(path, f"external_tools.{tool.name}.embedder", tool.embedder)
+        _reject_unpinned_version(path, tool.name, tool.version)
+        if tool.name in seen_tools:
+            raise HeadToHeadManifestError(
+                f"Invalid head-to-head manifest in {path}: duplicate external tool {tool.name!r}"
+            )
+        seen_tools.add(tool.name)
+
+
+def load_headtohead_manifest(path: Path) -> HeadToHeadManifest:
+    """Load and strictly validate a public head-to-head comparison manifest."""
+    manifest = _validate_yaml_model(path, HeadToHeadManifest)
+    _validate_manifest_shape(path, manifest)
+    return manifest
+
+
+def select_headtohead_tasks(
+    manifest: HeadToHeadManifest,
+    tasks_dir: Path,
+) -> list[BenchmarkTask]:
+    """Select the manifest-pinned external task subset in manifest order."""
+    all_tasks = {task.task_id: task for task in load_tasks(tasks_dir)}
+    missing = [task_id for task_id in manifest.task_subset if task_id not in all_tasks]
+    if missing:
+        raise HeadToHeadManifestError(
+            "Head-to-head manifest references unknown task ids: " + ", ".join(missing)
+        )
+
+    selected = [all_tasks[task_id] for task_id in manifest.task_subset]
+    self_tasks = [
+        task.task_id for task in selected if task.repo == "." or task.category == TaskCategory.SELF
+    ]
+    if self_tasks:
+        raise HeadToHeadManifestError(
+            "Head-to-head task subset must exclude self-repo tasks: " + ", ".join(self_tasks)
+        )
+    return selected
+
+
+def load_headtohead_tasks(
+    manifest_path: Path, tasks_dir: Path
+) -> tuple[HeadToHeadManifest, list[BenchmarkTask]]:
+    """Load a manifest and its external benchmark tasks."""
+    manifest = load_headtohead_manifest(manifest_path)
+    return manifest, select_headtohead_tasks(manifest, tasks_dir)

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from archex.models import (  # noqa: TCH001 — Pydantic needs at runtime
     DeltaMeta,
@@ -165,6 +165,22 @@ class ExternalToolBenchmarkConfig(BenchmarkSpecModel):
     extra_arguments: dict[str, object] = {}
     timeout_seconds: float = 120.0
     bootstrap_commands: list[ExternalToolCommandConfig] = []
+
+
+class HeadToHeadArchexConfig(BenchmarkSpecModel):
+    strategy: Strategy = Strategy.ARCHEX_QUERY
+    embedder: str = "jina-v2"
+    local_models_only: bool = True
+
+
+class HeadToHeadManifest(BenchmarkSpecModel):
+    manifest_version: int = 1
+    name: str
+    hardware_notes: str
+    task_subset: list[str]
+    archex: HeadToHeadArchexConfig = Field(default_factory=HeadToHeadArchexConfig)
+    external_tools: list[ExternalToolBenchmarkConfig]
+    raw_read_strategy: Strategy = Strategy.RAW_GREPPED
 
 
 class BenchmarkResult(BaseModel):

--- a/tests/benchmark/test_headtohead.py
+++ b/tests/benchmark/test_headtohead.py
@@ -1,0 +1,113 @@
+"""Tests for head-to-head benchmark manifest loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from archex.benchmark.headtohead import (
+    HeadToHeadManifestError,
+    load_headtohead_manifest,
+    load_headtohead_tasks,
+)
+
+
+def _write_task(path: Path, task_id: str, repo: str, category: str) -> None:
+    path.write_text(
+        f'''\
+task_id: {task_id}
+repo: "{repo}"
+commit: abc123
+category: {category}
+question: "How does this work?"
+expected_files:
+  - src/main.py
+''',
+        encoding="utf-8",
+    )
+
+
+def _manifest_text(task_subset: list[str]) -> str:
+    tasks_yaml = "\n".join(f"  - {task_id}" for task_id in task_subset)
+    return f"""\
+manifest_version: 1
+name: public-c1-comparison
+hardware_notes: "Apple M1 Pro, local models only"
+task_subset:
+{tasks_yaml}
+archex:
+  strategy: archex_query
+  embedder: jina-v2
+  local_models_only: true
+external_tools:
+  - name: ccc
+    version: "0.2.35"
+    command: ccc
+    args: [mcp]
+    embedder: Snowflake/snowflake-arctic-embed-xs
+    bootstrap_commands:
+      - command: ccc
+        args: [init, -f]
+      - command: ccc
+        args: [index]
+raw_read_strategy: raw_grepped
+"""
+
+
+def test_load_headtohead_manifest_accepts_pinned_external_tool(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(_manifest_text(["external_task"]), encoding="utf-8")
+
+    manifest = load_headtohead_manifest(manifest_path)
+
+    assert manifest.name == "public-c1-comparison"
+    assert manifest.external_tools[0].version == "0.2.35"
+    assert manifest.external_tools[0].embedder == "Snowflake/snowflake-arctic-embed-xs"
+    assert len(manifest.external_tools[0].bootstrap_commands) == 2
+
+
+def test_load_headtohead_manifest_rejects_unknown_fields(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(
+        _manifest_text(["external_task"]) + "unexpected: true\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(HeadToHeadManifestError, match="unknown field 'unexpected'"):
+        load_headtohead_manifest(manifest_path)
+
+
+def test_load_headtohead_manifest_rejects_unpinned_tool_version(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(
+        _manifest_text(["external_task"]).replace('version: "0.2.35"', "version: latest"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(HeadToHeadManifestError, match="must pin an exact released version"):
+        load_headtohead_manifest(manifest_path)
+
+
+def test_load_headtohead_tasks_selects_external_subset_in_order(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    _write_task(tasks_dir / "a.yaml", "task_a", "owner/repo", "external-framework")
+    _write_task(tasks_dir / "b.yaml", "task_b", "owner/repo", "external-large")
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(_manifest_text(["task_b", "task_a"]), encoding="utf-8")
+
+    _, tasks = load_headtohead_tasks(manifest_path, tasks_dir)
+
+    assert [task.task_id for task in tasks] == ["task_b", "task_a"]
+
+
+def test_load_headtohead_tasks_rejects_self_repo_subset(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    _write_task(tasks_dir / "self.yaml", "self_task", ".", "self")
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(_manifest_text(["self_task"]), encoding="utf-8")
+
+    with pytest.raises(HeadToHeadManifestError, match="exclude self-repo"):
+        load_headtohead_tasks(manifest_path, tasks_dir)


### PR DESCRIPTION
## Stack

Stack-Id: `headtohead-c1-20260611`
Base: `main`
Position: 2/4

1. `feat/headtohead-adapter` -> #185
2. `feat/headtohead-manifest` -> this PR
3. `feat/headtohead-token-parity`
4. `feat/headtohead-report`

Depends on: #185
Upstack: `feat/headtohead-token-parity`

## Summary

- Adds strict `HeadToHeadManifest` models and loader helpers.
- Selects the manifest-pinned external task subset in manifest order.
- Rejects self-repo tasks, unknown fields, duplicate task ids, unpinned external versions, and non-local archex settings.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright` — passed on this branch.
- `uv run pytest tests/benchmark/ -q` — passed on this branch (286 passed, 2 deselected).
- pr-review: manual diff review completed; no blocking findings after formatting fix.