### PR TITLE
feat: add archex Claude Code skill

### DIFF
--- a/skills/archex/SKILL.md
+++ b/skills/archex/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: archex
+description: Use when an agent needs local-first codebase context, architecture maps, scout/fetch bundles, or archex MCP setup for an existing repository.
+version: 0.1.0
+---
+
+# archex
+
+## Overview
+
+archex is a local code-context layer. It indexes the repository, returns structural maps and token-budgeted context bundles, and never requires hosted inference or API keys.
+
+## First Use
+
+Run diagnostics before retrieval:
+
+```bash
+archex doctor . --format json
+```
+
+If `index_health` is `error` because the project is uninitialized or missing an index, run:
+
+```bash
+archex init .
+archex index .
+```
+
+If `index_staleness` is `warning`, run `archex index .` before relying on results. If diagnostics still fail, stop and report the exact `archex doctor` check and message.
+
+## Scout → Fetch Protocol
+
+Use this for broad or architectural questions.
+
+1. Scout without code bodies:
+
+```bash
+archex scout . "How does authentication flow through this repo?" --budget 1000 --format json
+```
+
+2. Read `fetch_plan.recommended_strategy`:
+
+| Strategy | Action |
+| --- | --- |
+| `chunk_first` | Fetch the listed `symbol:` or `chunk:` handles before running a broader query. |
+| `hybrid_fetch` | Fetch the highest-scoring handles, then run `archex query` only if the fetched context is insufficient. |
+| `direct_query` | Skip handle fetch and run a normal context bundle query. |
+
+3. Fetch exact handles:
+
+```bash
+archex symbol . 'symbol:src/pkg/service.py::Service#class'
+archex symbol . 'chunk:src/pkg/service.py::Service#class'
+```
+
+For file handles, run a focused query naming the file path from the handle:
+
+```bash
+archex query . "Explain src/pkg/service.py in the auth flow" --format xml
+```
+
+For Python callers, pass all scout handles directly:
+
+```python
+from archex import query
+from archex.models import RepoSource
+
+bundle = query(
+    RepoSource(local_path="."),
+    "How does authentication flow through this repo?",
+    handles=["symbol:src/pkg/service.py::Service#class"],
+)
+print(bundle.to_prompt(format="xml"))
+```
+
+## MCP Wiring
+
+Install the MCP extra and register the stdio server with the client:
+
+```bash
+uv tool install "archex[mcp]"
+```
+
+```json
+{
+  "mcpServers": {
+    "archex": { "command": "archex", "args": ["mcp"] }
+  }
+}
+```
+
+Optional warm-container or long-running local sessions can keep the MCP server alive with watch mode:
+
+```bash
+archex mcp --watch --watch-path .
+```
+
+## Quick Reference
+
+| Need | Command |
+| --- | --- |
+| Trust check | `archex doctor .` |
+| Initialize | `archex init . && archex index .` |
+| Scout map | `archex scout . "question" --budget 1000 --format json` |
+| Context bundle | `archex query . "question" --format xml` |
+| Exact symbol body | `archex symbol . 'symbol:path.py::name#kind'` |
+| Architecture guide | `archex onboard .` |
+
+## Rules
+
+- Use local models only. Do not add hosted embedding providers or API-key dependencies.
+- Prefer scout before reading files for broad questions.
+- Use exact handles from scout output; do not re-search when a handle already identifies the target.
+- Keep `.archex/` generated and uncommitted.
+- Run `archex doctor .` for troubleshooting before changing configuration.

--- a/skills/archex/commands/archex.md
+++ b/skills/archex/commands/archex.md
@@ -1,0 +1,23 @@
+# /archex
+
+Use archex to gather local codebase context before reading files.
+
+## Arguments
+
+`/archex <question>` uses the current repository. `/archex <path> -- <question>` uses an explicit repository path.
+
+## Procedure
+
+1. Run `archex doctor <path> --format json`.
+2. If `index_health` is `error` for an uninitialized or missing index, run `archex init <path>` and `archex index <path>`.
+3. If `index_staleness` is `warning`, run `archex index <path>`.
+4. Run `archex scout <path> "<question>" --budget 1000 --format json`.
+5. Follow `fetch_plan.recommended_strategy`:
+   - `chunk_first`: fetch listed `symbol:` and `chunk:` handles with `archex symbol`.
+   - `hybrid_fetch`: fetch top handles, then run `archex query` if the fetched context is insufficient.
+   - `direct_query`: run `archex query <path> "<question>" --format xml`.
+6. Stop when the returned bundle answers the code-context need. Do not run long benchmarks.
+
+## Output
+
+Return the exact archex command outputs or summarize the fetched files, handles, and bundle provenance. Report any failing `archex doctor` check verbatim.


### PR DESCRIPTION
## Stack

Stack-Id: `c4-distribution-parity`
Base: `main`
Position: 2/4

1. `feat/archex-doctor` -> #223
2. `feat/claude-skill` -> this PR
3. `feat/docker-images` -> #225
4. `docs/archex-vs-cocoindex` -> #226

Depends on: #223
Upstack: #225

## Changes

- Adds publishable in-repo skill package at `skills/archex/SKILL.md`.
- Adds `/archex` command asset at `skills/archex/commands/archex.md`.
- Documents auto-init, doctor-first troubleshooting, MCP wiring, and scout→fetch guidance.

## Validation

- Passed: `uv run ruff check && uv run ruff format --check . && uv run pyright && uv run pytest tests/cli/ -q`
- PR review: completed; no blocking findings.