### PR TITLE
Add graph query CLI commands

### DIFF
--- a/src/archex/cli/graph_cmd.py
+++ b/src/archex/cli/graph_cmd.py
@@ -2,15 +2,34 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from typing import TYPE_CHECKING, TypeVar
 
 import click
+from pydantic import BaseModel
 
 from archex.api import index_repository
 from archex.config import load_config, load_index_config
 from archex.exceptions import ArchexError
 from archex.graph_artifact import GraphArtifactError, build_arch_graph_from_store, load_arch_graph
+from archex.graph_query import (
+    GraphDirection,
+    GraphEdgeSummary,
+    GraphHubsResult,
+    GraphNeighborsResult,
+    GraphNodeSummary,
+    GraphPathResult,
+    GraphQuery,
+    GraphQueryError,
+    GraphStatsResult,
+)
 from archex.models import RepoSource
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_ResultT = TypeVar("_ResultT", bound=BaseModel)
 
 
 @click.group("graph")
@@ -86,11 +105,338 @@ def inspect_cmd(graph: Path, output_format: str) -> None:
         "layers": len(artifact.layers),
     }
     if output_format == "json":
-        import json
-
         click.echo(json.dumps(summary, indent=2, sort_keys=True))
         return
     click.echo(f"Graph: {artifact.project.name}")
     click.echo(f"Schema: {artifact.schema_version.value}")
     click.echo(f"Nodes: {len(artifact.nodes)}")
     click.echo(f"Edges: {len(artifact.edges)}")
+
+
+@graph_cmd.command("neighbors")
+@click.argument("node")
+@click.option(
+    "--graph",
+    "graph_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Exported architecture graph JSON artifact. Supplying this avoids reindexing.",
+)
+@click.option(
+    "--direction",
+    default="both",
+    type=click.Choice(["out", "in", "both"]),
+    help="Edge direction to traverse.",
+)
+@click.option("--depth", default=1, type=int, show_default=True, help="Traversal depth.")
+@click.option("--limit", default=25, type=int, show_default=True, help="Maximum edges to return.")
+@click.option(
+    "--hub-degree",
+    default=50,
+    type=int,
+    show_default=True,
+    help="Degree at or above which non-seed nodes are treated as terminal hubs.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "markdown"]),
+    help="Output format.",
+)
+def neighbors_cmd(
+    node: str,
+    graph_path: Path,
+    direction: GraphDirection,
+    depth: int,
+    limit: int,
+    hub_degree: int,
+    output_format: str,
+) -> None:
+    """List graph neighbors for NODE without indexing source files."""
+    graph_query = _load_graph_query(graph_path, hub_degree=hub_degree)
+    try:
+        result = graph_query.neighbors(node, direction=direction, depth=depth, limit=limit)
+    except GraphQueryError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _emit_result(result, output_format, _render_neighbors_markdown)
+
+
+@graph_cmd.command("path")
+@click.argument("source")
+@click.argument("target")
+@click.option(
+    "--graph",
+    "graph_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Exported architecture graph JSON artifact. Supplying this avoids reindexing.",
+)
+@click.option(
+    "--direction",
+    default="both",
+    type=click.Choice(["out", "in", "both"]),
+    help="Edge direction to traverse.",
+)
+@click.option(
+    "--max-edges",
+    default=100,
+    type=int,
+    show_default=True,
+    help="Maximum edge expansions before truncating the search.",
+)
+@click.option(
+    "--hub-degree",
+    default=50,
+    type=int,
+    show_default=True,
+    help="Degree at or above which intermediate nodes are treated as terminal hubs.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "markdown"]),
+    help="Output format.",
+)
+def path_cmd(
+    source: str,
+    target: str,
+    graph_path: Path,
+    direction: GraphDirection,
+    max_edges: int,
+    hub_degree: int,
+    output_format: str,
+) -> None:
+    """Find a shortest structural path between SOURCE and TARGET."""
+    graph_query = _load_graph_query(graph_path, hub_degree=hub_degree)
+    try:
+        result = graph_query.shortest_path(
+            source,
+            target,
+            direction=direction,
+            max_edges=max_edges,
+        )
+    except GraphQueryError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _emit_result(result, output_format, _render_path_markdown)
+
+
+@graph_cmd.command("stats")
+@click.option(
+    "--graph",
+    "graph_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Exported architecture graph JSON artifact. Supplying this avoids reindexing.",
+)
+@click.option("--hub-limit", default=10, type=int, show_default=True, help="Maximum hubs to show.")
+@click.option(
+    "--hub-degree",
+    default=50,
+    type=int,
+    show_default=True,
+    help="Degree at or above which nodes are reported as hubs.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "markdown"]),
+    help="Output format.",
+)
+def stats_cmd(
+    graph_path: Path,
+    hub_limit: int,
+    hub_degree: int,
+    output_format: str,
+) -> None:
+    """Show graph-level structural statistics."""
+    graph_query = _load_graph_query(graph_path, hub_degree=hub_degree)
+    try:
+        result = graph_query.stats(hub_limit=hub_limit)
+    except GraphQueryError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _emit_result(result, output_format, _render_stats_markdown)
+
+
+@graph_cmd.command("hubs")
+@click.option(
+    "--graph",
+    "graph_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Exported architecture graph JSON artifact. Supplying this avoids reindexing.",
+)
+@click.option("--limit", default=25, type=int, show_default=True, help="Maximum hubs to return.")
+@click.option(
+    "--threshold",
+    default=None,
+    type=int,
+    help="Minimum degree for hub reporting. Defaults to --hub-degree.",
+)
+@click.option(
+    "--hub-degree",
+    default=50,
+    type=int,
+    show_default=True,
+    help="Default hub threshold.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "markdown"]),
+    help="Output format.",
+)
+def hubs_cmd(
+    graph_path: Path,
+    limit: int,
+    threshold: int | None,
+    hub_degree: int,
+    output_format: str,
+) -> None:
+    """List high-degree graph hubs."""
+    graph_query = _load_graph_query(graph_path, hub_degree=hub_degree)
+    try:
+        result = graph_query.hubs(limit=limit, threshold=threshold)
+    except GraphQueryError as exc:
+        raise click.ClickException(str(exc)) from exc
+    _emit_result(result, output_format, _render_hubs_markdown)
+
+
+def _load_graph_query(graph_path: Path, *, hub_degree: int) -> GraphQuery:
+    try:
+        return GraphQuery.from_artifact(graph_path, hub_degree=hub_degree)
+    except (GraphArtifactError, GraphQueryError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+def _emit_result(
+    result: _ResultT,
+    output_format: str,
+    markdown_renderer: Callable[[_ResultT], str],
+) -> None:
+    if output_format == "json":
+        click.echo(result.model_dump_json(indent=2))
+        return
+    click.echo(markdown_renderer(result), nl=False)
+
+
+def _render_neighbors_markdown(result: GraphNeighborsResult) -> str:
+    lines = [
+        f"# Graph Neighbors: {result.seed.id}",
+        "",
+        f"- Path: `{result.seed.path or result.seed.id}`",
+        f"- Direction: `{result.direction}`",
+        f"- Depth: {result.depth}",
+        f"- Truncated: {_yes_no(result.truncated)}",
+        "",
+        "## Edges",
+        "",
+    ]
+    lines.extend(_render_edge_list(result.edges))
+    if result.hubs:
+        lines.extend(["", "## Terminal Hubs", ""])
+        lines.extend(_render_node_list(result.hubs))
+    return _finish_markdown(lines)
+
+
+def _render_path_markdown(result: GraphPathResult) -> str:
+    source = result.source.path if result.source is not None else result.source_query
+    target = result.target.path if result.target is not None else result.target_query
+    lines = [
+        f"# Graph Path: {source} → {target}",
+        "",
+        f"- Found: {_yes_no(result.found)}",
+        f"- Direction: `{result.direction}`",
+        f"- Truncated: {_yes_no(result.truncated)}",
+        "",
+    ]
+    if result.nodes:
+        lines.extend(["## Nodes", ""])
+        lines.extend(_render_node_list(result.nodes))
+        lines.extend(["", "## Edges", ""])
+        lines.extend(_render_edge_list(result.edges))
+    if result.avoided_hubs:
+        lines.extend(["", "## Avoided Hubs", ""])
+        lines.extend(_render_node_list(result.avoided_hubs))
+    return _finish_markdown(lines)
+
+
+def _render_stats_markdown(result: GraphStatsResult) -> str:
+    lines = [
+        f"# Graph Stats: {result.project}",
+        "",
+        "| Metric | Value |",
+        "| --- | ---: |",
+        f"| Nodes | {result.nodes} |",
+        f"| Edges | {result.edges} |",
+        f"| Files | {result.files} |",
+        f"| Max degree | {result.max_degree} |",
+        "",
+    ]
+    if result.languages:
+        lines.extend(["## Languages", "", "| Language | Files |", "| --- | ---: |"])
+        for language, count in sorted(result.languages.items()):
+            lines.append(f"| {language} | {count} |")
+        lines.append("")
+    if result.edge_types:
+        lines.extend(["## Edge Types", "", "| Type | Count |", "| --- | ---: |"])
+        for edge_type, count in sorted(result.edge_types.items()):
+            lines.append(f"| {edge_type} | {count} |")
+        lines.append("")
+    if result.hubs:
+        lines.extend(["## Hubs", ""])
+        lines.extend(_render_node_list(result.hubs))
+    return _finish_markdown(lines)
+
+
+def _render_hubs_markdown(result: GraphHubsResult) -> str:
+    lines = [
+        "# Graph Hubs",
+        "",
+        f"- Threshold: {result.threshold}",
+        f"- Limit: {result.limit}",
+        f"- Truncated: {_yes_no(result.truncated)}",
+        "",
+    ]
+    lines.extend(_render_node_list(result.hubs))
+    return _finish_markdown(lines)
+
+
+def _render_edge_list(edges: list[GraphEdgeSummary]) -> list[str]:
+    if not edges:
+        return ["No edges."]
+    lines = [
+        "| Source path | Kind | Target path | Confidence | Evidence |",
+        "| --- | --- | --- | ---: | --- |",
+    ]
+    for edge in edges:
+        evidence = "; ".join(edge.evidence) if edge.evidence else ""
+        lines.append(
+            "| "
+            f"`{edge.source.path or edge.source.id}` | "
+            f"{edge.type} | "
+            f"`{edge.target.path or edge.target.id}` | "
+            f"{edge.confidence} ({edge.confidence_score:.2f}) | "
+            f"{evidence} |"
+        )
+    return lines
+
+
+def _render_node_list(nodes: list[GraphNodeSummary]) -> list[str]:
+    if not nodes:
+        return ["No nodes."]
+    lines = ["| Path | ID | Type | Degree |", "| --- | --- | --- | ---: |"]
+    for node in nodes:
+        lines.append(f"| `{node.path or ''}` | `{node.id}` | {node.type} | {node.degree} |")
+    return lines
+
+
+def _finish_markdown(lines: list[str]) -> str:
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"

--- a/tests/test_graph_export_cli.py
+++ b/tests/test_graph_export_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
@@ -72,3 +73,91 @@ def test_graph_export_markdown_can_write_explicit_output(
     assert rendered.startswith("# Architecture Graph:")
     assert "| Files |" in rendered
     assert "`file:main.py`" in rendered
+
+
+def _export_graph_artifact(repo: Path, output: Path) -> None:
+    result = CliRunner().invoke(
+        cli,
+        ["graph", "export", str(repo), "--output", str(output)],
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_graph_neighbors_reads_artifact_without_reindexing(
+    python_simple_repo: Path, tmp_path: Path
+) -> None:
+    artifact = tmp_path / "archgraph.json"
+    _export_graph_artifact(python_simple_repo, artifact)
+    runner = CliRunner()
+
+    with patch("archex.cli.graph_cmd.index_repository", side_effect=AssertionError("reindexed")):
+        result = runner.invoke(
+            cli,
+            [
+                "graph",
+                "neighbors",
+                "main.py",
+                "--graph",
+                str(artifact),
+                "--format",
+                "markdown",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "# Graph Neighbors:" in result.output
+    assert "`main.py`" in result.output
+    assert "imports" in result.output
+    assert "extracted (1.00)" in result.output
+    assert "parser chunk span main.py:8-15" in result.output
+
+
+def test_graph_path_outputs_edge_confidence_json(python_simple_repo: Path, tmp_path: Path) -> None:
+    artifact = tmp_path / "archgraph.json"
+    _export_graph_artifact(python_simple_repo, artifact)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        [
+            "graph",
+            "path",
+            "main.py",
+            "models.py",
+            "--graph",
+            str(artifact),
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["found"] is True
+    assert data["edges"][0]["type"] == "imports"
+    assert data["edges"][0]["confidence"] == "extracted"
+    assert data["edges"][0]["source"]["path"] == "main.py"
+    assert data["edges"][0]["target"]["path"] == "models.py"
+    assert data["edges"][0]["evidence"]
+
+
+def test_graph_stats_and_hubs_render_markdown(python_simple_repo: Path, tmp_path: Path) -> None:
+    artifact = tmp_path / "archgraph.json"
+    _export_graph_artifact(python_simple_repo, artifact)
+    runner = CliRunner()
+
+    stats = runner.invoke(
+        cli,
+        ["graph", "stats", "--graph", str(artifact), "--format", "markdown", "--hub-degree", "1"],
+    )
+    hubs = runner.invoke(
+        cli,
+        ["graph", "hubs", "--graph", str(artifact), "--format", "markdown", "--threshold", "1"],
+    )
+
+    assert stats.exit_code == 0, stats.output
+    assert "# Graph Stats:" in stats.output
+    assert "## Edge Types" in stats.output
+    assert hubs.exit_code == 0, hubs.output
+    assert "# Graph Hubs" in hubs.output
+    assert "| Path | ID | Type | Degree |" in hubs.output


### PR DESCRIPTION
## Stack

Stack-Id: `graph-query-g4`
Base: `main`
Position: 2/3

1. `feat/graph-query-core` -> #198
2. `feat/graph-query-cli` -> this PR (#199)
3. `feat/graph-query-mcp` -> #200

Depends on: #198
Upstack: #200

## Summary

- Adds `archex graph neighbors`, `path`, `stats`, and `hubs` commands.
- Commands require `--graph` artifact input and do not reindex when supplied.
- Markdown and JSON output include paths, edge kinds, confidence, and evidence where edges are returned.

## Validation

Passed:

```text
uv run ruff check && uv run ruff format --check . && uv run pyright
uv run pytest tests/test_graph_query.py tests/test_graph_export_cli.py tests/integrations/test_mcp.py -q
```

## Review

PR-review completed for this slice. No blocking findings.
