### PR TITLE
Export edge confidence provenance

### DIFF
--- a/src/archex/graph_artifact.py
+++ b/src/archex/graph_artifact.py
@@ -12,12 +12,12 @@ from typing import TYPE_CHECKING, Literal
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from archex import __version__
-from archex.models import CodeChunk, Edge, EdgeKind
+from archex.models import CodeChunk, Edge, EdgeConfidence, EdgeKind
 
 if TYPE_CHECKING:
     from archex.index.store import IndexStore
 
-GRAPH_SCHEMA_VERSION = "1.0.0"
+GRAPH_SCHEMA_VERSION = "1.1.0"
 SUPPORTED_GRAPH_SCHEMA_MAJOR = 1
 _KNOWN_CONFIG_NAMES = {
     "pyproject.toml",
@@ -53,6 +53,7 @@ class GraphEdgeType(StrEnum):
     EXPOSES = "exposes"
     TESTS = "tests"
     CONFIGURES = "configures"
+    CO_DIRECTORY = "co_directory"
 
 
 class GraphSchemaVersion(BaseModel):
@@ -123,6 +124,15 @@ class GraphEdge(BaseModel):
     type: GraphEdgeType
     label: str = ""
     location: str | None = None
+    confidence: EdgeConfidence = EdgeConfidence.EXTRACTED
+    confidence_score: float = 1.0
+    evidence: list[str] = []
+
+    @model_validator(mode="after")
+    def _validate_confidence_score(self) -> GraphEdge:
+        if not 0.0 <= self.confidence_score <= 1.0:
+            raise ValueError("confidence_score must be between 0.0 and 1.0")
+        return self
 
 
 class GraphLayer(BaseModel):
@@ -464,17 +474,39 @@ def _build_config_nodes(
     return nodes
 
 
+def _graph_edge_type_for(edge_kind: EdgeKind) -> GraphEdgeType | None:
+    if edge_kind == EdgeKind.IMPORTS:
+        return GraphEdgeType.IMPORTS
+    if edge_kind == EdgeKind.CO_DIRECTORY:
+        return GraphEdgeType.CO_DIRECTORY
+    return None
+
+
+def _chunk_contains_evidence(chunk: CodeChunk) -> list[str]:
+    return [f"parser chunk span {chunk.file_path}:{chunk.start_line}-{chunk.end_line}"]
+
+
+def _public_interface_evidence(chunk: CodeChunk) -> list[str]:
+    return [f"public {chunk.symbol_kind} {chunk.qualified_name or chunk.symbol_name}"]
+
+
 def _build_graph_edges(chunks: list[CodeChunk], edges: list[Edge]) -> list[GraphEdge]:
-    graph_edges = [
-        GraphEdge(
-            source=node_id_for_path(edge.source),
-            target=node_id_for_path(edge.target),
-            type=GraphEdgeType.IMPORTS,
-            location=edge.location,
+    graph_edges: list[GraphEdge] = []
+    for edge in edges:
+        edge_type = _graph_edge_type_for(edge.kind)
+        if edge_type is None:
+            continue
+        graph_edges.append(
+            GraphEdge(
+                source=node_id_for_path(edge.source),
+                target=node_id_for_path(edge.target),
+                type=edge_type,
+                location=edge.location,
+                confidence=edge.confidence,
+                confidence_score=edge.confidence_score,
+                evidence=edge.evidence,
+            )
         )
-        for edge in edges
-        if edge.kind == EdgeKind.IMPORTS
-    ]
     for chunk in chunks:
         if chunk.symbol_name is None or chunk.symbol_kind is None:
             continue
@@ -486,6 +518,9 @@ def _build_graph_edges(chunks: list[CodeChunk], edges: list[Edge]) -> list[Graph
                 source=node_id_for_path(chunk.file_path),
                 target=symbol_id,
                 type=GraphEdgeType.CONTAINS,
+                confidence=EdgeConfidence.EXTRACTED,
+                confidence_score=1.0,
+                evidence=_chunk_contains_evidence(chunk),
             )
         )
         if _is_public_interface_chunk(chunk):
@@ -494,6 +529,9 @@ def _build_graph_edges(chunks: list[CodeChunk], edges: list[Edge]) -> list[Graph
                     source=node_id_for_path(chunk.file_path),
                     target=interface_node_id(chunk.file_path, qualified_name),
                     type=GraphEdgeType.EXPOSES,
+                    confidence=EdgeConfidence.HEURISTIC,
+                    confidence_score=0.85,
+                    evidence=_public_interface_evidence(chunk),
                 )
             )
     return graph_edges

--- a/src/archex/index/graph.py
+++ b/src/archex/index/graph.py
@@ -2,15 +2,71 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from typing import TYPE_CHECKING, Any
 
 import networkx as nx
 
-from archex.models import Edge, EdgeKind, ImportStatement, ParsedFile
+from archex.models import Edge, EdgeConfidence, EdgeKind, ImportStatement, ParsedFile
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+_CO_DIRECTORY_CONFIDENCE_SCORE = 0.6
+_CO_DIRECTORY_EVIDENCE = [
+    "same directory package scope; added only when no direct import edge exists"
+]
+
+
+def _resolved_import_evidence(file_path: str, imported_module: str, line: int) -> list[str]:
+    return [f"resolved import {imported_module!r} at {file_path}:{line}"]
+
+
+def _edge_attrs(
+    *,
+    kind: EdgeKind | str,
+    location: str | None = None,
+    confidence: EdgeConfidence = EdgeConfidence.EXTRACTED,
+    confidence_score: float = 1.0,
+    evidence: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "kind": kind,
+        "location": location,
+        "confidence": confidence,
+        "confidence_score": confidence_score,
+        "evidence": list(evidence or []),
+        "traversable": confidence != EdgeConfidence.AMBIGUOUS,
+    }
+
+
+def _edge_from_data(source: object, target: object, data: dict[str, Any]) -> Edge:
+    return Edge(
+        source=str(source),
+        target=str(target),
+        kind=data.get("kind", EdgeKind.IMPORTS),
+        location=data.get("location"),
+        confidence=data.get("confidence", EdgeConfidence.EXTRACTED),
+        confidence_score=float(data.get("confidence_score", 1.0)),
+        evidence=list(data.get("evidence", [])),
+    )
+
+
+def _ensure_sqlite_edge_confidence_columns(conn: sqlite3.Connection) -> None:
+    edge_columns = {row[1] for row in conn.execute("PRAGMA table_info(edges)")}
+    edge_migrations = {
+        "confidence": "ALTER TABLE edges ADD COLUMN confidence TEXT DEFAULT 'extracted'",
+        "confidence_score": "ALTER TABLE edges ADD COLUMN confidence_score REAL DEFAULT 1.0",
+        "evidence": "ALTER TABLE edges ADD COLUMN evidence TEXT DEFAULT '[]'",
+    }
+    migrated = False
+    for column, statement in edge_migrations.items():
+        if column not in edge_columns:
+            conn.execute(statement)
+            migrated = True
+    if migrated:
+        conn.commit()
 
 
 class DependencyGraph:
@@ -52,8 +108,11 @@ class DependencyGraph:
                     graph._file_graph.add_edge(  # type: ignore[misc]
                         file_path,
                         imp.resolved_path,
-                        kind=EdgeKind.IMPORTS,
-                        location=f"{file_path}:{imp.line}",
+                        **_edge_attrs(
+                            kind=EdgeKind.IMPORTS,
+                            location=f"{file_path}:{imp.line}",
+                            evidence=_resolved_import_evidence(file_path, imp.module, imp.line),
+                        ),
                     )
 
         return graph
@@ -83,12 +142,26 @@ class DependencyGraph:
                 for tgt in files[i + 1 :]:
                     if not self._file_graph.has_edge(src, tgt):  # type: ignore[misc]
                         self._file_graph.add_edge(  # type: ignore[misc]
-                            src, tgt, kind=EdgeKind.CO_DIRECTORY
+                            src,
+                            tgt,
+                            **_edge_attrs(
+                                kind=EdgeKind.CO_DIRECTORY,
+                                confidence=EdgeConfidence.HEURISTIC,
+                                confidence_score=_CO_DIRECTORY_CONFIDENCE_SCORE,
+                                evidence=_CO_DIRECTORY_EVIDENCE,
+                            ),
                         )
                         added += 1
                     if not self._file_graph.has_edge(tgt, src):  # type: ignore[misc]
                         self._file_graph.add_edge(  # type: ignore[misc]
-                            tgt, src, kind=EdgeKind.CO_DIRECTORY
+                            tgt,
+                            src,
+                            **_edge_attrs(
+                                kind=EdgeKind.CO_DIRECTORY,
+                                confidence=EdgeConfidence.HEURISTIC,
+                                confidence_score=_CO_DIRECTORY_CONFIDENCE_SCORE,
+                                evidence=_CO_DIRECTORY_EVIDENCE,
+                            ),
                         )
                         added += 1
 
@@ -105,8 +178,13 @@ class DependencyGraph:
             graph._file_graph.add_edge(  # type: ignore[misc]
                 edge.source,
                 edge.target,
-                kind=edge.kind,
-                location=edge.location,
+                **_edge_attrs(
+                    kind=edge.kind,
+                    location=edge.location,
+                    confidence=edge.confidence,
+                    confidence_score=edge.confidence_score,
+                    evidence=edge.evidence,
+                ),
             )
         return graph
 
@@ -121,7 +199,7 @@ class DependencyGraph:
 
     def add_file_edge(self, source: str, target: str, kind: str = "imports") -> None:
         """Add an edge to the file-level graph."""
-        self._file_graph.add_edge(source, target, kind=kind)  # type: ignore[misc]
+        self._file_graph.add_edge(source, target, **_edge_attrs(kind=kind))  # type: ignore[misc]
         self._centrality_cache = None
 
     def update_files(
@@ -154,8 +232,13 @@ class DependencyGraph:
             self._file_graph.add_edge(  # type: ignore[misc]
                 edge.source,
                 edge.target,
-                kind=edge.kind,
-                location=edge.location,
+                **_edge_attrs(
+                    kind=edge.kind,
+                    location=edge.location,
+                    confidence=edge.confidence,
+                    confidence_score=edge.confidence_score,
+                    evidence=edge.evidence,
+                ),
             )
 
         self._centrality_cache = None
@@ -180,17 +263,8 @@ class DependencyGraph:
         """Return Edge objects for all file-level edges."""
         edges: list[Edge] = []
         for src, tgt, data in self._file_graph.edges(data=True):  # type: ignore[misc]
-            src_str = str(src)
-            tgt_str = str(tgt)
             edge_data: dict[str, Any] = data  # type: ignore[assignment]
-            edges.append(
-                Edge(
-                    source=src_str,
-                    target=tgt_str,
-                    kind=edge_data.get("kind", EdgeKind.IMPORTS),
-                    location=edge_data.get("location"),
-                )
-            )
+            edges.append(_edge_from_data(src, tgt, edge_data))
         return edges
 
     def neighborhood(self, node: str, hops: int = 1) -> set[str]:
@@ -204,14 +278,16 @@ class DependencyGraph:
         for _ in range(hops):
             next_frontier: set[str] = set()
             for n in frontier:
-                for pred in self._file_graph.predecessors(n):  # type: ignore[misc]
-                    pred_str = str(pred)
-                    if pred_str not in visited and pred_str != node:
-                        next_frontier.add(pred_str)
-                for succ in self._file_graph.successors(n):  # type: ignore[misc]
-                    succ_str = str(succ)
-                    if succ_str not in visited and succ_str != node:
-                        next_frontier.add(succ_str)
+                for pred, _, data in self._file_graph.in_edges(n, data=True):  # type: ignore[misc]
+                    if data.get("traversable", True):
+                        pred_str = str(pred)
+                        if pred_str not in visited and pred_str != node:
+                            next_frontier.add(pred_str)
+                for _, succ, data in self._file_graph.out_edges(n, data=True):  # type: ignore[misc]
+                    if data.get("traversable", True):
+                        succ_str = str(succ)
+                        if succ_str not in visited and succ_str != node:
+                            next_frontier.add(succ_str)
             visited |= frontier
             frontier = next_frontier - visited
 
@@ -223,13 +299,21 @@ class DependencyGraph:
         """Return files that *node* directly imports (successors in the directed graph)."""
         if not self._file_graph.has_node(node):  # type: ignore[misc]
             return set()
-        return {str(s) for s in self._file_graph.successors(node)}  # type: ignore[misc]
+        return {
+            str(succ)
+            for _, succ, data in self._file_graph.out_edges(node, data=True)  # type: ignore[misc]
+            if data.get("traversable", True)
+        }
 
     def imported_by(self, node: str) -> set[str]:
         """Return files that directly import *node* (predecessors in the directed graph)."""
         if not self._file_graph.has_node(node):  # type: ignore[misc]
             return set()
-        return {str(p) for p in self._file_graph.predecessors(node)}  # type: ignore[misc]
+        return {
+            str(pred)
+            for pred, _, data in self._file_graph.in_edges(node, data=True)  # type: ignore[misc]
+            if data.get("traversable", True)
+        }
 
     def structural_centrality(self) -> dict[str, float]:
         """Return PageRank centrality scores for all file nodes (lazily cached)."""
@@ -237,7 +321,14 @@ class DependencyGraph:
             return self._centrality_cache
         if self._file_graph.number_of_nodes() == 0:  # type: ignore[misc]
             return {}
-        raw: dict[Any, float] = nx.pagerank(self._file_graph)  # type: ignore[misc]
+        traversable_edges = [
+            (src, tgt)
+            for src, tgt, data in self._file_graph.edges(data=True)  # type: ignore[misc]
+            if data.get("traversable", True)
+        ]
+        graph = self._file_graph.edge_subgraph(traversable_edges).copy()  # type: ignore[misc]
+        graph.add_nodes_from(self._file_graph.nodes())  # type: ignore[misc]
+        raw: dict[Any, float] = nx.pagerank(graph)  # type: ignore[misc]
         self._centrality_cache = {str(k): v for k, v in raw.items()}
         return self._centrality_cache
 
@@ -253,8 +344,10 @@ class DependencyGraph:
             cur.execute("CREATE TABLE IF NOT EXISTS files (path TEXT PRIMARY KEY)")
             cur.execute(
                 "CREATE TABLE IF NOT EXISTS edges "
-                "(source TEXT, target TEXT, kind TEXT, location TEXT)"
+                "(source TEXT, target TEXT, kind TEXT, location TEXT, "
+                "confidence TEXT, confidence_score REAL, evidence TEXT)"
             )
+            _ensure_sqlite_edge_confidence_columns(conn)
             cur.execute("DELETE FROM files")
             cur.execute("DELETE FROM edges")
 
@@ -264,12 +357,17 @@ class DependencyGraph:
             for src, tgt, data in self._file_graph.edges(data=True):  # type: ignore[misc]
                 edge_data: dict[str, Any] = data  # type: ignore[assignment]
                 cur.execute(
-                    "INSERT INTO edges (source, target, kind, location) VALUES (?, ?, ?, ?)",
+                    "INSERT INTO edges "
+                    "(source, target, kind, location, confidence, confidence_score, evidence) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
                     (
                         str(src),
                         str(tgt),
                         edge_data.get("kind", EdgeKind.IMPORTS),
                         edge_data.get("location"),
+                        edge_data.get("confidence", EdgeConfidence.EXTRACTED),
+                        float(edge_data.get("confidence_score", 1.0)),
+                        json.dumps(edge_data.get("evidence", []), sort_keys=True),
                     ),
                 )
 
@@ -284,12 +382,24 @@ class DependencyGraph:
         conn = sqlite3.connect(str(db_path))
         try:
             cur = conn.cursor()
+            _ensure_sqlite_edge_confidence_columns(conn)
             for (path,) in cur.execute("SELECT path FROM files"):
                 graph._file_graph.add_node(str(path))  # type: ignore[misc]
-            for src, tgt, kind, location in cur.execute(
-                "SELECT source, target, kind, location FROM edges"
+            for src, tgt, kind, location, confidence, confidence_score, evidence in cur.execute(
+                "SELECT source, target, kind, location, confidence, confidence_score, evidence "
+                "FROM edges"
             ):
-                graph._file_graph.add_edge(str(src), str(tgt), kind=kind, location=location)  # type: ignore[misc]
+                graph._file_graph.add_edge(  # type: ignore[misc]
+                    str(src),
+                    str(tgt),
+                    **_edge_attrs(
+                        kind=EdgeKind(kind),
+                        location=location,
+                        confidence=EdgeConfidence(confidence),
+                        confidence_score=float(confidence_score),
+                        evidence=json.loads(str(evidence)),
+                    ),
+                )
         finally:
             conn.close()
         return graph

--- a/tests/index/test_graph.py
+++ b/tests/index/test_graph.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from archex.index.graph import DependencyGraph
-from archex.models import ImportStatement, ParsedFile, Symbol, SymbolKind, Visibility
+from archex.models import (
+    Edge,
+    EdgeConfidence,
+    EdgeKind,
+    ImportStatement,
+    ParsedFile,
+    Symbol,
+    SymbolKind,
+    Visibility,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -100,6 +109,16 @@ def test_file_edges_returns_edge_objects() -> None:
     assert edge.kind == EdgeKind.IMPORTS
 
 
+def test_resolved_import_edges_are_extracted_with_evidence() -> None:
+    graph = DependencyGraph.from_parsed_files(_make_parsed_files(), _make_import_map())
+
+    [edge] = graph.file_edges()
+
+    assert edge.confidence == EdgeConfidence.EXTRACTED
+    assert edge.confidence_score == 1.0
+    assert edge.evidence == ["resolved import 'models' at main.py:1"]
+
+
 def test_neighborhood_bfs() -> None:
     parsed = _make_parsed_files()
     import_map = _make_import_map()
@@ -138,6 +157,50 @@ def test_sqlite_round_trip(tmp_path: Path) -> None:
     restored = DependencyGraph.from_sqlite(db_path)
     assert restored.file_count == graph.file_count
     assert restored.file_edge_count == graph.file_edge_count
+
+
+def test_sqlite_round_trip_preserves_edge_confidence(tmp_path: Path) -> None:
+    edge = Edge(
+        source="a.py",
+        target="b.py",
+        kind=EdgeKind.IMPORTS,
+        confidence=EdgeConfidence.INFERRED,
+        confidence_score=0.4,
+        evidence=["external analyzer matched symbol"],
+    )
+    graph = DependencyGraph.from_edges([edge])
+
+    db_path = tmp_path / "graph-confidence.db"
+    graph.to_sqlite(db_path)
+    restored = DependencyGraph.from_sqlite(db_path)
+
+    [restored_edge] = restored.file_edges()
+    assert restored_edge.confidence == EdgeConfidence.INFERRED
+    assert restored_edge.confidence_score == 0.4
+    assert restored_edge.evidence == ["external analyzer matched symbol"]
+
+
+def test_old_sqlite_graph_migrates_edge_confidence(tmp_path: Path) -> None:
+    import sqlite3
+
+    db_path = tmp_path / "old-graph.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("""
+        CREATE TABLE files (path TEXT PRIMARY KEY);
+        CREATE TABLE edges (source TEXT, target TEXT, kind TEXT, location TEXT);
+        INSERT INTO files (path) VALUES ('a.py'), ('b.py');
+        INSERT INTO edges (source, target, kind, location)
+        VALUES ('a.py', 'b.py', 'imports', 'a.py:1');
+    """)
+    conn.commit()
+    conn.close()
+
+    graph = DependencyGraph.from_sqlite(db_path)
+    [edge] = graph.file_edges()
+
+    assert edge.confidence == EdgeConfidence.EXTRACTED
+    assert edge.confidence_score == 1.0
+    assert edge.evidence == []
 
 
 # ---------------------------------------------------------------------------
@@ -183,6 +246,24 @@ class TestUpdateFiles:
         new_edges = [Edge(source="a.py", target="b.py", kind=EdgeKind.IMPORTS)]
         graph.update_files(set(), new_edges)
         assert graph.file_edge_count == 1
+
+    def test_ambiguous_edges_do_not_drive_traversal(self) -> None:
+        graph = DependencyGraph.from_edges(
+            [
+                Edge(
+                    source="a.py",
+                    target="b.py",
+                    kind=EdgeKind.IMPORTS,
+                    confidence=EdgeConfidence.AMBIGUOUS,
+                    confidence_score=0.2,
+                    evidence=["multiple possible import targets"],
+                )
+            ]
+        )
+
+        assert graph.imports_of("a.py") == set()
+        assert graph.imported_by("b.py") == set()
+        assert graph.neighborhood("a.py") == set()
 
     def test_invalidates_centrality(self) -> None:
         parsed = [
@@ -329,3 +410,15 @@ class TestCoDirectoryEdges:
 
         edges = graph.file_edges()
         assert all(e.kind == EdgeKind.CO_DIRECTORY for e in edges)
+
+    def test_co_directory_edges_are_heuristic_with_evidence(self) -> None:
+        graph = DependencyGraph()
+        graph.add_file_node("pkg/a.go")
+        graph.add_file_node("pkg/b.go")
+
+        graph.add_co_directory_edges()
+        edges = graph.file_edges()
+
+        assert {edge.confidence for edge in edges} == {EdgeConfidence.HEURISTIC}
+        assert {edge.confidence_score for edge in edges} == {0.6}
+        assert all(edge.evidence for edge in edges)

--- a/tests/test_graph_artifact.py
+++ b/tests/test_graph_artifact.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -16,11 +17,14 @@ from archex.graph_artifact import (
     GraphProject,
     GraphSchemaVersion,
     assert_supported_schema_version,
+    build_arch_graph_from_store,
     file_node_id,
     interface_node_id,
     module_node_id,
     symbol_node_id,
 )
+from archex.index.store import IndexStore
+from archex.models import CodeChunk, Edge, EdgeConfidence, EdgeKind, SymbolKind
 
 
 def _metadata() -> GraphExportMetadata:
@@ -35,7 +39,7 @@ def test_empty_graph_serializes_with_schema_version() -> None:
 
     data = json.loads(graph.to_json())
 
-    assert data["schema_version"]["value"] == "1.0.0"
+    assert data["schema_version"]["value"] == "1.1.0"
     assert data["nodes"] == []
     assert data["edges"] == []
     assert data["project"]["name"] == "empty"
@@ -101,6 +105,30 @@ def test_graph_orders_nodes_edges_and_layer_members_deterministically() -> None:
     assert data["layers"][0]["node_ids"] == ["file:pkg/app.py", "module:pkg"]
 
 
+def test_graph_edge_serializes_confidence_and_evidence() -> None:
+    graph = ArchGraph(
+        project=GraphProject(name="edge-confidence"),
+        metadata=_metadata(),
+        edges=[
+            GraphEdge(
+                source=file_node_id("pkg/app.py"),
+                target=file_node_id("pkg/models.py"),
+                type=GraphEdgeType.IMPORTS,
+                location="pkg/app.py:1",
+                confidence=EdgeConfidence.HEURISTIC,
+                confidence_score=0.7,
+                evidence=["same package fallback"],
+            )
+        ],
+    )
+
+    data = json.loads(graph.to_json())
+
+    assert data["edges"][0]["confidence"] == "heuristic"
+    assert data["edges"][0]["confidence_score"] == 0.7
+    assert data["edges"][0]["evidence"] == ["same package fallback"]
+
+
 def test_symbol_rich_ids_preserve_structural_characters() -> None:
     graph = ArchGraph(
         project=GraphProject(name="symbols"),
@@ -140,3 +168,52 @@ def test_node_id_must_match_node_type_prefix() -> None:
 def test_rejects_unknown_major_schema_version() -> None:
     with pytest.raises(GraphArtifactError, match="Unsupported graph schema major version 2"):
         assert_supported_schema_version(GraphSchemaVersion(value="2.0.0"))
+
+
+def test_build_arch_graph_exports_edge_confidence_and_provenance(tmp_path: Path) -> None:
+    db = tmp_path / "graph.db"
+    with IndexStore(db) as store:
+        store.insert_chunks(
+            [
+                CodeChunk(
+                    id="pkg/app.py::run#function",
+                    content="def run():\n    pass",
+                    file_path="pkg/app.py",
+                    start_line=1,
+                    end_line=2,
+                    symbol_name="run",
+                    symbol_kind=SymbolKind.FUNCTION,
+                    language="python",
+                    symbol_id="pkg/app.py::run#function",
+                    qualified_name="run",
+                    visibility="public",
+                )
+            ]
+        )
+        store.insert_edges(
+            [
+                Edge(
+                    source="pkg/app.py",
+                    target="pkg/models.py",
+                    kind=EdgeKind.IMPORTS,
+                    location="pkg/app.py:1",
+                    confidence=EdgeConfidence.HEURISTIC,
+                    confidence_score=0.75,
+                    evidence=["fallback resolution"],
+                )
+            ]
+        )
+        graph = build_arch_graph_from_store(store)
+
+    data = graph.model_dump(mode="json")
+    import_edges = [edge for edge in data["edges"] if edge["type"] == "imports"]
+    contains_edges = [edge for edge in data["edges"] if edge["type"] == "contains"]
+    exposes_edges = [edge for edge in data["edges"] if edge["type"] == "exposes"]
+
+    assert import_edges[0]["confidence"] == "heuristic"
+    assert import_edges[0]["confidence_score"] == 0.75
+    assert import_edges[0]["evidence"] == ["fallback resolution"]
+    assert contains_edges[0]["confidence"] == "extracted"
+    assert contains_edges[0]["evidence"] == ["parser chunk span pkg/app.py:1-2"]
+    assert exposes_edges[0]["confidence"] == "heuristic"
+    assert exposes_edges[0]["evidence"] == ["public function run"]

--- a/tests/test_graph_export_cli.py
+++ b/tests/test_graph_export_cli.py
@@ -19,7 +19,7 @@ def test_graph_export_writes_default_json_artifact(python_simple_repo: Path) -> 
     data = json.loads(output_path.read_text(encoding="utf-8"))
     node_ids = [node["id"] for node in data["nodes"]]
     edge_types = [edge["type"] for edge in data["edges"]]
-    assert data["schema_version"]["value"] == "1.0.0"
+    assert data["schema_version"]["value"] == "1.1.0"
     assert data["project"]["total_files"] >= 4
     assert node_ids == sorted(node_ids, key=lambda node_id: (node_id.split(":", 1)[0], node_id))
     assert "file:main.py" in node_ids

--- a/tests/test_graph_load_cli.py
+++ b/tests/test_graph_load_cli.py
@@ -25,7 +25,7 @@ def test_graph_inspect_reads_exported_artifact(python_simple_repo: Path, tmp_pat
 
     assert result.exit_code == 0, result.output
     data = json.loads(result.output)
-    assert data["schema_version"] == "1.0.0"
+    assert data["schema_version"] == "1.1.0"
     assert data["nodes"] > 0
     assert data["edges"] > 0
 


### PR DESCRIPTION
## Stack

Stack-Id: `edge-confidence-g3`
Base: `main`
Position: 3/3

1. #195 `feat/edge-confidence-model`
2. #196 `feat/edge-confidence-store`
3. #197 `feat/edge-confidence-export` -> this PR

Depends on: #196
Upstack: none

## Change

Propagates edge confidence/provenance through `DependencyGraph` and graph artifact export. Resolved imports remain extracted at 1.0; co-directory and public-interface exports are heuristic with explicit evidence; ambiguous edges are excluded from default traversal.

## Validation

- Pass: `uv run ruff check && uv run ruff format --check . && uv run pyright`
- Pass: `uv run pytest -q` (2158 passed, 4 deselected, 90.11% coverage)
- Targeted G3 pytest selection passed functionally: 105 passed with `--cov-fail-under=0`; the exact narrow command exits non-zero because repository-level `--cov-fail-under=85` applies to narrow selections.

## PR Review

- pr-review completed for this slice: no blocking findings.
