### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## 0.9.1 (2026-06-15)
+
+### Changed
+
+- Refreshed the README as the project front page with a concise hero, proof bar, audience routing, quickstart, trust and operations guidance, measured-results pointers, and current CLI/MCP/Python/Docker usage.
+- Updated system design and roadmap documentation so shipped post-roadmap surfaces, historical execution records, and retrieval-default decision authority have one explicit documentation hierarchy.
+
 ## 0.9.0 (2026-06-13)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archex"
-version = "0.9.0"
+version = "0.9.1"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "archex"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump archex package version to 0.9.1.
- Add 0.9.1 changelog entry for the documentation authority refresh and README redesign.
- Update uv.lock package metadata.

## Validation
- uv run ruff check && uv run ruff format --check . && uv run pyright && uv run pytest: passed
- uv build --out-dir dist/release-0.9.1: passed
- uvx twine check dist/release-0.9.1/*: passed

## Release
- Tag to create after merge: v0.9.1
- PyPI artifacts built locally from this commit.