### PR TITLE
feat: add adaptive benchmark rerank cap

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -55,7 +55,7 @@ from archex.analyze.modules import detect_modules
 from archex.analyze.patterns import detect_patterns
 from archex.cache import CacheManager
 from archex.config import load_config, load_index_config
-from archex.exceptions import ArchexIndexError, DeltaIndexError
+from archex.exceptions import AcquireError, ArchexIndexError, DeltaIndexError
 from archex.index.bm25 import BM25Index
 from archex.index.graph import DependencyGraph
 from archex.index.store import IndexStore
@@ -1603,13 +1603,19 @@ def query(
     preopened_store: IndexStore | None = None
     if refresh and config.cache:
         metadata_timing = timing or PipelineTiming()
-        preopened_store = _ensure_index(
-            source,
-            config,
-            timing=metadata_timing,
-            index_config=index_config,
-        )
-        cached_db = preopened_store.db_path
+        try:
+            preopened_store = _ensure_index(
+                source,
+                config,
+                timing=metadata_timing,
+                index_config=index_config,
+            )
+        except AcquireError:
+            cached_db = cache.get(cache_key)
+            if cached_db is None:
+                raise
+        else:
+            cached_db = preopened_store.db_path
     else:
         cached_db = cache.get(cache_key) if config.cache else None
     if cached_db is not None:
@@ -1809,6 +1815,7 @@ def query(
                     avg_idf=query_avg_idf,
                     reranker=_reranker,
                     rerank_candidate_limit=index_config.rerank_candidate_limit,
+                    adaptive_rerank_limit=index_config.adaptive_rerank_limit,
                     apply_intent_budget=False,
                 )
                 bundle.retrieval_metadata.vector_mode = index_config.vector_mode
@@ -2179,6 +2186,7 @@ def query(
                 avg_idf=query_avg_idf_miss,
                 reranker=_reranker_miss,
                 rerank_candidate_limit=index_config.rerank_candidate_limit,
+                adaptive_rerank_limit=index_config.adaptive_rerank_limit,
                 apply_intent_budget=False,
             )
             bundle.retrieval_metadata.vector_mode = index_config.vector_mode

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -89,7 +89,7 @@ from archex.parse import (
     resolve_imports,
 )
 from archex.parse.adapters import LanguageAdapter, default_adapter_registry
-from archex.pipeline.chunker import Chunker, create_chunker
+from archex.pipeline.chunker import Chunker, chunker_revision, create_chunker
 from archex.pipeline.service import build_chunk_surrogates
 from archex.project import uses_project_cache_layout
 from archex.scout import (
@@ -128,11 +128,14 @@ def _cache_manager_for_source(source: RepoSource, config: Config) -> CacheManage
 
 
 def _index_config_metadata_matches(store: IndexStore, index_config: IndexConfig) -> bool:
-    return store.get_metadata("chunker") == index_config.chunker
+    return store.get_metadata("chunker") == index_config.chunker and store.get_metadata(
+        "chunker_revision"
+    ) == chunker_revision(index_config.chunker)
 
 
 def _set_index_config_metadata(store: IndexStore, index_config: IndexConfig) -> None:
     store.set_metadata("chunker", index_config.chunker)
+    store.set_metadata("chunker_revision", chunker_revision(index_config.chunker))
 
 
 def _full_index(
@@ -1350,6 +1353,20 @@ def _attach_refresh_metadata(bundle: ContextBundle, timing: PipelineTiming | Non
         )
 
 
+def _attach_index_metadata(
+    bundle: ContextBundle,
+    index_config: IndexConfig,
+    *,
+    chunk_count: int,
+    total_repo_tokens: int,
+) -> None:
+    bundle.retrieval_metadata.chunker = index_config.chunker
+    bundle.retrieval_metadata.index_chunk_count = chunk_count
+    bundle.retrieval_metadata.mean_chunk_tokens = (
+        total_repo_tokens / chunk_count if chunk_count else 0.0
+    )
+
+
 def _query_by_scout_handles(
     source: RepoSource,
     question: str,
@@ -1369,9 +1386,21 @@ def _query_by_scout_handles(
     store = _ensure_index(source, config, timing=timing, index_config=index_config)
     try:
         chunks = _chunks_for_scout_handles(store, handles)
+        stored_tokens = store.get_metadata("repo_total_tokens")
+        total_repo_tokens = (
+            int(stored_tokens) if stored_tokens is not None else store.get_total_tokens()
+        )
+        stored_count = store.get_metadata("chunk_count")
+        chunk_count = int(stored_count) if stored_count is not None else len(store.get_chunks())
     finally:
         store.close()
     bundle = _context_bundle_for_handle_chunks(question, chunks, token_budget)
+    _attach_index_metadata(
+        bundle,
+        index_config,
+        chunk_count=chunk_count,
+        total_repo_tokens=total_repo_tokens,
+    )
     bundle.retrieval_metadata.retrieval_time_ms = _elapsed_ms(t0)
     if timing is not None:
         timing.search_ms = bundle.retrieval_metadata.assembly_time_ms
@@ -1628,6 +1657,12 @@ def query(
                     if trace is not None:
                         trace.end_ns = time.perf_counter_ns()
                         trace.log_summary()
+                    _attach_index_metadata(
+                        pt,
+                        index_config,
+                        chunk_count=chunk_count,
+                        total_repo_tokens=total_repo_tokens,
+                    )
                     _attach_refresh_metadata(pt, metadata_timing)
                     return pt
 
@@ -1773,6 +1808,7 @@ def query(
                     trace=trace,
                     avg_idf=query_avg_idf,
                     reranker=_reranker,
+                    rerank_candidate_limit=index_config.rerank_candidate_limit,
                     apply_intent_budget=False,
                 )
                 bundle.retrieval_metadata.vector_mode = index_config.vector_mode
@@ -1780,6 +1816,12 @@ def query(
                     index_config.surrogate_version
                     if index_config.vector_mode == VectorMode.SURROGATE
                     else None
+                )
+                _attach_index_metadata(
+                    bundle,
+                    index_config,
+                    chunk_count=chunk_count,
+                    total_repo_tokens=total_repo_tokens,
                 )
                 if timing is not None:
                     timing.assemble_ms = bundle.retrieval_metadata.assembly_time_ms
@@ -2012,6 +2054,12 @@ def query(
                     trace.log_summary()
                 pt.retrieval_metadata.retrieval_time_ms = _elapsed_ms(t0)
                 logger.info("query() [passthrough] completed in %.0fms", _elapsed_ms(t0))
+                _attach_index_metadata(
+                    pt,
+                    index_config,
+                    chunk_count=len(all_chunks),
+                    total_repo_tokens=total_repo_tokens,
+                )
                 _attach_refresh_metadata(pt, metadata_timing)
                 return pt
 
@@ -2130,6 +2178,7 @@ def query(
                 trace=trace,
                 avg_idf=query_avg_idf_miss,
                 reranker=_reranker_miss,
+                rerank_candidate_limit=index_config.rerank_candidate_limit,
                 apply_intent_budget=False,
             )
             bundle.retrieval_metadata.vector_mode = index_config.vector_mode
@@ -2151,6 +2200,12 @@ def query(
         if trace is not None:
             trace.end_ns = time.perf_counter_ns()
             trace.log_summary()
+        _attach_index_metadata(
+            bundle,
+            index_config,
+            chunk_count=len(all_chunks),
+            total_repo_tokens=total_repo_tokens,
+        )
         _attach_refresh_metadata(bundle, metadata_timing)
         return bundle
     finally:

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -147,6 +147,7 @@ class BenchmarkRetrievalOptions(BaseModel):
     bm25_chunker: ChunkerName | None = None
     vector_chunker: ChunkerName | None = None
     rerank_candidate_limit: int | None = None
+    adaptive_rerank_limit: bool = False
 
 
 class ExternalToolCommandConfig(BenchmarkSpecModel):

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -7,6 +7,7 @@ from enum import StrEnum
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from archex.models import (  # noqa: TCH001 — Pydantic needs at runtime
+    ChunkerName,
     DeltaMeta,
     PipelineTiming,
     SymbolKind,
@@ -142,6 +143,10 @@ class BenchmarkRetrievalOptions(BaseModel):
     embedder: str = "jina-v2"
     rerank_model: str | None = None
     freshness: bool = False
+    chunker: ChunkerName = "default"
+    bm25_chunker: ChunkerName | None = None
+    vector_chunker: ChunkerName | None = None
+    rerank_candidate_limit: int | None = None
 
 
 class ExternalToolCommandConfig(BenchmarkSpecModel):
@@ -238,6 +243,9 @@ class BenchmarkResult(BaseModel):
     freshness_latency_ms: float = 0.0
     freshness_measured: bool = False
     freshness_correct: bool = False
+    chunker: ChunkerName = "default"
+    index_chunk_count: int = 0
+    mean_chunk_tokens: float = 0.0
 
 
 class BenchmarkReport(BaseModel):

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -53,6 +53,19 @@ def _mean(values: list[float]) -> float:
     return sum(values) / len(values)
 
 
+def _percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
 def _aggregate_strategy_metrics(
     reports: list[BenchmarkReport],
     fields: tuple[str, ...],
@@ -283,6 +296,57 @@ def format_strategy_comparison(reports: list[BenchmarkReport]) -> str:
         lines.append(f"- **{label}**: {best_strategy} ({best_count} wins)")
     lines.append("")
 
+    return "\n".join(lines)
+
+
+def format_chunker_frontier_table(
+    candidate_reports: list[BenchmarkReport],
+    baseline_reports: list[BenchmarkReport],
+) -> str:
+    """Render a default-vs-candidate chunker frontier table."""
+    if not candidate_reports or not baseline_reports:
+        return "No chunker frontier comparison available."
+
+    rows: dict[tuple[str, str], dict[str, list[float]]] = defaultdict(
+        lambda: {
+            "recall": [],
+            "precision": [],
+            "f1_score": [],
+            "token_efficiency": [],
+            "wall_time_ms": [],
+            "index_chunk_count": [],
+            "mean_chunk_tokens": [],
+        }
+    )
+    for report in [*baseline_reports, *candidate_reports]:
+        for result in report.results:
+            key = (result.strategy.value, result.chunker)
+            rows[key]["recall"].append(result.recall)
+            rows[key]["precision"].append(result.precision)
+            rows[key]["f1_score"].append(result.f1_score)
+            rows[key]["token_efficiency"].append(result.token_efficiency)
+            rows[key]["wall_time_ms"].append(result.wall_time_ms)
+            rows[key]["index_chunk_count"].append(float(result.index_chunk_count))
+            rows[key]["mean_chunk_tokens"].append(result.mean_chunk_tokens)
+
+    lines = [
+        "## Chunker Frontier Comparison",
+        "",
+        "| Strategy | Chunker | Recall | Precision | F1 | Token Efficiency | p95 ms "
+        "| Chunk Count | Mean Chunk Tokens |",
+        "|----------|---------|--------|-----------|----|------------------|--------|-------------|-------------------|",
+    ]
+    for strategy, chunker in sorted(rows):
+        metrics = rows[(strategy, chunker)]
+        lines.append(
+            f"| {strategy} | {chunker} | {_mean(metrics['recall']):.3f} "
+            f"| {_mean(metrics['precision']):.3f} | {_mean(metrics['f1_score']):.3f} "
+            f"| {_mean(metrics['token_efficiency']):.3f} "
+            f"| {_percentile(metrics['wall_time_ms'], 0.95):.0f} "
+            f"| {_mean(metrics['index_chunk_count']):.0f} "
+            f"| {_mean(metrics['mean_chunk_tokens']):.1f} |"
+        )
+    lines.append("")
     return "\n".join(lines)
 
 

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -19,6 +19,7 @@ from archex.benchmark.models import (
     Strategy,
 )
 from archex.benchmark.strategies import (
+    benchmark_index_config,
     benchmark_repo_source,
     default_strategy_registry,
     reset_benchmark_retrieval_options,
@@ -92,17 +93,20 @@ def _warm_repo_index(
     from archex.api import query
     from archex.models import Config, IndexConfig
 
-    source = benchmark_repo_source(task, repo_path)
-    config = Config(cache=True, languages=task.languages)
     retrieval_options = retrieval_options or BenchmarkRetrievalOptions()
-    index_config = IndexConfig(
-        vector=True,
-        embedder=retrieval_options.embedder,
-        splade=retrieval_options.splade,
-        module_prefilter=retrieval_options.module_prefilter,
-        rerank=warm_rerank,
-        rerank_model=retrieval_options.rerank_model,
+    warm_strategy = (
+        Strategy.ARCHEX_QUERY_FUSION_RERANK if warm_rerank else Strategy.ARCHEX_QUERY_FUSION
     )
+    token = set_benchmark_retrieval_options(retrieval_options)
+    try:
+        source = benchmark_repo_source(task, repo_path, strategy=warm_strategy)
+        config = Config(cache=True, languages=task.languages)
+        index_config = benchmark_index_config(
+            IndexConfig(vector=True, rerank=warm_rerank),
+            strategy=warm_strategy,
+        )
+    finally:
+        reset_benchmark_retrieval_options(token)
     query(
         source,
         task.question,

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -23,7 +23,7 @@ from archex.benchmark.models import (
 )
 from archex.cache import CacheManager
 from archex.exceptions import ArchexError, ConfigError
-from archex.models import IndexConfig, PipelineTiming, RepoSource
+from archex.models import ChunkerName, IndexConfig, PipelineTiming, RepoSource
 from archex.reporting import count_tokens
 
 logger = logging.getLogger(__name__)
@@ -415,7 +415,14 @@ class _ArchexFields:
         "expansion_zero_candidate_reason",
         "expansion_reason_counts",
         "expanded_file_reasons",
+        "chunker",
+        "index_chunk_count",
+        "mean_chunk_tokens",
     )
+
+    chunker: ChunkerName
+    index_chunk_count: int
+    mean_chunk_tokens: float
 
     def __init__(
         self,
@@ -439,6 +446,9 @@ class _ArchexFields:
         expansion_test_candidates_skipped: int,
         expansion_zero_candidate_reason: str,
         expansion_reason_counts: dict[str, int],
+        chunker: ChunkerName,
+        index_chunk_count: int,
+        mean_chunk_tokens: float,
         expanded_file_reasons: dict[str, list[str]],
     ) -> None:
         self.tokens_input = tokens_input
@@ -460,6 +470,9 @@ class _ArchexFields:
         self.expansion_test_candidates_skipped = expansion_test_candidates_skipped
         self.expansion_zero_candidate_reason = expansion_zero_candidate_reason
         self.expansion_reason_counts = expansion_reason_counts
+        self.chunker = chunker
+        self.index_chunk_count = index_chunk_count
+        self.mean_chunk_tokens = mean_chunk_tokens
         self.expanded_file_reasons = expanded_file_reasons
 
 
@@ -483,6 +496,9 @@ def _archex_fields(
     # Seed vs expansion: candidates_found is a chunk count, while
     # seed_files_found is the file boundary for graph expansion diagnostics.
     meta = bundle.retrieval_metadata
+    chunker = meta.chunker
+    index_chunk_count = meta.index_chunk_count
+    mean_chunk_tokens = meta.mean_chunk_tokens
     if meta.seed_file_paths or meta.expanded_file_paths:
         seed_files = list(meta.seed_file_paths)
         expanded_files = list(meta.expanded_file_paths)
@@ -514,6 +530,9 @@ def _archex_fields(
             expanded_file_reasons={
                 path: list(reasons) for path, reasons in meta.expanded_file_reasons.items()
             },
+            chunker=chunker,
+            index_chunk_count=index_chunk_count,
+            mean_chunk_tokens=mean_chunk_tokens,
         )
 
     seed_file_count = meta.seed_files_found
@@ -566,6 +585,9 @@ def _archex_fields(
         expanded_file_reasons={
             path: list(reasons) for path, reasons in meta.expanded_file_reasons.items()
         },
+        chunker=chunker,
+        index_chunk_count=index_chunk_count,
+        mean_chunk_tokens=mean_chunk_tokens,
     )
 
 
@@ -575,6 +597,26 @@ def _cache_state(timing: PipelineTiming) -> str:
 
 def current_benchmark_retrieval_options() -> BenchmarkRetrievalOptions:
     return _BENCHMARK_RETRIEVAL_OPTIONS.get() or BenchmarkRetrievalOptions()
+
+
+_VECTOR_CHUNKER_STRATEGIES = frozenset(
+    {
+        Strategy.ARCHEX_QUERY_VECTOR,
+        Strategy.SURROGATE_VECTOR,
+        Strategy.ARCHEX_QUERY_FUSION,
+        Strategy.ARCHEX_QUERY_FUSION_RERANK,
+        Strategy.CROSS_LAYER_FUSION,
+    }
+)
+
+
+def _chunker_for_strategy(
+    strategy: Strategy,
+    options: BenchmarkRetrievalOptions,
+) -> ChunkerName:
+    if strategy in _VECTOR_CHUNKER_STRATEGIES:
+        return options.vector_chunker or options.chunker
+    return options.bm25_chunker or options.chunker
 
 
 def set_benchmark_retrieval_options(
@@ -603,8 +645,22 @@ def _embedder_cache_identity(embedder: str) -> str:
     )
 
 
-def _retrieval_cache_suffix(options: BenchmarkRetrievalOptions) -> str:
+def _retrieval_cache_suffix(
+    options: BenchmarkRetrievalOptions,
+    *,
+    strategy: Strategy | None = None,
+) -> str:
     enabled: list[str] = [f"embedder={_embedder_cache_identity(options.embedder)}"]
+    if strategy is None:
+        bm25_chunker = _chunker_for_strategy(Strategy.ARCHEX_QUERY, options)
+        vector_chunker = _chunker_for_strategy(Strategy.ARCHEX_QUERY_FUSION, options)
+        if bm25_chunker == vector_chunker:
+            enabled.append(f"chunker={bm25_chunker}")
+        else:
+            enabled.append(f"bm25-chunker={bm25_chunker}")
+            enabled.append(f"vector-chunker={vector_chunker}")
+    else:
+        enabled.append(f"chunker={_chunker_for_strategy(strategy, options)}")
     if options.splade:
         enabled.append("splade")
     if options.module_prefilter:
@@ -618,9 +674,20 @@ def _corpus_cache_suffix(task: BenchmarkTask) -> str:
     return "scope=" + "|".join(sorted(task.include_paths))
 
 
-def benchmark_index_config(index_config: IndexConfig) -> IndexConfig:
+def benchmark_index_config(
+    index_config: IndexConfig,
+    *,
+    strategy: Strategy | None = None,
+) -> IndexConfig:
     options = current_benchmark_retrieval_options()
-    updates: dict[str, bool | str] = {}
+    strategy_chunker = (
+        _chunker_for_strategy(strategy, options)
+        if strategy is not None
+        else (options.vector_chunker or options.chunker)
+        if index_config.vector
+        else (options.bm25_chunker or options.chunker)
+    )
+    updates: dict[str, bool | str | int] = {"chunker": strategy_chunker}
     if index_config.vector:
         updates["embedder"] = options.embedder
     if options.splade:
@@ -629,6 +696,8 @@ def benchmark_index_config(index_config: IndexConfig) -> IndexConfig:
         updates["module_prefilter"] = True
     if index_config.rerank and options.rerank_model is not None:
         updates["rerank_model"] = options.rerank_model
+    if index_config.rerank and options.rerank_candidate_limit is not None:
+        updates["rerank_candidate_limit"] = options.rerank_candidate_limit
     if not updates:
         return index_config
     return index_config.model_copy(update=updates)
@@ -639,7 +708,11 @@ def benchmark_cache_enabled(default: bool) -> bool:
     return default or options.splade or options.module_prefilter
 
 
-def benchmark_repo_source(task: BenchmarkTask, repo_path: Path) -> RepoSource:
+def benchmark_repo_source(
+    task: BenchmarkTask,
+    repo_path: Path,
+    strategy: Strategy | None = None,
+) -> RepoSource:
     commit = task.commit or CacheManager.git_head(str(repo_path))
     if not commit:
         raise ConfigError(
@@ -650,7 +723,10 @@ def benchmark_repo_source(task: BenchmarkTask, repo_path: Path) -> RepoSource:
         suffix
         for suffix in (
             _corpus_cache_suffix(task),
-            _retrieval_cache_suffix(current_benchmark_retrieval_options()),
+            _retrieval_cache_suffix(
+                current_benchmark_retrieval_options(),
+                strategy=strategy,
+            ),
         )
         if suffix
     ]
@@ -702,8 +778,11 @@ def measure_archex_freshness(task: BenchmarkTask, repo_path: Path) -> tuple[floa
         if edit_target is None:
             return (0.0, False)
 
-        source = benchmark_repo_source(task, target)
-        index_config = benchmark_index_config(IndexConfig(vector=False))
+        source = benchmark_repo_source(task, target, strategy=Strategy.ARCHEX_QUERY)
+        index_config = benchmark_index_config(
+            IndexConfig(vector=False),
+            strategy=Strategy.ARCHEX_QUERY,
+        )
         config = Config(cache=True, languages=task.languages, cache_dir=str(workdir / "cache"))
         query(source, _FRESHNESS_MARKER, config=config, index_config=index_config)
         with edit_target.open("a", encoding="utf-8") as handle:
@@ -731,12 +810,15 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path, strategy=Strategy.ARCHEX_QUERY)
     config = Config(
         cache=benchmark_cache_enabled(default=False),
         languages=task.languages,
     )
-    index_config = benchmark_index_config(IndexConfig(vector=False))
+    index_config = benchmark_index_config(
+        IndexConfig(vector=False),
+        strategy=Strategy.ARCHEX_QUERY,
+    )
 
     bundle = query(
         source,
@@ -810,6 +892,9 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         expansion_reason_counts=af.expansion_reason_counts,
         expanded_file_reasons=af.expanded_file_reasons,
+        chunker=af.chunker,
+        index_chunk_count=af.index_chunk_count,
+        mean_chunk_tokens=af.mean_chunk_tokens,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -827,12 +912,15 @@ def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path, strategy=Strategy.ARCHEX_SCOUT_FETCH)
     config = Config(
         cache=benchmark_cache_enabled(default=False),
         languages=task.languages,
     )
-    index_config = benchmark_index_config(IndexConfig(vector=False))
+    index_config = benchmark_index_config(
+        IndexConfig(vector=False),
+        strategy=Strategy.ARCHEX_SCOUT_FETCH,
+    )
 
     scout_result, direct_bundle = scout_with_bundle(
         source,
@@ -939,6 +1027,9 @@ def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
         expansion_ratio=0.0,
         seed_recall=compute_recall(set(scout_ranked_files), task.expected_files),
         seed_precision=compute_precision(set(scout_ranked_files), task.expected_files),
+        chunker=fetch_fields.chunker,
+        index_chunk_count=fetch_fields.index_chunk_count,
+        mean_chunk_tokens=fetch_fields.mean_chunk_tokens,
         category=task.category,
         cache_state=_cache_state(timing),
         provenance={
@@ -977,9 +1068,12 @@ def run_archex_query_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path, strategy=Strategy.ARCHEX_QUERY_VECTOR)
     config = Config(cache=True, languages=task.languages)
-    index_config = benchmark_index_config(IndexConfig(bm25=False, vector=True))
+    index_config = benchmark_index_config(
+        IndexConfig(bm25=False, vector=True),
+        strategy=Strategy.ARCHEX_QUERY_VECTOR,
+    )
 
     bundle = query(
         source,
@@ -1046,6 +1140,9 @@ def run_archex_query_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         expansion_reason_counts=af.expansion_reason_counts,
         expanded_file_reasons=af.expanded_file_reasons,
+        chunker=af.chunker,
+        index_chunk_count=af.index_chunk_count,
+        mean_chunk_tokens=af.mean_chunk_tokens,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -1059,7 +1156,7 @@ def run_surrogate_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResul
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path, strategy=Strategy.SURROGATE_VECTOR)
     config = Config(cache=True, languages=task.languages)
     index_config = benchmark_index_config(
         IndexConfig(
@@ -1068,7 +1165,8 @@ def run_surrogate_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResul
             embedder=current_benchmark_retrieval_options().embedder,
             vector_mode=VectorMode.SURROGATE,
             retrieval_policy=RetrievalPolicy.VECTOR_ONLY,
-        )
+        ),
+        strategy=Strategy.SURROGATE_VECTOR,
     )
 
     bundle = query(
@@ -1129,6 +1227,9 @@ def run_surrogate_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResul
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         expansion_reason_counts=af.expansion_reason_counts,
         expanded_file_reasons=af.expanded_file_reasons,
+        chunker=af.chunker,
+        index_chunk_count=af.index_chunk_count,
+        mean_chunk_tokens=af.mean_chunk_tokens,
         category=task.category,
         vector_mode=index_config.vector_mode,
         surrogate_version=index_config.surrogate_version,
@@ -1143,9 +1244,12 @@ def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path, strategy=Strategy.ARCHEX_QUERY_FUSION)
     config = Config(cache=True, languages=task.languages)
-    index_config = benchmark_index_config(IndexConfig(vector=True))
+    index_config = benchmark_index_config(
+        IndexConfig(vector=True),
+        strategy=Strategy.ARCHEX_QUERY_FUSION,
+    )
 
     bundle = query(
         source,
@@ -1212,6 +1316,9 @@ def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         expansion_reason_counts=af.expansion_reason_counts,
         expanded_file_reasons=af.expanded_file_reasons,
+        chunker=af.chunker,
+        index_chunk_count=af.index_chunk_count,
+        mean_chunk_tokens=af.mean_chunk_tokens,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -1225,9 +1332,12 @@ def run_archex_query_fusion_rerank(task: BenchmarkTask, repo_path: Path) -> Benc
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path, strategy=Strategy.ARCHEX_QUERY_FUSION_RERANK)
     config = Config(cache=True, languages=task.languages)
-    index_config = benchmark_index_config(IndexConfig(vector=True, rerank=True))
+    index_config = benchmark_index_config(
+        IndexConfig(vector=True, rerank=True),
+        strategy=Strategy.ARCHEX_QUERY_FUSION_RERANK,
+    )
 
     bundle = query(
         source,
@@ -1287,6 +1397,9 @@ def run_archex_query_fusion_rerank(task: BenchmarkTask, repo_path: Path) -> Benc
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         expansion_reason_counts=af.expansion_reason_counts,
         expanded_file_reasons=af.expanded_file_reasons,
+        chunker=af.chunker,
+        index_chunk_count=af.index_chunk_count,
+        mean_chunk_tokens=af.mean_chunk_tokens,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -1300,7 +1413,7 @@ def run_cross_layer_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path, strategy=Strategy.CROSS_LAYER_FUSION)
     config = Config(cache=True, languages=task.languages)
     index_config = benchmark_index_config(
         IndexConfig(
@@ -1308,7 +1421,8 @@ def run_cross_layer_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
             embedder=current_benchmark_retrieval_options().embedder,
             vector_mode=VectorMode.SURROGATE,
             retrieval_policy=RetrievalPolicy.CROSS_LAYER,
-        )
+        ),
+        strategy=Strategy.CROSS_LAYER_FUSION,
     )
 
     bundle = query(
@@ -1369,6 +1483,9 @@ def run_cross_layer_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         expansion_reason_counts=af.expansion_reason_counts,
         expanded_file_reasons=af.expanded_file_reasons,
+        chunker=af.chunker,
+        index_chunk_count=af.index_chunk_count,
+        mean_chunk_tokens=af.mean_chunk_tokens,
         category=task.category,
         vector_mode=index_config.vector_mode,
         surrogate_version=index_config.surrogate_version,

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -698,6 +698,8 @@ def benchmark_index_config(
         updates["rerank_model"] = options.rerank_model
     if index_config.rerank and options.rerank_candidate_limit is not None:
         updates["rerank_candidate_limit"] = options.rerank_candidate_limit
+    if index_config.rerank and options.adaptive_rerank_limit:
+        updates["adaptive_rerank_limit"] = True
     if not updates:
         return index_config
     return index_config.model_copy(update=updates)

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 
@@ -51,6 +52,7 @@ from archex.benchmark.readiness import (
 )
 from archex.benchmark.reporter import (
     format_bucketed_summary,
+    format_chunker_frontier_table,
     format_delta_summary,
     format_json,
     format_markdown,
@@ -64,6 +66,9 @@ from archex.benchmark.triage import (
     load_benchmark_tasks,
     triage_failures,
 )
+
+if TYPE_CHECKING:
+    from archex.models import ChunkerName
 
 DEFAULT_BENCHMARK_RESULTS_DIR = ".archex/benchmark-results"
 DEFAULT_DELTA_RESULTS_DIR = ".archex/delta-results"
@@ -139,9 +144,34 @@ def benchmark_cmd() -> None:
     help="Embedder to pin across every vector-backed benchmark strategy.",
 )
 @click.option(
+    "--chunker",
+    default="default",
+    show_default=True,
+    type=click.Choice(["default", "cast"]),
+    help="Chunker to pin across every archex benchmark strategy.",
+)
+@click.option(
+    "--bm25-chunker",
+    default=None,
+    type=click.Choice(["default", "cast"]),
+    help="Override chunker for BM25-backed strategies only.",
+)
+@click.option(
+    "--vector-chunker",
+    default=None,
+    type=click.Choice(["default", "cast"]),
+    help="Override chunker for vector-backed strategies only.",
+)
+@click.option(
     "--rerank-model",
     default=None,
     help="Cross-encoder model to use for the fusion+rerank benchmark strategy.",
+)
+@click.option(
+    "--rerank-candidate-limit",
+    default=None,
+    type=int,
+    help="Cap candidates scored by the cross-encoder reranker.",
 )
 @click.option(
     "--self-only",
@@ -167,7 +197,11 @@ def run_cmd(
     splade: bool,
     module_prefilter: bool,
     embedder: str,
+    chunker: ChunkerName,
+    bm25_chunker: ChunkerName | None,
+    vector_chunker: ChunkerName | None,
     rerank_model: str | None,
+    rerank_candidate_limit: int | None,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -194,6 +228,10 @@ def run_cmd(
         module_prefilter=module_prefilter,
         embedder=embedder,
         rerank_model=rerank_model,
+        chunker=chunker,
+        bm25_chunker=bm25_chunker,
+        vector_chunker=vector_chunker,
+        rerank_candidate_limit=rerank_candidate_limit,
     )
     warmed_models = warm_benchmark_models(strategies, retrieval_options)
     if warmed_models:
@@ -588,6 +626,7 @@ def gate_cmd(
             baseline_reports.append(BenchmarkReport.model_validate(data))
         if not baseline_reports:
             raise click.ClickException(f"No baseline result files found in {baseline_dir}")
+        click.echo(format_chunker_frontier_table(reports, baseline_reports))
 
         recall_regressions = check_recall_regressions(reports, baseline_reports, thresholds)
         if advisory_warnings:

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -174,6 +174,14 @@ def benchmark_cmd() -> None:
     help="Cap candidates scored by the cross-encoder reranker.",
 )
 @click.option(
+    "--adaptive-rerank-limit/--no-adaptive-rerank-limit",
+    default=False,
+    help=(
+        "Benchmark-only policy: shrink rerank windows for low-agreement narrow frontiers "
+        "while preserving broader multi-file queries."
+    ),
+)
+@click.option(
     "--self-only",
     is_flag=True,
     default=False,
@@ -202,6 +210,7 @@ def run_cmd(
     vector_chunker: ChunkerName | None,
     rerank_model: str | None,
     rerank_candidate_limit: int | None,
+    adaptive_rerank_limit: bool,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -232,6 +241,7 @@ def run_cmd(
         bm25_chunker=bm25_chunker,
         vector_chunker=vector_chunker,
         rerank_candidate_limit=rerank_candidate_limit,
+        adaptive_rerank_limit=adaptive_rerank_limit,
     )
     warmed_models = warm_benchmark_models(strategies, retrieval_options)
     if warmed_models:

--- a/src/archex/index/delta.py
+++ b/src/archex/index/delta.py
@@ -367,6 +367,7 @@ def apply_delta(
         resolve_imports,
     )
     from archex.parse.adapters import default_adapter_registry
+    from archex.pipeline.chunker import chunker_revision
 
     t_start = time.perf_counter()
 
@@ -457,6 +458,7 @@ def apply_delta(
 
     # 6. Update metadata
     store.set_metadata("chunker", effective_index_config.chunker)
+    store.set_metadata("chunker_revision", chunker_revision(effective_index_config.chunker))
     store.set_metadata("repo_total_tokens", str(sum(chunk.token_count for chunk in all_chunks)))
     store.set_metadata("chunk_count", str(len(all_chunks)))
     store.set_metadata("commit_hash", manifest.current_commit)

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -162,6 +162,7 @@ class IndexConfig(BaseModel):
     retrieval_policy: RetrievalPolicy = RetrievalPolicy.AUTO
     rerank: bool = False
     rerank_model: str | None = None
+    rerank_candidate_limit: int = 4
     chunker: ChunkerName = "default"
     chunk_max_tokens: int = 500
     chunk_min_tokens: int = 50
@@ -181,6 +182,8 @@ class IndexConfig(BaseModel):
             raise ValueError("chunk_min_tokens must be <= chunk_max_tokens")
         if not self.surrogate_version.strip():
             raise ValueError("surrogate_version must not be empty")
+        if self.rerank_candidate_limit < 1:
+            raise ValueError("rerank_candidate_limit must be at least 1")
         return self
 
 
@@ -629,6 +632,9 @@ class RetrievalMetadata(BaseModel):
     refresh_time_ms: float = 0.0
     refresh_files_changed: int = 0
     refresh_skipped_reason: str = ""
+    chunker: ChunkerName = "default"
+    index_chunk_count: int = 0
+    mean_chunk_tokens: float = 0.0
 
 
 class ContextBundle(BaseModel):

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -163,6 +163,7 @@ class IndexConfig(BaseModel):
     rerank: bool = False
     rerank_model: str | None = None
     rerank_candidate_limit: int = 4
+    adaptive_rerank_limit: bool = False
     chunker: ChunkerName = "default"
     chunk_max_tokens: int = 500
     chunk_min_tokens: int = 50

--- a/src/archex/pipeline/chunker.py
+++ b/src/archex/pipeline/chunker.py
@@ -9,6 +9,7 @@ from typing import Protocol, runtime_checkable
 import tiktoken
 
 from archex.models import (
+    ChunkerName,
     CodeChunk,
     ImportStatement,
     IndexConfig,
@@ -477,6 +478,16 @@ class CastChunker(ASTChunker):
         result.sort(key=lambda c: c.start_line)
         _disambiguate_symbol_ids(result)
         return result
+
+
+_CHUNKER_REVISIONS: dict[ChunkerName, str] = {
+    "default": "v1",
+    "cast": "v2",
+}
+
+
+def chunker_revision(chunker: ChunkerName) -> str:
+    return _CHUNKER_REVISIONS[chunker]
 
 
 def create_chunker(config: IndexConfig | None = None) -> Chunker:

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -903,6 +903,7 @@ def assemble_context(
     expansion_min_override: float | None = None,
     avg_idf: float | None = None,
     reranker: object | None = None,
+    rerank_candidate_limit: int = 4,
     apply_intent_budget: bool = True,
 ) -> ContextBundle:
     """Assemble a token-budgeted ContextBundle from search results and a dependency graph.
@@ -1335,18 +1336,14 @@ def assemble_context(
     # complete candidate pool for file-level aggregation and only update scores
     # for the bounded window sent through the expensive cross-encoder.
     if reranker is not None:
-        from archex.index.rerank import (
-            DEFAULT_TOP_K,
-            RERANK_CANDIDATE_LIMIT,
-            CrossEncoderReranker,
-        )
+        from archex.index.rerank import DEFAULT_TOP_K, CrossEncoderReranker
 
         if isinstance(reranker, CrossEncoderReranker):
             rerank_start = time.perf_counter_ns()
             candidate_list = [
                 (chunk, bm25_by_id.get(chunk.id, 0.0)) for chunk in candidate_map.values()
             ]
-            candidates_for_rerank = candidate_list[:RERANK_CANDIDATE_LIMIT]
+            candidates_for_rerank = candidate_list[:rerank_candidate_limit]
             reranked = reranker.rerank(question, candidates_for_rerank, top_k=DEFAULT_TOP_K)
             for chunk_id, rerank_score in _normalized_rerank_scores(reranked).items():
                 bm25_by_id[chunk_id] = max(bm25_by_id.get(chunk_id, 0.0), rerank_score)

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -476,6 +476,33 @@ def _adaptive_max_files(
     return default
 
 
+def _resolve_rerank_candidate_limit(
+    candidate_list: list[tuple[CodeChunk, float]],
+    *,
+    configured_limit: int,
+    adaptive: bool,
+    signal_agreement: float | None,
+    bm25_cv: float | None,
+    broad_query: bool,
+) -> tuple[int, str]:
+    candidate_cap = min(configured_limit, len(candidate_list))
+    if candidate_cap <= 2 or not adaptive:
+        return candidate_cap, "fixed"
+    top_window_files = {chunk.file_path for chunk, _ in candidate_list[:candidate_cap]}
+    if broad_query:
+        return candidate_cap, "broad_query"
+    if len(top_window_files) >= min(3, candidate_cap):
+        return candidate_cap, "broad_multi_file_window"
+    if (
+        signal_agreement is not None
+        and signal_agreement <= 0.25
+        and bm25_cv is not None
+        and bm25_cv >= 0.35
+    ):
+        return 2, "low_agreement_high_lexical_concentration"
+    return candidate_cap, "fixed"
+
+
 def _is_architecture_query(question: str) -> bool:
     """Return True if the query contains any architecture keyword."""
     q_lower = question.lower()
@@ -904,6 +931,7 @@ def assemble_context(
     avg_idf: float | None = None,
     reranker: object | None = None,
     rerank_candidate_limit: int = 4,
+    adaptive_rerank_limit: bool = False,
     apply_intent_budget: bool = True,
 ) -> ContextBundle:
     """Assemble a token-budgeted ContextBundle from search results and a dependency graph.
@@ -950,11 +978,18 @@ def assemble_context(
     splade_fusion_skipped = False
     splade_fusion_skip_reason = ""
     bm25_cv_val: float | None = None
+    signal_agreement_pre: float | None = None
     effective_vector: list[tuple[CodeChunk, float]] = []
     effective_splade: list[tuple[CodeChunk, float]] = []
     base_results = search_results
     if vector_results:
         from archex.index.fusion import adaptive_rsf, bm25_score_cv, should_fuse
+
+        _k_agree = 20
+        _bm25_top_k = {chunk.file_path for chunk, _ in search_results[:_k_agree]}
+        _vec_top_k = {chunk.file_path for chunk, _ in vector_results[:_k_agree]}
+        _union = _bm25_top_k | _vec_top_k
+        signal_agreement_pre = len(_bm25_top_k & _vec_top_k) / len(_union) if _union else 0.0
 
         # Gate fusion: skip when BM25 is confident and signals agree.
         # Always fuse when BM25 is empty — vector is the only signal.
@@ -962,15 +997,6 @@ def assemble_context(
         bm25_cv_val = bm25_score_cv(search_results)
 
         if fuse or not search_results:
-            # Compute signal_agreement (Jaccard of BM25 top-20 and vector top-20 file paths)
-            _k_agree = 20
-            _bm25_top_k = {chunk.file_path for chunk, _ in search_results[:_k_agree]}
-            _vec_top_k = {chunk.file_path for chunk, _ in vector_results[:_k_agree]}
-            _union = _bm25_top_k | _vec_top_k
-            signal_agreement_pre: float = (
-                len(_bm25_top_k & _vec_top_k) / len(_union) if _union else 0.0
-            )
-
             # RSF preserves score magnitude (unlike RRF which flattens to
             # rank-based 1/(k+rank)). Adaptive weights give vector meaningful
             # influence so unique vector hits can surface.
@@ -983,14 +1009,12 @@ def assemble_context(
             logger.debug("Fusion applied (RSF): %s", fuse_reason)
         else:
             # BM25 is confident — skip fusion, use BM25 results only
-            signal_agreement_pre = 0.0
             fusion_skipped = True
             fusion_skip_reason = fuse_reason
             strategy = "bm25+graph"  # downgrade strategy label
             bm25_by_id = _normalized_scores(search_results)
             logger.debug("Fusion skipped: %s", fuse_reason)
     else:
-        signal_agreement_pre = 0.0
         bm25_by_id = _normalized_scores(search_results)
 
     if splade_results:
@@ -1343,7 +1367,15 @@ def assemble_context(
             candidate_list = [
                 (chunk, bm25_by_id.get(chunk.id, 0.0)) for chunk in candidate_map.values()
             ]
-            candidates_for_rerank = candidate_list[:rerank_candidate_limit]
+            resolved_rerank_limit, rerank_limit_reason = _resolve_rerank_candidate_limit(
+                candidate_list,
+                configured_limit=rerank_candidate_limit,
+                adaptive=adaptive_rerank_limit,
+                signal_agreement=signal_agreement_pre if vector_results else None,
+                bm25_cv=bm25_cv_val,
+                broad_query=intent == QueryIntent.CLI,
+            )
+            candidates_for_rerank = candidate_list[:resolved_rerank_limit]
             reranked = reranker.rerank(question, candidates_for_rerank, top_k=DEFAULT_TOP_K)
             for chunk_id, rerank_score in _normalized_rerank_scores(reranked).items():
                 bm25_by_id[chunk_id] = max(bm25_by_id.get(chunk_id, 0.0), rerank_score)
@@ -1356,6 +1388,9 @@ def assemble_context(
                         end_ns=rerank_end,
                         metadata={
                             "candidates_available": len(candidate_list),
+                            "candidate_limit_configured": rerank_candidate_limit,
+                            "candidate_limit_used": resolved_rerank_limit,
+                            "candidate_limit_reason": rerank_limit_reason,
                             "candidates_scored": len(candidates_for_rerank),
                             "candidates_returned": len(reranked),
                             "candidate_files_preserved": len(
@@ -1365,9 +1400,10 @@ def assemble_context(
                     )
                 )
             logger.debug(
-                "Cross-encoder reranked %d/%d candidates",
+                "Cross-encoder reranked %d/%d candidates (%s)",
                 len(candidates_for_rerank),
                 len(candidate_list),
+                rerank_limit_reason,
             )
 
     # --- Scoring phase ---
@@ -1377,8 +1413,9 @@ def assemble_context(
     centrality = graph.structural_centrality()
 
     # Signal agreement was computed pre-fusion; carry it forward for metadata
-    signal_agreement: float | None = signal_agreement_pre if vector_results else None
-
+    # Signal agreement is measured whenever a vector leg is present, regardless
+    # of whether fusion was later applied or skipped.
+    signal_agreement: float | None = signal_agreement_pre
     # Candidate file set for cohesion computation
     candidate_files = {c.file_path for c in candidate_map.values()}
 

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -630,6 +630,35 @@ class TestRunCommand:
         assert result.exit_code == 0
         assert captured["retrieval_options"] == BenchmarkRetrievalOptions(rerank_candidate_limit=3)
 
+    def test_run_passes_adaptive_rerank_limit_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(benchmark_cmd, ["run", "--adaptive-rerank-limit"])
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(
+            adaptive_rerank_limit=True
+        )
+
     def test_run_passes_rerank_model_flag(
         self,
         runner: CliRunner,

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -543,6 +543,93 @@ class TestRunCommand:
         assert result.exit_code == 0
         assert captured["retrieval_options"] == BenchmarkRetrievalOptions(embedder="coderank")
 
+    def test_run_passes_chunker_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(benchmark_cmd, ["run", "--chunker", "cast"])
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(chunker="cast")
+
+    def test_run_passes_strategy_chunker_flags(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(
+            benchmark_cmd,
+            ["run", "--bm25-chunker", "default", "--vector-chunker", "cast"],
+        )
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(
+            bm25_chunker="default",
+            vector_chunker="cast",
+        )
+
+    def test_run_passes_rerank_candidate_limit_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(benchmark_cmd, ["run", "--rerank-candidate-limit", "3"])
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(rerank_candidate_limit=3)
+
     def test_run_passes_rerank_model_flag(
         self,
         runner: CliRunner,

--- a/tests/benchmark/test_reporter.py
+++ b/tests/benchmark/test_reporter.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from archex.benchmark.models import BenchmarkReport, BenchmarkResult, Strategy, TaskCategory
 from archex.benchmark.reporter import (
     format_bucketed_summary,
+    format_chunker_frontier_table,
     format_json,
     format_markdown,
     format_strategy_comparison,
     format_summary,
 )
+
+if TYPE_CHECKING:
+    from archex.models import ChunkerName
 
 
 def _make_result(
@@ -21,6 +27,9 @@ def _make_result(
     tokens_input: int = 2000,
     tokens_output: int = 1000,
     token_efficiency: float = 0.5,
+    chunker: ChunkerName = "default",
+    index_chunk_count: int = 10,
+    mean_chunk_tokens: float = 50.0,
     category: TaskCategory | None = None,
 ) -> BenchmarkResult:
     return BenchmarkResult(
@@ -38,6 +47,9 @@ def _make_result(
         wall_time_ms=50.0,
         cached=False,
         timestamp="2025-01-01T00:00:00Z",
+        chunker=chunker,
+        index_chunk_count=index_chunk_count,
+        mean_chunk_tokens=mean_chunk_tokens,
         category=category,
     )
 
@@ -190,3 +202,41 @@ class TestFormatBucketedSummary:
         assert "external-framework (1 tasks)" in output
         assert "All Tasks (2 tasks)" in output
         assert "Seed Recall" in output
+
+
+class TestFormatChunkerFrontierTable:
+    def test_contains_quality_latency_and_granularity_axes(self) -> None:
+        baseline = _make_report(
+            [
+                _make_result(
+                    Strategy.ARCHEX_QUERY_FUSION_RERANK,
+                    recall=0.80,
+                    precision=0.40,
+                    token_efficiency=0.60,
+                    chunker="default",
+                    index_chunk_count=100,
+                    mean_chunk_tokens=80.0,
+                )
+            ]
+        )
+        candidate = _make_report(
+            [
+                _make_result(
+                    Strategy.ARCHEX_QUERY_FUSION_RERANK,
+                    recall=0.82,
+                    precision=0.42,
+                    token_efficiency=0.61,
+                    chunker="cast",
+                    index_chunk_count=120,
+                    mean_chunk_tokens=70.0,
+                )
+            ]
+        )
+
+        table = format_chunker_frontier_table([candidate], [baseline])
+
+        assert "Chunker Frontier Comparison" in table
+        assert "archex_query_fusion_rerank | default" in table
+        assert "archex_query_fusion_rerank | cast" in table
+        assert "Chunk Count" in table
+        assert "Mean Chunk Tokens" in table

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -251,7 +251,7 @@ class TestRunBenchmark:
         from archex.models import ContextBundle, IndexConfig
 
         task, repo_path = fixture_task
-        captured: list[tuple[str | None, bool, str | None]] = []
+        captured: list[tuple[str | None, bool, str | None, str, int]] = []
 
         def fake_query(
             _source: object,
@@ -264,7 +264,15 @@ class TestRunBenchmark:
         ) -> ContextBundle:
             del config
             del explicit_token_budget
-            captured.append((index_config.embedder, index_config.rerank, index_config.rerank_model))
+            captured.append(
+                (
+                    index_config.embedder,
+                    index_config.rerank,
+                    index_config.rerank_model,
+                    index_config.chunker,
+                    index_config.rerank_candidate_limit,
+                )
+            )
             return ContextBundle(
                 query=question,
                 chunks=[],
@@ -276,21 +284,26 @@ class TestRunBenchmark:
             runner_mod._warm_repo_index(  # pyright: ignore[reportPrivateUsage]
                 task,
                 repo_path,
-                BenchmarkRetrievalOptions(embedder="coderank"),
+                BenchmarkRetrievalOptions(
+                    embedder="coderank",
+                    vector_chunker="cast",
+                ),
             )
             runner_mod._warm_repo_index(  # pyright: ignore[reportPrivateUsage]
                 task,
                 repo_path,
                 BenchmarkRetrievalOptions(
                     embedder="coderank",
+                    vector_chunker="cast",
                     rerank_model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+                    rerank_candidate_limit=3,
                 ),
                 warm_rerank=True,
             )
 
         assert captured == [
-            ("coderank", False, None),
-            ("coderank", True, "cross-encoder/ms-marco-MiniLM-L-6-v2"),
+            ("coderank", False, None, "cast", 4),
+            ("coderank", True, "cross-encoder/ms-marco-MiniLM-L-6-v2", "cast", 3),
         ]
 
     def test_skips_warmup_for_raw_only_strategies(
@@ -446,7 +459,9 @@ class TestRunBenchmark:
             f"+max_seq={JINA_V2_MAX_SEQ_LENGTH}"
         )
         source = benchmark_repo_source(task, repo_path)
-        assert source.stable_identity == f"test/python_simple@HEAD#embedder={jina_identity}"
+        assert source.stable_identity == (
+            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=default"
+        )
 
         token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions(splade=True))
         try:
@@ -455,7 +470,7 @@ class TestRunBenchmark:
             reset_benchmark_retrieval_options(token)
 
         assert splade_source.stable_identity == (
-            f"test/python_simple@HEAD#embedder={jina_identity}+splade"
+            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=default+splade"
         )
 
         coderank_token = set_benchmark_retrieval_options(
@@ -466,6 +481,12 @@ class TestRunBenchmark:
         finally:
             reset_benchmark_retrieval_options(coderank_token)
 
+        cast_token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions(chunker="cast"))
+        try:
+            cast_source = benchmark_repo_source(task, repo_path)
+        finally:
+            reset_benchmark_retrieval_options(cast_token)
+
         scoped_token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions())
         scoped_task = task.model_copy(update={"include_paths": ["src", "tests"]})
         try:
@@ -474,10 +495,39 @@ class TestRunBenchmark:
             reset_benchmark_retrieval_options(scoped_token)
 
         assert scoped_source.stable_identity == (
-            f"test/python_simple@HEAD#scope=src|tests+embedder={jina_identity}"
+            f"test/python_simple@HEAD#scope=src|tests+embedder={jina_identity}+chunker=default"
+        )
+        assert cast_source.stable_identity == (
+            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=cast"
         )
 
-        assert coderank_source.stable_identity == "test/python_simple@HEAD#embedder=coderank"
+        assert coderank_source.stable_identity == (
+            "test/python_simple@HEAD#embedder=coderank+chunker=default"
+        )
+
+        split_token = set_benchmark_retrieval_options(
+            BenchmarkRetrievalOptions(bm25_chunker="default", vector_chunker="cast")
+        )
+        try:
+            split_bm25_source = benchmark_repo_source(
+                task,
+                repo_path,
+                strategy=Strategy.ARCHEX_QUERY,
+            )
+            split_vector_source = benchmark_repo_source(
+                task,
+                repo_path,
+                strategy=Strategy.ARCHEX_QUERY_FUSION,
+            )
+        finally:
+            reset_benchmark_retrieval_options(split_token)
+
+        assert split_bm25_source.stable_identity == (
+            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=default"
+        )
+        assert split_vector_source.stable_identity == (
+            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=cast"
+        )
 
     def test_benchmark_index_config_applies_module_prefilter_only_with_bm25(self) -> None:
         from archex.benchmark.strategies import (
@@ -514,6 +564,7 @@ class TestRunBenchmark:
         assert vector_config.embedder == "jina-v2"
         assert vector_config.rerank_model is None
         assert rerank_config.rerank_model == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+        assert bm25_config.chunker == "default"
         assert cache_enabled is True
 
 

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -511,6 +511,7 @@ class TestRunArchexQuery:
                 bm25_chunker="default",
                 vector_chunker="cast",
                 rerank_candidate_limit=3,
+                adaptive_rerank_limit=True,
             )
         )
         try:
@@ -528,6 +529,7 @@ class TestRunArchexQuery:
         assert bm25_config.chunker == "default"
         assert rerank_config.chunker == "cast"
         assert rerank_config.rerank_candidate_limit == 3
+        assert rerank_config.adaptive_rerank_limit is True
 
     def test_archex_scout_fetch_strategy(self, python_simple_repo: Path) -> None:
         from archex.scout import ScoutBudget, ScoutFetchPlan, ScoutFile, ScoutResult, symbol_handle

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -11,6 +11,7 @@ from archex.benchmark.models import BenchmarkRetrievalOptions, BenchmarkTask, St
 from archex.benchmark.strategies import (
     _archex_fields,  # pyright: ignore[reportPrivateUsage]
     _deduplicate_ranked,  # pyright: ignore[reportPrivateUsage]
+    benchmark_index_config,
     benchmark_repo_source,
     compute_bundle_completion_penalty,
     compute_map,
@@ -388,8 +389,12 @@ class TestRunArchexQuery:
         source_a = benchmark_repo_source(sample_task, repo_a)
         source_b = benchmark_repo_source(sample_task, repo_b)
 
-        assert source_a.stable_identity == f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}"
-        assert source_b.stable_identity == f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}"
+        assert source_a.stable_identity == (
+            f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}+chunker=default"
+        )
+        assert source_b.stable_identity == (
+            f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}+chunker=default"
+        )
         assert cache.cache_key(source_a) == cache.cache_key(source_b)
 
     def test_benchmark_source_resolves_missing_commit_from_git_head(
@@ -407,7 +412,9 @@ class TestRunArchexQuery:
         with patch.object(CacheManager, "git_head", return_value="resolved"):
             source = benchmark_repo_source(task, tmp_path)
 
-        assert source.stable_identity == (f"test/repo@resolved#embedder={JINA_V2_CACHE_IDENTITY}")
+        assert source.stable_identity == (
+            f"test/repo@resolved#embedder={JINA_V2_CACHE_IDENTITY}+chunker=default"
+        )
 
     def test_benchmark_source_rejects_missing_commit_without_git_head(
         self,
@@ -445,6 +452,82 @@ class TestRunArchexQuery:
         assert result.tokens_input >= 0
         assert result.tokens_output >= 0
         assert result.tokens_raw_baseline >= 0
+
+    def test_archex_query_reports_configured_chunker_metadata(
+        self,
+        python_simple_repo: Path,
+    ) -> None:
+        task = BenchmarkTask(
+            task_id="test",
+            repo="test/repo",
+            commit="abc",
+            question="How does the main module work?",
+            expected_files=["main.py"],
+            token_budget=4096,
+        )
+
+        token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions(bm25_chunker="cast"))
+        try:
+            result = run_archex_query(task, python_simple_repo)
+        finally:
+            reset_benchmark_retrieval_options(token)
+
+        assert result.chunker == "cast"
+        assert result.index_chunk_count > 0
+        assert result.mean_chunk_tokens > 0.0
+
+    def test_strategy_specific_chunkers_split_cache_identity(
+        self,
+        sample_task: BenchmarkTask,
+        tmp_path: Path,
+    ) -> None:
+        token = set_benchmark_retrieval_options(
+            BenchmarkRetrievalOptions(bm25_chunker="default", vector_chunker="cast")
+        )
+        try:
+            bm25_source = benchmark_repo_source(
+                sample_task,
+                tmp_path,
+                strategy=Strategy.ARCHEX_QUERY,
+            )
+            vector_source = benchmark_repo_source(
+                sample_task,
+                tmp_path,
+                strategy=Strategy.ARCHEX_QUERY_FUSION,
+            )
+        finally:
+            reset_benchmark_retrieval_options(token)
+
+        assert bm25_source.stable_identity is not None
+        assert vector_source.stable_identity is not None
+        assert bm25_source.stable_identity.endswith("chunker=default")
+        assert vector_source.stable_identity.endswith("chunker=cast")
+
+    def test_benchmark_index_config_uses_strategy_chunker_and_rerank_limit(self) -> None:
+        from archex.models import IndexConfig
+
+        token = set_benchmark_retrieval_options(
+            BenchmarkRetrievalOptions(
+                bm25_chunker="default",
+                vector_chunker="cast",
+                rerank_candidate_limit=3,
+            )
+        )
+        try:
+            bm25_config = benchmark_index_config(
+                IndexConfig(vector=False),
+                strategy=Strategy.ARCHEX_QUERY,
+            )
+            rerank_config = benchmark_index_config(
+                IndexConfig(vector=True, rerank=True),
+                strategy=Strategy.ARCHEX_QUERY_FUSION_RERANK,
+            )
+        finally:
+            reset_benchmark_retrieval_options(token)
+
+        assert bm25_config.chunker == "default"
+        assert rerank_config.chunker == "cast"
+        assert rerank_config.rerank_candidate_limit == 3
 
     def test_archex_scout_fetch_strategy(self, python_simple_repo: Path) -> None:
         from archex.scout import ScoutBudget, ScoutFetchPlan, ScoutFile, ScoutResult, symbol_handle

--- a/tests/index/test_chunker.py
+++ b/tests/index/test_chunker.py
@@ -24,6 +24,7 @@ from archex.models import (
     SymbolKind,
     Visibility,
 )
+from archex.pipeline.chunker import chunker_revision
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -640,6 +641,7 @@ def test_index_metadata_prevents_cross_chunker_cache_reuse(
     )
     try:
         assert default_store.get_metadata("chunker") == "default"
+        assert default_store.get_metadata("chunker_revision") == chunker_revision("default")
     finally:
         default_store.close()
 

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -1141,6 +1141,28 @@ def test_assemble_context_honors_reranker_default_top_k() -> None:
     assert reranker.seen_top_k == DEFAULT_TOP_K
 
 
+def test_assemble_context_honors_custom_rerank_candidate_limit() -> None:
+    graph = DependencyGraph()
+    chunks = [make_chunk(f"c{i}", f"f{i}.py", token_count=10) for i in range(DEFAULT_TOP_K + 5)]
+    for chunk in chunks:
+        graph.add_file_node(chunk.file_path)
+    search_results = [(chunk, float(DEFAULT_TOP_K + 5 - i)) for i, chunk in enumerate(chunks)]
+    reranker = RecordingReranker()
+
+    assemble_context(
+        search_results=search_results,
+        graph=graph,
+        all_chunks=chunks,
+        question="query",
+        token_budget=1000,
+        reranker=reranker,
+        rerank_candidate_limit=3,
+    )
+
+    assert reranker.seen_candidate_count == 3
+    assert reranker.seen_top_k == DEFAULT_TOP_K
+
+
 def test_assemble_context_reranker_preserves_candidates_outside_rerank_window() -> None:
     graph = DependencyGraph()
     distractors = [

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -8,6 +8,7 @@ import xml.etree.ElementTree as ET
 from archex.index.graph import DependencyGraph
 from archex.index.rerank import DEFAULT_TOP_K, RERANK_CANDIDATE_LIMIT, CrossEncoderReranker
 from archex.models import CodeChunk, ContextBundle, Module, SymbolKind
+from archex.observe import PipelineTrace
 from archex.serve.context import assemble_context
 from archex.serve.intent import INTENT_TOKEN_BUDGETS, QueryIntent
 from archex.serve.renderers.json import render_json
@@ -1161,6 +1162,111 @@ def test_assemble_context_honors_custom_rerank_candidate_limit() -> None:
 
     assert reranker.seen_candidate_count == 3
     assert reranker.seen_top_k == DEFAULT_TOP_K
+
+
+def test_assemble_context_adaptive_rerank_shrinks_low_agreement_narrow_window() -> None:
+    graph = DependencyGraph()
+    a1 = make_chunk("a1", "alpha.py", token_count=10)
+    a2 = make_chunk("a2", "alpha.py", token_count=10)
+    b1 = make_chunk("b1", "beta.py", token_count=10)
+    c1 = make_chunk("c1", "gamma.py", token_count=10)
+    d1 = make_chunk("d1", "delta.py", token_count=10)
+    e1 = make_chunk("e1", "epsilon.py", token_count=10)
+    chunks = [a1, a2, b1, c1, d1, e1]
+    for chunk in chunks:
+        graph.add_file_node(chunk.file_path)
+    search_results = [(a1, 10.0), (a2, 2.0), (b1, 1.0)]
+    vector_results = [(c1, 5.0), (d1, 4.0), (e1, 3.0)]
+    reranker = RecordingReranker()
+    trace = PipelineTrace(operation="query")
+
+    assemble_context(
+        search_results=search_results,
+        graph=graph,
+        all_chunks=chunks,
+        question="How does archex detect architectural patterns?",
+        token_budget=1000,
+        vector_results=vector_results,
+        reranker=reranker,
+        rerank_candidate_limit=3,
+        adaptive_rerank_limit=True,
+        apply_intent_budget=False,
+        trace=trace,
+    )
+
+    rerank = next(step for step in trace.steps if step.name == "rerank")
+    assert reranker.seen_candidate_count == 2
+    assert rerank.metadata["candidate_limit_used"] == 2
+    assert rerank.metadata["candidate_limit_reason"] == "low_agreement_high_lexical_concentration"
+
+
+def test_assemble_context_adaptive_rerank_preserves_broad_multi_file_window() -> None:
+    graph = DependencyGraph()
+    a1 = make_chunk("a1", "alpha.py", token_count=10)
+    b1 = make_chunk("b1", "beta.py", token_count=10)
+    c1 = make_chunk("c1", "gamma.py", token_count=10)
+    d1 = make_chunk("d1", "delta.py", token_count=10)
+    e1 = make_chunk("e1", "epsilon.py", token_count=10)
+    f1 = make_chunk("f1", "zeta.py", token_count=10)
+    chunks = [a1, b1, c1, d1, e1, f1]
+    for chunk in chunks:
+        graph.add_file_node(chunk.file_path)
+    search_results = [(a1, 10.0), (b1, 2.0), (c1, 1.0)]
+    vector_results = [(d1, 5.0), (e1, 4.0), (f1, 3.0)]
+    reranker = RecordingReranker()
+    trace = PipelineTrace(operation="query")
+
+    assemble_context(
+        search_results=search_results,
+        graph=graph,
+        all_chunks=chunks,
+        question="How does archex turn benchmark and dogfood results into a regression gate?",
+        token_budget=1000,
+        vector_results=vector_results,
+        reranker=reranker,
+        rerank_candidate_limit=3,
+        adaptive_rerank_limit=True,
+        apply_intent_budget=False,
+        trace=trace,
+    )
+
+    rerank = next(step for step in trace.steps if step.name == "rerank")
+    assert reranker.seen_candidate_count == 3
+    assert rerank.metadata["candidate_limit_used"] == 3
+    assert rerank.metadata["candidate_limit_reason"] == "broad_multi_file_window"
+
+
+def test_assemble_context_adaptive_rerank_does_not_treat_fusion_skip_as_low_agreement() -> None:
+    graph = DependencyGraph()
+    a1 = make_chunk("a1", "alpha.py", token_count=10)
+    b1 = make_chunk("b1", "beta.py", token_count=10)
+    c1 = make_chunk("c1", "gamma.py", token_count=10)
+    chunks = [a1, b1, c1]
+    for chunk in chunks:
+        graph.add_file_node(chunk.file_path)
+    search_results = [(a1, 10.0), (b1, 2.0), (c1, 1.0)]
+    vector_results = [(a1, 9.0), (b1, 1.5), (c1, 0.8)]
+    reranker = RecordingReranker()
+    trace = PipelineTrace(operation="query")
+
+    bundle = assemble_context(
+        search_results=search_results,
+        graph=graph,
+        all_chunks=chunks,
+        question="How does archex implement the query pipeline?",
+        token_budget=1000,
+        vector_results=vector_results,
+        reranker=reranker,
+        rerank_candidate_limit=3,
+        adaptive_rerank_limit=True,
+        apply_intent_budget=False,
+        trace=trace,
+    )
+
+    rerank = next(step for step in trace.steps if step.name == "rerank")
+    assert bundle.retrieval_metadata.signal_agreement == 1.0
+    assert reranker.seen_candidate_count == 3
+    assert rerank.metadata["candidate_limit_reason"] != "low_agreement_high_lexical_concentration"
 
 
 def test_assemble_context_reranker_preserves_candidates_outside_rerank_window() -> None:

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -18,6 +18,7 @@ from archex.parse.adapters import ADAPTERS
 from archex.parse.engine import TreeSitterEngine
 from archex.parse.imports import parse_imports
 from archex.parse.symbols import extract_symbols, extract_symbols_and_imports
+from archex.pipeline.chunker import chunker_revision
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -333,6 +334,8 @@ class TestQueryCacheSkipsParse:
         store.insert_edges([Edge(source="t.py", target="u.py", kind=EdgeKind.IMPORTS)])
         bm25 = BM25Index(store)
         bm25.build([chunk])
+        store.set_metadata("chunker", "default")
+        store.set_metadata("chunker_revision", chunker_revision("default"))
         store.conn.execute("PRAGMA wal_checkpoint(FULL)")
         store.close()
 


### PR DESCRIPTION
## Stack

Stack-Id: `c6-benchmark-stack`
Base: `main`
Position: 3/4

1. `feat/cast-chunker` -> #212
2. `feat/chunker-benchmark-arm` -> #213
3. `feat/adaptive-rerank-benchmark-policy` -> this PR
4. `feat/adaptive-fusion-benchmark-policy` -> #215

Depends on: #213
Upstack: #215

## Summary

- Adds the benchmark-only `--adaptive-rerank-limit` control.
- Records rerank candidate-limit decisions in query traces.
- Keeps runtime defaults unchanged unless benchmark retrieval options explicitly enable the heuristic.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright`
- `uv run pytest -q`
- Targeted smokes run before promoting the experiment