### PR TITLE
feat: add benchmark expansion controls

### DIFF
--- a/docs/RETRIEVAL_DEFAULT_DECISIONS.md
+++ b/docs/RETRIEVAL_DEFAULT_DECISIONS.md
@@ -162,3 +162,39 @@ uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --bm25-ch
 uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --tasks-dir benchmarks/tasks --output .archex/file-stage-candidate-full
 uv run archex benchmark gate --input .archex/file-stage-candidate-full --baseline .archex/file-stage-control-full --warn-latency-ms 3000
 ```
+
+### 2026-06-14 — file-stage strict expansion controls targeted rerun
+
+Follow-up after the file-stage frontier regressions:
+
+- control: `--bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration`
+- candidate: `--bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --strict-expansion-controls`
+
+2026-06-14 targeted result: keep as an experimental benchmark knob, but do not run a wider frontier yet. The stricter expansion controls recovered `fastapi_dependency_injection` on the rerank path from `0.667` to `1.000` recall and materially cut latency there, but they did not recover the four remaining self-repo failure families.
+
+Targeted smoke comparison:
+
+| Task | Strategy | Recall | F1 | Token efficiency | Latency |
+| --- | --- | --- | --- | --- | --- |
+| `archex_adapter_registry` | fusion | `0.333 -> 0.333` | `0.222 -> 0.250` | `0.769 -> 0.756` | `862 ms -> 477 ms` |
+| `archex_adapter_registry` | fusion+rereank | `0.333 -> 0.333` | `0.222 -> 0.222` | `0.769 -> 0.772` | `2776 ms -> 2818 ms` |
+| `archex_project_init` | fusion | `0.500 -> 0.500` | `0.500 -> 0.500` | `0.635 -> 0.635` | `1116 ms -> 1052 ms` |
+| `archex_project_init` | fusion+rereank | `0.500 -> 0.500` | `0.500 -> 0.500` | `0.635 -> 0.635` | `2094 ms -> 2144 ms` |
+| `archex_project_reset` | fusion | `0.333 -> 0.333` | `0.286 -> 0.286` | `0.615 -> 0.615` | `510 ms -> 632 ms` |
+| `archex_project_reset` | fusion+rereank | `0.333 -> 0.333` | `0.286 -> 0.286` | `0.615 -> 0.615` | `1405 ms -> 1472 ms` |
+| `archex_query_cache_lifecycle` | fusion | `0.800 -> 0.800` | `0.800 -> 0.800` | `0.753 -> 0.753` | `509 ms -> 618 ms` |
+| `archex_query_cache_lifecycle` | fusion+rereank | `0.800 -> 0.800` | `0.800 -> 0.800` | `0.753 -> 0.753` | `1791 ms -> 1707 ms` |
+| `fastapi_dependency_injection` | fusion | `1.000 -> 1.000` | `0.857 -> 0.857` | `0.800 -> 0.797` | `203 ms -> 168 ms` |
+| `fastapi_dependency_injection` | fusion+rereank | `0.667 -> 1.000` | `0.571 -> 0.857` | `0.808 -> 0.797` | `1504 ms -> 759 ms` |
+
+Operator commands:
+
+```bash
+for task in archex_adapter_registry archex_project_init archex_project_reset archex_query_cache_lifecycle fastapi_dependency_injection; do
+  uv run archex benchmark run --task "$task" --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --tasks-dir benchmarks/tasks --output .archex/expansion-control-control-smoke
+done
+
+for task in archex_adapter_registry archex_project_init archex_project_reset archex_query_cache_lifecycle fastapi_dependency_injection; do
+  uv run archex benchmark run --task "$task" --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --strict-expansion-controls --tasks-dir benchmarks/tasks --output .archex/expansion-control-candidate-smoke
+done
+```

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1534,6 +1534,7 @@ def query_dual_leg_benchmark(
     timing: PipelineTiming | None = None,
     trace: PipelineTrace | None = None,
     file_stage_orchestration: bool = False,
+    strict_expansion_controls: bool = False,
 ) -> ContextBundle:
     """Benchmark-only query path using separate BM25 and vector chunk inventories."""
     if bm25_index_config.splade or vector_index_config.splade:
@@ -1585,6 +1586,10 @@ def query_dual_leg_benchmark(
                 total_repo_tokens=bm25_total_repo_tokens,
                 bm25_chunker=bm25_index_config.chunker,
                 vector_chunker=vector_index_config.chunker,
+            )
+            bundle.retrieval_metadata.file_stage_orchestration = file_stage_orchestration
+            bundle.retrieval_metadata.expansion_control_mode = (
+                "strict" if strict_expansion_controls else "baseline"
             )
             bundle.retrieval_metadata.retrieval_time_ms = _elapsed_ms(t0)
             if timing is not None:
@@ -1691,6 +1696,7 @@ def query_dual_leg_benchmark(
                         "vector_results_projected": len(projected_vector_results),
                         "vector_projection_misses": projection_misses,
                         "file_stage_orchestration": file_stage_orchestration,
+                        "strict_expansion_controls": strict_expansion_controls,
                         "file_stage_selected_files": len(selected_files or ()),
                         "top_k": top_k,
                         "vector_top_k": vector_top_k,
@@ -1709,7 +1715,11 @@ def query_dual_leg_benchmark(
             avg_idf=bm25.avg_idf(question) if filtered_vector_results else None,
             reranker=_maybe_reranker(vector_index_config),
             rerank_candidate_limit=vector_index_config.rerank_candidate_limit,
+            strict_expansion_controls=strict_expansion_controls,
             apply_intent_budget=False,
+        )
+        bundle.retrieval_metadata.expansion_control_mode = (
+            "strict" if strict_expansion_controls else "baseline"
         )
         bundle.retrieval_metadata.file_stage_orchestration = file_stage_orchestration
         bundle.retrieval_metadata.vector_mode = vector_index_config.vector_mode

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -149,6 +149,7 @@ class BenchmarkRetrievalOptions(BaseModel):
     rerank_candidate_limit: int | None = None
     dual_leg_orchestration: bool = False
     file_stage_orchestration: bool = False
+    strict_expansion_controls: bool = False
 
 
 class ExternalToolCommandConfig(BenchmarkSpecModel):

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -122,6 +122,7 @@ def _warm_repo_index(
                 bm25_index_config=bm25_index_config,
                 vector_index_config=vector_index_config,
                 file_stage_orchestration=retrieval_options.file_stage_orchestration,
+                strict_expansion_controls=retrieval_options.strict_expansion_controls,
             )
             return
         source = benchmark_repo_source(task, repo_path, strategy=warm_strategy)

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -1304,6 +1304,7 @@ def _run_benchmark_fusion_query(
             vector_index_config=vector_index_config,
             timing=timing,
             file_stage_orchestration=options.file_stage_orchestration,
+            strict_expansion_controls=options.strict_expansion_controls,
         )
     source = benchmark_repo_source(task, repo_path, strategy=strategy)
     index_config = benchmark_index_config(

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -190,6 +190,14 @@ def benchmark_cmd() -> None:
     ),
 )
 @click.option(
+    "--strict-expansion-controls/--no-strict-expansion-controls",
+    default=False,
+    help=(
+        "Benchmark-only path: tighten graph-expansion seeds and candidate priority for "
+        "dual-leg file-stage queries."
+    ),
+)
+@click.option(
     "--self-only",
     is_flag=True,
     default=False,
@@ -220,6 +228,7 @@ def run_cmd(
     rerank_candidate_limit: int | None,
     dual_leg_orchestration: bool,
     file_stage_orchestration: bool,
+    strict_expansion_controls: bool,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -239,6 +248,8 @@ def run_cmd(
         raise click.UsageError(
             "--file-stage-orchestration requires different --bm25-chunker and --vector-chunker"
         )
+    if strict_expansion_controls and not file_stage_orchestration:
+        raise click.UsageError("--strict-expansion-controls requires --file-stage-orchestration")
     if query_fusion and Strategy.ARCHEX_QUERY_FUSION not in strategies:
         strategies.append(Strategy.ARCHEX_QUERY_FUSION)
     if cross_layer_fusion and Strategy.CROSS_LAYER_FUSION not in strategies:
@@ -260,6 +271,7 @@ def run_cmd(
         rerank_candidate_limit=rerank_candidate_limit,
         dual_leg_orchestration=dual_leg_orchestration,
         file_stage_orchestration=file_stage_orchestration,
+        strict_expansion_controls=strict_expansion_controls,
     )
     warmed_models = warm_benchmark_models(strategies, retrieval_options)
     if warmed_models:

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -636,6 +636,7 @@ class RetrievalMetadata(BaseModel):
     bm25_chunker: ChunkerName | None = None
     vector_chunker: ChunkerName | None = None
     file_stage_orchestration: bool = False
+    expansion_control_mode: str = "baseline"
     index_chunk_count: int = 0
     mean_chunk_tokens: float = 0.0
 

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from archex.models import (
@@ -110,6 +111,14 @@ def _is_support_file(file_path: str, query_terms: set[str]) -> bool:
     if any(marker in lower_path for marker in _SUPPORT_PATH_MARKERS):
         return not query_terms & _SUPPORT_QUERY_TERMS
     return False
+
+
+def _is_file_first_support_artifact(file_path: str) -> bool:
+    lower_path = file_path.lower()
+    if lower_path.startswith(("tests/", "benchmarks/", "docs/", ".github/")):
+        return True
+    suffix = Path(lower_path).suffix
+    return suffix in {".json", ".md", ".rst", ".toml", ".txt", ".yaml", ".yml"}
 
 
 def _type_definitions(chunks: list[RankedChunk]) -> list[TypeDefinition]:
@@ -775,6 +784,65 @@ def _is_low_signal_expansion_candidate(
     return not any(term in file_path.lower() for term in query_terms)
 
 
+def _strict_expansion_bonus(
+    file_path: str,
+    reasons: set[str],
+    source_count: int,
+    query_terms: set[str],
+) -> float:
+    lower_path = file_path.lower()
+    path_match = any(term in lower_path for term in query_terms)
+    bonus = 0.0
+    if "entry_point" in reasons:
+        bonus += 0.8
+    if "same_module" in reasons:
+        bonus += 0.5
+    if "import_target" in reasons:
+        bonus += 0.35
+    if path_match:
+        bonus += 0.25
+    if source_count >= 2:
+        bonus += 0.2
+    if "importer" in reasons and "import_target" not in reasons:
+        bonus -= 0.2
+    if "cross_module" in reasons and "same_module" not in reasons:
+        bonus -= 0.25
+    if "hub" in reasons and source_count < 2 and not path_match:
+        bonus -= 0.4
+    if _is_support_file(file_path, query_terms) or _is_file_first_support_artifact(file_path):
+        bonus -= 0.75
+    return bonus
+
+
+def _should_skip_strict_expansion_candidate(
+    file_path: str,
+    reasons: set[str],
+    source_count: int,
+    query_terms: set[str],
+) -> bool:
+    lower_path = file_path.lower()
+    path_match = any(term in lower_path for term in query_terms)
+    if _is_file_first_support_artifact(file_path):
+        return True
+    if _is_support_file(file_path, query_terms) and not (
+        "entry_point" in reasons or path_match or source_count >= 2
+    ):
+        return True
+    if "same_module" in reasons or "entry_point" in reasons:
+        return False
+    return "cross_module" in reasons and not (path_match or source_count >= 2)
+
+
+def _strict_expansion_seed_files(seed_files: set[str], query_terms: set[str]) -> set[str]:
+    filtered = {
+        file_path
+        for file_path in seed_files
+        if not _is_support_file(file_path, query_terms)
+        and not _is_file_first_support_artifact(file_path)
+    }
+    return filtered or seed_files
+
+
 def _hop2_expansion_priority(expansion: _Hop2Expansion) -> dict[str, float]:
     hop1_files = set(expansion.hop1_files_added)
     hop2_priority: dict[str, float] = {}
@@ -904,6 +972,7 @@ def assemble_context(
     avg_idf: float | None = None,
     reranker: object | None = None,
     rerank_candidate_limit: int = 4,
+    strict_expansion_controls: bool = False,
     apply_intent_budget: bool = True,
 ) -> ContextBundle:
     """Assemble a token-budgeted ContextBundle from search results and a dependency graph.
@@ -1068,6 +1137,11 @@ def assemble_context(
     qualifying_seeds = [
         fp for fp in seed_files if norm_seed_scores.get(fp, 0.0) >= effective_expansion_min
     ]
+    expansion_control_mode = "strict" if strict_expansion_controls else "baseline"
+    expansion_seed_files = set(qualifying_seeds)
+    if strict_expansion_controls:
+        expansion_seed_files = _strict_expansion_seed_files(expansion_seed_files, q_terms)
+        qualifying_seeds = [fp for fp in qualifying_seeds if fp in expansion_seed_files]
     expansion_eligible_seeds = len(qualifying_seeds)
     logger.debug(
         "graph_expansion: %d/%d seed files qualify (threshold=%.3f)",
@@ -1092,7 +1166,7 @@ def assemble_context(
     import_neighbor_edges = 0
     same_module_candidates: set[str] = set()
     hub_candidates: set[str] = set()
-    for file_path in seed_files:
+    for file_path in expansion_seed_files:
         # Only expand from seeds above the confidence threshold
         if norm_seed_scores.get(file_path, 0.0) < effective_expansion_min:
             continue
@@ -1199,7 +1273,21 @@ def assemble_context(
 
     sorted_expansion = sorted(
         expansion_priority.keys(),
-        key=lambda f: -expansion_priority[f],
+        key=lambda f: (
+            -(
+                expansion_priority[f]
+                + (
+                    _strict_expansion_bonus(
+                        f,
+                        expansion_reasons_by_file.get(f, set()),
+                        expansion_source_count.get(f, 0),
+                        q_terms,
+                    )
+                    if strict_expansion_controls
+                    else 0.0
+                )
+            )
+        ),
     )
 
     # Build chunk lookup by file
@@ -1208,7 +1296,7 @@ def assemble_context(
     # Collect candidate chunks (seed + file-capped expansion), dedup by id
     # Cap per-file to prevent one large file from monopolizing the expansion budget.
     # Skip test files in expansion — they add noise without improving relevance.
-    max_per_file = 1 if intent == QueryIntent.CLI else 3
+    max_per_file = 1 if intent == QueryIntent.CLI else (2 if strict_expansion_controls else 3)
     # Vector-only seeds participate in scoring even when BM25 returned nothing
     # for that file.
     candidate_map = _initial_candidate_map(search_results, effective_vector, effective_splade)
@@ -1216,6 +1304,7 @@ def assemble_context(
     expansion_test_candidates_skipped = 0
     hop1_files_added: list[str] = []
     expanded_file_paths: list[str] = []
+    max_expansion_files = 6 if strict_expansion_controls else MAX_EXPANSION_FILES
     for file_path in sorted_expansion:
         if _is_test_file(file_path):
             expansion_test_candidates_skipped += 1
@@ -1226,11 +1315,21 @@ def assemble_context(
                 "test_file",
             )
             continue
+        reasons = expansion_reasons_by_file.get(file_path, set())
+        source_count = expansion_source_count.get(file_path, 0)
         if _is_low_signal_expansion_candidate(
             file_path,
-            expansion_reasons_by_file.get(file_path, set()),
-            expansion_source_count.get(file_path, 0),
+            reasons,
+            source_count,
             q_terms,
+        ) or (
+            strict_expansion_controls
+            and _should_skip_strict_expansion_candidate(
+                file_path,
+                reasons,
+                source_count,
+                q_terms,
+            )
         ):
             _record_expansion_reason(
                 expansion_reasons_by_file,
@@ -1256,7 +1355,7 @@ def assemble_context(
             expansion_files_added += 1
             hop1_files_added.append(file_path)
             expanded_file_paths.append(file_path)
-        if expansion_files_added >= MAX_EXPANSION_FILES:
+        if expansion_files_added >= max_expansion_files:
             break
 
     expansion_zero_candidate_reason = _zero_expansion_reason(
@@ -1320,13 +1419,13 @@ def assemble_context(
                     "expansion_import_neighbor_edges": import_neighbor_edges,
                     "expansion_same_module_candidates": len(same_module_candidates),
                     "expansion_hub_candidates": len(hub_candidates),
-                    "expansion_test_candidates_skipped": expansion_test_candidates_skipped,
                     "expansion_zero_candidate_reason": expansion_zero_candidate_reason,
                     "expansion_reason_counts": ",".join(
                         f"{reason}:{count}"
                         for reason, count in sorted(expansion_reason_counts.items())
                     ),
                     "expanded_file_reasons": len(expanded_file_reasons),
+                    "expansion_control_mode": expansion_control_mode,
                 },
             )
         )
@@ -1572,10 +1671,10 @@ def assemble_context(
         expansion_zero_candidate_reason=expansion_zero_candidate_reason,
         expansion_import_neighbor_edges=import_neighbor_edges,
         expansion_same_module_candidates=len(same_module_candidates),
-        expansion_hub_candidates=len(hub_candidates),
         expansion_test_candidates_skipped=expansion_test_candidates_skipped,
         expansion_reason_counts=dict(expansion_reason_counts),
         expanded_file_reasons=expanded_file_reasons,
+        expansion_control_mode=expansion_control_mode,
         bm25_cv=bm25_cv_val,
         splade_results=len(splade_results or []),
         splade_used=bool(effective_splade),

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -688,6 +688,7 @@ class TestRunCommand:
                 "run",
                 "--dual-leg-orchestration",
                 "--file-stage-orchestration",
+                "--strict-expansion-controls",
                 "--bm25-chunker",
                 "default",
                 "--vector-chunker",
@@ -700,6 +701,7 @@ class TestRunCommand:
             vector_chunker="cast",
             dual_leg_orchestration=True,
             file_stage_orchestration=True,
+            strict_expansion_controls=True,
         )
 
     def test_run_rejects_file_stage_without_dual_leg(
@@ -732,6 +734,19 @@ class TestRunCommand:
         )
         assert result.exit_code != 0
         assert "requires different --bm25-chunker and --vector-chunker" in result.output
+
+    def test_run_rejects_strict_expansion_without_file_stage(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        result = runner.invoke(
+            benchmark_cmd,
+            ["run", "--dual-leg-orchestration", "--strict-expansion-controls"],
+        )
+        assert result.exit_code != 0
+        assert "--strict-expansion-controls requires --file-stage-orchestration" in result.output
 
     def test_run_passes_rerank_model_flag(
         self,

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -325,7 +325,7 @@ class TestRunBenchmark:
         from archex.models import Config, ContextBundle, IndexConfig, RepoSource
 
         task, repo_path = fixture_task
-        captured: list[tuple[str, str, str, str, bool, bool]] = []
+        captured: list[tuple[str, str, str, str, bool, bool, bool]] = []
 
         def fake_dual_leg_query(
             *,
@@ -340,6 +340,7 @@ class TestRunBenchmark:
             timing: object | None = None,
             trace: object | None = None,
             file_stage_orchestration: bool = False,
+            strict_expansion_controls: bool = False,
         ) -> ContextBundle:
             del question, token_budget, config, scoring_weights, timing, trace
             captured.append(
@@ -350,6 +351,7 @@ class TestRunBenchmark:
                     vector_index_config.chunker,
                     vector_index_config.rerank,
                     file_stage_orchestration,
+                    strict_expansion_controls,
                 )
             )
             return ContextBundle(query=task.question, token_budget=task.token_budget)
@@ -363,6 +365,7 @@ class TestRunBenchmark:
                     vector_chunker="cast",
                     dual_leg_orchestration=True,
                     file_stage_orchestration=True,
+                    strict_expansion_controls=True,
                 ),
             )
 
@@ -373,6 +376,7 @@ class TestRunBenchmark:
                 "default",
                 "cast",
                 False,
+                True,
                 True,
             )
         ]

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -1032,7 +1032,7 @@ class TestRunArchexQueryFusion:
             expected_files=["main.py"],
             token_budget=4096,
         )
-        calls: list[tuple[str, str, str, str, bool]] = []
+        calls: list[tuple[str, str, str, str, bool, bool]] = []
 
         def fake_dual_leg_query(
             *,
@@ -1047,6 +1047,7 @@ class TestRunArchexQueryFusion:
             timing: object | None = None,
             trace: object | None = None,
             file_stage_orchestration: bool = False,
+            strict_expansion_controls: bool = False,
         ) -> ContextBundle:
             del question, token_budget, config, scoring_weights, timing, trace
             calls.append(
@@ -1056,6 +1057,7 @@ class TestRunArchexQueryFusion:
                     bm25_index_config.chunker,
                     vector_index_config.chunker,
                     file_stage_orchestration,
+                    strict_expansion_controls,
                 )
             )
             return ContextBundle(query=task.question, token_budget=task.token_budget)
@@ -1066,6 +1068,7 @@ class TestRunArchexQueryFusion:
                 vector_chunker="cast",
                 dual_leg_orchestration=True,
                 file_stage_orchestration=True,
+                strict_expansion_controls=True,
             )
         )
         try:
@@ -1081,6 +1084,7 @@ class TestRunArchexQueryFusion:
                 f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}+chunker=cast",
                 "default",
                 "cast",
+                True,
                 True,
             )
         ]

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -800,6 +800,64 @@ def test_expansion_metadata_records_file_reasons_without_changing_output() -> No
     assert meta.expansion_reason_counts["test_file"] == 1
 
 
+def test_strict_expansion_seed_filter_drops_support_seed_files() -> None:
+    from archex.serve.context import _strict_expansion_seed_files  # pyright: ignore[reportPrivateUsage]
+
+    seeds = {
+        "src/archex/project.py",
+        "src/archex/serve/compare/state_management.py",
+        "tests/acquire/test_local.py",
+    }
+
+    filtered = _strict_expansion_seed_files(seeds, {"project", "state"})
+
+    assert filtered == {"src/archex/project.py"}
+
+
+def test_strict_expansion_controls_skip_support_and_keep_entry_point() -> None:
+    graph = DependencyGraph()
+    for file_path in (
+        "src/app/project.py",
+        "src/app/core.py",
+        "src/cli/main.py",
+        "src/serve/compare/state_management.py",
+    ):
+        graph.add_file_node(file_path)
+    graph.add_file_edge("src/app/project.py", "src/app/core.py", kind="imports")
+    graph.add_file_edge("src/app/project.py", "src/cli/main.py", kind="imports")
+    graph.add_file_edge(
+        "src/app/project.py",
+        "src/serve/compare/state_management.py",
+        kind="imports",
+    )
+
+    seed_chunk = make_chunk("seed", "src/app/project.py", token_count=10)
+    core_chunk = make_chunk("core", "src/app/core.py", token_count=10)
+    main_chunk = make_chunk("main", "src/cli/main.py", token_count=10)
+    support_chunk = make_chunk("support", "src/serve/compare/state_management.py", token_count=10)
+
+    bundle = assemble_context(
+        [(seed_chunk, 5.0)],
+        graph,
+        [seed_chunk, core_chunk, main_chunk, support_chunk],
+        "How does the project init command work?",
+        strict_expansion_controls=True,
+        modules=[
+            Module(
+                name="app",
+                root_path="src/app",
+                files=["src/app/project.py", "src/app/core.py"],
+            )
+        ],
+    )
+
+    included_files = {rc.chunk.file_path for rc in bundle.chunks}
+    assert "src/app/core.py" in included_files
+    assert "src/cli/main.py" in included_files
+    assert "src/serve/compare/state_management.py" not in included_files
+    assert bundle.retrieval_metadata.expansion_control_mode == "strict"
+
+
 def test_low_signal_hub_expansion_is_suppressed_without_dropping_aligned_file() -> None:
     graph = DependencyGraph()
     for file_path in (


### PR DESCRIPTION
## Summary
- add a benchmark-only strict expansion controls mode on top of file-stage dual-leg orchestration
- filter support/test seeds and reprioritize same-module, import-target, and entry-point expansions
- record the targeted benchmark verdict in the retrieval decision log

## Validation
- uv run ruff check && uv run ruff format --check . && uv run pyright
- uv run pytest tests/pipeline/ tests/index/ tests/benchmark/ -q
- targeted smokes against `.archex/expansion-control-control-smoke` and `.archex/expansion-control-candidate-smoke`

## Verdict
- useful for `fastapi_dependency_injection`
- insufficient recovery across the remaining self-repo failure families
- keep draft; do not widen to a full frontier rerun yet

## Stack
Base: #218
