### PR TITLE
Persist edge confidence fields

### DIFF
--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
-from archex.models import ChunkSurrogate, CodeChunk, Edge, EdgeKind, Module, SymbolKind
+from archex.models import (
+    ChunkSurrogate,
+    CodeChunk,
+    Edge,
+    EdgeConfidence,
+    EdgeKind,
+    Module,
+    SymbolKind,
+)
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -37,7 +46,10 @@ CREATE TABLE IF NOT EXISTS edges (
     source TEXT NOT NULL,
     target TEXT NOT NULL,
     kind TEXT NOT NULL,
-    location TEXT
+    location TEXT,
+    confidence TEXT NOT NULL DEFAULT 'extracted',
+    confidence_score REAL NOT NULL DEFAULT 1.0,
+    evidence TEXT NOT NULL DEFAULT '[]'
 );
 """
 
@@ -147,6 +159,16 @@ def _row_to_chunk(row: tuple[object, ...]) -> CodeChunk:
 
 def _batched_ids(ids: list[str], batch_size: int = _SQLITE_VARIABLE_BATCH) -> list[list[str]]:
     return [ids[i : i + batch_size] for i in range(0, len(ids), batch_size)]
+
+
+def _decode_edge_evidence(raw: object) -> list[str]:
+    decoded: object = json.loads(str(raw))
+    if not isinstance(decoded, list):
+        raise ValueError("edge evidence must be a JSON array of strings")
+    evidence = cast("list[object]", decoded)
+    if not all(isinstance(item, str) for item in evidence):
+        raise ValueError("edge evidence must be a JSON array of strings")
+    return cast("list[str]", evidence)
 
 
 class IndexStore:
@@ -260,8 +282,21 @@ class IndexStore:
 
     def _insert_edges_no_commit(self, edges: list[Edge]) -> None:
         self._conn.executemany(
-            "INSERT INTO edges (source, target, kind, location) VALUES (?, ?, ?, ?)",
-            [(e.source, e.target, str(e.kind), e.location) for e in edges],
+            "INSERT INTO edges "
+            "(source, target, kind, location, confidence, confidence_score, evidence) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    e.source,
+                    e.target,
+                    str(e.kind),
+                    e.location,
+                    str(e.confidence),
+                    e.confidence_score,
+                    json.dumps(e.evidence, sort_keys=True),
+                )
+                for e in edges
+            ],
         )
 
     def insert_edges(self, edges: list[Edge]) -> None:
@@ -657,9 +692,20 @@ class IndexStore:
         return int(row[0])
 
     def get_edges(self) -> list[Edge]:
-        cur = self._conn.execute("SELECT source, target, kind, location FROM edges")
+        cur = self._conn.execute(
+            "SELECT source, target, kind, location, confidence, confidence_score, evidence "
+            "FROM edges"
+        )
         return [
-            Edge(source=str(r[0]), target=str(r[1]), kind=EdgeKind(r[2]), location=r[3])
+            Edge(
+                source=str(r[0]),
+                target=str(r[1]),
+                kind=EdgeKind(r[2]),
+                location=r[3],
+                confidence=EdgeConfidence(r[4]),
+                confidence_score=float(r[5]),
+                evidence=_decode_edge_evidence(r[6]),
+            )
             for r in cur.fetchall()
         ]
 
@@ -704,8 +750,25 @@ class IndexStore:
             + _CREATE_IDX_MODULES_NAME
             + _CREATE_SYMBOLS_FTS
         )
+        edge_columns = {row[1] for row in self._conn.execute("PRAGMA table_info(edges)")}
+        edge_migrations = {
+            "confidence": (
+                "ALTER TABLE edges ADD COLUMN confidence TEXT NOT NULL DEFAULT 'extracted'"
+            ),
+            "confidence_score": (
+                "ALTER TABLE edges ADD COLUMN confidence_score REAL NOT NULL DEFAULT 1.0"
+            ),
+            "evidence": "ALTER TABLE edges ADD COLUMN evidence TEXT NOT NULL DEFAULT '[]'",
+        }
+        for column, statement in edge_migrations.items():
+            if column not in edge_columns:
+                self._conn.execute(statement)
+        edge_columns = {row[1] for row in self._conn.execute("PRAGMA table_info(edges)")}
+        if {"confidence", "confidence_score", "evidence"} - edge_columns:
+            raise RuntimeError("edges table missing confidence columns after migration")
+
         # Set schema version and detect stale data needing re-index
-        self.set_metadata("schema_version", "3")
+        self.set_metadata("schema_version", "4")
         cur = self._conn.execute("SELECT COUNT(*) FROM chunks WHERE symbol_id IS NULL")
         null_count = cur.fetchone()[0]
         if null_count > 0:

--- a/tests/index/test_store.py
+++ b/tests/index/test_store.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from archex.index.store import IndexStore
-from archex.models import ChunkSurrogate, CodeChunk, Edge, EdgeKind, SymbolKind
+from archex.models import ChunkSurrogate, CodeChunk, Edge, EdgeConfidence, EdgeKind, SymbolKind
 
 SAMPLE_CHUNKS = [
     CodeChunk(
@@ -234,6 +234,25 @@ def test_edge_kind_preserved(store: IndexStore) -> None:
     assert kind_map["utils.py"] == EdgeKind.CALLS
 
 
+def test_edge_confidence_round_trip(store: IndexStore) -> None:
+    edge = Edge(
+        source="tests/test_auth.py",
+        target="src/auth.py",
+        kind=EdgeKind.CALLS,
+        location="tests/test_auth.py:7",
+        confidence=EdgeConfidence.HEURISTIC,
+        confidence_score=0.72,
+        evidence=["same symbol stem", "test path targets source path"],
+    )
+
+    store.insert_edges([edge])
+    [stored] = store.get_edges()
+
+    assert stored.confidence == EdgeConfidence.HEURISTIC
+    assert stored.confidence_score == 0.72
+    assert stored.evidence == ["same symbol stem", "test path targets source path"]
+
+
 def test_empty_store_returns_empty_lists(store: IndexStore) -> None:
     assert store.get_chunks() == []
     assert store.get_edges() == []
@@ -337,7 +356,13 @@ def test_fresh_store_does_not_need_reindex(store: IndexStore) -> None:
 
 
 def test_fresh_store_has_schema_version(store: IndexStore) -> None:
-    assert store.get_metadata("schema_version") == "3"
+    assert store.get_metadata("schema_version") == "4"
+
+
+def test_fresh_store_has_edge_confidence_columns(store: IndexStore) -> None:
+    columns = {row[1] for row in store.conn.execute("PRAGMA table_info(edges)")}
+
+    assert {"confidence", "confidence_score", "evidence"} <= columns
 
 
 def test_migrated_store_with_null_symbol_ids_needs_reindex(tmp_path: Path) -> None:
@@ -374,7 +399,53 @@ def test_migrated_store_with_null_symbol_ids_needs_reindex(tmp_path: Path) -> No
 
     with IndexStore(db) as s:
         assert s.needs_reindex() is True
-        assert s.get_metadata("schema_version") == "3"
+        assert s.get_metadata("schema_version") == "4"
+        columns = {row[1] for row in s.conn.execute("PRAGMA table_info(edges)")}
+        assert {"confidence", "confidence_score", "evidence"} <= columns
+
+
+def test_old_edges_migrate_with_confidence_defaults(tmp_path: Path) -> None:
+    import sqlite3
+
+    db = tmp_path / "old_edges.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript("""
+        CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            content TEXT NOT NULL,
+            file_path TEXT NOT NULL,
+            start_line INTEGER NOT NULL,
+            end_line INTEGER NOT NULL,
+            symbol_name TEXT,
+            symbol_kind TEXT,
+            language TEXT NOT NULL,
+            imports_context TEXT DEFAULT '',
+            token_count INTEGER DEFAULT 0,
+            symbol_id TEXT,
+            qualified_name TEXT,
+            visibility TEXT DEFAULT 'public',
+            signature TEXT,
+            docstring TEXT
+        );
+        CREATE TABLE edges (
+            source TEXT NOT NULL, target TEXT NOT NULL,
+            kind TEXT NOT NULL, location TEXT
+        );
+        CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    """)
+    conn.execute(
+        "INSERT INTO edges (source, target, kind, location) VALUES (?, ?, ?, ?)",
+        ("a.py", "b.py", "imports", "a.py:1"),
+    )
+    conn.commit()
+    conn.close()
+
+    with IndexStore(db) as s:
+        [edge] = s.get_edges()
+
+    assert edge.confidence == EdgeConfidence.EXTRACTED
+    assert edge.confidence_score == 1.0
+    assert edge.evidence == []
 
 
 def test_clear_reindex_flag(tmp_path: Path) -> None:


### PR DESCRIPTION
## Stack

Stack-Id: `edge-confidence-g3`
Base: `main`
Position: 2/3

1. #195 `feat/edge-confidence-model`
2. #196 `feat/edge-confidence-store` -> this PR
3. #197 `feat/edge-confidence-export`

Depends on: #195
Upstack: #197

## Change

Persists edge confidence, score, and evidence fields in `IndexStore`, with migration defaults for existing rows.

## Validation

- Pass: `uv run ruff check && uv run ruff format --check . && uv run pyright`
- Pass: `uv run pytest -q` (2158 passed, 4 deselected, 90.11% coverage)
- Targeted G3 pytest selection passed functionally: 105 passed with `--cov-fail-under=0`; the exact narrow command exits non-zero because repository-level `--cov-fail-under=85` applies to narrow selections.

## PR Review

- pr-review completed for this slice: no blocking findings.
