### PR TITLE
feat: add benchmark adaptive fusion policy

### DIFF
--- a/docs/RETRIEVAL_DEFAULT_DECISIONS.md
+++ b/docs/RETRIEVAL_DEFAULT_DECISIONS.md
@@ -62,6 +62,35 @@ uv run archex benchmark readiness --input .archex/e2e-rerank-tinybert --tasks-di
 uv run archex benchmark gate --input .archex/e2e-rerank-tinybert --warn-latency-ms 3000
 ```
 
+
+## Chunker decision
+
+Candidate chunkers:
+
+| Candidate | Benchmark flag | Decision role |
+| --- | --- | --- |
+| `default` | `--chunker default` | Current index chunker; keep unless the candidate wins the full frontier |
+| `cast` | `--chunker cast` | Recursive AST split + greedy sibling merge candidate |
+
+Switch from `default` to `cast` only when the clean local run shows the same retrieval strategy improving F1, holding recall flat or better, keeping token efficiency at least flat, and staying within the `3000 ms` p95 budget. Chunk count and mean chunk tokens are diagnostic only; they explain the granularity shift but do not override the quality, efficiency, and latency rules.
+
+2026-06-13 rerun after the benchmark metadata fix and cast merge-budget retune: keep `default`. On `archex_query_fusion_rerank`, `default` scored recall `0.867`, precision `0.570`, F1 `0.672`, token efficiency `0.679`, and p95 `3029 ms`; `cast` scored recall `0.877`, precision `0.581`, F1 `0.684`, token efficiency `0.693`, and p95 `3213 ms`. The candidate now wins on quality and token efficiency, and its granularity is materially tighter than the first cast attempt (`1015` mean index chunks at `302.8` tokens vs the prior `769` at `385.7`), but it still misses the `<= 3000 ms` latency budget and remains slower than `default` at p95.
+
+The rerun fixed the earlier measurement defect: `archex_query` rows now report `chunker=cast` with non-zero chunk metadata, and stale cached stores are invalidated on `chunker_revision` mismatches before reuse. Even with that fix, `archex_query` itself still regresses versus `default` on recall (`0.872` vs `0.907`), F1 (`0.669` vs `0.687`), token efficiency (`0.728` vs `0.759`), and p95 (`2231 ms` vs `1723 ms`), so the current BM25-only default path should not change.
+
+The same gate still failed on `11` recall regressions against the default baseline, concentrated in `archex_benchmark_gate_lifecycle`, `archex_mcp_query_lifecycle`, `archex_pattern_detection`, `django_middleware`, `mini_redis_async`, and `rust_tokio_runtime`. `cast` is closer to the default-switch bar than the first run, but it is still not a full-frontier winner.
+
+
+Follow-up experiment, 2026-06-14: a tighter cast merge budget (`3755` total cast chunks at `279.0` mean tokens on the local repo before benchmark packing, versus the prior `3236` at `323.7`) improved targeted smoke runs on the fusion paths, but failed the full rerun and was not kept. The full cast rerun moved `archex_query_fusion_rerank` to recall `0.883`, precision `0.587`, F1 `0.689`, token efficiency `0.708`, and p95 `3681 ms`; `archex_query` fell further to recall `0.851`, precision `0.555`, F1 `0.656`, token efficiency `0.747`, and p95 `2543 ms`. The gate still failed on `11` baseline regressions, including new `archex_query` losses on `archex_adapter_registry` and `archex_benchmark_gate_lifecycle`.
+
+Interpretation: one global cast granularity is still trading BM25 recall against fusion quality/efficiency. The tighter merge budget helped the vector-assisted paths but degraded the BM25-only path and pushed rerank p95 farther above budget. Keep the earlier cast tuning as the best candidate state on this branch; a materially better result likely needs a different design, such as strategy-specific chunking or a hybrid chunk inventory, not another blind global budget tweak.
+Operator commands:
+
+```bash
+uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --chunker default --tasks-dir benchmarks/tasks --output .archex/e2e-chunk-default
+uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --chunker cast --tasks-dir benchmarks/tasks --output .archex/e2e-chunk-cast
+uv run archex benchmark gate --input .archex/e2e-chunk-cast --baseline .archex/e2e-chunk-default --warn-latency-ms 3000
+```
 ## Product strategy decision
 
 Candidate product defaults:

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1816,6 +1816,7 @@ def query(
                     reranker=_reranker,
                     rerank_candidate_limit=index_config.rerank_candidate_limit,
                     adaptive_rerank_limit=index_config.adaptive_rerank_limit,
+                    adaptive_fusion_policy=index_config.adaptive_fusion_policy,
                     apply_intent_budget=False,
                 )
                 bundle.retrieval_metadata.vector_mode = index_config.vector_mode
@@ -2187,6 +2188,7 @@ def query(
                 reranker=_reranker_miss,
                 rerank_candidate_limit=index_config.rerank_candidate_limit,
                 adaptive_rerank_limit=index_config.adaptive_rerank_limit,
+                adaptive_fusion_policy=index_config.adaptive_fusion_policy,
                 apply_intent_budget=False,
             )
             bundle.retrieval_metadata.vector_mode = index_config.vector_mode

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -148,6 +148,7 @@ class BenchmarkRetrievalOptions(BaseModel):
     vector_chunker: ChunkerName | None = None
     rerank_candidate_limit: int | None = None
     adaptive_rerank_limit: bool = False
+    adaptive_fusion_policy: bool = False
 
 
 class ExternalToolCommandConfig(BenchmarkSpecModel):

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -694,6 +694,8 @@ def benchmark_index_config(
         updates["splade"] = True
     if options.module_prefilter and index_config.bm25:
         updates["module_prefilter"] = True
+    if index_config.vector and options.adaptive_fusion_policy:
+        updates["adaptive_fusion_policy"] = True
     if index_config.rerank and options.rerank_model is not None:
         updates["rerank_model"] = options.rerank_model
     if index_config.rerank and options.rerank_candidate_limit is not None:

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -182,6 +182,14 @@ def benchmark_cmd() -> None:
     ),
 )
 @click.option(
+    "--adaptive-fusion-policy/--no-adaptive-fusion-policy",
+    default=False,
+    help=(
+        "Benchmark-only policy: rebalance BM25/vector fusion for query families where "
+        "the default fusion weights over-amplify vector novelty."
+    ),
+)
+@click.option(
     "--self-only",
     is_flag=True,
     default=False,
@@ -211,6 +219,7 @@ def run_cmd(
     rerank_model: str | None,
     rerank_candidate_limit: int | None,
     adaptive_rerank_limit: bool,
+    adaptive_fusion_policy: bool,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -242,6 +251,7 @@ def run_cmd(
         vector_chunker=vector_chunker,
         rerank_candidate_limit=rerank_candidate_limit,
         adaptive_rerank_limit=adaptive_rerank_limit,
+        adaptive_fusion_policy=adaptive_fusion_policy,
     )
     warmed_models = warm_benchmark_models(strategies, retrieval_options)
     if warmed_models:

--- a/src/archex/index/fusion.py
+++ b/src/archex/index/fusion.py
@@ -7,6 +7,8 @@ that decides whether fusion adds value for a given query.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -30,6 +32,90 @@ def bm25_score_cv(bm25_results: list[tuple[CodeChunk, float]], top_n: int = 10) 
     if mean < 1e-9:
         return 0.0
     return float(arr.std() / mean)
+
+
+@dataclass(frozen=True)
+class FusionPolicyDecision:
+    should_fuse: bool
+    reason: str
+    bm25_weight: float | None = None
+    vector_weight: float | None = None
+
+
+def _signal_agreement(
+    bm25_results: list[tuple[CodeChunk, float]],
+    vector_results: list[tuple[CodeChunk, float]],
+    *,
+    top_n: int = 20,
+) -> float:
+    bm25_top = {chunk.file_path for chunk, _ in bm25_results[:top_n]}
+    vec_top = {chunk.file_path for chunk, _ in vector_results[:top_n]}
+    union = bm25_top | vec_top
+    return len(bm25_top & vec_top) / len(union) if union else 0.0
+
+
+def _non_code_file_count(results: list[tuple[CodeChunk, float]], *, top_n: int = 5) -> int:
+    non_code_suffixes = {".json", ".md", ".rst", ".toml", ".txt", ".yaml", ".yml"}
+    return sum(
+        1
+        for chunk, _ in results[:top_n]
+        if Path(chunk.file_path).suffix.lower() in non_code_suffixes
+    )
+
+
+def resolve_fusion_policy(
+    bm25_results: list[tuple[CodeChunk, float]],
+    vector_results: list[tuple[CodeChunk, float]],
+    *,
+    avg_idf: float | None = None,
+    adaptive: bool = False,
+    query_intent: str | None = None,
+) -> FusionPolicyDecision:
+    should_apply, reason = should_fuse(bm25_results, vector_results, avg_idf=avg_idf)
+    if not should_apply or not adaptive:
+        return FusionPolicyDecision(should_fuse=should_apply, reason=reason)
+
+    signal_agreement = _signal_agreement(bm25_results, vector_results)
+    bm25_cv = bm25_score_cv(bm25_results)
+    vector_non_code = _non_code_file_count(vector_results)
+    bm25_non_code = _non_code_file_count(bm25_results)
+
+    if query_intent == "architecture_broad" and signal_agreement <= 0.25 and bm25_cv >= 0.30:
+        return FusionPolicyDecision(
+            should_fuse=True,
+            reason=(
+                f"adaptive_architecture_bm25_bias:cv={bm25_cv:.3f},agreement={signal_agreement:.3f}"
+            ),
+            bm25_weight=0.65,
+            vector_weight=0.35,
+        )
+
+    if (
+        query_intent == "architecture_broad"
+        and not reason.startswith("low_idf_force_fusion")
+        and signal_agreement >= 0.4
+        and bm25_cv <= 0.15
+        and vector_non_code > 0
+        and vector_non_code >= bm25_non_code
+    ):
+        return FusionPolicyDecision(
+            should_fuse=False,
+            reason=(
+                "adaptive_architecture_skip_non_code_vector:"
+                f"cv={bm25_cv:.3f},agreement={signal_agreement:.3f},"
+                f"vector_non_code={vector_non_code}"
+            ),
+        )
+
+    if query_intent == "general" and signal_agreement <= 0.05 and bm25_cv >= 0.25:
+        return FusionPolicyDecision(
+            should_fuse=True,
+            reason=(f"adaptive_general_balance:cv={bm25_cv:.3f},agreement={signal_agreement:.3f}"),
+            bm25_weight=0.50,
+            vector_weight=0.50,
+        )
+
+    return FusionPolicyDecision(should_fuse=True, reason=reason)
 
 
 def should_fuse(
@@ -220,12 +306,17 @@ def adaptive_rsf(
     vector_results: list[tuple[CodeChunk, float]],
     signal_agreement: float,
     bm25_cv: float,
+    *,
+    weight_override: tuple[float, float] | None = None,
 ) -> tuple[list[tuple[CodeChunk, float]], float, float]:
     """Fuse BM25 and vector results using RSF with adaptive weights.
 
     Combines RSF's score-magnitude preservation with confidence-aware
     weight scheduling. Returns (fused_results, bm25_weight, vector_weight).
     """
-    bm25_weight, vector_weight = adaptive_rsf_weights(signal_agreement, bm25_cv)
+    if weight_override is None:
+        bm25_weight, vector_weight = adaptive_rsf_weights(signal_agreement, bm25_cv)
+    else:
+        bm25_weight, vector_weight = weight_override
     fused = relative_score_fusion(bm25_results, vector_results, bm25_weight, vector_weight)
     return fused, bm25_weight, vector_weight

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -164,6 +164,7 @@ class IndexConfig(BaseModel):
     rerank_model: str | None = None
     rerank_candidate_limit: int = 4
     adaptive_rerank_limit: bool = False
+    adaptive_fusion_policy: bool = False
     chunker: ChunkerName = "default"
     chunk_max_tokens: int = 500
     chunk_min_tokens: int = 50

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -932,6 +932,7 @@ def assemble_context(
     reranker: object | None = None,
     rerank_candidate_limit: int = 4,
     adaptive_rerank_limit: bool = False,
+    adaptive_fusion_policy: bool = False,
     apply_intent_budget: bool = True,
 ) -> ContextBundle:
     """Assemble a token-budgeted ContextBundle from search results and a dependency graph.
@@ -983,37 +984,77 @@ def assemble_context(
     effective_splade: list[tuple[CodeChunk, float]] = []
     base_results = search_results
     if vector_results:
-        from archex.index.fusion import adaptive_rsf, bm25_score_cv, should_fuse
+        from archex.index.fusion import (
+            FusionPolicyDecision,
+            adaptive_rsf,
+            bm25_score_cv,
+            resolve_fusion_policy,
+        )
 
+        fusion_start = time.perf_counter_ns()
         _k_agree = 20
         _bm25_top_k = {chunk.file_path for chunk, _ in search_results[:_k_agree]}
         _vec_top_k = {chunk.file_path for chunk, _ in vector_results[:_k_agree]}
         _union = _bm25_top_k | _vec_top_k
         signal_agreement_pre = len(_bm25_top_k & _vec_top_k) / len(_union) if _union else 0.0
-
-        # Gate fusion: skip when BM25 is confident and signals agree.
-        # Always fuse when BM25 is empty — vector is the only signal.
-        fuse, fuse_reason = should_fuse(search_results, vector_results, avg_idf=avg_idf)
         bm25_cv_val = bm25_score_cv(search_results)
+        fusion_decision = resolve_fusion_policy(
+            search_results,
+            vector_results,
+            avg_idf=avg_idf,
+            adaptive=adaptive_fusion_policy,
+            query_intent=str(intent),
+        )
+        if not search_results and not fusion_decision.should_fuse:
+            fusion_decision = FusionPolicyDecision(True, "vector_only_force_fusion")
 
-        if fuse or not search_results:
-            # RSF preserves score magnitude (unlike RRF which flattens to
-            # rank-based 1/(k+rank)). Adaptive weights give vector meaningful
-            # influence so unique vector hits can surface.
+        if fusion_decision.should_fuse:
+            weight_override = None
+            if (
+                fusion_decision.bm25_weight is not None
+                and fusion_decision.vector_weight is not None
+            ):
+                weight_override = (
+                    fusion_decision.bm25_weight,
+                    fusion_decision.vector_weight,
+                )
             merged, fusion_bm25_weight, fusion_vector_weight = adaptive_rsf(
-                search_results, vector_results, signal_agreement_pre, bm25_cv_val
+                search_results,
+                vector_results,
+                signal_agreement_pre,
+                bm25_cv_val,
+                weight_override=weight_override,
             )
             base_results = merged
             bm25_by_id = _normalized_scores(merged)
             effective_vector = vector_results
-            logger.debug("Fusion applied (RSF): %s", fuse_reason)
+            logger.debug("Fusion applied (RSF): %s", fusion_decision.reason)
         else:
-            # BM25 is confident — skip fusion, use BM25 results only
             fusion_skipped = True
-            fusion_skip_reason = fuse_reason
-            strategy = "bm25+graph"  # downgrade strategy label
+            fusion_skip_reason = fusion_decision.reason
+            strategy = "bm25+graph"
             bm25_by_id = _normalized_scores(search_results)
-            logger.debug("Fusion skipped: %s", fuse_reason)
+            logger.debug("Fusion skipped: %s", fusion_decision.reason)
+
+        if trace is not None:
+            fusion_metadata: dict[str, str | int | float | bool] = {
+                "adaptive": adaptive_fusion_policy,
+                "applied": not fusion_skipped,
+                "reason": fusion_decision.reason,
+                "signal_agreement": signal_agreement_pre,
+                "bm25_cv": bm25_cv_val,
+            }
+            if fusion_bm25_weight is not None and fusion_vector_weight is not None:
+                fusion_metadata["bm25_weight"] = fusion_bm25_weight
+                fusion_metadata["vector_weight"] = fusion_vector_weight
+            trace.add_step(
+                StepTiming(
+                    name="fusion",
+                    start_ns=fusion_start,
+                    end_ns=time.perf_counter_ns(),
+                    metadata=fusion_metadata,
+                )
+            )
     else:
         bm25_by_id = _normalized_scores(search_results)
 

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -659,6 +659,35 @@ class TestRunCommand:
             adaptive_rerank_limit=True
         )
 
+    def test_run_passes_adaptive_fusion_policy_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(benchmark_cmd, ["run", "--adaptive-fusion-policy"])
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(
+            adaptive_fusion_policy=True
+        )
+
     def test_run_passes_rerank_model_flag(
         self,
         runner: CliRunner,

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -512,6 +512,7 @@ class TestRunArchexQuery:
                 vector_chunker="cast",
                 rerank_candidate_limit=3,
                 adaptive_rerank_limit=True,
+                adaptive_fusion_policy=True,
             )
         )
         try:
@@ -530,6 +531,7 @@ class TestRunArchexQuery:
         assert rerank_config.chunker == "cast"
         assert rerank_config.rerank_candidate_limit == 3
         assert rerank_config.adaptive_rerank_limit is True
+        assert rerank_config.adaptive_fusion_policy is True
 
     def test_archex_scout_fetch_strategy(self, python_simple_repo: Path) -> None:
         from archex.scout import ScoutBudget, ScoutFetchPlan, ScoutFile, ScoutResult, symbol_handle

--- a/tests/index/test_fusion.py
+++ b/tests/index/test_fusion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from archex.index.fusion import (
+    FusionPolicyDecision,
     adaptive_rsf,
     adaptive_rsf_weights,
     bm25_score_cv,
@@ -12,6 +13,7 @@ from archex.index.fusion import (
     normalize_scores,
     reciprocal_rank_fusion,
     relative_score_fusion,
+    resolve_fusion_policy,
     should_fuse,
 )
 from archex.models import CodeChunk, SymbolKind
@@ -209,6 +211,117 @@ class TestAdaptiveRSFWeights:
             for cv in [0.1, 0.3, 0.5, 0.8]:
                 bw, vw = adaptive_rsf_weights(agreement, cv)
                 assert bw + vw == pytest.approx(1.0)  # pyright: ignore[reportUnknownMemberType]
+
+
+class TestResolveFusionPolicy:
+    def test_default_policy_defers_to_should_fuse(self) -> None:
+        bm25 = _results([("a", "a.py", 5.0), ("b", "b.py", 4.9), ("c", "c.py", 4.8)])
+        vec = _results([("x", "x.py", 0.9), ("y", "y.py", 0.8), ("z", "z.py", 0.7)])
+        decision = resolve_fusion_policy(bm25, vec)
+        assert decision == FusionPolicyDecision(True, "fusion_needed:cv=0.017,agreement=0.000")
+
+    def test_architecture_policy_biases_bm25_when_vector_is_non_code_heavy(self) -> None:
+        bm25 = _results(
+            [
+                ("a", "src/archex/analyze/patterns.py", 5.0),
+                ("b", "src/archex/models.py", 4.9),
+                ("c", "benchmarks/tasks/archex_pattern_detection.yaml", 4.8),
+            ]
+        )
+        vec = _results(
+            [
+                ("x", "docs/OVERVIEW.md", 0.9),
+                ("y", "src/archex/models.py", 0.8),
+                ("z", "src/archex/analyze/patterns.py", 0.7),
+            ]
+        )
+        decision = resolve_fusion_policy(
+            bm25,
+            vec,
+            adaptive=True,
+            query_intent="architecture_broad",
+        )
+        assert not decision.should_fuse
+        assert decision.bm25_weight is None
+        assert decision.vector_weight is None
+        assert decision.reason.startswith("adaptive_architecture_skip_non_code_vector:")
+
+    def test_architecture_skip_does_not_override_low_idf_force_fusion(self) -> None:
+        bm25 = _results(
+            [
+                ("a", "src/archex/analyze/patterns.py", 5.0),
+                ("b", "src/archex/models.py", 4.9),
+                ("c", "benchmarks/tasks/archex_pattern_detection.yaml", 4.8),
+            ]
+        )
+        vec = _results(
+            [
+                ("x", "docs/OVERVIEW.md", 0.9),
+                ("y", "src/archex/models.py", 0.8),
+                ("z", "src/archex/analyze/patterns.py", 0.7),
+            ]
+        )
+        decision = resolve_fusion_policy(
+            bm25,
+            vec,
+            avg_idf=1.0,
+            adaptive=True,
+            query_intent="architecture_broad",
+        )
+        assert decision.should_fuse
+        assert decision.reason.startswith("low_idf_force_fusion:")
+
+    def test_architecture_policy_can_bias_bm25_without_skipping(self) -> None:
+        bm25 = _results(
+            [
+                ("a", "src/archex/analyze/patterns.py", 10.0),
+                ("b", "src/archex/models.py", 2.0),
+                ("c", "benchmarks/tasks/archex_pattern_detection.yaml", 1.0),
+            ]
+        )
+        vec = _results(
+            [
+                ("x", "docs/OVERVIEW.md", 0.9),
+                ("y", "benchmarks/arch_tasks/python_patterns.yaml", 0.8),
+                ("z", "src/archex/analyze/patterns.py", 0.7),
+            ]
+        )
+        decision = resolve_fusion_policy(
+            bm25,
+            vec,
+            adaptive=True,
+            query_intent="architecture_broad",
+        )
+        assert decision.should_fuse
+        assert decision.bm25_weight == 0.65
+        assert decision.vector_weight == 0.35
+        assert decision.reason.startswith("adaptive_architecture_bm25_bias:")
+
+    def test_general_policy_balances_non_code_vector_disagreement(self) -> None:
+        bm25 = _results(
+            [
+                ("a", "src/archex/benchmark/gate.py", 10.0),
+                ("b", "src/archex/benchmark/reporter.py", 2.0),
+                ("c", "src/archex/benchmark/baseline.py", 1.0),
+            ]
+        )
+        vec = _results(
+            [
+                ("x", "benchmarks/baseline.json", 0.9),
+                ("y", "docs/OVERVIEW.md", 0.8),
+                ("z", "src/archex/dogfood.py", 0.7),
+            ]
+        )
+        decision = resolve_fusion_policy(
+            bm25,
+            vec,
+            adaptive=True,
+            query_intent="general",
+        )
+        assert decision.should_fuse
+        assert decision.bm25_weight == 0.50
+        assert decision.vector_weight == 0.50
+        assert decision.reason.startswith("adaptive_general_balance:")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -1072,6 +1072,111 @@ def test_fusion_weights_reflect_high_agreement() -> None:
     assert meta.fusion_vector_weight == 0.40
 
 
+def test_adaptive_fusion_policy_biases_architecture_queries_toward_bm25() -> None:
+    graph = DependencyGraph()
+    chunks = [
+        make_chunk("a", "src/archex/analyze/patterns.py", token_count=10),
+        make_chunk("b", "src/archex/models.py", token_count=10),
+        make_chunk("c", "benchmarks/tasks/archex_pattern_detection.yaml", token_count=10),
+        make_chunk("d", "docs/OVERVIEW.md", token_count=10),
+        make_chunk("e", "benchmarks/arch_tasks/python_patterns.yaml", token_count=10),
+    ]
+    for chunk in chunks:
+        graph.add_file_node(chunk.file_path)
+    bm25_results = [(chunks[0], 5.0), (chunks[1], 4.9), (chunks[2], 4.8)]
+    vec_results = [(chunks[3], 0.9), (chunks[1], 0.8), (chunks[0], 0.7)]
+    trace = PipelineTrace(operation="query")
+
+    bundle = assemble_context(
+        bm25_results,
+        graph,
+        chunks,
+        "How does archex detect architectural patterns?",
+        token_budget=1000,
+        vector_results=vec_results,
+        trace=trace,
+        adaptive_fusion_policy=False,
+        apply_intent_budget=False,
+    )
+
+    fusion = next(step for step in trace.steps if step.name == "fusion")
+    assert not bundle.retrieval_metadata.fusion_skipped
+    assert bundle.retrieval_metadata.fusion_bm25_weight == 0.40
+    assert fusion.metadata["adaptive"] is False
+
+
+def test_adaptive_fusion_policy_records_bm25_biased_fusion_trace() -> None:
+    graph = DependencyGraph()
+    chunks = [
+        make_chunk("a", "src/archex/analyze/patterns.py", token_count=10),
+        make_chunk("b", "src/archex/models.py", token_count=10),
+        make_chunk("c", "benchmarks/tasks/archex_pattern_detection.yaml", token_count=10),
+        make_chunk("d", "docs/OVERVIEW.md", token_count=10),
+        make_chunk("e", "benchmarks/arch_tasks/python_patterns.yaml", token_count=10),
+    ]
+    for chunk in chunks:
+        graph.add_file_node(chunk.file_path)
+    bm25_results = [(chunks[0], 5.0), (chunks[1], 4.9), (chunks[2], 4.8)]
+    vec_results = [(chunks[3], 0.9), (chunks[1], 0.8), (chunks[0], 0.7)]
+    trace = PipelineTrace(operation="query")
+
+    bundle = assemble_context(
+        bm25_results,
+        graph,
+        chunks,
+        "How does archex detect architectural patterns?",
+        token_budget=1000,
+        vector_results=vec_results,
+        trace=trace,
+        adaptive_fusion_policy=True,
+        apply_intent_budget=False,
+    )
+
+    fusion = next(step for step in trace.steps if step.name == "fusion")
+    reason = fusion.metadata["reason"]
+    assert isinstance(reason, str)
+    assert bundle.retrieval_metadata.fusion_skipped
+    assert bundle.retrieval_metadata.fusion_bm25_weight is None
+    assert fusion.metadata["adaptive"] is True
+    assert reason.startswith("adaptive_architecture_skip_non_code_vector:")
+
+
+def test_adaptive_fusion_policy_biases_low_agreement_architecture_query() -> None:
+    graph = DependencyGraph()
+    chunks = [
+        make_chunk("a", "src/archex/analyze/patterns.py", token_count=10),
+        make_chunk("b", "src/archex/models.py", token_count=10),
+        make_chunk("c", "benchmarks/tasks/archex_pattern_detection.yaml", token_count=10),
+        make_chunk("d", "docs/OVERVIEW.md", token_count=10),
+        make_chunk("e", "benchmarks/arch_tasks/python_patterns.yaml", token_count=10),
+    ]
+    for chunk in chunks:
+        graph.add_file_node(chunk.file_path)
+    bm25_results = [(chunks[0], 10.0), (chunks[1], 2.0), (chunks[2], 1.0)]
+    vec_results = [(chunks[3], 0.9), (chunks[4], 0.8), (chunks[0], 0.7)]
+    trace = PipelineTrace(operation="query")
+
+    bundle = assemble_context(
+        bm25_results,
+        graph,
+        chunks,
+        "How does archex detect architectural patterns?",
+        token_budget=1000,
+        vector_results=vec_results,
+        trace=trace,
+        adaptive_fusion_policy=True,
+        apply_intent_budget=False,
+    )
+
+    fusion = next(step for step in trace.steps if step.name == "fusion")
+    reason = fusion.metadata["reason"]
+    assert isinstance(reason, str)
+    assert not bundle.retrieval_metadata.fusion_skipped
+    assert bundle.retrieval_metadata.fusion_bm25_weight == 0.65
+    assert bundle.retrieval_metadata.fusion_vector_weight == 0.35
+    assert reason.startswith("adaptive_architecture_bm25_bias:")
+
+
 # ---------------------------------------------------------------------------
 # Vector-seed retrieval tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stack

Stack-Id: `c6-benchmark-stack`
Base: `main`
Position: 4/4

1. `feat/cast-chunker` -> #212
2. `feat/chunker-benchmark-arm` -> #213
3. `feat/adaptive-rerank-benchmark-policy` -> #214
4. `feat/adaptive-fusion-benchmark-policy` -> this PR

Depends on: #214
Upstack: none

## Summary

- Adds the benchmark-only `--adaptive-fusion-policy` control.
- Adds fusion-policy trace metadata and coverage for adaptive skip/bias branches.
- Carries the current chunker decision record state from the previous unsplit branch.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright`
- `uv run pytest -q`
- Targeted smokes run before promoting the experiment