### PR TITLE
feat: add dual-leg file-stage orchestration

### DIFF
--- a/docs/RETRIEVAL_DEFAULT_DECISIONS.md
+++ b/docs/RETRIEVAL_DEFAULT_DECISIONS.md
@@ -124,3 +124,41 @@ for task in archex_benchmark_gate_lifecycle archex_mcp_query_lifecycle archex_pa
   uv run archex benchmark run --task "$task" --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --tasks-dir benchmarks/tasks --output .archex/file-stage-candidate-smoke-v2
 done
 ```
+
+### 2026-06-14 — dual-leg file-stage orchestration full frontier rerun
+
+Follow-up after the targeted pass:
+
+- control: `--bm25-chunker default --vector-chunker cast --dual-leg-orchestration`
+- candidate: `--bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration`
+
+2026-06-14 full-frontier result: do not adopt the candidate yet. The targeted pattern-detection win did not generalize. The broader rerun improved token efficiency and p95 latency, but it reduced mean F1 on both fusion paths and failed the baseline gate with nine recall regressions.
+
+Frontier summary:
+
+| Strategy | Recall | F1 | Token efficiency | p95 latency |
+| --- | --- | --- | --- | --- |
+| Control `archex_query_fusion` | `0.834` | `0.648` | `0.708` | `1207 ms` |
+| Candidate `archex_query_fusion` | `0.838` | `0.626` | `0.739` | `1099 ms` |
+| Control `archex_query_fusion_rerank` | `0.834` | `0.648` | `0.709` | `2341 ms` |
+| Candidate `archex_query_fusion_rerank` | `0.828` | `0.620` | `0.738` | `2094 ms` |
+
+Baseline-gate failures:
+
+- `archex_adapter_registry/archex_query_fusion`
+- `archex_adapter_registry/archex_query_fusion_rerank`
+- `archex_project_init/archex_query_fusion`
+- `archex_project_init/archex_query_fusion_rerank`
+- `archex_project_reset/archex_query_fusion`
+- `archex_project_reset/archex_query_fusion_rerank`
+- `archex_query_cache_lifecycle/archex_query_fusion`
+- `archex_query_cache_lifecycle/archex_query_fusion_rerank`
+- `fastapi_dependency_injection/archex_query_fusion_rerank`
+
+Operator commands:
+
+```bash
+uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --tasks-dir benchmarks/tasks --output .archex/file-stage-control-full
+uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --tasks-dir benchmarks/tasks --output .archex/file-stage-candidate-full
+uv run archex benchmark gate --input .archex/file-stage-candidate-full --baseline .archex/file-stage-control-full --warn-latency-ms 3000
+```

--- a/docs/RETRIEVAL_DEFAULT_DECISIONS.md
+++ b/docs/RETRIEVAL_DEFAULT_DECISIONS.md
@@ -82,3 +82,45 @@ uv run archex benchmark readiness --input .archex/e2e-jina --tasks-dir benchmark
 uv run archex benchmark readiness --input .archex/e2e-jina --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
 uv run archex benchmark gate --input .archex/e2e-jina --baseline .archex/e2e-tier2 --warn-latency-ms 3000
 ```
+
+## Targeted benchmark experiments
+
+### 2026-06-14 — dual-leg file-stage orchestration
+
+Candidate:
+
+| Candidate | Benchmark flags | Decision role |
+| --- | --- | --- |
+| Dual-leg control | `--bm25-chunker default --vector-chunker cast --dual-leg-orchestration` | Current benchmark-only control |
+| Dual-leg file-stage orchestration | `--bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration` | Richer within-query file selection before final chunk packing |
+
+Decision rule:
+
+- Run only the targeted failing families first: `archex_benchmark_gate_lifecycle`, `archex_mcp_query_lifecycle`, `archex_pattern_detection`.
+- Keep the candidate only if it improves at least one failing family with no regression on the others.
+- Run a wider frontier only after the targeted set clears that bar.
+
+2026-06-14 targeted result: keep the candidate and promote it to the next wider frontier rerun. It preserved or improved recall on every targeted family, recovered `archex_pattern_detection` from `0.5` to `1.0` recall on both fusion paths, and reduced latency materially on all three tasks. Token efficiency improved on `archex_benchmark_gate_lifecycle` and `archex_mcp_query_lifecycle`, but regressed on `archex_pattern_detection`, so this is still a benchmark candidate rather than a default decision.
+
+Targeted smoke comparison:
+
+| Task | Strategy | Recall | F1 | Token efficiency | Latency |
+| --- | --- | --- | --- | --- | --- |
+| `archex_benchmark_gate_lifecycle` | fusion | `1.0 -> 1.0` | `1.000 -> 1.000` | `0.591 -> 0.698` | `5329 ms -> 797 ms` |
+| `archex_benchmark_gate_lifecycle` | fusion+rereank | `1.0 -> 1.0` | `1.000 -> 1.000` | `0.591 -> 0.698` | `9127 ms -> 2992 ms` |
+| `archex_mcp_query_lifecycle` | fusion | `0.8 -> 0.8` | `0.800 -> 0.800` | `0.842 -> 0.848` | `325 ms -> 272 ms` |
+| `archex_mcp_query_lifecycle` | fusion+rereank | `0.8 -> 0.8` | `0.800 -> 0.800` | `0.842 -> 0.848` | `1159 ms -> 592 ms` |
+| `archex_pattern_detection` | fusion | `0.5 -> 1.0` | `0.286 -> 0.571` | `0.873 -> 0.716` | `287 ms -> 256 ms` |
+| `archex_pattern_detection` | fusion+rereank | `0.5 -> 1.0` | `0.286 -> 0.571` | `0.873 -> 0.716` | `1133 ms -> 695 ms` |
+
+Operator commands:
+
+```bash
+for task in archex_benchmark_gate_lifecycle archex_mcp_query_lifecycle archex_pattern_detection; do
+  uv run archex benchmark run --task "$task" --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --tasks-dir benchmarks/tasks --output .archex/file-stage-control-smoke
+done
+
+for task in archex_benchmark_gate_lifecycle archex_mcp_query_lifecycle archex_pattern_detection; do
+  uv run archex benchmark run --task "$task" --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --tasks-dir benchmarks/tasks --output .archex/file-stage-candidate-smoke-v2
+done
+```

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1257,6 +1257,87 @@ def _project_results_to_corpus(
     return [(projected_chunks[chunk_id], projected_scores[chunk_id]) for chunk_id in order], misses
 
 
+def _is_dual_leg_support_artifact(file_path: str) -> bool:
+    lower_path = file_path.lower()
+    if lower_path.startswith(("tests/", "benchmarks/", "docs/", ".github/")):
+        return True
+    suffix = Path(lower_path).suffix
+    return suffix in {".json", ".md", ".rst", ".toml", ".txt", ".yaml", ".yml"}
+
+
+def _aggregate_dual_leg_file_scores(
+    results: list[tuple[CodeChunk, float]],
+) -> list[tuple[str, float]]:
+    if not results:
+        return []
+    max_score = max(score for _chunk, score in results)
+    if max_score <= 0:
+        return []
+    per_file: dict[str, list[float]] = {}
+    for chunk, score in results:
+        per_file.setdefault(chunk.file_path, []).append(score / max_score)
+    aggregated: list[tuple[str, float]] = []
+    for file_path, scores in per_file.items():
+        total = 0.0
+        weight = 1.0
+        for normalized in sorted(scores, reverse=True):
+            total += normalized * weight
+            weight *= 0.5
+        aggregated.append((file_path, total))
+    aggregated.sort(key=lambda item: item[1], reverse=True)
+    return aggregated
+
+
+def _dual_leg_file_cap(file_scores: list[tuple[str, float]], *, default: int) -> int:
+    if len(file_scores) <= default:
+        return len(file_scores)
+    if len(file_scores) < 3:
+        return default
+    top = file_scores[0][1]
+    median = file_scores[len(file_scores) // 2][1]
+    if median <= 0:
+        return default
+    ratio = top / median
+    if ratio > 4.0:
+        return max(3, default - 2)
+    if ratio > 2.5:
+        return max(4, default - 1)
+    return default
+
+
+def _select_dual_leg_file_stage(
+    lexical_results: list[tuple[CodeChunk, float]],
+    semantic_results: list[tuple[CodeChunk, float]],
+) -> set[str]:
+    lexical_files = _aggregate_dual_leg_file_scores(lexical_results)
+    semantic_files = _aggregate_dual_leg_file_scores(semantic_results)
+    if not lexical_files:
+        return {file_path for file_path, _score in semantic_files[:6]}
+    lexical_cap = _dual_leg_file_cap(lexical_files, default=5)
+    semantic_cap = _dual_leg_file_cap(semantic_files, default=6)
+    allowed: list[str] = []
+    seen: set[str] = set()
+
+    def add_file(file_path: str) -> None:
+        if file_path in seen:
+            return
+        seen.add(file_path)
+        allowed.append(file_path)
+
+    top_lexical = {file_path for file_path, _score in lexical_files[:lexical_cap]}
+    top_semantic = {file_path for file_path, _score in semantic_files[:semantic_cap]}
+    for file_path in top_lexical & top_semantic:
+        add_file(file_path)
+    for file_path, _score in lexical_files[:lexical_cap]:
+        add_file(file_path)
+    semantic_primary = [
+        item for item in semantic_files if not _is_dual_leg_support_artifact(item[0])
+    ]
+    for file_path, _score in semantic_primary[:semantic_cap]:
+        add_file(file_path)
+    return set(allowed)
+
+
 def _stored_corpus_stats(store: IndexStore) -> tuple[int, int]:
     stored_tokens = store.get_metadata("repo_total_tokens")
     total_repo_tokens = (
@@ -1452,6 +1533,7 @@ def query_dual_leg_benchmark(
     scoring_weights: ScoringWeights | None = None,
     timing: PipelineTiming | None = None,
     trace: PipelineTrace | None = None,
+    file_stage_orchestration: bool = False,
 ) -> ContextBundle:
     """Benchmark-only query path using separate BM25 and vector chunk inventories."""
     if bm25_index_config.splade or vector_index_config.splade:
@@ -1572,9 +1654,27 @@ def query_dual_leg_benchmark(
             vector_results or [],
             bm25_chunks,
         )
+        selected_files: set[str] | None = None
+        filtered_search_results = search_results
+        filtered_vector_results = projected_vector_results
+        if file_stage_orchestration and projected_vector_results:
+            selected_files = _select_dual_leg_file_stage(search_results, vector_results or [])
+            if selected_files:
+                filtered_search_results = [
+                    (chunk, score)
+                    for chunk, score in search_results
+                    if chunk.file_path in selected_files
+                ]
+                filtered_vector_results = [
+                    (chunk, score)
+                    for chunk, score in projected_vector_results
+                    if chunk.file_path in selected_files
+                ]
+            else:
+                selected_files = None
         if timing is not None:
             timing.search_ms = _elapsed_ms(search_start)
-            timing.vector_used = bool(projected_vector_results)
+            timing.vector_used = bool(filtered_vector_results)
             timing.vector_build_ms = _elapsed_ms(search_start)
         if trace is not None:
             trace.add_step(
@@ -1590,25 +1690,28 @@ def query_dual_leg_benchmark(
                         "vector_results_raw": len(vector_results or []),
                         "vector_results_projected": len(projected_vector_results),
                         "vector_projection_misses": projection_misses,
+                        "file_stage_orchestration": file_stage_orchestration,
+                        "file_stage_selected_files": len(selected_files or ()),
                         "top_k": top_k,
                         "vector_top_k": vector_top_k,
                     },
                 )
             )
         bundle = assemble_context(
-            search_results=search_results,
+            search_results=filtered_search_results,
             graph=graph,
             all_chunks=bm25_chunks,
             question=question,
             token_budget=effective_budget,
-            vector_results=projected_vector_results,
+            vector_results=filtered_vector_results,
             scoring_weights=scoring_weights,
             trace=trace,
-            avg_idf=bm25.avg_idf(question) if projected_vector_results else None,
+            avg_idf=bm25.avg_idf(question) if filtered_vector_results else None,
             reranker=_maybe_reranker(vector_index_config),
             rerank_candidate_limit=vector_index_config.rerank_candidate_limit,
             apply_intent_budget=False,
         )
+        bundle.retrieval_metadata.file_stage_orchestration = file_stage_orchestration
         bundle.retrieval_metadata.vector_mode = vector_index_config.vector_mode
         bundle.retrieval_metadata.surrogate_version = (
             vector_index_config.surrogate_version

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -148,6 +148,7 @@ class BenchmarkRetrievalOptions(BaseModel):
     vector_chunker: ChunkerName | None = None
     rerank_candidate_limit: int | None = None
     dual_leg_orchestration: bool = False
+    file_stage_orchestration: bool = False
 
 
 class ExternalToolCommandConfig(BenchmarkSpecModel):

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -121,6 +121,7 @@ def _warm_repo_index(
                 config=config,
                 bm25_index_config=bm25_index_config,
                 vector_index_config=vector_index_config,
+                file_stage_orchestration=retrieval_options.file_stage_orchestration,
             )
             return
         source = benchmark_repo_source(task, repo_path, strategy=warm_strategy)

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -1303,6 +1303,7 @@ def _run_benchmark_fusion_query(
             bm25_index_config=bm25_index_config,
             vector_index_config=vector_index_config,
             timing=timing,
+            file_stage_orchestration=options.file_stage_orchestration,
         )
     source = benchmark_repo_source(task, repo_path, strategy=strategy)
     index_config = benchmark_index_config(

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -182,6 +182,14 @@ def benchmark_cmd() -> None:
     ),
 )
 @click.option(
+    "--file-stage-orchestration/--no-file-stage-orchestration",
+    default=False,
+    help=(
+        "Benchmark-only path: preselect file candidates from the BM25 and vector legs "
+        "before final chunk assembly."
+    ),
+)
+@click.option(
     "--self-only",
     is_flag=True,
     default=False,
@@ -211,6 +219,7 @@ def run_cmd(
     rerank_model: str | None,
     rerank_candidate_limit: int | None,
     dual_leg_orchestration: bool,
+    file_stage_orchestration: bool,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -222,6 +231,14 @@ def run_cmd(
             strategies.append(strategy)
     if scout and Strategy.ARCHEX_SCOUT_FETCH not in strategies:
         strategies.append(Strategy.ARCHEX_SCOUT_FETCH)
+    resolved_bm25_chunker = bm25_chunker or chunker
+    resolved_vector_chunker = vector_chunker or chunker
+    if file_stage_orchestration and not dual_leg_orchestration:
+        raise click.UsageError("--file-stage-orchestration requires --dual-leg-orchestration")
+    if file_stage_orchestration and resolved_bm25_chunker == resolved_vector_chunker:
+        raise click.UsageError(
+            "--file-stage-orchestration requires different --bm25-chunker and --vector-chunker"
+        )
     if query_fusion and Strategy.ARCHEX_QUERY_FUSION not in strategies:
         strategies.append(Strategy.ARCHEX_QUERY_FUSION)
     if cross_layer_fusion and Strategy.CROSS_LAYER_FUSION not in strategies:
@@ -242,6 +259,7 @@ def run_cmd(
         vector_chunker=vector_chunker,
         rerank_candidate_limit=rerank_candidate_limit,
         dual_leg_orchestration=dual_leg_orchestration,
+        file_stage_orchestration=file_stage_orchestration,
     )
     warmed_models = warm_benchmark_models(strategies, retrieval_options)
     if warmed_models:

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -635,6 +635,7 @@ class RetrievalMetadata(BaseModel):
     chunker: ChunkerName = "default"
     bm25_chunker: ChunkerName | None = None
     vector_chunker: ChunkerName | None = None
+    file_stage_orchestration: bool = False
     index_chunk_count: int = 0
     mean_chunk_tokens: float = 0.0
 

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -659,6 +659,80 @@ class TestRunCommand:
             dual_leg_orchestration=True
         )
 
+    def test_run_passes_file_stage_orchestration_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "run",
+                "--dual-leg-orchestration",
+                "--file-stage-orchestration",
+                "--bm25-chunker",
+                "default",
+                "--vector-chunker",
+                "cast",
+            ],
+        )
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(
+            bm25_chunker="default",
+            vector_chunker="cast",
+            dual_leg_orchestration=True,
+            file_stage_orchestration=True,
+        )
+
+    def test_run_rejects_file_stage_without_dual_leg(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        result = runner.invoke(benchmark_cmd, ["run", "--file-stage-orchestration"])
+        assert result.exit_code != 0
+        assert "--file-stage-orchestration requires --dual-leg-orchestration" in result.output
+
+    def test_run_rejects_file_stage_with_same_chunkers(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "run",
+                "--dual-leg-orchestration",
+                "--file-stage-orchestration",
+                "--bm25-chunker",
+                "default",
+                "--vector-chunker",
+                "default",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "requires different --bm25-chunker and --vector-chunker" in result.output
+
     def test_run_passes_rerank_model_flag(
         self,
         runner: CliRunner,

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -325,7 +325,7 @@ class TestRunBenchmark:
         from archex.models import Config, ContextBundle, IndexConfig, RepoSource
 
         task, repo_path = fixture_task
-        captured: list[tuple[str, str, str, str, bool]] = []
+        captured: list[tuple[str, str, str, str, bool, bool]] = []
 
         def fake_dual_leg_query(
             *,
@@ -339,6 +339,7 @@ class TestRunBenchmark:
             scoring_weights: object | None = None,
             timing: object | None = None,
             trace: object | None = None,
+            file_stage_orchestration: bool = False,
         ) -> ContextBundle:
             del question, token_budget, config, scoring_weights, timing, trace
             captured.append(
@@ -348,6 +349,7 @@ class TestRunBenchmark:
                     bm25_index_config.chunker,
                     vector_index_config.chunker,
                     vector_index_config.rerank,
+                    file_stage_orchestration,
                 )
             )
             return ContextBundle(query=task.question, token_budget=task.token_budget)
@@ -360,6 +362,7 @@ class TestRunBenchmark:
                     bm25_chunker="default",
                     vector_chunker="cast",
                     dual_leg_orchestration=True,
+                    file_stage_orchestration=True,
                 ),
             )
 
@@ -370,6 +373,7 @@ class TestRunBenchmark:
                 "default",
                 "cast",
                 False,
+                True,
             )
         ]
 

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -1032,7 +1032,7 @@ class TestRunArchexQueryFusion:
             expected_files=["main.py"],
             token_budget=4096,
         )
-        calls: list[tuple[str, str, str, str]] = []
+        calls: list[tuple[str, str, str, str, bool]] = []
 
         def fake_dual_leg_query(
             *,
@@ -1046,6 +1046,7 @@ class TestRunArchexQueryFusion:
             scoring_weights: object | None = None,
             timing: object | None = None,
             trace: object | None = None,
+            file_stage_orchestration: bool = False,
         ) -> ContextBundle:
             del question, token_budget, config, scoring_weights, timing, trace
             calls.append(
@@ -1054,6 +1055,7 @@ class TestRunArchexQueryFusion:
                     vector_source.stable_identity or "",
                     bm25_index_config.chunker,
                     vector_index_config.chunker,
+                    file_stage_orchestration,
                 )
             )
             return ContextBundle(query=task.question, token_budget=task.token_budget)
@@ -1063,6 +1065,7 @@ class TestRunArchexQueryFusion:
                 bm25_chunker="default",
                 vector_chunker="cast",
                 dual_leg_orchestration=True,
+                file_stage_orchestration=True,
             )
         )
         try:
@@ -1078,6 +1081,7 @@ class TestRunArchexQueryFusion:
                 f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}+chunker=cast",
                 "default",
                 "cast",
+                True,
             )
         ]
 

--- a/tests/test_api_precision.py
+++ b/tests/test_api_precision.py
@@ -120,6 +120,26 @@ class TestProjectResultsToCorpus:
         assert misses == 0
         assert projected == [(corpus_chunks[0], 0.9)]
 
+    def test_select_dual_leg_file_stage_prefers_semantic_code_over_support(self) -> None:
+        from archex.api import _select_dual_leg_file_stage  # pyright: ignore[reportPrivateUsage]
+
+        lexical = [
+            (_chunk(file_path="src/archex/analyze/patterns.py", token_count=8), 9.0),
+            (_chunk(file_path="src/archex/acquire/discovery.py", token_count=8), 1.0),
+            (_chunk(file_path="src/archex/analyze/modules.py", token_count=8), 1.0),
+        ]
+        semantic = [
+            (_chunk(file_path="src/archex/serve/intent.py", token_count=8), 8.0),
+            (_chunk(file_path="tests/analyze/test_patterns.py", token_count=8), 7.5),
+            (_chunk(file_path="src/archex/models.py", token_count=8), 7.0),
+        ]
+
+        selected = _select_dual_leg_file_stage(lexical, semantic)
+
+        assert "src/archex/analyze/patterns.py" in selected
+        assert "src/archex/models.py" in selected
+        assert "tests/analyze/test_patterns.py" not in selected
+
     def test_dual_leg_query_uses_passthrough_when_budget_covers_corpus(self) -> None:
         from archex.api import query_dual_leg_benchmark
         from archex.models import Config, IndexConfig, RepoSource


### PR DESCRIPTION
## Summary
- add a benchmark-only file-stage orchestration mode for dual-leg fusion queries
- preselect file candidates from the BM25/default and vector/cast legs before final chunk packing
- guard the mode so it only runs with dual-leg orchestration and differing chunkers

## Validation
- uv run ruff check && uv run ruff format --check . && uv run pyright
- uv run pytest tests/pipeline/ tests/index/ tests/benchmark/ -q
- targeted benchmark smokes against `.archex/file-stage-control-smoke` and `.archex/file-stage-candidate-smoke-v2`

## Stack
Base: #216
