### PR TITLE
Promote tree-sitter language pack runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ uv add "archex[vector-torch]"             # sentence-transformers / torch
 uv add "archex[splade]"                   # SPLADE sparse retrieval
 
 # Everything
-uv add "archex[all]"                      # vector + graph + mcp + langchain + llamaindex + language-pack
+uv add "archex[all]"                      # vector + graph + mcp + langchain + llamaindex
 ```
 
 ## Usage

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -301,10 +301,9 @@ archex follows a minimal-dependency strategy:
 | `archex[voyage]`        | `voyageai`                  | Voyage Code API embeddings                   |
 | `archex[openai]`        | `openai`                    | OpenAI API embeddings + LLM enrichment       |
 | `archex[anthropic]`     | `anthropic`                 | Anthropic API LLM enrichment                 |
-| `archex[language-pack]` | `tree-sitter-language-pack` | Additional grammars (Swift)                  |
 | `archex[all]`           | All optional deps           | Everything                                   |
 
-Core grammar dependencies include `tree-sitter-java`, `tree-sitter-kotlin`, and `tree-sitter-c-sharp` in addition to the original four. Swift uses `tree-sitter-language-pack` (optional extra).
+Core grammar dependencies include the standalone tree-sitter packages for tier-full languages plus `tree-sitter-language-pack` for the shared runtime grammar path.
 
 No SQLAlchemy, no FastAPI, no heavy frameworks. SQLite via stdlib `sqlite3`. Git operations via `git` CLI (assumed installed). HTTP via stdlib `urllib` where needed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "tree-sitter-java>=0.23",
     "tree-sitter-kotlin>=1.1",
     "tree-sitter-c-sharp>=0.23",
+    "tree-sitter-language-pack>=0.13",
     "tiktoken>=0.7",
     "pydantic>=2.7",
     "networkx>=3.3",
@@ -57,8 +58,7 @@ mcp = ["mcp>=1.0"]
 langchain = ["langchain-core>=0.2"]
 llamaindex = ["llama-index-core>=0.10"]
 lsap = ["lsp-client>=0.3; python_version >= '3.12'"]
-language-pack = ["tree-sitter-language-pack>=0.13"]
-all = ["archex[vector,graph,mcp,langchain,llamaindex,language-pack]"]
+all = ["archex[vector,graph,mcp,langchain,llamaindex]"]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
@@ -137,5 +137,4 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.0.0",
     "scipy>=1.17.1",
-    "tree-sitter-language-pack>=0.13",
 ]

--- a/src/archex/parse/engine.py
+++ b/src/archex/parse/engine.py
@@ -9,8 +9,8 @@ from tree_sitter import Language, Parser
 
 from archex.exceptions import ParseError
 
-# Maps language_id → (module_name, function_name)
-_LANGUAGE_LOADERS: dict[str, tuple[str, str]] = {
+# Maps language_id → (preferred module_name, function_name).
+_PREFERRED_LANGUAGE_LOADERS: dict[str, tuple[str, str]] = {
     "python": ("tree_sitter_python", "language"),
     "javascript": ("tree_sitter_javascript", "language"),
     "typescript": ("tree_sitter_typescript", "language_typescript"),
@@ -21,6 +21,11 @@ _LANGUAGE_LOADERS: dict[str, tuple[str, str]] = {
     "kotlin": ("tree_sitter_kotlin", "language"),
     "csharp": ("tree_sitter_c_sharp", "language"),
     "swift": ("tree_sitter_swift", "language"),
+}
+
+# Maps language_id → tree-sitter-language-pack grammar name.
+_LANGUAGE_PACK_NAMES: dict[str, str] = {
+    language_id: language_id for language_id in _PREFERRED_LANGUAGE_LOADERS
 }
 
 
@@ -34,15 +39,20 @@ class TreeSitterEngine:
     def get_language(self, language_id: str) -> Language:
         """Return a cached Language for the given language_id.
 
-        Raises ParseError if the language is not supported or the module is missing.
+        Raises ParseError if the language is not supported or the grammar cannot be loaded.
         """
         if language_id in self._languages:
             return self._languages[language_id]
 
-        if language_id not in _LANGUAGE_LOADERS:
+        if language_id not in _PREFERRED_LANGUAGE_LOADERS:
             raise ParseError(f"Unsupported language: {language_id!r}")
 
-        module_name, func_name = _LANGUAGE_LOADERS[language_id]
+        lang = self._load_preferred_language(language_id)
+        self._languages[language_id] = lang
+        return lang
+
+    def _load_preferred_language(self, language_id: str) -> Language:
+        module_name, func_name = _PREFERRED_LANGUAGE_LOADERS[language_id]
         try:
             module = importlib.import_module(module_name)
         except ImportError:
@@ -50,23 +60,19 @@ class TreeSitterEngine:
 
         try:
             func = getattr(module, func_name)
-            lang = Language(func())  # pyright: ignore[reportDeprecated]
+            return Language(func())  # pyright: ignore[reportDeprecated]
         except Exception as exc:
             raise ParseError(f"Failed to load tree-sitter language {language_id!r}: {exc}") from exc
 
-        self._languages[language_id] = lang
-        return lang
-
     def _try_language_pack(self, language_id: str) -> Language:
-        """Fallback: load grammar from tree-sitter-language-pack if standalone unavailable."""
+        """Load grammar from tree-sitter-language-pack after standalone lookup misses."""
+        pack_name = _LANGUAGE_PACK_NAMES[language_id]
         try:
             from tree_sitter_language_pack import (
                 get_language as _pack_get_language,  # type: ignore[import-untyped]
             )
 
-            raw = _pack_get_language(language_id)  # pyright: ignore[reportUnknownVariableType,reportArgumentType]
-            # tree-sitter-language-pack >=0.7 returns Language directly; older returns capsule
-            lang = raw if isinstance(raw, Language) else Language(raw)  # pyright: ignore[reportDeprecated,reportUnknownArgumentType,reportUnnecessaryIsInstance]
+            return _pack_get_language(pack_name)  # pyright: ignore[reportUnknownVariableType,reportArgumentType]
         except ImportError as exc:
             raise ParseError(
                 f"tree-sitter grammar for {language_id!r} not installed "
@@ -76,8 +82,6 @@ class TreeSitterEngine:
             raise ParseError(
                 f"Failed to load tree-sitter language {language_id!r} from language-pack: {exc}"
             ) from exc
-        self._languages[language_id] = lang
-        return lang
 
     def get_parser(self, language_id: str) -> Parser:
         """Return a cached Parser for the given language_id."""

--- a/uv.lock
+++ b/uv.lock
@@ -190,6 +190,7 @@ dependencies = [
     { name = "tree-sitter-java" },
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-kotlin" },
+    { name = "tree-sitter-language-pack" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
     { name = "tree-sitter-typescript" },
@@ -205,7 +206,6 @@ all = [
     { name = "onnxruntime" },
     { name = "python-igraph" },
     { name = "tokenizers" },
-    { name = "tree-sitter-language-pack" },
 ]
 dev = [
     { name = "httpx" },
@@ -222,9 +222,6 @@ graph = [
 ]
 langchain = [
     { name = "langchain-core" },
-]
-language-pack = [
-    { name = "tree-sitter-language-pack" },
 ]
 llamaindex = [
     { name = "llama-index-core" },
@@ -261,12 +258,11 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "scipy" },
-    { name = "tree-sitter-language-pack" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "archex", extras = ["vector", "graph", "mcp", "langchain", "llamaindex", "language-pack"], marker = "extra == 'all'" },
+    { name = "archex", extras = ["vector", "graph", "mcp", "langchain", "llamaindex"], marker = "extra == 'all'" },
     { name = "click", specifier = ">=8.1" },
     { name = "einops", specifier = ">=0.8.2" },
     { name = "fastembed", marker = "extra == 'vector-fast'", specifier = ">=0.4" },
@@ -300,13 +296,13 @@ requires-dist = [
     { name = "tree-sitter-java", specifier = ">=0.23" },
     { name = "tree-sitter-javascript", specifier = ">=0.23" },
     { name = "tree-sitter-kotlin", specifier = ">=1.1" },
-    { name = "tree-sitter-language-pack", marker = "extra == 'language-pack'", specifier = ">=0.13" },
+    { name = "tree-sitter-language-pack", specifier = ">=0.13" },
     { name = "tree-sitter-python", specifier = ">=0.23" },
     { name = "tree-sitter-rust", specifier = ">=0.23" },
     { name = "tree-sitter-typescript", specifier = ">=0.23" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
-provides-extras = ["vector", "vector-fast", "graph", "vector-torch", "splade", "mcp", "langchain", "llamaindex", "lsap", "language-pack", "all", "dev"]
+provides-extras = ["vector", "vector-fast", "graph", "vector-torch", "splade", "mcp", "langchain", "llamaindex", "lsap", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -318,7 +314,6 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "scipy", specifier = ">=1.17.1" },
-    { name = "tree-sitter-language-pack", specifier = ">=0.13" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stack: C3 language coverage expansion

Position: 1/4
Base: main
Head: feat/lang-pack-runtime
Next: feat/lang-expansion-grammars

Changes:
- Promote tree-sitter-language-pack to runtime dependencies.
- Keep standalone per-language grammars preferred for the existing full-tier languages.
- Remove stale language-pack optional-extra docs.

Validation:
- uv run ruff check && uv run ruff format --check . && uv run pyright
- uv run pytest tests/parse/ tests/pipeline/ -q (functional pass; project coverage config makes this subset command exit non-zero)
- uv run pytest -q