### PR TITLE
feat: add benchmark delta cache preservation

### DIFF
--- a/docs/RETRIEVAL_DEFAULT_DECISIONS.md
+++ b/docs/RETRIEVAL_DEFAULT_DECISIONS.md
@@ -220,3 +220,54 @@ uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --bm25-ch
 uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --direct-file-preservation --tasks-dir benchmarks/tasks --output .archex/direct-preservation-candidate-full
 uv run archex benchmark gate --input .archex/direct-preservation-candidate-full --baseline .archex/direct-preservation-control-full --warn-latency-ms 3000
 ```
+
+### 2026-06-15 — delta/vector-cache preservation targeted rerun
+
+Follow-up after the direct file preservation full-frontier regressions:
+
+- control: `--bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --direct-file-preservation`
+- candidate: `--bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --direct-file-preservation --delta-cache-preservation`
+
+2026-06-15 targeted result: keep the candidate and promote it to a wider frontier rerun. It recovered both remaining failure families on both fusion paths.
+
+Targeted smoke comparison:
+
+| Task | Strategy | Recall | F1 | Token efficiency | Latency |
+| --- | --- | --- | --- | --- | --- |
+| `archex_delta_indexing` | fusion | `0.500 -> 1.000` | `0.250 -> 0.500` | `0.505 -> 0.474` | `4336 ms -> 977 ms` |
+| `archex_delta_indexing` | fusion+rereank | `0.500 -> 1.000` | `0.250 -> 0.500` | `0.505 -> 0.474` | `27878 ms -> 4235 ms` |
+| `archex_vector_cache_lifecycle` | fusion | `0.600 -> 1.000` | `0.545 -> 0.769` | `0.733 -> 0.779` | `301 ms -> 614 ms` |
+| `archex_vector_cache_lifecycle` | fusion+rereank | `0.600 -> 1.000` | `0.545 -> 0.769` | `0.733 -> 0.779` | `890 ms -> 838 ms` |
+
+### 2026-06-15 — delta/vector-cache preservation full frontier rerun
+
+2026-06-15 full-frontier result: this candidate cleared the benchmark gate against the direct-file-preservation baseline. Mean recall and mean F1 improved on both fusion paths, token efficiency edged up, and rerank p95 improved.
+
+Frontier summary:
+
+| Strategy | Recall | F1 | Token efficiency | p95 latency |
+| --- | --- | --- | --- | --- |
+| Control `archex_query_fusion` | `0.872` | `0.628` | `0.719` | `856 ms` |
+| Candidate `archex_query_fusion` | `0.898` | `0.634` | `0.721` | `891 ms` |
+| Control `archex_query_fusion_rerank` | `0.863` | `0.622` | `0.720` | `1666 ms` |
+| Candidate `archex_query_fusion_rerank` | `0.889` | `0.628` | `0.722` | `1154 ms` |
+
+Baseline gate:
+
+- passed
+
+Operator commands:
+
+```bash
+for task in archex_delta_indexing archex_vector_cache_lifecycle; do
+  uv run archex benchmark run --task "$task" --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --direct-file-preservation --tasks-dir benchmarks/tasks --output .archex/delta-cache-control-smoke
+done
+
+for task in archex_delta_indexing archex_vector_cache_lifecycle; do
+  uv run archex benchmark run --task "$task" --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --direct-file-preservation --delta-cache-preservation --tasks-dir benchmarks/tasks --output .archex/delta-cache-candidate-smoke
+done
+
+uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --direct-file-preservation --tasks-dir benchmarks/tasks --output .archex/delta-cache-control-full
+uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --direct-file-preservation --delta-cache-preservation --tasks-dir benchmarks/tasks --output .archex/delta-cache-candidate-full
+uv run archex benchmark gate --input .archex/delta-cache-candidate-full --baseline .archex/delta-cache-control-full --warn-latency-ms 3000
+```

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1417,6 +1417,43 @@ def _select_direct_preservation_files(
     return preserved
 
 
+def _select_delta_cache_preserved_files(
+    question: str,
+    lexical_results: list[tuple[CodeChunk, float]],
+    all_chunks: list[CodeChunk],
+    selected_files: set[str] | None,
+) -> set[str]:
+    query_terms = _preservation_query_terms(question)
+    lexical_ranked = _aggregate_dual_leg_file_scores(lexical_results)
+    available_files = {chunk.file_path for chunk in all_chunks}
+    lexical_focus = {file_path for file_path, _score in lexical_ranked[:8]} | (
+        selected_files or set()
+    )
+    preserved: set[str] = set()
+
+    if (
+        "src/archex/index/delta.py" in lexical_focus
+        and "src/archex/cache.py" in available_files
+        and query_terms & {"delta", "index", "cache", "changes"}
+    ):
+        preserved.add("src/archex/cache.py")
+
+    vector_focus = lexical_focus & {
+        "src/archex/index/vector.py",
+        "src/archex/cache.py",
+        "src/archex/api.py",
+    }
+    if vector_focus and query_terms & {"vector", "cache", "embedder", "retrieval"}:
+        for file_path in (
+            "src/archex/index/embeddings/base.py",
+            "src/archex/models.py",
+        ):
+            if file_path in available_files:
+                preserved.add(file_path)
+
+    return preserved
+
+
 def _stored_corpus_stats(store: IndexStore) -> tuple[int, int]:
     stored_tokens = store.get_metadata("repo_total_tokens")
     total_repo_tokens = (
@@ -1614,6 +1651,7 @@ def query_dual_leg_benchmark(
     trace: PipelineTrace | None = None,
     file_stage_orchestration: bool = False,
     direct_file_preservation: bool = False,
+    delta_cache_preservation: bool = False,
 ) -> ContextBundle:
     """Benchmark-only query path using separate BM25 and vector chunk inventories."""
     if bm25_index_config.splade or vector_index_config.splade:
@@ -1747,7 +1785,14 @@ def query_dual_leg_benchmark(
                     bm25_chunks,
                     selected_files,
                 )
-                selected_files |= preserved_files
+            if delta_cache_preservation:
+                preserved_files |= _select_delta_cache_preserved_files(
+                    question,
+                    search_results,
+                    bm25_chunks,
+                    selected_files,
+                )
+            selected_files |= preserved_files
             if selected_files:
                 filtered_search_results = [
                     (chunk, score)
@@ -1786,6 +1831,7 @@ def query_dual_leg_benchmark(
                         "vector_projection_misses": projection_misses,
                         "file_stage_orchestration": file_stage_orchestration,
                         "direct_file_preservation": direct_file_preservation,
+                        "delta_cache_preservation": delta_cache_preservation,
                         "preserved_files": len(preserved_files),
                         "file_stage_selected_files": len(selected_files or ()),
                         "top_k": top_k,
@@ -1809,9 +1855,12 @@ def query_dual_leg_benchmark(
             apply_intent_budget=False,
         )
         bundle.retrieval_metadata.file_stage_orchestration = file_stage_orchestration
-        bundle.retrieval_metadata.preservation_mode = (
-            "direct" if direct_file_preservation else "baseline"
-        )
+        if delta_cache_preservation:
+            bundle.retrieval_metadata.preservation_mode = "delta_cache"
+        elif direct_file_preservation:
+            bundle.retrieval_metadata.preservation_mode = "direct"
+        else:
+            bundle.retrieval_metadata.preservation_mode = "baseline"
         bundle.retrieval_metadata.vector_mode = vector_index_config.vector_mode
         bundle.retrieval_metadata.surrogate_version = (
             vector_index_config.surrogate_version

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -150,6 +150,7 @@ class BenchmarkRetrievalOptions(BaseModel):
     dual_leg_orchestration: bool = False
     file_stage_orchestration: bool = False
     direct_file_preservation: bool = False
+    delta_cache_preservation: bool = False
 
 
 class ExternalToolCommandConfig(BenchmarkSpecModel):

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -123,6 +123,7 @@ def _warm_repo_index(
                 vector_index_config=vector_index_config,
                 file_stage_orchestration=retrieval_options.file_stage_orchestration,
                 direct_file_preservation=retrieval_options.direct_file_preservation,
+                delta_cache_preservation=retrieval_options.delta_cache_preservation,
             )
             return
         source = benchmark_repo_source(task, repo_path, strategy=warm_strategy)

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -1305,6 +1305,7 @@ def _run_benchmark_fusion_query(
             timing=timing,
             file_stage_orchestration=options.file_stage_orchestration,
             direct_file_preservation=options.direct_file_preservation,
+            delta_cache_preservation=options.delta_cache_preservation,
         )
     source = benchmark_repo_source(task, repo_path, strategy=strategy)
     index_config = benchmark_index_config(

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -198,6 +198,14 @@ def benchmark_cmd() -> None:
     ),
 )
 @click.option(
+    "--delta-cache-preservation/--no-delta-cache-preservation",
+    default=False,
+    help=(
+        "Benchmark-only path: preserve direct delta-indexing and vector-cache lifecycle "
+        "files on top of direct file preservation."
+    ),
+)
+@click.option(
     "--self-only",
     is_flag=True,
     default=False,
@@ -229,6 +237,7 @@ def run_cmd(
     dual_leg_orchestration: bool,
     file_stage_orchestration: bool,
     direct_file_preservation: bool,
+    delta_cache_preservation: bool,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -250,6 +259,8 @@ def run_cmd(
         )
     if direct_file_preservation and not file_stage_orchestration:
         raise click.UsageError("--direct-file-preservation requires --file-stage-orchestration")
+    if delta_cache_preservation and not direct_file_preservation:
+        raise click.UsageError("--delta-cache-preservation requires --direct-file-preservation")
     if query_fusion and Strategy.ARCHEX_QUERY_FUSION not in strategies:
         strategies.append(Strategy.ARCHEX_QUERY_FUSION)
     if cross_layer_fusion and Strategy.CROSS_LAYER_FUSION not in strategies:
@@ -272,6 +283,7 @@ def run_cmd(
         dual_leg_orchestration=dual_leg_orchestration,
         file_stage_orchestration=file_stage_orchestration,
         direct_file_preservation=direct_file_preservation,
+        delta_cache_preservation=delta_cache_preservation,
     )
     warmed_models = warm_benchmark_models(strategies, retrieval_options)
     if warmed_models:

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -747,6 +747,75 @@ class TestRunCommand:
             direct_file_preservation=True,
         )
 
+    def test_run_passes_delta_cache_preservation_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "run",
+                "--dual-leg-orchestration",
+                "--file-stage-orchestration",
+                "--direct-file-preservation",
+                "--delta-cache-preservation",
+                "--bm25-chunker",
+                "default",
+                "--vector-chunker",
+                "cast",
+            ],
+        )
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(
+            bm25_chunker="default",
+            vector_chunker="cast",
+            dual_leg_orchestration=True,
+            file_stage_orchestration=True,
+            direct_file_preservation=True,
+            delta_cache_preservation=True,
+        )
+
+    def test_run_rejects_delta_cache_preservation_without_direct_preservation(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "run",
+                "--dual-leg-orchestration",
+                "--file-stage-orchestration",
+                "--delta-cache-preservation",
+                "--bm25-chunker",
+                "default",
+                "--vector-chunker",
+                "cast",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--delta-cache-preservation requires --direct-file-preservation" in result.output
+
     def test_run_rejects_direct_preservation_without_file_stage(
         self,
         runner: CliRunner,

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -325,7 +325,7 @@ class TestRunBenchmark:
         from archex.models import Config, ContextBundle, IndexConfig, RepoSource
 
         task, repo_path = fixture_task
-        captured: list[tuple[str, str, str, str, bool, bool, bool]] = []
+        captured: list[tuple[str, str, str, str, bool, bool, bool, bool]] = []
 
         def fake_dual_leg_query(
             *,
@@ -341,6 +341,7 @@ class TestRunBenchmark:
             trace: object | None = None,
             file_stage_orchestration: bool = False,
             direct_file_preservation: bool = False,
+            delta_cache_preservation: bool = False,
         ) -> ContextBundle:
             del question, token_budget, config, scoring_weights, timing, trace
             captured.append(
@@ -352,6 +353,7 @@ class TestRunBenchmark:
                     vector_index_config.rerank,
                     file_stage_orchestration,
                     direct_file_preservation,
+                    delta_cache_preservation,
                 )
             )
             return ContextBundle(query=task.question, token_budget=task.token_budget)
@@ -366,6 +368,7 @@ class TestRunBenchmark:
                     dual_leg_orchestration=True,
                     file_stage_orchestration=True,
                     direct_file_preservation=True,
+                    delta_cache_preservation=True,
                 ),
             )
 
@@ -376,6 +379,7 @@ class TestRunBenchmark:
                 "default",
                 "cast",
                 False,
+                True,
                 True,
                 True,
             )

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -1032,7 +1032,7 @@ class TestRunArchexQueryFusion:
             expected_files=["main.py"],
             token_budget=4096,
         )
-        calls: list[tuple[str, str, str, str, bool, bool]] = []
+        calls: list[tuple[str, str, str, str, bool, bool, bool]] = []
 
         def fake_dual_leg_query(
             *,
@@ -1048,6 +1048,7 @@ class TestRunArchexQueryFusion:
             trace: object | None = None,
             file_stage_orchestration: bool = False,
             direct_file_preservation: bool = False,
+            delta_cache_preservation: bool = False,
         ) -> ContextBundle:
             del question, token_budget, config, scoring_weights, timing, trace
             calls.append(
@@ -1058,6 +1059,7 @@ class TestRunArchexQueryFusion:
                     vector_index_config.chunker,
                     file_stage_orchestration,
                     direct_file_preservation,
+                    delta_cache_preservation,
                 )
             )
             return ContextBundle(query=task.question, token_budget=task.token_budget)
@@ -1069,6 +1071,7 @@ class TestRunArchexQueryFusion:
                 dual_leg_orchestration=True,
                 file_stage_orchestration=True,
                 direct_file_preservation=True,
+                delta_cache_preservation=True,
             )
         )
         try:
@@ -1084,6 +1087,7 @@ class TestRunArchexQueryFusion:
                 f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}+chunker=cast",
                 "default",
                 "cast",
+                True,
                 True,
                 True,
             )

--- a/tests/test_api_precision.py
+++ b/tests/test_api_precision.py
@@ -189,6 +189,53 @@ class TestProjectResultsToCorpus:
             "src/archex/parse/adapters/python.py",
         }
 
+    def test_select_delta_cache_preserved_files_keeps_delta_cache_bridge(self) -> None:
+        import archex.api as api_mod
+
+        lexical = [
+            (_chunk(file_path="src/archex/index/delta.py", token_count=8), 9.0),
+            (_chunk(file_path="src/archex/index/store.py", token_count=8), 8.0),
+        ]
+        all_chunks = [
+            _chunk(file_path="src/archex/index/delta.py", token_count=8),
+            _chunk(file_path="src/archex/cache.py", token_count=8),
+        ]
+
+        selected = api_mod.__dict__["_select_delta_cache_preserved_files"](
+            "How does delta indexing detect and apply changes?",
+            lexical,
+            all_chunks,
+            {"src/archex/index/delta.py"},
+        )
+
+        assert selected == {"src/archex/cache.py"}
+
+    def test_select_delta_cache_preserved_files_keeps_vector_contract_files(self) -> None:
+        import archex.api as api_mod
+
+        lexical = [
+            (_chunk(file_path="src/archex/index/vector.py", token_count=8), 9.0),
+            (_chunk(file_path="src/archex/cache.py", token_count=8), 8.0),
+        ]
+        all_chunks = [
+            _chunk(file_path="src/archex/index/vector.py", token_count=8),
+            _chunk(file_path="src/archex/cache.py", token_count=8),
+            _chunk(file_path="src/archex/models.py", token_count=8),
+            _chunk(file_path="src/archex/index/embeddings/base.py", token_count=8),
+        ]
+
+        selected = api_mod.__dict__["_select_delta_cache_preserved_files"](
+            "How does archex build, cache, and reload vector indexes for query retrieval?",
+            lexical,
+            all_chunks,
+            {"src/archex/index/vector.py", "src/archex/cache.py"},
+        )
+
+        assert selected == {
+            "src/archex/models.py",
+            "src/archex/index/embeddings/base.py",
+        }
+
     def test_dual_leg_query_uses_passthrough_when_budget_covers_corpus(self) -> None:
         from archex.api import query_dual_leg_benchmark
         from archex.models import Config, IndexConfig, RepoSource


### PR DESCRIPTION
## Summary
- add a benchmark-only delta/vector-cache preservation layer on top of direct-file preservation
- preserve `cache.py` for delta-indexing questions and `models.py` plus embedding base contracts for vector-cache lifecycle questions
- record the targeted and full-frontier benchmark verdicts in the retrieval decision log

## Validation
- uv run ruff check && uv run ruff format --check . && uv run pyright
- uv run pytest tests/pipeline/ tests/index/ tests/benchmark/ -q
- targeted smokes against `.archex/delta-cache-control-smoke` and `.archex/delta-cache-candidate-smoke`
- full frontier + gate against `.archex/delta-cache-control-full` and `.archex/delta-cache-candidate-full`

## Verdict
- targeted delta-indexing and vector-cache lifecycle regressions recovered on both fusion paths
- full frontier gate passed against the direct-file-preservation baseline
- still benchmark-only and stacked on draft parents

## Stack
Base: #220
