### PR TITLE
C2.3: Add debounced MCP watch mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pyyaml>=6.0",
     "einops>=0.8.2",
     "rich==14.3.3",
+    "watchdog>=6.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/archex/cache.py
+++ b/src/archex/cache.py
@@ -177,7 +177,13 @@ class CacheManager:
 
         dest = self.db_path(key)
         if source_db.resolve() != dest.resolve():
-            shutil.copy2(str(source_db), str(dest))
+            tmp_dest = dest.with_name(f".{dest.name}.{time.time_ns()}.tmp")
+            try:
+                shutil.copy2(str(source_db), str(tmp_dest))
+                tmp_dest.replace(dest)
+            finally:
+                if tmp_dest.exists():
+                    tmp_dest.unlink()
         meta = self.meta_path(key)
         meta_data = {
             "cache_key": key,

--- a/src/archex/cli/mcp_cmd.py
+++ b/src/archex/cli/mcp_cmd.py
@@ -8,7 +8,21 @@ import click
 
 
 @click.command("mcp")
-def mcp_cmd() -> None:
+@click.option("--watch", is_flag=True, default=False, help="Watch the repo and refresh the index.")
+@click.option(
+    "--watch-path",
+    default=".",
+    show_default=True,
+    help="Repository path to watch when --watch is enabled.",
+)
+@click.option(
+    "--watch-debounce-ms",
+    default=300,
+    show_default=True,
+    type=int,
+    help="Debounce interval for filesystem refreshes.",
+)
+def mcp_cmd(watch: bool, watch_path: str, watch_debounce_ms: int) -> None:
     """Start the archex MCP server (stdio transport).
 
     Exposes analyze_repo, query_repo, and compare_repos as MCP tools.
@@ -21,4 +35,10 @@ def mcp_cmd() -> None:
             "MCP integration requires the 'mcp' package. Install it with: uv add mcp"
         ) from exc
 
-    asyncio.run(run_stdio_server())
+    asyncio.run(
+        run_stdio_server(
+            watch=watch,
+            watch_path=watch_path,
+            watch_debounce_ms=watch_debounce_ms,
+        )
+    )

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -584,6 +584,7 @@ def _start_index_watch(repo_path: Path, debounce_ms: int) -> Any:
         def __init__(self) -> None:
             self._timer: threading.Timer | None = None
             self._lock = threading.Lock()
+            self._refreshing = False
 
         def on_any_event(self, event: FileSystemEvent) -> None:
             src_path = str(event.src_path)
@@ -600,13 +601,21 @@ def _start_index_watch(repo_path: Path, debounce_ms: int) -> Any:
                 self._timer.start()
 
         def _refresh(self) -> None:
-            source = RepoSource(local_path=str(repo_path))
-            timing = PipelineTiming()
-            store = index_repository(source, timing=timing)
+            with self._lock:
+                if self._refreshing:
+                    return
+                self._refreshing = True
             try:
-                logger.info("MCP watch refreshed %s via %s", repo_path, timing.strategy)
+                source = RepoSource(local_path=str(repo_path))
+                timing = PipelineTiming()
+                store = index_repository(source, timing=timing)
+                try:
+                    logger.info("MCP watch refreshed %s via %s", repo_path, timing.strategy)
+                finally:
+                    store.close()
             finally:
-                store.close()
+                with self._lock:
+                    self._refreshing = False
 
     observer = Observer()
     observer.schedule(DebouncedIndexHandler(), str(repo_path), recursive=True)

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -584,6 +584,7 @@ def _start_index_watch(repo_path: Path, debounce_ms: int) -> Any:
         def __init__(self) -> None:
             self._timer: threading.Timer | None = None
             self._lock = threading.Lock()
+            self._pending_refresh = False
             self._refreshing = False
 
         def on_any_event(self, event: FileSystemEvent) -> None:
@@ -594,11 +595,17 @@ def _start_index_watch(repo_path: Path, debounce_ms: int) -> Any:
 
         def _schedule(self) -> None:
             with self._lock:
-                if self._timer is not None:
-                    self._timer.cancel()
-                self._timer = threading.Timer(debounce_ms / 1000.0, self._refresh)
-                self._timer.daemon = True
-                self._timer.start()
+                if self._refreshing:
+                    self._pending_refresh = True
+                    return
+                self._arm_timer_locked()
+
+        def _arm_timer_locked(self) -> None:
+            if self._timer is not None:
+                self._timer.cancel()
+            self._timer = threading.Timer(debounce_ms / 1000.0, self._refresh)
+            self._timer.daemon = True
+            self._timer.start()
 
         def _refresh(self) -> None:
             with self._lock:
@@ -616,6 +623,9 @@ def _start_index_watch(repo_path: Path, debounce_ms: int) -> Any:
             finally:
                 with self._lock:
                     self._refreshing = False
+                    if self._pending_refresh:
+                        self._pending_refresh = False
+                        self._arm_timer_locked()
 
     observer = Observer()
     observer.schedule(DebouncedIndexHandler(), str(repo_path), recursive=True)

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import threading
 import time
+from pathlib import Path
 from typing import Any
 
 from archex.api import (
@@ -18,10 +20,11 @@ from archex.api import (
     get_repo_total_tokens,
     get_symbol,
     get_symbols_batch,
+    index_repository,
     query,
     search_symbols,
 )
-from archex.models import PipelineTiming
+from archex.models import PipelineTiming, RepoSource
 from archex.reporting import compute_meta, count_tokens
 from archex.serve.compare import validate_dimensions
 from archex.serve.intent import DEFAULT_TOKEN_BUDGET
@@ -565,7 +568,59 @@ def build_server() -> Any:
     return server
 
 
-async def run_stdio_server() -> None:
+def _ignored_watch_path(path: str) -> bool:
+    parts = Path(path).parts
+    return any(part in {".git", ".archex", "__pycache__", ".pytest_cache"} for part in parts)
+
+
+def _start_index_watch(repo_path: Path, debounce_ms: int) -> Any:
+    try:
+        from watchdog.events import FileSystemEvent, FileSystemEventHandler
+        from watchdog.observers import Observer
+    except ImportError as exc:
+        raise ImportError("watch mode requires the 'watchdog' package") from exc
+
+    class DebouncedIndexHandler(FileSystemEventHandler):
+        def __init__(self) -> None:
+            self._timer: threading.Timer | None = None
+            self._lock = threading.Lock()
+
+        def on_any_event(self, event: FileSystemEvent) -> None:
+            src_path = str(event.src_path)
+            if event.is_directory or _ignored_watch_path(src_path):
+                return
+            self._schedule()
+
+        def _schedule(self) -> None:
+            with self._lock:
+                if self._timer is not None:
+                    self._timer.cancel()
+                self._timer = threading.Timer(debounce_ms / 1000.0, self._refresh)
+                self._timer.daemon = True
+                self._timer.start()
+
+        def _refresh(self) -> None:
+            source = RepoSource(local_path=str(repo_path))
+            timing = PipelineTiming()
+            store = index_repository(source, timing=timing)
+            try:
+                logger.info("MCP watch refreshed %s via %s", repo_path, timing.strategy)
+            finally:
+                store.close()
+
+    observer = Observer()
+    observer.schedule(DebouncedIndexHandler(), str(repo_path), recursive=True)
+    observer.start()
+    logger.info("MCP watch enabled for %s", repo_path)
+    return observer
+
+
+async def run_stdio_server(
+    *,
+    watch: bool = False,
+    watch_path: str = ".",
+    watch_debounce_ms: int = 300,
+) -> None:
     """Run the archex MCP server over stdio."""
     try:
         from mcp.server.stdio import stdio_server
@@ -574,7 +629,16 @@ async def run_stdio_server() -> None:
             "The 'mcp' package is required for MCP integration. Install it with: uv add mcp"
         ) from exc
 
+    observer: Any | None = None
+    if watch:
+        observer = _start_index_watch(Path(watch_path).expanduser().resolve(), watch_debounce_ms)
+
     server = build_server()
-    async with stdio_server() as (read_stream, write_stream):
-        init_opts = server.create_initialization_options()
-        await server.run(read_stream, write_stream, init_opts, raise_exceptions=True)
+    try:
+        async with stdio_server() as (read_stream, write_stream):
+            init_opts = server.create_initialization_options()
+            await server.run(read_stream, write_stream, init_opts, raise_exceptions=True)
+    finally:
+        if observer is not None:
+            observer.stop()
+            observer.join(timeout=5)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -611,7 +611,29 @@ class TestMcpCmd:
         ):
             result = runner.invoke(cli, ["mcp"])
         assert result.exit_code == 0, result.output
-        mock_asyncio_run.assert_called_once_with(mock_run_stdio())
+        mock_run_stdio.assert_called_once_with(watch=False, watch_path=".", watch_debounce_ms=300)
+        mock_asyncio_run.assert_called_once_with(mock_run_stdio.return_value)
+
+    def test_mcp_watch_options_pass_to_server(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        mock_run_stdio = MagicMock()
+        mock_mcp_module = MagicMock()
+        mock_mcp_module.run_stdio_server = mock_run_stdio
+
+        runner = CliRunner()
+        with (
+            patch.dict("sys.modules", {"archex.integrations.mcp": mock_mcp_module}),
+            patch("archex.cli.mcp_cmd.asyncio.run") as mock_asyncio_run,
+        ):
+            result = runner.invoke(
+                cli,
+                ["mcp", "--watch", "--watch-path", "src", "--watch-debounce-ms", "50"],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_run_stdio.assert_called_once_with(watch=True, watch_path="src", watch_debounce_ms=50)
+        mock_asyncio_run.assert_called_once_with(mock_run_stdio.return_value)
 
 
 class TestCacheList:

--- a/uv.lock
+++ b/uv.lock
@@ -193,6 +193,7 @@ dependencies = [
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
     { name = "tree-sitter-typescript" },
+    { name = "watchdog" },
 ]
 
 [package.optional-dependencies]
@@ -303,6 +304,7 @@ requires-dist = [
     { name = "tree-sitter-python", specifier = ">=0.23" },
     { name = "tree-sitter-rust", specifier = ">=0.23" },
     { name = "tree-sitter-typescript", specifier = ">=0.23" },
+    { name = "watchdog", specifier = ">=6.0.0" },
 ]
 provides-extras = ["vector", "vector-fast", "graph", "vector-torch", "splade", "mcp", "langchain", "llamaindex", "lsap", "language-pack", "all", "dev"]
 
@@ -3947,6 +3949,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/4f/d6a5ff3b020c801c808b14e2d2330cdc8ebefe1cdfbc457ecc368e971fec/virtualenv-21.0.0.tar.gz", hash = "sha256:e8efe4271b4a5efe7a4dce9d60a05fd11859406c0d6aa8464f4cf451bc132889", size = 5836591 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/d1/3f62e4f9577b28c352c11623a03fb916096d5c131303d4861b4914481b6b/virtualenv-21.0.0-py3-none-any.whl", hash = "sha256:d44e70637402c7f4b10f48491c02a6397a3a187152a70cba0b6bc7642d69fb05", size = 5817167 },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393 },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392 },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019 },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471 },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449 },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054 },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480 },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451 },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057 },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076 },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Stack

Stack-Id: `c2-freshness-20260611`
Base: `main`
Position: 4/5

1. `feat/worktree-delta`
2. `feat/embedding-content-cache`
3. `feat/query-auto-refresh`
4. `feat/mcp-watch` -> this PR
5. `feat/freshness-benchmark`

Depends on: feat/query-auto-refresh
Upstack: `feat/freshness-benchmark`

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright` passed on leaf.
- `uv run pytest tests/index/ tests/integrations/test_mcp.py -q` ran tests successfully but failed coverage-only partial-suite gate.
- Targeted changed tests passed with `--no-cov` on leaf.