### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
 
+## 0.9.0 (2026-06-13)
+
+### Added
+
+- Added working-tree delta indexing, query auto-refresh, and MCP watch mode so dirty local edits refresh indexes without full re-indexing.
+- Added graph-query core, CLI commands, and MCP tools for neighborhood, path, and symbol dependency exploration.
+- Added the scout protocol with token-capped map/fetch flows across Python API, CLI, MCP, and benchmark coverage.
+- Added head-to-head benchmark harnesses and reports for external MCP adapter comparisons.
+- Expanded tree-sitter language coverage through the language-pack runtime, chunk-only grammars, language-tier fixtures, and unknown-text fallback handling.
+
+### Changed
+
+- Improved graph expansion selectivity, benchmark diagnostics, architecture extraction hardening, and framework-semantic query normalization.
+- Persisted edge-confidence provenance and embedding content-cache reuse to reduce redundant work across refreshes.
+
+### Fixed
+
+- Fixed stale-index query paths, MCP watch refresh rearming, delta vector persistence, and implementation-slice coverage runs.
+
 ## 0.8.0 (2026-06-09)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archex"
-version = "0.8.0"
+version = "0.9.0"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "archex"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump package version to 0.9.0
- add 0.9.0 changelog entry
- refresh uv.lock project package version

## Verification
- uv run ruff check
- uv run ruff format --check .
- uv run pyright
- uv run pytest
- uv build --out-dir dist/release-0.9.0
- wheel zip integrity check
- sdist open check
- isolated wheel import reports 0.9.0