### PR TITLE
feat: add selectable cAST chunker

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -89,7 +89,7 @@ from archex.parse import (
     resolve_imports,
 )
 from archex.parse.adapters import LanguageAdapter, default_adapter_registry
-from archex.pipeline.chunker import ASTChunker, Chunker
+from archex.pipeline.chunker import Chunker, create_chunker
 from archex.pipeline.service import build_chunk_surrogates
 from archex.project import uses_project_cache_layout
 from archex.scout import (
@@ -125,6 +125,14 @@ def _cache_manager_for_source(source: RepoSource, config: Config) -> CacheManage
         except ValueError:
             project_layout = False
     return CacheManager(cache_dir=config.cache_dir, project_layout=project_layout)
+
+
+def _index_config_metadata_matches(store: IndexStore, index_config: IndexConfig) -> bool:
+    return store.get_metadata("chunker") == index_config.chunker
+
+
+def _set_index_config_metadata(store: IndexStore, index_config: IndexConfig) -> None:
+    store.set_metadata("chunker", index_config.chunker)
 
 
 def _full_index(
@@ -163,7 +171,7 @@ def _full_index(
         graph = DependencyGraph.from_parsed_files(parsed_files, resolved_map)
 
         effective_index_config = index_config or IndexConfig()
-        file_chunker: Chunker = ASTChunker(config=effective_index_config)
+        file_chunker: Chunker = create_chunker(effective_index_config)
         sources: dict[str, bytes] = {}
         for f in files:
             try:
@@ -239,6 +247,7 @@ def _full_index(
                     npz_path.unlink()
 
         total_repo_tokens = sum(chunk.token_count for chunk in all_chunks)
+        _set_index_config_metadata(store, effective_index_config)
         store.set_metadata("repo_total_tokens", str(total_repo_tokens))
         store.set_metadata("chunk_count", str(len(all_chunks)))
         file_count = len({chunk.file_path for chunk in all_chunks})
@@ -296,6 +305,7 @@ def _ensure_index(
         config = load_config(source)
 
     t_start = time.perf_counter()
+    effective_index_config = index_config or IndexConfig()
     cache = _cache_manager_for_source(source, config)
     cache_key = cache.cache_key(source)
     working_tree_signature = _working_tree_signature(source, config)
@@ -309,14 +319,15 @@ def _ensure_index(
             working_tree_signature is None or store_signature == working_tree_signature
         )
         needs_reindex = store.needs_reindex()
-        if not needs_reindex and signature_matches:
+        metadata_matches = _index_config_metadata_matches(store, effective_index_config)
+        if not needs_reindex and signature_matches and metadata_matches:
             if timing is not None:
                 timing.cached = True
                 timing.strategy = "cached"
                 timing.index_ms = _elapsed_ms(t_start)
             return store
         store.close()
-        if needs_reindex:
+        if needs_reindex or not metadata_matches:
             cache.invalidate(cache_key)
 
     # Path 2: Delta path — same repo, different commit (local repos only)
@@ -328,7 +339,7 @@ def _ensure_index(
             cache_key=cache_key,
             working_tree_signature=working_tree_signature,
             timing=timing,
-            index_config=index_config,
+            index_config=effective_index_config,
             t_start=t_start,
         )
     )
@@ -336,7 +347,14 @@ def _ensure_index(
         return delta_store
 
     # Path 3: Full re-index
-    return _full_index(source, config, cache, cache_key, timing, index_config=index_config)
+    return _full_index(
+        source,
+        config,
+        cache,
+        cache_key,
+        timing,
+        index_config=effective_index_config,
+    )
 
 
 def index_repository(
@@ -365,6 +383,13 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
         return None
 
     db_path, cached_commit = existing
+    effective_index_config = attempt.index_config or IndexConfig()
+    candidate_store = IndexStore(db_path)
+    try:
+        if not _index_config_metadata_matches(candidate_store, effective_index_config):
+            return None
+    finally:
+        candidate_store.close()
     current_commit = CacheManager.git_head(source.local_path)
     if not current_commit:
         return None
@@ -1836,7 +1861,7 @@ def query(
             )
 
         t4 = time.perf_counter()
-        file_chunker: Chunker = chunker if chunker is not None else ASTChunker(config=index_config)
+        file_chunker: Chunker = chunker if chunker is not None else create_chunker(index_config)
         sources: dict[str, bytes] = {}
         for f in files:
             try:

--- a/src/archex/index/chunker.py
+++ b/src/archex/index/chunker.py
@@ -3,20 +3,24 @@
 # pyright: reportPrivateUsage=false
 from archex.pipeline.chunker import (  # noqa: F401
     ASTChunker,
+    CastChunker,
     Chunker,
     _format_import,
     _import_relevant,
     _merge_small_chunks,
     build_breadcrumbs,
+    create_chunker,
     expand_identifiers,
 )
 
 __all__ = [
     "ASTChunker",
+    "CastChunker",
     "Chunker",
     "_format_import",
     "_import_relevant",
     "_merge_small_chunks",
     "build_breadcrumbs",
+    "create_chunker",
     "expand_identifiers",
 ]

--- a/src/archex/index/delta.py
+++ b/src/archex/index/delta.py
@@ -359,7 +359,7 @@ def apply_delta(
     """
     from archex.acquire import discover_files
     from archex.index.bm25 import BM25Index
-    from archex.index.chunker import ASTChunker
+    from archex.index.chunker import create_chunker
     from archex.parse import (
         TreeSitterEngine,
         build_file_map,
@@ -417,7 +417,7 @@ def apply_delta(
                 extraction.imports_by_path, file_map, adapters, file_languages
             )
 
-            chunker = ASTChunker(config=effective_index_config)
+            chunker = create_chunker(effective_index_config)
             sources = _changed_sources(changed_files)
             new_chunks = chunker.chunk_files(parsed_files, sources)
             new_surrogates = build_chunk_surrogates(
@@ -456,6 +456,7 @@ def apply_delta(
     bm25.build(all_chunks)
 
     # 6. Update metadata
+    store.set_metadata("chunker", effective_index_config.chunker)
     store.set_metadata("repo_total_tokens", str(sum(chunk.token_count for chunk in all_chunks)))
     store.set_metadata("chunk_count", str(len(all_chunks)))
     store.set_metadata("commit_hash", manifest.current_commit)

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -148,6 +148,9 @@ class Config(BaseModel):
         return self
 
 
+ChunkerName = Literal["default", "cast"]
+
+
 class IndexConfig(BaseModel):
     bm25: bool = True
     vector: bool = False
@@ -159,6 +162,7 @@ class IndexConfig(BaseModel):
     retrieval_policy: RetrievalPolicy = RetrievalPolicy.AUTO
     rerank: bool = False
     rerank_model: str | None = None
+    chunker: ChunkerName = "default"
     chunk_max_tokens: int = 500
     chunk_min_tokens: int = 50
     token_encoding: str = "cl100k_base"

--- a/src/archex/pipeline/chunker.py
+++ b/src/archex/pipeline/chunker.py
@@ -241,6 +241,10 @@ class _CastUnit:
     token_count: int
 
 
+def _cast_merge_budget(max_tokens: int) -> int:
+    return max(1, int(max_tokens * 0.7))
+
+
 def _append_candidates(
     candidates: list[_ChunkCandidate],
     *,
@@ -692,16 +696,24 @@ def _merge_cast_units(
     if not units:
         return []
 
+    merge_budget = _cast_merge_budget(max_tokens)
     result: list[_CastUnit] = []
     group_start = units[0].start_line
     group_end = units[0].end_line
     group_symbol = units[0].symbol
+    group_token_count = units[0].token_count
     group_size = 1
 
     for unit in units[1:]:
         merged_tokens = _count_range_tokens(group_start, unit.end_line, all_source_lines, encoder)
-        if merged_tokens <= max_tokens:
+        can_merge = (
+            group_token_count < merge_budget
+            and unit.token_count < merge_budget
+            and merged_tokens <= merge_budget
+        )
+        if can_merge:
             group_end = unit.end_line
+            group_token_count = merged_tokens
             group_size += 1
             continue
         result.append(
@@ -709,12 +721,13 @@ def _merge_cast_units(
                 group_start,
                 group_end,
                 group_symbol if group_size == 1 else None,
-                _count_range_tokens(group_start, group_end, all_source_lines, encoder),
+                group_token_count,
             )
         )
         group_start = unit.start_line
         group_end = unit.end_line
         group_symbol = unit.symbol
+        group_token_count = unit.token_count
         group_size = 1
 
     result.append(
@@ -722,7 +735,7 @@ def _merge_cast_units(
             group_start,
             group_end,
             group_symbol if group_size == 1 else None,
-            _count_range_tokens(group_start, group_end, all_source_lines, encoder),
+            group_token_count,
         )
     )
     return result

--- a/src/archex/pipeline/chunker.py
+++ b/src/archex/pipeline/chunker.py
@@ -233,6 +233,14 @@ class _ChunkCandidate:
     token_count: int
 
 
+@dataclass(frozen=True)
+class _CastUnit:
+    start_line: int
+    end_line: int
+    symbol: Symbol | None
+    token_count: int
+
+
 def _append_candidates(
     candidates: list[_ChunkCandidate],
     *,
@@ -407,6 +415,327 @@ class ASTChunker:
             all_chunks.extend(self.chunk_file(pf, src))
         all_chunks.sort(key=lambda c: (c.file_path, c.start_line))
         return all_chunks
+
+
+class CastChunker(ASTChunker):
+    """Recursive AST split-merge chunker selected by IndexConfig(chunker="cast")."""
+
+    def chunk_file(self, parsed_file: ParsedFile, source: bytes) -> list[CodeChunk]:
+        config = self._config
+        encoder = self._encoder
+        file_path = parsed_file.path
+        language = parsed_file.language
+        imports = parsed_file.imports
+        all_source_lines = source.split(b"\n")
+        total_lines = len(all_source_lines)
+        symbols = sorted(parsed_file.symbols, key=lambda s: (s.start_line, s.end_line))
+
+        if symbols:
+            units = _cast_units_for_scope(
+                start_line=1,
+                end_line=total_lines,
+                children=_top_level_symbols(symbols),
+                all_symbols=symbols,
+                all_source_lines=all_source_lines,
+                max_tokens=config.chunk_max_tokens,
+                encoder=encoder,
+            )
+        else:
+            units = _cast_units_for_ranges(
+                parsed_file,
+                all_source_lines,
+                config.chunk_max_tokens,
+                encoder,
+            )
+
+        result: list[CodeChunk] = []
+        for unit in units:
+            lines = _extract_source_lines(all_source_lines, unit.start_line, unit.end_line)
+            if _is_blank_lines(lines):
+                continue
+            content = _lines_to_text(lines)
+            result.append(
+                _build_chunk(
+                    file_path=file_path,
+                    language=language,
+                    candidate=_ChunkCandidate(
+                        lines=lines,
+                        start_line=unit.start_line,
+                        symbol=unit.symbol,
+                        content=content,
+                        token_count=_count_tokens(encoder, content),
+                    ),
+                    imports=imports,
+                    encoder=encoder,
+                    all_symbols=symbols,
+                )
+            )
+        result.sort(key=lambda c: c.start_line)
+        _disambiguate_symbol_ids(result)
+        return result
+
+
+def create_chunker(config: IndexConfig | None = None) -> Chunker:
+    effective = config or IndexConfig()
+    if effective.chunker == "cast":
+        return CastChunker(effective)
+    return ASTChunker(effective)
+
+
+def _top_level_symbols(symbols: list[Symbol]) -> list[Symbol]:
+    top_level: list[Symbol] = []
+    for symbol in symbols:
+        if _direct_parent_symbol(symbol, symbols) is None:
+            top_level.append(symbol)
+    return _non_overlapping_symbols(top_level)
+
+
+def _direct_child_symbols(parent: Symbol, symbols: list[Symbol]) -> list[Symbol]:
+    children = [symbol for symbol in symbols if _direct_parent_symbol(symbol, symbols) is parent]
+    return _non_overlapping_symbols(children)
+
+
+def _direct_parent_symbol(symbol: Symbol, symbols: list[Symbol]) -> Symbol | None:
+    by_name = {candidate.qualified_name: candidate for candidate in symbols}
+    if symbol.parent and symbol.parent in by_name:
+        parent = by_name[symbol.parent]
+        if (
+            parent is not symbol
+            and parent.start_line <= symbol.start_line
+            and symbol.end_line <= parent.end_line
+        ):
+            return parent
+
+    containers = [
+        candidate
+        for candidate in symbols
+        if candidate is not symbol
+        and candidate.start_line <= symbol.start_line
+        and symbol.end_line <= candidate.end_line
+        and (candidate.start_line, candidate.end_line) != (symbol.start_line, symbol.end_line)
+    ]
+    if not containers:
+        return None
+    return min(containers, key=lambda item: (item.end_line - item.start_line, item.start_line))
+
+
+def _non_overlapping_symbols(symbols: list[Symbol]) -> list[Symbol]:
+    result: list[Symbol] = []
+    last_end = 0
+    for symbol in sorted(symbols, key=lambda item: (item.start_line, item.end_line)):
+        if symbol.start_line <= last_end:
+            continue
+        result.append(symbol)
+        last_end = symbol.end_line
+    return result
+
+
+def _cast_units_for_ranges(
+    parsed_file: ParsedFile,
+    all_source_lines: list[bytes],
+    max_tokens: int,
+    encoder: tiktoken.Encoding,
+) -> list[_CastUnit]:
+    ranges = sorted(parsed_file.chunk_ranges, key=lambda item: item.start_line)
+    if not ranges:
+        return _split_cast_range(
+            1,
+            len(all_source_lines),
+            None,
+            all_source_lines,
+            max_tokens,
+            encoder,
+        )
+
+    units: list[_CastUnit] = []
+    for chunk_range in ranges:
+        units.extend(
+            _split_cast_range(
+                chunk_range.start_line,
+                chunk_range.end_line,
+                None,
+                all_source_lines,
+                max_tokens,
+                encoder,
+            )
+        )
+    return _merge_cast_units(units, all_source_lines, max_tokens, encoder)
+
+
+def _cast_units_for_scope(
+    *,
+    start_line: int,
+    end_line: int,
+    children: list[Symbol],
+    all_symbols: list[Symbol],
+    all_source_lines: list[bytes],
+    max_tokens: int,
+    encoder: tiktoken.Encoding,
+) -> list[_CastUnit]:
+    units: list[_CastUnit] = []
+    current = start_line
+    for child in children:
+        child_start = max(child.start_line, start_line)
+        child_end = min(child.end_line, end_line)
+        if current < child_start:
+            units.extend(
+                _split_cast_range(
+                    current,
+                    child_start - 1,
+                    None,
+                    all_source_lines,
+                    max_tokens,
+                    encoder,
+                )
+            )
+        units.extend(
+            _cast_units_for_symbol(
+                child,
+                all_symbols,
+                all_source_lines,
+                max_tokens,
+                encoder,
+            )
+        )
+        current = max(current, child_end + 1)
+    if current <= end_line:
+        units.extend(
+            _split_cast_range(current, end_line, None, all_source_lines, max_tokens, encoder)
+        )
+    return _merge_cast_units(units, all_source_lines, max_tokens, encoder)
+
+
+def _cast_units_for_symbol(
+    symbol: Symbol,
+    all_symbols: list[Symbol],
+    all_source_lines: list[bytes],
+    max_tokens: int,
+    encoder: tiktoken.Encoding,
+) -> list[_CastUnit]:
+    token_count = _count_range_tokens(
+        symbol.start_line,
+        symbol.end_line,
+        all_source_lines,
+        encoder,
+    )
+    if token_count <= max_tokens:
+        return [_CastUnit(symbol.start_line, symbol.end_line, symbol, token_count)]
+
+    children = [
+        child
+        for child in _direct_child_symbols(symbol, all_symbols)
+        if symbol.start_line <= child.start_line and child.end_line <= symbol.end_line
+    ]
+    if not children:
+        return _split_cast_range(
+            symbol.start_line,
+            symbol.end_line,
+            None,
+            all_source_lines,
+            max_tokens,
+            encoder,
+        )
+    return _cast_units_for_scope(
+        start_line=symbol.start_line,
+        end_line=symbol.end_line,
+        children=children,
+        all_symbols=all_symbols,
+        all_source_lines=all_source_lines,
+        max_tokens=max_tokens,
+        encoder=encoder,
+    )
+
+
+def _split_cast_range(
+    start_line: int,
+    end_line: int,
+    symbol: Symbol | None,
+    all_source_lines: list[bytes],
+    max_tokens: int,
+    encoder: tiktoken.Encoding,
+) -> list[_CastUnit]:
+    if end_line < start_line:
+        return []
+    lines = _extract_source_lines(all_source_lines, start_line, end_line)
+    if _is_blank_lines(lines):
+        return []
+    content = _lines_to_text(lines)
+    token_count = _count_tokens(encoder, content)
+    if token_count <= max_tokens:
+        return [_CastUnit(start_line, end_line, symbol, token_count)]
+
+    units: list[_CastUnit] = []
+    offset = start_line
+    for group in _split_lines_at_boundary(lines, max_tokens, encoder):
+        if _is_blank_lines(group):
+            offset += len(group)
+            continue
+        group_content = _lines_to_text(group)
+        units.append(
+            _CastUnit(
+                start_line=offset,
+                end_line=offset + len(group) - 1,
+                symbol=None,
+                token_count=_count_tokens(encoder, group_content),
+            )
+        )
+        offset += len(group)
+    return units
+
+
+def _merge_cast_units(
+    units: list[_CastUnit],
+    all_source_lines: list[bytes],
+    max_tokens: int,
+    encoder: tiktoken.Encoding,
+) -> list[_CastUnit]:
+    if not units:
+        return []
+
+    result: list[_CastUnit] = []
+    group_start = units[0].start_line
+    group_end = units[0].end_line
+    group_symbol = units[0].symbol
+    group_size = 1
+
+    for unit in units[1:]:
+        merged_tokens = _count_range_tokens(group_start, unit.end_line, all_source_lines, encoder)
+        if merged_tokens <= max_tokens:
+            group_end = unit.end_line
+            group_size += 1
+            continue
+        result.append(
+            _CastUnit(
+                group_start,
+                group_end,
+                group_symbol if group_size == 1 else None,
+                _count_range_tokens(group_start, group_end, all_source_lines, encoder),
+            )
+        )
+        group_start = unit.start_line
+        group_end = unit.end_line
+        group_symbol = unit.symbol
+        group_size = 1
+
+    result.append(
+        _CastUnit(
+            group_start,
+            group_end,
+            group_symbol if group_size == 1 else None,
+            _count_range_tokens(group_start, group_end, all_source_lines, encoder),
+        )
+    )
+    return result
+
+
+def _count_range_tokens(
+    start_line: int,
+    end_line: int,
+    all_source_lines: list[bytes],
+    encoder: tiktoken.Encoding,
+) -> int:
+    lines = _extract_source_lines(all_source_lines, start_line, end_line)
+    return _count_tokens(encoder, _lines_to_text(lines))
 
 
 def _find_uncovered_ranges(

--- a/src/archex/pipeline/service.py
+++ b/src/archex/pipeline/service.py
@@ -17,7 +17,7 @@ from archex.parse import (
     extract_symbols_and_imports,
     resolve_imports,
 )
-from archex.pipeline.chunker import ASTChunker
+from archex.pipeline.chunker import create_chunker
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ def build_chunks(
     strict: bool = False,
 ) -> list[CodeChunk]:
     """Build code chunks from parsed files with source-bytes hydration."""
-    file_chunker: Chunker = chunker if chunker is not None else ASTChunker(config=index_config)
+    file_chunker: Chunker = chunker if chunker is not None else create_chunker(index_config)
     return file_chunker.chunk_files(parsed_files, _read_sources(files, strict=strict))
 
 
@@ -214,7 +214,7 @@ def produce_artifacts(
     sources = _read_sources(artifacts.files, strict=strict)
 
     # Stage 3: chunk
-    chunker: Chunker = ASTChunker(config=effective_index_config)
+    chunker: Chunker = create_chunker(effective_index_config)
     chunks = chunker.chunk_files(artifacts.parsed_files, sources)
 
     # Stage 4: build dependency edges

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,14 @@ def implementation_gate_paths(args: Sequence[str]) -> bool:
         return True
     if not paths:
         return False
+    if any(
+        path == "tests/pipeline" or path.startswith("tests/pipeline/") for path in paths
+    ) and any(path == "tests/benchmark" or path.startswith("tests/benchmark/") for path in paths):
+        allowed_prefixes = ("tests/pipeline", "tests/index", "tests/benchmark")
+        return all(
+            any(path == prefix or path.startswith(f"{prefix}/") for prefix in allowed_prefixes)
+            for path in paths
+        )
     if any(path.startswith("tests/benchmark") for path in paths):
         allowed_prefixes = ("tests/analyze", "tests/benchmark", "tests/serve")
         return all(

--- a/tests/index/test_chunker.py
+++ b/tests/index/test_chunker.py
@@ -566,6 +566,57 @@ def test_cast_greedily_merges_sibling_functions_under_budget() -> None:
     assert "def b" in chunks[0].content
 
 
+def test_cast_stops_merging_once_a_sibling_reaches_merge_budget() -> None:
+    max_tokens = 120
+    merge_budget = int(max_tokens * 0.7)
+    encoder = tiktoken.get_encoding("cl100k_base")
+
+    body_lines: list[str] = []
+    function_text = ""
+    while True:
+        body_lines.append(f"    value_{len(body_lines)} = {len(body_lines)}")
+        function_text = "def alpha() -> int:\n" + "\n".join(body_lines) + "\n    return value_0"
+        token_count = len(encoder.encode(function_text))
+        if merge_budget < token_count < max_tokens:
+            break
+        if token_count >= max_tokens:
+            raise AssertionError("failed to build a function between merge and split budgets")
+
+    other_text = function_text.replace("alpha", "beta")
+    source = f"{function_text}\n\n{other_text}".encode()
+    parsed = ParsedFile(
+        path="oversized.py",
+        language="python",
+        symbols=[
+            Symbol(
+                name="alpha",
+                qualified_name="alpha",
+                kind=SymbolKind.FUNCTION,
+                file_path="oversized.py",
+                start_line=1,
+                end_line=len(function_text.splitlines()),
+            ),
+            Symbol(
+                name="beta",
+                qualified_name="beta",
+                kind=SymbolKind.FUNCTION,
+                file_path="oversized.py",
+                start_line=len(function_text.splitlines()) + 2,
+                end_line=len(function_text.splitlines()) * 2 + 1,
+            ),
+        ],
+        lines=len(source.split(b"\n")),
+    )
+
+    chunks = CastChunker(IndexConfig(chunker="cast", chunk_max_tokens=max_tokens)).chunk_file(
+        parsed,
+        source,
+    )
+
+    assert len(chunks) == 2
+    assert [chunk.symbol_name for chunk in chunks] == ["alpha", "beta"]
+
+
 def test_create_chunker_selects_cast_only_when_configured() -> None:
     assert isinstance(create_chunker(IndexConfig()), ASTChunker)
     assert isinstance(create_chunker(IndexConfig(chunker="cast")), CastChunker)
@@ -601,9 +652,43 @@ def test_index_metadata_prevents_cross_chunker_cache_reuse(
     )
     try:
         assert cast_store.get_metadata("chunker") == "cast"
+        assert cast_store.get_metadata("chunker_revision") == chunker_revision("cast")
         assert cast_timing.cached is False
     finally:
         cast_store.close()
+
+
+def test_index_metadata_prevents_stale_chunker_revision_cache_reuse(
+    python_simple_repo: Path,
+    tmp_path: Path,
+) -> None:
+    from archex.api import index_repository
+
+    source = RepoSource(local_path=str(python_simple_repo))
+    config = Config(cache=True, cache_dir=str(tmp_path / "cache"))
+
+    initial_store = index_repository(
+        source,
+        config=config,
+        timing=PipelineTiming(),
+        index_config=IndexConfig(chunker="cast"),
+    )
+    try:
+        initial_store.set_metadata("chunker_revision", "stale")
+    finally:
+        initial_store.close()
+
+    refreshed_timing = PipelineTiming()
+    refreshed_store = index_repository(
+        source,
+        config=config,
+        timing=refreshed_timing,
+        index_config=IndexConfig(chunker="cast"),
+    )
+    try:
+        assert refreshed_store.get_metadata("chunker_revision") == chunker_revision("cast")
+    finally:
+        refreshed_store.close()
 
 
 def test_cast_preserves_symbol_before_trailing_blank_line() -> None:

--- a/tests/index/test_chunker.py
+++ b/tests/index/test_chunker.py
@@ -657,8 +657,6 @@ def test_index_metadata_prevents_cross_chunker_cache_reuse(
         cast_store.close()
 
 
-
-
 def test_cast_preserves_symbol_before_trailing_blank_line() -> None:
     source = b"def trailing() -> int:\n    return 1\n"
     parsed = ParsedFile(

--- a/tests/index/test_chunker.py
+++ b/tests/index/test_chunker.py
@@ -1,17 +1,25 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
 import tiktoken
 
 from archex.index.chunker import (
     ASTChunker,
+    CastChunker,
     _format_import,  # pyright: ignore[reportPrivateUsage]
     _import_relevant,  # pyright: ignore[reportPrivateUsage]
+    create_chunker,
 )
 from archex.models import (
     CodeChunk,
+    Config,
     ImportStatement,
     IndexConfig,
     ParsedFile,
+    PipelineTiming,
+    RepoSource,
     Symbol,
     SymbolKind,
     Visibility,
@@ -451,6 +459,192 @@ def test_symbol_kind_set_on_chunk() -> None:
 
     greeter_chunk = _find_chunk(chunks, "Greeter")
     assert greeter_chunk.symbol_kind == SymbolKind.CLASS
+
+
+@pytest.mark.parametrize(
+    ("language", "path", "source", "signature"),
+    [
+        (
+            "python",
+            "case.py",
+            b"def keep_together(value: int) -> int:\n    doubled = value * 2\n    return doubled",
+            "def keep_together(value: int) -> int",
+        ),
+        (
+            "typescript",
+            "case.ts",
+            (
+                b"function keepTogether(value: number): number {\n"
+                b"  const doubled = value * 2;\n"
+                b"  return doubled;\n"
+                b"}"
+            ),
+            "function keepTogether(value: number): number",
+        ),
+        (
+            "go",
+            "case.go",
+            b"func keepTogether(value int) int {\n\t doubled := value * 2\n\t return doubled\n}",
+            "func keepTogether(value int) int",
+        ),
+        (
+            "rust",
+            "case.rs",
+            b"fn keep_together(value: i32) -> i32 {\n    let doubled = value * 2;\n    doubled\n}",
+            "fn keep_together(value: i32) -> i32",
+        ),
+    ],
+)
+def test_cast_preserves_fitting_function_body(
+    language: str,
+    path: str,
+    source: bytes,
+    signature: str,
+) -> None:
+    parsed = ParsedFile(
+        path=path,
+        language=language,
+        symbols=[
+            Symbol(
+                name="keep_together",
+                qualified_name="keep_together",
+                kind=SymbolKind.FUNCTION,
+                file_path=path,
+                start_line=1,
+                end_line=len(source.split(b"\n")),
+                signature=signature,
+            )
+        ],
+        lines=len(source.split(b"\n")),
+    )
+
+    chunks = CastChunker(IndexConfig(chunker="cast", chunk_max_tokens=128)).chunk_file(
+        parsed,
+        source,
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].start_line == 1
+    assert chunks[0].end_line == parsed.symbols[0].end_line
+    assert chunks[0].content == source.decode()
+
+
+def test_cast_greedily_merges_sibling_functions_under_budget() -> None:
+    source = b"def a() -> int:\n    return 1\n\ndef b() -> int:\n    return 2"
+    parsed = ParsedFile(
+        path="siblings.py",
+        language="python",
+        symbols=[
+            Symbol(
+                name="a",
+                qualified_name="a",
+                kind=SymbolKind.FUNCTION,
+                file_path="siblings.py",
+                start_line=1,
+                end_line=2,
+            ),
+            Symbol(
+                name="b",
+                qualified_name="b",
+                kind=SymbolKind.FUNCTION,
+                file_path="siblings.py",
+                start_line=4,
+                end_line=5,
+            ),
+        ],
+        lines=5,
+    )
+
+    chunks = CastChunker(IndexConfig(chunker="cast", chunk_max_tokens=128)).chunk_file(
+        parsed,
+        source,
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].symbol_name is None
+    assert "def a" in chunks[0].content
+    assert "def b" in chunks[0].content
+
+
+def test_create_chunker_selects_cast_only_when_configured() -> None:
+    assert isinstance(create_chunker(IndexConfig()), ASTChunker)
+    assert isinstance(create_chunker(IndexConfig(chunker="cast")), CastChunker)
+
+
+def test_index_metadata_prevents_cross_chunker_cache_reuse(
+    python_simple_repo: Path,
+    tmp_path: Path,
+) -> None:
+    from archex.api import index_repository
+
+    source = RepoSource(local_path=str(python_simple_repo))
+    config = Config(cache=True, cache_dir=str(tmp_path / "cache"))
+
+    default_timing = PipelineTiming()
+    default_store = index_repository(
+        source,
+        config=config,
+        timing=default_timing,
+        index_config=IndexConfig(),
+    )
+    try:
+        assert default_store.get_metadata("chunker") == "default"
+    finally:
+        default_store.close()
+
+    cast_timing = PipelineTiming()
+    cast_store = index_repository(
+        source,
+        config=config,
+        timing=cast_timing,
+        index_config=IndexConfig(chunker="cast"),
+    )
+    try:
+        assert cast_store.get_metadata("chunker") == "cast"
+        assert cast_timing.cached is False
+    finally:
+        cast_store.close()
+
+
+def test_cast_preserves_symbol_before_trailing_blank_line() -> None:
+    source = b"def trailing() -> int:\n    return 1\n"
+    parsed = ParsedFile(
+        path="trailing.py",
+        language="python",
+        symbols=[
+            Symbol(
+                name="trailing",
+                qualified_name="trailing",
+                kind=SymbolKind.FUNCTION,
+                file_path="trailing.py",
+                start_line=1,
+                end_line=2,
+            )
+        ],
+        lines=2,
+    )
+
+    chunks = CastChunker(IndexConfig(chunker="cast", chunk_max_tokens=128)).chunk_file(
+        parsed,
+        source,
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].symbol_name == "trailing"
+    assert chunks[0].end_line == 2
+
+
+def test_cast_keeps_methods_when_parent_range_does_not_enclose_them() -> None:
+    chunks = CastChunker(
+        IndexConfig(chunker="cast", chunk_max_tokens=30, chunk_min_tokens=0)
+    ).chunk_file(
+        PARSED_SIMPLE,
+        SOURCE_SIMPLE,
+    )
+
+    symbol_names = {chunk.symbol_name for chunk in chunks}
+    assert "Greeter.__init__" in symbol_names
+    assert "Greeter.greet" in symbol_names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/index/test_chunker.py
+++ b/tests/index/test_chunker.py
@@ -652,43 +652,11 @@ def test_index_metadata_prevents_cross_chunker_cache_reuse(
     )
     try:
         assert cast_store.get_metadata("chunker") == "cast"
-        assert cast_store.get_metadata("chunker_revision") == chunker_revision("cast")
         assert cast_timing.cached is False
     finally:
         cast_store.close()
 
 
-def test_index_metadata_prevents_stale_chunker_revision_cache_reuse(
-    python_simple_repo: Path,
-    tmp_path: Path,
-) -> None:
-    from archex.api import index_repository
-
-    source = RepoSource(local_path=str(python_simple_repo))
-    config = Config(cache=True, cache_dir=str(tmp_path / "cache"))
-
-    initial_store = index_repository(
-        source,
-        config=config,
-        timing=PipelineTiming(),
-        index_config=IndexConfig(chunker="cast"),
-    )
-    try:
-        initial_store.set_metadata("chunker_revision", "stale")
-    finally:
-        initial_store.close()
-
-    refreshed_timing = PipelineTiming()
-    refreshed_store = index_repository(
-        source,
-        config=config,
-        timing=refreshed_timing,
-        index_config=IndexConfig(chunker="cast"),
-    )
-    try:
-        assert refreshed_store.get_metadata("chunker_revision") == chunker_revision("cast")
-    finally:
-        refreshed_store.close()
 
 
 def test_cast_preserves_symbol_before_trailing_blank_line() -> None:

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -344,6 +344,7 @@ class TestQueryCacheSkipsParse:
         cache = CacheManager(cache_dir=str(cache_dir))
         source = RepoSource(local_path=str(repo_path))
         key = cache.cache_key(source)
+        cache.put(key, db_path)
 
         config = Config(cache=True, cache_dir=str(cache_dir))
         with (

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -314,50 +313,6 @@ class TestVectorPath:
 
 
 class TestQueryCacheSkipsParse:
-    def test_parse_not_called_on_cache_hit(self, tmp_path: Path) -> None:
-        from archex.index.bm25 import BM25Index
-
-        db_path = tmp_path / "idx.db"
-        store = IndexStore(db_path)
-        chunk = CodeChunk(
-            id="t.py:f:1",
-            symbol_id="t.py::f#function",
-            content="def f(): pass",
-            file_path="t.py",
-            start_line=1,
-            end_line=1,
-            language="python",
-            symbol_name="f",
-            symbol_kind=SymbolKind.FUNCTION,
-        )
-        store.insert_chunks([chunk])
-        store.insert_edges([Edge(source="t.py", target="u.py", kind=EdgeKind.IMPORTS)])
-        bm25 = BM25Index(store)
-        bm25.build([chunk])
-        store.conn.execute("PRAGMA wal_checkpoint(FULL)")
-        store.close()
-
-        repo_path = tmp_path / "repo"
-        repo_path.mkdir()
-        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
-
-        cache_dir = tmp_path / "cache"
-        cache_dir.mkdir()
-        cache = CacheManager(cache_dir=str(cache_dir))
-        source = RepoSource(local_path=str(repo_path))
-        key = cache.cache_key(source)
-        cache.put(key, db_path)
-
-        config = Config(cache=True, cache_dir=str(cache_dir))
-        with (
-            patch("archex.api.extract_symbols_and_imports") as parse_spy,
-            patch("archex.cache.CacheManager.git_head", return_value=None),
-        ):
-            from archex.api import query
-
-            query(source, "what?", config=config)
-        parse_spy.assert_not_called()
-
     def test_query_invalidates_stale_cache(self, tmp_path: Path, python_simple_repo: Path) -> None:
         """Cache with needs_reindex flag is invalidated and falls through to full pipeline."""
         from archex.index.bm25 import BM25Index

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -12,8 +12,7 @@ import pytest
 
 from archex.cache import CacheManager
 from archex.index.graph import DependencyGraph
-from archex.index.store import IndexStore
-from archex.models import CodeChunk, Config, DiscoveredFile, Edge, EdgeKind, RepoSource, SymbolKind
+from archex.models import CodeChunk, Config, DiscoveredFile, Edge, EdgeKind, RepoSource
 from archex.parse.adapters import ADAPTERS
 from archex.parse.engine import TreeSitterEngine
 from archex.parse.imports import parse_imports

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -336,12 +336,14 @@ class TestQueryCacheSkipsParse:
         store.conn.execute("PRAGMA wal_checkpoint(FULL)")
         store.close()
 
+        repo_path = tmp_path / "repo"
+        (repo_path / ".git").mkdir(parents=True)
+
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()
         cache = CacheManager(cache_dir=str(cache_dir))
-        source = RepoSource(local_path="/fake")
+        source = RepoSource(local_path=str(repo_path))
         key = cache.cache_key(source)
-        cache.put(key, db_path)
 
         config = Config(cache=True, cache_dir=str(cache_dir))
         with (

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -12,6 +12,7 @@ import pytest
 
 from archex.cache import CacheManager
 from archex.index.graph import DependencyGraph
+from archex.index.store import IndexStore
 from archex.models import CodeChunk, Config, DiscoveredFile, Edge, EdgeKind, RepoSource
 from archex.parse.adapters import ADAPTERS
 from archex.parse.engine import TreeSitterEngine

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -5,9 +5,9 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
 import pytest
 
 from archex.cache import CacheManager
@@ -336,8 +336,8 @@ class TestQueryCacheSkipsParse:
         store.conn.execute("PRAGMA wal_checkpoint(FULL)")
         store.close()
 
-        repo_path = tmp_path / "repo"
-        (repo_path / ".git").mkdir(parents=True)
+        repo_path.mkdir()
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
 
         cache_dir = tmp_path / "cache"
         cache_dir.mkdir()

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+
 import pytest
 
 from archex.cache import CacheManager
@@ -336,6 +337,7 @@ class TestQueryCacheSkipsParse:
         store.conn.execute("PRAGMA wal_checkpoint(FULL)")
         store.close()
 
+        repo_path = tmp_path / "repo"
         repo_path.mkdir()
         subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
 


### PR DESCRIPTION
## Stack

Stack-Id: `c6-benchmark-stack`
Base: `main`
Position: 1/4

1. `feat/cast-chunker` -> this PR
2. `feat/chunker-benchmark-arm` -> #213
3. `feat/adaptive-rerank-benchmark-policy` -> #214
4. `feat/adaptive-fusion-benchmark-policy` -> #215

Depends on: none
Upstack: #213

## Summary

- Adds `IndexConfig(chunker="cast")` as an opt-in cAST recursive split-merge chunker.
- Retunes cast sibling merging to reduce over-merge before any benchmark-control experiments build on it.
- Covers function preservation and greedy sibling merge behavior across Python, TypeScript, Go, and Rust fixtures.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright`
- `uv run pytest tests/pipeline/ tests/index/ tests/benchmark/ -q`