### PR TITLE
feat: consolidate retrieval policy line

### DIFF
--- a/docs/RETRIEVAL_DEFAULT_DECISIONS.md
+++ b/docs/RETRIEVAL_DEFAULT_DECISIONS.md
@@ -82,3 +82,55 @@ uv run archex benchmark readiness --input .archex/e2e-jina --tasks-dir benchmark
 uv run archex benchmark readiness --input .archex/e2e-jina --tasks-dir benchmarks/tasks --strategy archex_query_fusion_rerank --format markdown
 uv run archex benchmark gate --input .archex/e2e-jina --baseline .archex/e2e-tier2 --warn-latency-ms 3000
 ```
+
+## Retrieval policy consolidation
+
+### 2026-06-15 — consolidated retrieval policy line vs stable benchmark spine
+
+Candidate branches consolidated into one benchmark-only line:
+
+- dual-leg benchmark orchestration
+- file-stage orchestration
+- direct file preservation
+- delta/vector-cache preservation
+
+Comparison:
+
+- stable spine: `feat/chunker-benchmark-arm`
+- candidate: `feat/retrieval-policy-consolidation`
+
+Decision rule:
+
+- run one full-frontier comparison of the consolidated candidate against the stable benchmark spine
+- require no baseline gate regressions before replacing the exploratory draft ladder with a mergeable retrieval-policy branch
+
+2026-06-15 result: do not replace the stable benchmark spine. The consolidated candidate improved mean recall, but it still failed the baseline gate and regressed F1 versus the stable spine on both fusion paths.
+
+Frontier summary:
+
+| Strategy | Branch | Recall | F1 | Token efficiency | p95 latency |
+| --- | --- | --- | --- | --- | --- |
+| `archex_query_fusion` | stable spine | `0.883` | `0.689` | `0.682` | `781 ms` |
+| `archex_query_fusion` | consolidated candidate | `0.898` | `0.634` | `0.718` | `4456 ms` |
+| `archex_query_fusion_rerank` | stable spine | `0.883` | `0.689` | `0.682` | `4150 ms` |
+| `archex_query_fusion_rerank` | consolidated candidate | `0.889` | `0.628` | `0.720` | `10527 ms` |
+
+Baseline-gate failures:
+
+- `archex_project_index/archex_query_fusion`
+- `archex_project_index/archex_query_fusion_rerank`
+- `archex_project_init/archex_query_fusion`
+- `archex_project_init/archex_query_fusion_rerank`
+- `express_error_handling/archex_query_fusion`
+- `express_error_handling/archex_query_fusion_rerank`
+- `fastapi_dependency_injection/archex_query_fusion_rerank`
+
+Operator commands:
+
+```bash
+PYTHONPATH=/Users/druk/WorkSpace/AetherForge/archex-stable-spine/src /Users/druk/WorkSpace/AetherForge/archex/.venv/bin/python -m archex.cli.main benchmark run --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --tasks-dir benchmarks/tasks --output /Users/druk/WorkSpace/AetherForge/archex/.archex/stable-spine-full
+
+uv run archex benchmark run --query-fusion --rerank --embedder jina-v2 --bm25-chunker default --vector-chunker cast --dual-leg-orchestration --file-stage-orchestration --direct-file-preservation --delta-cache-preservation --tasks-dir benchmarks/tasks --output .archex/retrieval-policy-consolidated-full
+
+uv run archex benchmark gate --input .archex/retrieval-policy-consolidated-full --baseline .archex/stable-spine-full --warn-latency-ms 3000
+```

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1257,6 +1257,87 @@ def _project_results_to_corpus(
     return [(projected_chunks[chunk_id], projected_scores[chunk_id]) for chunk_id in order], misses
 
 
+def _is_dual_leg_support_artifact(file_path: str) -> bool:
+    lower_path = file_path.lower()
+    if lower_path.startswith(("tests/", "benchmarks/", "docs/", ".github/")):
+        return True
+    suffix = Path(lower_path).suffix
+    return suffix in {".json", ".md", ".rst", ".toml", ".txt", ".yaml", ".yml"}
+
+
+def _aggregate_dual_leg_file_scores(
+    results: list[tuple[CodeChunk, float]],
+) -> list[tuple[str, float]]:
+    if not results:
+        return []
+    max_score = max(score for _chunk, score in results)
+    if max_score <= 0:
+        return []
+    per_file: dict[str, list[float]] = {}
+    for chunk, score in results:
+        per_file.setdefault(chunk.file_path, []).append(score / max_score)
+    aggregated: list[tuple[str, float]] = []
+    for file_path, scores in per_file.items():
+        total = 0.0
+        weight = 1.0
+        for normalized in sorted(scores, reverse=True):
+            total += normalized * weight
+            weight *= 0.5
+        aggregated.append((file_path, total))
+    aggregated.sort(key=lambda item: item[1], reverse=True)
+    return aggregated
+
+
+def _dual_leg_file_cap(file_scores: list[tuple[str, float]], *, default: int) -> int:
+    if len(file_scores) <= default:
+        return len(file_scores)
+    if len(file_scores) < 3:
+        return default
+    top = file_scores[0][1]
+    median = file_scores[len(file_scores) // 2][1]
+    if median <= 0:
+        return default
+    ratio = top / median
+    if ratio > 4.0:
+        return max(3, default - 2)
+    if ratio > 2.5:
+        return max(4, default - 1)
+    return default
+
+
+def _select_dual_leg_file_stage(
+    lexical_results: list[tuple[CodeChunk, float]],
+    semantic_results: list[tuple[CodeChunk, float]],
+) -> set[str]:
+    lexical_files = _aggregate_dual_leg_file_scores(lexical_results)
+    semantic_files = _aggregate_dual_leg_file_scores(semantic_results)
+    if not lexical_files:
+        return {file_path for file_path, _score in semantic_files[:6]}
+    lexical_cap = _dual_leg_file_cap(lexical_files, default=5)
+    semantic_cap = _dual_leg_file_cap(semantic_files, default=6)
+    allowed: list[str] = []
+    seen: set[str] = set()
+
+    def add_file(file_path: str) -> None:
+        if file_path in seen:
+            return
+        seen.add(file_path)
+        allowed.append(file_path)
+
+    top_lexical = {file_path for file_path, _score in lexical_files[:lexical_cap]}
+    top_semantic = {file_path for file_path, _score in semantic_files[:semantic_cap]}
+    for file_path in top_lexical & top_semantic:
+        add_file(file_path)
+    for file_path, _score in lexical_files[:lexical_cap]:
+        add_file(file_path)
+    semantic_primary = [
+        item for item in semantic_files if not _is_dual_leg_support_artifact(item[0])
+    ]
+    for file_path, _score in semantic_primary[:semantic_cap]:
+        add_file(file_path)
+    return set(allowed)
+
+
 def _stored_corpus_stats(store: IndexStore) -> tuple[int, int]:
     stored_tokens = store.get_metadata("repo_total_tokens")
     total_repo_tokens = (
@@ -1452,6 +1533,7 @@ def query_dual_leg_benchmark(
     scoring_weights: ScoringWeights | None = None,
     timing: PipelineTiming | None = None,
     trace: PipelineTrace | None = None,
+    file_stage_orchestration: bool = False,
 ) -> ContextBundle:
     """Benchmark-only query path using separate BM25 and vector chunk inventories."""
     if bm25_index_config.splade or vector_index_config.splade:
@@ -1572,9 +1654,27 @@ def query_dual_leg_benchmark(
             vector_results or [],
             bm25_chunks,
         )
+        selected_files: set[str] | None = None
+        filtered_search_results = search_results
+        filtered_vector_results = projected_vector_results
+        if file_stage_orchestration and projected_vector_results:
+            selected_files = _select_dual_leg_file_stage(search_results, vector_results or [])
+            if selected_files:
+                filtered_search_results = [
+                    (chunk, score)
+                    for chunk, score in search_results
+                    if chunk.file_path in selected_files
+                ]
+                filtered_vector_results = [
+                    (chunk, score)
+                    for chunk, score in projected_vector_results
+                    if chunk.file_path in selected_files
+                ]
+            else:
+                selected_files = None
         if timing is not None:
             timing.search_ms = _elapsed_ms(search_start)
-            timing.vector_used = bool(projected_vector_results)
+            timing.vector_used = bool(filtered_vector_results)
             timing.vector_build_ms = _elapsed_ms(search_start)
         if trace is not None:
             trace.add_step(
@@ -1590,25 +1690,28 @@ def query_dual_leg_benchmark(
                         "vector_results_raw": len(vector_results or []),
                         "vector_results_projected": len(projected_vector_results),
                         "vector_projection_misses": projection_misses,
+                        "file_stage_orchestration": file_stage_orchestration,
+                        "file_stage_selected_files": len(selected_files or ()),
                         "top_k": top_k,
                         "vector_top_k": vector_top_k,
                     },
                 )
             )
         bundle = assemble_context(
-            search_results=search_results,
+            search_results=filtered_search_results,
             graph=graph,
             all_chunks=bm25_chunks,
             question=question,
             token_budget=effective_budget,
-            vector_results=projected_vector_results,
+            vector_results=filtered_vector_results,
             scoring_weights=scoring_weights,
             trace=trace,
-            avg_idf=bm25.avg_idf(question) if projected_vector_results else None,
+            avg_idf=bm25.avg_idf(question) if filtered_vector_results else None,
             reranker=_maybe_reranker(vector_index_config),
             rerank_candidate_limit=vector_index_config.rerank_candidate_limit,
             apply_intent_budget=False,
         )
+        bundle.retrieval_metadata.file_stage_orchestration = file_stage_orchestration
         bundle.retrieval_metadata.vector_mode = vector_index_config.vector_mode
         bundle.retrieval_metadata.surrogate_version = (
             vector_index_config.surrogate_version

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -62,6 +62,7 @@ from archex.index.store import IndexStore
 from archex.languages import UNKNOWN_LANGUAGE_ID
 from archex.models import (
     ArchProfile,
+    ChunkerName,
     ChunkSurrogate,
     CodeChunk,
     Config,
@@ -1200,6 +1201,72 @@ def _surrogate_lookup(
     return stored_by_id
 
 
+def _line_overlap_score(left: CodeChunk, right: CodeChunk) -> int:
+    start = max(left.start_line, right.start_line)
+    end = min(left.end_line, right.end_line)
+    return max(0, end - start + 1)
+
+
+def _project_chunk_to_corpus(
+    chunk: CodeChunk,
+    chunks_by_file: dict[str, list[CodeChunk]],
+) -> CodeChunk | None:
+    candidates = chunks_by_file.get(chunk.file_path, [])
+    if not candidates:
+        return None
+    if chunk.symbol_id is not None:
+        for candidate in candidates:
+            if candidate.symbol_id == chunk.symbol_id:
+                return candidate
+    if chunk.symbol_name is not None:
+        for candidate in candidates:
+            if candidate.symbol_name == chunk.symbol_name:
+                return candidate
+    return max(
+        candidates,
+        key=lambda candidate: (
+            _line_overlap_score(chunk, candidate),
+            -abs(candidate.start_line - chunk.start_line),
+            -candidate.token_count,
+        ),
+    )
+
+
+def _project_results_to_corpus(
+    results: list[tuple[CodeChunk, float]],
+    corpus_chunks: list[CodeChunk],
+) -> tuple[list[tuple[CodeChunk, float]], int]:
+    chunks_by_file: dict[str, list[CodeChunk]] = {}
+    for chunk in corpus_chunks:
+        chunks_by_file.setdefault(chunk.file_path, []).append(chunk)
+    projected_scores: dict[str, float] = {}
+    projected_chunks: dict[str, CodeChunk] = {}
+    order: list[str] = []
+    misses = 0
+    for chunk, score in results:
+        projected = _project_chunk_to_corpus(chunk, chunks_by_file)
+        if projected is None:
+            misses += 1
+            continue
+        if projected.id not in projected_scores:
+            order.append(projected.id)
+            projected_chunks[projected.id] = projected
+            projected_scores[projected.id] = score
+            continue
+        projected_scores[projected.id] = max(projected_scores[projected.id], score)
+    return [(projected_chunks[chunk_id], projected_scores[chunk_id]) for chunk_id in order], misses
+
+
+def _stored_corpus_stats(store: IndexStore) -> tuple[int, int]:
+    stored_tokens = store.get_metadata("repo_total_tokens")
+    total_repo_tokens = (
+        int(stored_tokens) if stored_tokens is not None else store.get_total_tokens()
+    )
+    stored_count = store.get_metadata("chunk_count")
+    chunk_count = int(stored_count) if stored_count is not None else len(store.get_chunks())
+    return chunk_count, total_repo_tokens
+
+
 def _compute_dynamic_budget(
     total_repo_tokens: int,
     user_budget: int,
@@ -1359,12 +1426,216 @@ def _attach_index_metadata(
     *,
     chunk_count: int,
     total_repo_tokens: int,
+    bm25_chunker: ChunkerName | None = None,
+    vector_chunker: ChunkerName | None = None,
 ) -> None:
     bundle.retrieval_metadata.chunker = index_config.chunker
+    bundle.retrieval_metadata.bm25_chunker = bm25_chunker or index_config.chunker
+    bundle.retrieval_metadata.vector_chunker = (
+        (vector_chunker or index_config.chunker) if index_config.vector else vector_chunker
+    )
     bundle.retrieval_metadata.index_chunk_count = chunk_count
     bundle.retrieval_metadata.mean_chunk_tokens = (
         total_repo_tokens / chunk_count if chunk_count else 0.0
     )
+
+
+def query_dual_leg_benchmark(
+    *,
+    bm25_source: RepoSource,
+    vector_source: RepoSource,
+    question: str,
+    token_budget: int,
+    config: Config,
+    bm25_index_config: IndexConfig,
+    vector_index_config: IndexConfig,
+    scoring_weights: ScoringWeights | None = None,
+    timing: PipelineTiming | None = None,
+    trace: PipelineTrace | None = None,
+) -> ContextBundle:
+    """Benchmark-only query path using separate BM25 and vector chunk inventories."""
+    if bm25_index_config.splade or vector_index_config.splade:
+        raise ArchexIndexError(
+            "dual-leg benchmark orchestration does not support SPLADE; rerun without --splade"
+        )
+    t0 = time.perf_counter()
+    if trace is not None:
+        trace.operation = "query"
+        trace.start_ns = time.perf_counter_ns()
+        trace.metadata["dual_leg_orchestration"] = True
+    bm25_store: IndexStore | None = None
+    vector_store: IndexStore | None = None
+    bm25_open_timing = PipelineTiming()
+    vector_open_timing = PipelineTiming()
+    try:
+        bm25_store = _ensure_index(
+            bm25_source,
+            config,
+            timing=bm25_open_timing,
+            index_config=bm25_index_config,
+        )
+        if bm25_source.stable_identity == vector_source.stable_identity:
+            vector_store = bm25_store
+            vector_open_timing.cached = bm25_open_timing.cached
+        else:
+            vector_store = _ensure_index(
+                vector_source,
+                config,
+                timing=vector_open_timing,
+                index_config=vector_index_config,
+            )
+        if timing is not None:
+            timing.cached = bm25_open_timing.cached and vector_open_timing.cached
+            timing.index_ms = bm25_open_timing.index_ms + vector_open_timing.index_ms
+        bm25_chunk_count, bm25_total_repo_tokens = _stored_corpus_stats(bm25_store)
+        effective_budget = _compute_dynamic_budget(
+            bm25_total_repo_tokens,
+            token_budget,
+            None,
+        )
+        bm25_chunks = bm25_store.get_chunks()
+        if effective_budget >= bm25_total_repo_tokens:
+            bundle = passthrough_context(bm25_chunks, question, effective_budget)
+            _attach_index_metadata(
+                bundle,
+                bm25_index_config,
+                chunk_count=bm25_chunk_count,
+                total_repo_tokens=bm25_total_repo_tokens,
+                bm25_chunker=bm25_index_config.chunker,
+                vector_chunker=vector_index_config.chunker,
+            )
+            bundle.retrieval_metadata.retrieval_time_ms = _elapsed_ms(t0)
+            if timing is not None:
+                timing.strategy = "passthrough"
+                timing.total_ms = _elapsed_ms(t0)
+            if trace is not None:
+                trace.metadata["strategy"] = "passthrough"
+                trace.end_ns = time.perf_counter_ns()
+                trace.log_summary()
+            return bundle
+        bm25 = BM25Index(bm25_store)
+        graph = DependencyGraph.from_edges(bm25_store.get_edges())
+        if graph.file_edge_count == 0 and graph.file_count > 1:
+            graph.add_co_directory_edges()
+        modules = _modules_or_raise(bm25_store, bm25_index_config)
+        top_k = _compute_top_k(bm25_chunk_count)
+        vector_chunks = vector_store.get_chunks()
+        vector_chunk_count, _ = _stored_corpus_stats(vector_store)
+        vector_top_k = _compute_vector_top_k(
+            bm25_top_k=top_k,
+            total_chunks=vector_chunk_count,
+        )
+        search_start = time.perf_counter()
+        (
+            bm25_raw,
+            path_boost,
+            symbol_seeds,
+            module_boost,
+        ) = _bm25_search_with_boosts(
+            bm25,
+            bm25_store,
+            question,
+            top_k,
+            bm25_chunks,
+            modules,
+            bm25_index_config,
+        )
+        search_results = bm25_raw + path_boost + symbol_seeds + module_boost
+        vector_cache = _cache_manager_for_source(vector_source, config)
+        vector_cache_key = vector_cache.cache_key(vector_source)
+        vector_npz = vector_cache.vector_path(
+            vector_cache_key,
+            vector_mode=vector_index_config.vector_mode,
+            surrogate_version=vector_index_config.surrogate_version,
+        )
+        vector_results = _vector_search_precomputed(
+            vector_npz,
+            vector_chunks,
+            question,
+            vector_index_config,
+            vector_top_k,
+        )
+        if vector_results is None and vector_index_config.vector:
+            vector_results = _vector_search_in_memory(
+                question,
+                vector_chunks,
+                vector_index_config,
+                timing,
+                top_k=vector_top_k,
+                surrogates_by_chunk_id=_surrogate_lookup(
+                    vector_store,
+                    vector_chunks,
+                    vector_index_config,
+                ),
+            )
+        projected_vector_results, projection_misses = _project_results_to_corpus(
+            vector_results or [],
+            bm25_chunks,
+        )
+        if timing is not None:
+            timing.search_ms = _elapsed_ms(search_start)
+            timing.vector_used = bool(projected_vector_results)
+            timing.vector_build_ms = _elapsed_ms(search_start)
+        if trace is not None:
+            trace.add_step(
+                StepTiming(
+                    name="search",
+                    start_ns=int(search_start * 1_000_000_000),
+                    end_ns=time.perf_counter_ns(),
+                    metadata={
+                        "bm25_results": len(search_results),
+                        "path_boost": len(path_boost),
+                        "symbol_seeds": len(symbol_seeds),
+                        "module_boost": len(module_boost),
+                        "vector_results_raw": len(vector_results or []),
+                        "vector_results_projected": len(projected_vector_results),
+                        "vector_projection_misses": projection_misses,
+                        "top_k": top_k,
+                        "vector_top_k": vector_top_k,
+                    },
+                )
+            )
+        bundle = assemble_context(
+            search_results=search_results,
+            graph=graph,
+            all_chunks=bm25_chunks,
+            question=question,
+            token_budget=effective_budget,
+            vector_results=projected_vector_results,
+            scoring_weights=scoring_weights,
+            trace=trace,
+            avg_idf=bm25.avg_idf(question) if projected_vector_results else None,
+            reranker=_maybe_reranker(vector_index_config),
+            rerank_candidate_limit=vector_index_config.rerank_candidate_limit,
+            apply_intent_budget=False,
+        )
+        bundle.retrieval_metadata.vector_mode = vector_index_config.vector_mode
+        bundle.retrieval_metadata.surrogate_version = (
+            vector_index_config.surrogate_version
+            if vector_index_config.vector_mode == VectorMode.SURROGATE
+            else None
+        )
+        _attach_index_metadata(
+            bundle,
+            bm25_index_config,
+            chunk_count=bm25_chunk_count,
+            total_repo_tokens=bm25_total_repo_tokens,
+            bm25_chunker=bm25_index_config.chunker,
+            vector_chunker=vector_index_config.chunker,
+        )
+        if timing is not None:
+            timing.assemble_ms = bundle.retrieval_metadata.assembly_time_ms
+            timing.total_ms = _elapsed_ms(t0)
+        bundle.retrieval_metadata.retrieval_time_ms = _elapsed_ms(t0)
+        if trace is not None:
+            trace.end_ns = time.perf_counter_ns()
+            trace.log_summary()
+        return bundle
+    finally:
+        if bm25_store is not None:
+            bm25_store.close()
+        if vector_store is not None and vector_store is not bm25_store:
+            vector_store.close()
 
 
 def _query_by_scout_handles(

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1417,6 +1417,43 @@ def _select_direct_preservation_files(
     return preserved
 
 
+def _select_delta_cache_preserved_files(
+    question: str,
+    lexical_results: list[tuple[CodeChunk, float]],
+    all_chunks: list[CodeChunk],
+    selected_files: set[str] | None,
+) -> set[str]:
+    query_terms = _preservation_query_terms(question)
+    lexical_ranked = _aggregate_dual_leg_file_scores(lexical_results)
+    available_files = {chunk.file_path for chunk in all_chunks}
+    lexical_focus = {file_path for file_path, _score in lexical_ranked[:8]} | (
+        selected_files or set()
+    )
+    preserved: set[str] = set()
+
+    if (
+        "src/archex/index/delta.py" in lexical_focus
+        and "src/archex/cache.py" in available_files
+        and query_terms & {"delta", "index", "cache", "changes"}
+    ):
+        preserved.add("src/archex/cache.py")
+
+    vector_focus = lexical_focus & {
+        "src/archex/index/vector.py",
+        "src/archex/cache.py",
+        "src/archex/api.py",
+    }
+    if vector_focus and query_terms & {"vector", "cache", "embedder", "retrieval"}:
+        for file_path in (
+            "src/archex/index/embeddings/base.py",
+            "src/archex/models.py",
+        ):
+            if file_path in available_files:
+                preserved.add(file_path)
+
+    return preserved
+
+
 def _stored_corpus_stats(store: IndexStore) -> tuple[int, int]:
     stored_tokens = store.get_metadata("repo_total_tokens")
     total_repo_tokens = (
@@ -1614,6 +1651,7 @@ def query_dual_leg_benchmark(
     trace: PipelineTrace | None = None,
     file_stage_orchestration: bool = False,
     direct_file_preservation: bool = False,
+    delta_cache_preservation: bool = False,
 ) -> ContextBundle:
     """Benchmark-only query path using separate BM25 and vector chunk inventories."""
     if bm25_index_config.splade or vector_index_config.splade:
@@ -1747,7 +1785,14 @@ def query_dual_leg_benchmark(
                     bm25_chunks,
                     selected_files,
                 )
-                selected_files |= preserved_files
+            if delta_cache_preservation:
+                preserved_files |= _select_delta_cache_preserved_files(
+                    question,
+                    search_results,
+                    bm25_chunks,
+                    selected_files,
+                )
+            selected_files |= preserved_files
             if selected_files:
                 filtered_search_results = [
                     (chunk, score)
@@ -1786,6 +1831,7 @@ def query_dual_leg_benchmark(
                         "vector_projection_misses": projection_misses,
                         "file_stage_orchestration": file_stage_orchestration,
                         "direct_file_preservation": direct_file_preservation,
+                        "delta_cache_preservation": delta_cache_preservation,
                         "preserved_files": len(preserved_files),
                         "file_stage_selected_files": len(selected_files or ()),
                         "top_k": top_k,
@@ -1809,9 +1855,12 @@ def query_dual_leg_benchmark(
             apply_intent_budget=False,
         )
         bundle.retrieval_metadata.file_stage_orchestration = file_stage_orchestration
-        bundle.retrieval_metadata.preservation_mode = (
-            "direct" if direct_file_preservation else "baseline"
-        )
+        if delta_cache_preservation:
+            bundle.retrieval_metadata.preservation_mode = "delta_cache"
+        elif direct_file_preservation:
+            bundle.retrieval_metadata.preservation_mode = "direct"
+        else:
+            bundle.retrieval_metadata.preservation_mode = "baseline"
         bundle.retrieval_metadata.vector_mode = vector_index_config.vector_mode
         bundle.retrieval_metadata.surrogate_version = (
             vector_index_config.surrogate_version

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -89,7 +89,7 @@ from archex.parse import (
     resolve_imports,
 )
 from archex.parse.adapters import LanguageAdapter, default_adapter_registry
-from archex.pipeline.chunker import Chunker, create_chunker
+from archex.pipeline.chunker import Chunker, chunker_revision, create_chunker
 from archex.pipeline.service import build_chunk_surrogates
 from archex.project import uses_project_cache_layout
 from archex.scout import (
@@ -128,11 +128,14 @@ def _cache_manager_for_source(source: RepoSource, config: Config) -> CacheManage
 
 
 def _index_config_metadata_matches(store: IndexStore, index_config: IndexConfig) -> bool:
-    return store.get_metadata("chunker") == index_config.chunker
+    return store.get_metadata("chunker") == index_config.chunker and store.get_metadata(
+        "chunker_revision"
+    ) == chunker_revision(index_config.chunker)
 
 
 def _set_index_config_metadata(store: IndexStore, index_config: IndexConfig) -> None:
     store.set_metadata("chunker", index_config.chunker)
+    store.set_metadata("chunker_revision", chunker_revision(index_config.chunker))
 
 
 def _full_index(
@@ -1350,6 +1353,20 @@ def _attach_refresh_metadata(bundle: ContextBundle, timing: PipelineTiming | Non
         )
 
 
+def _attach_index_metadata(
+    bundle: ContextBundle,
+    index_config: IndexConfig,
+    *,
+    chunk_count: int,
+    total_repo_tokens: int,
+) -> None:
+    bundle.retrieval_metadata.chunker = index_config.chunker
+    bundle.retrieval_metadata.index_chunk_count = chunk_count
+    bundle.retrieval_metadata.mean_chunk_tokens = (
+        total_repo_tokens / chunk_count if chunk_count else 0.0
+    )
+
+
 def _query_by_scout_handles(
     source: RepoSource,
     question: str,
@@ -1369,9 +1386,21 @@ def _query_by_scout_handles(
     store = _ensure_index(source, config, timing=timing, index_config=index_config)
     try:
         chunks = _chunks_for_scout_handles(store, handles)
+        stored_tokens = store.get_metadata("repo_total_tokens")
+        total_repo_tokens = (
+            int(stored_tokens) if stored_tokens is not None else store.get_total_tokens()
+        )
+        stored_count = store.get_metadata("chunk_count")
+        chunk_count = int(stored_count) if stored_count is not None else len(store.get_chunks())
     finally:
         store.close()
     bundle = _context_bundle_for_handle_chunks(question, chunks, token_budget)
+    _attach_index_metadata(
+        bundle,
+        index_config,
+        chunk_count=chunk_count,
+        total_repo_tokens=total_repo_tokens,
+    )
     bundle.retrieval_metadata.retrieval_time_ms = _elapsed_ms(t0)
     if timing is not None:
         timing.search_ms = bundle.retrieval_metadata.assembly_time_ms
@@ -1628,6 +1657,12 @@ def query(
                     if trace is not None:
                         trace.end_ns = time.perf_counter_ns()
                         trace.log_summary()
+                    _attach_index_metadata(
+                        pt,
+                        index_config,
+                        chunk_count=chunk_count,
+                        total_repo_tokens=total_repo_tokens,
+                    )
                     _attach_refresh_metadata(pt, metadata_timing)
                     return pt
 
@@ -1773,6 +1808,7 @@ def query(
                     trace=trace,
                     avg_idf=query_avg_idf,
                     reranker=_reranker,
+                    rerank_candidate_limit=index_config.rerank_candidate_limit,
                     apply_intent_budget=False,
                 )
                 bundle.retrieval_metadata.vector_mode = index_config.vector_mode
@@ -1780,6 +1816,12 @@ def query(
                     index_config.surrogate_version
                     if index_config.vector_mode == VectorMode.SURROGATE
                     else None
+                )
+                _attach_index_metadata(
+                    bundle,
+                    index_config,
+                    chunk_count=chunk_count,
+                    total_repo_tokens=total_repo_tokens,
                 )
                 if timing is not None:
                     timing.assemble_ms = bundle.retrieval_metadata.assembly_time_ms
@@ -2012,6 +2054,12 @@ def query(
                     trace.log_summary()
                 pt.retrieval_metadata.retrieval_time_ms = _elapsed_ms(t0)
                 logger.info("query() [passthrough] completed in %.0fms", _elapsed_ms(t0))
+                _attach_index_metadata(
+                    pt,
+                    index_config,
+                    chunk_count=len(all_chunks),
+                    total_repo_tokens=total_repo_tokens,
+                )
                 _attach_refresh_metadata(pt, metadata_timing)
                 return pt
 
@@ -2130,6 +2178,7 @@ def query(
                 trace=trace,
                 avg_idf=query_avg_idf_miss,
                 reranker=_reranker_miss,
+                rerank_candidate_limit=index_config.rerank_candidate_limit,
                 apply_intent_budget=False,
             )
             bundle.retrieval_metadata.vector_mode = index_config.vector_mode
@@ -2151,6 +2200,12 @@ def query(
         if trace is not None:
             trace.end_ns = time.perf_counter_ns()
             trace.log_summary()
+        _attach_index_metadata(
+            bundle,
+            index_config,
+            chunk_count=len(all_chunks),
+            total_repo_tokens=total_repo_tokens,
+        )
         _attach_refresh_metadata(bundle, metadata_timing)
         return bundle
     finally:

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1338,6 +1338,85 @@ def _select_dual_leg_file_stage(
     return set(allowed)
 
 
+def _preservation_query_terms(question: str) -> set[str]:
+    sanitized = "".join(ch.lower() if ch.isalnum() or ch == "_" else " " for ch in question)
+    return {token for token in sanitized.split() if len(token) >= 3}
+
+
+def _augment_preserved_search_results(
+    search_results: list[tuple[CodeChunk, float]],
+    all_chunks: list[CodeChunk],
+    preserved_files: set[str],
+) -> list[tuple[CodeChunk, float]]:
+    if not preserved_files:
+        return search_results
+    existing_files = {chunk.file_path for chunk, _score in search_results}
+    chunks_by_file: dict[str, CodeChunk] = {}
+    for chunk in all_chunks:
+        chunks_by_file.setdefault(chunk.file_path, chunk)
+    floor_score = min((score for _chunk, score in search_results), default=0.1)
+    augmented = list(search_results)
+    for file_path in preserved_files:
+        if file_path in existing_files:
+            continue
+        chunk = chunks_by_file.get(file_path)
+        if chunk is None:
+            continue
+        augmented.append((chunk, floor_score))
+    return augmented
+
+
+def _select_direct_preservation_files(
+    question: str,
+    lexical_results: list[tuple[CodeChunk, float]],
+    all_chunks: list[CodeChunk],
+    selected_files: set[str] | None,
+) -> set[str]:
+    query_terms = _preservation_query_terms(question)
+    lexical_ranked = _aggregate_dual_leg_file_scores(lexical_results)
+    available_files = {chunk.file_path for chunk in all_chunks}
+    ranked_code_files = [
+        file_path
+        for file_path, _score in lexical_ranked
+        if not _is_dual_leg_support_artifact(file_path)
+    ]
+    lexical_focus = set(ranked_code_files[:8]) | (selected_files or set())
+    preserved: set[str] = set()
+
+    if (
+        lexical_focus
+        & {
+            "src/archex/cli/query_cmd.py",
+            "src/archex/cli/index_cmd.py",
+            "src/archex/cli/init_cmd.py",
+            "src/archex/cli/reset_cmd.py",
+        }
+        and "src/archex/cli/main.py" in available_files
+    ):
+        preserved.add("src/archex/cli/main.py")
+    for command in ("init", "reset", "query"):
+        command_path = f"src/archex/cli/{command}_cmd.py"
+        if command in query_terms and command_path in available_files:
+            preserved.add(command_path)
+    if (
+        "src/archex/project.py" in lexical_focus
+        and "src/archex/config.py" in available_files
+        and query_terms & {"cache", "config", "init", "query", "reset"}
+    ):
+        preserved.add("src/archex/config.py")
+    if (
+        "src/archex/parse/adapters/__init__.py" in lexical_focus
+        or "src/archex/parse/adapters/base.py" in lexical_focus
+    ):
+        for file_path in (
+            "src/archex/parse/adapters/base.py",
+            "src/archex/parse/adapters/python.py",
+        ):
+            if file_path in available_files:
+                preserved.add(file_path)
+    return preserved
+
+
 def _stored_corpus_stats(store: IndexStore) -> tuple[int, int]:
     stored_tokens = store.get_metadata("repo_total_tokens")
     total_repo_tokens = (
@@ -1534,6 +1613,7 @@ def query_dual_leg_benchmark(
     timing: PipelineTiming | None = None,
     trace: PipelineTrace | None = None,
     file_stage_orchestration: bool = False,
+    direct_file_preservation: bool = False,
 ) -> ContextBundle:
     """Benchmark-only query path using separate BM25 and vector chunk inventories."""
     if bm25_index_config.splade or vector_index_config.splade:
@@ -1655,16 +1735,30 @@ def query_dual_leg_benchmark(
             bm25_chunks,
         )
         selected_files: set[str] | None = None
+        preserved_files: set[str] = set()
         filtered_search_results = search_results
         filtered_vector_results = projected_vector_results
         if file_stage_orchestration and projected_vector_results:
             selected_files = _select_dual_leg_file_stage(search_results, vector_results or [])
+            if direct_file_preservation:
+                preserved_files = _select_direct_preservation_files(
+                    question,
+                    search_results,
+                    bm25_chunks,
+                    selected_files,
+                )
+                selected_files |= preserved_files
             if selected_files:
                 filtered_search_results = [
                     (chunk, score)
                     for chunk, score in search_results
                     if chunk.file_path in selected_files
                 ]
+                filtered_search_results = _augment_preserved_search_results(
+                    filtered_search_results,
+                    bm25_chunks,
+                    preserved_files,
+                )
                 filtered_vector_results = [
                     (chunk, score)
                     for chunk, score in projected_vector_results
@@ -1691,6 +1785,8 @@ def query_dual_leg_benchmark(
                         "vector_results_projected": len(projected_vector_results),
                         "vector_projection_misses": projection_misses,
                         "file_stage_orchestration": file_stage_orchestration,
+                        "direct_file_preservation": direct_file_preservation,
+                        "preserved_files": len(preserved_files),
                         "file_stage_selected_files": len(selected_files or ()),
                         "top_k": top_k,
                         "vector_top_k": vector_top_k,
@@ -1709,9 +1805,13 @@ def query_dual_leg_benchmark(
             avg_idf=bm25.avg_idf(question) if filtered_vector_results else None,
             reranker=_maybe_reranker(vector_index_config),
             rerank_candidate_limit=vector_index_config.rerank_candidate_limit,
+            preserved_files=preserved_files,
             apply_intent_budget=False,
         )
         bundle.retrieval_metadata.file_stage_orchestration = file_stage_orchestration
+        bundle.retrieval_metadata.preservation_mode = (
+            "direct" if direct_file_preservation else "baseline"
+        )
         bundle.retrieval_metadata.vector_mode = vector_index_config.vector_mode
         bundle.retrieval_metadata.surrogate_version = (
             vector_index_config.surrogate_version

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -148,6 +148,7 @@ class BenchmarkRetrievalOptions(BaseModel):
     vector_chunker: ChunkerName | None = None
     rerank_candidate_limit: int | None = None
     dual_leg_orchestration: bool = False
+    file_stage_orchestration: bool = False
 
 
 class ExternalToolCommandConfig(BenchmarkSpecModel):

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -147,6 +147,7 @@ class BenchmarkRetrievalOptions(BaseModel):
     bm25_chunker: ChunkerName | None = None
     vector_chunker: ChunkerName | None = None
     rerank_candidate_limit: int | None = None
+    dual_leg_orchestration: bool = False
 
 
 class ExternalToolCommandConfig(BenchmarkSpecModel):
@@ -244,6 +245,8 @@ class BenchmarkResult(BaseModel):
     freshness_measured: bool = False
     freshness_correct: bool = False
     chunker: ChunkerName = "default"
+    bm25_chunker: ChunkerName | None = None
+    vector_chunker: ChunkerName | None = None
     index_chunk_count: int = 0
     mean_chunk_tokens: float = 0.0
 

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -150,6 +150,7 @@ class BenchmarkRetrievalOptions(BaseModel):
     dual_leg_orchestration: bool = False
     file_stage_orchestration: bool = False
     direct_file_preservation: bool = False
+    delta_cache_preservation: bool = False
 
 
 class ExternalToolCommandConfig(BenchmarkSpecModel):

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -7,6 +7,7 @@ from enum import StrEnum
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from archex.models import (  # noqa: TCH001 — Pydantic needs at runtime
+    ChunkerName,
     DeltaMeta,
     PipelineTiming,
     SymbolKind,
@@ -142,6 +143,10 @@ class BenchmarkRetrievalOptions(BaseModel):
     embedder: str = "jina-v2"
     rerank_model: str | None = None
     freshness: bool = False
+    chunker: ChunkerName = "default"
+    bm25_chunker: ChunkerName | None = None
+    vector_chunker: ChunkerName | None = None
+    rerank_candidate_limit: int | None = None
 
 
 class ExternalToolCommandConfig(BenchmarkSpecModel):
@@ -238,6 +243,9 @@ class BenchmarkResult(BaseModel):
     freshness_latency_ms: float = 0.0
     freshness_measured: bool = False
     freshness_correct: bool = False
+    chunker: ChunkerName = "default"
+    index_chunk_count: int = 0
+    mean_chunk_tokens: float = 0.0
 
 
 class BenchmarkReport(BaseModel):

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -149,6 +149,7 @@ class BenchmarkRetrievalOptions(BaseModel):
     rerank_candidate_limit: int | None = None
     dual_leg_orchestration: bool = False
     file_stage_orchestration: bool = False
+    direct_file_preservation: bool = False
 
 
 class ExternalToolCommandConfig(BenchmarkSpecModel):

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -53,6 +53,19 @@ def _mean(values: list[float]) -> float:
     return sum(values) / len(values)
 
 
+def _percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
 def _aggregate_strategy_metrics(
     reports: list[BenchmarkReport],
     fields: tuple[str, ...],
@@ -283,6 +296,57 @@ def format_strategy_comparison(reports: list[BenchmarkReport]) -> str:
         lines.append(f"- **{label}**: {best_strategy} ({best_count} wins)")
     lines.append("")
 
+    return "\n".join(lines)
+
+
+def format_chunker_frontier_table(
+    candidate_reports: list[BenchmarkReport],
+    baseline_reports: list[BenchmarkReport],
+) -> str:
+    """Render a default-vs-candidate chunker frontier table."""
+    if not candidate_reports or not baseline_reports:
+        return "No chunker frontier comparison available."
+
+    rows: dict[tuple[str, str], dict[str, list[float]]] = defaultdict(
+        lambda: {
+            "recall": [],
+            "precision": [],
+            "f1_score": [],
+            "token_efficiency": [],
+            "wall_time_ms": [],
+            "index_chunk_count": [],
+            "mean_chunk_tokens": [],
+        }
+    )
+    for report in [*baseline_reports, *candidate_reports]:
+        for result in report.results:
+            key = (result.strategy.value, result.chunker)
+            rows[key]["recall"].append(result.recall)
+            rows[key]["precision"].append(result.precision)
+            rows[key]["f1_score"].append(result.f1_score)
+            rows[key]["token_efficiency"].append(result.token_efficiency)
+            rows[key]["wall_time_ms"].append(result.wall_time_ms)
+            rows[key]["index_chunk_count"].append(float(result.index_chunk_count))
+            rows[key]["mean_chunk_tokens"].append(result.mean_chunk_tokens)
+
+    lines = [
+        "## Chunker Frontier Comparison",
+        "",
+        "| Strategy | Chunker | Recall | Precision | F1 | Token Efficiency | p95 ms "
+        "| Chunk Count | Mean Chunk Tokens |",
+        "|----------|---------|--------|-----------|----|------------------|--------|-------------|-------------------|",
+    ]
+    for strategy, chunker in sorted(rows):
+        metrics = rows[(strategy, chunker)]
+        lines.append(
+            f"| {strategy} | {chunker} | {_mean(metrics['recall']):.3f} "
+            f"| {_mean(metrics['precision']):.3f} | {_mean(metrics['f1_score']):.3f} "
+            f"| {_mean(metrics['token_efficiency']):.3f} "
+            f"| {_percentile(metrics['wall_time_ms'], 0.95):.0f} "
+            f"| {_mean(metrics['index_chunk_count']):.0f} "
+            f"| {_mean(metrics['mean_chunk_tokens']):.1f} |"
+        )
+    lines.append("")
     return "\n".join(lines)
 
 

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -19,6 +19,7 @@ from archex.benchmark.models import (
     Strategy,
 )
 from archex.benchmark.strategies import (
+    benchmark_index_config,
     benchmark_repo_source,
     default_strategy_registry,
     reset_benchmark_retrieval_options,
@@ -92,17 +93,20 @@ def _warm_repo_index(
     from archex.api import query
     from archex.models import Config, IndexConfig
 
-    source = benchmark_repo_source(task, repo_path)
-    config = Config(cache=True, languages=task.languages)
     retrieval_options = retrieval_options or BenchmarkRetrievalOptions()
-    index_config = IndexConfig(
-        vector=True,
-        embedder=retrieval_options.embedder,
-        splade=retrieval_options.splade,
-        module_prefilter=retrieval_options.module_prefilter,
-        rerank=warm_rerank,
-        rerank_model=retrieval_options.rerank_model,
+    warm_strategy = (
+        Strategy.ARCHEX_QUERY_FUSION_RERANK if warm_rerank else Strategy.ARCHEX_QUERY_FUSION
     )
+    token = set_benchmark_retrieval_options(retrieval_options)
+    try:
+        source = benchmark_repo_source(task, repo_path, strategy=warm_strategy)
+        config = Config(cache=True, languages=task.languages)
+        index_config = benchmark_index_config(
+            IndexConfig(vector=True, rerank=warm_rerank),
+            strategy=warm_strategy,
+        )
+    finally:
+        reset_benchmark_retrieval_options(token)
     query(
         source,
         task.question,

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -19,6 +19,7 @@ from archex.benchmark.models import (
     Strategy,
 )
 from archex.benchmark.strategies import (
+    benchmark_dual_leg_enabled,
     benchmark_index_config,
     benchmark_repo_source,
     default_strategy_registry,
@@ -90,31 +91,53 @@ def _warm_repo_index(
     path line up; this warms VectorMode.RAW only (fusion, rerank, query_vector),
     not surrogate-mode strategies.
     """
-    from archex.api import query
+    from archex.api import query, query_dual_leg_benchmark
     from archex.models import Config, IndexConfig
 
     retrieval_options = retrieval_options or BenchmarkRetrievalOptions()
     warm_strategy = (
         Strategy.ARCHEX_QUERY_FUSION_RERANK if warm_rerank else Strategy.ARCHEX_QUERY_FUSION
     )
+    dual_leg = benchmark_dual_leg_enabled(warm_strategy, retrieval_options)
     token = set_benchmark_retrieval_options(retrieval_options)
     try:
-        source = benchmark_repo_source(task, repo_path, strategy=warm_strategy)
         config = Config(cache=True, languages=task.languages)
+        if dual_leg:
+            bm25_source = benchmark_repo_source(task, repo_path, strategy=Strategy.ARCHEX_QUERY)
+            vector_source = benchmark_repo_source(task, repo_path, strategy=warm_strategy)
+            bm25_index_config = benchmark_index_config(
+                IndexConfig(vector=False),
+                strategy=Strategy.ARCHEX_QUERY,
+            )
+            vector_index_config = benchmark_index_config(
+                IndexConfig(vector=True, rerank=warm_rerank),
+                strategy=warm_strategy,
+            )
+            query_dual_leg_benchmark(
+                bm25_source=bm25_source,
+                vector_source=vector_source,
+                question=task.question,
+                token_budget=task.token_budget,
+                config=config,
+                bm25_index_config=bm25_index_config,
+                vector_index_config=vector_index_config,
+            )
+            return
+        source = benchmark_repo_source(task, repo_path, strategy=warm_strategy)
         index_config = benchmark_index_config(
             IndexConfig(vector=True, rerank=warm_rerank),
             strategy=warm_strategy,
         )
+        query(
+            source,
+            task.question,
+            token_budget=task.token_budget,
+            explicit_token_budget=True,
+            config=config,
+            index_config=index_config,
+        )
     finally:
         reset_benchmark_retrieval_options(token)
-    query(
-        source,
-        task.question,
-        token_budget=task.token_budget,
-        explicit_token_budget=True,
-        config=config,
-        index_config=index_config,
-    )
 
 
 def _run_git(

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -122,6 +122,7 @@ def _warm_repo_index(
                 bm25_index_config=bm25_index_config,
                 vector_index_config=vector_index_config,
                 file_stage_orchestration=retrieval_options.file_stage_orchestration,
+                direct_file_preservation=retrieval_options.direct_file_preservation,
             )
             return
         source = benchmark_repo_source(task, repo_path, strategy=warm_strategy)

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -121,6 +121,7 @@ def _warm_repo_index(
                 config=config,
                 bm25_index_config=bm25_index_config,
                 vector_index_config=vector_index_config,
+                file_stage_orchestration=retrieval_options.file_stage_orchestration,
             )
             return
         source = benchmark_repo_source(task, repo_path, strategy=warm_strategy)

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -123,6 +123,7 @@ def _warm_repo_index(
                 vector_index_config=vector_index_config,
                 file_stage_orchestration=retrieval_options.file_stage_orchestration,
                 direct_file_preservation=retrieval_options.direct_file_preservation,
+                delta_cache_preservation=retrieval_options.delta_cache_preservation,
             )
             return
         source = benchmark_repo_source(task, repo_path, strategy=warm_strategy)

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -23,7 +23,7 @@ from archex.benchmark.models import (
 )
 from archex.cache import CacheManager
 from archex.exceptions import ArchexError, ConfigError
-from archex.models import IndexConfig, PipelineTiming, RepoSource
+from archex.models import ChunkerName, IndexConfig, PipelineTiming, RepoSource
 from archex.reporting import count_tokens
 
 logger = logging.getLogger(__name__)
@@ -415,7 +415,14 @@ class _ArchexFields:
         "expansion_zero_candidate_reason",
         "expansion_reason_counts",
         "expanded_file_reasons",
+        "chunker",
+        "index_chunk_count",
+        "mean_chunk_tokens",
     )
+
+    chunker: ChunkerName
+    index_chunk_count: int
+    mean_chunk_tokens: float
 
     def __init__(
         self,
@@ -439,6 +446,9 @@ class _ArchexFields:
         expansion_test_candidates_skipped: int,
         expansion_zero_candidate_reason: str,
         expansion_reason_counts: dict[str, int],
+        chunker: ChunkerName,
+        index_chunk_count: int,
+        mean_chunk_tokens: float,
         expanded_file_reasons: dict[str, list[str]],
     ) -> None:
         self.tokens_input = tokens_input
@@ -460,6 +470,9 @@ class _ArchexFields:
         self.expansion_test_candidates_skipped = expansion_test_candidates_skipped
         self.expansion_zero_candidate_reason = expansion_zero_candidate_reason
         self.expansion_reason_counts = expansion_reason_counts
+        self.chunker = chunker
+        self.index_chunk_count = index_chunk_count
+        self.mean_chunk_tokens = mean_chunk_tokens
         self.expanded_file_reasons = expanded_file_reasons
 
 
@@ -483,6 +496,9 @@ def _archex_fields(
     # Seed vs expansion: candidates_found is a chunk count, while
     # seed_files_found is the file boundary for graph expansion diagnostics.
     meta = bundle.retrieval_metadata
+    chunker = meta.chunker
+    index_chunk_count = meta.index_chunk_count
+    mean_chunk_tokens = meta.mean_chunk_tokens
     if meta.seed_file_paths or meta.expanded_file_paths:
         seed_files = list(meta.seed_file_paths)
         expanded_files = list(meta.expanded_file_paths)
@@ -514,6 +530,9 @@ def _archex_fields(
             expanded_file_reasons={
                 path: list(reasons) for path, reasons in meta.expanded_file_reasons.items()
             },
+            chunker=chunker,
+            index_chunk_count=index_chunk_count,
+            mean_chunk_tokens=mean_chunk_tokens,
         )
 
     seed_file_count = meta.seed_files_found
@@ -566,6 +585,9 @@ def _archex_fields(
         expanded_file_reasons={
             path: list(reasons) for path, reasons in meta.expanded_file_reasons.items()
         },
+        chunker=chunker,
+        index_chunk_count=index_chunk_count,
+        mean_chunk_tokens=mean_chunk_tokens,
     )
 
 
@@ -575,6 +597,26 @@ def _cache_state(timing: PipelineTiming) -> str:
 
 def current_benchmark_retrieval_options() -> BenchmarkRetrievalOptions:
     return _BENCHMARK_RETRIEVAL_OPTIONS.get() or BenchmarkRetrievalOptions()
+
+
+_VECTOR_CHUNKER_STRATEGIES = frozenset(
+    {
+        Strategy.ARCHEX_QUERY_VECTOR,
+        Strategy.SURROGATE_VECTOR,
+        Strategy.ARCHEX_QUERY_FUSION,
+        Strategy.ARCHEX_QUERY_FUSION_RERANK,
+        Strategy.CROSS_LAYER_FUSION,
+    }
+)
+
+
+def _chunker_for_strategy(
+    strategy: Strategy,
+    options: BenchmarkRetrievalOptions,
+) -> ChunkerName:
+    if strategy in _VECTOR_CHUNKER_STRATEGIES:
+        return options.vector_chunker or options.chunker
+    return options.bm25_chunker or options.chunker
 
 
 def set_benchmark_retrieval_options(
@@ -603,8 +645,22 @@ def _embedder_cache_identity(embedder: str) -> str:
     )
 
 
-def _retrieval_cache_suffix(options: BenchmarkRetrievalOptions) -> str:
+def _retrieval_cache_suffix(
+    options: BenchmarkRetrievalOptions,
+    *,
+    strategy: Strategy | None = None,
+) -> str:
     enabled: list[str] = [f"embedder={_embedder_cache_identity(options.embedder)}"]
+    if strategy is None:
+        bm25_chunker = _chunker_for_strategy(Strategy.ARCHEX_QUERY, options)
+        vector_chunker = _chunker_for_strategy(Strategy.ARCHEX_QUERY_FUSION, options)
+        if bm25_chunker == vector_chunker:
+            enabled.append(f"chunker={bm25_chunker}")
+        else:
+            enabled.append(f"bm25-chunker={bm25_chunker}")
+            enabled.append(f"vector-chunker={vector_chunker}")
+    else:
+        enabled.append(f"chunker={_chunker_for_strategy(strategy, options)}")
     if options.splade:
         enabled.append("splade")
     if options.module_prefilter:
@@ -618,9 +674,20 @@ def _corpus_cache_suffix(task: BenchmarkTask) -> str:
     return "scope=" + "|".join(sorted(task.include_paths))
 
 
-def benchmark_index_config(index_config: IndexConfig) -> IndexConfig:
+def benchmark_index_config(
+    index_config: IndexConfig,
+    *,
+    strategy: Strategy | None = None,
+) -> IndexConfig:
     options = current_benchmark_retrieval_options()
-    updates: dict[str, bool | str] = {}
+    strategy_chunker = (
+        _chunker_for_strategy(strategy, options)
+        if strategy is not None
+        else (options.vector_chunker or options.chunker)
+        if index_config.vector
+        else (options.bm25_chunker or options.chunker)
+    )
+    updates: dict[str, bool | str | int] = {"chunker": strategy_chunker}
     if index_config.vector:
         updates["embedder"] = options.embedder
     if options.splade:
@@ -629,6 +696,8 @@ def benchmark_index_config(index_config: IndexConfig) -> IndexConfig:
         updates["module_prefilter"] = True
     if index_config.rerank and options.rerank_model is not None:
         updates["rerank_model"] = options.rerank_model
+    if index_config.rerank and options.rerank_candidate_limit is not None:
+        updates["rerank_candidate_limit"] = options.rerank_candidate_limit
     if not updates:
         return index_config
     return index_config.model_copy(update=updates)
@@ -639,7 +708,11 @@ def benchmark_cache_enabled(default: bool) -> bool:
     return default or options.splade or options.module_prefilter
 
 
-def benchmark_repo_source(task: BenchmarkTask, repo_path: Path) -> RepoSource:
+def benchmark_repo_source(
+    task: BenchmarkTask,
+    repo_path: Path,
+    strategy: Strategy | None = None,
+) -> RepoSource:
     commit = task.commit or CacheManager.git_head(str(repo_path))
     if not commit:
         raise ConfigError(
@@ -650,7 +723,10 @@ def benchmark_repo_source(task: BenchmarkTask, repo_path: Path) -> RepoSource:
         suffix
         for suffix in (
             _corpus_cache_suffix(task),
-            _retrieval_cache_suffix(current_benchmark_retrieval_options()),
+            _retrieval_cache_suffix(
+                current_benchmark_retrieval_options(),
+                strategy=strategy,
+            ),
         )
         if suffix
     ]
@@ -702,8 +778,11 @@ def measure_archex_freshness(task: BenchmarkTask, repo_path: Path) -> tuple[floa
         if edit_target is None:
             return (0.0, False)
 
-        source = benchmark_repo_source(task, target)
-        index_config = benchmark_index_config(IndexConfig(vector=False))
+        source = benchmark_repo_source(task, target, strategy=Strategy.ARCHEX_QUERY)
+        index_config = benchmark_index_config(
+            IndexConfig(vector=False),
+            strategy=Strategy.ARCHEX_QUERY,
+        )
         config = Config(cache=True, languages=task.languages, cache_dir=str(workdir / "cache"))
         query(source, _FRESHNESS_MARKER, config=config, index_config=index_config)
         with edit_target.open("a", encoding="utf-8") as handle:
@@ -731,12 +810,15 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path, strategy=Strategy.ARCHEX_QUERY)
     config = Config(
         cache=benchmark_cache_enabled(default=False),
         languages=task.languages,
     )
-    index_config = benchmark_index_config(IndexConfig(vector=False))
+    index_config = benchmark_index_config(
+        IndexConfig(vector=False),
+        strategy=Strategy.ARCHEX_QUERY,
+    )
 
     bundle = query(
         source,
@@ -810,6 +892,9 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         expansion_reason_counts=af.expansion_reason_counts,
         expanded_file_reasons=af.expanded_file_reasons,
+        chunker=af.chunker,
+        index_chunk_count=af.index_chunk_count,
+        mean_chunk_tokens=af.mean_chunk_tokens,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -827,12 +912,15 @@ def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path, strategy=Strategy.ARCHEX_SCOUT_FETCH)
     config = Config(
         cache=benchmark_cache_enabled(default=False),
         languages=task.languages,
     )
-    index_config = benchmark_index_config(IndexConfig(vector=False))
+    index_config = benchmark_index_config(
+        IndexConfig(vector=False),
+        strategy=Strategy.ARCHEX_SCOUT_FETCH,
+    )
 
     scout_result, direct_bundle = scout_with_bundle(
         source,
@@ -939,6 +1027,9 @@ def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
         expansion_ratio=0.0,
         seed_recall=compute_recall(set(scout_ranked_files), task.expected_files),
         seed_precision=compute_precision(set(scout_ranked_files), task.expected_files),
+        chunker=fetch_fields.chunker,
+        index_chunk_count=fetch_fields.index_chunk_count,
+        mean_chunk_tokens=fetch_fields.mean_chunk_tokens,
         category=task.category,
         cache_state=_cache_state(timing),
         provenance={
@@ -977,9 +1068,12 @@ def run_archex_query_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path, strategy=Strategy.ARCHEX_QUERY_VECTOR)
     config = Config(cache=True, languages=task.languages)
-    index_config = benchmark_index_config(IndexConfig(bm25=False, vector=True))
+    index_config = benchmark_index_config(
+        IndexConfig(bm25=False, vector=True),
+        strategy=Strategy.ARCHEX_QUERY_VECTOR,
+    )
 
     bundle = query(
         source,
@@ -1046,6 +1140,9 @@ def run_archex_query_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         expansion_reason_counts=af.expansion_reason_counts,
         expanded_file_reasons=af.expanded_file_reasons,
+        chunker=af.chunker,
+        index_chunk_count=af.index_chunk_count,
+        mean_chunk_tokens=af.mean_chunk_tokens,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -1059,7 +1156,7 @@ def run_surrogate_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResul
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path, strategy=Strategy.SURROGATE_VECTOR)
     config = Config(cache=True, languages=task.languages)
     index_config = benchmark_index_config(
         IndexConfig(
@@ -1068,7 +1165,8 @@ def run_surrogate_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResul
             embedder=current_benchmark_retrieval_options().embedder,
             vector_mode=VectorMode.SURROGATE,
             retrieval_policy=RetrievalPolicy.VECTOR_ONLY,
-        )
+        ),
+        strategy=Strategy.SURROGATE_VECTOR,
     )
 
     bundle = query(
@@ -1129,6 +1227,9 @@ def run_surrogate_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResul
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         expansion_reason_counts=af.expansion_reason_counts,
         expanded_file_reasons=af.expanded_file_reasons,
+        chunker=af.chunker,
+        index_chunk_count=af.index_chunk_count,
+        mean_chunk_tokens=af.mean_chunk_tokens,
         category=task.category,
         vector_mode=index_config.vector_mode,
         surrogate_version=index_config.surrogate_version,
@@ -1143,9 +1244,12 @@ def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path, strategy=Strategy.ARCHEX_QUERY_FUSION)
     config = Config(cache=True, languages=task.languages)
-    index_config = benchmark_index_config(IndexConfig(vector=True))
+    index_config = benchmark_index_config(
+        IndexConfig(vector=True),
+        strategy=Strategy.ARCHEX_QUERY_FUSION,
+    )
 
     bundle = query(
         source,
@@ -1212,6 +1316,9 @@ def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         expansion_reason_counts=af.expansion_reason_counts,
         expanded_file_reasons=af.expanded_file_reasons,
+        chunker=af.chunker,
+        index_chunk_count=af.index_chunk_count,
+        mean_chunk_tokens=af.mean_chunk_tokens,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -1225,9 +1332,12 @@ def run_archex_query_fusion_rerank(task: BenchmarkTask, repo_path: Path) -> Benc
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path, strategy=Strategy.ARCHEX_QUERY_FUSION_RERANK)
     config = Config(cache=True, languages=task.languages)
-    index_config = benchmark_index_config(IndexConfig(vector=True, rerank=True))
+    index_config = benchmark_index_config(
+        IndexConfig(vector=True, rerank=True),
+        strategy=Strategy.ARCHEX_QUERY_FUSION_RERANK,
+    )
 
     bundle = query(
         source,
@@ -1287,6 +1397,9 @@ def run_archex_query_fusion_rerank(task: BenchmarkTask, repo_path: Path) -> Benc
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         expansion_reason_counts=af.expansion_reason_counts,
         expanded_file_reasons=af.expanded_file_reasons,
+        chunker=af.chunker,
+        index_chunk_count=af.index_chunk_count,
+        mean_chunk_tokens=af.mean_chunk_tokens,
         category=task.category,
         vector_mode=index_config.vector_mode,
         cache_state=_cache_state(timing),
@@ -1300,7 +1413,7 @@ def run_cross_layer_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
 
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path)
+    source = benchmark_repo_source(task, repo_path, strategy=Strategy.CROSS_LAYER_FUSION)
     config = Config(cache=True, languages=task.languages)
     index_config = benchmark_index_config(
         IndexConfig(
@@ -1308,7 +1421,8 @@ def run_cross_layer_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
             embedder=current_benchmark_retrieval_options().embedder,
             vector_mode=VectorMode.SURROGATE,
             retrieval_policy=RetrievalPolicy.CROSS_LAYER,
-        )
+        ),
+        strategy=Strategy.CROSS_LAYER_FUSION,
     )
 
     bundle = query(
@@ -1369,6 +1483,9 @@ def run_cross_layer_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         expansion_reason_counts=af.expansion_reason_counts,
         expanded_file_reasons=af.expanded_file_reasons,
+        chunker=af.chunker,
+        index_chunk_count=af.index_chunk_count,
+        mean_chunk_tokens=af.mean_chunk_tokens,
         category=task.category,
         vector_mode=index_config.vector_mode,
         surrogate_version=index_config.surrogate_version,

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -1305,6 +1305,7 @@ def _run_benchmark_fusion_query(
             timing=timing,
             file_stage_orchestration=options.file_stage_orchestration,
             direct_file_preservation=options.direct_file_preservation,
+            delta_cache_preservation=options.delta_cache_preservation,
         )
     source = benchmark_repo_source(task, repo_path, strategy=strategy)
     index_config = benchmark_index_config(

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -1304,6 +1304,7 @@ def _run_benchmark_fusion_query(
             vector_index_config=vector_index_config,
             timing=timing,
             file_stage_orchestration=options.file_stage_orchestration,
+            direct_file_preservation=options.direct_file_preservation,
         )
     source = benchmark_repo_source(task, repo_path, strategy=strategy)
     index_config = benchmark_index_config(

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -416,11 +416,15 @@ class _ArchexFields:
         "expansion_reason_counts",
         "expanded_file_reasons",
         "chunker",
+        "bm25_chunker",
+        "vector_chunker",
         "index_chunk_count",
         "mean_chunk_tokens",
     )
 
     chunker: ChunkerName
+    bm25_chunker: ChunkerName | None
+    vector_chunker: ChunkerName | None
     index_chunk_count: int
     mean_chunk_tokens: float
 
@@ -446,10 +450,12 @@ class _ArchexFields:
         expansion_test_candidates_skipped: int,
         expansion_zero_candidate_reason: str,
         expansion_reason_counts: dict[str, int],
+        expanded_file_reasons: dict[str, list[str]],
         chunker: ChunkerName,
+        bm25_chunker: ChunkerName | None,
+        vector_chunker: ChunkerName | None,
         index_chunk_count: int,
         mean_chunk_tokens: float,
-        expanded_file_reasons: dict[str, list[str]],
     ) -> None:
         self.tokens_input = tokens_input
         self.tokens_output = tokens_output
@@ -470,10 +476,12 @@ class _ArchexFields:
         self.expansion_test_candidates_skipped = expansion_test_candidates_skipped
         self.expansion_zero_candidate_reason = expansion_zero_candidate_reason
         self.expansion_reason_counts = expansion_reason_counts
+        self.expanded_file_reasons = expanded_file_reasons
         self.chunker = chunker
+        self.bm25_chunker = bm25_chunker
+        self.vector_chunker = vector_chunker
         self.index_chunk_count = index_chunk_count
         self.mean_chunk_tokens = mean_chunk_tokens
-        self.expanded_file_reasons = expanded_file_reasons
 
 
 def _archex_fields(
@@ -497,6 +505,8 @@ def _archex_fields(
     # seed_files_found is the file boundary for graph expansion diagnostics.
     meta = bundle.retrieval_metadata
     chunker = meta.chunker
+    bm25_chunker = meta.bm25_chunker
+    vector_chunker = meta.vector_chunker
     index_chunk_count = meta.index_chunk_count
     mean_chunk_tokens = meta.mean_chunk_tokens
     if meta.seed_file_paths or meta.expanded_file_paths:
@@ -531,6 +541,8 @@ def _archex_fields(
                 path: list(reasons) for path, reasons in meta.expanded_file_reasons.items()
             },
             chunker=chunker,
+            bm25_chunker=bm25_chunker,
+            vector_chunker=vector_chunker,
             index_chunk_count=index_chunk_count,
             mean_chunk_tokens=mean_chunk_tokens,
         )
@@ -586,6 +598,8 @@ def _archex_fields(
             path: list(reasons) for path, reasons in meta.expanded_file_reasons.items()
         },
         chunker=chunker,
+        bm25_chunker=bm25_chunker,
+        vector_chunker=vector_chunker,
         index_chunk_count=index_chunk_count,
         mean_chunk_tokens=mean_chunk_tokens,
     )
@@ -608,6 +622,25 @@ _VECTOR_CHUNKER_STRATEGIES = frozenset(
         Strategy.CROSS_LAYER_FUSION,
     }
 )
+
+_DUAL_LEG_STRATEGIES = frozenset(
+    {
+        Strategy.ARCHEX_QUERY_FUSION,
+        Strategy.ARCHEX_QUERY_FUSION_RERANK,
+    }
+)
+
+
+def benchmark_dual_leg_enabled(
+    strategy: Strategy,
+    options: BenchmarkRetrievalOptions,
+) -> bool:
+    if strategy not in _DUAL_LEG_STRATEGIES or not options.dual_leg_orchestration or options.splade:
+        return False
+    return _chunker_for_strategy(Strategy.ARCHEX_QUERY, options) != _chunker_for_strategy(
+        strategy,
+        options,
+    )
 
 
 def _chunker_for_strategy(
@@ -1237,27 +1270,73 @@ def run_surrogate_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResul
     )
 
 
-def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
-    """Full fusion strategy: BM25 + independent vector + confidence-aware RRF."""
-    from archex.api import query
+def _run_benchmark_fusion_query(
+    task: BenchmarkTask,
+    repo_path: Path,
+    *,
+    strategy: Strategy,
+    rerank: bool,
+    timing: PipelineTiming,
+):
+    from archex.api import query, query_dual_leg_benchmark
     from archex.models import Config
 
-    t0 = time.perf_counter()
-    timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path, strategy=Strategy.ARCHEX_QUERY_FUSION)
+    options = current_benchmark_retrieval_options()
     config = Config(cache=True, languages=task.languages)
+    if benchmark_dual_leg_enabled(strategy, options):
+        bm25_source = benchmark_repo_source(task, repo_path, strategy=Strategy.ARCHEX_QUERY)
+        vector_source = benchmark_repo_source(task, repo_path, strategy=strategy)
+        bm25_index_config = benchmark_index_config(
+            IndexConfig(vector=False),
+            strategy=Strategy.ARCHEX_QUERY,
+        )
+        vector_index_config = benchmark_index_config(
+            IndexConfig(vector=True, rerank=rerank),
+            strategy=strategy,
+        )
+        return query_dual_leg_benchmark(
+            bm25_source=bm25_source,
+            vector_source=vector_source,
+            question=task.question,
+            token_budget=task.token_budget,
+            config=config,
+            bm25_index_config=bm25_index_config,
+            vector_index_config=vector_index_config,
+            timing=timing,
+        )
+    source = benchmark_repo_source(task, repo_path, strategy=strategy)
     index_config = benchmark_index_config(
-        IndexConfig(vector=True),
-        strategy=Strategy.ARCHEX_QUERY_FUSION,
+        IndexConfig(vector=True, rerank=rerank),
+        strategy=strategy,
     )
-
-    bundle = query(
+    return query(
         source,
         task.question,
         token_budget=task.token_budget,
         explicit_token_budget=True,
         config=config,
         index_config=index_config,
+        timing=timing,
+    )
+
+
+def _fusion_result_index_config(*, rerank: bool) -> IndexConfig:
+    strategy = Strategy.ARCHEX_QUERY_FUSION_RERANK if rerank else Strategy.ARCHEX_QUERY_FUSION
+    return benchmark_index_config(
+        IndexConfig(vector=True, rerank=rerank),
+        strategy=strategy,
+    )
+
+
+def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
+    """Full fusion strategy: BM25 + independent vector + confidence-aware RRF."""
+    t0 = time.perf_counter()
+    timing = PipelineTiming()
+    bundle = _run_benchmark_fusion_query(
+        task,
+        repo_path,
+        strategy=Strategy.ARCHEX_QUERY_FUSION,
+        rerank=False,
         timing=timing,
     )
 
@@ -1316,36 +1395,26 @@ def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         expansion_reason_counts=af.expansion_reason_counts,
         expanded_file_reasons=af.expanded_file_reasons,
+        category=task.category,
+        vector_mode=_fusion_result_index_config(rerank=False).vector_mode,
+        cache_state=_cache_state(timing),
         chunker=af.chunker,
+        bm25_chunker=af.bm25_chunker,
+        vector_chunker=af.vector_chunker,
         index_chunk_count=af.index_chunk_count,
         mean_chunk_tokens=af.mean_chunk_tokens,
-        category=task.category,
-        vector_mode=index_config.vector_mode,
-        cache_state=_cache_state(timing),
     )
 
 
 def run_archex_query_fusion_rerank(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Fusion strategy with cross-encoder reranking: BM25 + vector + rerank."""
-    from archex.api import query
-    from archex.models import Config
-
     t0 = time.perf_counter()
     timing = PipelineTiming()
-    source = benchmark_repo_source(task, repo_path, strategy=Strategy.ARCHEX_QUERY_FUSION_RERANK)
-    config = Config(cache=True, languages=task.languages)
-    index_config = benchmark_index_config(
-        IndexConfig(vector=True, rerank=True),
+    bundle = _run_benchmark_fusion_query(
+        task,
+        repo_path,
         strategy=Strategy.ARCHEX_QUERY_FUSION_RERANK,
-    )
-
-    bundle = query(
-        source,
-        task.question,
-        token_budget=task.token_budget,
-        explicit_token_budget=True,
-        config=config,
-        index_config=index_config,
+        rerank=True,
         timing=timing,
     )
 
@@ -1397,12 +1466,14 @@ def run_archex_query_fusion_rerank(task: BenchmarkTask, repo_path: Path) -> Benc
         expansion_zero_candidate_reason=af.expansion_zero_candidate_reason,
         expansion_reason_counts=af.expansion_reason_counts,
         expanded_file_reasons=af.expanded_file_reasons,
+        category=task.category,
+        vector_mode=_fusion_result_index_config(rerank=True).vector_mode,
+        cache_state=_cache_state(timing),
         chunker=af.chunker,
+        bm25_chunker=af.bm25_chunker,
+        vector_chunker=af.vector_chunker,
         index_chunk_count=af.index_chunk_count,
         mean_chunk_tokens=af.mean_chunk_tokens,
-        category=task.category,
-        vector_mode=index_config.vector_mode,
-        cache_state=_cache_state(timing),
     )
 
 

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -1303,6 +1303,7 @@ def _run_benchmark_fusion_query(
             bm25_index_config=bm25_index_config,
             vector_index_config=vector_index_config,
             timing=timing,
+            file_stage_orchestration=options.file_stage_orchestration,
         )
     source = benchmark_repo_source(task, repo_path, strategy=strategy)
     index_config = benchmark_index_config(

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -174,6 +174,14 @@ def benchmark_cmd() -> None:
     help="Cap candidates scored by the cross-encoder reranker.",
 )
 @click.option(
+    "--dual-leg-orchestration/--no-dual-leg-orchestration",
+    default=False,
+    help=(
+        "Benchmark-only path: run BM25 on the BM25 chunker inventory and vector retrieval on "
+        "the vector chunker inventory inside one fusion query."
+    ),
+)
+@click.option(
     "--self-only",
     is_flag=True,
     default=False,
@@ -202,6 +210,7 @@ def run_cmd(
     vector_chunker: ChunkerName | None,
     rerank_model: str | None,
     rerank_candidate_limit: int | None,
+    dual_leg_orchestration: bool,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -232,6 +241,7 @@ def run_cmd(
         bm25_chunker=bm25_chunker,
         vector_chunker=vector_chunker,
         rerank_candidate_limit=rerank_candidate_limit,
+        dual_leg_orchestration=dual_leg_orchestration,
     )
     warmed_models = warm_benchmark_models(strategies, retrieval_options)
     if warmed_models:

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -182,6 +182,14 @@ def benchmark_cmd() -> None:
     ),
 )
 @click.option(
+    "--file-stage-orchestration/--no-file-stage-orchestration",
+    default=False,
+    help=(
+        "Benchmark-only path: preselect file candidates from the BM25 and vector legs "
+        "before final chunk assembly."
+    ),
+)
+@click.option(
     "--self-only",
     is_flag=True,
     default=False,
@@ -211,6 +219,7 @@ def run_cmd(
     rerank_model: str | None,
     rerank_candidate_limit: int | None,
     dual_leg_orchestration: bool,
+    file_stage_orchestration: bool,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -222,6 +231,14 @@ def run_cmd(
             strategies.append(strategy)
     if scout and Strategy.ARCHEX_SCOUT_FETCH not in strategies:
         strategies.append(Strategy.ARCHEX_SCOUT_FETCH)
+    resolved_bm25_chunker = bm25_chunker or chunker
+    resolved_vector_chunker = vector_chunker or chunker
+    if file_stage_orchestration and not dual_leg_orchestration:
+        raise click.UsageError("--file-stage-orchestration requires --dual-leg-orchestration")
+    if file_stage_orchestration and resolved_bm25_chunker == resolved_vector_chunker:
+        raise click.UsageError(
+            "--file-stage-orchestration requires different --bm25-chunker and --vector-chunker"
+        )
     if query_fusion and Strategy.ARCHEX_QUERY_FUSION not in strategies:
         strategies.append(Strategy.ARCHEX_QUERY_FUSION)
     if cross_layer_fusion and Strategy.CROSS_LAYER_FUSION not in strategies:
@@ -242,6 +259,7 @@ def run_cmd(
         vector_chunker=vector_chunker,
         rerank_candidate_limit=rerank_candidate_limit,
         dual_leg_orchestration=dual_leg_orchestration,
+        file_stage_orchestration=file_stage_orchestration,
     )
     warmed_models = warm_benchmark_models(strategies, retrieval_options)
     if warmed_models:

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -190,6 +190,14 @@ def benchmark_cmd() -> None:
     ),
 )
 @click.option(
+    "--direct-file-preservation/--no-direct-file-preservation",
+    default=False,
+    help=(
+        "Benchmark-only path: preserve direct lexical files and narrow sibling bridges "
+        "before final chunk packing."
+    ),
+)
+@click.option(
     "--self-only",
     is_flag=True,
     default=False,
@@ -220,6 +228,7 @@ def run_cmd(
     rerank_candidate_limit: int | None,
     dual_leg_orchestration: bool,
     file_stage_orchestration: bool,
+    direct_file_preservation: bool,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -239,6 +248,8 @@ def run_cmd(
         raise click.UsageError(
             "--file-stage-orchestration requires different --bm25-chunker and --vector-chunker"
         )
+    if direct_file_preservation and not file_stage_orchestration:
+        raise click.UsageError("--direct-file-preservation requires --file-stage-orchestration")
     if query_fusion and Strategy.ARCHEX_QUERY_FUSION not in strategies:
         strategies.append(Strategy.ARCHEX_QUERY_FUSION)
     if cross_layer_fusion and Strategy.CROSS_LAYER_FUSION not in strategies:
@@ -260,6 +271,7 @@ def run_cmd(
         rerank_candidate_limit=rerank_candidate_limit,
         dual_leg_orchestration=dual_leg_orchestration,
         file_stage_orchestration=file_stage_orchestration,
+        direct_file_preservation=direct_file_preservation,
     )
     warmed_models = warm_benchmark_models(strategies, retrieval_options)
     if warmed_models:

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 
@@ -51,6 +52,7 @@ from archex.benchmark.readiness import (
 )
 from archex.benchmark.reporter import (
     format_bucketed_summary,
+    format_chunker_frontier_table,
     format_delta_summary,
     format_json,
     format_markdown,
@@ -64,6 +66,9 @@ from archex.benchmark.triage import (
     load_benchmark_tasks,
     triage_failures,
 )
+
+if TYPE_CHECKING:
+    from archex.models import ChunkerName
 
 DEFAULT_BENCHMARK_RESULTS_DIR = ".archex/benchmark-results"
 DEFAULT_DELTA_RESULTS_DIR = ".archex/delta-results"
@@ -139,9 +144,34 @@ def benchmark_cmd() -> None:
     help="Embedder to pin across every vector-backed benchmark strategy.",
 )
 @click.option(
+    "--chunker",
+    default="default",
+    show_default=True,
+    type=click.Choice(["default", "cast"]),
+    help="Chunker to pin across every archex benchmark strategy.",
+)
+@click.option(
+    "--bm25-chunker",
+    default=None,
+    type=click.Choice(["default", "cast"]),
+    help="Override chunker for BM25-backed strategies only.",
+)
+@click.option(
+    "--vector-chunker",
+    default=None,
+    type=click.Choice(["default", "cast"]),
+    help="Override chunker for vector-backed strategies only.",
+)
+@click.option(
     "--rerank-model",
     default=None,
     help="Cross-encoder model to use for the fusion+rerank benchmark strategy.",
+)
+@click.option(
+    "--rerank-candidate-limit",
+    default=None,
+    type=int,
+    help="Cap candidates scored by the cross-encoder reranker.",
 )
 @click.option(
     "--self-only",
@@ -167,7 +197,11 @@ def run_cmd(
     splade: bool,
     module_prefilter: bool,
     embedder: str,
+    chunker: ChunkerName,
+    bm25_chunker: ChunkerName | None,
+    vector_chunker: ChunkerName | None,
     rerank_model: str | None,
+    rerank_candidate_limit: int | None,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -194,6 +228,10 @@ def run_cmd(
         module_prefilter=module_prefilter,
         embedder=embedder,
         rerank_model=rerank_model,
+        chunker=chunker,
+        bm25_chunker=bm25_chunker,
+        vector_chunker=vector_chunker,
+        rerank_candidate_limit=rerank_candidate_limit,
     )
     warmed_models = warm_benchmark_models(strategies, retrieval_options)
     if warmed_models:
@@ -588,6 +626,7 @@ def gate_cmd(
             baseline_reports.append(BenchmarkReport.model_validate(data))
         if not baseline_reports:
             raise click.ClickException(f"No baseline result files found in {baseline_dir}")
+        click.echo(format_chunker_frontier_table(reports, baseline_reports))
 
         recall_regressions = check_recall_regressions(reports, baseline_reports, thresholds)
         if advisory_warnings:

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -198,6 +198,14 @@ def benchmark_cmd() -> None:
     ),
 )
 @click.option(
+    "--delta-cache-preservation/--no-delta-cache-preservation",
+    default=False,
+    help=(
+        "Benchmark-only path: preserve direct delta-indexing and vector-cache lifecycle "
+        "files on top of direct file preservation."
+    ),
+)
+@click.option(
     "--self-only",
     is_flag=True,
     default=False,
@@ -229,6 +237,7 @@ def run_cmd(
     dual_leg_orchestration: bool,
     file_stage_orchestration: bool,
     direct_file_preservation: bool,
+    delta_cache_preservation: bool,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -250,6 +259,8 @@ def run_cmd(
         )
     if direct_file_preservation and not file_stage_orchestration:
         raise click.UsageError("--direct-file-preservation requires --file-stage-orchestration")
+    if delta_cache_preservation and not direct_file_preservation:
+        raise click.UsageError("--delta-cache-preservation requires --direct-file-preservation")
     if query_fusion and Strategy.ARCHEX_QUERY_FUSION not in strategies:
         strategies.append(Strategy.ARCHEX_QUERY_FUSION)
     if cross_layer_fusion and Strategy.CROSS_LAYER_FUSION not in strategies:
@@ -272,6 +283,7 @@ def run_cmd(
         dual_leg_orchestration=dual_leg_orchestration,
         file_stage_orchestration=file_stage_orchestration,
         direct_file_preservation=direct_file_preservation,
+        delta_cache_preservation=delta_cache_preservation,
     )
     warmed_models = warm_benchmark_models(strategies, retrieval_options)
     if warmed_models:

--- a/src/archex/index/delta.py
+++ b/src/archex/index/delta.py
@@ -367,6 +367,7 @@ def apply_delta(
         resolve_imports,
     )
     from archex.parse.adapters import default_adapter_registry
+    from archex.pipeline.chunker import chunker_revision
 
     t_start = time.perf_counter()
 
@@ -457,6 +458,7 @@ def apply_delta(
 
     # 6. Update metadata
     store.set_metadata("chunker", effective_index_config.chunker)
+    store.set_metadata("chunker_revision", chunker_revision(effective_index_config.chunker))
     store.set_metadata("repo_total_tokens", str(sum(chunk.token_count for chunk in all_chunks)))
     store.set_metadata("chunk_count", str(len(all_chunks)))
     store.set_metadata("commit_hash", manifest.current_commit)

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -162,6 +162,7 @@ class IndexConfig(BaseModel):
     retrieval_policy: RetrievalPolicy = RetrievalPolicy.AUTO
     rerank: bool = False
     rerank_model: str | None = None
+    rerank_candidate_limit: int = 4
     chunker: ChunkerName = "default"
     chunk_max_tokens: int = 500
     chunk_min_tokens: int = 50
@@ -181,6 +182,8 @@ class IndexConfig(BaseModel):
             raise ValueError("chunk_min_tokens must be <= chunk_max_tokens")
         if not self.surrogate_version.strip():
             raise ValueError("surrogate_version must not be empty")
+        if self.rerank_candidate_limit < 1:
+            raise ValueError("rerank_candidate_limit must be at least 1")
         return self
 
 
@@ -629,6 +632,9 @@ class RetrievalMetadata(BaseModel):
     refresh_time_ms: float = 0.0
     refresh_files_changed: int = 0
     refresh_skipped_reason: str = ""
+    chunker: ChunkerName = "default"
+    index_chunk_count: int = 0
+    mean_chunk_tokens: float = 0.0
 
 
 class ContextBundle(BaseModel):

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -635,6 +635,7 @@ class RetrievalMetadata(BaseModel):
     chunker: ChunkerName = "default"
     bm25_chunker: ChunkerName | None = None
     vector_chunker: ChunkerName | None = None
+    file_stage_orchestration: bool = False
     index_chunk_count: int = 0
     mean_chunk_tokens: float = 0.0
 

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -633,6 +633,8 @@ class RetrievalMetadata(BaseModel):
     refresh_files_changed: int = 0
     refresh_skipped_reason: str = ""
     chunker: ChunkerName = "default"
+    bm25_chunker: ChunkerName | None = None
+    vector_chunker: ChunkerName | None = None
     index_chunk_count: int = 0
     mean_chunk_tokens: float = 0.0
 

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -636,6 +636,7 @@ class RetrievalMetadata(BaseModel):
     bm25_chunker: ChunkerName | None = None
     vector_chunker: ChunkerName | None = None
     file_stage_orchestration: bool = False
+    preservation_mode: str = "baseline"
     index_chunk_count: int = 0
     mean_chunk_tokens: float = 0.0
 

--- a/src/archex/pipeline/chunker.py
+++ b/src/archex/pipeline/chunker.py
@@ -9,6 +9,7 @@ from typing import Protocol, runtime_checkable
 import tiktoken
 
 from archex.models import (
+    ChunkerName,
     CodeChunk,
     ImportStatement,
     IndexConfig,
@@ -477,6 +478,16 @@ class CastChunker(ASTChunker):
         result.sort(key=lambda c: c.start_line)
         _disambiguate_symbol_ids(result)
         return result
+
+
+_CHUNKER_REVISIONS: dict[ChunkerName, str] = {
+    "default": "v1",
+    "cast": "v2",
+}
+
+
+def chunker_revision(chunker: ChunkerName) -> str:
+    return _CHUNKER_REVISIONS[chunker]
 
 
 def create_chunker(config: IndexConfig | None = None) -> Chunker:

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -903,6 +903,7 @@ def assemble_context(
     expansion_min_override: float | None = None,
     avg_idf: float | None = None,
     reranker: object | None = None,
+    rerank_candidate_limit: int = 4,
     apply_intent_budget: bool = True,
 ) -> ContextBundle:
     """Assemble a token-budgeted ContextBundle from search results and a dependency graph.
@@ -1335,18 +1336,14 @@ def assemble_context(
     # complete candidate pool for file-level aggregation and only update scores
     # for the bounded window sent through the expensive cross-encoder.
     if reranker is not None:
-        from archex.index.rerank import (
-            DEFAULT_TOP_K,
-            RERANK_CANDIDATE_LIMIT,
-            CrossEncoderReranker,
-        )
+        from archex.index.rerank import DEFAULT_TOP_K, CrossEncoderReranker
 
         if isinstance(reranker, CrossEncoderReranker):
             rerank_start = time.perf_counter_ns()
             candidate_list = [
                 (chunk, bm25_by_id.get(chunk.id, 0.0)) for chunk in candidate_map.values()
             ]
-            candidates_for_rerank = candidate_list[:RERANK_CANDIDATE_LIMIT]
+            candidates_for_rerank = candidate_list[:rerank_candidate_limit]
             reranked = reranker.rerank(question, candidates_for_rerank, top_k=DEFAULT_TOP_K)
             for chunk_id, rerank_score in _normalized_rerank_scores(reranked).items():
                 bm25_by_id[chunk_id] = max(bm25_by_id.get(chunk_id, 0.0), rerank_score)

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -904,6 +904,7 @@ def assemble_context(
     avg_idf: float | None = None,
     reranker: object | None = None,
     rerank_candidate_limit: int = 4,
+    preserved_files: set[str] | None = None,
     apply_intent_budget: bool = True,
 ) -> ContextBundle:
     """Assemble a token-budgeted ContextBundle from search results and a dependency graph.
@@ -1489,6 +1490,8 @@ def assemble_context(
         if score < score_cutoff:
             break
         top_files.add(fp)
+    if preserved_files:
+        top_files.update(file_path for file_path in preserved_files if file_path in file_agg)
     ranked = [rc for rc in ranked if rc.chunk.file_path in top_files]
 
     # Pack at least one high-scoring chunk per selected file before spending

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -702,6 +702,64 @@ class TestRunCommand:
             file_stage_orchestration=True,
         )
 
+    def test_run_passes_direct_file_preservation_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "run",
+                "--dual-leg-orchestration",
+                "--file-stage-orchestration",
+                "--direct-file-preservation",
+                "--bm25-chunker",
+                "default",
+                "--vector-chunker",
+                "cast",
+            ],
+        )
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(
+            bm25_chunker="default",
+            vector_chunker="cast",
+            dual_leg_orchestration=True,
+            file_stage_orchestration=True,
+            direct_file_preservation=True,
+        )
+
+    def test_run_rejects_direct_preservation_without_file_stage(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        result = runner.invoke(
+            benchmark_cmd,
+            ["run", "--dual-leg-orchestration", "--direct-file-preservation"],
+        )
+        assert result.exit_code != 0
+        assert "--direct-file-preservation requires --file-stage-orchestration" in result.output
+
     def test_run_rejects_file_stage_without_dual_leg(
         self,
         runner: CliRunner,

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -747,6 +747,75 @@ class TestRunCommand:
             direct_file_preservation=True,
         )
 
+    def test_run_passes_delta_cache_preservation_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "run",
+                "--dual-leg-orchestration",
+                "--file-stage-orchestration",
+                "--direct-file-preservation",
+                "--delta-cache-preservation",
+                "--bm25-chunker",
+                "default",
+                "--vector-chunker",
+                "cast",
+            ],
+        )
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(
+            bm25_chunker="default",
+            vector_chunker="cast",
+            dual_leg_orchestration=True,
+            file_stage_orchestration=True,
+            direct_file_preservation=True,
+            delta_cache_preservation=True,
+        )
+
+    def test_run_rejects_delta_cache_preservation_without_direct_preservation(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "run",
+                "--dual-leg-orchestration",
+                "--file-stage-orchestration",
+                "--delta-cache-preservation",
+                "--bm25-chunker",
+                "default",
+                "--vector-chunker",
+                "cast",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--delta-cache-preservation requires --direct-file-preservation" in result.output
+
     def test_run_rejects_direct_preservation_without_file_stage(
         self,
         runner: CliRunner,

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -543,6 +543,93 @@ class TestRunCommand:
         assert result.exit_code == 0
         assert captured["retrieval_options"] == BenchmarkRetrievalOptions(embedder="coderank")
 
+    def test_run_passes_chunker_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(benchmark_cmd, ["run", "--chunker", "cast"])
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(chunker="cast")
+
+    def test_run_passes_strategy_chunker_flags(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(
+            benchmark_cmd,
+            ["run", "--bm25-chunker", "default", "--vector-chunker", "cast"],
+        )
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(
+            bm25_chunker="default",
+            vector_chunker="cast",
+        )
+
+    def test_run_passes_rerank_candidate_limit_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(benchmark_cmd, ["run", "--rerank-candidate-limit", "3"])
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(rerank_candidate_limit=3)
+
     def test_run_passes_rerank_model_flag(
         self,
         runner: CliRunner,

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -659,6 +659,80 @@ class TestRunCommand:
             dual_leg_orchestration=True
         )
 
+    def test_run_passes_file_stage_orchestration_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "run",
+                "--dual-leg-orchestration",
+                "--file-stage-orchestration",
+                "--bm25-chunker",
+                "default",
+                "--vector-chunker",
+                "cast",
+            ],
+        )
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(
+            bm25_chunker="default",
+            vector_chunker="cast",
+            dual_leg_orchestration=True,
+            file_stage_orchestration=True,
+        )
+
+    def test_run_rejects_file_stage_without_dual_leg(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        result = runner.invoke(benchmark_cmd, ["run", "--file-stage-orchestration"])
+        assert result.exit_code != 0
+        assert "--file-stage-orchestration requires --dual-leg-orchestration" in result.output
+
+    def test_run_rejects_file_stage_with_same_chunkers(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "run",
+                "--dual-leg-orchestration",
+                "--file-stage-orchestration",
+                "--bm25-chunker",
+                "default",
+                "--vector-chunker",
+                "default",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "requires different --bm25-chunker and --vector-chunker" in result.output
+
     def test_run_passes_rerank_model_flag(
         self,
         runner: CliRunner,

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -630,6 +630,35 @@ class TestRunCommand:
         assert result.exit_code == 0
         assert captured["retrieval_options"] == BenchmarkRetrievalOptions(rerank_candidate_limit=3)
 
+    def test_run_passes_dual_leg_orchestration_flag(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all(
+            tasks_dir: Path,
+            output_dir: Path,
+            strategies: list[Strategy] | None = None,
+            task_filter: str | None = None,
+            self_only: bool = False,
+            progress: object | None = None,
+            tasks: object | None = None,
+            retrieval_options: BenchmarkRetrievalOptions | None = None,
+        ) -> list[BenchmarkReport]:
+            del tasks_dir, output_dir, strategies, task_filter, self_only, progress, tasks
+            captured["retrieval_options"] = retrieval_options
+            return []
+
+        monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
+        monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
+        result = runner.invoke(benchmark_cmd, ["run", "--dual-leg-orchestration"])
+        assert result.exit_code == 0
+        assert captured["retrieval_options"] == BenchmarkRetrievalOptions(
+            dual_leg_orchestration=True
+        )
+
     def test_run_passes_rerank_model_flag(
         self,
         runner: CliRunner,

--- a/tests/benchmark/test_reporter.py
+++ b/tests/benchmark/test_reporter.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from archex.benchmark.models import BenchmarkReport, BenchmarkResult, Strategy, TaskCategory
 from archex.benchmark.reporter import (
     format_bucketed_summary,
+    format_chunker_frontier_table,
     format_json,
     format_markdown,
     format_strategy_comparison,
     format_summary,
 )
+
+if TYPE_CHECKING:
+    from archex.models import ChunkerName
 
 
 def _make_result(
@@ -21,6 +27,9 @@ def _make_result(
     tokens_input: int = 2000,
     tokens_output: int = 1000,
     token_efficiency: float = 0.5,
+    chunker: ChunkerName = "default",
+    index_chunk_count: int = 10,
+    mean_chunk_tokens: float = 50.0,
     category: TaskCategory | None = None,
 ) -> BenchmarkResult:
     return BenchmarkResult(
@@ -38,6 +47,9 @@ def _make_result(
         wall_time_ms=50.0,
         cached=False,
         timestamp="2025-01-01T00:00:00Z",
+        chunker=chunker,
+        index_chunk_count=index_chunk_count,
+        mean_chunk_tokens=mean_chunk_tokens,
         category=category,
     )
 
@@ -190,3 +202,41 @@ class TestFormatBucketedSummary:
         assert "external-framework (1 tasks)" in output
         assert "All Tasks (2 tasks)" in output
         assert "Seed Recall" in output
+
+
+class TestFormatChunkerFrontierTable:
+    def test_contains_quality_latency_and_granularity_axes(self) -> None:
+        baseline = _make_report(
+            [
+                _make_result(
+                    Strategy.ARCHEX_QUERY_FUSION_RERANK,
+                    recall=0.80,
+                    precision=0.40,
+                    token_efficiency=0.60,
+                    chunker="default",
+                    index_chunk_count=100,
+                    mean_chunk_tokens=80.0,
+                )
+            ]
+        )
+        candidate = _make_report(
+            [
+                _make_result(
+                    Strategy.ARCHEX_QUERY_FUSION_RERANK,
+                    recall=0.82,
+                    precision=0.42,
+                    token_efficiency=0.61,
+                    chunker="cast",
+                    index_chunk_count=120,
+                    mean_chunk_tokens=70.0,
+                )
+            ]
+        )
+
+        table = format_chunker_frontier_table([candidate], [baseline])
+
+        assert "Chunker Frontier Comparison" in table
+        assert "archex_query_fusion_rerank | default" in table
+        assert "archex_query_fusion_rerank | cast" in table
+        assert "Chunk Count" in table
+        assert "Mean Chunk Tokens" in table

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -251,7 +251,7 @@ class TestRunBenchmark:
         from archex.models import ContextBundle, IndexConfig
 
         task, repo_path = fixture_task
-        captured: list[tuple[str | None, bool, str | None]] = []
+        captured: list[tuple[str | None, bool, str | None, str, int]] = []
 
         def fake_query(
             _source: object,
@@ -264,7 +264,15 @@ class TestRunBenchmark:
         ) -> ContextBundle:
             del config
             del explicit_token_budget
-            captured.append((index_config.embedder, index_config.rerank, index_config.rerank_model))
+            captured.append(
+                (
+                    index_config.embedder,
+                    index_config.rerank,
+                    index_config.rerank_model,
+                    index_config.chunker,
+                    index_config.rerank_candidate_limit,
+                )
+            )
             return ContextBundle(
                 query=question,
                 chunks=[],
@@ -276,21 +284,26 @@ class TestRunBenchmark:
             runner_mod._warm_repo_index(  # pyright: ignore[reportPrivateUsage]
                 task,
                 repo_path,
-                BenchmarkRetrievalOptions(embedder="coderank"),
+                BenchmarkRetrievalOptions(
+                    embedder="coderank",
+                    vector_chunker="cast",
+                ),
             )
             runner_mod._warm_repo_index(  # pyright: ignore[reportPrivateUsage]
                 task,
                 repo_path,
                 BenchmarkRetrievalOptions(
                     embedder="coderank",
+                    vector_chunker="cast",
                     rerank_model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+                    rerank_candidate_limit=3,
                 ),
                 warm_rerank=True,
             )
 
         assert captured == [
-            ("coderank", False, None),
-            ("coderank", True, "cross-encoder/ms-marco-MiniLM-L-6-v2"),
+            ("coderank", False, None, "cast", 4),
+            ("coderank", True, "cross-encoder/ms-marco-MiniLM-L-6-v2", "cast", 3),
         ]
 
     def test_skips_warmup_for_raw_only_strategies(
@@ -446,7 +459,9 @@ class TestRunBenchmark:
             f"+max_seq={JINA_V2_MAX_SEQ_LENGTH}"
         )
         source = benchmark_repo_source(task, repo_path)
-        assert source.stable_identity == f"test/python_simple@HEAD#embedder={jina_identity}"
+        assert source.stable_identity == (
+            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=default"
+        )
 
         token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions(splade=True))
         try:
@@ -455,7 +470,7 @@ class TestRunBenchmark:
             reset_benchmark_retrieval_options(token)
 
         assert splade_source.stable_identity == (
-            f"test/python_simple@HEAD#embedder={jina_identity}+splade"
+            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=default+splade"
         )
 
         coderank_token = set_benchmark_retrieval_options(
@@ -466,6 +481,12 @@ class TestRunBenchmark:
         finally:
             reset_benchmark_retrieval_options(coderank_token)
 
+        cast_token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions(chunker="cast"))
+        try:
+            cast_source = benchmark_repo_source(task, repo_path)
+        finally:
+            reset_benchmark_retrieval_options(cast_token)
+
         scoped_token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions())
         scoped_task = task.model_copy(update={"include_paths": ["src", "tests"]})
         try:
@@ -474,10 +495,39 @@ class TestRunBenchmark:
             reset_benchmark_retrieval_options(scoped_token)
 
         assert scoped_source.stable_identity == (
-            f"test/python_simple@HEAD#scope=src|tests+embedder={jina_identity}"
+            f"test/python_simple@HEAD#scope=src|tests+embedder={jina_identity}+chunker=default"
+        )
+        assert cast_source.stable_identity == (
+            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=cast"
         )
 
-        assert coderank_source.stable_identity == "test/python_simple@HEAD#embedder=coderank"
+        assert coderank_source.stable_identity == (
+            "test/python_simple@HEAD#embedder=coderank+chunker=default"
+        )
+
+        split_token = set_benchmark_retrieval_options(
+            BenchmarkRetrievalOptions(bm25_chunker="default", vector_chunker="cast")
+        )
+        try:
+            split_bm25_source = benchmark_repo_source(
+                task,
+                repo_path,
+                strategy=Strategy.ARCHEX_QUERY,
+            )
+            split_vector_source = benchmark_repo_source(
+                task,
+                repo_path,
+                strategy=Strategy.ARCHEX_QUERY_FUSION,
+            )
+        finally:
+            reset_benchmark_retrieval_options(split_token)
+
+        assert split_bm25_source.stable_identity == (
+            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=default"
+        )
+        assert split_vector_source.stable_identity == (
+            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=cast"
+        )
 
     def test_benchmark_index_config_applies_module_prefilter_only_with_bm25(self) -> None:
         from archex.benchmark.strategies import (
@@ -514,6 +564,7 @@ class TestRunBenchmark:
         assert vector_config.embedder == "jina-v2"
         assert vector_config.rerank_model is None
         assert rerank_config.rerank_model == "cross-encoder/ms-marco-MiniLM-L-6-v2"
+        assert bm25_config.chunker == "default"
         assert cache_enabled is True
 
 

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -325,7 +325,7 @@ class TestRunBenchmark:
         from archex.models import Config, ContextBundle, IndexConfig, RepoSource
 
         task, repo_path = fixture_task
-        captured: list[tuple[str, str, str, str, bool]] = []
+        captured: list[tuple[str, str, str, str, bool, bool]] = []
 
         def fake_dual_leg_query(
             *,
@@ -339,6 +339,7 @@ class TestRunBenchmark:
             scoring_weights: object | None = None,
             timing: object | None = None,
             trace: object | None = None,
+            file_stage_orchestration: bool = False,
         ) -> ContextBundle:
             del question, token_budget, config, scoring_weights, timing, trace
             captured.append(
@@ -348,6 +349,7 @@ class TestRunBenchmark:
                     bm25_index_config.chunker,
                     vector_index_config.chunker,
                     vector_index_config.rerank,
+                    file_stage_orchestration,
                 )
             )
             return ContextBundle(query=task.question, token_budget=task.token_budget)
@@ -360,6 +362,7 @@ class TestRunBenchmark:
                     bm25_chunker="default",
                     vector_chunker="cast",
                     dual_leg_orchestration=True,
+                    file_stage_orchestration=True,
                 ),
             )
 
@@ -370,6 +373,7 @@ class TestRunBenchmark:
                 "default",
                 "cast",
                 False,
+                True,
             )
         ]
 

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -325,7 +325,7 @@ class TestRunBenchmark:
         from archex.models import Config, ContextBundle, IndexConfig, RepoSource
 
         task, repo_path = fixture_task
-        captured: list[tuple[str, str, str, str, bool, bool]] = []
+        captured: list[tuple[str, str, str, str, bool, bool, bool]] = []
 
         def fake_dual_leg_query(
             *,
@@ -340,6 +340,7 @@ class TestRunBenchmark:
             timing: object | None = None,
             trace: object | None = None,
             file_stage_orchestration: bool = False,
+            direct_file_preservation: bool = False,
         ) -> ContextBundle:
             del question, token_budget, config, scoring_weights, timing, trace
             captured.append(
@@ -350,6 +351,7 @@ class TestRunBenchmark:
                     vector_index_config.chunker,
                     vector_index_config.rerank,
                     file_stage_orchestration,
+                    direct_file_preservation,
                 )
             )
             return ContextBundle(query=task.question, token_budget=task.token_budget)
@@ -363,6 +365,7 @@ class TestRunBenchmark:
                     vector_chunker="cast",
                     dual_leg_orchestration=True,
                     file_stage_orchestration=True,
+                    direct_file_preservation=True,
                 ),
             )
 
@@ -373,6 +376,7 @@ class TestRunBenchmark:
                 "default",
                 "cast",
                 False,
+                True,
                 True,
             )
         ]

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -10,9 +10,20 @@ import pytest
 
 from archex.benchmark.models import BenchmarkRetrievalOptions, BenchmarkTask, Strategy
 from archex.benchmark.runner import AVAILABLE_STRATEGIES, DEFAULT_STRATEGIES, run_benchmark
+from archex.index.embeddings import (
+    JINA_BERT_CODE_REVISION,
+    JINA_V2_MAX_SEQ_LENGTH,
+    JINA_V2_MODEL_REVISION,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+JINA_V2_CACHE_IDENTITY = (
+    f"jina-v2@{JINA_V2_MODEL_REVISION}"
+    f"+code={JINA_BERT_CODE_REVISION}"
+    f"+max_seq={JINA_V2_MAX_SEQ_LENGTH}"
+)
 
 
 @pytest.fixture
@@ -304,6 +315,62 @@ class TestRunBenchmark:
         assert captured == [
             ("coderank", False, None, "cast", 4),
             ("coderank", True, "cross-encoder/ms-marco-MiniLM-L-6-v2", "cast", 3),
+        ]
+
+    def test_warm_repo_index_uses_dual_leg_helper_when_enabled(
+        self,
+        fixture_task: tuple[BenchmarkTask, Path],
+    ) -> None:
+        from archex.benchmark import runner as runner_mod
+        from archex.models import Config, ContextBundle, IndexConfig, RepoSource
+
+        task, repo_path = fixture_task
+        captured: list[tuple[str, str, str, str, bool]] = []
+
+        def fake_dual_leg_query(
+            *,
+            bm25_source: RepoSource,
+            vector_source: RepoSource,
+            question: str,
+            token_budget: int,
+            config: Config,
+            bm25_index_config: IndexConfig,
+            vector_index_config: IndexConfig,
+            scoring_weights: object | None = None,
+            timing: object | None = None,
+            trace: object | None = None,
+        ) -> ContextBundle:
+            del question, token_budget, config, scoring_weights, timing, trace
+            captured.append(
+                (
+                    bm25_source.stable_identity or "",
+                    vector_source.stable_identity or "",
+                    bm25_index_config.chunker,
+                    vector_index_config.chunker,
+                    vector_index_config.rerank,
+                )
+            )
+            return ContextBundle(query=task.question, token_budget=task.token_budget)
+
+        with patch("archex.api.query_dual_leg_benchmark", fake_dual_leg_query):
+            runner_mod._warm_repo_index(  # pyright: ignore[reportPrivateUsage]
+                task,
+                repo_path,
+                BenchmarkRetrievalOptions(
+                    bm25_chunker="default",
+                    vector_chunker="cast",
+                    dual_leg_orchestration=True,
+                ),
+            )
+
+        assert captured == [
+            (
+                f"test/python_simple@HEAD#embedder={JINA_V2_CACHE_IDENTITY}+chunker=default",
+                f"test/python_simple@HEAD#embedder={JINA_V2_CACHE_IDENTITY}+chunker=cast",
+                "default",
+                "cast",
+                False,
+            )
         ]
 
     def test_skips_warmup_for_raw_only_strategies(

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -325,7 +325,7 @@ class TestRunBenchmark:
         from archex.models import Config, ContextBundle, IndexConfig, RepoSource
 
         task, repo_path = fixture_task
-        captured: list[tuple[str, str, str, str, bool, bool, bool]] = []
+        captured: list[tuple[str, str, str, str, bool, bool, bool, bool]] = []
 
         def fake_dual_leg_query(
             *,
@@ -341,6 +341,7 @@ class TestRunBenchmark:
             trace: object | None = None,
             file_stage_orchestration: bool = False,
             direct_file_preservation: bool = False,
+            delta_cache_preservation: bool = False,
         ) -> ContextBundle:
             del question, token_budget, config, scoring_weights, timing, trace
             captured.append(
@@ -352,6 +353,7 @@ class TestRunBenchmark:
                     vector_index_config.rerank,
                     file_stage_orchestration,
                     direct_file_preservation,
+                    delta_cache_preservation,
                 )
             )
             return ContextBundle(query=task.question, token_budget=task.token_budget)
@@ -366,6 +368,7 @@ class TestRunBenchmark:
                     dual_leg_orchestration=True,
                     file_stage_orchestration=True,
                     direct_file_preservation=True,
+                    delta_cache_preservation=True,
                 ),
             )
 
@@ -376,6 +379,7 @@ class TestRunBenchmark:
                 "default",
                 "cast",
                 False,
+                True,
                 True,
                 True,
             )

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -11,6 +11,7 @@ from archex.benchmark.models import BenchmarkRetrievalOptions, BenchmarkTask, St
 from archex.benchmark.strategies import (
     _archex_fields,  # pyright: ignore[reportPrivateUsage]
     _deduplicate_ranked,  # pyright: ignore[reportPrivateUsage]
+    benchmark_dual_leg_enabled,
     benchmark_index_config,
     benchmark_repo_source,
     compute_bundle_completion_penalty,
@@ -529,6 +530,38 @@ class TestRunArchexQuery:
         assert rerank_config.chunker == "cast"
         assert rerank_config.rerank_candidate_limit == 3
 
+    def test_benchmark_dual_leg_enabled_requires_split_chunkers(self) -> None:
+        options = BenchmarkRetrievalOptions(
+            bm25_chunker="default",
+            vector_chunker="cast",
+            dual_leg_orchestration=True,
+        )
+        assert benchmark_dual_leg_enabled(Strategy.ARCHEX_QUERY_FUSION, options) is True
+        assert benchmark_dual_leg_enabled(Strategy.ARCHEX_QUERY, options) is False
+        assert (
+            benchmark_dual_leg_enabled(
+                Strategy.ARCHEX_QUERY_FUSION,
+                BenchmarkRetrievalOptions(
+                    bm25_chunker="default",
+                    vector_chunker="default",
+                    dual_leg_orchestration=True,
+                ),
+            )
+            is False
+        )
+        assert (
+            benchmark_dual_leg_enabled(
+                Strategy.ARCHEX_QUERY_FUSION,
+                BenchmarkRetrievalOptions(
+                    bm25_chunker="default",
+                    vector_chunker="cast",
+                    dual_leg_orchestration=True,
+                    splade=True,
+                ),
+            )
+            is False
+        )
+
     def test_archex_scout_fetch_strategy(self, python_simple_repo: Path) -> None:
         from archex.scout import ScoutBudget, ScoutFetchPlan, ScoutFile, ScoutResult, symbol_handle
 
@@ -984,6 +1017,69 @@ class TestRunArchexQueryFusion:
         assert result.files_accessed >= 0
         assert isinstance(result.recall, float)
         assert isinstance(result.precision, float)
+
+    def test_fusion_strategy_uses_dual_leg_helper_when_enabled(
+        self,
+        python_simple_repo: Path,
+    ) -> None:
+        from archex.models import Config, ContextBundle, RepoSource
+
+        task = BenchmarkTask(
+            task_id="test",
+            repo="test/repo",
+            commit="abc",
+            question="How does the main module work?",
+            expected_files=["main.py"],
+            token_budget=4096,
+        )
+        calls: list[tuple[str, str, str, str]] = []
+
+        def fake_dual_leg_query(
+            *,
+            bm25_source: RepoSource,
+            vector_source: RepoSource,
+            question: str,
+            token_budget: int,
+            config: Config,
+            bm25_index_config: IndexConfig,
+            vector_index_config: IndexConfig,
+            scoring_weights: object | None = None,
+            timing: object | None = None,
+            trace: object | None = None,
+        ) -> ContextBundle:
+            del question, token_budget, config, scoring_weights, timing, trace
+            calls.append(
+                (
+                    bm25_source.stable_identity or "",
+                    vector_source.stable_identity or "",
+                    bm25_index_config.chunker,
+                    vector_index_config.chunker,
+                )
+            )
+            return ContextBundle(query=task.question, token_budget=task.token_budget)
+
+        token = set_benchmark_retrieval_options(
+            BenchmarkRetrievalOptions(
+                bm25_chunker="default",
+                vector_chunker="cast",
+                dual_leg_orchestration=True,
+            )
+        )
+        try:
+            with patch("archex.api.query_dual_leg_benchmark", fake_dual_leg_query):
+                result = run_archex_query_fusion(task, python_simple_repo)
+        finally:
+            reset_benchmark_retrieval_options(token)
+
+        assert result.strategy == Strategy.ARCHEX_QUERY_FUSION
+        assert calls == [
+            (
+                f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}+chunker=default",
+                f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}+chunker=cast",
+                "default",
+                "cast",
+            )
+        ]
 
 
 class TestRunSurrogateVector:

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -1032,7 +1032,7 @@ class TestRunArchexQueryFusion:
             expected_files=["main.py"],
             token_budget=4096,
         )
-        calls: list[tuple[str, str, str, str]] = []
+        calls: list[tuple[str, str, str, str, bool]] = []
 
         def fake_dual_leg_query(
             *,
@@ -1046,6 +1046,7 @@ class TestRunArchexQueryFusion:
             scoring_weights: object | None = None,
             timing: object | None = None,
             trace: object | None = None,
+            file_stage_orchestration: bool = False,
         ) -> ContextBundle:
             del question, token_budget, config, scoring_weights, timing, trace
             calls.append(
@@ -1054,6 +1055,7 @@ class TestRunArchexQueryFusion:
                     vector_source.stable_identity or "",
                     bm25_index_config.chunker,
                     vector_index_config.chunker,
+                    file_stage_orchestration,
                 )
             )
             return ContextBundle(query=task.question, token_budget=task.token_budget)
@@ -1063,6 +1065,7 @@ class TestRunArchexQueryFusion:
                 bm25_chunker="default",
                 vector_chunker="cast",
                 dual_leg_orchestration=True,
+                file_stage_orchestration=True,
             )
         )
         try:
@@ -1078,6 +1081,7 @@ class TestRunArchexQueryFusion:
                 f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}+chunker=cast",
                 "default",
                 "cast",
+                True,
             )
         ]
 

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -1032,7 +1032,7 @@ class TestRunArchexQueryFusion:
             expected_files=["main.py"],
             token_budget=4096,
         )
-        calls: list[tuple[str, str, str, str, bool, bool]] = []
+        calls: list[tuple[str, str, str, str, bool, bool, bool]] = []
 
         def fake_dual_leg_query(
             *,
@@ -1048,6 +1048,7 @@ class TestRunArchexQueryFusion:
             trace: object | None = None,
             file_stage_orchestration: bool = False,
             direct_file_preservation: bool = False,
+            delta_cache_preservation: bool = False,
         ) -> ContextBundle:
             del question, token_budget, config, scoring_weights, timing, trace
             calls.append(
@@ -1058,6 +1059,7 @@ class TestRunArchexQueryFusion:
                     vector_index_config.chunker,
                     file_stage_orchestration,
                     direct_file_preservation,
+                    delta_cache_preservation,
                 )
             )
             return ContextBundle(query=task.question, token_budget=task.token_budget)
@@ -1069,6 +1071,7 @@ class TestRunArchexQueryFusion:
                 dual_leg_orchestration=True,
                 file_stage_orchestration=True,
                 direct_file_preservation=True,
+                delta_cache_preservation=True,
             )
         )
         try:
@@ -1084,6 +1087,7 @@ class TestRunArchexQueryFusion:
                 f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}+chunker=cast",
                 "default",
                 "cast",
+                True,
                 True,
                 True,
             )

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -11,6 +11,7 @@ from archex.benchmark.models import BenchmarkRetrievalOptions, BenchmarkTask, St
 from archex.benchmark.strategies import (
     _archex_fields,  # pyright: ignore[reportPrivateUsage]
     _deduplicate_ranked,  # pyright: ignore[reportPrivateUsage]
+    benchmark_index_config,
     benchmark_repo_source,
     compute_bundle_completion_penalty,
     compute_map,
@@ -388,8 +389,12 @@ class TestRunArchexQuery:
         source_a = benchmark_repo_source(sample_task, repo_a)
         source_b = benchmark_repo_source(sample_task, repo_b)
 
-        assert source_a.stable_identity == f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}"
-        assert source_b.stable_identity == f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}"
+        assert source_a.stable_identity == (
+            f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}+chunker=default"
+        )
+        assert source_b.stable_identity == (
+            f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}+chunker=default"
+        )
         assert cache.cache_key(source_a) == cache.cache_key(source_b)
 
     def test_benchmark_source_resolves_missing_commit_from_git_head(
@@ -407,7 +412,9 @@ class TestRunArchexQuery:
         with patch.object(CacheManager, "git_head", return_value="resolved"):
             source = benchmark_repo_source(task, tmp_path)
 
-        assert source.stable_identity == (f"test/repo@resolved#embedder={JINA_V2_CACHE_IDENTITY}")
+        assert source.stable_identity == (
+            f"test/repo@resolved#embedder={JINA_V2_CACHE_IDENTITY}+chunker=default"
+        )
 
     def test_benchmark_source_rejects_missing_commit_without_git_head(
         self,
@@ -445,6 +452,82 @@ class TestRunArchexQuery:
         assert result.tokens_input >= 0
         assert result.tokens_output >= 0
         assert result.tokens_raw_baseline >= 0
+
+    def test_archex_query_reports_configured_chunker_metadata(
+        self,
+        python_simple_repo: Path,
+    ) -> None:
+        task = BenchmarkTask(
+            task_id="test",
+            repo="test/repo",
+            commit="abc",
+            question="How does the main module work?",
+            expected_files=["main.py"],
+            token_budget=4096,
+        )
+
+        token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions(bm25_chunker="cast"))
+        try:
+            result = run_archex_query(task, python_simple_repo)
+        finally:
+            reset_benchmark_retrieval_options(token)
+
+        assert result.chunker == "cast"
+        assert result.index_chunk_count > 0
+        assert result.mean_chunk_tokens > 0.0
+
+    def test_strategy_specific_chunkers_split_cache_identity(
+        self,
+        sample_task: BenchmarkTask,
+        tmp_path: Path,
+    ) -> None:
+        token = set_benchmark_retrieval_options(
+            BenchmarkRetrievalOptions(bm25_chunker="default", vector_chunker="cast")
+        )
+        try:
+            bm25_source = benchmark_repo_source(
+                sample_task,
+                tmp_path,
+                strategy=Strategy.ARCHEX_QUERY,
+            )
+            vector_source = benchmark_repo_source(
+                sample_task,
+                tmp_path,
+                strategy=Strategy.ARCHEX_QUERY_FUSION,
+            )
+        finally:
+            reset_benchmark_retrieval_options(token)
+
+        assert bm25_source.stable_identity is not None
+        assert vector_source.stable_identity is not None
+        assert bm25_source.stable_identity.endswith("chunker=default")
+        assert vector_source.stable_identity.endswith("chunker=cast")
+
+    def test_benchmark_index_config_uses_strategy_chunker_and_rerank_limit(self) -> None:
+        from archex.models import IndexConfig
+
+        token = set_benchmark_retrieval_options(
+            BenchmarkRetrievalOptions(
+                bm25_chunker="default",
+                vector_chunker="cast",
+                rerank_candidate_limit=3,
+            )
+        )
+        try:
+            bm25_config = benchmark_index_config(
+                IndexConfig(vector=False),
+                strategy=Strategy.ARCHEX_QUERY,
+            )
+            rerank_config = benchmark_index_config(
+                IndexConfig(vector=True, rerank=True),
+                strategy=Strategy.ARCHEX_QUERY_FUSION_RERANK,
+            )
+        finally:
+            reset_benchmark_retrieval_options(token)
+
+        assert bm25_config.chunker == "default"
+        assert rerank_config.chunker == "cast"
+        assert rerank_config.rerank_candidate_limit == 3
 
     def test_archex_scout_fetch_strategy(self, python_simple_repo: Path) -> None:
         from archex.scout import ScoutBudget, ScoutFetchPlan, ScoutFile, ScoutResult, symbol_handle

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -1032,7 +1032,7 @@ class TestRunArchexQueryFusion:
             expected_files=["main.py"],
             token_budget=4096,
         )
-        calls: list[tuple[str, str, str, str, bool]] = []
+        calls: list[tuple[str, str, str, str, bool, bool]] = []
 
         def fake_dual_leg_query(
             *,
@@ -1047,6 +1047,7 @@ class TestRunArchexQueryFusion:
             timing: object | None = None,
             trace: object | None = None,
             file_stage_orchestration: bool = False,
+            direct_file_preservation: bool = False,
         ) -> ContextBundle:
             del question, token_budget, config, scoring_weights, timing, trace
             calls.append(
@@ -1056,6 +1057,7 @@ class TestRunArchexQueryFusion:
                     bm25_index_config.chunker,
                     vector_index_config.chunker,
                     file_stage_orchestration,
+                    direct_file_preservation,
                 )
             )
             return ContextBundle(query=task.question, token_budget=task.token_budget)
@@ -1066,6 +1068,7 @@ class TestRunArchexQueryFusion:
                 vector_chunker="cast",
                 dual_leg_orchestration=True,
                 file_stage_orchestration=True,
+                direct_file_preservation=True,
             )
         )
         try:
@@ -1081,6 +1084,7 @@ class TestRunArchexQueryFusion:
                 f"test/repo@abc#embedder={JINA_V2_CACHE_IDENTITY}+chunker=cast",
                 "default",
                 "cast",
+                True,
                 True,
             )
         ]

--- a/tests/index/test_chunker.py
+++ b/tests/index/test_chunker.py
@@ -24,6 +24,7 @@ from archex.models import (
     SymbolKind,
     Visibility,
 )
+from archex.pipeline.chunker import chunker_revision
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -640,6 +641,7 @@ def test_index_metadata_prevents_cross_chunker_cache_reuse(
     )
     try:
         assert default_store.get_metadata("chunker") == "default"
+        assert default_store.get_metadata("chunker_revision") == chunker_revision("default")
     finally:
         default_store.close()
 

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -1141,6 +1141,28 @@ def test_assemble_context_honors_reranker_default_top_k() -> None:
     assert reranker.seen_top_k == DEFAULT_TOP_K
 
 
+def test_assemble_context_honors_custom_rerank_candidate_limit() -> None:
+    graph = DependencyGraph()
+    chunks = [make_chunk(f"c{i}", f"f{i}.py", token_count=10) for i in range(DEFAULT_TOP_K + 5)]
+    for chunk in chunks:
+        graph.add_file_node(chunk.file_path)
+    search_results = [(chunk, float(DEFAULT_TOP_K + 5 - i)) for i, chunk in enumerate(chunks)]
+    reranker = RecordingReranker()
+
+    assemble_context(
+        search_results=search_results,
+        graph=graph,
+        all_chunks=chunks,
+        question="query",
+        token_budget=1000,
+        reranker=reranker,
+        rerank_candidate_limit=3,
+    )
+
+    assert reranker.seen_candidate_count == 3
+    assert reranker.seen_top_k == DEFAULT_TOP_K
+
+
 def test_assemble_context_reranker_preserves_candidates_outside_rerank_window() -> None:
     graph = DependencyGraph()
     distractors = [

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -501,6 +501,25 @@ def test_file_tree_built_from_included_chunks() -> None:
     assert "b.py" in bundle.structural_context.file_tree
 
 
+def test_preserved_files_survive_file_cutoff() -> None:
+    graph = DependencyGraph()
+    primary = make_chunk("primary", "src/archex/project.py", token_count=10)
+    preserved = make_chunk("preserved", "src/archex/cli/main.py", token_count=10)
+    other = make_chunk("other", "src/archex/cache.py", token_count=10)
+    bundle = assemble_context(
+        [(primary, 10.0), (preserved, 0.1), (other, 0.09)],
+        graph,
+        [primary, preserved, other],
+        "How does the project init command work?",
+        token_budget=1000,
+        preserved_files={"src/archex/cli/main.py"},
+        apply_intent_budget=False,
+    )
+    included_files = {rc.chunk.file_path for rc in bundle.chunks}
+    assert "src/archex/project.py" in included_files
+    assert "src/archex/cli/main.py" in included_files
+
+
 def test_empty_search_results_returns_empty_bundle() -> None:
     graph = DependencyGraph()
     bundle = assemble_context([], graph, [], "q", token_budget=1000)

--- a/tests/test_api_precision.py
+++ b/tests/test_api_precision.py
@@ -120,6 +120,26 @@ class TestProjectResultsToCorpus:
         assert misses == 0
         assert projected == [(corpus_chunks[0], 0.9)]
 
+    def test_select_dual_leg_file_stage_prefers_semantic_code_over_support(self) -> None:
+        from archex.api import _select_dual_leg_file_stage  # pyright: ignore[reportPrivateUsage]
+
+        lexical = [
+            (_chunk(file_path="src/archex/analyze/patterns.py", token_count=8), 9.0),
+            (_chunk(file_path="src/archex/acquire/discovery.py", token_count=8), 1.0),
+            (_chunk(file_path="src/archex/analyze/modules.py", token_count=8), 1.0),
+        ]
+        semantic = [
+            (_chunk(file_path="src/archex/serve/intent.py", token_count=8), 8.0),
+            (_chunk(file_path="tests/analyze/test_patterns.py", token_count=8), 7.5),
+            (_chunk(file_path="src/archex/models.py", token_count=8), 7.0),
+        ]
+
+        selected = _select_dual_leg_file_stage(lexical, semantic)
+
+        assert "src/archex/analyze/patterns.py" in selected
+        assert "src/archex/models.py" in selected
+        assert "tests/analyze/test_patterns.py" not in selected
+
     def test_dual_leg_query_uses_passthrough_when_budget_covers_corpus(self) -> None:
         from archex.api import query_dual_leg_benchmark
         from archex.models import Config, IndexConfig, RepoSource

--- a/tests/test_api_precision.py
+++ b/tests/test_api_precision.py
@@ -189,6 +189,53 @@ class TestProjectResultsToCorpus:
             "src/archex/parse/adapters/python.py",
         }
 
+    def test_select_delta_cache_preserved_files_keeps_delta_cache_bridge(self) -> None:
+        import archex.api as api_mod
+
+        lexical = [
+            (_chunk(file_path="src/archex/index/delta.py", token_count=8), 9.0),
+            (_chunk(file_path="src/archex/index/store.py", token_count=8), 8.0),
+        ]
+        all_chunks = [
+            _chunk(file_path="src/archex/index/delta.py", token_count=8),
+            _chunk(file_path="src/archex/cache.py", token_count=8),
+        ]
+
+        selected = api_mod.__dict__["_select_delta_cache_preserved_files"](
+            "How does delta indexing detect and apply changes?",
+            lexical,
+            all_chunks,
+            {"src/archex/index/delta.py"},
+        )
+
+        assert selected == {"src/archex/cache.py"}
+
+    def test_select_delta_cache_preserved_files_keeps_vector_contract_files(self) -> None:
+        import archex.api as api_mod
+
+        lexical = [
+            (_chunk(file_path="src/archex/index/vector.py", token_count=8), 9.0),
+            (_chunk(file_path="src/archex/cache.py", token_count=8), 8.0),
+        ]
+        all_chunks = [
+            _chunk(file_path="src/archex/index/vector.py", token_count=8),
+            _chunk(file_path="src/archex/cache.py", token_count=8),
+            _chunk(file_path="src/archex/models.py", token_count=8),
+            _chunk(file_path="src/archex/index/embeddings/base.py", token_count=8),
+        ]
+
+        selected = api_mod.__dict__["_select_delta_cache_preserved_files"](
+            "How does archex build, cache, and reload vector indexes for query retrieval?",
+            lexical,
+            all_chunks,
+            {"src/archex/index/vector.py", "src/archex/cache.py"},
+        )
+
+        assert selected == {
+            "src/archex/models.py",
+            "src/archex/index/embeddings/base.py",
+        }
+
     def test_dual_leg_query_uses_passthrough_when_budget_covers_corpus(self) -> None:
         from archex.api import query_dual_leg_benchmark
         from archex.models import Config, IndexConfig, RepoSource

--- a/tests/test_api_precision.py
+++ b/tests/test_api_precision.py
@@ -121,7 +121,7 @@ class TestProjectResultsToCorpus:
         assert projected == [(corpus_chunks[0], 0.9)]
 
     def test_select_dual_leg_file_stage_prefers_semantic_code_over_support(self) -> None:
-        from archex.api import _select_dual_leg_file_stage  # pyright: ignore[reportPrivateUsage]
+        import archex.api as api_mod
 
         lexical = [
             (_chunk(file_path="src/archex/analyze/patterns.py", token_count=8), 9.0),
@@ -134,11 +134,60 @@ class TestProjectResultsToCorpus:
             (_chunk(file_path="src/archex/models.py", token_count=8), 7.0),
         ]
 
-        selected = _select_dual_leg_file_stage(lexical, semantic)
+        selected = api_mod.__dict__["_select_dual_leg_file_stage"](lexical, semantic)
 
         assert "src/archex/analyze/patterns.py" in selected
         assert "src/archex/models.py" in selected
         assert "tests/analyze/test_patterns.py" not in selected
+
+    def test_select_direct_preservation_files_keeps_cli_bridges(self) -> None:
+        import archex.api as api_mod
+
+        lexical = [
+            (_chunk(file_path="src/archex/project.py", token_count=8), 9.0),
+            (_chunk(file_path="src/archex/cli/query_cmd.py", token_count=8), 8.0),
+            (_chunk(file_path="src/archex/cache.py", token_count=8), 7.0),
+        ]
+        all_chunks = [
+            _chunk(file_path="src/archex/project.py", token_count=8),
+            _chunk(file_path="src/archex/cli/query_cmd.py", token_count=8),
+            _chunk(file_path="src/archex/cli/main.py", token_count=8),
+            _chunk(file_path="src/archex/config.py", token_count=8),
+        ]
+
+        selected = api_mod.__dict__["_select_direct_preservation_files"](
+            "How does archex query cache lifecycle work?",
+            lexical,
+            all_chunks,
+            {"src/archex/project.py", "src/archex/cli/query_cmd.py"},
+        )
+
+        assert "src/archex/cli/main.py" in selected
+        assert "src/archex/config.py" in selected
+
+    def test_select_direct_preservation_files_keeps_adapter_core(self) -> None:
+        import archex.api as api_mod
+
+        lexical = [
+            (_chunk(file_path="src/archex/parse/adapters/__init__.py", token_count=8), 9.0),
+        ]
+        all_chunks = [
+            _chunk(file_path="src/archex/parse/adapters/__init__.py", token_count=8),
+            _chunk(file_path="src/archex/parse/adapters/base.py", token_count=8),
+            _chunk(file_path="src/archex/parse/adapters/python.py", token_count=8),
+        ]
+
+        selected = api_mod.__dict__["_select_direct_preservation_files"](
+            "How does archex register language adapters?",
+            lexical,
+            all_chunks,
+            {"src/archex/parse/adapters/__init__.py"},
+        )
+
+        assert selected == {
+            "src/archex/parse/adapters/base.py",
+            "src/archex/parse/adapters/python.py",
+        }
 
     def test_dual_leg_query_uses_passthrough_when_budget_covers_corpus(self) -> None:
         from archex.api import query_dual_leg_benchmark

--- a/tests/test_api_precision.py
+++ b/tests/test_api_precision.py
@@ -61,6 +61,91 @@ def _chunk(
     )
 
 
+class TestProjectResultsToCorpus:
+    def test_projects_by_symbol_id(self) -> None:
+        from archex.api import _project_results_to_corpus  # pyright: ignore[reportPrivateUsage]
+
+        corpus_chunks = [
+            _chunk(file_path="src/main.py", name="alpha", start_line=1, end_line=5),
+            _chunk(file_path="src/main.py", name="beta", start_line=7, end_line=12),
+        ]
+        projected, misses = _project_results_to_corpus(
+            [
+                (
+                    _chunk(file_path="src/main.py", name="beta", start_line=6, end_line=20),
+                    0.8,
+                )
+            ],
+            corpus_chunks,
+        )
+
+        assert misses == 0
+        assert projected == [(corpus_chunks[1], 0.8)]
+
+    def test_projects_by_overlap_and_deduplicates_scores(self) -> None:
+        from archex.api import _project_results_to_corpus  # pyright: ignore[reportPrivateUsage]
+
+        corpus_chunks = [
+            _chunk(file_path="src/main.py", name="alpha", start_line=1, end_line=5),
+            _chunk(file_path="src/main.py", name="beta", start_line=7, end_line=12),
+        ]
+        projected, misses = _project_results_to_corpus(
+            [
+                (
+                    _chunk(
+                        file_path="src/main.py",
+                        name="span",
+                        qualified_name="span",
+                        start_line=2,
+                        end_line=6,
+                        content="span",
+                    ),
+                    0.4,
+                ),
+                (
+                    _chunk(
+                        file_path="src/main.py",
+                        name="span-2",
+                        qualified_name="span-2",
+                        start_line=1,
+                        end_line=4,
+                        content="span-2",
+                    ),
+                    0.9,
+                ),
+            ],
+            corpus_chunks,
+        )
+
+        assert misses == 0
+        assert projected == [(corpus_chunks[0], 0.9)]
+
+    def test_dual_leg_query_uses_passthrough_when_budget_covers_corpus(self) -> None:
+        from archex.api import query_dual_leg_benchmark
+        from archex.models import Config, IndexConfig, RepoSource
+
+        chunk = _chunk(file_path="src/main.py", content="def foo():\n    return 1\n", token_count=6)
+        store = _make_store([chunk])
+        store.set_metadata("repo_total_tokens", "6")
+        store.set_metadata("chunk_count", "1")
+        source = RepoSource(local_path="/fake", stable_identity="repo@abc#chunker=default")
+
+        with patch("archex.api._ensure_index", return_value=store):
+            bundle = query_dual_leg_benchmark(
+                bm25_source=source,
+                vector_source=source,
+                question="How does foo work?",
+                token_budget=100,
+                config=Config(cache=True),
+                bm25_index_config=IndexConfig(vector=False, chunker="default"),
+                vector_index_config=IndexConfig(vector=True, chunker="cast"),
+            )
+
+        assert [ranked.chunk.file_path for ranked in bundle.chunks] == ["src/main.py"]
+        assert bundle.retrieval_metadata.bm25_chunker == "default"
+        assert bundle.retrieval_metadata.vector_chunker == "cast"
+
+
 # Shared test chunks
 CHUNKS = [
     _chunk(

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -18,6 +18,7 @@ from archex.parse.adapters import ADAPTERS
 from archex.parse.engine import TreeSitterEngine
 from archex.parse.imports import parse_imports
 from archex.parse.symbols import extract_symbols, extract_symbols_and_imports
+from archex.pipeline.chunker import chunker_revision
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
@@ -333,6 +334,8 @@ class TestQueryCacheSkipsParse:
         store.insert_edges([Edge(source="t.py", target="u.py", kind=EdgeKind.IMPORTS)])
         bm25 = BM25Index(store)
         bm25.build([chunk])
+        store.set_metadata("chunker", "default")
+        store.set_metadata("chunker_revision", chunker_revision("default"))
         store.conn.execute("PRAGMA wal_checkpoint(FULL)")
         store.close()
 


### PR DESCRIPTION
## Summary
- consolidate the surviving benchmark-only retrieval policy experiments onto the stable benchmark spine
- include dual-leg orchestration, file-stage orchestration, direct file preservation, and delta/vector-cache preservation
- record the decisive benchmark comparison against the stable spine

## Validation
- uv run ruff check && uv run ruff format --check . && uv run pyright
- uv run pytest tests/pipeline/ tests/index/ tests/benchmark/ -q
- full benchmark run against the stable benchmark spine and gate comparison

## Verdict
- consolidated candidate improved mean recall
- consolidated candidate still regressed F1 and failed the stable-spine baseline gate
- keep draft; do not replace `feat/chunker-benchmark-arm`
