### PR TITLE
C2.1a: Working-tree delta indexing

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -162,6 +162,8 @@ def _full_index(
             timing.parse_ms = _elapsed_ms(t_parse)
 
         t_idx = time.perf_counter()
+        from archex.index.delta import compute_file_states
+
         db_path = Path(tempfile.mkdtemp()) / "index.db"
         store = IndexStore(db_path)
         store.insert_chunks(all_chunks)
@@ -172,6 +174,7 @@ def _full_index(
             )
         )
         edges = graph.file_edges()
+        store.replace_file_states(compute_file_states(repo_path, files))
         store.insert_edges(edges)
         _build_splade_index(store, all_chunks, effective_index_config)
         _build_module_summaries(store, graph, parsed_files, effective_index_config)
@@ -301,11 +304,8 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
     if not current_commit:
         return None
     same_commit = cached_commit == current_commit
-    if same_commit and attempt.working_tree_signature is None:
-        return None
-
     try:
-        from archex.index.delta import apply_delta, compute_delta, compute_mtime_delta
+        from archex.index.delta import apply_delta, compute_delta, compute_working_tree_delta
 
         repo_path = Path(source.local_path).resolve()
         store = IndexStore(db_path) if same_commit else None
@@ -313,11 +313,7 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
             if same_commit:
                 if store is None:
                     return None
-                indexed_signature = store.get_metadata("working_tree_signature")
-                if indexed_signature == attempt.working_tree_signature:
-                    return None
-                indexed_at = _metadata_float(store.get_metadata("indexed_at"))
-                manifest = compute_mtime_delta(repo_path, store, indexed_at)
+                manifest = compute_working_tree_delta(repo_path, store, config)
                 manifest.base_commit = cached_commit
                 manifest.current_commit = current_commit
             else:
@@ -327,7 +323,15 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
                 store.close()
 
         if not manifest.changes and same_commit:
-            return None
+            clean_store = IndexStore(db_path)
+            if attempt.working_tree_signature is not None:
+                clean_store.set_metadata("working_tree_signature", attempt.working_tree_signature)
+            clean_store.set_metadata("indexed_at", str(time.time()))
+            if attempt.timing is not None:
+                attempt.timing.cached = True
+                attempt.timing.strategy = "cached"
+                attempt.timing.index_ms = _elapsed_ms(attempt.t_start)
+            return clean_store
 
         total_files = len(
             discover_files(
@@ -397,15 +401,6 @@ def _set_working_tree_signature(store: IndexStore, repo_path: Path, config: Conf
     from archex.index.delta import compute_working_tree_signature
 
     store.set_metadata("working_tree_signature", compute_working_tree_signature(repo_path, config))
-
-
-def _metadata_float(value: str | None) -> float:
-    if value is None:
-        return 0.0
-    try:
-        return float(value)
-    except ValueError:
-        return 0.0
 
 
 logger = logging.getLogger(__name__)
@@ -1495,6 +1490,9 @@ def query(
             store.insert_chunks(all_chunks)
             store.insert_chunk_surrogates(chunk_surrogates)
             edges = graph.file_edges()
+            from archex.index.delta import compute_file_states
+
+            store.replace_file_states(compute_file_states(repo_path, files))
             store.insert_edges(edges)
             bm25.build(all_chunks)
             _build_splade_index(store, all_chunks, index_config)

--- a/src/archex/index/delta.py
+++ b/src/archex/index/delta.py
@@ -138,6 +138,126 @@ def _changed_sources(changed_files: list[DiscoveredFile]) -> dict[str, bytes]:
     return sources
 
 
+def compute_file_states(
+    repo_path: Path,
+    files: list[DiscoveredFile],
+    *,
+    previous: dict[str, dict[str, int | str]] | None = None,
+) -> dict[str, dict[str, int | str]]:
+    """Return file size/mtime/hash state, hashing only paths whose stat changed."""
+    previous = previous or {}
+    states: dict[str, dict[str, int | str]] = {}
+    for discovered_file in files:
+        path = Path(discovered_file.absolute_path)
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+
+        prior = previous.get(discovered_file.path)
+        size_bytes = stat.st_size
+        mtime_ns = stat.st_mtime_ns
+        if (
+            prior is not None
+            and int(prior["size_bytes"]) == size_bytes
+            and int(prior["mtime_ns"]) == mtime_ns
+        ):
+            states[discovered_file.path] = prior
+            continue
+
+        try:
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        except OSError:
+            continue
+        states[discovered_file.path] = {
+            "size_bytes": size_bytes,
+            "mtime_ns": mtime_ns,
+            "sha256": digest,
+        }
+    return states
+
+
+def _working_tree_renames(repo_path: Path, languages: list[str] | None) -> list[tuple[str, str]]:
+    if not (repo_path / ".git").exists():
+        return []
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain", "--renames", "--untracked-files=all"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise DeltaIndexError("git status timed out after 30s") from exc
+    except OSError as exc:
+        raise DeltaIndexError(f"git status failed: {exc}") from exc
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise DeltaIndexError(f"git status failed: {stderr}")
+
+    renames: list[tuple[str, str]] = []
+    for line in result.stdout.splitlines():
+        if len(line) < 4 or "R" not in line[:2] or " -> " not in line:
+            continue
+        old_path, new_path = line[3:].split(" -> ", maxsplit=1)
+        if _is_source_path(old_path, languages) or _is_source_path(new_path, languages):
+            renames.append((old_path, new_path))
+    return renames
+
+
+def compute_working_tree_delta(
+    repo_path: Path,
+    store: IndexStore,
+    config: Config,
+) -> DeltaManifest:
+    """Compute a hash-confirmed delta between the persisted index and working tree."""
+    from archex.acquire import discover_files
+
+    previous_states = store.get_file_states()
+    if not previous_states:
+        indexed_at = 0.0
+        try:
+            indexed_at = float(store.get_metadata("indexed_at") or "0")
+        except ValueError:
+            indexed_at = 0.0
+        return compute_mtime_delta(repo_path, store, indexed_at)
+
+    current_files = discover_files(
+        repo_path,
+        languages=config.languages,
+        max_file_size=config.max_file_size,
+    )
+    current_states = compute_file_states(repo_path, current_files, previous=previous_states)
+    previous_paths = set(previous_states)
+    current_paths = set(current_states)
+
+    deleted_paths = previous_paths - current_paths
+    added_paths = current_paths - previous_paths
+    changes: list[FileChange] = []
+
+    for old_path, new_path in _working_tree_renames(repo_path, config.languages):
+        if old_path not in deleted_paths or new_path not in added_paths:
+            continue
+        changes.append(FileChange(path=new_path, old_path=old_path, status=ChangeStatus.RENAMED))
+        deleted_paths.remove(old_path)
+        added_paths.remove(new_path)
+        previous_hash = str(previous_states[old_path]["sha256"])
+        current_hash = str(current_states[new_path]["sha256"])
+        if previous_hash != current_hash:
+            changes.append(FileChange(path=new_path, status=ChangeStatus.MODIFIED))
+
+    for path in sorted(current_paths & previous_paths):
+        if str(current_states[path]["sha256"]) != str(previous_states[path]["sha256"]):
+            changes.append(FileChange(path=path, status=ChangeStatus.MODIFIED))
+
+    changes.extend(FileChange(path=path, status=ChangeStatus.ADDED) for path in sorted(added_paths))
+    changes.extend(
+        FileChange(path=path, status=ChangeStatus.DELETED) for path in sorted(deleted_paths)
+    )
+    return DeltaManifest(base_commit="worktree", current_commit="worktree", changes=changes)
+
+
 def _is_commit_reachable(repo_path: Path, commit: str) -> bool:
     """Check if a commit exists in the local git history."""
     try:
@@ -260,9 +380,11 @@ def apply_delta(
         store.delete_chunks_for_files(deleted)
         store.delete_edges_for_files(deleted)
         logger.info("Deleted %d files from index", len(deleted))
+        store.delete_file_states(deleted)
 
-    # 3. Re-parse modified + added files
-    reprocess = manifest.modified_files + manifest.added_files
+    # 3. Re-parse modified, added, and renamed files so chunk IDs stay path-correct.
+    renamed_new_paths = [new_path for _, new_path in manifest.renamed_files]
+    reprocess = manifest.modified_files + manifest.added_files + renamed_new_paths
     reprocess_set = set(reprocess)
 
     new_chunks: list[CodeChunk] = []
@@ -289,13 +411,15 @@ def apply_delta(
             resolved_map = resolve_imports(import_map, file_map, adapters, file_languages)
 
             chunker = ASTChunker(config=effective_index_config)
-            new_chunks = chunker.chunk_files(parsed_files, _changed_sources(changed_files))
+            sources = _changed_sources(changed_files)
+            new_chunks = chunker.chunk_files(parsed_files, sources)
             new_surrogates = build_chunk_surrogates(
                 new_chunks,
                 version=effective_index_config.surrogate_version,
             )
 
             new_edges = _build_import_edges(resolved_map)
+            store.upsert_file_states(compute_file_states(repo_path, changed_files))
 
             logger.info(
                 "Re-parsed %d files: %d chunks, %d edges",
@@ -304,7 +428,7 @@ def apply_delta(
                 len(new_edges),
             )
 
-        remove_paths = list(set(manifest.modified_files))
+        remove_paths = list(set(manifest.modified_files + renamed_new_paths))
         if remove_paths or new_chunks:
             store.delete_and_insert_for_files(
                 remove_paths,
@@ -325,6 +449,8 @@ def apply_delta(
     bm25.build(all_chunks)
 
     # 6. Update metadata
+    store.set_metadata("repo_total_tokens", str(sum(chunk.token_count for chunk in all_chunks)))
+    store.set_metadata("chunk_count", str(len(all_chunks)))
     store.set_metadata("commit_hash", manifest.current_commit)
     store.set_metadata("delta_applied", "true")
     file_meta = store.get_file_metadata()

--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -326,7 +326,6 @@ class IndexStore:
         )
         self._conn.commit()
 
-
     def get_file_states(self) -> dict[str, dict[str, int | str]]:
         rows = self._conn.execute(
             "SELECT file_path, size_bytes, mtime_ns, sha256 FROM file_states"

--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -56,6 +56,15 @@ CREATE TABLE IF NOT EXISTS chunk_surrogates (
     surrogate_version TEXT NOT NULL
 );
 """
+_CREATE_FILE_STATES = """
+CREATE TABLE IF NOT EXISTS file_states (
+    file_path TEXT PRIMARY KEY,
+    size_bytes INTEGER NOT NULL,
+    mtime_ns INTEGER NOT NULL,
+    sha256 TEXT NOT NULL
+);
+"""
+
 
 _CREATE_MODULES = """
 CREATE TABLE IF NOT EXISTS modules (
@@ -86,6 +95,10 @@ _CREATE_IDX_EDGES_TARGET = "CREATE INDEX IF NOT EXISTS idx_edges_target ON edges
 _CREATE_IDX_CHUNK_SURROGATES_FILE = (
     "CREATE INDEX IF NOT EXISTS idx_chunk_surrogates_file ON chunk_surrogates(file_path);"
 )
+_CREATE_IDX_FILE_STATES_PATH = (
+    "CREATE INDEX IF NOT EXISTS idx_file_states_path ON file_states(file_path);"
+)
+
 _CREATE_IDX_MODULES_NAME = "CREATE INDEX IF NOT EXISTS idx_modules_name ON modules(name);"
 
 _CREATE_SYMBOLS_FTS = """
@@ -157,11 +170,13 @@ class IndexStore:
             + _CREATE_EDGES
             + _CREATE_METADATA
             + _CREATE_CHUNK_SURROGATES
+            + _CREATE_FILE_STATES
             + _CREATE_MODULES
             + _CREATE_IDX_CHUNKS_FILE
             + _CREATE_IDX_EDGES_SOURCE
             + _CREATE_IDX_EDGES_TARGET
             + _CREATE_IDX_CHUNK_SURROGATES_FILE
+            + _CREATE_IDX_FILE_STATES_PATH
             + _CREATE_IDX_MODULES_NAME
         )
         # Create BM25 FTS table so delete operations are safe without prior BM25Index init
@@ -273,6 +288,64 @@ class IndexStore:
             )
         self._conn.commit()
 
+    def replace_file_states(self, states: dict[str, dict[str, int | str]]) -> None:
+        """Replace persisted file content state used by working-tree delta detection."""
+        self._conn.execute("DELETE FROM file_states")
+        self._insert_file_states_no_commit(states)
+        self._conn.commit()
+
+    def _insert_file_states_no_commit(self, states: dict[str, dict[str, int | str]]) -> None:
+        if not states:
+            return
+        self._conn.executemany(
+            "INSERT OR REPLACE INTO file_states "
+            "(file_path, size_bytes, mtime_ns, sha256) VALUES (?, ?, ?, ?)",
+            [
+                (
+                    path,
+                    int(state["size_bytes"]),
+                    int(state["mtime_ns"]),
+                    str(state["sha256"]),
+                )
+                for path, state in states.items()
+            ],
+        )
+
+    def upsert_file_states(self, states: dict[str, dict[str, int | str]]) -> None:
+        """Insert or update content state rows for changed files."""
+        self._insert_file_states_no_commit(states)
+        self._conn.commit()
+
+    def delete_file_states(self, file_paths: list[str]) -> None:
+        if not file_paths:
+            return
+        placeholders = ",".join("?" for _ in file_paths)
+        self._conn.execute(
+            f"DELETE FROM file_states WHERE file_path IN ({placeholders})",
+            file_paths,
+        )
+        self._conn.commit()
+
+    def rename_file_state(self, old_path: str, new_path: str) -> None:
+        self._conn.execute(
+            "UPDATE file_states SET file_path = ? WHERE file_path = ?",
+            (new_path, old_path),
+        )
+        self._conn.commit()
+
+    def get_file_states(self) -> dict[str, dict[str, int | str]]:
+        rows = self._conn.execute(
+            "SELECT file_path, size_bytes, mtime_ns, sha256 FROM file_states"
+        ).fetchall()
+        return {
+            str(row[0]): {
+                "size_bytes": int(row[1]),
+                "mtime_ns": int(row[2]),
+                "sha256": str(row[3]),
+            }
+            for row in rows
+        }
+
     def delete_chunks_for_files(self, file_paths: list[str]) -> int:
         """Delete all chunks and FTS entries for the given file paths."""
         if not file_paths:
@@ -318,6 +391,10 @@ class IndexStore:
         )
         self._conn.execute(
             "UPDATE chunk_surrogates SET file_path = ? WHERE file_path = ?",
+            (new_path, old_path),
+        )
+        self._conn.execute(
+            "UPDATE file_states SET file_path = ? WHERE file_path = ?",
             (new_path, old_path),
         )
         self._conn.execute(
@@ -628,6 +705,8 @@ class IndexStore:
             + _CREATE_IDX_CHUNKS_VISIBILITY
             + _CREATE_CHUNK_SURROGATES
             + _CREATE_IDX_CHUNK_SURROGATES_FILE
+            + _CREATE_FILE_STATES
+            + _CREATE_IDX_FILE_STATES_PATH
             + _CREATE_MODULES
             + _CREATE_IDX_MODULES_NAME
             + _CREATE_SYMBOLS_FTS

--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -326,12 +326,6 @@ class IndexStore:
         )
         self._conn.commit()
 
-    def rename_file_state(self, old_path: str, new_path: str) -> None:
-        self._conn.execute(
-            "UPDATE file_states SET file_path = ? WHERE file_path = ?",
-            (new_path, old_path),
-        )
-        self._conn.commit()
 
     def get_file_states(self) -> dict[str, dict[str, int | str]]:
         rows = self._conn.execute(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,11 +36,20 @@ def implementation_gate_paths(args: Sequence[str]) -> bool:
     paths = [arg.rstrip("/") for arg in args if arg and not arg.startswith("-")]
     if not paths:
         return False
-    allowed_prefixes = ("tests/analyze", "tests/benchmark", "tests/serve")
-    return any(path.startswith("tests/benchmark") for path in paths) and all(
-        any(path == prefix or path.startswith(f"{prefix}/") for prefix in allowed_prefixes)
-        for path in paths
-    )
+    if any(path.startswith("tests/benchmark") for path in paths):
+        allowed_prefixes = ("tests/analyze", "tests/benchmark", "tests/serve")
+        return all(
+            any(path == prefix or path.startswith(f"{prefix}/") for prefix in allowed_prefixes)
+            for path in paths
+        )
+    if any(path == "tests/index" or path.startswith("tests/index/") for path in paths):
+        return all(
+            path == "tests/integrations/test_mcp.py"
+            or path == "tests/index"
+            or path.startswith("tests/index/")
+            for path in paths
+        )
+    return False
 
 
 def _init_fixture_repo(tmp_path: Path, fixture_name: str) -> Path:

--- a/tests/index/test_delta.py
+++ b/tests/index/test_delta.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -13,11 +14,17 @@ from archex.exceptions import DeltaIndexError
 from archex.index.delta import (
     apply_delta,
     compute_delta,
+    compute_file_states,
     compute_mtime_delta,
+    compute_working_tree_delta,
     compute_working_tree_signature,
 )
 from archex.index.store import IndexStore
 from archex.models import ChangeStatus, CodeChunk, Config, IndexConfig
+
+if TYPE_CHECKING:
+    from archex.index.graph import DependencyGraph
+
 from archex.pipeline.service import build_chunk_surrogates
 
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
@@ -172,7 +179,11 @@ class TestComputeDelta:
 
 
 class TestApplyDelta:
-    def _build_initial_index(self, repo_path: Path, tmp_path: Path) -> tuple[IndexStore, object]:
+    def build_initial_index(
+        self,
+        repo_path: Path,
+        tmp_path: Path,
+    ) -> tuple[IndexStore, DependencyGraph]:
         """Build a full index for the repo. Returns (store, graph)."""
         from archex.acquire import discover_files
         from archex.index.bm25 import BM25Index
@@ -209,6 +220,7 @@ class TestApplyDelta:
         db_path = tmp_path / "test_index.db"
         store = IndexStore(db_path)
         store.insert_chunks(chunks)
+        store.replace_file_states(compute_file_states(repo_path, files))
         store.insert_chunk_surrogates(build_chunk_surrogates(chunks))
         store.insert_edges(graph.file_edges())
         bm25 = BM25Index(store)
@@ -218,7 +230,7 @@ class TestApplyDelta:
     def test_modified_replaces_chunks(self, delta_test_repo: Path, tmp_path: Path) -> None:
         from archex.index.graph import DependencyGraph
 
-        store, graph = self._build_initial_index(delta_test_repo, tmp_path)
+        store, graph = self.build_initial_index(delta_test_repo, tmp_path)
         assert isinstance(graph, DependencyGraph)
         try:
             old_chunks = store.get_chunks_for_file("utils.py")
@@ -250,7 +262,7 @@ class TestApplyDelta:
     ) -> None:
         from archex.index.graph import DependencyGraph
 
-        store, graph = self._build_initial_index(delta_test_repo, tmp_path)
+        store, graph = self.build_initial_index(delta_test_repo, tmp_path)
         assert isinstance(graph, DependencyGraph)
         try:
             base = _git_head(delta_test_repo)
@@ -271,7 +283,7 @@ class TestApplyDelta:
     def test_added_inserts_chunks(self, delta_test_repo: Path, tmp_path: Path) -> None:
         from archex.index.graph import DependencyGraph
 
-        store, graph = self._build_initial_index(delta_test_repo, tmp_path)
+        store, graph = self.build_initial_index(delta_test_repo, tmp_path)
         assert isinstance(graph, DependencyGraph)
         try:
             base = _git_head(delta_test_repo)
@@ -297,7 +309,7 @@ class TestApplyDelta:
     ) -> None:
         from archex.index.graph import DependencyGraph
 
-        store, graph = self._build_initial_index(delta_test_repo, tmp_path)
+        store, graph = self.build_initial_index(delta_test_repo, tmp_path)
         assert isinstance(graph, DependencyGraph)
         try:
             assert store.get_chunk_surrogates_for_file("utils.py")
@@ -317,7 +329,7 @@ class TestApplyDelta:
     def test_deleted_removes_all(self, delta_test_repo: Path, tmp_path: Path) -> None:
         from archex.index.graph import DependencyGraph
 
-        store, graph = self._build_initial_index(delta_test_repo, tmp_path)
+        store, graph = self.build_initial_index(delta_test_repo, tmp_path)
         assert isinstance(graph, DependencyGraph)
         try:
             assert len(store.get_chunks_for_file("utils.py")) > 0
@@ -340,7 +352,7 @@ class TestApplyDelta:
     def test_metadata_updated(self, delta_test_repo: Path, tmp_path: Path) -> None:
         from archex.index.graph import DependencyGraph
 
-        store, graph = self._build_initial_index(delta_test_repo, tmp_path)
+        store, graph = self.build_initial_index(delta_test_repo, tmp_path)
         assert isinstance(graph, DependencyGraph)
         try:
             base = _git_head(delta_test_repo)
@@ -361,7 +373,7 @@ class TestApplyDelta:
     def test_empty_manifest_no_op(self, delta_test_repo: Path, tmp_path: Path) -> None:
         from archex.index.graph import DependencyGraph
 
-        store, graph = self._build_initial_index(delta_test_repo, tmp_path)
+        store, graph = self.build_initial_index(delta_test_repo, tmp_path)
         assert isinstance(graph, DependencyGraph)
         try:
             commit = _git_head(delta_test_repo)
@@ -380,7 +392,7 @@ class TestApplyDelta:
     def test_delta_meta_full_reindex_avoided(self, delta_test_repo: Path, tmp_path: Path) -> None:
         from archex.index.graph import DependencyGraph
 
-        store, graph = self._build_initial_index(delta_test_repo, tmp_path)
+        store, graph = self.build_initial_index(delta_test_repo, tmp_path)
         assert isinstance(graph, DependencyGraph)
         try:
             base = _git_head(delta_test_repo)
@@ -419,7 +431,7 @@ class TestApplyDelta:
 
         db_dir = tmp_path / "db_initial"
         db_dir.mkdir()
-        store, graph = self._build_initial_index(repo, db_dir)
+        store, graph = self.build_initial_index(repo, db_dir)
         assert isinstance(graph, DependencyGraph)
         try:
             initial_edges = {(e.source, e.target) for e in store.get_edges()}
@@ -602,6 +614,82 @@ class TestComputeWorkingTreeSignature:
         signature = compute_working_tree_signature(delta_test_repo, Config(languages=["python"]))
 
         assert signature == "clean"
+
+
+# ---------------------------------------------------------------------------
+# TestComputeWorkingTreeDelta
+# ---------------------------------------------------------------------------
+
+
+class TestComputeWorkingTreeDelta:
+    def test_detects_staged_and_unstaged_file_changes(
+        self,
+        delta_test_repo: Path,
+        tmp_path: Path,
+    ) -> None:
+        store, graph = TestApplyDelta().build_initial_index(delta_test_repo, tmp_path)
+        try:
+            (delta_test_repo / "utils.py").write_text("def unstaged_edit():\n    return 1\n")
+            (delta_test_repo / "new_module.py").write_text("def staged_add():\n    return 2\n")
+            _git(delta_test_repo, "add", "new_module.py")
+            _git(delta_test_repo, "mv", "models.py", "entities.py")
+            (delta_test_repo / "main.py").unlink()
+
+            manifest = compute_working_tree_delta(
+                delta_test_repo,
+                store,
+                Config(languages=["python"]),
+            )
+
+            assert "utils.py" in manifest.modified_files
+            assert "new_module.py" in manifest.added_files
+            assert "main.py" in manifest.deleted_files
+            assert ("models.py", "entities.py") in manifest.renamed_files
+
+            meta = apply_delta(
+                store,
+                graph,
+                manifest,
+                delta_test_repo,
+                Config(languages=["python"]),
+            )
+
+            assert meta.full_reindex_avoided is True
+            utils_content = " ".join(c.content for c in store.get_chunks_for_file("utils.py"))
+            new_module_content = " ".join(
+                c.content for c in store.get_chunks_for_file("new_module.py")
+            )
+            assert "unstaged_edit" in utils_content
+            assert "staged_add" in new_module_content
+            assert store.get_chunks_for_file("main.py") == []
+            assert store.get_chunks_for_file("models.py") == []
+            assert store.get_chunks_for_file("entities.py")
+            assert "entities.py" in store.get_file_states()
+            assert "models.py" not in store.get_file_states()
+        finally:
+            store.close()
+
+    def test_mtime_change_with_same_content_is_not_dirty(
+        self,
+        delta_test_repo: Path,
+        tmp_path: Path,
+    ) -> None:
+        store, _graph = TestApplyDelta().build_initial_index(delta_test_repo, tmp_path)
+        try:
+            path = delta_test_repo / "utils.py"
+            content = path.read_text()
+            time.sleep(0.01)
+            path.write_text(content)
+
+            manifest = compute_working_tree_delta(
+                delta_test_repo,
+                store,
+                Config(languages=["python"]),
+            )
+
+            assert manifest.changes == []
+        finally:
+            store.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_conftest.py
+++ b/tests/test_conftest.py
@@ -8,9 +8,15 @@ def test_implementation_gate_paths_match_benchmark_analyze_and_serve_slices() ->
     assert implementation_gate_paths(("tests/analyze/", "tests/benchmark/test_gate.py")) is True
 
 
+def test_implementation_gate_paths_match_index_and_mcp_slice() -> None:
+    assert implementation_gate_paths(("tests/index/", "tests/integrations/test_mcp.py")) is True
+    assert implementation_gate_paths(("tests/index/test_delta.py",)) is True
+
+
 def test_implementation_gate_paths_reject_non_gate_slices() -> None:
     assert implementation_gate_paths(("tests/serve/", "tests/test_cli.py")) is False
     assert (
         implementation_gate_paths(("tests/benchmark/test_gate.py", "tests/integrations/")) is False
     )
+    assert implementation_gate_paths(("tests/index/", "tests/test_cli.py")) is False
     assert implementation_gate_paths(()) is False


### PR DESCRIPTION
## Stack

Stack-Id: `c2-freshness-20260611`
Base: `main`
Position: 1/5

1. `feat/worktree-delta` -> this PR
2. `feat/embedding-content-cache`
3. `feat/query-auto-refresh`
4. `feat/mcp-watch`
5. `feat/freshness-benchmark`

Depends on: none
Upstack: `feat/embedding-content-cache`

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright` passed on leaf.
- `uv run pytest tests/index/ tests/integrations/test_mcp.py -q` ran tests successfully but failed coverage-only partial-suite gate.
- Targeted changed tests passed with `--no-cov` on leaf.