### PR TITLE
Register expanded language grammar coverage

### DIFF
--- a/src/archex/acquire/discovery.py
+++ b/src/archex/acquire/discovery.py
@@ -6,22 +6,10 @@ import subprocess
 from pathlib import Path
 
 from archex.exceptions import AcquireError
+from archex.languages import EXTENSION_LANGUAGE_MAP
 from archex.models import DiscoveredFile
 
-EXTENSION_MAP: dict[str, str] = {
-    ".py": "python",
-    ".ts": "typescript",
-    ".tsx": "typescript",
-    ".js": "javascript",
-    ".jsx": "javascript",
-    ".go": "go",
-    ".rs": "rust",
-    ".java": "java",
-    ".kt": "kotlin",
-    ".kts": "kotlin",
-    ".cs": "csharp",
-    ".swift": "swift",
-}
+EXTENSION_MAP: dict[str, str] = dict(EXTENSION_LANGUAGE_MAP)
 
 DEFAULT_IGNORES: list[str] = [
     "node_modules/",

--- a/src/archex/index/delta.py
+++ b/src/archex/index/delta.py
@@ -215,6 +215,12 @@ def compute_working_tree_delta(
     from archex.acquire import discover_files
 
     previous_states = store.get_file_states()
+    if config.languages is not None:
+        previous_states = {
+            path: state
+            for path, state in previous_states.items()
+            if _is_source_path(path, config.languages)
+        }
     if not previous_states:
         indexed_at = 0.0
         try:

--- a/src/archex/languages.py
+++ b/src/archex/languages.py
@@ -1,0 +1,232 @@
+"""Language support registry and tier metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from archex.models import LanguageTier
+
+
+@dataclass(frozen=True, slots=True)
+class LanguageSupport:
+    """Declared parser capability for one language identifier."""
+
+    language_id: str
+    display_name: str
+    extensions: tuple[str, ...]
+    tier: LanguageTier
+    pack_name: str
+    chunk_node_types: frozenset[str] = frozenset()
+
+
+_FULL = LanguageTier.FULL
+_CHUNK = LanguageTier.CHUNK_ONLY
+
+LANGUAGE_SUPPORT: dict[str, LanguageSupport] = {
+    "python": LanguageSupport("python", "Python", (".py",), _FULL, "python"),
+    "javascript": LanguageSupport("javascript", "JavaScript", (".js", ".jsx"), _FULL, "javascript"),
+    "typescript": LanguageSupport("typescript", "TypeScript", (".ts", ".tsx"), _FULL, "typescript"),
+    "tsx": LanguageSupport("tsx", "TSX", (".tsx",), _FULL, "tsx"),
+    "go": LanguageSupport("go", "Go", (".go",), _FULL, "go"),
+    "rust": LanguageSupport("rust", "Rust", (".rs",), _FULL, "rust"),
+    "java": LanguageSupport("java", "Java", (".java",), _FULL, "java"),
+    "kotlin": LanguageSupport("kotlin", "Kotlin", (".kt", ".kts"), _FULL, "kotlin"),
+    "csharp": LanguageSupport("csharp", "C#", (".cs",), _FULL, "csharp"),
+    "swift": LanguageSupport("swift", "Swift", (".swift",), _FULL, "swift"),
+    "c": LanguageSupport(
+        "c",
+        "C",
+        (".c", ".h"),
+        _CHUNK,
+        "c",
+        frozenset({"function_definition", "struct_specifier", "preproc_include"}),
+    ),
+    "cpp": LanguageSupport(
+        "cpp",
+        "C++",
+        (".cc", ".cpp", ".cxx", ".hpp", ".hh", ".hxx"),
+        _CHUNK,
+        "cpp",
+        frozenset(
+            {
+                "function_definition",
+                "class_specifier",
+                "struct_specifier",
+                "namespace_definition",
+                "preproc_include",
+            }
+        ),
+    ),
+    "php": LanguageSupport(
+        "php",
+        "PHP",
+        (".php",),
+        _CHUNK,
+        "php",
+        frozenset(
+            {
+                "function_definition",
+                "class_declaration",
+                "interface_declaration",
+                "trait_declaration",
+                "namespace_definition",
+                "namespace_use_declaration",
+            }
+        ),
+    ),
+    "ruby": LanguageSupport(
+        "ruby",
+        "Ruby",
+        (".rb",),
+        _CHUNK,
+        "ruby",
+        frozenset({"module", "class", "method", "singleton_method", "call"}),
+    ),
+    "scala": LanguageSupport(
+        "scala",
+        "Scala",
+        (".scala", ".sc"),
+        _CHUNK,
+        "scala",
+        frozenset(
+            {
+                "class_definition",
+                "object_definition",
+                "trait_definition",
+                "function_definition",
+                "import_declaration",
+            }
+        ),
+    ),
+    "lua": LanguageSupport(
+        "lua",
+        "Lua",
+        (".lua",),
+        _CHUNK,
+        "lua",
+        frozenset({"function_declaration", "variable_declaration", "function_call"}),
+    ),
+    "bash": LanguageSupport(
+        "bash",
+        "Bash / Shell",
+        (".sh", ".bash", ".zsh"),
+        _CHUNK,
+        "bash",
+        frozenset(
+            {
+                "function_definition",
+                "if_statement",
+                "for_statement",
+                "while_statement",
+                "case_statement",
+                "command",
+            }
+        ),
+    ),
+    "sql": LanguageSupport("sql", "SQL", (".sql",), _CHUNK, "sql", frozenset({"statement"})),
+    "html": LanguageSupport(
+        "html",
+        "HTML",
+        (".html", ".htm"),
+        _CHUNK,
+        "html",
+        frozenset({"element", "script_element", "style_element"}),
+    ),
+    "css": LanguageSupport(
+        "css",
+        "CSS",
+        (".css",),
+        _CHUNK,
+        "css",
+        frozenset({"rule_set", "media_statement", "import_statement"}),
+    ),
+    "yaml": LanguageSupport(
+        "yaml", "YAML", (".yaml", ".yml"), _CHUNK, "yaml", frozenset({"document"})
+    ),
+    "toml": LanguageSupport(
+        "toml", "TOML", (".toml",), _CHUNK, "toml", frozenset({"table", "table_array_element"})
+    ),
+    "json": LanguageSupport(
+        "json", "JSON", (".json",), _CHUNK, "json", frozenset({"object", "array"})
+    ),
+    "markdown": LanguageSupport(
+        "markdown", "Markdown", (".md", ".markdown"), _CHUNK, "markdown", frozenset({"section"})
+    ),
+    "solidity": LanguageSupport(
+        "solidity",
+        "Solidity",
+        (".sol",),
+        _CHUNK,
+        "solidity",
+        frozenset(
+            {
+                "contract_declaration",
+                "interface_declaration",
+                "library_declaration",
+                "function_definition",
+                "pragma_directive",
+            }
+        ),
+    ),
+}
+
+EXTENSION_LANGUAGE_MAP: dict[str, str] = {
+    ".py": "python",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".go": "go",
+    ".rs": "rust",
+    ".java": "java",
+    ".kt": "kotlin",
+    ".kts": "kotlin",
+    ".cs": "csharp",
+    ".swift": "swift",
+    ".c": "c",
+    ".h": "c",
+    ".cc": "cpp",
+    ".cpp": "cpp",
+    ".cxx": "cpp",
+    ".hpp": "cpp",
+    ".hh": "cpp",
+    ".hxx": "cpp",
+    ".php": "php",
+    ".rb": "ruby",
+    ".scala": "scala",
+    ".sc": "scala",
+    ".lua": "lua",
+    ".sh": "bash",
+    ".bash": "bash",
+    ".zsh": "bash",
+    ".sql": "sql",
+    ".html": "html",
+    ".htm": "html",
+    ".css": "css",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".toml": "toml",
+    ".json": "json",
+    ".md": "markdown",
+    ".markdown": "markdown",
+    ".sol": "solidity",
+}
+
+LANGUAGE_PACK_NAMES: dict[str, str] = {
+    language_id: support.pack_name for language_id, support in LANGUAGE_SUPPORT.items()
+}
+
+CHUNK_ONLY_LANGUAGE_IDS: frozenset[str] = frozenset(
+    language_id
+    for language_id, support in LANGUAGE_SUPPORT.items()
+    if support.tier == LanguageTier.CHUNK_ONLY
+)
+
+
+def get_language_support(language_id: str) -> LanguageSupport | None:
+    return LANGUAGE_SUPPORT.get(language_id)
+
+
+def get_language_tier(language_id: str) -> LanguageTier:
+    support = get_language_support(language_id)
+    return support.tier if support is not None else LanguageTier.UNKNOWN

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -76,6 +76,12 @@ class RetrievalPolicy(StrEnum):
     CROSS_LAYER = "cross_layer"
 
 
+class LanguageTier(StrEnum):
+    FULL = "full"
+    CHUNK_ONLY = "chunk-only"
+    UNKNOWN = "unknown"
+
+
 # ---------------------------------------------------------------------------
 # Type aliases
 # ---------------------------------------------------------------------------
@@ -250,11 +256,17 @@ class ImportStatement(BaseModel):
     resolved_path: str | None = None
 
 
+class ChunkRange(BaseModel):
+    start_line: int
+    end_line: int
+
+
 class ParsedFile(BaseModel):
     path: str
     language: str
     symbols: list[Symbol] = []
     imports: list[ImportStatement] = []
+    chunk_ranges: list[ChunkRange] = []
     lines: int = 0
     tokens: int = 0
 
@@ -374,6 +386,7 @@ class LanguageStats(BaseModel):
     lines: int = 0
     symbols: int = 0
     percentage: float = 0.0
+    tier: LanguageTier = LanguageTier.UNKNOWN
 
 
 class CodebaseStats(BaseModel):

--- a/src/archex/parse/adapters/__init__.py
+++ b/src/archex/parse/adapters/__init__.py
@@ -6,7 +6,9 @@ import importlib.metadata
 import logging
 
 from archex.exceptions import ConfigError
+from archex.languages import CHUNK_ONLY_LANGUAGE_IDS
 from archex.parse.adapters.base import LanguageAdapter
+from archex.parse.adapters.chunk_only import make_chunk_only_adapter
 from archex.parse.adapters.csharp import CSharpAdapter
 from archex.parse.adapters.go import GoAdapter
 from archex.parse.adapters.java import JavaAdapter
@@ -88,6 +90,8 @@ default_adapter_registry.register("java", JavaAdapter)  # type: ignore[type-abst
 default_adapter_registry.register("csharp", CSharpAdapter)  # type: ignore[type-abstract]
 default_adapter_registry.register("kotlin", KotlinAdapter)  # type: ignore[type-abstract]
 default_adapter_registry.register("swift", SwiftAdapter)  # type: ignore[type-abstract]
+for _language_id in sorted(CHUNK_ONLY_LANGUAGE_IDS):
+    default_adapter_registry.register(_language_id, make_chunk_only_adapter(_language_id))
 
 # Legacy compat
 ADAPTERS: dict[str, type[LanguageAdapter]] = default_adapter_registry.adapter_classes

--- a/src/archex/parse/adapters/chunk_only.py
+++ b/src/archex/parse/adapters/chunk_only.py
@@ -1,0 +1,96 @@
+"""Chunk-only adapter for grammars without symbol/import extraction."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from archex.languages import get_language_support
+from archex.models import ChunkRange, DiscoveredFile, ImportStatement, Symbol, Visibility
+
+
+class ChunkOnlyAdapter:
+    """Parse a language for AST chunk ranges without claiming symbols or imports."""
+
+    _language_id: str = ""
+
+    @property
+    def language_id(self) -> str:
+        return self._language_id
+
+    @property
+    def file_extensions(self) -> list[str]:
+        support = get_language_support(self._language_id)
+        return list(support.extensions) if support is not None else []
+
+    @property
+    def tree_sitter_name(self) -> str:
+        support = get_language_support(self._language_id)
+        return support.pack_name if support is not None else self._language_id
+
+    def extract_symbols(self, tree: object, source: bytes, file_path: str) -> list[Symbol]:
+        return []
+
+    def parse_imports(self, tree: object, source: bytes, file_path: str) -> list[ImportStatement]:
+        return []
+
+    def resolve_import(self, imp: ImportStatement, file_map: dict[str, str]) -> str | None:
+        return None
+
+    def detect_entry_points(self, files: list[DiscoveredFile]) -> list[str]:
+        return []
+
+    def classify_visibility(self, symbol: Symbol) -> Visibility:
+        return Visibility.PUBLIC
+
+    def extract_chunk_ranges(self, tree: object, source: bytes, file_path: str) -> list[ChunkRange]:
+        support = get_language_support(self._language_id)
+        if support is None or not support.chunk_node_types:
+            return []
+
+        root = _root_node(tree)
+        ranges: list[ChunkRange] = []
+        for node in _walk_named(root):
+            if node.type not in support.chunk_node_types:
+                continue
+            start_line = int(node.start_point[0]) + 1
+            end_row = int(node.end_point[0])
+            end_column = int(node.end_point[1])
+            end_line = end_row + 1 if end_column > 0 else end_row
+            if end_line < start_line:
+                continue
+            ranges.append(ChunkRange(start_line=start_line, end_line=end_line))
+        return _deduplicate_ranges(ranges)
+
+
+def make_chunk_only_adapter(language_id: str) -> type[ChunkOnlyAdapter]:
+    class _Adapter(ChunkOnlyAdapter):
+        _language_id = language_id
+
+    _Adapter.__name__ = f"{language_id.title().replace('_', '')}ChunkOnlyAdapter"
+    return _Adapter
+
+
+def _root_node(tree: object) -> Any:
+    parsed_tree: Any = tree
+    return parsed_tree.root_node
+
+
+def _walk_named(node: Any) -> list[Any]:
+    children = [child for child in node.children if child.is_named]
+    result: list[Any] = []
+    for child in children:
+        result.append(child)
+        result.extend(_walk_named(child))
+    return result
+
+
+def _deduplicate_ranges(ranges: list[ChunkRange]) -> list[ChunkRange]:
+    ranges.sort(key=lambda item: (item.start_line, item.end_line))
+    result: list[ChunkRange] = []
+    last_end = 0
+    for item in ranges:
+        if item.start_line <= last_end:
+            continue
+        result.append(item)
+        last_end = item.end_line
+    return result

--- a/src/archex/parse/engine.py
+++ b/src/archex/parse/engine.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from tree_sitter import Language, Parser
 
 from archex.exceptions import ParseError
+from archex.languages import LANGUAGE_PACK_NAMES
 
 # Maps language_id → (preferred module_name, function_name).
 _PREFERRED_LANGUAGE_LOADERS: dict[str, tuple[str, str]] = {
@@ -21,11 +22,6 @@ _PREFERRED_LANGUAGE_LOADERS: dict[str, tuple[str, str]] = {
     "kotlin": ("tree_sitter_kotlin", "language"),
     "csharp": ("tree_sitter_c_sharp", "language"),
     "swift": ("tree_sitter_swift", "language"),
-}
-
-# Maps language_id → tree-sitter-language-pack grammar name.
-_LANGUAGE_PACK_NAMES: dict[str, str] = {
-    language_id: language_id for language_id in _PREFERRED_LANGUAGE_LOADERS
 }
 
 
@@ -44,10 +40,13 @@ class TreeSitterEngine:
         if language_id in self._languages:
             return self._languages[language_id]
 
-        if language_id not in _PREFERRED_LANGUAGE_LOADERS:
+        if language_id not in LANGUAGE_PACK_NAMES:
             raise ParseError(f"Unsupported language: {language_id!r}")
 
-        lang = self._load_preferred_language(language_id)
+        if language_id in _PREFERRED_LANGUAGE_LOADERS:
+            lang = self._load_preferred_language(language_id)
+        else:
+            lang = self._try_language_pack(language_id)
         self._languages[language_id] = lang
         return lang
 
@@ -66,7 +65,7 @@ class TreeSitterEngine:
 
     def _try_language_pack(self, language_id: str) -> Language:
         """Load grammar from tree-sitter-language-pack after standalone lookup misses."""
-        pack_name = _LANGUAGE_PACK_NAMES[language_id]
+        pack_name = LANGUAGE_PACK_NAMES[language_id]
         try:
             from tree_sitter_language_pack import (
                 get_language as _pack_get_language,  # type: ignore[import-untyped]

--- a/src/archex/parse/symbols.py
+++ b/src/archex/parse/symbols.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from archex.exceptions import ParseError
-from archex.models import ParsedFile
+from archex.models import ChunkRange, ParsedFile
 
 logger = logging.getLogger(__name__)
 
@@ -35,10 +36,16 @@ def _parse_with_adapter(
     tree = engine.parse_file(absolute_path, language)
     source = Path(absolute_path).read_bytes()
     symbols = adapter.extract_symbols(tree, source, relative_path)
+    extract_chunk_ranges = getattr(adapter, "extract_chunk_ranges", None)
+    chunk_ranges: list[ChunkRange] = []
+    if callable(extract_chunk_ranges):
+        extractor = cast("Callable[[object, bytes, str], list[ChunkRange]]", extract_chunk_ranges)
+        chunk_ranges = extractor(tree, source, relative_path)
     return ParsedFile(
         path=relative_path,
         language=language,
         symbols=symbols,
+        chunk_ranges=chunk_ranges,
         lines=_count_lines(source),
     )
 

--- a/src/archex/pipeline/chunker.py
+++ b/src/archex/pipeline/chunker.py
@@ -307,26 +307,41 @@ class ASTChunker:
         all_source_lines = source.split(b"\n")
         total_lines = len(all_source_lines)
 
-        # Sort symbols by start_line; methods nested under classes are already separate
+        # Sort symbols by start_line; methods nested under classes are already separate.
         symbols = sorted(parsed_file.symbols, key=lambda s: s.start_line)
 
-        # Track which lines are covered by symbols so we can emit file-level chunks
-        covered: list[tuple[int, int]] = [(s.start_line, s.end_line) for s in symbols]
-
-        # Collect raw chunk candidates: (lines_list, start_line, symbol_or_None)
+        # Collect raw chunk candidates: (lines_list, start_line, symbol_or_None).
         candidates: list[tuple[list[bytes], int, Symbol | None]] = []
+        has_structural_ranges = False
 
-        for sym in symbols:
-            _append_candidates(
-                candidates,
-                lines=_extract_source_lines(all_source_lines, sym.start_line, sym.end_line),
-                start_line=sym.start_line,
-                symbol=sym,
-                max_tokens=config.chunk_max_tokens,
-                encoder=encoder,
-            )
+        if symbols:
+            covered: list[tuple[int, int]] = [(s.start_line, s.end_line) for s in symbols]
+            for sym in symbols:
+                _append_candidates(
+                    candidates,
+                    lines=_extract_source_lines(all_source_lines, sym.start_line, sym.end_line),
+                    start_line=sym.start_line,
+                    symbol=sym,
+                    max_tokens=config.chunk_max_tokens,
+                    encoder=encoder,
+                )
+        else:
+            ranges = sorted(parsed_file.chunk_ranges, key=lambda r: r.start_line)
+            has_structural_ranges = bool(ranges)
+            covered = [(r.start_line, r.end_line) for r in ranges]
+            for chunk_range in ranges:
+                _append_candidates(
+                    candidates,
+                    lines=_extract_source_lines(
+                        all_source_lines, chunk_range.start_line, chunk_range.end_line
+                    ),
+                    start_line=chunk_range.start_line,
+                    symbol=None,
+                    max_tokens=config.chunk_max_tokens,
+                    encoder=encoder,
+                )
 
-        # File-level code: lines not covered by any symbol
+        # File-level code: lines not covered by symbols or chunk-only AST ranges.
         uncovered_ranges = _find_uncovered_ranges(covered, total_lines)
         for range_start, range_end in uncovered_ranges:
             _append_candidates(
@@ -338,8 +353,12 @@ class ASTChunker:
                 encoder=encoder,
             )
 
-        # Merge small adjacent file-level chunks
-        merged = _merge_small_chunks(candidates, config.chunk_min_tokens, encoder)
+        # Merge small adjacent file-level chunks. Chunk-only AST ranges must remain
+        # line-stable; merging them can combine non-contiguous source ranges.
+        if has_structural_ranges:
+            merged = sorted(candidates, key=lambda item: item[1])
+        else:
+            merged = _merge_small_chunks(candidates, config.chunk_min_tokens, encoder)
 
         # Build CodeChunk objects
         result: list[CodeChunk] = []

--- a/src/archex/serve/profile.py
+++ b/src/archex/serve/profile.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from archex.languages import get_language_tier
 from archex.models import (
     ArchDecision,
     ArchProfile,
@@ -48,6 +49,7 @@ def _compute_stats(parsed_files: list[ParsedFile]) -> CodebaseStats:
             lines=lang_lines.get(lang, 0),
             symbols=lang_symbols.get(lang, 0),
             percentage=round(percentage, 2),
+            tier=get_language_tier(lang),
         )
 
     return CodebaseStats(

--- a/tests/acquire/test_discovery.py
+++ b/tests/acquire/test_discovery.py
@@ -21,13 +21,15 @@ from archex.exceptions import AcquireError
 
 def test_discover_file_count(python_simple_repo: Path) -> None:
     files = discover_files(python_simple_repo)
-    # python_simple has: main.py, models.py, utils.py, services/__init__.py, services/auth.py
-    assert len(files) == 5
+    # python_simple has 5 Python files plus pyproject.toml.
+    assert len(files) == 6
 
 
-def test_discover_all_python(python_simple_repo: Path) -> None:
+def test_discover_python_fixture_languages(python_simple_repo: Path) -> None:
     files = discover_files(python_simple_repo)
-    assert all(f.language == "python" for f in files)
+    languages = {f.path: f.language for f in files}
+    assert languages["pyproject.toml"] == "toml"
+    assert all(language == "python" for path, language in languages.items() if path.endswith(".py"))
 
 
 def test_discover_language_filter(python_simple_repo: Path) -> None:
@@ -115,8 +117,8 @@ def test_detect_language_rust() -> None:
     assert _detect_language(Path("lib.rs")) == "rust"
 
 
-def test_detect_language_unknown() -> None:
-    assert _detect_language(Path("README.md")) is None
+def test_detect_language_markdown_and_unknown() -> None:
+    assert _detect_language(Path("README.md")) == "markdown"
     assert _detect_language(Path("Makefile")) is None
 
 
@@ -174,7 +176,7 @@ def test_discover_files_includes_file_at_size_limit(tmp_path: Path) -> None:
 def test_discover_files_default_max_size_allows_normal_files(python_simple_repo: Path) -> None:
     """Default max_file_size (10MB) allows all fixture files through."""
     files = discover_files(python_simple_repo)
-    assert len(files) == 5
+    assert len(files) == 6
 
 
 def test_git_ls_files_called_process_error(tmp_path: Path) -> None:

--- a/tests/pipeline/test_service.py
+++ b/tests/pipeline/test_service.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from archex.models import Config, EdgeKind, IndexConfig
+from archex.models import ChunkRange, Config, EdgeKind, IndexConfig, ParsedFile
 from archex.parse.adapters import LanguageAdapter, default_adapter_registry
+from archex.pipeline.chunker import ASTChunker
 from archex.pipeline.models import ArtifactBundle
 from archex.pipeline.service import (
     ParseArtifacts,
@@ -143,6 +144,43 @@ class TestMultiLanguage:
         config = Config(languages=["typescript"])
         bundle = produce_artifacts(ts_fixture, config, _adapters())
         assert len(bundle.chunks) > 0
+
+    def test_chunk_only_ranges_keep_line_stable_chunks(self) -> None:
+        source = b"SELECT * FROM users;\n-- keep the separator\nCREATE TABLE users(id INT);\n"
+        parsed = ParsedFile(
+            path="schema.sql",
+            language="sql",
+            chunk_ranges=[
+                ChunkRange(start_line=1, end_line=1),
+                ChunkRange(start_line=3, end_line=3),
+            ],
+            lines=3,
+        )
+
+        chunks = ASTChunker(IndexConfig()).chunk_file(parsed, source)
+
+        assert [(chunk.start_line, chunk.end_line) for chunk in chunks] == [(1, 1), (2, 2), (3, 3)]
+        assert [chunk.content for chunk in chunks] == [
+            "SELECT * FROM users;",
+            "-- keep the separator",
+            "CREATE TABLE users(id INT);",
+        ]
+
+    def test_chunk_only_toml_tables_keep_headers(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            '[a]\nname = "a"\n\n[b]\nname = "b"\n\n[c]\nname = "c"\n',
+        )
+
+        bundle = produce_artifacts(tmp_path, Config(languages=["toml"]), _adapters())
+
+        assert [(chunk.start_line, chunk.end_line) for chunk in bundle.chunks] == [
+            (1, 3),
+            (4, 6),
+            (7, 8),
+        ]
+        assert [chunk.content.splitlines()[0] for chunk in bundle.chunks] == ["[a]", "[b]", "[c]"]
+        assert all(chunk.symbol_name is None for chunk in bundle.chunks)
 
 
 class TestSurrogateSummaryInclusion:

--- a/tests/test_pipeline_service.py
+++ b/tests/test_pipeline_service.py
@@ -72,7 +72,7 @@ class TestBuildChunks:
         for chunk in chunks:
             assert chunk.file_path
             assert chunk.content
-            assert chunk.language == "python"
+            assert chunk.language in {"python", "toml"}
 
     def test_strict_mode_raises_on_missing_file(self, python_simple_repo: Path) -> None:
         config = Config(cache=False)


### PR DESCRIPTION
Stack: C3 language coverage expansion

Position: 2/4
Base: feat/lang-pack-runtime
Head: feat/lang-expansion-grammars
Next: feat/lang-extraction-fixtures

Changes:
- Register C, C++, PHP, Ruby, Scala, Lua, Bash/Shell, SQL, HTML, CSS, YAML, TOML, JSON, Markdown, and Solidity as chunk-only grammar-backed languages.
- Add central language support metadata and LanguageStats tier reporting.
- Add chunk-only adapters and AST chunk ranges without symbol/import graph claims.

Validation:
- uv run ruff check && uv run ruff format --check . && uv run pyright
- uv run pytest tests/parse/ tests/pipeline/ -q (functional pass; project coverage config makes this subset command exit non-zero)
- uv run pytest -q