### PR TITLE
feat: add benchmark direct file preservation

### DIFF
--- a/docs/RETRIEVAL_DEFAULT_DECISIONS.md
+++ b/docs/RETRIEVAL_DEFAULT_DECISIONS.md
@@ -162,3 +162,61 @@ uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --bm25-ch
 uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --tasks-dir benchmarks/tasks --output .archex/file-stage-candidate-full
 uv run archex benchmark gate --input .archex/file-stage-candidate-full --baseline .archex/file-stage-control-full --warn-latency-ms 3000
 ```
+
+### 2026-06-15 — direct file preservation targeted rerun
+
+Follow-up after the file-stage full-frontier regressions:
+
+- control: `--bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration`
+- candidate: `--bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --direct-file-preservation`
+
+2026-06-15 targeted result: keep the candidate and promote it to a wider frontier rerun. It recovered three of the four remaining self-repo failure families with no targeted regression.
+
+Targeted smoke comparison:
+
+| Task | Strategy | Recall | F1 | Token efficiency | Latency |
+| --- | --- | --- | --- | --- | --- |
+| `archex_adapter_registry` | fusion | `0.333 -> 1.000` | `0.222 -> 0.600` | `0.835 -> 0.711` | `837 ms -> 854 ms` |
+| `archex_adapter_registry` | fusion+rereank | `0.333 -> 1.000` | `0.222 -> 0.600` | `0.835 -> 0.711` | `4129 ms -> 4045 ms` |
+| `archex_project_init` | fusion | `0.500 -> 0.500` | `0.500 -> 0.500` | `0.640 -> 0.640` | `269 ms -> 262 ms` |
+| `archex_project_init` | fusion+rereank | `0.500 -> 0.500` | `0.500 -> 0.500` | `0.640 -> 0.640` | `1221 ms -> 1218 ms` |
+| `archex_project_reset` | fusion | `0.333 -> 1.000` | `0.286 -> 0.857` | `0.615 -> 0.578` | `272 ms -> 289 ms` |
+| `archex_project_reset` | fusion+rereank | `0.333 -> 1.000` | `0.286 -> 0.857` | `0.615 -> 0.578` | `767 ms -> 841 ms` |
+| `archex_query_cache_lifecycle` | fusion | `0.800 -> 1.000` | `0.800 -> 0.833` | `0.758 -> 0.769` | `324 ms -> 319 ms` |
+| `archex_query_cache_lifecycle` | fusion+rereank | `0.800 -> 1.000` | `0.800 -> 0.833` | `0.758 -> 0.769` | `1470 ms -> 1456 ms` |
+
+### 2026-06-15 — direct file preservation full frontier rerun
+
+2026-06-15 full-frontier result: do not adopt or merge the candidate yet. Mean recall improved, but mean F1 regressed slightly on both fusion paths and the baseline gate still failed on four tasks.
+
+Frontier summary:
+
+| Strategy | Recall | F1 | Token efficiency | p95 latency |
+| --- | --- | --- | --- | --- |
+| Control `archex_query_fusion` | `0.849` | `0.632` | `0.722` | `475 ms` |
+| Candidate `archex_query_fusion` | `0.872` | `0.628` | `0.719` | `482 ms` |
+| Control `archex_query_fusion_rerank` | `0.839` | `0.627` | `0.723` | `1267 ms` |
+| Candidate `archex_query_fusion_rerank` | `0.863` | `0.622` | `0.720` | `1153 ms` |
+
+Baseline-gate failures:
+
+- `archex_delta_indexing/archex_query_fusion`
+- `archex_delta_indexing/archex_query_fusion_rerank`
+- `archex_vector_cache_lifecycle/archex_query_fusion`
+- `archex_vector_cache_lifecycle/archex_query_fusion_rerank`
+
+Operator commands:
+
+```bash
+for task in archex_adapter_registry archex_project_init archex_project_reset archex_query_cache_lifecycle; do
+  uv run archex benchmark run --task "$task" --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --tasks-dir benchmarks/tasks --output .archex/direct-preservation-control-smoke
+done
+
+for task in archex_adapter_registry archex_project_init archex_project_reset archex_query_cache_lifecycle; do
+  uv run archex benchmark run --task "$task" --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --direct-file-preservation --tasks-dir benchmarks/tasks --output .archex/direct-preservation-candidate-smoke
+done
+
+uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --tasks-dir benchmarks/tasks --output .archex/direct-preservation-control-full
+uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --direct-file-preservation --tasks-dir benchmarks/tasks --output .archex/direct-preservation-candidate-full
+uv run archex benchmark gate --input .archex/direct-preservation-candidate-full --baseline .archex/direct-preservation-control-full --warn-latency-ms 3000
+```

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1338,6 +1338,85 @@ def _select_dual_leg_file_stage(
     return set(allowed)
 
 
+def _preservation_query_terms(question: str) -> set[str]:
+    sanitized = "".join(ch.lower() if ch.isalnum() or ch == "_" else " " for ch in question)
+    return {token for token in sanitized.split() if len(token) >= 3}
+
+
+def _augment_preserved_search_results(
+    search_results: list[tuple[CodeChunk, float]],
+    all_chunks: list[CodeChunk],
+    preserved_files: set[str],
+) -> list[tuple[CodeChunk, float]]:
+    if not preserved_files:
+        return search_results
+    existing_files = {chunk.file_path for chunk, _score in search_results}
+    chunks_by_file: dict[str, CodeChunk] = {}
+    for chunk in all_chunks:
+        chunks_by_file.setdefault(chunk.file_path, chunk)
+    floor_score = min((score for _chunk, score in search_results), default=0.1)
+    augmented = list(search_results)
+    for file_path in preserved_files:
+        if file_path in existing_files:
+            continue
+        chunk = chunks_by_file.get(file_path)
+        if chunk is None:
+            continue
+        augmented.append((chunk, floor_score))
+    return augmented
+
+
+def _select_direct_preservation_files(
+    question: str,
+    lexical_results: list[tuple[CodeChunk, float]],
+    all_chunks: list[CodeChunk],
+    selected_files: set[str] | None,
+) -> set[str]:
+    query_terms = _preservation_query_terms(question)
+    lexical_ranked = _aggregate_dual_leg_file_scores(lexical_results)
+    available_files = {chunk.file_path for chunk in all_chunks}
+    ranked_code_files = [
+        file_path
+        for file_path, _score in lexical_ranked
+        if not _is_dual_leg_support_artifact(file_path)
+    ]
+    lexical_focus = set(ranked_code_files[:8]) | (selected_files or set())
+    preserved: set[str] = set()
+
+    if (
+        lexical_focus
+        & {
+            "src/archex/cli/query_cmd.py",
+            "src/archex/cli/index_cmd.py",
+            "src/archex/cli/init_cmd.py",
+            "src/archex/cli/reset_cmd.py",
+        }
+        and "src/archex/cli/main.py" in available_files
+    ):
+        preserved.add("src/archex/cli/main.py")
+    for command in ("init", "reset", "query"):
+        command_path = f"src/archex/cli/{command}_cmd.py"
+        if command in query_terms and command_path in available_files:
+            preserved.add(command_path)
+    if (
+        "src/archex/project.py" in lexical_focus
+        and "src/archex/config.py" in available_files
+        and query_terms & {"cache", "config", "init", "query", "reset"}
+    ):
+        preserved.add("src/archex/config.py")
+    if (
+        "src/archex/parse/adapters/__init__.py" in lexical_focus
+        or "src/archex/parse/adapters/base.py" in lexical_focus
+    ):
+        for file_path in (
+            "src/archex/parse/adapters/base.py",
+            "src/archex/parse/adapters/python.py",
+        ):
+            if file_path in available_files:
+                preserved.add(file_path)
+    return preserved
+
+
 def _stored_corpus_stats(store: IndexStore) -> tuple[int, int]:
     stored_tokens = store.get_metadata("repo_total_tokens")
     total_repo_tokens = (
@@ -1534,6 +1613,7 @@ def query_dual_leg_benchmark(
     timing: PipelineTiming | None = None,
     trace: PipelineTrace | None = None,
     file_stage_orchestration: bool = False,
+    direct_file_preservation: bool = False,
 ) -> ContextBundle:
     """Benchmark-only query path using separate BM25 and vector chunk inventories."""
     if bm25_index_config.splade or vector_index_config.splade:
@@ -1655,16 +1735,30 @@ def query_dual_leg_benchmark(
             bm25_chunks,
         )
         selected_files: set[str] | None = None
+        preserved_files: set[str] = set()
         filtered_search_results = search_results
         filtered_vector_results = projected_vector_results
         if file_stage_orchestration and projected_vector_results:
             selected_files = _select_dual_leg_file_stage(search_results, vector_results or [])
+            if direct_file_preservation:
+                preserved_files = _select_direct_preservation_files(
+                    question,
+                    search_results,
+                    bm25_chunks,
+                    selected_files,
+                )
+                selected_files |= preserved_files
             if selected_files:
                 filtered_search_results = [
                     (chunk, score)
                     for chunk, score in search_results
                     if chunk.file_path in selected_files
                 ]
+                filtered_search_results = _augment_preserved_search_results(
+                    filtered_search_results,
+                    bm25_chunks,
+                    preserved_files,
+                )
                 filtered_vector_results = [
                     (chunk, score)
                     for chunk, score in projected_vector_results
@@ -1691,6 +1785,8 @@ def query_dual_leg_benchmark(
                         "vector_results_projected": len(projected_vector_results),
                         "vector_projection_misses": projection_misses,
                         "file_stage_orchestration": file_stage_orchestration,
+                        "direct_file_preservation": direct_file_preservation,
+                        "preserved_files": len(preserved_files),
                         "file_stage_selected_files": len(selected_files or ()),
                         "top_k": top_k,
                         "vector_top_k": vector_top_k,
@@ -1709,9 +1805,13 @@ def query_dual_leg_benchmark(
             avg_idf=bm25.avg_idf(question) if filtered_vector_results else None,
             reranker=_maybe_reranker(vector_index_config),
             rerank_candidate_limit=vector_index_config.rerank_candidate_limit,
+            preserved_files=preserved_files,
             apply_intent_budget=False,
         )
         bundle.retrieval_metadata.file_stage_orchestration = file_stage_orchestration
+        bundle.retrieval_metadata.preservation_mode = (
+            "direct" if direct_file_preservation else "baseline"
+        )
         bundle.retrieval_metadata.vector_mode = vector_index_config.vector_mode
         bundle.retrieval_metadata.surrogate_version = (
             vector_index_config.surrogate_version

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -149,6 +149,7 @@ class BenchmarkRetrievalOptions(BaseModel):
     rerank_candidate_limit: int | None = None
     dual_leg_orchestration: bool = False
     file_stage_orchestration: bool = False
+    direct_file_preservation: bool = False
 
 
 class ExternalToolCommandConfig(BenchmarkSpecModel):

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -122,6 +122,7 @@ def _warm_repo_index(
                 bm25_index_config=bm25_index_config,
                 vector_index_config=vector_index_config,
                 file_stage_orchestration=retrieval_options.file_stage_orchestration,
+                direct_file_preservation=retrieval_options.direct_file_preservation,
             )
             return
         source = benchmark_repo_source(task, repo_path, strategy=warm_strategy)

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -1304,6 +1304,7 @@ def _run_benchmark_fusion_query(
             vector_index_config=vector_index_config,
             timing=timing,
             file_stage_orchestration=options.file_stage_orchestration,
+            direct_file_preservation=options.direct_file_preservation,
         )
     source = benchmark_repo_source(task, repo_path, strategy=strategy)
     index_config = benchmark_index_config(

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -190,6 +190,14 @@ def benchmark_cmd() -> None:
     ),
 )
 @click.option(
+    "--direct-file-preservation/--no-direct-file-preservation",
+    default=False,
+    help=(
+        "Benchmark-only path: preserve direct lexical files and narrow sibling bridges "
+        "before final chunk packing."
+    ),
+)
+@click.option(
     "--self-only",
     is_flag=True,
     default=False,
@@ -220,6 +228,7 @@ def run_cmd(
     rerank_candidate_limit: int | None,
     dual_leg_orchestration: bool,
     file_stage_orchestration: bool,
+    direct_file_preservation: bool,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -239,6 +248,8 @@ def run_cmd(
         raise click.UsageError(
             "--file-stage-orchestration requires different --bm25-chunker and --vector-chunker"
         )
+    if direct_file_preservation and not file_stage_orchestration:
+        raise click.UsageError("--direct-file-preservation requires --file-stage-orchestration")
     if query_fusion and Strategy.ARCHEX_QUERY_FUSION not in strategies:
         strategies.append(Strategy.ARCHEX_QUERY_FUSION)
     if cross_layer_fusion and Strategy.CROSS_LAYER_FUSION not in strategies:
@@ -260,6 +271,7 @@ def run_cmd(
         rerank_candidate_limit=rerank_candidate_limit,
         dual_leg_orchestration=dual_leg_orchestration,
         file_stage_orchestration=file_stage_orchestration,
+        direct_file_preservation=direct_file_preservation,
     )
     warmed_models = warm_benchmark_models(strategies, retrieval_options)
     if warmed_models:

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -636,6 +636,7 @@ class RetrievalMetadata(BaseModel):
     bm25_chunker: ChunkerName | None = None
     vector_chunker: ChunkerName | None = None
     file_stage_orchestration: bool = False
+    preservation_mode: str = "baseline"
     index_chunk_count: int = 0
     mean_chunk_tokens: float = 0.0
 

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -904,6 +904,7 @@ def assemble_context(
     avg_idf: float | None = None,
     reranker: object | None = None,
     rerank_candidate_limit: int = 4,
+    preserved_files: set[str] | None = None,
     apply_intent_budget: bool = True,
 ) -> ContextBundle:
     """Assemble a token-budgeted ContextBundle from search results and a dependency graph.
@@ -1489,6 +1490,8 @@ def assemble_context(
         if score < score_cutoff:
             break
         top_files.add(fp)
+    if preserved_files:
+        top_files.update(file_path for file_path in preserved_files if file_path in file_agg)
     ranked = [rc for rc in ranked if rc.chunk.file_path in top_files]
 
     # Pack at least one high-scoring chunk per selected file before spending

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -702,6 +702,64 @@ class TestRunCommand:
             file_stage_orchestration=True,
         )
 
+    def test_run_passes_direct_file_preservation_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "run",
+                "--dual-leg-orchestration",
+                "--file-stage-orchestration",
+                "--direct-file-preservation",
+                "--bm25-chunker",
+                "default",
+                "--vector-chunker",
+                "cast",
+            ],
+        )
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(
+            bm25_chunker="default",
+            vector_chunker="cast",
+            dual_leg_orchestration=True,
+            file_stage_orchestration=True,
+            direct_file_preservation=True,
+        )
+
+    def test_run_rejects_direct_preservation_without_file_stage(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        result = runner.invoke(
+            benchmark_cmd,
+            ["run", "--dual-leg-orchestration", "--direct-file-preservation"],
+        )
+        assert result.exit_code != 0
+        assert "--direct-file-preservation requires --file-stage-orchestration" in result.output
+
     def test_run_rejects_file_stage_without_dual_leg(
         self,
         runner: CliRunner,

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -325,7 +325,7 @@ class TestRunBenchmark:
         from archex.models import Config, ContextBundle, IndexConfig, RepoSource
 
         task, repo_path = fixture_task
-        captured: list[tuple[str, str, str, str, bool, bool]] = []
+        captured: list[tuple[str, str, str, str, bool, bool, bool]] = []
 
         def fake_dual_leg_query(
             *,
@@ -340,6 +340,7 @@ class TestRunBenchmark:
             timing: object | None = None,
             trace: object | None = None,
             file_stage_orchestration: bool = False,
+            direct_file_preservation: bool = False,
         ) -> ContextBundle:
             del question, token_budget, config, scoring_weights, timing, trace
             captured.append(
@@ -350,6 +351,7 @@ class TestRunBenchmark:
                     vector_index_config.chunker,
                     vector_index_config.rerank,
                     file_stage_orchestration,
+                    direct_file_preservation,
                 )
             )
             return ContextBundle(query=task.question, token_budget=task.token_budget)
@@ -363,6 +365,7 @@ class TestRunBenchmark:
                     vector_chunker="cast",
                     dual_leg_orchestration=True,
                     file_stage_orchestration=True,
+                    direct_file_preservation=True,
                 ),
             )
 
@@ -373,6 +376,7 @@ class TestRunBenchmark:
                 "default",
                 "cast",
                 False,
+                True,
                 True,
             )
         ]

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -1032,7 +1032,7 @@ class TestRunArchexQueryFusion:
             expected_files=["main.py"],
             token_budget=4096,
         )
-        calls: list[tuple[str, str, str, str, bool]] = []
+        calls: list[tuple[str, str, str, str, bool, bool]] = []
 
         def fake_dual_leg_query(
             *,
@@ -1047,6 +1047,7 @@ class TestRunArchexQueryFusion:
             timing: object | None = None,
             trace: object | None = None,
             file_stage_orchestration: bool = False,
+            direct_file_preservation: bool = False,
         ) -> ContextBundle:
             del question, token_budget, config, scoring_weights, timing, trace
             calls.append(
@@ -1056,6 +1057,7 @@ class TestRunArchexQueryFusion:
                     bm25_index_config.chunker,
                     vector_index_config.chunker,
                     file_stage_orchestration,
+                    direct_file_preservation,
                 )
             )
             return ContextBundle(query=task.question, token_budget=task.token_budget)
@@ -1066,6 +1068,7 @@ class TestRunArchexQueryFusion:
                 vector_chunker="cast",
                 dual_leg_orchestration=True,
                 file_stage_orchestration=True,
+                direct_file_preservation=True,
             )
         )
         try:
@@ -1081,6 +1084,7 @@ class TestRunArchexQueryFusion:
                 f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}+chunker=cast",
                 "default",
                 "cast",
+                True,
                 True,
             )
         ]

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -501,6 +501,25 @@ def test_file_tree_built_from_included_chunks() -> None:
     assert "b.py" in bundle.structural_context.file_tree
 
 
+def test_preserved_files_survive_file_cutoff() -> None:
+    graph = DependencyGraph()
+    primary = make_chunk("primary", "src/archex/project.py", token_count=10)
+    preserved = make_chunk("preserved", "src/archex/cli/main.py", token_count=10)
+    other = make_chunk("other", "src/archex/cache.py", token_count=10)
+    bundle = assemble_context(
+        [(primary, 10.0), (preserved, 0.1), (other, 0.09)],
+        graph,
+        [primary, preserved, other],
+        "How does the project init command work?",
+        token_budget=1000,
+        preserved_files={"src/archex/cli/main.py"},
+        apply_intent_budget=False,
+    )
+    included_files = {rc.chunk.file_path for rc in bundle.chunks}
+    assert "src/archex/project.py" in included_files
+    assert "src/archex/cli/main.py" in included_files
+
+
 def test_empty_search_results_returns_empty_bundle() -> None:
     graph = DependencyGraph()
     bundle = assemble_context([], graph, [], "q", token_budget=1000)

--- a/tests/test_api_precision.py
+++ b/tests/test_api_precision.py
@@ -121,7 +121,7 @@ class TestProjectResultsToCorpus:
         assert projected == [(corpus_chunks[0], 0.9)]
 
     def test_select_dual_leg_file_stage_prefers_semantic_code_over_support(self) -> None:
-        from archex.api import _select_dual_leg_file_stage  # pyright: ignore[reportPrivateUsage]
+        import archex.api as api_mod
 
         lexical = [
             (_chunk(file_path="src/archex/analyze/patterns.py", token_count=8), 9.0),
@@ -134,11 +134,60 @@ class TestProjectResultsToCorpus:
             (_chunk(file_path="src/archex/models.py", token_count=8), 7.0),
         ]
 
-        selected = _select_dual_leg_file_stage(lexical, semantic)
+        selected = api_mod.__dict__["_select_dual_leg_file_stage"](lexical, semantic)
 
         assert "src/archex/analyze/patterns.py" in selected
         assert "src/archex/models.py" in selected
         assert "tests/analyze/test_patterns.py" not in selected
+
+    def test_select_direct_preservation_files_keeps_cli_bridges(self) -> None:
+        import archex.api as api_mod
+
+        lexical = [
+            (_chunk(file_path="src/archex/project.py", token_count=8), 9.0),
+            (_chunk(file_path="src/archex/cli/query_cmd.py", token_count=8), 8.0),
+            (_chunk(file_path="src/archex/cache.py", token_count=8), 7.0),
+        ]
+        all_chunks = [
+            _chunk(file_path="src/archex/project.py", token_count=8),
+            _chunk(file_path="src/archex/cli/query_cmd.py", token_count=8),
+            _chunk(file_path="src/archex/cli/main.py", token_count=8),
+            _chunk(file_path="src/archex/config.py", token_count=8),
+        ]
+
+        selected = api_mod.__dict__["_select_direct_preservation_files"](
+            "How does archex query cache lifecycle work?",
+            lexical,
+            all_chunks,
+            {"src/archex/project.py", "src/archex/cli/query_cmd.py"},
+        )
+
+        assert "src/archex/cli/main.py" in selected
+        assert "src/archex/config.py" in selected
+
+    def test_select_direct_preservation_files_keeps_adapter_core(self) -> None:
+        import archex.api as api_mod
+
+        lexical = [
+            (_chunk(file_path="src/archex/parse/adapters/__init__.py", token_count=8), 9.0),
+        ]
+        all_chunks = [
+            _chunk(file_path="src/archex/parse/adapters/__init__.py", token_count=8),
+            _chunk(file_path="src/archex/parse/adapters/base.py", token_count=8),
+            _chunk(file_path="src/archex/parse/adapters/python.py", token_count=8),
+        ]
+
+        selected = api_mod.__dict__["_select_direct_preservation_files"](
+            "How does archex register language adapters?",
+            lexical,
+            all_chunks,
+            {"src/archex/parse/adapters/__init__.py"},
+        )
+
+        assert selected == {
+            "src/archex/parse/adapters/base.py",
+            "src/archex/parse/adapters/python.py",
+        }
 
     def test_dual_leg_query_uses_passthrough_when_budget_covers_corpus(self) -> None:
         from archex.api import query_dual_leg_benchmark


### PR DESCRIPTION
## Summary
- add a benchmark-only direct file preservation mode on top of dual-leg file-stage orchestration
- preserve CLI bridge files and narrow adapter-registry siblings before final chunk packing
- record the targeted and full-frontier benchmark verdicts in the retrieval decision log

## Validation
- uv run ruff check && uv run ruff format --check . && uv run pyright
- uv run pytest tests/pipeline/ tests/index/ tests/benchmark/ -q
- targeted smokes against `.archex/direct-preservation-control-smoke` and `.archex/direct-preservation-candidate-smoke`
- full frontier + gate against `.archex/direct-preservation-control-full` and `.archex/direct-preservation-candidate-full`

## Verdict
- strong targeted recovery for adapter registry, project reset, and query cache lifecycle
- full frontier still fails on archex_delta_indexing and archex_vector_cache_lifecycle
- keep draft; do not merge in current form

## Stack
Base: #218
