### PR TITLE
C2.2: Refresh stale indexes during queries

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -169,17 +169,61 @@ def _full_index(
         db_path = Path(tempfile.mkdtemp()) / "index.db"
         store = IndexStore(db_path)
         store.insert_chunks(all_chunks)
-        store.insert_chunk_surrogates(
-            build_chunk_surrogates(
-                all_chunks,
-                version=effective_index_config.surrogate_version,
-            )
+        chunk_surrogates = build_chunk_surrogates(
+            all_chunks,
+            version=effective_index_config.surrogate_version,
         )
+        store.insert_chunk_surrogates(chunk_surrogates)
         edges = graph.file_edges()
         store.replace_file_states(compute_file_states(repo_path, files))
         store.insert_edges(edges)
         _build_splade_index(store, all_chunks, effective_index_config)
         _build_module_summaries(store, graph, parsed_files, effective_index_config)
+        if effective_index_config.vector:
+            embedder = _get_embedder(effective_index_config)
+            if embedder is not None:
+                from archex.index.vector import VectorIndex
+
+                surrogate_lookup = {
+                    surrogate.chunk_id: surrogate for surrogate in chunk_surrogates
+                }
+                vec_idx = VectorIndex()
+                cache_hits, cache_misses = vec_idx.build(
+                    all_chunks,
+                    embedder,
+                    surrogates_by_chunk_id=surrogate_lookup,
+                    vector_mode=effective_index_config.vector_mode,
+                )
+                store.set_metadata("embedding_cache_hits", str(cache_hits))
+                store.set_metadata("embedding_cache_misses", str(cache_misses))
+                npz_path = (
+                    cache.vector_path(
+                        cache_key,
+                        vector_mode=effective_index_config.vector_mode,
+                        surrogate_version=effective_index_config.surrogate_version,
+                    )
+                    if config.cache
+                    else store.vector_index_path_for(
+                        vector_mode=effective_index_config.vector_mode,
+                        surrogate_version=effective_index_config.surrogate_version,
+                    )
+                )
+                if all_chunks:
+                    vec_idx.save(
+                        npz_path,
+                        embedder_name=effective_index_config.embedder or "",
+                        vector_dim=embedder.dimension,
+                        vector_mode=effective_index_config.vector_mode,
+                        surrogate_version=effective_index_config.surrogate_version,
+                    )
+                elif npz_path.exists():
+                    npz_path.unlink()
+
+        total_repo_tokens = sum(chunk.token_count for chunk in all_chunks)
+        store.set_metadata("repo_total_tokens", str(total_repo_tokens))
+        store.set_metadata("chunk_count", str(len(all_chunks)))
+        file_count = len({chunk.file_path for chunk in all_chunks})
+        store.set_metadata("file_count", str(file_count))
 
         if config.cache:
             commit = cloned_head or cache.git_head(source.local_path) or source.commit or ""

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1232,6 +1232,20 @@ def analyze(
         cleanup()
 
 
+def _attach_refresh_metadata(bundle: ContextBundle, timing: PipelineTiming | None) -> None:
+    if timing is None:
+        return
+    bundle.retrieval_metadata.index_stale = timing.delta_attempted
+    bundle.retrieval_metadata.refresh_time_ms = timing.delta_ms
+    if timing.delta_meta is not None:
+        bundle.retrieval_metadata.refresh_files_changed = (
+            timing.delta_meta.files_modified
+            + timing.delta_meta.files_added
+            + timing.delta_meta.files_deleted
+            + timing.delta_meta.files_renamed
+        )
+
+
 def query(
     source: RepoSource,
     question: str,
@@ -1243,6 +1257,7 @@ def query(
     timing: PipelineTiming | None = None,
     trace: PipelineTrace | None = None,
     explicit_token_budget: bool = False,
+    refresh: bool = True,
 ) -> ContextBundle:
     """Retrieve a ranked ContextBundle for a natural-language query.
 
@@ -1266,13 +1281,25 @@ def query(
         trace.operation = "query"
         trace.start_ns = time.perf_counter_ns()
     cache = _cache_manager_for_source(source, config)
+    metadata_timing = timing
     cache_key = cache.cache_key(source)
 
-    # Check cache BEFORE parsing — if cached, skip the expensive parse pipeline
-    cached_db = cache.get(cache_key) if config.cache else None
+    # Check cache BEFORE parsing — if cached, skip the expensive parse pipeline.
+    preopened_store: IndexStore | None = None
+    if refresh and config.cache:
+        metadata_timing = timing or PipelineTiming()
+        preopened_store = _ensure_index(
+            source,
+            config,
+            timing=metadata_timing,
+            index_config=index_config,
+        )
+        cached_db = preopened_store.db_path
+    else:
+        cached_db = cache.get(cache_key) if config.cache else None
     if cached_db is not None:
         logger.info("Cache hit for %s", cache_key[:12])
-        store = IndexStore(cached_db)
+        store = preopened_store or IndexStore(cached_db)
         if store.needs_reindex():
             logger.info("Stale cache (missing symbol_ids) — forcing full re-index")
             store.close()
@@ -1315,6 +1342,7 @@ def query(
                     if trace is not None:
                         trace.end_ns = time.perf_counter_ns()
                         trace.log_summary()
+                    _attach_refresh_metadata(pt, metadata_timing)
                     return pt
 
                 bm25 = BM25Index(store)
@@ -1476,6 +1504,7 @@ def query(
                 if trace is not None:
                     trace.end_ns = time.perf_counter_ns()
                     trace.log_summary()
+                _attach_refresh_metadata(bundle, metadata_timing)
                 return bundle
             finally:
                 store.close()
@@ -1682,6 +1711,7 @@ def query(
                     trace.log_summary()
                 pt.retrieval_metadata.retrieval_time_ms = _elapsed_ms(t0)
                 logger.info("query() [passthrough] completed in %.0fms", _elapsed_ms(t0))
+                _attach_refresh_metadata(pt, metadata_timing)
                 return pt
 
             t6 = time.perf_counter()
@@ -1820,6 +1850,7 @@ def query(
         if trace is not None:
             trace.end_ns = time.perf_counter_ns()
             trace.log_summary()
+        _attach_refresh_metadata(bundle, metadata_timing)
         return bundle
     finally:
         cleanup()

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -184,9 +184,7 @@ def _full_index(
             if embedder is not None:
                 from archex.index.vector import VectorIndex
 
-                surrogate_lookup = {
-                    surrogate.chunk_id: surrogate for surrogate in chunk_surrogates
-                }
+                surrogate_lookup = {surrogate.chunk_id: surrogate for surrogate in chunk_surrogates}
                 vec_idx = VectorIndex()
                 cache_hits, cache_misses = vec_idx.build(
                     all_chunks,

--- a/src/archex/cli/query_cmd.py
+++ b/src/archex/cli/query_cmd.py
@@ -43,6 +43,18 @@ from archex.utils import resolve_source
     default=False,
     help="Use opt-in module responsibility prefiltering.",
 )
+@click.option(
+    "--no-refresh",
+    is_flag=True,
+    default=False,
+    help="Skip working-tree freshness checks and query the existing index as-is.",
+)
+@click.option(
+    "--refresh-threshold",
+    type=float,
+    default=None,
+    help="Maximum changed-file ratio eligible for inline refresh.",
+)
 def query_cmd(
     args: tuple[str, ...],
     budget: int | None,
@@ -53,6 +65,8 @@ def query_cmd(
     metrics: bool,
     splade: bool,
     module_prefilter: bool,
+    no_refresh: bool,
+    refresh_threshold: float | None,
 ) -> None:
     """Query a repository and return a context bundle."""
     from archex.config import load_config, load_index_config
@@ -61,6 +75,8 @@ def query_cmd(
     source, question = _source_and_question(args)
     repo_source = resolve_source(source)
     config = load_config(repo_source)
+    if refresh_threshold is not None:
+        config = config.model_copy(update={"delta_threshold": refresh_threshold})
     if language:
         config = config.model_copy(update={"languages": list(language)})
     index_config = load_index_config(repo_source)
@@ -82,6 +98,7 @@ def query_cmd(
             config=config,
             index_config=index_config,
             timing=pt,
+            refresh=not no_refresh,
         )
     except ArchexError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -115,6 +115,7 @@ def handle_query_repo(repo_url: str, question: str, budget: int | None = None) -
         cached=pt.cached,
         index_time_ms=pt.index_ms,
         query_time_ms=pt.total_ms,
+        delta=pt.delta_meta,
     )
     return json.dumps({"content": content, "_meta": meta.model_dump()}, indent=2)
 

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -592,6 +592,10 @@ class RetrievalMetadata(BaseModel):
     surrogate_version: str | None = None
     expansion_reason_counts: dict[str, int] = {}
     expanded_file_reasons: dict[str, list[str]] = {}
+    index_stale: bool = False
+    refresh_time_ms: float = 0.0
+    refresh_files_changed: int = 0
+    refresh_skipped_reason: str = ""
 
 
 class ContextBundle(BaseModel):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -330,11 +330,33 @@ def test_query_command_defaults_source_to_cwd(
 
     with patch("archex.cli.query_cmd.query", return_value=FakeBundle()) as query_mock:
         result = runner.invoke(cli, ["query", "How does the query pipeline work?"])
-
     assert result.exit_code == 0, result.output
     assert result.output.strip() == "format=xml"
     assert query_mock.call_args.args[0].local_path == "."
     assert query_mock.call_args.args[1] == "How does the query pipeline work?"
+    assert query_mock.call_args.kwargs["refresh"] is True
+
+
+def test_query_command_no_refresh_disables_inline_refresh(
+    python_simple_repo: Path,
+) -> None:
+    class FakeBundle:
+        chunks: list[object] = []
+        token_count = 0
+
+        def to_prompt(self, *, format: str) -> str:
+            return f"format={format}"
+
+    runner = CliRunner()
+
+    with patch("archex.cli.query_cmd.query", return_value=FakeBundle()) as query_mock:
+        result = runner.invoke(
+            cli,
+            ["query", str(python_simple_repo), "How does search work?", "--no-refresh"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert query_mock.call_args.kwargs["refresh"] is False
 
 
 def test_analyze_tree_and_symbols_default_source_to_cwd(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -165,6 +165,43 @@ class TestQueryEndToEnd:
         bundle2 = query(source, "authentication", config=config)
         assert bundle2.retrieval_metadata is not None
 
+    def test_query_auto_refresh_matches_full_reindex_after_worktree_edit(
+        self,
+        python_simple_repo: Path,
+        tmp_path: Path,
+    ) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        cache_config = Config(
+            languages=["python"],
+            cache=True,
+            cache_dir=str(tmp_path / "cache"),
+            delta_threshold=1.0,
+        )
+
+        query(source, "fresh marker", config=cache_config)
+        (python_simple_repo / "utils.py").write_text(
+            "def fresh_marker_delta():\n    return 'fresh-marker'\n",
+            encoding="utf-8",
+        )
+
+        stale = query(source, "fresh_marker_delta", config=cache_config, refresh=False)
+        refreshed = query(source, "fresh_marker_delta", config=cache_config)
+        full = query(
+            source,
+            "fresh_marker_delta",
+            config=Config(languages=["python"], cache=False),
+        )
+
+        stale_text = "\n".join(chunk.chunk.content for chunk in stale.chunks)
+        refreshed_text = "\n".join(chunk.chunk.content for chunk in refreshed.chunks)
+        full_text = "\n".join(chunk.chunk.content for chunk in full.chunks)
+
+        assert "fresh_marker_delta" not in stale_text
+        assert "fresh_marker_delta" in refreshed_text
+        assert refreshed_text == full_text
+        assert refreshed.retrieval_metadata.index_stale is True
+        assert refreshed.retrieval_metadata.refresh_files_changed == 1
+
     def test_query_with_index_config(self, python_simple_repo: Path) -> None:
         source = RepoSource(local_path=str(python_simple_repo))
         index_cfg = IndexConfig(chunk_max_tokens=256, chunk_min_tokens=32)


### PR DESCRIPTION
## Stack

Stack-Id: `c2-freshness-20260611`
Base: `main`
Position: 3/5

1. `feat/worktree-delta`
2. `feat/embedding-content-cache`
3. `feat/query-auto-refresh` -> this PR
4. `feat/mcp-watch`
5. `feat/freshness-benchmark`

Depends on: feat/embedding-content-cache
Upstack: `feat/mcp-watch`

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright` passed on leaf.
- `uv run pytest tests/index/ tests/integrations/test_mcp.py -q` ran tests successfully but failed coverage-only partial-suite gate.
- Targeted changed tests passed with `--no-cov` on leaf.