### PR TITLE
feat: add file-first benchmark ranking

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1548,6 +1548,7 @@ def query_dual_leg_benchmark(
             vector_mode=vector_index_config.vector_mode,
             surrogate_version=vector_index_config.surrogate_version,
         )
+        vector_search_start = time.perf_counter()
         vector_results = _vector_search_precomputed(
             vector_npz,
             vector_chunks,
@@ -1555,6 +1556,7 @@ def query_dual_leg_benchmark(
             vector_index_config,
             vector_top_k,
         )
+        used_precomputed_vector = vector_results is not None
         if vector_results is None and vector_index_config.vector:
             vector_results = _vector_search_in_memory(
                 question,
@@ -1575,7 +1577,8 @@ def query_dual_leg_benchmark(
         if timing is not None:
             timing.search_ms = _elapsed_ms(search_start)
             timing.vector_used = bool(projected_vector_results)
-            timing.vector_build_ms = _elapsed_ms(search_start)
+            if used_precomputed_vector:
+                timing.vector_build_ms = _elapsed_ms(vector_search_start)
         if trace is not None:
             trace.add_step(
                 StepTiming(
@@ -1607,6 +1610,7 @@ def query_dual_leg_benchmark(
             avg_idf=bm25.avg_idf(question) if projected_vector_results else None,
             reranker=_maybe_reranker(vector_index_config),
             rerank_candidate_limit=vector_index_config.rerank_candidate_limit,
+            prefer_code_files=True,
             apply_intent_budget=False,
         )
         bundle.retrieval_metadata.vector_mode = vector_index_config.vector_mode

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from archex.models import (
@@ -110,6 +111,16 @@ def _is_support_file(file_path: str, query_terms: set[str]) -> bool:
     if any(marker in lower_path for marker in _SUPPORT_PATH_MARKERS):
         return not query_terms & _SUPPORT_QUERY_TERMS
     return False
+
+
+def _is_file_first_support_artifact(file_path: str) -> bool:
+    lower_path = file_path.lower()
+    if _is_test_file(lower_path):
+        return True
+    if lower_path.startswith(("docs/", "benchmarks/", ".github/")):
+        return True
+    suffix = Path(lower_path).suffix
+    return suffix in {".json", ".md", ".rst", ".toml", ".txt", ".yaml", ".yml"}
 
 
 def _type_definitions(chunks: list[RankedChunk]) -> list[TypeDefinition]:
@@ -550,6 +561,32 @@ def _aggregate_file_scores(ranked: list[RankedChunk]) -> dict[str, float]:
     return aggregated
 
 
+def _adjust_file_scores_code_first(
+    file_scores: dict[str, float],
+    *,
+    lexical_files: set[str],
+    semantic_files: set[str],
+) -> dict[str, float]:
+    adjusted: dict[str, float] = {}
+    for file_path, score in file_scores.items():
+        lexical = file_path in lexical_files
+        semantic = file_path in semantic_files
+        if _is_file_first_support_artifact(file_path):
+            adjusted[file_path] = score * (0.10 if semantic and not lexical else 0.20)
+            continue
+        if lexical and semantic:
+            adjusted[file_path] = score * 1.15
+            continue
+        if lexical:
+            adjusted[file_path] = score * 1.10
+            continue
+        if semantic:
+            adjusted[file_path] = score * 1.05
+            continue
+        adjusted[file_path] = score
+    return adjusted
+
+
 def _nested_included_range(
     chunk: CodeChunk,
     included_ranges: dict[str, list[tuple[int, int]]],
@@ -605,6 +642,7 @@ def _pack_ranked_chunks(
     top_files: set[str],
     token_budget: int,
     max_chunks_per_file: int | None = None,
+    prefer_file_rank_order: bool = False,
 ) -> tuple[list[RankedChunk], int]:
     included: list[RankedChunk] = []
     included_ids: set[str] = set()
@@ -620,12 +658,13 @@ def _pack_ranked_chunks(
         for file_path, _score in sorted_files
         if file_path in top_files and file_path in best_by_file
     ]
-    ordered_files.sort(
-        key=lambda file_path: (
-            _is_test_file(file_path),
-            -best_by_file[file_path].final_score,
+    if not prefer_file_rank_order:
+        ordered_files.sort(
+            key=lambda file_path: (
+                _is_test_file(file_path),
+                -best_by_file[file_path].final_score,
+            )
         )
-    )
     for file_path in ordered_files:
         total_tokens = _try_include_ranked_chunk(
             best_by_file[file_path],
@@ -904,6 +943,7 @@ def assemble_context(
     avg_idf: float | None = None,
     reranker: object | None = None,
     rerank_candidate_limit: int = 4,
+    prefer_code_files: bool = False,
     apply_intent_budget: bool = True,
 ) -> ContextBundle:
     """Assemble a token-budgeted ContextBundle from search results and a dependency graph.
@@ -1452,13 +1492,28 @@ def assemble_context(
     # relevant chunks does not swamp a file with one or two highly relevant
     # chunks. The strongest chunk keeps full weight; each later chunk halves.
     file_agg = _aggregate_file_scores(ranked)
-    sorted_files = sorted(file_agg.items(), key=lambda x: -x[1])
-    top_file_score = sorted_files[0][1] if sorted_files else 0.0
+    if prefer_code_files:
+        file_agg = _adjust_file_scores_code_first(
+            file_agg,
+            lexical_files={chunk.file_path for chunk, _ in search_results},
+            semantic_files={chunk.file_path for chunk, _ in effective_vector},
+        )
+    score_sorted_files = sorted(file_agg.items(), key=lambda x: -x[1])
+    sorted_files = score_sorted_files
+    if prefer_code_files:
+        code_files = [
+            item for item in score_sorted_files if not _is_file_first_support_artifact(item[0])
+        ]
+        support_files = [
+            item for item in score_sorted_files if _is_file_first_support_artifact(item[0])
+        ]
+        sorted_files = code_files + support_files
+    top_file_score = score_sorted_files[0][1] if score_sorted_files else 0.0
     score_cutoff = top_file_score * _file_score_cutoff_ratio(
         fusion_applied=fusion_bm25_weight is not None or bool(effective_splade)
     )
     top_files: set[str] = set()
-    adaptive_max = _adaptive_max_files(sorted_files)
+    adaptive_max = _adaptive_max_files(score_sorted_files)
     if intent == QueryIntent.CLI or q_terms & {
         "graph",
         "dependency",
@@ -1472,35 +1527,48 @@ def assemble_context(
             adaptive_max = cap
         else:
             adaptive_max = min(adaptive_max, cap)
-    aligned_files = {
-        fp for fp, _score in sorted_files if _path_alignment_boost(fp, alignment_terms) > 1.0
-    }
-    for fp, _score in sorted_files:
-        if fp not in aligned_files:
-            continue
-        top_files.add(fp)
-        if len(top_files) >= adaptive_max:
-            break
-    for fp, score in sorted_files:
-        if len(top_files) >= adaptive_max:
-            break
-        if fp in top_files:
-            continue
-        if score < score_cutoff:
-            break
-        top_files.add(fp)
+    if prefer_code_files:
+        code_files = [
+            (fp, score) for fp, score in sorted_files if not _is_file_first_support_artifact(fp)
+        ]
+        support_files = [
+            (fp, score) for fp, score in sorted_files if _is_file_first_support_artifact(fp)
+        ]
+        for fp, _score in code_files[:adaptive_max]:
+            top_files.add(fp)
+        for fp, score in support_files:
+            if len(top_files) >= adaptive_max:
+                break
+            if score < score_cutoff:
+                break
+            top_files.add(fp)
+    else:
+        aligned_files = {
+            fp for fp, _score in sorted_files if _path_alignment_boost(fp, alignment_terms) > 1.0
+        }
+        for fp, _score in sorted_files:
+            if fp not in aligned_files:
+                continue
+            top_files.add(fp)
+            if len(top_files) >= adaptive_max:
+                break
+        for fp, score in sorted_files:
+            if len(top_files) >= adaptive_max:
+                break
+            if fp in top_files:
+                continue
+            if score < score_cutoff:
+                break
+            top_files.add(fp)
     ranked = [rc for rc in ranked if rc.chunk.file_path in top_files]
 
-    # Pack at least one high-scoring chunk per selected file before spending
-    # remaining budget on extra chunks. This preserves file-level recall when one
-    # high-scoring file has many chunks, while nested-range suppression prevents
-    # class/module chunks and their child chunks from duplicating the same lines.
     included, total_tokens = _pack_ranked_chunks(
         ranked,
         sorted_files,
         top_files,
         token_budget,
         max_chunks_per_file=CLI_MAX_CHUNKS_PER_FILE if intent == QueryIntent.CLI else None,
+        prefer_file_rank_order=prefer_code_files,
     )
 
     chunks_dropped = len(ranked) - len(included)

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -1521,6 +1521,65 @@ def test_support_file_penalty_is_0_15() -> None:
     assert 0.10 < ratio < 0.20, f"Expected ~0.15 ratio, got {ratio}"
 
 
+def test_adjust_file_scores_code_first_penalizes_support_files() -> None:
+    from archex.serve.context import _adjust_file_scores_code_first  # pyright: ignore[reportPrivateUsage]
+
+    adjusted = _adjust_file_scores_code_first(
+        {
+            "benchmarks/tasks/archex_pattern_detection.yaml": 10.0,
+            "src/archex/models.py": 4.0,
+        },
+        lexical_files={
+            "benchmarks/tasks/archex_pattern_detection.yaml",
+            "src/archex/models.py",
+        },
+        semantic_files={"src/archex/models.py"},
+    )
+
+    assert (
+        adjusted["src/archex/models.py"]
+        > adjusted["benchmarks/tasks/archex_pattern_detection.yaml"]
+    )
+
+
+def test_prefer_code_files_selects_code_before_support_files() -> None:
+    graph = DependencyGraph()
+    support = make_chunk("support", "benchmarks/tasks/archex_pattern_detection.yaml", token_count=9)
+    code_a = make_chunk("code_a", "src/archex/models.py", token_count=9)
+    code_b = make_chunk("code_b", "src/archex/analyze/patterns.py", token_count=9)
+    for chunk in (support, code_a, code_b):
+        graph.add_file_node(chunk.file_path)
+
+    bundle_default = assemble_context(
+        [(support, 100.0), (code_a, 6.0), (code_b, 5.0)],
+        graph,
+        [support, code_a, code_b],
+        "How does archex detect architectural patterns?",
+        token_budget=12,
+        vector_results=[(code_a, 0.9)],
+        prefer_code_files=False,
+        apply_intent_budget=False,
+    )
+    bundle_code_first = assemble_context(
+        [(support, 100.0), (code_a, 6.0), (code_b, 5.0)],
+        graph,
+        [support, code_a, code_b],
+        "How does archex detect architectural patterns?",
+        token_budget=12,
+        vector_results=[(code_a, 0.9)],
+        prefer_code_files=True,
+        apply_intent_budget=False,
+    )
+
+    assert (
+        bundle_default.chunks[0].chunk.file_path == "benchmarks/tasks/archex_pattern_detection.yaml"
+    )
+    assert bundle_code_first.chunks[0].chunk.file_path in {
+        "src/archex/models.py",
+        "src/archex/analyze/patterns.py",
+    }
+
+
 # ---------------------------------------------------------------------------
 # _is_entry_point unit tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stack

Stack-Id: `c6-file-first-ranking`
Base: `feat/dual-leg-benchmark-orchestration`
Position: 1/1

Depends on: #216
Upstack: none

## Summary

- Changes the benchmark-only dual-leg ranking contract to prefer code files over benchmark/docs/workflow artifacts during final file selection.
- Keeps runtime retrieval unchanged; the new behavior is only reached from `query_dual_leg_benchmark(...)`.
- Preserves the existing dual-leg efficiency gains while testing whether file-first code selection recovers recall on the targeted failing tasks.

## Validation

- `uv run ruff check && uv run ruff format --check . && uv run pyright`
- `uv run pytest -q`
- Targeted smokes:
  - `archex_benchmark_gate_lifecycle`
  - `archex_mcp_query_lifecycle`
  - `archex_pattern_detection`

## Result

- No recall improvement on the targeted failing tasks.
- Slight latency improvements on most targeted runs.
- Token efficiency improved for the benchmark gate / MCP tasks but regressed for pattern detection.
- Do not promote this ranking contract to a full frontier rerun.