### PR TITLE
Expose scout CLI and MCP tool

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -92,7 +92,13 @@ from archex.parse.adapters import LanguageAdapter, default_adapter_registry
 from archex.pipeline.chunker import ASTChunker, Chunker
 from archex.pipeline.service import build_chunk_surrogates
 from archex.project import uses_project_cache_layout
-from archex.scout import parse_scout_handle
+from archex.scout import (
+    DEFAULT_SCOUT_TOKEN_BUDGET,
+    ScoutFormat,
+    ScoutResult,
+    assemble_scout_from_store,
+    parse_scout_handle,
+)
 from archex.serve.compare import compare_repos
 from archex.serve.context import assemble_context, passthrough_context
 from archex.serve.profile import build_profile
@@ -1386,6 +1392,44 @@ def _chunk_token_count(chunk: CodeChunk) -> int:
     if chunk.token_count > 0:
         return chunk.token_count
     return int(len(chunk.content.split()) * 1.3)
+
+
+def scout(
+    source: RepoSource,
+    question: str,
+    *,
+    token_budget: int = DEFAULT_SCOUT_TOKEN_BUDGET,
+    output_format: ScoutFormat = "markdown",
+    config: Config | None = None,
+    index_config: IndexConfig | None = None,
+    timing: PipelineTiming | None = None,
+    refresh: bool = True,
+) -> ScoutResult:
+    """Return a token-capped no-body structural scout map for a repository question."""
+    if config is None:
+        config = load_config(source)
+    if index_config is None:
+        index_config = load_index_config(source)
+    ranking_timing = timing or PipelineTiming()
+    bundle = query(
+        source,
+        question,
+        config=config,
+        index_config=index_config,
+        timing=ranking_timing,
+        refresh=refresh,
+    )
+    store = _ensure_index(source, config, timing=ranking_timing, index_config=index_config)
+    try:
+        return assemble_scout_from_store(
+            store,
+            question,
+            ranked_chunks=bundle.chunks,
+            token_budget=token_budget,
+            output_format=output_format,
+        )
+    finally:
+        store.close()
 
 
 def query(

--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -20,6 +20,7 @@ from archex.cli.onboard_cmd import onboard_cmd
 from archex.cli.outline_cmd import outline_cmd
 from archex.cli.query_cmd import query_cmd
 from archex.cli.reset_cmd import reset_cmd
+from archex.cli.scout_cmd import scout_cmd
 from archex.cli.status_cmd import status_cmd
 from archex.cli.symbol_cmd import symbol_cmd
 from archex.cli.symbols_cmd import symbols_cmd
@@ -45,6 +46,7 @@ cli.add_command(dogfood_cmd)
 cli.add_command(mcp_cmd)
 cli.add_command(tree_cmd)
 cli.add_command(outline_cmd)
+cli.add_command(scout_cmd)
 cli.add_command(symbols_cmd)
 cli.add_command(symbol_cmd)
 cli.add_command(graph_cmd)

--- a/src/archex/cli/scout_cmd.py
+++ b/src/archex/cli/scout_cmd.py
@@ -1,0 +1,62 @@
+"""CLI scout subcommand: emit a token-capped structural map without code bodies."""
+
+from __future__ import annotations
+
+import click
+
+from archex.api import scout
+from archex.exceptions import ArchexError
+from archex.scout import DEFAULT_SCOUT_TOKEN_BUDGET, ScoutFormat, render_scout
+from archex.utils import resolve_source
+
+
+@click.command("scout")
+@click.argument("args", nargs=-1, required=True)
+@click.option(
+    "--budget",
+    default=DEFAULT_SCOUT_TOKEN_BUDGET,
+    show_default=True,
+    type=int,
+    help="Hard token cap for the structural scout map.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="markdown",
+    type=click.Choice(["markdown", "json"]),
+    help="Output format.",
+)
+@click.option(
+    "--no-refresh",
+    is_flag=True,
+    default=False,
+    help="Skip working-tree freshness checks and scout the existing index as-is.",
+)
+def scout_cmd(
+    args: tuple[str, ...],
+    budget: int,
+    output_format: ScoutFormat,
+    no_refresh: bool,
+) -> None:
+    """Return a compact no-body structural map for a repository question."""
+    source, question = _source_and_question(args)
+    repo_source = resolve_source(source)
+    try:
+        result = scout(
+            repo_source,
+            question,
+            token_budget=budget,
+            output_format=output_format,
+            refresh=not no_refresh,
+        )
+    except (ArchexError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(render_scout(result, output_format=output_format), nl=False)
+
+
+def _source_and_question(args: tuple[str, ...]) -> tuple[str, str]:
+    if len(args) == 1:
+        return ".", args[0]
+    if len(args) >= 2:
+        return args[0], " ".join(args[1:])
+    raise click.UsageError("scout requires a question")

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -23,6 +23,7 @@ from archex.api import (
     get_symbols_batch,
     index_repository,
     query,
+    scout,
     search_symbols,
 )
 from archex.graph_artifact import GraphArtifactError
@@ -40,6 +41,7 @@ from archex.graph_query import (
 )
 from archex.models import PipelineTiming, RepoSource
 from archex.reporting import compute_meta, count_tokens
+from archex.scout import DEFAULT_SCOUT_TOKEN_BUDGET, ScoutFormat, render_scout
 from archex.serve.compare import validate_dimensions
 from archex.serve.intent import DEFAULT_TOKEN_BUDGET
 from archex.serve.renderers.xml import render_xml, render_xml_envelope
@@ -130,6 +132,40 @@ def handle_query_repo(repo_url: str, question: str, budget: int | None = None) -
         raw_file_tokens=max(raw_tokens, 1),
         envelope_overhead_tokens=envelope_overhead,
         strategy="bm25+graph",
+        cached=pt.cached,
+        index_time_ms=pt.index_ms,
+        query_time_ms=pt.total_ms,
+        delta=pt.delta_meta,
+    )
+    return json.dumps({"content": content, "_meta": meta.model_dump()}, indent=2)
+
+
+def handle_scout_repo(
+    repo_url: str,
+    question: str,
+    budget: int | None = None,
+    output_format: ScoutFormat = "json",
+) -> str:
+    """Return a token-capped structural map with stable second-call handles."""
+    _validate_output_format(output_format)
+    source = resolve_source(repo_url)
+    token_budget = DEFAULT_SCOUT_TOKEN_BUDGET if budget is None else budget
+    pt = PipelineTiming()
+    result = scout(
+        source,
+        question,
+        token_budget=token_budget,
+        output_format=output_format,
+        timing=pt,
+    )
+    rendered = render_scout(result, output_format=output_format)
+    content = json.loads(rendered) if output_format == "json" else rendered
+    raw = get_repo_total_tokens(source)
+    meta = compute_meta(
+        tool_name="scout_repo",
+        response_text=rendered,
+        raw_file_tokens=raw,
+        strategy="scout",
         cached=pt.cached,
         index_time_ms=pt.index_ms,
         query_time_ms=pt.total_ms,
@@ -662,6 +698,40 @@ def build_server() -> Any:
                 },
             ),
             mcp_types.Tool(
+                name="scout_repo",
+                description=(
+                    "Return a compact structural scout map for a repository question. "
+                    "The map contains ranked files, module boundaries, top symbols, graph "
+                    "sketches, and stable file/symbol/chunk handles, but no code bodies."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "repo_url": {
+                            "type": "string",
+                            "description": (
+                                "Local filesystem path or HTTP(S) Git URL of the repository."
+                            ),
+                        },
+                        "question": {
+                            "type": "string",
+                            "description": "Natural-language scout question.",
+                        },
+                        "budget": {
+                            "type": "integer",
+                            "default": DEFAULT_SCOUT_TOKEN_BUDGET,
+                            "description": "Hard token cap for the scout map.",
+                        },
+                        "format": {
+                            "type": "string",
+                            "enum": ["json", "markdown"],
+                            "default": "json",
+                        },
+                    },
+                    "required": ["repo_url", "question"],
+                },
+            ),
+            mcp_types.Tool(
                 name="query_repo",
                 description=(
                     "Retrieve relevant code context from a repository to answer a "
@@ -1011,6 +1081,16 @@ def build_server() -> Any:
             repo_url: str = arguments["repo_url"]
             fmt: str = arguments.get("format", "json")
             result_text = await loop.run_in_executor(None, handle_analyze_repo, repo_url, fmt)
+        elif name == "scout_repo":
+            repo_url = arguments["repo_url"]
+            question = arguments["question"]
+            budget_arg = arguments.get("budget")
+            budget = int(budget_arg) if budget_arg is not None else None
+            fmt_arg = arguments.get("format", "json")
+            scout_fmt: ScoutFormat = "markdown" if fmt_arg == "markdown" else "json"
+            result_text = await loop.run_in_executor(
+                None, handle_scout_repo, repo_url, question, budget, scout_fmt
+            )
         elif name == "query_repo":
             repo_url = arguments["repo_url"]
             question: str = arguments["question"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def _disable_slice_coverage_threshold(config: pytest.Config) -> None:
 
 
 def implementation_gate_paths(args: Sequence[str]) -> bool:
-    paths = [arg.rstrip("/") for arg in args if arg and not arg.startswith("-")]
+    paths = _path_args(args)
     if "tests" in paths and _implementation_gate_keyword(args):
         return True
     if not paths:
@@ -60,6 +60,21 @@ def implementation_gate_paths(args: Sequence[str]) -> bool:
         }
         return all(path in allowed_paths for path in paths)
     return False
+
+
+def _path_args(args: Sequence[str]) -> list[str]:
+    paths: list[str] = []
+    skip_next = False
+    for arg in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in {"-k", "-m"}:
+            skip_next = True
+            continue
+        if arg and not arg.startswith("-"):
+            paths.append(arg.rstrip("/"))
+    return paths
 
 
 def _implementation_gate_keyword(args: Sequence[str]) -> bool:

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -33,6 +33,7 @@ from archex.integrations.mcp import (
     handle_graph_path,
     handle_graph_stats,
     handle_query_repo,
+    handle_scout_repo,
 )
 from archex.models import (
     ArchProfile,
@@ -278,6 +279,42 @@ class TestHandleQueryRepo:
             handle_query_repo("https://github.com/example/repo", "question?")
         source = mock_query.call_args[0][0]
         assert source.url == "https://github.com/example/repo"
+
+
+class TestHandleScoutRepo:
+    def test_returns_scout_markdown_with_meta(self) -> None:
+        from archex.scout import ScoutBudget, ScoutFile, ScoutResult, file_handle
+
+        result_model = ScoutResult(
+            query="delta indexing",
+            ranked_files=[
+                ScoutFile(
+                    path="src/archex/index/delta.py",
+                    language="python",
+                    lines=100,
+                    symbol_count=4,
+                    handle=file_handle("src/archex/index/delta.py"),
+                )
+            ],
+            budget=ScoutBudget(token_budget=120),
+        )
+        with (
+            patch("archex.integrations.mcp.scout", return_value=result_model) as scout_mock,
+            patch("archex.integrations.mcp.get_repo_total_tokens", return_value=1000),
+        ):
+            output = handle_scout_repo(
+                "/fake/repo",
+                "delta indexing",
+                budget=120,
+                output_format="markdown",
+            )
+
+        parsed = json.loads(output)
+        assert parsed["content"].startswith("# archex scout")
+        assert file_handle("src/archex/index/delta.py") in parsed["content"]
+        assert parsed["_meta"]["tool_name"] == "scout_repo"
+        assert parsed["_meta"]["strategy"] == "scout"
+        assert scout_mock.call_args.kwargs["token_budget"] == 120
 
 
 class TestHandleCompareRepos:
@@ -565,8 +602,9 @@ class TestBuildServer:
         server_result = await handler(req)
         result = server_result.root
         assert isinstance(result, mcp_types.ListToolsResult)
-        assert len(result.tools) == 13
+        assert len(result.tools) == 14
         tool_names = {t.name for t in result.tools}
+        assert "scout_repo" in tool_names
         assert "get_file_tree" in tool_names
         assert "get_symbol" in tool_names
         assert "search_symbols" in tool_names

--- a/tests/test_scout.py
+++ b/tests/test_scout.py
@@ -155,3 +155,33 @@ def test_scout_handles_fetch_exact_symbols_and_query_chunks(tmp_path: Path) -> N
         "pkg/models.py::Model#class",
     ]
     assert bundle.retrieval_metadata.strategy == "scout_handle"
+
+
+def test_scout_cli_emits_handles_and_budget() -> None:
+    from click.testing import CliRunner
+
+    from archex.cli.main import cli
+    from archex.scout import ScoutBudget, ScoutFile, ScoutResult
+
+    result_model = ScoutResult(
+        query="delta indexing",
+        ranked_files=[
+            ScoutFile(
+                path="src/archex/index/delta.py",
+                language="python",
+                lines=100,
+                symbol_count=4,
+                handle=file_handle("src/archex/index/delta.py"),
+            )
+        ],
+        budget=ScoutBudget(token_budget=120),
+    )
+    with patch("archex.cli.scout_cmd.scout", return_value=result_model) as scout_mock:
+        result = CliRunner().invoke(
+            cli,
+            ["scout", ".", "how does delta indexing work", "--budget", "120"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert file_handle("src/archex/index/delta.py") in result.output
+    assert scout_mock.call_args.kwargs["token_budget"] == 120


### PR DESCRIPTION
## Stack

Stack-Id: `scout-protocol-c5`
Base: `feat/scout-handles`
Position: 3/4

1. `feat/scout-core` -> ancestor
2. `feat/scout-handles` -> parent
3. `feat/scout-cli-mcp` -> this PR
4. `feat/scout-benchmark` -> follow-up

Depends on: feat/scout-handles
Upstack: feat/scout-benchmark

## Summary

Expose the scout protocol through `archex scout` and MCP `scout_repo`. Both surfaces emit compact JSON/Markdown maps with stable handles and explicit budgets.

## Validation

- `uv run ruff check`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest tests/ -q -k "scout or graph_query or mcp"`

## Review

Manual PR review completed. Fixed MCP schema wiring and CLI coverage handling before advancing.
