### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Changelog
 
 
-## 0.9.1 (2026-06-15)
+## 0.10.0 (2026-06-15)
 
 ### Changed
 
 - Refreshed the README as the project front page with a concise hero, proof bar, audience routing, quickstart, trust and operations guidance, measured-results pointers, and current CLI/MCP/Python/Docker usage.
+- Removed unnecessary local-repo positional arguments from README examples now that repo-local CLI commands default to the current working directory.
 - Updated system design and roadmap documentation so shipped post-roadmap surfaces, historical execution records, and retrieval-default decision authority have one explicit documentation hierarchy.
+- Supersedes the mistaken `0.9.1` patch release with the intended minor release number.
+
+## 0.9.1 (2026-06-15)
+
+### Changed
+
+- Published with patch numbering by mistake; superseded by `0.10.0`.
 
 ## 0.9.0 (2026-06-13)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ archex turns a repository into a ranked, token-budgeted context bundle with symb
 
 | If you are evaluating... | Start here | Why |
 | --- | --- | --- |
-| Agent workflows | `archex doctor .`, then `archex scout . "question" --budget 1000 --format json` | Checks local trust first, then returns a compact map plus exact fetch handles. |
+| Agent workflows | `archex doctor`, then `archex scout "question" --budget 1000 --format json` | Checks local trust first, then returns a compact map plus exact fetch handles. |
 | Claude Code or MCP | [MCP and Claude Code](#mcp-and-claude-code) | Stdio MCP server, optional warm `--watch`, and an in-repo skill that teaches doctor → scout → fetch. |
 | Python applications | [Python API](#python-api) | Deterministic `query()`, `analyze()`, `compare()`, and retriever integrations. |
 | Benchmark proof | [Measured results](#measured-results) and [archex vs. cocoindex-code](docs/ARCHEX_VS_COCOINDEX.md) | Same-task C1 report, retrieval gates, and default-strategy decisions. |
@@ -32,16 +32,16 @@ archex turns a repository into a ranked, token-budgeted context bundle with symb
 
 ```bash
 uv tool install archex
-archex doctor .
-archex query ./my-project "How does authentication work?" --format xml
+archex doctor
+archex query "How does authentication work?" --format xml
 ```
 
-`archex doctor .` reports whether the local index, grammar support, model cache, MCP registration, and `.archex/` state are healthy. If the repo has not been initialized yet:
+`archex doctor` reports whether the local index, grammar support, model cache, MCP registration, and `.archex/` state are healthy. Repo-local commands default to the current working directory. If the repo has not been initialized yet:
 
 ```bash
-archex init ./my-project
-archex index ./my-project
-archex query ./my-project "How does authentication work?" --format xml
+archex init
+archex index
+archex query "How does authentication work?" --format xml
 ```
 
 ## What archex returns
@@ -99,11 +99,11 @@ archex is a selection and assembly layer. Compression tools can shrink the final
 ### CLI
 
 ```bash
-archex query ./repo "Where is cache invalidation handled?" --format xml
-archex scout ./repo "How does authentication flow through this repo?" --budget 1000 --format json
-archex graph export ./repo --output .archex/archgraph.json
+archex query "Where is cache invalidation handled?" --format xml
+archex scout "How does authentication flow through this repo?" --budget 1000 --format json
+archex graph export --output .archex/archgraph.json
 archex graph neighbors src/auth/middleware.py --graph .archex/archgraph.json --format markdown
-archex symbol ./repo 'symbol:src/auth/middleware.py::authenticate#function'
+archex symbol 'symbol:src/auth/middleware.py::authenticate#function'
 ```
 
 ### MCP and Claude Code
@@ -137,7 +137,7 @@ from archex import query
 from archex.models import RepoSource
 
 bundle = query(
-    RepoSource(local_path="./my-project"),
+    RepoSource(local_path="."),
     "Where is database connection pooling implemented?",
 )
 print(bundle.to_prompt(format="xml"))
@@ -151,10 +151,10 @@ Two local-first images are built in CI:
 
 ```bash
 # BM25-only, no torch
-docker run --rm -v "$PWD:/workspace" -w /workspace ghcr.io/mathews-tom/archex:slim archex doctor .
+docker run --rm -v "$PWD:/workspace" -w /workspace ghcr.io/mathews-tom/archex:slim archex doctor
 
 # Full local-embedding image with FastEmbed prewarmed
-docker run --rm -v "$PWD:/workspace" -w /workspace ghcr.io/mathews-tom/archex:full archex query . "Where is cache invalidation handled?" --strategy hybrid
+docker run --rm -v "$PWD:/workspace" -w /workspace ghcr.io/mathews-tom/archex:full archex query "Where is cache invalidation handled?" --strategy hybrid
 ```
 
 Warm-container MCP pattern:
@@ -205,22 +205,22 @@ The local 35-task retrieval benchmark still governs default-strategy decisions. 
 
 ```bash
 # Repo-local lifecycle
-archex init .
-archex index .
+archex init
+archex index
 archex status --strict
-archex doctor . --format json
+archex doctor --format json
 
 # Architecture and graph surfaces
-archex analyze . --format markdown
-archex onboard .
-archex graph export . --output .archex/archgraph.json
+archex analyze --format markdown
+archex onboard
+archex graph export --output .archex/archgraph.json
 archex graph path src/archex/cli/query_cmd.py src/archex/serve/context.py --graph .archex/archgraph.json --format markdown
-archex impact . src/archex/serve/context.py
+archex impact --changed-file src/archex/serve/context.py
 
 # Benchmarks and gates
 archex benchmark headtohead report --input .archex/headtohead --format markdown
 archex benchmark gate --input .archex/e2e --baseline .archex/e2e-baseline --warn-latency-ms 3000
-archex dogfood . --all --baseline benchmarks/dogfood_baseline.json --format dogfood-delta
+archex dogfood --all --baseline benchmarks/dogfood_baseline.json --format dogfood-delta
 ```
 
 ## Installation details

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archex"
-version = "0.9.1"
+version = "0.10.0"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/archex/cli/symbol_cmd.py
+++ b/src/archex/cli/symbol_cmd.py
@@ -12,12 +12,12 @@ from archex.utils import resolve_source
 
 
 @click.command("symbol")
-@click.argument("source")
-@click.argument("symbol_id")
+@click.argument("args", nargs=-1, required=True)
 @click.option("--json", "output_json", is_flag=True, default=False, help="Output as JSON.")
 @click.option("--timing", is_flag=True, default=False, help="Print timing breakdown.")
-def symbol_cmd(source: str, symbol_id: str, output_json: bool, timing: bool) -> None:
+def symbol_cmd(args: tuple[str, ...], output_json: bool, timing: bool) -> None:
     """Retrieve the full source for a single symbol by its stable ID."""
+    source, symbol_id = _source_and_symbol_id(args)
     source_obj = resolve_source(source)
 
     pt = PipelineTiming() if timing else None
@@ -40,3 +40,11 @@ def symbol_cmd(source: str, symbol_id: str, output_json: bool, timing: bool) -> 
         print_timing(pt)
         raw = get_file_token_count(source_obj, result.file_path)
         print_savings(result.token_count, raw, pt.total_ms)
+
+
+def _source_and_symbol_id(args: tuple[str, ...]) -> tuple[str, str]:
+    if len(args) == 1:
+        return ".", args[0]
+    if len(args) == 2:
+        return args[0], args[1]
+    raise click.UsageError("symbol requires a symbol ID, or source and symbol ID")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -974,6 +974,27 @@ class TestSymbolCmd:
         assert "def greet():" in result.output
         assert "print('hi')" in result.output
 
+    def test_symbol_defaults_source_to_cwd(self) -> None:
+        from unittest.mock import patch
+
+        from archex.models import SymbolKind, SymbolSource
+
+        sym = SymbolSource(
+            symbol_id="f.py::greet#function",
+            name="greet",
+            kind=SymbolKind.FUNCTION,
+            file_path="f.py",
+            start_line=1,
+            end_line=1,
+            source="def greet(): pass",
+        )
+        runner = CliRunner()
+        with patch("archex.cli.symbol_cmd.get_symbol", return_value=sym) as symbol_mock:
+            result = runner.invoke(cli, ["symbol", "f.py::greet#function"])
+        assert result.exit_code == 0, result.output
+        assert symbol_mock.call_args.args[0].local_path == "."
+        assert symbol_mock.call_args.kwargs["symbol_id"] == "f.py::greet#function"
+
     def test_symbol_json(self) -> None:
         from unittest.mock import patch
 

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "archex"
-version = "0.9.1"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump archex to 0.10.0 and document that 0.9.1 was superseded by the intended minor release.
- Update README examples to use repo-local CLI defaults instead of unnecessary current-repo positional paths.
- Allow `archex symbol <symbol-id>` to default to the current directory, matching query/scout/symbols local behavior.

## Changes since v0.9.0
- README front-page redesign and documentation authority refresh.
- System design and roadmap authority cleanup for shipped scout, working-tree delta, graph query, language expansion, head-to-head harness, skill, Docker, and comparison surfaces.
- README local-default correction for repo-local command examples.

## Validation
- uv run ruff check && uv run ruff format --check . && uv run pyright && uv run pytest: passed
- targeted symbol CLI tests passed before full-suite validation.