### PR TITLE
Add security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The mounted repository owns `.archex/`, so indexes survive container restarts an
 
 | Surface | Contract |
 | --- | --- |
+| Security policy | Supported versions, disclosure workflow, no-telemetry posture, secret-handling guidance, and model remote-code policy live in [SECURITY.md](SECURITY.md). |
 | `archex doctor` | Text/JSON diagnostics for index health, staleness, local model cache presence, grammar availability by tier, MCP registration, and `.archex/` disk usage. |
 | Repo-local `.archex/` | Generated state: settings, metadata, SQLite index, optional vectors, graph artifacts, dogfood history. Keep it uncommitted. |
 | Freshness | Query and MCP paths can apply small working-tree deltas; `archex mcp --watch` keeps a warm process current when enabled. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,64 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are accepted for the current minor release line and `main`. Older minor releases are reviewed case by case when a low-risk patch can be backported without changing public behavior.
+
+## Reporting vulnerabilities
+
+Report suspected vulnerabilities privately by opening a GitHub security advisory for this repository or by contacting the maintainer listed on the PyPI project page. Do not file public issues for unpatched vulnerabilities.
+
+Include:
+
+- affected archex version or commit
+- operating system and Python version
+- exact command, API call, MCP request, or Docker image used
+- configuration relevant to indexing, model loading, MCP, or Docker
+- minimal reproduction steps
+- observed impact and any known workaround
+
+Do not include secrets, private source code, proprietary indexes, or model cache contents unless the maintainer explicitly requests them through a private channel.
+
+## Response expectations
+
+The maintainer aims to acknowledge valid private reports within 5 business days, confirm scope and severity after reproduction, and coordinate a fix timeline based on impact. Critical issues that expose secrets, execute untrusted code, or corrupt source/index data are prioritized over hardening requests.
+
+## Scope
+
+In scope:
+
+- archex CLI commands
+- Python API entry points
+- stdio MCP server behavior
+- Docker images published for archex
+- model-loading paths and local model cache handling
+- repo-local `.archex/` index, vector, graph, and settings state
+- dependency and model supply-chain risks that affect normal archex operation
+
+Out of scope:
+
+- social engineering, phishing, or physical attacks
+- denial-of-service against public services not operated by archex
+- vulnerabilities in downstream LLM clients that consume archex output
+- vulnerabilities requiring malicious local administrator access
+- reports based only on unsupported forks or modified packages
+
+## Telemetry and data handling
+
+archex does not send telemetry from core CLI, Python API, MCP, or Docker slim workflows. It reads the repository paths you point it at and writes generated state under repo-local `.archex/` or configured cache directories.
+
+Core operation does not require hosted inference credentials or API keys. Optional integrations may require their own client configuration, but archex does not need hosted API keys for core retrieval, indexing, MCP, or Docker slim use.
+
+## Secrets
+
+Do not store secrets in `.archex/` settings, indexes, benchmark manifests, Docker command lines, or MCP client configs. archex indexes repository files; if secrets are present in indexed source files, they can appear in local indexes and returned context bundles. Rotate leaked secrets outside archex and rebuild the affected index after removing them from source.
+
+## Model downloads and remote code
+
+Core BM25-only operation does not load Hugging Face remote code. Optional model paths that require Hugging Face remote code must be explicitly enabled by configuration or command choice, and built-in paths with published revision pins should keep those pins in place.
+
+Model downloads are local to the executing machine or container. Review model licenses, revisions, and cache locations before enabling optional vector, SPLADE, rerank, or remote-code model paths in an enterprise environment.
+
+## Coordinated disclosure
+
+Keep vulnerability details private until a fix or mitigation is available and published. The maintainer will credit reporters who want attribution, unless disclosure would expose sensitive operational details or the reporter requests anonymity.


### PR DESCRIPTION
## Stack

Stack-Id: `enterprise-clearance-20260615`
Base: `main`
Position: 1/4

1. `enterprise-clearance/security-policy` -> this PR
2. `enterprise-clearance/remote-code-policy` -> #241
3. `enterprise-clearance/doctor-security` -> #242
4. `enterprise-clearance/install-contract` -> #243

Depends on: (none - root)
Upstack: #241

## Summary

- Add root `SECURITY.md` covering supported versions, private reporting, response expectations, scope, out-of-scope examples, telemetry, secrets, model downloads, remote-code policy, and coordinated disclosure.
- Link the policy from the README trust and operations table.

## Validation

- `uv run python -c "from pathlib import Path; security = Path('SECURITY.md').read_text(encoding='utf-8'); readme = Path('README.md').read_text(encoding='utf-8'); required = ['Supported versions', 'Reporting vulnerabilities', 'Response expectations', 'Scope', 'Telemetry', 'Secrets', 'Model downloads and remote code', 'Coordinated disclosure']; missing = [item for item in required if item not in security]; assert not missing, missing; assert '[SECURITY.md](SECURITY.md)' in readme"`: passed
- `/review` security-policy slice: passed after wording fix
