### PR TITLE
Add scout handle round trips

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -71,8 +71,10 @@ from archex.models import (
     Module,
     ParsedFile,
     PipelineTiming,
+    RankedChunk,
     RepoMetadata,
     RepoSource,
+    RetrievalMetadata,
     ScoringWeights,
     SymbolMatch,
     SymbolSource,
@@ -90,6 +92,7 @@ from archex.parse.adapters import LanguageAdapter, default_adapter_registry
 from archex.pipeline.chunker import ASTChunker, Chunker
 from archex.pipeline.service import build_chunk_surrogates
 from archex.project import uses_project_cache_layout
+from archex.scout import parse_scout_handle
 from archex.serve.compare import compare_repos
 from archex.serve.context import assemble_context, passthrough_context
 from archex.serve.profile import build_profile
@@ -1288,6 +1291,103 @@ def _attach_refresh_metadata(bundle: ContextBundle, timing: PipelineTiming | Non
         )
 
 
+def _query_by_scout_handles(
+    source: RepoSource,
+    question: str,
+    handles: list[str],
+    *,
+    token_budget: int,
+    config: Config,
+    index_config: IndexConfig,
+    timing: PipelineTiming | None,
+    trace: PipelineTrace | None,
+) -> ContextBundle:
+    t0 = time.perf_counter()
+    if trace is not None:
+        trace.operation = "query"
+        trace.start_ns = time.perf_counter_ns()
+        trace.metadata["scout_handles"] = len(handles)
+    store = _ensure_index(source, config, timing=timing, index_config=index_config)
+    try:
+        chunks = _chunks_for_scout_handles(store, handles)
+    finally:
+        store.close()
+    bundle = _context_bundle_for_handle_chunks(question, chunks, token_budget)
+    bundle.retrieval_metadata.retrieval_time_ms = _elapsed_ms(t0)
+    if timing is not None:
+        timing.search_ms = bundle.retrieval_metadata.assembly_time_ms
+        timing.total_ms = _elapsed_ms(t0)
+    if trace is not None:
+        trace.end_ns = time.perf_counter_ns()
+    return bundle
+
+
+def _chunks_for_scout_handles(store: IndexStore, handles: list[str]) -> list[CodeChunk]:
+    chunks: list[CodeChunk] = []
+    seen: set[str] = set()
+    for raw_handle in handles:
+        handle = parse_scout_handle(raw_handle)
+        if handle is None:
+            chunk = store.get_chunk_by_symbol_id(raw_handle)
+            candidate_chunks = [chunk] if chunk is not None else []
+        elif handle.kind == "file":
+            candidate_chunks = sorted(
+                store.get_chunks_for_file(handle.value),
+                key=lambda item: (item.start_line, item.id),
+            )
+        elif handle.kind == "symbol":
+            chunk = store.get_chunk_by_symbol_id(handle.value)
+            candidate_chunks = [chunk] if chunk is not None else []
+        else:
+            chunk = store.get_chunk(handle.value)
+            candidate_chunks = [chunk] if chunk is not None else []
+        for chunk in candidate_chunks:
+            if chunk.id in seen:
+                continue
+            seen.add(chunk.id)
+            chunks.append(chunk)
+    return chunks
+
+
+def _context_bundle_for_handle_chunks(
+    question: str,
+    chunks: list[CodeChunk],
+    token_budget: int,
+) -> ContextBundle:
+    t0 = time.perf_counter()
+    included: list[RankedChunk] = []
+    total_tokens = 0
+    dropped = 0
+    for chunk in chunks:
+        tokens = _chunk_token_count(chunk)
+        if included and total_tokens + tokens > token_budget:
+            dropped += 1
+            continue
+        included.append(RankedChunk(chunk=chunk, relevance_score=1.0, final_score=1.0))
+        total_tokens += tokens
+    return ContextBundle(
+        query=question,
+        chunks=included,
+        token_count=total_tokens,
+        token_budget=token_budget,
+        truncated=dropped > 0 or total_tokens > token_budget,
+        retrieval_metadata=RetrievalMetadata(
+            candidates_found=len(chunks),
+            candidates_after_expansion=len(chunks),
+            chunks_included=len(included),
+            chunks_dropped=dropped,
+            strategy="scout_handle",
+            assembly_time_ms=_elapsed_ms(t0),
+        ),
+    )
+
+
+def _chunk_token_count(chunk: CodeChunk) -> int:
+    if chunk.token_count > 0:
+        return chunk.token_count
+    return int(len(chunk.content.split()) * 1.3)
+
+
 def query(
     source: RepoSource,
     question: str,
@@ -1300,6 +1400,7 @@ def query(
     trace: PipelineTrace | None = None,
     explicit_token_budget: bool = False,
     refresh: bool = True,
+    handles: list[str] | None = None,
 ) -> ContextBundle:
     """Retrieve a ranked ContextBundle for a natural-language query.
 
@@ -1322,6 +1423,17 @@ def query(
     if trace is not None:
         trace.operation = "query"
         trace.start_ns = time.perf_counter_ns()
+    if handles:
+        return _query_by_scout_handles(
+            source,
+            question,
+            handles,
+            token_budget=token_budget,
+            config=config,
+            index_config=index_config,
+            timing=timing,
+            trace=trace,
+        )
     cache = _cache_manager_for_source(source, config)
     metadata_timing = timing
     cache_key = cache.cache_key(source)

--- a/src/archex/precision.py
+++ b/src/archex/precision.py
@@ -20,6 +20,7 @@ from archex.models import (
     SymbolSource,
     Visibility,
 )
+from archex.scout import normalize_symbol_lookup_handle, parse_scout_handle
 
 if TYPE_CHECKING:
     from archex.index.store import IndexStore
@@ -210,12 +211,12 @@ def get_symbol(
     timing: PipelineTiming | None,
     ensure_index: EnsureIndex,
 ) -> SymbolSource | None:
-    """Retrieve the full source code of a single symbol by its stable ID."""
+    """Retrieve the full source code of a single symbol by its stable ID or scout handle."""
     t0 = time.perf_counter()
     store = ensure_index(source, config, timing)
     try:
         t_op = time.perf_counter()
-        chunk = store.get_chunk_by_symbol_id(symbol_id)
+        chunk = _chunk_for_symbol_lookup(store, symbol_id)
         if timing is not None:
             timing.search_ms = _elapsed_ms(t_op)
     finally:
@@ -235,7 +236,7 @@ def get_symbols_batch(
     timing: PipelineTiming | None,
     ensure_index: EnsureIndex,
 ) -> list[SymbolSource | None]:
-    """Batch retrieve N symbols by their stable IDs. Preserves input order."""
+    """Batch retrieve symbols by stable IDs or scout handles. Preserves input order."""
     if len(symbol_ids) > 50:
         raise ValueError(f"Maximum 50 symbol IDs per batch, got {len(symbol_ids)}")
 
@@ -243,16 +244,25 @@ def get_symbols_batch(
     store = ensure_index(source, config, timing)
     try:
         t_op = time.perf_counter()
-        chunks = store.get_chunks_by_symbol_ids(symbol_ids)
+        chunks = [_chunk_for_symbol_lookup(store, symbol_id) for symbol_id in symbol_ids]
         if timing is not None:
             timing.search_ms = _elapsed_ms(t_op)
     finally:
         store.close()
 
-    by_sid: dict[str, CodeChunk] = {c.symbol_id: c for c in chunks if c.symbol_id}
     if timing is not None:
         timing.total_ms = _elapsed_ms(t0)
-    return [_chunk_to_symbol_source(by_sid[sid]) if sid in by_sid else None for sid in symbol_ids]
+    return [_chunk_to_symbol_source(chunk) if chunk is not None else None for chunk in chunks]
+
+
+def _chunk_for_symbol_lookup(store: IndexStore, symbol_id: str) -> CodeChunk | None:
+    lookup_id = normalize_symbol_lookup_handle(symbol_id)
+    handle = parse_scout_handle(symbol_id)
+    if handle is not None and handle.kind == "chunk":
+        return store.get_chunk(handle.value)
+    if handle is not None and handle.kind == "file":
+        return None
+    return store.get_chunk_by_symbol_id(lookup_id)
 
 
 def get_repo_total_tokens(

--- a/src/archex/scout.py
+++ b/src/archex/scout.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from archex.index.store import IndexStore
 
 ScoutFormat = Literal["json", "markdown"]
+ScoutHandleKind = Literal["file", "symbol", "chunk"]
 
 DEFAULT_SCOUT_TOKEN_BUDGET = 1000
 MIN_SCOUT_TOKEN_BUDGET = 64
@@ -22,6 +23,14 @@ DEFAULT_SCOUT_FILE_LIMIT = 12
 DEFAULT_SCOUT_SYMBOLS_PER_FILE = 3
 DEFAULT_SCOUT_MODULE_LIMIT = 6
 DEFAULT_SCOUT_GRAPH_EDGE_LIMIT = 12
+FILE_HANDLE_PREFIX = "file:"
+SYMBOL_HANDLE_PREFIX = "symbol:"
+CHUNK_HANDLE_PREFIX = "chunk:"
+
+
+class ScoutHandle(BaseModel):
+    kind: ScoutHandleKind
+    value: str
 
 
 class ScoutBudget(BaseModel):
@@ -39,6 +48,7 @@ class ScoutFile(BaseModel):
     language: str
     lines: int
     symbol_count: int
+    handle: str
     score: float = 0.0
     reason: str = "ranked"
 
@@ -49,8 +59,13 @@ class ScoutSymbol(BaseModel):
     file_path: str
     start_line: int
     end_line: int
+    chunk_id: str
+    file_handle: str
+    chunk_handle: str
     signature: str | None = None
     visibility: str | None = None
+    symbol_id: str | None = None
+    symbol_handle: str | None = None
     score: float = 0.0
 
 
@@ -61,6 +76,7 @@ class ScoutModule(BaseModel):
     cohesion_score: float = 0.0
     file_count: int = 0
     relevant_files: list[str] = []
+    file_handles: list[str] = []
     exports: list[str] = []
     score: float = 0.0
 
@@ -71,6 +87,8 @@ class ScoutGraphEdge(BaseModel):
     kind: str
     source_path: str | None = None
     target_path: str | None = None
+    source_handle: str | None = None
+    target_handle: str | None = None
     confidence: str
     confidence_score: float
     evidence: list[str] = []
@@ -83,6 +101,37 @@ class ScoutResult(BaseModel):
     symbols: list[ScoutSymbol] = []
     graph: list[ScoutGraphEdge] = []
     budget: ScoutBudget
+
+
+def file_handle(file_path: str) -> str:
+    return f"{FILE_HANDLE_PREFIX}{file_path}"
+
+
+def symbol_handle(symbol_id: str) -> str:
+    return f"{SYMBOL_HANDLE_PREFIX}{symbol_id}"
+
+
+def chunk_handle(chunk_id: str) -> str:
+    return f"{CHUNK_HANDLE_PREFIX}{chunk_id}"
+
+
+def parse_scout_handle(value: str) -> ScoutHandle | None:
+    if value.startswith(FILE_HANDLE_PREFIX):
+        return ScoutHandle(kind="file", value=value.removeprefix(FILE_HANDLE_PREFIX))
+    if value.startswith(SYMBOL_HANDLE_PREFIX):
+        return ScoutHandle(kind="symbol", value=value.removeprefix(SYMBOL_HANDLE_PREFIX))
+    if value.startswith(CHUNK_HANDLE_PREFIX):
+        return ScoutHandle(kind="chunk", value=value.removeprefix(CHUNK_HANDLE_PREFIX))
+    return None
+
+
+def normalize_symbol_lookup_handle(value: str) -> str:
+    handle = parse_scout_handle(value)
+    if handle is None:
+        return value
+    if handle.kind == "symbol":
+        return handle.value
+    return value
 
 
 def assemble_scout_from_store(
@@ -193,6 +242,7 @@ def _rank_files(
             language=str(metadata.get(path, {}).get("language", "unknown")),
             lines=int(metadata.get(path, {}).get("lines", 0)),
             symbol_count=int(metadata.get(path, {}).get("symbol_count", 0)),
+            handle=file_handle(path),
             score=round(file_scores[path], 6),
             reason="query_rank" if ranked_chunks else "file_tree",
         )
@@ -236,6 +286,7 @@ def _top_symbols(
             ),
         )
         for chunk in chunks[:symbols_per_file]:
+            symbol_id = str(chunk.symbol_id) if chunk.symbol_id else None
             symbols.append(
                 ScoutSymbol(
                     name=chunk.qualified_name or chunk.symbol_name or chunk.id,
@@ -243,8 +294,13 @@ def _top_symbols(
                     file_path=chunk.file_path,
                     start_line=chunk.start_line,
                     end_line=chunk.end_line,
+                    chunk_id=chunk.id,
+                    file_handle=file_handle(chunk.file_path),
+                    chunk_handle=chunk_handle(chunk.id),
                     signature=chunk.signature,
                     visibility=chunk.visibility,
+                    symbol_id=symbol_id,
+                    symbol_handle=symbol_handle(symbol_id) if symbol_id else None,
                     score=round(score_by_chunk.get(chunk.id, 0.0), 6),
                 )
             )
@@ -263,6 +319,7 @@ def _rank_modules(
     for module in modules:
         relevant = sorted(path for path in module.files if path in file_scores)
         score = sum(file_scores[path] for path in relevant) + len(relevant) if relevant else 0.0
+        relevant_files = relevant[:5]
         ranked.append(
             ScoutModule(
                 name=module.name,
@@ -270,7 +327,8 @@ def _rank_modules(
                 responsibility=module.responsibility,
                 cohesion_score=module.cohesion_score,
                 file_count=module.file_count or len(module.files),
-                relevant_files=relevant[:5],
+                relevant_files=relevant_files,
+                file_handles=[file_handle(path) for path in relevant_files],
                 exports=sorted(ref.qualified_name or ref.name for ref in module.exports)[:5],
                 score=round(score, 6),
             )
@@ -315,6 +373,8 @@ def _graph_sketch(
                     kind=edge.type,
                     source_path=edge.source.path,
                     target_path=edge.target.path,
+                    source_handle=file_handle(edge.source.path) if edge.source.path else None,
+                    target_handle=file_handle(edge.target.path) if edge.target.path else None,
                     confidence=edge.confidence,
                     confidence_score=edge.confidence_score,
                     evidence=edge.evidence[:2],
@@ -345,7 +405,7 @@ def _render_markdown(result: ScoutResult) -> str:
     if result.ranked_files:
         for item in result.ranked_files:
             lines.append(
-                f"- {item.path} ({item.language}, {item.lines} lines, "
+                f"- {item.path} (`{item.handle}`, {item.language}, {item.lines} lines, "
                 f"{item.symbol_count} symbols, score={item.score:.3f})"
             )
     else:
@@ -353,11 +413,11 @@ def _render_markdown(result: ScoutResult) -> str:
     lines.extend(["", "## Module boundaries"])
     if result.modules:
         for item in result.modules:
-            relevant = ", ".join(item.relevant_files) if item.relevant_files else "no ranked files"
+            handles = ", ".join(item.file_handles) if item.file_handles else "no handles"
             responsibility = f" — {item.responsibility}" if item.responsibility else ""
             lines.append(
                 f"- {item.name} ({item.root_path}, files={item.file_count}, "
-                f"cohesion={item.cohesion_score:.3f}){responsibility}; relevant: {relevant}"
+                f"cohesion={item.cohesion_score:.3f}){responsibility}; handles: {handles}"
             )
     else:
         lines.append("- none")
@@ -365,9 +425,13 @@ def _render_markdown(result: ScoutResult) -> str:
     if result.symbols:
         for item in result.symbols:
             signature = f" — {item.signature}" if item.signature else ""
+            handles = [item.file_handle, item.chunk_handle]
+            if item.symbol_handle:
+                handles.append(item.symbol_handle)
             lines.append(
                 f"- {item.name} [{item.kind.value}] "
-                f"{item.file_path}:{item.start_line}-{item.end_line}"
+                f"{item.file_path}:{item.start_line}-{item.end_line} "
+                f"handles: {', '.join(handles)}"
                 f"{signature}"
             )
     else:
@@ -377,10 +441,12 @@ def _render_markdown(result: ScoutResult) -> str:
         for item in result.graph:
             source = item.source_path or item.source
             target = item.target_path or item.target
+            source_handle = f" `{item.source_handle}`" if item.source_handle else ""
+            target_handle = f" `{item.target_handle}`" if item.target_handle else ""
             evidence = f"; evidence: {'; '.join(item.evidence)}" if item.evidence else ""
             lines.append(
-                f"- {source} --{item.kind}/{item.confidence}:{item.confidence_score:.2f}--> "
-                f"{target}{evidence}"
+                f"- {source}{source_handle} --{item.kind}/{item.confidence}:"
+                f"{item.confidence_score:.2f}--> {target}{target_handle}{evidence}"
             )
     else:
         lines.append("- none")

--- a/tests/test_scout.py
+++ b/tests/test_scout.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 from archex.index.store import IndexStore
 from archex.models import CodeChunk, Edge, EdgeConfidence, EdgeKind, Module, RankedChunk, SymbolKind
 from archex.reporting import count_tokens
-from archex.scout import assemble_scout_from_store, render_scout
+from archex.scout import (
+    assemble_scout_from_store,
+    chunk_handle,
+    file_handle,
+    render_scout,
+    symbol_handle,
+)
 
 
 def _populate_store(db_path: Path) -> IndexStore:
@@ -88,6 +95,12 @@ def test_scout_assembles_no_body_structural_map(tmp_path: Path) -> None:
     assert result.ranked_files[0].path == "pkg/app.py"
     assert result.modules[0].name == "pkg"
     assert result.symbols[0].name == "run"
+    assert result.symbols[0].chunk_handle == chunk_handle("pkg/app.py::run#function")
+    assert result.symbols[0].symbol_handle == symbol_handle("pkg/app.py::run#function")
+    assert result.ranked_files[0].handle == file_handle("pkg/app.py")
+    assert chunk_handle("pkg/app.py::run#function") in rendered
+    assert symbol_handle("pkg/app.py::run#function") in rendered
+    assert file_handle("pkg/app.py") in rendered
     import_edge = next(edge for edge in result.graph if edge.kind == "imports")
     assert import_edge.confidence == "heuristic"
     assert "SECRET BODY" not in rendered
@@ -102,3 +115,43 @@ def test_scout_truncates_deterministically_under_cap(tmp_path: Path) -> None:
     assert first.budget.truncated is True
     assert count_tokens(render_scout(first)) <= 140
     assert first.budget.token_count == count_tokens(render_scout(first))
+
+
+def test_scout_handles_fetch_exact_symbols_and_query_chunks(tmp_path: Path) -> None:
+    from archex.api import get_symbol, get_symbols_batch, query
+    from archex.models import RepoSource
+
+    store = _populate_store(tmp_path / "index.db")
+    source = RepoSource(local_path="/fake")
+    with (
+        patch("archex.api._ensure_index", return_value=store),
+        patch.object(store, "close", return_value=None),
+    ):
+        symbol = get_symbol(source, symbol_id=symbol_handle("pkg/app.py::run#function"))
+        chunk_symbol = get_symbol(source, symbol_id=chunk_handle("pkg/models.py::Model#class"))
+        batch = get_symbols_batch(
+            source,
+            symbol_ids=[
+                symbol_handle("pkg/app.py::run#function"),
+                chunk_handle("pkg/models.py::Model#class"),
+            ],
+        )
+        bundle = query(
+            source,
+            "fetch exact scout handles",
+            handles=[file_handle("pkg/app.py"), chunk_handle("pkg/models.py::Model#class")],
+        )
+
+    assert symbol is not None
+    assert symbol.symbol_id == "pkg/app.py::run#function"
+    assert chunk_symbol is not None
+    assert chunk_symbol.symbol_id == "pkg/models.py::Model#class"
+    assert [item.symbol_id if item is not None else None for item in batch] == [
+        "pkg/app.py::run#function",
+        "pkg/models.py::Model#class",
+    ]
+    assert [ranked.chunk.id for ranked in bundle.chunks] == [
+        "pkg/app.py::run#function",
+        "pkg/models.py::Model#class",
+    ]
+    assert bundle.retrieval_metadata.strategy == "scout_handle"


### PR DESCRIPTION
## Stack

Stack-Id: `scout-protocol-c5`
Base: `feat/scout-core`
Position: 2/4

1. `feat/scout-core` -> parent
2. `feat/scout-handles` -> this PR
3. `feat/scout-cli-mcp` -> follow-up
4. `feat/scout-benchmark` -> follow-up

Depends on: feat/scout-core
Upstack: feat/scout-cli-mcp

## Summary

Add stable scout handles for file, symbol, and chunk items. Extend exact second-phase fetch so `query`, `get_symbol`, and `get_symbols_batch` accept scout handles directly without a re-search.

## Validation

- `uv run ruff check`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest tests/ -q -k "scout or graph_query or mcp"`

## Review

Manual PR review completed. Fixed stale token-count reporting and handle round-trip coverage before advancing.
