### PR TITLE
Add unknown text BM25 fallback

### DIFF
--- a/src/archex/acquire/discovery.py
+++ b/src/archex/acquire/discovery.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import codecs
 import subprocess
 from pathlib import Path
 
 from archex.exceptions import AcquireError
-from archex.languages import EXTENSION_LANGUAGE_MAP
+from archex.languages import EXTENSION_LANGUAGE_MAP, UNKNOWN_LANGUAGE_ID
 from archex.models import DiscoveredFile
 
 EXTENSION_MAP: dict[str, str] = dict(EXTENSION_LANGUAGE_MAP)
@@ -48,6 +49,21 @@ def _matches_ignore(rel_path: str, ignores: list[str]) -> bool:
             if rel_path == pattern or Path(rel_path).name == pattern:
                 return True
     return False
+
+
+def _is_text_file(path: Path) -> bool:
+    try:
+        with path.open("rb") as handle:
+            sample = handle.read(8192)
+    except OSError:
+        return False
+    if b"\x00" in sample:
+        return False
+    try:
+        codecs.getincrementaldecoder("utf-8")().decode(sample)
+    except UnicodeDecodeError:
+        return False
+    return True
 
 
 def discover_files(
@@ -99,7 +115,11 @@ def discover_files(
 
         lang = _detect_language(file_path)
         if lang is None:
-            continue
+            if languages is not None and UNKNOWN_LANGUAGE_ID not in languages:
+                continue
+            if not _is_text_file(file_path):
+                continue
+            lang = UNKNOWN_LANGUAGE_ID
 
         if languages is not None and lang not in languages:
             continue

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -59,6 +59,7 @@ from archex.exceptions import ArchexIndexError, DeltaIndexError
 from archex.index.bm25 import BM25Index
 from archex.index.graph import DependencyGraph
 from archex.index.store import IndexStore
+from archex.languages import UNKNOWN_LANGUAGE_ID
 from archex.models import (
     ArchProfile,
     ChunkSurrogate,
@@ -84,8 +85,7 @@ from archex.observe import PipelineTrace, StepTiming
 from archex.parse import (
     TreeSitterEngine,
     build_file_map,
-    extract_symbols,
-    parse_imports,
+    extract_symbols_and_imports,
     resolve_imports,
 )
 from archex.parse.adapters import LanguageAdapter, default_adapter_registry
@@ -152,11 +152,13 @@ def _full_index(
         )
         engine = TreeSitterEngine()
         adapters = _build_adapters()
-        parsed_files = extract_symbols(files, engine, adapters, parallel=config.parallel)
-        import_map = parse_imports(files, engine, adapters, parallel=config.parallel)
+        extraction = extract_symbols_and_imports(files, engine, adapters, parallel=config.parallel)
+        parsed_files = extraction.parsed_files
         file_map = build_file_map(files)
         file_languages = {f.path: f.language for f in files}
-        resolved_map = resolve_imports(import_map, file_map, adapters, file_languages)
+        resolved_map = resolve_imports(
+            extraction.imports_by_path, file_map, adapters, file_languages
+        )
 
         graph = DependencyGraph.from_parsed_files(parsed_files, resolved_map)
 
@@ -178,11 +180,16 @@ def _full_index(
         db_path = Path(tempfile.mkdtemp()) / "index.db"
         store = IndexStore(db_path)
         store.insert_chunks(all_chunks)
-        chunk_surrogates = build_chunk_surrogates(
-            all_chunks,
-            version=effective_index_config.surrogate_version,
+        chunk_surrogates = (
+            build_chunk_surrogates(
+                all_chunks,
+                version=effective_index_config.surrogate_version,
+            )
+            if _surrogates_required(effective_index_config)
+            else []
         )
-        store.insert_chunk_surrogates(chunk_surrogates)
+        if chunk_surrogates:
+            store.insert_chunk_surrogates(chunk_surrogates)
         edges = graph.file_edges()
         store.replace_file_states(compute_file_states(repo_path, files))
         store.insert_edges(edges)
@@ -193,10 +200,15 @@ def _full_index(
             if embedder is not None:
                 from archex.index.vector import VectorIndex
 
-                surrogate_lookup = {surrogate.chunk_id: surrogate for surrogate in chunk_surrogates}
+                surrogate_lookup = (
+                    {surrogate.chunk_id: surrogate for surrogate in chunk_surrogates}
+                    if chunk_surrogates
+                    else None
+                )
+                vector_chunks = embedding_eligible_chunks(all_chunks)
                 vec_idx = VectorIndex()
                 cache_hits, cache_misses = vec_idx.build(
-                    all_chunks,
+                    vector_chunks,
                     embedder,
                     surrogates_by_chunk_id=surrogate_lookup,
                     vector_mode=effective_index_config.vector_mode,
@@ -215,7 +227,7 @@ def _full_index(
                         surrogate_version=effective_index_config.surrogate_version,
                     )
                 )
-                if all_chunks:
+                if vector_chunks:
                     vec_idx.save(
                         npz_path,
                         embedder_name=effective_index_config.embedder or "",
@@ -430,7 +442,8 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
                 from archex.index.vector import VectorIndex
 
                 new_chunks = store.get_chunks()
-                new_surrogates = _surrogate_lookup(store, new_chunks, index_config)
+                vector_chunks = embedding_eligible_chunks(new_chunks)
+                new_surrogates = _surrogate_lookup(store, vector_chunks, index_config)
                 cached_vectors = _cached_vectors_by_content_hash(
                     old_vector_path,
                     old_chunks,
@@ -439,7 +452,7 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
                 )
                 vec_idx = VectorIndex()
                 cache_hits, cache_misses = vec_idx.build(
-                    new_chunks,
+                    vector_chunks,
                     embedder,
                     surrogates_by_chunk_id=new_surrogates,
                     vector_mode=index_config.vector_mode,
@@ -450,7 +463,7 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
                     vector_mode=index_config.vector_mode,
                     surrogate_version=index_config.surrogate_version,
                 )
-                if new_chunks:
+                if vector_chunks:
                     vec_idx.save(
                         vector_path,
                         embedder_name=index_config.embedder or "",
@@ -609,6 +622,14 @@ def _compute_splade_top_k(*, bm25_top_k: int, total_chunks: int) -> int:
     return min(total_chunks, bm25_top_k * 2)
 
 
+def embedding_eligible_chunks(chunks: list[CodeChunk]) -> list[CodeChunk]:
+    return [chunk for chunk in chunks if chunk.language != UNKNOWN_LANGUAGE_ID]
+
+
+def _surrogates_required(index_config: IndexConfig) -> bool:
+    return index_config.vector and index_config.vector_mode == VectorMode.SURROGATE
+
+
 def _build_splade_index(
     store: IndexStore,
     chunks: list[CodeChunk],
@@ -616,10 +637,13 @@ def _build_splade_index(
 ) -> None:
     if not index_config.splade:
         return
+    eligible_chunks = embedding_eligible_chunks(chunks)
+    if not eligible_chunks:
+        return
     from archex.index.splade import SPLADEIndex
 
     splade = SPLADEIndex(store)
-    splade.build(chunks)
+    splade.build(eligible_chunks)
 
 
 def _build_module_summaries(
@@ -647,6 +671,8 @@ def _splade_search_or_raise(
 
     splade = SPLADEIndex(store)
     if not splade.has_data:
+        if not embedding_eligible_chunks(store.get_chunks()):
+            return None
         raise ArchexIndexError(
             "SPLADE requested but the cached index has no SPLADE rows; "
             "refresh it with `archex index --splade`."
@@ -1223,11 +1249,13 @@ def analyze(
         adapters = _build_adapters()
 
         t2 = time.perf_counter()
-        parsed_files = extract_symbols(files, engine, adapters, parallel=config.parallel)
-        import_map = parse_imports(files, engine, adapters, parallel=config.parallel)
+        extraction = extract_symbols_and_imports(files, engine, adapters, parallel=config.parallel)
+        parsed_files = extraction.parsed_files
         file_map = build_file_map(files)
         file_languages = {f.path: f.language for f in files}
-        resolved_map = resolve_imports(import_map, file_map, adapters, file_languages)
+        resolved_map = resolve_imports(
+            extraction.imports_by_path, file_map, adapters, file_languages
+        )
         parse_ms = _elapsed_ms(t1)  # discover + parse combined
         logger.info("Parsed %d files in %.0fms", len(parsed_files), _elapsed_ms(t2))
         if timing is not None:
@@ -1772,11 +1800,13 @@ def query(
         adapters = _build_adapters()
 
         t3 = time.perf_counter()
-        parsed_files = extract_symbols(files, engine, adapters, parallel=config.parallel)
-        import_map = parse_imports(files, engine, adapters, parallel=config.parallel)
+        extraction = extract_symbols_and_imports(files, engine, adapters, parallel=config.parallel)
+        parsed_files = extraction.parsed_files
         file_map = build_file_map(files)
         file_languages = {f.path: f.language for f in files}
-        resolved_map = resolve_imports(import_map, file_map, adapters, file_languages)
+        resolved_map = resolve_imports(
+            extraction.imports_by_path, file_map, adapters, file_languages
+        )
         parse_ms = _elapsed_ms(t3)
         logger.info("Parsed %d files in %.0fms", len(parsed_files), parse_ms)
         if timing is not None:
@@ -1821,16 +1851,25 @@ def query(
 
         db_path = Path(tempfile.mkdtemp()) / "index.db"
         store = IndexStore(db_path)
-        chunk_surrogates = build_chunk_surrogates(
-            all_chunks,
-            version=index_config.surrogate_version,
+        chunk_surrogates = (
+            build_chunk_surrogates(
+                all_chunks,
+                version=index_config.surrogate_version,
+            )
+            if _surrogates_required(index_config)
+            else []
         )
-        surrogate_lookup = {surrogate.chunk_id: surrogate for surrogate in chunk_surrogates}
+        surrogate_lookup = (
+            {surrogate.chunk_id: surrogate for surrogate in chunk_surrogates}
+            if chunk_surrogates
+            else None
+        )
 
         try:
             bm25 = BM25Index(store)
             store.insert_chunks(all_chunks)
-            store.insert_chunk_surrogates(chunk_surrogates)
+            if chunk_surrogates:
+                store.insert_chunk_surrogates(chunk_surrogates)
             edges = graph.file_edges()
             from archex.index.delta import compute_file_states
 
@@ -1848,9 +1887,10 @@ def query(
                     from archex.index.vector import VectorIndex
 
                     t_vec_build = time.perf_counter()
+                    vector_chunks = embedding_eligible_chunks(all_chunks)
                     vec_idx = VectorIndex()
                     cache_hits, cache_misses = vec_idx.build(
-                        all_chunks,
+                        vector_chunks,
                         embedder,
                         surrogates_by_chunk_id=surrogate_lookup,
                         vector_mode=index_config.vector_mode,
@@ -1869,14 +1909,17 @@ def query(
                             surrogate_version=index_config.surrogate_version,
                         )
                     )
-                    vec_idx.save(
-                        npz_path,
-                        embedder_name=index_config.embedder or "",
-                        vector_dim=embedder.dimension,
-                        vector_mode=index_config.vector_mode,
-                        surrogate_version=index_config.surrogate_version,
-                    )
-                    _precomputed_vector_path = npz_path
+                    if vector_chunks:
+                        vec_idx.save(
+                            npz_path,
+                            embedder_name=index_config.embedder or "",
+                            vector_dim=embedder.dimension,
+                            vector_mode=index_config.vector_mode,
+                            surrogate_version=index_config.surrogate_version,
+                        )
+                        _precomputed_vector_path = npz_path
+                    elif npz_path.exists():
+                        npz_path.unlink()
                     vec_build_ms = _elapsed_ms(t_vec_build)
                     if timing is not None:
                         timing.vector_index_ms = vec_build_ms
@@ -2105,13 +2148,17 @@ def _two_stage_rerank(
     Embeds only the top BM25 candidate chunks + query instead of the full corpus.
     Caps at _RERANK_MAX_CANDIDATES to bound embedding latency.
     """
+    candidates = embedding_eligible_chunks(
+        [chunk for chunk, _ in bm25_results[:_RERANK_MAX_CANDIDATES]]
+    )
+    if not candidates:
+        return None
     embedder = _get_embedder(index_config)
     if embedder is None:
         return None
 
     from archex.index.vector import VectorIndex
 
-    candidates = [chunk for chunk, _ in bm25_results[:_RERANK_MAX_CANDIDATES]]
     t_vec = time.perf_counter()
     vec_idx = VectorIndex()
     vector_results = vec_idx.rerank(
@@ -2139,6 +2186,9 @@ def _vector_search_in_memory(
     surrogates_by_chunk_id: dict[str, ChunkSurrogate] | None = None,
 ) -> list[tuple[CodeChunk, float]] | None:
     """Build an in-memory vector index when no persisted artifact is available."""
+    eligible_chunks = embedding_eligible_chunks(all_chunks)
+    if not eligible_chunks:
+        return None
     embedder = _get_embedder(index_config)
     if embedder is None:
         return None
@@ -2148,7 +2198,7 @@ def _vector_search_in_memory(
     t_vec = time.perf_counter()
     vec_idx = VectorIndex()
     vec_idx.build(
-        all_chunks,
+        eligible_chunks,
         embedder,  # type: ignore[arg-type]
         surrogates_by_chunk_id=surrogates_by_chunk_id,
         vector_mode=index_config.vector_mode,
@@ -2158,7 +2208,7 @@ def _vector_search_in_memory(
     if timing is not None:
         timing.vector_used = True
         timing.vector_build_ms = build_ms
-    logger.info("In-memory vector search (%d chunks) in %.0fms", len(all_chunks), build_ms)
+    logger.info("In-memory vector search (%d chunks) in %.0fms", len(eligible_chunks), build_ms)
     return vector_results  # type: ignore[return-value]
 
 

--- a/src/archex/index/delta.py
+++ b/src/archex/index/delta.py
@@ -363,8 +363,7 @@ def apply_delta(
     from archex.parse import (
         TreeSitterEngine,
         build_file_map,
-        extract_symbols,
-        parse_imports,
+        extract_symbols_and_imports,
         resolve_imports,
     )
     from archex.parse.adapters import default_adapter_registry
@@ -410,11 +409,13 @@ def apply_delta(
             engine = TreeSitterEngine()
             adapters = default_adapter_registry.build_all()
 
-            parsed_files = extract_symbols(changed_files, engine, adapters)
-            import_map = parse_imports(changed_files, engine, adapters)
+            extraction = extract_symbols_and_imports(changed_files, engine, adapters)
+            parsed_files = extraction.parsed_files
             file_map = build_file_map(all_files)
             file_languages = {f.path: f.language for f in all_files}
-            resolved_map = resolve_imports(import_map, file_map, adapters, file_languages)
+            resolved_map = resolve_imports(
+                extraction.imports_by_path, file_map, adapters, file_languages
+            )
 
             chunker = ASTChunker(config=effective_index_config)
             sources = _changed_sources(changed_files)

--- a/src/archex/languages.py
+++ b/src/archex/languages.py
@@ -21,6 +21,8 @@ class LanguageSupport:
 
 _FULL = LanguageTier.FULL
 _CHUNK = LanguageTier.CHUNK_ONLY
+UNKNOWN_LANGUAGE_ID = "unknown"
+UNKNOWN_LINE_WINDOW = 80
 
 LANGUAGE_SUPPORT: dict[str, LanguageSupport] = {
     "python": LanguageSupport("python", "Python", (".py",), _FULL, "python"),

--- a/src/archex/parse/__init__.py
+++ b/src/archex/parse/__init__.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from archex.parse.adapters.base import LanguageAdapter
 from archex.parse.engine import TreeSitterEngine
 from archex.parse.imports import build_file_map, parse_imports, resolve_imports
-from archex.parse.symbols import extract_symbols
+from archex.parse.symbols import extract_symbols, extract_symbols_and_imports
 
 __all__ = [
     "TreeSitterEngine",
     "LanguageAdapter",
     "extract_symbols",
+    "extract_symbols_and_imports",
     "parse_imports",
     "resolve_imports",
     "build_file_map",

--- a/src/archex/parse/symbols.py
+++ b/src/archex/parse/symbols.py
@@ -3,26 +3,63 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from archex.exceptions import ParseError
+from archex.languages import UNKNOWN_LANGUAGE_ID, UNKNOWN_LINE_WINDOW
 from archex.models import ChunkRange, ParsedFile
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
-    from archex.models import DiscoveredFile
+    from archex.models import DiscoveredFile, ImportStatement
     from archex.parse.adapters.base import LanguageAdapter
     from archex.parse.engine import TreeSitterEngine
 
 
 def _count_lines(source: bytes) -> int:
     return source.count(b"\n") + (1 if source and not source.endswith(b"\n") else 0)
+
+
+@dataclass(frozen=True)
+class ParsedExtraction:
+    parsed_files: list[ParsedFile]
+    imports_by_path: dict[str, list[ImportStatement]]
+
+
+def _extract_chunk_ranges(
+    adapter: LanguageAdapter,
+    tree: object,
+    source: bytes,
+    relative_path: str,
+) -> list[ChunkRange]:
+    extract_chunk_ranges = getattr(adapter, "extract_chunk_ranges", None)
+    if not callable(extract_chunk_ranges):
+        return []
+    extractor = cast("Callable[[object, bytes, str], list[ChunkRange]]", extract_chunk_ranges)
+    return extractor(tree, source, relative_path)
+
+
+def _line_window_ranges(total_lines: int) -> list[ChunkRange]:
+    return [
+        ChunkRange(start_line=start, end_line=min(start + UNKNOWN_LINE_WINDOW - 1, total_lines))
+        for start in range(1, total_lines + 1, UNKNOWN_LINE_WINDOW)
+    ]
+
+
+def _parse_unknown_file(absolute_path: str, relative_path: str) -> ParsedFile:
+    source = Path(absolute_path).read_bytes()
+    line_count = _count_lines(source)
+    return ParsedFile(
+        path=relative_path,
+        language=UNKNOWN_LANGUAGE_ID,
+        chunk_ranges=_line_window_ranges(line_count),
+        lines=line_count,
+    )
 
 
 def _parse_with_adapter(
@@ -36,18 +73,34 @@ def _parse_with_adapter(
     tree = engine.parse_file(absolute_path, language)
     source = Path(absolute_path).read_bytes()
     symbols = adapter.extract_symbols(tree, source, relative_path)
-    extract_chunk_ranges = getattr(adapter, "extract_chunk_ranges", None)
-    chunk_ranges: list[ChunkRange] = []
-    if callable(extract_chunk_ranges):
-        extractor = cast("Callable[[object, bytes, str], list[ChunkRange]]", extract_chunk_ranges)
-        chunk_ranges = extractor(tree, source, relative_path)
     return ParsedFile(
         path=relative_path,
         language=language,
         symbols=symbols,
-        chunk_ranges=chunk_ranges,
+        chunk_ranges=_extract_chunk_ranges(adapter, tree, source, relative_path),
         lines=_count_lines(source),
     )
+
+
+def _parse_with_adapter_and_imports(
+    *,
+    absolute_path: str,
+    relative_path: str,
+    language: str,
+    engine: TreeSitterEngine,
+    adapter: LanguageAdapter,
+) -> tuple[ParsedFile, list[ImportStatement]]:
+    tree = engine.parse_file(absolute_path, language)
+    source = Path(absolute_path).read_bytes()
+    symbols = adapter.extract_symbols(tree, source, relative_path)
+    parsed = ParsedFile(
+        path=relative_path,
+        language=language,
+        symbols=symbols,
+        chunk_ranges=_extract_chunk_ranges(adapter, tree, source, relative_path),
+        lines=_count_lines(source),
+    )
+    return parsed, adapter.parse_imports(tree, source, relative_path)
 
 
 def _extract_symbols_sequential(
@@ -59,6 +112,9 @@ def _extract_symbols_sequential(
     for discovered_file in files:
         adapter = adapters.get(discovered_file.language)
         if adapter is None:
+            if discovered_file.language != UNKNOWN_LANGUAGE_ID:
+                continue
+            results.append(_parse_unknown_file(discovered_file.absolute_path, discovered_file.path))
             continue
         results.append(
             _parse_with_adapter(
@@ -77,12 +133,65 @@ def _parse_file_worker(absolute_path: str, relative_path: str, language: str) ->
     from archex.parse.adapters import ADAPTERS
     from archex.parse.engine import TreeSitterEngine as _Engine
 
-    engine = _Engine()
     adapter_class = ADAPTERS.get(language)
     if adapter_class is None:
-        return None
+        if language != UNKNOWN_LANGUAGE_ID:
+            return None
+        return _parse_unknown_file(absolute_path, relative_path)
 
+    engine = _Engine()
     return _parse_with_adapter(
+        absolute_path=absolute_path,
+        relative_path=relative_path,
+        language=language,
+        engine=engine,
+        adapter=adapter_class(),
+    )
+
+
+def _extract_symbols_and_imports_sequential(
+    files: list[DiscoveredFile],
+    engine: TreeSitterEngine,
+    adapters: Mapping[str, LanguageAdapter],
+) -> ParsedExtraction:
+    parsed_files: list[ParsedFile] = []
+    imports_by_path: dict[str, list[ImportStatement]] = {}
+    for discovered_file in files:
+        adapter = adapters.get(discovered_file.language)
+        if adapter is None:
+            if discovered_file.language != UNKNOWN_LANGUAGE_ID:
+                continue
+            parsed = _parse_unknown_file(discovered_file.absolute_path, discovered_file.path)
+            parsed_files.append(parsed)
+            imports_by_path[discovered_file.path] = []
+            continue
+        parsed, imports = _parse_with_adapter_and_imports(
+            absolute_path=str(discovered_file.absolute_path),
+            relative_path=discovered_file.path,
+            language=discovered_file.language,
+            engine=engine,
+            adapter=adapter,
+        )
+        parsed_files.append(parsed)
+        imports_by_path[discovered_file.path] = imports
+    return ParsedExtraction(parsed_files=parsed_files, imports_by_path=imports_by_path)
+
+
+def _parse_artifacts_worker(
+    absolute_path: str, relative_path: str, language: str
+) -> tuple[ParsedFile, list[ImportStatement]] | None:
+    """Worker function for parallel parsing of symbols and imports."""
+    from archex.parse.adapters import ADAPTERS
+    from archex.parse.engine import TreeSitterEngine as _Engine
+
+    adapter_class = ADAPTERS.get(language)
+    if adapter_class is None:
+        if language != UNKNOWN_LANGUAGE_ID:
+            return None
+        return _parse_unknown_file(absolute_path, relative_path), []
+
+    engine = _Engine()
+    return _parse_with_adapter_and_imports(
         absolute_path=absolute_path,
         relative_path=relative_path,
         language=language,
@@ -100,10 +209,15 @@ def extract_symbols(
 ) -> list[ParsedFile]:
     """Extract symbols from all discovered files using the appropriate language adapter.
 
-    Files whose language has no registered adapter are skipped.
+    Files whose language has no registered adapter are skipped, except unknown
+    text files, which receive deterministic line-window chunk ranges.
     When parallel=True and len(files) > 10, uses ProcessPoolExecutor for concurrency.
     """
-    eligible = [f for f in files if adapters.get(f.language) is not None]
+    eligible = [
+        f
+        for f in files
+        if adapters.get(f.language) is not None or f.language == UNKNOWN_LANGUAGE_ID
+    ]
 
     if parallel and len(files) > 10:
         try:
@@ -138,3 +252,55 @@ def extract_symbols(
             logger.error("Parallel executor failed, falling back to sequential: %s", e)
 
     return _extract_symbols_sequential(eligible, engine, adapters)
+
+
+def extract_symbols_and_imports(
+    files: list[DiscoveredFile],
+    engine: TreeSitterEngine,
+    adapters: Mapping[str, LanguageAdapter],
+    parallel: bool = False,
+    strict: bool = False,
+) -> ParsedExtraction:
+    """Extract parsed files and imports with one tree-sitter parse per file."""
+    eligible = [
+        f
+        for f in files
+        if adapters.get(f.language) is not None or f.language == UNKNOWN_LANGUAGE_ID
+    ]
+
+    if parallel and len(files) > 10:
+        try:
+            parsed_files: list[ParsedFile] = []
+            imports_by_path: dict[str, list[ImportStatement]] = {}
+            errors: list[tuple[str, Exception]] = []
+            with ProcessPoolExecutor() as executor:
+                futures = [
+                    executor.submit(
+                        _parse_artifacts_worker,
+                        str(f.absolute_path),
+                        f.path,
+                        f.language,
+                    )
+                    for f in eligible
+                ]
+                for fut, f in zip(futures, eligible, strict=True):
+                    try:
+                        result = fut.result()
+                        if result is not None:
+                            parsed, imports = result
+                            parsed_files.append(parsed)
+                            imports_by_path[f.path] = imports
+                    except Exception as e:
+                        errors.append((f.path, e))
+            if errors and strict:
+                paths = ", ".join(p for p, _ in errors)
+                raise ParseError(f"Parallel parsing failed for {len(errors)} file(s): {paths}")
+            return ParsedExtraction(parsed_files=parsed_files, imports_by_path=imports_by_path)
+        except ParseError:
+            raise
+        except Exception as e:
+            if strict:
+                raise ParseError(f"Parallel parsing failed: {e}") from e
+            logger.error("Parallel executor failed, falling back to sequential: %s", e)
+
+    return _extract_symbols_and_imports_sequential(eligible, engine, adapters)

--- a/src/archex/pipeline/chunker.py
+++ b/src/archex/pipeline/chunker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 import tiktoken
@@ -223,8 +224,17 @@ def _lines_to_text(lines: list[bytes]) -> str:
     return "\n".join(line.decode("utf-8", errors="replace") for line in lines)
 
 
+@dataclass
+class _ChunkCandidate:
+    lines: list[bytes]
+    start_line: int
+    symbol: Symbol | None
+    content: str
+    token_count: int
+
+
 def _append_candidates(
-    candidates: list[tuple[list[bytes], int, Symbol | None]],
+    candidates: list[_ChunkCandidate],
     *,
     lines: list[bytes],
     start_line: int,
@@ -234,15 +244,32 @@ def _append_candidates(
 ) -> None:
     if _is_blank_lines(lines):
         return
-
-    token_count = _count_tokens(encoder, _lines_to_text(lines))
+    content = _lines_to_text(lines)
+    token_count = _count_tokens(encoder, content)
     if token_count <= max_tokens:
-        candidates.append((lines, start_line, symbol))
+        candidates.append(
+            _ChunkCandidate(
+                lines=lines,
+                start_line=start_line,
+                symbol=symbol,
+                content=content,
+                token_count=token_count,
+            )
+        )
         return
 
     offset = start_line
     for group in _split_lines_at_boundary(lines, max_tokens, encoder):
-        candidates.append((group, offset, symbol))
+        group_content = _lines_to_text(group)
+        candidates.append(
+            _ChunkCandidate(
+                lines=group,
+                start_line=offset,
+                symbol=symbol,
+                content=group_content,
+                token_count=_count_tokens(encoder, group_content),
+            )
+        )
         offset += len(group)
 
 
@@ -250,41 +277,40 @@ def _build_chunk(
     *,
     file_path: str,
     language: str,
-    lines: list[bytes],
-    start_line: int,
-    symbol: Symbol | None,
+    candidate: _ChunkCandidate,
     imports: list[ImportStatement],
     encoder: tiktoken.Encoding,
     all_symbols: list[Symbol] | None = None,
 ) -> CodeChunk:
-    content = _lines_to_text(lines)
+    content = candidate.content
 
-    # Filter imports relevant to this chunk
     relevant_imports = [imp for imp in imports if _import_relevant(imp, content)]
     imports_context = "\n".join(_format_import(imp) for imp in relevant_imports)
-
     combined = (imports_context + "\n" + content) if imports_context else content
-    token_count = _count_tokens(encoder, combined)
-
-    breadcrumbs = build_breadcrumbs(file_path, symbol, all_symbols)
+    token_count = _count_tokens(encoder, combined) if imports_context else candidate.token_count
+    breadcrumbs = build_breadcrumbs(file_path, candidate.symbol, all_symbols)
 
     return CodeChunk(
-        id=_make_chunk_id(file_path, symbol.name if symbol else None, start_line),
+        id=_make_chunk_id(
+            file_path,
+            candidate.symbol.name if candidate.symbol else None,
+            candidate.start_line,
+        ),
         symbol_id=_make_symbol_id(
             file_path,
-            symbol.qualified_name if symbol else None,
-            symbol.kind if symbol else None,
+            candidate.symbol.qualified_name if candidate.symbol else None,
+            candidate.symbol.kind if candidate.symbol else None,
         ),
-        qualified_name=symbol.qualified_name if symbol else None,
-        visibility=str(symbol.visibility) if symbol else "public",
-        signature=symbol.signature if symbol else None,
-        docstring=symbol.docstring if symbol else None,
+        qualified_name=candidate.symbol.qualified_name if candidate.symbol else None,
+        visibility=str(candidate.symbol.visibility) if candidate.symbol else "public",
+        signature=candidate.symbol.signature if candidate.symbol else None,
+        docstring=candidate.symbol.docstring if candidate.symbol else None,
         content=content,
         file_path=file_path,
-        start_line=start_line,
-        end_line=start_line + len(lines) - 1,
-        symbol_name=symbol.name if symbol else None,
-        symbol_kind=symbol.kind if symbol else None,
+        start_line=candidate.start_line,
+        end_line=candidate.start_line + len(candidate.lines) - 1,
+        symbol_name=candidate.symbol.name if candidate.symbol else None,
+        symbol_kind=candidate.symbol.kind if candidate.symbol else None,
         language=language,
         imports_context=imports_context,
         token_count=token_count,
@@ -307,11 +333,8 @@ class ASTChunker:
         all_source_lines = source.split(b"\n")
         total_lines = len(all_source_lines)
 
-        # Sort symbols by start_line; methods nested under classes are already separate.
         symbols = sorted(parsed_file.symbols, key=lambda s: s.start_line)
-
-        # Collect raw chunk candidates: (lines_list, start_line, symbol_or_None).
-        candidates: list[tuple[list[bytes], int, Symbol | None]] = []
+        candidates: list[_ChunkCandidate] = []
         has_structural_ranges = False
 
         if symbols:
@@ -341,7 +364,6 @@ class ASTChunker:
                     encoder=encoder,
                 )
 
-        # File-level code: lines not covered by symbols or chunk-only AST ranges.
         uncovered_ranges = _find_uncovered_ranges(covered, total_lines)
         for range_start, range_end in uncovered_ranges:
             _append_candidates(
@@ -353,30 +375,25 @@ class ASTChunker:
                 encoder=encoder,
             )
 
-        # Merge small adjacent file-level chunks. Chunk-only AST ranges must remain
-        # line-stable; merging them can combine non-contiguous source ranges.
         if has_structural_ranges:
-            merged = sorted(candidates, key=lambda item: item[1])
+            merged = sorted(candidates, key=lambda item: item.start_line)
         else:
             merged = _merge_small_chunks(candidates, config.chunk_min_tokens, encoder)
 
-        # Build CodeChunk objects
         result: list[CodeChunk] = []
-        for lines_group, start_line, sym in merged:
-            if _is_blank_lines(lines_group):
+        for candidate in merged:
+            if _is_blank_lines(candidate.lines):
                 continue
-            chunk = _build_chunk(
-                file_path=file_path,
-                language=language,
-                lines=lines_group,
-                start_line=start_line,
-                symbol=sym,
-                imports=imports,
-                encoder=encoder,
-                all_symbols=symbols,
+            result.append(
+                _build_chunk(
+                    file_path=file_path,
+                    language=language,
+                    candidate=candidate,
+                    imports=imports,
+                    encoder=encoder,
+                    all_symbols=symbols,
+                )
             )
-            result.append(chunk)
-
         result.sort(key=lambda c: c.start_line)
         _disambiguate_symbol_ids(result)
         return result
@@ -415,41 +432,47 @@ def _find_uncovered_ranges(
     return uncovered
 
 
+def _merge_candidates(
+    left: _ChunkCandidate,
+    right: _ChunkCandidate,
+    encoder: tiktoken.Encoding,
+) -> _ChunkCandidate:
+    lines = left.lines + right.lines
+    content = left.content + "\n" + right.content
+    return _ChunkCandidate(
+        lines=lines,
+        start_line=left.start_line,
+        symbol=None,
+        content=content,
+        token_count=_count_tokens(encoder, content),
+    )
+
+
 def _merge_small_chunks(
-    candidates: list[tuple[list[bytes], int, Symbol | None]],
+    candidates: list[_ChunkCandidate],
     min_tokens: int,
     encoder: tiktoken.Encoding,
-) -> list[tuple[list[bytes], int, Symbol | None]]:
+) -> list[_ChunkCandidate]:
     """Merge adjacent small (below min_tokens) file-level chunks."""
     if not candidates:
         return []
 
-    result: list[tuple[list[bytes], int, Symbol | None]] = []
+    result: list[_ChunkCandidate] = []
     i = 0
     while i < len(candidates):
-        lines, start, sym = candidates[i]
-        tokens = _count_tokens(encoder, _lines_to_text(lines))
+        candidate = candidates[i]
 
-        # Only merge file-level (sym is None) small chunks with adjacent file-level chunks
-        if tokens < min_tokens and sym is None:
-            # Try to merge with next file-level chunk
-            if i + 1 < len(candidates) and candidates[i + 1][2] is None:
-                next_lines: list[bytes] = candidates[i + 1][0]
-                merged_fwd: list[bytes] = lines + next_lines
-                candidates[i + 1] = (merged_fwd, start, None)
+        if candidate.token_count < min_tokens and candidate.symbol is None:
+            if i + 1 < len(candidates) and candidates[i + 1].symbol is None:
+                candidates[i + 1] = _merge_candidates(candidate, candidates[i + 1], encoder)
                 i += 1
                 continue
-            # Try to merge into previous result if it's also file-level
-            if result and result[-1][2] is None:
-                prev_entry = result[-1]
-                prev_lines: list[bytes] = prev_entry[0]
-                prev_start: int = prev_entry[1]
-                merged_back: list[bytes] = prev_lines + lines
-                result[-1] = (merged_back, prev_start, None)
+            if result and result[-1].symbol is None:
+                result[-1] = _merge_candidates(result[-1], candidate, encoder)
                 i += 1
                 continue
 
-        result.append((lines, start, sym))
+        result.append(candidate)
         i += 1
 
     return result

--- a/src/archex/pipeline/service.py
+++ b/src/archex/pipeline/service.py
@@ -14,8 +14,7 @@ from archex.models import EdgeKind
 from archex.parse import (
     TreeSitterEngine,
     build_file_map,
-    extract_symbols,
-    parse_imports,
+    extract_symbols_and_imports,
     resolve_imports,
 )
 from archex.pipeline.chunker import ASTChunker
@@ -60,16 +59,11 @@ def parse_repository(
         max_file_size=config.max_file_size,
     )
     engine = TreeSitterEngine()
-    parsed_files = extract_symbols(
+    extraction = extract_symbols_and_imports(
         files, engine, adapters, parallel=config.parallel, strict=config.strict
     )
-    import_map = parse_imports(
-        files,
-        engine,
-        adapters,
-        parallel=config.parallel,
-        strict=config.strict,
-    )
+    parsed_files = extraction.parsed_files
+    import_map = extraction.imports_by_path
     file_map = build_file_map(files)
     file_languages = {f.path: f.language for f in files}
     resolved_map = resolve_imports(import_map, file_map, adapters, file_languages)

--- a/tests/acquire/test_discovery.py
+++ b/tests/acquire/test_discovery.py
@@ -14,6 +14,9 @@ from archex.acquire.discovery import (
     _detect_language as _detect_language,  # pyright: ignore[reportPrivateUsage]
 )
 from archex.acquire.discovery import (
+    _is_text_file as _is_text_file,  # pyright: ignore[reportPrivateUsage]
+)
+from archex.acquire.discovery import (
     _matches_ignore as _matches_ignore,  # pyright: ignore[reportPrivateUsage]
 )
 from archex.exceptions import AcquireError
@@ -120,6 +123,20 @@ def test_detect_language_rust() -> None:
 def test_detect_language_markdown_and_unknown() -> None:
     assert _detect_language(Path("README.md")) == "markdown"
     assert _detect_language(Path("Makefile")) is None
+
+
+def test_is_text_file_accepts_multibyte_boundary(tmp_path: Path) -> None:
+    path = tmp_path / "notes.custom"
+    path.write_bytes((b"a" * 8191) + "é".encode() + b"\n")
+
+    assert _is_text_file(path)
+
+
+def test_is_text_file_rejects_nul_binary(tmp_path: Path) -> None:
+    path = tmp_path / "image.bin"
+    path.write_bytes(b"text\x00binary")
+
+    assert not _is_text_file(path)
 
 
 def test_matches_ignore_directory() -> None:

--- a/tests/index/test_chunker.py
+++ b/tests/index/test_chunker.py
@@ -544,7 +544,12 @@ def test_merge_small_chunks_backward_merge_direct() -> None:
       → forward merge blocked; result[-1] is file-level → backward merge triggers
     - symbol_chunk: always appended as-is
     """
-    from archex.index.chunker import _merge_small_chunks  # pyright: ignore[reportPrivateUsage]
+    from archex.pipeline.chunker import (
+        _ChunkCandidate,  # pyright: ignore[reportPrivateUsage]
+        _count_tokens,  # pyright: ignore[reportPrivateUsage]
+        _lines_to_text,  # pyright: ignore[reportPrivateUsage]
+        _merge_small_chunks,  # pyright: ignore[reportPrivateUsage]
+    )
 
     encoder = tiktoken.get_encoding("cl100k_base")
 
@@ -564,10 +569,28 @@ def test_merge_small_chunks_backward_merge_direct() -> None:
     # A symbol chunk
     sym_lines = [b"def foo(): pass\n"]
 
-    candidates: list[tuple[list[bytes], int, Symbol | None]] = [
-        (normal_lines, 1, None),
-        (small_lines, 31, None),
-        (sym_lines, 32, sym),
+    candidates = [
+        _ChunkCandidate(
+            normal_lines,
+            1,
+            None,
+            _lines_to_text(normal_lines),
+            _count_tokens(encoder, _lines_to_text(normal_lines)),
+        ),
+        _ChunkCandidate(
+            small_lines,
+            31,
+            None,
+            _lines_to_text(small_lines),
+            _count_tokens(encoder, _lines_to_text(small_lines)),
+        ),
+        _ChunkCandidate(
+            sym_lines,
+            32,
+            sym,
+            _lines_to_text(sym_lines),
+            _count_tokens(encoder, _lines_to_text(sym_lines)),
+        ),
     ]
 
     result = _merge_small_chunks(candidates, min_tokens=50, encoder=encoder)
@@ -577,18 +600,23 @@ def test_merge_small_chunks_backward_merge_direct() -> None:
     assert len(result) == 2
 
     merged_entry = result[0]
-    assert merged_entry[2] is None  # still file-level
-    merged_text = b"".join(merged_entry[0]).decode()
+    assert merged_entry.symbol is None  # still file-level
+    merged_text = b"".join(merged_entry.lines).decode()
     assert "y = 1" in merged_text  # small chunk content present
     assert "x = 0" in merged_text  # normal chunk content present
 
     sym_entry = result[1]
-    assert sym_entry[2] is sym
+    assert sym_entry.symbol is sym
 
 
 def test_merge_small_chunks_backward_merge_blocked_by_symbol_in_result() -> None:
     """Small file-level chunk does NOT merge when result[-1] is a symbol chunk."""
-    from archex.index.chunker import _merge_small_chunks  # pyright: ignore[reportPrivateUsage]
+    from archex.pipeline.chunker import (
+        _ChunkCandidate,  # pyright: ignore[reportPrivateUsage]
+        _count_tokens,  # pyright: ignore[reportPrivateUsage]
+        _lines_to_text,  # pyright: ignore[reportPrivateUsage]
+        _merge_small_chunks,  # pyright: ignore[reportPrivateUsage]
+    )
 
     encoder = tiktoken.get_encoding("cl100k_base")
 
@@ -606,17 +634,29 @@ def test_merge_small_chunks_backward_merge_blocked_by_symbol_in_result() -> None
 
     # [symbol_chunk, small_file_level] — small_file_level can't merge forward (end of list)
     # and can't merge backward (result[-1] is a symbol, not file-level)
-    candidates: list[tuple[list[bytes], int, Symbol | None]] = [
-        (sym_lines, 1, sym),
-        (small_lines, 3, None),
+    candidates = [
+        _ChunkCandidate(
+            sym_lines,
+            1,
+            sym,
+            _lines_to_text(sym_lines),
+            _count_tokens(encoder, _lines_to_text(sym_lines)),
+        ),
+        _ChunkCandidate(
+            small_lines,
+            3,
+            None,
+            _lines_to_text(small_lines),
+            _count_tokens(encoder, _lines_to_text(small_lines)),
+        ),
     ]
 
     result = _merge_small_chunks(candidates, min_tokens=50, encoder=encoder)
 
     # Both entries remain separate because backward merge is blocked by the symbol
     assert len(result) == 2
-    assert result[0][2] is sym
-    assert result[1][2] is None
+    assert result[0].symbol is sym
+    assert result[1].symbol is None
 
 
 def test_blank_lines_only_file_level_skipped() -> None:

--- a/tests/parse/test_symbols.py
+++ b/tests/parse/test_symbols.py
@@ -9,7 +9,8 @@ import pytest
 from archex.models import DiscoveredFile, SymbolKind
 from archex.parse.adapters import default_adapter_registry
 from archex.parse.engine import TreeSitterEngine
-from archex.parse.symbols import extract_symbols
+from archex.parse.imports import parse_imports
+from archex.parse.symbols import extract_symbols, extract_symbols_and_imports
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -60,6 +61,25 @@ def test_extract_symbols_returns_parsed_files(
 ) -> None:
     parsed = extract_symbols(python_simple_files, engine, adapters)
     assert len(parsed) == len(python_simple_files)
+
+
+def test_extract_symbols_and_imports_matches_separate_passes(
+    python_simple_files: list[DiscoveredFile],
+    engine: TreeSitterEngine,
+    adapters: dict[str, LanguageAdapter],
+) -> None:
+    combined = extract_symbols_and_imports(python_simple_files, engine, adapters)
+
+    separate_symbols = extract_symbols(python_simple_files, TreeSitterEngine(), adapters)
+    separate_imports = parse_imports(python_simple_files, TreeSitterEngine(), adapters)
+
+    assert [parsed.model_dump() for parsed in combined.parsed_files] == [
+        parsed.model_dump() for parsed in separate_symbols
+    ]
+    assert {
+        path: [imp.model_dump() for imp in imports]
+        for path, imports in combined.imports_by_path.items()
+    } == {path: [imp.model_dump() for imp in imports] for path, imports in separate_imports.items()}
 
 
 def test_all_files_have_correct_language(

--- a/tests/pipeline/test_service.py
+++ b/tests/pipeline/test_service.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from archex.models import ChunkRange, Config, EdgeKind, IndexConfig, ParsedFile
+import pytest
+
+from archex.api import embedding_eligible_chunks
+from archex.exceptions import ArchexIndexError
+from archex.index.store import IndexStore
+from archex.models import ChunkRange, CodeChunk, Config, EdgeKind, IndexConfig, ParsedFile
 from archex.parse.adapters import LanguageAdapter, default_adapter_registry
 from archex.pipeline.chunker import ASTChunker
 from archex.pipeline.models import ArtifactBundle
@@ -181,6 +186,80 @@ class TestMultiLanguage:
         ]
         assert [chunk.content.splitlines()[0] for chunk in bundle.chunks] == ["[a]", "[b]", "[c]"]
         assert all(chunk.symbol_name is None for chunk in bundle.chunks)
+
+    def test_unknown_text_files_get_line_window_chunks(self, tmp_path: Path) -> None:
+        lines = [f"line {index}" for index in range(1, 86)]
+        (tmp_path / "notes.custom").write_text("\n".join(lines) + "\n")
+        (tmp_path / "image.bin").write_bytes(b"ok\x00not text")
+        (tmp_path / "main.py").write_text("def run():\n    return 1\n")
+
+        bundle = produce_artifacts(tmp_path, Config(cache=False), _adapters())
+
+        assert {parsed.language for parsed in bundle.parsed_files} == {"python", "unknown"}
+        unknown_chunks = [chunk for chunk in bundle.chunks if chunk.language == "unknown"]
+        assert [(chunk.start_line, chunk.end_line) for chunk in unknown_chunks] == [
+            (1, 80),
+            (81, 85),
+        ]
+        assert all(chunk.file_path == "notes.custom" for chunk in unknown_chunks)
+        assert not any(chunk.file_path == "image.bin" for chunk in bundle.chunks)
+
+    def test_unknown_chunks_are_not_embedding_eligible(self) -> None:
+        python_chunk = CodeChunk(
+            id="main.py:_module:1",
+            content="def run():\n    return 1",
+            file_path="main.py",
+            start_line=1,
+            end_line=2,
+            language="python",
+            token_count=8,
+        )
+        unknown_chunk = CodeChunk(
+            id="notes.custom:_module:1",
+            content="notes",
+            file_path="notes.custom",
+            start_line=1,
+            end_line=1,
+            language="unknown",
+            token_count=1,
+        )
+
+        assert embedding_eligible_chunks([unknown_chunk, python_chunk]) == [python_chunk]
+
+    def test_splade_skips_all_unknown_corpus_without_sparse_rows(self, tmp_path: Path) -> None:
+        from archex.api import _splade_search_or_raise  # pyright: ignore[reportPrivateUsage]
+
+        unknown_chunk = CodeChunk(
+            id="notes.custom:_module:1",
+            content="notes",
+            file_path="notes.custom",
+            start_line=1,
+            end_line=1,
+            language="unknown",
+            token_count=1,
+        )
+        with IndexStore(tmp_path / "unknown.db") as store:
+            store.insert_chunks([unknown_chunk])
+
+            assert _splade_search_or_raise(store, "notes", IndexConfig(splade=True), 10) is None
+
+    def test_splade_still_requires_sparse_rows_for_supported_corpus(self, tmp_path: Path) -> None:
+        from archex.api import _splade_search_or_raise  # pyright: ignore[reportPrivateUsage]
+
+        python_chunk = CodeChunk(
+            id="main.py:_module:1",
+            content="def run():\n    return 1",
+            file_path="main.py",
+            start_line=1,
+            end_line=2,
+            language="python",
+            token_count=8,
+        )
+        with IndexStore(tmp_path / "supported.db") as store:
+            store.insert_chunks([python_chunk])
+
+            with pytest.raises(ArchexIndexError, match="no SPLADE rows"):
+                _splade_search_or_raise(store, "run", IndexConfig(splade=True), 10)
 
 
 class TestSurrogateSummaryInclusion:

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -17,7 +17,7 @@ from archex.models import CodeChunk, Config, DiscoveredFile, Edge, EdgeKind, Rep
 from archex.parse.adapters import ADAPTERS
 from archex.parse.engine import TreeSitterEngine
 from archex.parse.imports import parse_imports
-from archex.parse.symbols import extract_symbols
+from archex.parse.symbols import extract_symbols, extract_symbols_and_imports
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -345,13 +345,13 @@ class TestQueryCacheSkipsParse:
 
         config = Config(cache=True, cache_dir=str(cache_dir))
         with (
-            patch("archex.api.extract_symbols") as mock_es,
+            patch("archex.api.extract_symbols_and_imports") as parse_spy,
             patch("archex.cache.CacheManager.git_head", return_value=None),
         ):
             from archex.api import query
 
             query(source, "what?", config=config)
-        mock_es.assert_not_called()
+        parse_spy.assert_not_called()
 
     def test_query_invalidates_stale_cache(self, tmp_path: Path, python_simple_repo: Path) -> None:
         """Cache with needs_reindex flag is invalidated and falls through to full pipeline."""
@@ -392,14 +392,17 @@ class TestQueryCacheSkipsParse:
 
         config = Config(cache=True, cache_dir=str(cache_dir))
         with (
-            patch("archex.api.extract_symbols", wraps=extract_symbols) as mock_es,
+            patch(
+                "archex.api.extract_symbols_and_imports",
+                wraps=extract_symbols_and_imports,
+            ) as parse_spy,
             patch("archex.cache.CacheManager.git_head", return_value=None),
         ):
             from archex.api import query
 
             query(source, "what?", config=config)
-        # extract_symbols must have been called because the stale cache was invalidated.
-        mock_es.assert_called()
+        # Parsing must have been called because the stale cache was invalidated.
+        parse_spy.assert_called()
 
 
 class TestGetEmbedder:


### PR DESCRIPTION
Stack: C3 language coverage expansion

Position: 4/4
Base: feat/lang-extraction-fixtures
Head: feat/unknown-file-fallback

Changes:
- Add deterministic 80-line windows for unknown UTF-8 text files.
- Keep binary files skipped.
- Keep unknown chunks BM25-only by excluding them from vector, rerank, and SPLADE embedding paths.
- Reduce cold parse/index cost by extracting symbols and imports from one tree-sitter parse per file.
- Reduce chunking/index cost by caching chunk candidate text/token counts and skipping surrogate generation for BM25-only indexes.

Validation:
- uv run ruff check && uv run ruff format --check . && uv run pyright passed.
- uv run pytest tests/parse/ tests/pipeline/ tests/index/test_chunker.py tests/test_performance.py::TestQueryCacheSkipsParse -q reported 510 passed, but exits non-zero because coverage is configured for the whole source tree.
- uv run pytest -q reported 2240 passed, 4 deselected, 89.33% coverage.
- Operator run before the optimization completed 35 benchmarks and `archex benchmark gate` printed `Quality gate passed`.
- Existing-language recall regression check: 0 regressions across archex_query, archex_query_fusion, and archex_query_fusion_rerank.
- Local micro-timing on the archex_project_index query improved from pre-fix mean parse/index/total 490.6/1632.9/2316.6 ms to 325.0/1092.4/1560.8 ms including first cold import, and approximately 264/1079/1499 ms after warm import. Rerun the operator benchmark gate to confirm the 10% benchmark-wide index-time ceiling with full task coverage.