### PR TITLE
Add head-to-head token parity accounting

### DIFF
--- a/src/archex/benchmark/external_mcp.py
+++ b/src/archex/benchmark/external_mcp.py
@@ -20,6 +20,7 @@ from archex.benchmark.models import (
     Strategy,
 )
 from archex.benchmark.strategies import (
+    compute_bundle_completion_penalty,
     compute_f1,
     compute_map,
     compute_mrr,
@@ -284,6 +285,9 @@ def run_external_mcp(
     result_files = set(unique_files)
     tokens_input = count_file_tokens(repo_path, unique_files)
     tokens_output, token_mode = _external_output_tokens(repo_path, hits)
+    completion_tokens, completion_files = compute_bundle_completion_penalty(
+        repo_path, result_files, task.expected_files
+    )
     recall = compute_recall(result_files, task.expected_files)
     precision = compute_precision(result_files, task.expected_files)
     wall_ms = (time.perf_counter() - total_started) * 1000
@@ -296,6 +300,11 @@ def run_external_mcp(
         tokens_input=tokens_input,
         tokens_output=tokens_output,
         token_efficiency=compute_token_efficiency(tokens_output, tokens_input),
+        bundle_completion_tokens=completion_tokens,
+        bundle_completion_files=completion_files,
+        token_efficiency_with_completion=compute_token_efficiency(
+            tokens_output + completion_tokens, tokens_input + completion_tokens
+        ),
         tokens_raw_baseline=count_file_tokens(repo_path, task.expected_files),
         tool_calls=1 + len(config.bootstrap_commands),
         files_accessed=len(result_files),

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -227,6 +227,9 @@ class BenchmarkResult(BaseModel):
     expansion_reason_counts: dict[str, int] = {}
     expanded_file_reasons: dict[str, list[str]] = {}
     result_files: list[str] = []
+    bundle_completion_tokens: int = 0
+    bundle_completion_files: list[str] = []
+    token_efficiency_with_completion: float = 0.0
     cold_start_ms: float = 0.0
     warm_latency_ms: float = 0.0
     provenance: dict[str, str] = {}

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -267,6 +267,16 @@ def compute_token_efficiency(tokens_output: int, tokens_input: int) -> float:
     return max(0.0, min(1.0, ratio))
 
 
+def compute_bundle_completion_penalty(
+    repo_path: Path,
+    result_files: set[str],
+    expected_files: list[str],
+) -> tuple[int, list[str]]:
+    """Return extra oracle-file tokens needed after an incomplete result bundle."""
+    missing_files = [path for path in expected_files if path not in result_files]
+    return count_file_tokens(repo_path, missing_files), missing_files
+
+
 def run_raw_files(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Baseline strategy: read all expected files, count tokens."""
     t0 = time.perf_counter()
@@ -280,6 +290,8 @@ def run_raw_files(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         tokens_input=tokens,
         tokens_output=tokens,
         token_efficiency=compute_token_efficiency(tokens, tokens),
+        result_files=list(task.expected_files),
+        token_efficiency_with_completion=compute_token_efficiency(tokens, tokens),
         tokens_raw_baseline=tokens,
         tool_calls=len(task.expected_files),
         files_accessed=len(task.expected_files),
@@ -343,6 +355,10 @@ def run_raw_grepped(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     mrr_val = compute_mrr(matched_files_ordered, task.expected_files)
     ndcg_val = compute_ndcg(matched_files_ordered, task.expected_files)
     map_val = compute_map(matched_files_ordered, task.expected_files)
+    completion_tokens, completion_files = compute_bundle_completion_penalty(
+        repo_path, matched_files_seen, task.expected_files
+    )
+    tokens_with_completion = tokens + completion_tokens
 
     return BenchmarkResult(
         task_id=task.task_id,
@@ -351,6 +367,12 @@ def run_raw_grepped(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         tokens_input=tokens,
         tokens_output=tokens,
         token_efficiency=compute_token_efficiency(tokens, tokens),
+        result_files=_deduplicate_ranked(matched_files_ordered),
+        bundle_completion_tokens=completion_tokens,
+        bundle_completion_files=completion_files,
+        token_efficiency_with_completion=compute_token_efficiency(
+            tokens_with_completion, tokens + completion_tokens
+        ),
         tokens_raw_baseline=tokens_raw_baseline,
         tool_calls=len(keywords),
         files_accessed=len(matched_files_seen),
@@ -663,7 +685,8 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     )
 
     ranked_files = [c.chunk.file_path for c in bundle.chunks]
-    result_files = set(_deduplicate_ranked(ranked_files))
+    unique_ranked = _deduplicate_ranked(ranked_files)
+    result_files = set(unique_ranked)
     wall_ms = (time.perf_counter() - t0) * 1000
     recall = compute_recall(result_files, task.expected_files)
     precision = compute_precision(result_files, task.expected_files)
@@ -672,6 +695,9 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     ndcg_val = compute_ndcg(ranked_files, task.expected_files)
     map_val = compute_map(ranked_files, task.expected_files)
     af = _archex_fields(bundle, task, repo_path)
+    completion_tokens, completion_files = compute_bundle_completion_penalty(
+        repo_path, result_files, task.expected_files
+    )
 
     return BenchmarkResult(
         task_id=task.task_id,
@@ -680,6 +706,12 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         tokens_input=af.tokens_input,
         tokens_output=af.tokens_output,
         token_efficiency=af.token_efficiency,
+        result_files=unique_ranked,
+        bundle_completion_tokens=completion_tokens,
+        bundle_completion_files=completion_files,
+        token_efficiency_with_completion=compute_token_efficiency(
+            af.tokens_output + completion_tokens, af.tokens_input + completion_tokens
+        ),
         tokens_raw_baseline=af.tokens_raw_baseline,
         symbol_recall=af.symbol_recall,
         tool_calls=1,

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -12,6 +12,7 @@ from archex.benchmark.strategies import (
     _archex_fields,  # pyright: ignore[reportPrivateUsage]
     _deduplicate_ranked,  # pyright: ignore[reportPrivateUsage]
     benchmark_repo_source,
+    compute_bundle_completion_penalty,
     compute_map,
     compute_mrr,
     compute_ndcg,
@@ -202,6 +203,19 @@ class TestRankingMetricsDedup:
         clean = compute_map(["a.py", "b.py"], ["a.py", "b.py"])
         with_dup = compute_map(["a.py", "a.py", "b.py"], ["a.py", "b.py"])
         assert with_dup == clean
+
+
+class TestBundleCompletionPenalty:
+    def test_missing_expected_files_count_as_completion_tokens(self, tmp_path: Path) -> None:
+        (tmp_path / "found.py").write_text("print('found')\n", encoding="utf-8")
+        (tmp_path / "missing.py").write_text("print('missing')\n", encoding="utf-8")
+
+        tokens, files = compute_bundle_completion_penalty(
+            tmp_path, {"found.py"}, ["found.py", "missing.py"]
+        )
+
+        assert tokens == count_file_tokens(tmp_path, ["missing.py"])
+        assert files == ["missing.py"]
 
 
 class TestExtractKeywords:


### PR DESCRIPTION
## Stack

Stack-Id: `headtohead-c1-20260611`
Base: `main`
Position: 3/4

1. `feat/headtohead-adapter` -> #185
2. `feat/headtohead-manifest` -> #186
3. `feat/headtohead-token-parity` -> this PR
4. `feat/headtohead-report`

Depends on: #186
Upstack: `feat/headtohead-report`

## Summary

- Adds shared bundle-completion penalty fields to benchmark results.
- Applies identical returned-token/accessed-file-token accounting to raw grep/read, `archex_query`, and external MCP lanes.
- Measures missing expected-file tokens as the agent completion penalty.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright` — passed on this branch.
- `uv run pytest tests/benchmark/ -q` — passed on this branch (287 passed, 2 deselected).
- pr-review: manual diff review completed; no blocking findings.