### PR TITLE
Add edge confidence model fields

### DIFF
--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -43,6 +43,13 @@ class EdgeKind(StrEnum):
     CO_DIRECTORY = "co_directory"
 
 
+class EdgeConfidence(StrEnum):
+    EXTRACTED = "extracted"
+    HEURISTIC = "heuristic"
+    INFERRED = "inferred"
+    AMBIGUOUS = "ambiguous"
+
+
 class PatternCategory(StrEnum):
     STRUCTURAL = "structural"
     BEHAVIORAL = "behavioral"
@@ -346,6 +353,15 @@ class Edge(BaseModel):
     target: str
     kind: EdgeKind
     location: str | None = None
+    confidence: EdgeConfidence = EdgeConfidence.EXTRACTED
+    confidence_score: float = 1.0
+    evidence: list[str] = []
+
+    @model_validator(mode="after")
+    def _validate_confidence_score(self) -> Edge:
+        if not 0.0 <= self.confidence_score <= 1.0:
+            raise ValueError("confidence_score must be between 0.0 and 1.0")
+        return self
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,6 +9,8 @@ from archex.models import (
     Config,
     ContextBundle,
     DetectedPattern,
+    Edge,
+    EdgeConfidence,
     EdgeKind,
     IndexConfig,
     Interface,
@@ -47,6 +49,31 @@ def test_edge_kind_members() -> None:
     assert EdgeKind.CALLS == "calls"
     assert EdgeKind.INHERITS == "inherits"
     assert EdgeKind.IMPLEMENTS == "implements"
+
+
+def test_edge_confidence_members() -> None:
+    assert EdgeConfidence.EXTRACTED == "extracted"
+    assert EdgeConfidence.HEURISTIC == "heuristic"
+    assert EdgeConfidence.INFERRED == "inferred"
+    assert EdgeConfidence.AMBIGUOUS == "ambiguous"
+
+
+def test_edge_confidence_defaults() -> None:
+    edge = Edge(source="a.py", target="b.py", kind=EdgeKind.IMPORTS)
+
+    assert edge.confidence == EdgeConfidence.EXTRACTED
+    assert edge.confidence_score == 1.0
+    assert edge.evidence == []
+
+
+def test_edge_confidence_score_bounds() -> None:
+    with pytest.raises(ValueError, match="confidence_score must be between"):
+        Edge(
+            source="a.py",
+            target="b.py",
+            kind=EdgeKind.IMPORTS,
+            confidence_score=1.1,
+        )
 
 
 def test_vector_mode_members() -> None:


### PR DESCRIPTION
## Stack

Stack-Id: `edge-confidence-g3`
Base: `main`
Position: 1/3

1. #195 `feat/edge-confidence-model` -> this PR
2. #196 `feat/edge-confidence-store`
3. #197 `feat/edge-confidence-export`

Depends on: none
Upstack: #196

## Change

Adds `EdgeConfidence` and `Edge` confidence, score, and evidence fields with defaults preserving existing callers.

## Validation

- Pass: `uv run ruff check && uv run ruff format --check . && uv run pyright`
- Pass: `uv run pytest -q` (2158 passed, 4 deselected, 90.11% coverage)
- Targeted G3 pytest selection passed functionally: 105 passed with `--cov-fail-under=0`; the exact narrow command exits non-zero because repository-level `--cov-fail-under=85` applies to narrow selections.

## PR Review

- pr-review completed for this slice: no blocking findings.
