### PR TITLE
C2.4: Report edit-to-correct freshness

### DIFF
--- a/src/archex/benchmark/headtohead.py
+++ b/src/archex/benchmark/headtohead.py
@@ -194,7 +194,10 @@ def run_headtohead(
                 Strategy.EXTERNAL_MCP,
             ],
             tasks=tasks,
-            retrieval_options=BenchmarkRetrievalOptions(embedder=manifest.archex.embedder),
+            retrieval_options=BenchmarkRetrievalOptions(
+                embedder=manifest.archex.embedder,
+                freshness=True,
+            ),
         )
     finally:
         reset_external_tool_config(token)
@@ -236,6 +239,18 @@ def _mean(values: list[float]) -> float:
 
 def _metric_cell(value: float, provenance: str, field: str, *, digits: int = 2) -> str:
     return f"{value:.{digits}f}<br><sub>prov: {provenance}; field={field}</sub>"
+
+
+def _optional_metric_cell(
+    value: float | None,
+    provenance: str,
+    field: str,
+    *,
+    digits: int = 2,
+) -> str:
+    if value is None:
+        return f"n/a<br><sub>prov: {provenance}; field={field}</sub>"
+    return _metric_cell(value, provenance, field, digits=digits)
 
 
 def _integer_metric_cell(value: float, provenance: str, field: str) -> str:
@@ -319,13 +334,24 @@ def format_headtohead_markdown(
                         provenance,
                         "cold_start_ms",
                     ),
-                    _integer_metric_cell(
-                        _mean([r.freshness_latency_ms for r in results]),
+                    _optional_metric_cell(
+                        _mean([r.freshness_latency_ms for r in results if r.freshness_measured])
+                        if any(r.freshness_measured for r in results)
+                        else None,
                         provenance,
                         "freshness_latency_ms",
+                        digits=0,
                     ),
-                    _metric_cell(
-                        _mean([1.0 if r.freshness_correct else 0.0 for r in results]),
+                    _optional_metric_cell(
+                        _mean(
+                            [
+                                1.0 if r.freshness_correct else 0.0
+                                for r in results
+                                if r.freshness_measured
+                            ]
+                        )
+                        if any(r.freshness_measured for r in results)
+                        else None,
                         provenance,
                         "freshness_correct",
                     ),

--- a/src/archex/benchmark/headtohead.py
+++ b/src/archex/benchmark/headtohead.py
@@ -278,8 +278,9 @@ def format_headtohead_markdown(
         "Every metric cell includes its provenance. No winner filtering is applied.",
         "",
         "| Lane | Recall | Precision | F1 | Token efficiency | Completion penalty tokens "
-        "| Efficiency after completion | Warm latency ms | Cold-start ms |",
-        "| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+        "| Efficiency after completion | Warm latency ms | Cold-start ms | Edit-to-correct ms "
+        "| Freshness correct |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
     ]
 
     for lane in sorted(lanes):
@@ -317,6 +318,16 @@ def format_headtohead_markdown(
                         _mean([r.cold_start_ms for r in results]),
                         provenance,
                         "cold_start_ms",
+                    ),
+                    _integer_metric_cell(
+                        _mean([r.freshness_latency_ms for r in results]),
+                        provenance,
+                        "freshness_latency_ms",
+                    ),
+                    _metric_cell(
+                        _mean([1.0 if r.freshness_correct else 0.0 for r in results]),
+                        provenance,
+                        "freshness_correct",
                     ),
                 ]
             )

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -233,6 +233,8 @@ class BenchmarkResult(BaseModel):
     cold_start_ms: float = 0.0
     warm_latency_ms: float = 0.0
     provenance: dict[str, str] = {}
+    freshness_latency_ms: float = 0.0
+    freshness_correct: bool = False
 
 
 class BenchmarkReport(BaseModel):

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -140,6 +140,7 @@ class BenchmarkRetrievalOptions(BaseModel):
     module_prefilter: bool = False
     embedder: str = "jina-v2"
     rerank_model: str | None = None
+    freshness: bool = False
 
 
 class ExternalToolCommandConfig(BenchmarkSpecModel):
@@ -234,6 +235,7 @@ class BenchmarkResult(BaseModel):
     warm_latency_ms: float = 0.0
     provenance: dict[str, str] = {}
     freshness_latency_ms: float = 0.0
+    freshness_measured: bool = False
     freshness_correct: bool = False
 
 

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -75,6 +75,8 @@ def _warm_repo_index(
     task: BenchmarkTask,
     repo_path: Path,
     retrieval_options: BenchmarkRetrievalOptions | None = None,
+    *,
+    warm_rerank: bool = False,
 ) -> None:
     """Pre-build the shared vector index so every vector strategy runs warm.
 
@@ -97,6 +99,8 @@ def _warm_repo_index(
         embedder=retrieval_options.embedder,
         splade=retrieval_options.splade,
         module_prefilter=retrieval_options.module_prefilter,
+        rerank=warm_rerank,
+        rerank_model=retrieval_options.rerank_model,
     )
     query(
         source,
@@ -178,11 +182,17 @@ def run_benchmark(
     token = set_benchmark_retrieval_options(retrieval_options)
     try:
         should_warm = _check_vector_available() and any(s in _VECTOR_STRATEGIES for s in strategies)
+        should_warm_rerank = Strategy.ARCHEX_QUERY_FUSION_RERANK in strategies
         if should_warm:
             _log_progress(progress, f"  warming vector index for {task.task_id}...")
             if progress is not None:
                 progress.start_warmup()
-            _warm_repo_index(task, repo_path, retrieval_options)
+            _warm_repo_index(
+                task,
+                repo_path,
+                retrieval_options,
+                warm_rerank=should_warm_rerank,
+            )
         if progress is not None:
             progress.finish_warmup(strategies)
 

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -6,7 +6,9 @@ import importlib.metadata
 import logging
 import math
 import re
+import shutil
 import subprocess
+import tempfile
 import time
 from collections.abc import Callable
 from contextvars import ContextVar, Token
@@ -660,6 +662,66 @@ def benchmark_repo_source(task: BenchmarkTask, repo_path: Path) -> RepoSource:
     )
 
 
+_FRESHNESS_MARKER = "archex_freshness_probe"
+
+
+def _freshness_edit_text(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".py":
+        return f"\n\ndef {_FRESHNESS_MARKER}():\n    return 'freshness-probe'\n"
+    if suffix in {".js", ".jsx", ".ts", ".tsx"}:
+        return f"\n\nexport const {_FRESHNESS_MARKER} = 'freshness-probe';\n"
+    if suffix == ".go":
+        return f'\n\nfunc {_FRESHNESS_MARKER}() string {{ return "freshness-probe" }}\n'
+    if suffix == ".rs":
+        return f'\n\nfn {_FRESHNESS_MARKER}() -> &\'static str {{ "freshness-probe" }}\n'
+    return f"\n\n{_FRESHNESS_MARKER} freshness-probe\n"
+
+
+def _freshness_target(task: BenchmarkTask, repo_path: Path) -> Path | None:
+    for expected in task.expected_files:
+        candidate = repo_path / expected
+        if candidate.is_file():
+            return candidate
+    for candidate in repo_path.rglob("*"):
+        if candidate.is_file() and candidate.suffix.lower() in {".py", ".js", ".ts", ".go", ".rs"}:
+            return candidate
+    return None
+
+
+def measure_archex_freshness(task: BenchmarkTask, repo_path: Path) -> tuple[float, bool]:
+    """Measure edit-to-correct-result latency on an isolated repo copy."""
+    from archex.api import query
+    from archex.models import Config
+
+    workdir = Path(tempfile.mkdtemp(prefix="archex-freshness-"))
+    try:
+        target = workdir / repo_path.name
+        shutil.copytree(repo_path, target)
+        edit_target = _freshness_target(task, target)
+        if edit_target is None:
+            return (0.0, False)
+
+        source = benchmark_repo_source(task, target)
+        index_config = benchmark_index_config(IndexConfig(vector=False))
+        config = Config(cache=True, languages=task.languages, cache_dir=str(workdir / "cache"))
+        query(source, _FRESHNESS_MARKER, config=config, index_config=index_config)
+        with edit_target.open("a", encoding="utf-8") as handle:
+            handle.write(_freshness_edit_text(edit_target))
+        started = time.perf_counter()
+        bundle = query(
+            source,
+            _FRESHNESS_MARKER,
+            config=config,
+            index_config=index_config,
+        )
+        latency_ms = (time.perf_counter() - started) * 1000
+        found = any(_FRESHNESS_MARKER in chunk.chunk.content for chunk in bundle.chunks)
+        return (latency_ms, found)
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
 def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """archex query strategy: use BM25-based retrieval."""
     from archex.api import query
@@ -698,6 +760,7 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     completion_tokens, completion_files = compute_bundle_completion_penalty(
         repo_path, result_files, task.expected_files
     )
+    freshness_latency_ms, freshness_correct = measure_archex_freshness(task, repo_path)
 
     return BenchmarkResult(
         task_id=task.task_id,
@@ -745,6 +808,8 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
+        freshness_latency_ms=freshness_latency_ms,
+        freshness_correct=freshness_correct,
     )
 
 

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -22,7 +22,7 @@ from archex.benchmark.models import (
     Strategy,
 )
 from archex.cache import CacheManager
-from archex.exceptions import ConfigError
+from archex.exceptions import ArchexError, ConfigError
 from archex.models import IndexConfig, PipelineTiming, RepoSource
 from archex.reporting import count_tokens
 
@@ -718,6 +718,8 @@ def measure_archex_freshness(task: BenchmarkTask, repo_path: Path) -> tuple[floa
         latency_ms = (time.perf_counter() - started) * 1000
         found = any(_FRESHNESS_MARKER in chunk.chunk.content for chunk in bundle.chunks)
         return (latency_ms, found)
+    except (ArchexError, OSError, ValueError):
+        return (0.0, False)
     finally:
         shutil.rmtree(workdir, ignore_errors=True)
 
@@ -760,7 +762,10 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     completion_tokens, completion_files = compute_bundle_completion_penalty(
         repo_path, result_files, task.expected_files
     )
-    freshness_latency_ms, freshness_correct = measure_archex_freshness(task, repo_path)
+    if current_benchmark_retrieval_options().freshness:
+        freshness_latency_ms, freshness_correct = measure_archex_freshness(task, repo_path)
+    else:
+        freshness_latency_ms, freshness_correct = (0.0, False)
 
     return BenchmarkResult(
         task_id=task.task_id,
@@ -809,6 +814,7 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
         freshness_latency_ms=freshness_latency_ms,
+        freshness_measured=current_benchmark_retrieval_options().freshness,
         freshness_correct=freshness_correct,
     )
 

--- a/src/archex/index/rerank.py
+++ b/src/archex/index/rerank.py
@@ -22,19 +22,21 @@ MODEL_REVISIONS = {
 }
 
 # Maximum content length passed to the reranker per chunk.
-# Keep code snippets short because listwise reranking scores every candidate in
-# one prompt window and latency scales sharply with total document text.
-MAX_CONTENT_CHARS = 4096
+# The Jina listwise reranker on Apple Silicon scales sharply with total prompt
+# text; keeping each candidate near 1k chars preserves the representative code
+# region while holding warm rerank latency under the benchmark gate.
+MAX_CONTENT_CHARS = 1024
 
 # Default number of top candidates to keep after reranking.
-# Sized to cover ~8-10 files x 3-4 chunks each, giving downstream
-# scoring enough diversity without losing cross-encoder precision.
+# Sized to cover ~8-10 files x 3-4 chunks each, giving downstream scoring
+# enough diversity without losing cross-encoder precision.
 DEFAULT_TOP_K = 30
 
 # Maximum candidates sent through the expensive model. The caller preserves the
-# full candidate pool and treats rerank output as a score boost, so this cap
-# bounds latency without deleting lower-ranked retrieval candidates.
-RERANK_CANDIDATE_LIMIT = 12
+# full candidate pool and treats rerank output as a score boost, so a small
+# window is enough to bias the highest-confidence hits without paying the
+# latency cost of listwise scoring across the entire frontier.
+RERANK_CANDIDATE_LIMIT = 4
 
 _MODEL_CACHE: dict[str, Any] = {}
 

--- a/tests/benchmark/test_headtohead_report.py
+++ b/tests/benchmark/test_headtohead_report.py
@@ -36,6 +36,8 @@ def _result(strategy: Strategy, *, label: str | None = None) -> BenchmarkResult:
         f1_score=0.67,
         savings_vs_raw=0.0,
         wall_time_ms=12.0,
+        freshness_latency_ms=42.0,
+        freshness_correct=True,
         warm_latency_ms=10.0,
         cold_start_ms=2.0,
         cached=True,
@@ -81,6 +83,8 @@ def test_format_headtohead_markdown_keeps_all_lanes_and_provenance() -> None:
     assert "| ccc |" in output
     assert "| raw-grep/read |" in output
     assert "prov: manifest=comparison" in output
+    assert "field=freshness_latency_ms" in output
+    assert "field=freshness_correct" in output
     assert "field=bundle_completion_tokens" in output
     assert "No winner filtering" in output
 

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -175,14 +175,16 @@ class TestRunBenchmark:
         from archex.benchmark.strategies import default_strategy_registry
         from archex.exceptions import ArchexIndexError
 
-        warmed: list[tuple[Path, BenchmarkRetrievalOptions | None]] = []
+        warmed: list[tuple[Path, BenchmarkRetrievalOptions | None, bool]] = []
 
         def _record(
             _task: BenchmarkTask,
             path: Path,
             options: BenchmarkRetrievalOptions | None = None,
+            *,
+            warm_rerank: bool = False,
         ) -> None:
-            warmed.append((path, options))
+            warmed.append((path, options, warm_rerank))
 
         def _raise(_task: BenchmarkTask, _path: Path) -> None:
             raise ArchexIndexError("no vector backend in test")
@@ -199,7 +201,46 @@ class TestRunBenchmark:
             repo_path=repo_path,
             retrieval_options=BenchmarkRetrievalOptions(embedder="coderank"),
         )
-        assert warmed == [(repo_path, BenchmarkRetrievalOptions(embedder="coderank"))]
+        assert warmed == [(repo_path, BenchmarkRetrievalOptions(embedder="coderank"), False)]
+
+    def test_warms_reranker_when_rerank_strategy_present(
+        self,
+        fixture_task: tuple[BenchmarkTask, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from archex.benchmark import runner as runner_mod
+        from archex.benchmark.strategies import default_strategy_registry
+        from archex.exceptions import ArchexIndexError
+
+        task, repo_path = fixture_task
+        warmed: list[tuple[Path, BenchmarkRetrievalOptions | None, bool]] = []
+
+        def _record(
+            _task: BenchmarkTask,
+            path: Path,
+            options: BenchmarkRetrievalOptions | None = None,
+            *,
+            warm_rerank: bool = False,
+        ) -> None:
+            warmed.append((path, options, warm_rerank))
+
+        def _raise(_task: BenchmarkTask, _path: Path) -> None:
+            raise ArchexIndexError("no vector backend in test")
+
+        monkeypatch.setattr(runner_mod, "_check_vector_available", lambda: True)
+        monkeypatch.setattr(runner_mod, "_warm_repo_index", _record)
+
+        key = Strategy.ARCHEX_QUERY_FUSION_RERANK.value
+        monkeypatch.setitem(default_strategy_registry._runners, key, _raise)  # pyright: ignore[reportPrivateUsage]
+
+        options = BenchmarkRetrievalOptions(rerank_model="cross-encoder/ms-marco-MiniLM-L-6-v2")
+        run_benchmark(
+            task,
+            strategies=[Strategy.ARCHEX_QUERY_FUSION_RERANK],
+            repo_path=repo_path,
+            retrieval_options=options,
+        )
+        assert warmed == [(repo_path, options, True)]
 
     def test_warm_repo_index_uses_configured_embedder(
         self,
@@ -209,7 +250,7 @@ class TestRunBenchmark:
         from archex.models import ContextBundle, IndexConfig
 
         task, repo_path = fixture_task
-        captured: list[str | None] = []
+        captured: list[tuple[str | None, bool, str | None]] = []
 
         def fake_query(
             _source: object,
@@ -222,7 +263,7 @@ class TestRunBenchmark:
         ) -> ContextBundle:
             del config
             del explicit_token_budget
-            captured.append(index_config.embedder)
+            captured.append((index_config.embedder, index_config.rerank, index_config.rerank_model))
             return ContextBundle(
                 query=question,
                 chunks=[],
@@ -236,8 +277,20 @@ class TestRunBenchmark:
                 repo_path,
                 BenchmarkRetrievalOptions(embedder="coderank"),
             )
+            runner_mod._warm_repo_index(  # pyright: ignore[reportPrivateUsage]
+                task,
+                repo_path,
+                BenchmarkRetrievalOptions(
+                    embedder="coderank",
+                    rerank_model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+                ),
+                warm_rerank=True,
+            )
 
-        assert captured == ["coderank"]
+        assert captured == [
+            ("coderank", False, None),
+            ("coderank", True, "cross-encoder/ms-marco-MiniLM-L-6-v2"),
+        ]
 
     def test_skips_warmup_for_raw_only_strategies(
         self,

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -22,6 +22,7 @@ from archex.benchmark.strategies import (
     compute_token_efficiency,
     count_file_tokens,
     extract_keywords,
+    measure_archex_freshness,
     reset_benchmark_retrieval_options,
     run_archex_query,
     run_archex_query_fusion,
@@ -62,6 +63,16 @@ def sample_task() -> BenchmarkTask:
         expected_files=["main.py", "services/auth.py"],
         keywords=["auth", "login"],
     )
+
+
+def test_measure_archex_freshness_returns_correct_probe(
+    sample_task: BenchmarkTask,
+    python_simple_repo: Path,
+) -> None:
+    latency_ms, correct = measure_archex_freshness(sample_task, python_simple_repo)
+
+    assert latency_ms > 0
+    assert correct is True
 
 
 def _ranked_chunk(chunk_id: str, file_path: str, *, score: float) -> RankedChunk:

--- a/tests/index/test_rerank.py
+++ b/tests/index/test_rerank.py
@@ -92,9 +92,9 @@ class TestConstants:
     def test_default_top_k_is_30(self) -> None:
         assert DEFAULT_TOP_K == 30
 
-    def test_max_content_chars_bounds_listwise_latency(self) -> None:
-        assert MAX_CONTENT_CHARS == 4096
-        assert RERANK_CANDIDATE_LIMIT == 12
+    def test_listwise_caps_target_warm_benchmark_latency(self) -> None:
+        assert MAX_CONTENT_CHARS == 1024
+        assert RERANK_CANDIDATE_LIMIT == 4
 
     def test_default_model_is_jina_reranker(self) -> None:
         assert DEFAULT_MODEL == JINA_RERANKER_MODEL


### PR DESCRIPTION
## Stack

Stack-Id: `c2-freshness-20260611`
Base: `main`
Position: 5/5

1. `feat/worktree-delta`
2. `feat/embedding-content-cache`
3. `feat/query-auto-refresh`
4. `feat/mcp-watch`
5. `feat/freshness-benchmark` -> this PR

Depends on: feat/mcp-watch
Upstack: none

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright` passed on leaf.
- `uv run pytest tests/index/ tests/integrations/test_mcp.py -q` ran tests successfully but failed coverage-only partial-suite gate.
- Targeted changed tests passed with `--no-cov` on leaf.

## Operator block

```bash
uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --tasks-dir benchmarks/tasks --output .archex/e2e-freshness
uv run archex benchmark gate --input .archex/e2e-freshness --baseline .archex/e2e-tokens --warn-latency-ms 3000
uv run archex dogfood . --all --baseline benchmarks/dogfood_baseline.json --format dogfood-delta
```