### PR TITLE
C2.1b: Reuse embeddings by content hash

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -351,9 +351,18 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
         store = IndexStore(db_path)
         index_config = attempt.index_config or IndexConfig()
         old_chunks = store.get_chunks() if index_config.vector else []
-        old_vector_path = store.vector_index_path_for(
+        cache_vector_path = attempt.cache.vector_path(
+            attempt.cache_key,
             vector_mode=index_config.vector_mode,
             surrogate_version=index_config.surrogate_version,
+        )
+        old_vector_path = (
+            cache_vector_path
+            if cache_vector_path.exists()
+            else store.vector_index_path_for(
+                vector_mode=index_config.vector_mode,
+                surrogate_version=index_config.surrogate_version,
+            )
         )
         graph = DependencyGraph.from_edges(store.get_edges())
         delta_meta = apply_delta(

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -399,13 +399,16 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
                     vector_mode=index_config.vector_mode,
                     surrogate_version=index_config.surrogate_version,
                 )
-                vec_idx.save(
-                    vector_path,
-                    embedder_name=index_config.embedder or "",
-                    vector_dim=embedder.dimension,
-                    vector_mode=index_config.vector_mode,
-                    surrogate_version=index_config.surrogate_version,
-                )
+                if new_chunks:
+                    vec_idx.save(
+                        vector_path,
+                        embedder_name=index_config.embedder or "",
+                        vector_dim=embedder.dimension,
+                        vector_mode=index_config.vector_mode,
+                        surrogate_version=index_config.surrogate_version,
+                    )
+                elif vector_path.exists():
+                    vector_path.unlink()
                 store.set_metadata("embedding_cache_hits", str(cache_hits))
                 store.set_metadata("embedding_cache_misses", str(cache_misses))
         identity = source.url or source.local_path or ""

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -97,6 +97,8 @@ from archex.serve.profile import build_profile
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    import numpy as np
+
     from archex.index.embeddings.base import Embedder
     from archex.index.rerank import CrossEncoderReranker
     from archex.models import ComparisonResult
@@ -347,6 +349,12 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
         if attempt.timing is not None:
             attempt.timing.delta_attempted = True
         store = IndexStore(db_path)
+        index_config = attempt.index_config or IndexConfig()
+        old_chunks = store.get_chunks() if index_config.vector else []
+        old_vector_path = store.vector_index_path_for(
+            vector_mode=index_config.vector_mode,
+            surrogate_version=index_config.surrogate_version,
+        )
         graph = DependencyGraph.from_edges(store.get_edges())
         delta_meta = apply_delta(
             store,
@@ -354,8 +362,43 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
             manifest,
             repo_path,
             config,
-            index_config=attempt.index_config,
+            index_config=index_config,
         )
+        if index_config.vector:
+            embedder = _get_embedder(index_config)
+            if embedder is not None:
+                from archex.index.vector import VectorIndex
+
+                new_chunks = store.get_chunks()
+                new_surrogates = _surrogate_lookup(store, new_chunks, index_config)
+                cached_vectors = _cached_vectors_by_content_hash(
+                    old_vector_path,
+                    old_chunks,
+                    index_config,
+                    embedder,
+                )
+                vec_idx = VectorIndex()
+                cache_hits, cache_misses = vec_idx.build(
+                    new_chunks,
+                    embedder,
+                    surrogates_by_chunk_id=new_surrogates,
+                    vector_mode=index_config.vector_mode,
+                    cached_vectors_by_content_hash=cached_vectors,
+                )
+                vector_path = attempt.cache.vector_path(
+                    attempt.cache_key,
+                    vector_mode=index_config.vector_mode,
+                    surrogate_version=index_config.surrogate_version,
+                )
+                vec_idx.save(
+                    vector_path,
+                    embedder_name=index_config.embedder or "",
+                    vector_dim=embedder.dimension,
+                    vector_mode=index_config.vector_mode,
+                    surrogate_version=index_config.surrogate_version,
+                )
+                store.set_metadata("embedding_cache_hits", str(cache_hits))
+                store.set_metadata("embedding_cache_misses", str(cache_misses))
         identity = source.url or source.local_path or ""
         store.set_metadata("commit_hash", current_commit)
         store.set_metadata("source_identity", identity)
@@ -955,6 +998,31 @@ def _bm25_search_with_boosts(
     return results, path_boost, symbol_seeds, module_boost
 
 
+def _cached_vectors_by_content_hash(
+    npz_path: Path,
+    chunks: list[CodeChunk],
+    index_config: IndexConfig,
+    embedder: Embedder,
+) -> dict[str, np.ndarray]:
+    if not npz_path.exists():
+        return {}
+    from archex.index.vector import VectorIndex
+
+    vec_idx = VectorIndex()
+    try:
+        vec_idx.load(
+            npz_path,
+            chunks,
+            embedder_name=index_config.embedder or "",
+            vector_dim=embedder.dimension,
+            vector_mode=index_config.vector_mode,
+            surrogate_version=index_config.surrogate_version,
+        )
+    except ArchexIndexError:
+        return {}
+    return vec_idx.vectors_by_content_hash()
+
+
 def _vector_search_precomputed(
     npz_path: Path,
     all_chunks: list[CodeChunk],
@@ -1507,12 +1575,14 @@ def query(
 
                     t_vec_build = time.perf_counter()
                     vec_idx = VectorIndex()
-                    vec_idx.build(
+                    cache_hits, cache_misses = vec_idx.build(
                         all_chunks,
                         embedder,
                         surrogates_by_chunk_id=surrogate_lookup,
                         vector_mode=index_config.vector_mode,
                     )
+                    store.set_metadata("embedding_cache_hits", str(cache_hits))
+                    store.set_metadata("embedding_cache_misses", str(cache_misses))
                     npz_path = (
                         cache.vector_path(
                             cache_key,

--- a/src/archex/cli/index_cmd.py
+++ b/src/archex/cli/index_cmd.py
@@ -87,6 +87,8 @@ def index_cmd(source: str, output_format: str, splade: bool, module_prefilter: b
             "chunks_indexed": store.get_chunk_count(),
             "languages": languages,
             "duration_ms": duration_ms,
+            "embedding_cache_hits": int(store.get_metadata("embedding_cache_hits") or "0"),
+            "embedding_cache_misses": int(store.get_metadata("embedding_cache_misses") or "0"),
         }
     finally:
         store.close()
@@ -106,4 +108,8 @@ def index_cmd(source: str, output_format: str, splade: bool, module_prefilter: b
     else:
         language_summary = "none"
     click.echo(f"Languages:          {language_summary}")
+    click.echo(
+        "Embedding cache:    "
+        f"hits={summary['embedding_cache_hits']}, misses={summary['embedding_cache_misses']}"
+    )
     click.echo(f"Duration:           {summary['duration_ms']} ms")

--- a/src/archex/index/vector.py
+++ b/src/archex/index/vector.py
@@ -29,6 +29,27 @@ def _chunk_embedding_text(chunk: CodeChunk) -> str:
     return chunk.content
 
 
+def _embedding_text_for(
+    chunk: CodeChunk,
+    *,
+    surrogates_by_chunk_id: dict[str, ChunkSurrogate] | None = None,
+    vector_mode: VectorMode = VectorMode.RAW,
+) -> str:
+    if (
+        vector_mode == VectorMode.SURROGATE
+        and surrogates_by_chunk_id
+        and chunk.id in surrogates_by_chunk_id
+    ):
+        return surrogates_by_chunk_id[chunk.id].surrogate_text
+    return _chunk_embedding_text(chunk)
+
+
+def _embedding_content_hash(text: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
 def _encode_query(embedder: Embedder, query: str) -> list[float]:
     encode_queries = getattr(embedder, "encode_queries", None)
     if encode_queries is not None:
@@ -58,6 +79,7 @@ class VectorIndex:
         self._quantized_norms: np.ndarray | None = None
         self._quantized_scale: np.ndarray | None = None
         self._quantized_dim: int = 0
+        self._content_hashes: list[str] = []
 
     def build(
         self,
@@ -66,30 +88,50 @@ class VectorIndex:
         *,
         surrogates_by_chunk_id: dict[str, ChunkSurrogate] | None = None,
         vector_mode: VectorMode = VectorMode.RAW,
-    ) -> None:
-        """Encode all chunks and store normalized vectors."""
+        cached_vectors_by_content_hash: dict[str, np.ndarray] | None = None,
+    ) -> tuple[int, int]:
+        """Encode chunks and reuse cached vectors for unchanged embedding text."""
         if not chunks:
             self._vectors = None
             self._chunk_ids = []
             self._chunks_by_id = {}
+            self._content_hashes = []
             self._quantized_codes = None
             self._quantized_norms = None
             self._quantized_scale = None
             self._quantized_dim = 0
-            return
+            return (0, 0)
 
         texts = [
-            surrogates_by_chunk_id[c.id].surrogate_text
-            if (
-                vector_mode == VectorMode.SURROGATE
-                and surrogates_by_chunk_id
-                and c.id in surrogates_by_chunk_id
+            _embedding_text_for(
+                c,
+                surrogates_by_chunk_id=surrogates_by_chunk_id,
+                vector_mode=vector_mode,
             )
-            else _chunk_embedding_text(c)
             for c in chunks
         ]
-        raw_embeddings = embedder.encode(texts)
-        vectors = np.array(raw_embeddings, dtype=np.float32)
+        content_hashes = [_embedding_content_hash(text) for text in texts]
+        cached_vectors_by_content_hash = cached_vectors_by_content_hash or {}
+        raw_by_position: list[np.ndarray | None] = []
+        misses: list[str] = []
+        miss_positions: list[int] = []
+        hits = 0
+        for position, (content_hash, text) in enumerate(zip(content_hashes, texts, strict=True)):
+            cached_vector = cached_vectors_by_content_hash.get(content_hash)
+            if cached_vector is None:
+                raw_by_position.append(None)
+                misses.append(text)
+                miss_positions.append(position)
+                continue
+            raw_by_position.append(cached_vector)
+            hits += 1
+
+        if misses:
+            encoded = embedder.encode(misses)
+            for position, embedding in zip(miss_positions, encoded, strict=True):
+                raw_by_position[position] = np.array(embedding, dtype=np.float32)
+
+        vectors = np.vstack([v for v in raw_by_position if v is not None]).astype(np.float32)
 
         # L2 normalize for cosine similarity via dot product
         norms = np.linalg.norm(vectors, axis=1, keepdims=True)
@@ -97,6 +139,7 @@ class VectorIndex:
         vectors = vectors / norms
 
         self._chunk_ids = [c.id for c in chunks]
+        self._content_hashes = content_hashes
         self._chunks_by_id = {c.id: c for c in chunks}
 
         if self._quantize:
@@ -112,6 +155,7 @@ class VectorIndex:
             self._quantized_norms = None
             self._quantized_scale = None
             self._quantized_dim = 0
+        return (hits, len(misses))
 
     @property
     def is_quantized(self) -> bool:
@@ -192,6 +236,7 @@ class VectorIndex:
 
         common = {
             "chunk_ids": np.array(self._chunk_ids, dtype="U512"),
+            "content_hashes": np.array(self._content_hashes, dtype="U64"),
             "embedder_meta": np.array([embedder_name, str(vector_dim)], dtype="U256"),
             "vector_meta": np.array([str(vector_mode), surrogate_version], dtype="U256"),
         }
@@ -239,6 +284,11 @@ class VectorIndex:
 
         data = np.load(str(path), allow_pickle=False)
         chunk_ids = list(data["chunk_ids"])
+        content_hashes = (
+            [str(value) for value in data["content_hashes"]]
+            if "content_hashes" in data
+            else ["" for _ in chunk_ids]
+        )
 
         # Validate embedder/vector metadata (shared by both formats)
         if "embedder_meta" in data:
@@ -297,6 +347,7 @@ class VectorIndex:
             self._quantized_dim = 0
 
         self._chunk_ids = chunk_ids
+        self._content_hashes = content_hashes
         self._chunks_by_id = {c.id: c for c in chunks}
 
     def rerank(
@@ -356,3 +407,13 @@ class VectorIndex:
     def size(self) -> int:
         """Number of indexed chunks."""
         return len(self._chunk_ids)
+
+    def vectors_by_content_hash(self) -> dict[str, np.ndarray]:
+        """Return raw normalized vectors keyed by embedding content hash."""
+        if self._vectors is None:
+            return {}
+        return {
+            content_hash: self._vectors[idx].copy()
+            for idx, content_hash in enumerate(self._content_hashes)
+            if content_hash
+        }

--- a/tests/index/test_vector.py
+++ b/tests/index/test_vector.py
@@ -45,6 +45,16 @@ class FakeEmbedder:
         return self._dim
 
 
+class CountingEmbedder(FakeEmbedder):
+    def __init__(self, dim: int = 64) -> None:
+        super().__init__(dim=dim)
+        self.encoded_batches: list[list[str]] = []
+
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        self.encoded_batches.append(texts)
+        return super().encode(texts)
+
+
 class QueryPrefixEmbedder:
     dimension = 2
 
@@ -173,6 +183,31 @@ class TestVectorIndexBuild:
         idx = VectorIndex()
         idx.build([SAMPLE_CHUNKS[0]], embedder)
         assert idx.size == 1
+
+    def test_build_reuses_cached_vectors_by_content_hash(self) -> None:
+        embedder = CountingEmbedder(dim=64)
+        first = VectorIndex()
+        hits, misses = first.build(SAMPLE_CHUNKS[:2], embedder)
+        assert (hits, misses) == (0, 2)
+        assert embedder.encoded_batches == [[SAMPLE_CHUNKS[0].content, SAMPLE_CHUNKS[1].content]]
+
+        second = VectorIndex()
+        changed = SAMPLE_CHUNKS[1].model_copy(
+            update={
+                "id": "auth.py:authenticate:12",
+                "content": (
+                    "def authenticate(username: str, password: str) -> bool:\n    return True"
+                ),
+            }
+        )
+        hits, misses = second.build(
+            [SAMPLE_CHUNKS[0], changed],
+            embedder,
+            cached_vectors_by_content_hash=first.vectors_by_content_hash(),
+        )
+
+        assert (hits, misses) == (1, 1)
+        assert embedder.encoded_batches[-1] == [changed.content]
 
 
 class TestVectorIndexSearch:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,6 +104,7 @@ def test_index_command_uses_project_config(python_simple_repo: Path) -> None:
 
     assert result.exit_code == 0, result.output
     assert "Indexed repository:" in result.output
+    assert "Embedding cache:    hits=0, misses=0" in result.output
     assert "Strategy:" in result.output
     assert "python=2" in result.output
     config = index_mock.call_args.kwargs["config"]


### PR DESCRIPTION
## Stack

Stack-Id: `c2-freshness-20260611`
Base: `main`
Position: 2/5

1. `feat/worktree-delta`
2. `feat/embedding-content-cache` -> this PR
3. `feat/query-auto-refresh`
4. `feat/mcp-watch`
5. `feat/freshness-benchmark`

Depends on: feat/worktree-delta
Upstack: `feat/query-auto-refresh`

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright` passed on leaf.
- `uv run pytest tests/index/ tests/integrations/test_mcp.py -q` ran tests successfully but failed coverage-only partial-suite gate.
- Targeted changed tests passed with `--no-cov` on leaf.