### PR TITLE
Gate remote-code model loading

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -624,6 +624,7 @@ def _maybe_reranker(index_config: IndexConfig) -> CrossEncoderReranker | None:
     if index_config.rerank:
         return CrossEncoderReranker(
             model_name=index_config.rerank_model or DEFAULT_MODEL,
+            allow_remote_code=index_config.allow_remote_code,
         )
 
     return None

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -141,6 +141,7 @@ class BenchmarkRetrievalOptions(BaseModel):
     module_prefilter: bool = False
     embedder: str = "jina-v2"
     rerank_model: str | None = None
+    allow_remote_code: bool = False
     freshness: bool = False
     chunker: ChunkerName = "default"
     bm25_chunker: ChunkerName | None = None

--- a/src/archex/benchmark/preflight.py
+++ b/src/archex/benchmark/preflight.py
@@ -30,7 +30,11 @@ def warm_benchmark_models(
 
         default_embedder_registry.load_entry_points()
         embedder = default_embedder_registry.create(
-            IndexConfig(vector=True, embedder=retrieval_options.embedder)
+            IndexConfig(
+                vector=True,
+                embedder=retrieval_options.embedder,
+                allow_remote_code=retrieval_options.allow_remote_code,
+            )
         )
         if embedder is None:
             msg = "Benchmark vector strategy requires a configured embedder"
@@ -52,7 +56,10 @@ def warm_benchmark_models(
         from archex.index.rerank import DEFAULT_MODEL, CrossEncoderReranker
 
         rerank_model = retrieval_options.rerank_model or DEFAULT_MODEL
-        CrossEncoderReranker(model_name=rerank_model).warm()
+        CrossEncoderReranker(
+            model_name=rerank_model,
+            allow_remote_code=retrieval_options.allow_remote_code,
+        ).warm()
         warmed.append(rerank_model)
 
     return warmed

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -697,6 +697,8 @@ def benchmark_index_config(
         updates["module_prefilter"] = True
     if index_config.rerank and options.rerank_model is not None:
         updates["rerank_model"] = options.rerank_model
+    if options.allow_remote_code:
+        updates["allow_remote_code"] = True
     if index_config.rerank and options.rerank_candidate_limit is not None:
         updates["rerank_candidate_limit"] = options.rerank_candidate_limit
     if not updates:

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -66,6 +66,7 @@ from archex.benchmark.triage import (
     load_benchmark_tasks,
     triage_failures,
 )
+from archex.exceptions import ArchexError
 
 if TYPE_CHECKING:
     from archex.models import ChunkerName
@@ -138,6 +139,12 @@ def benchmark_cmd() -> None:
     help="Enable the opt-in module responsibility prefilter for BM25-backed archex strategies.",
 )
 @click.option(
+    "--allow-remote-code",
+    is_flag=True,
+    default=False,
+    help="Allow explicitly selected pinned model paths that require Hugging Face remote code.",
+)
+@click.option(
     "--embedder",
     default="jina-v2",
     show_default=True,
@@ -196,6 +203,7 @@ def run_cmd(
     rerank: bool,
     splade: bool,
     module_prefilter: bool,
+    allow_remote_code: bool,
     embedder: str,
     chunker: ChunkerName,
     bm25_chunker: ChunkerName | None,
@@ -227,13 +235,17 @@ def run_cmd(
         splade=splade,
         module_prefilter=module_prefilter,
         embedder=embedder,
+        allow_remote_code=allow_remote_code,
         rerank_model=rerank_model,
         chunker=chunker,
         bm25_chunker=bm25_chunker,
         vector_chunker=vector_chunker,
         rerank_candidate_limit=rerank_candidate_limit,
     )
-    warmed_models = warm_benchmark_models(strategies, retrieval_options)
+    try:
+        warmed_models = warm_benchmark_models(strategies, retrieval_options)
+    except ArchexError as exc:
+        raise click.ClickException(str(exc)) from exc
     if warmed_models:
         click.echo(
             f"Benchmark model preflight loaded {len(warmed_models)} model(s).",
@@ -242,17 +254,20 @@ def run_cmd(
 
     tasks_path = Path(tasks_dir)
     tasks = load_selected_tasks(tasks_path, task_filter=task_id, self_only=self_only)
-    with BenchmarkProgress(tasks, force_disable=no_progress) as progress:
-        reports = run_all(
-            tasks_dir=tasks_path,
-            output_dir=Path(output_dir),
-            strategies=strategies,
-            task_filter=task_id,
-            self_only=self_only,
-            progress=progress,
-            tasks=tasks,
-            retrieval_options=retrieval_options,
-        )
+    try:
+        with BenchmarkProgress(tasks, force_disable=no_progress) as progress:
+            reports = run_all(
+                tasks_dir=tasks_path,
+                output_dir=Path(output_dir),
+                strategies=strategies,
+                task_filter=task_id,
+                self_only=self_only,
+                progress=progress,
+                tasks=tasks,
+                retrieval_options=retrieval_options,
+            )
+    except ArchexError as exc:
+        raise click.ClickException(str(exc)) from exc
 
     click.echo(f"\nCompleted {len(reports)} benchmark(s).", err=True)
 

--- a/src/archex/cli/index_cmd.py
+++ b/src/archex/cli/index_cmd.py
@@ -40,12 +40,26 @@ def _language_counts(file_metadata: list[dict[str, str | int]]) -> dict[str, int
     default=False,
     help="Build opt-in module responsibility summaries.",
 )
-def index_cmd(source: str, output_format: str, splade: bool, module_prefilter: bool) -> None:
+@click.option(
+    "--allow-remote-code",
+    is_flag=True,
+    default=False,
+    help="Allow explicitly selected pinned model paths that require Hugging Face remote code.",
+)
+def index_cmd(
+    source: str,
+    output_format: str,
+    splade: bool,
+    module_prefilter: bool,
+    allow_remote_code: bool,
+) -> None:
     """Build or refresh the index for SOURCE without running a query."""
     repo_source = RepoSource(local_path=source)
     repo_root = Path(source).expanduser().resolve()
     config = load_config(repo_source)
     index_config = load_index_config(repo_source)
+    if allow_remote_code:
+        index_config = index_config.model_copy(update={"allow_remote_code": True})
     if splade:
         index_config = index_config.model_copy(update={"splade": True})
     if module_prefilter:

--- a/src/archex/cli/query_cmd.py
+++ b/src/archex/cli/query_cmd.py
@@ -44,6 +44,12 @@ from archex.utils import resolve_source
     help="Use opt-in module responsibility prefiltering.",
 )
 @click.option(
+    "--allow-remote-code",
+    is_flag=True,
+    default=False,
+    help="Allow explicitly selected pinned model paths that require Hugging Face remote code.",
+)
+@click.option(
     "--no-refresh",
     is_flag=True,
     default=False,
@@ -65,6 +71,7 @@ def query_cmd(
     metrics: bool,
     splade: bool,
     module_prefilter: bool,
+    allow_remote_code: bool,
     no_refresh: bool,
     refresh_threshold: float | None,
 ) -> None:
@@ -82,6 +89,8 @@ def query_cmd(
     index_config = load_index_config(repo_source)
     if strategy is not None:
         index_config = index_config.model_copy(update={"vector": strategy == "hybrid"})
+    if allow_remote_code:
+        index_config = index_config.model_copy(update={"allow_remote_code": True})
     if splade:
         index_config = index_config.model_copy(update={"splade": True})
     if module_prefilter:

--- a/src/archex/index/embeddings/__init__.py
+++ b/src/archex/index/embeddings/__init__.py
@@ -3,23 +3,26 @@
 from __future__ import annotations
 
 import importlib.metadata
+import inspect
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import cast
 
 from archex.exceptions import ConfigError
 from archex.index.embeddings.base import Embedder
-
-if TYPE_CHECKING:
-    from archex.models import IndexConfig
+from archex.index.model_policy import (
+    JINA_BERT_CODE_REVISION,
+    JINA_V2_MAX_SEQ_LENGTH,
+    JINA_V2_MODEL_ID,
+    JINA_V2_MODEL_REVISION,
+    embedder_security_profile,
+    remote_code_trust_value,
+)
+from archex.models import IndexConfig
 
 logger = logging.getLogger(__name__)
 
-EmbedderFactory = Callable[[], Embedder]
-JINA_V2_MODEL_ID = "jinaai/jina-embeddings-v2-base-code"
-JINA_V2_MODEL_REVISION = "516f4baf13dec4ddddda8631e019b5737c8bc250"
-JINA_BERT_CODE_REVISION = "3baf9e3ac750e76e8edd3019170176884695fb94"
-JINA_V2_MAX_SEQ_LENGTH = 1024
+EmbedderFactory = Callable[[], Embedder] | Callable[[IndexConfig], Embedder]
 
 
 __all__ = [
@@ -29,24 +32,35 @@ __all__ = [
 ]
 
 
-def _fastembed_factory() -> Embedder:
+def _fastembed_factory(index_config: IndexConfig) -> Embedder:
+    del index_config
     from archex.index.embeddings.fast import FastEmbedder
 
     return FastEmbedder()
 
 
-def _nomic_factory() -> Embedder:
+def _nomic_factory(index_config: IndexConfig) -> Embedder:
     from archex.index.embeddings.nomic import NomicCodeEmbedder
 
-    return NomicCodeEmbedder()
+    profile = embedder_security_profile("nomic")
+    return NomicCodeEmbedder(
+        allow_remote_code=index_config.allow_remote_code,
+        revision=profile.model_revision,
+    )
 
 
-def _jina_v2_factory() -> Embedder:
+def _jina_v2_factory(index_config: IndexConfig) -> Embedder:
     from archex.index.embeddings.sentence_tf import SentenceTransformerEmbedder
 
+    profile = embedder_security_profile("jina-v2")
+    trust_remote_code = remote_code_trust_value(
+        profile,
+        allow_remote_code=index_config.allow_remote_code,
+    )
     return SentenceTransformerEmbedder(
         model_name=JINA_V2_MODEL_ID,
-        trust_remote_code=True,
+        trust_remote_code=trust_remote_code,
+        allow_remote_code=index_config.allow_remote_code,
         revision=JINA_V2_MODEL_REVISION,
         model_kwargs={"code_revision": JINA_BERT_CODE_REVISION},
         config_kwargs={"code_revision": JINA_BERT_CODE_REVISION},
@@ -54,16 +68,34 @@ def _jina_v2_factory() -> Embedder:
     )
 
 
-def _sentence_tf_factory() -> Embedder:
+def _sentence_tf_factory(index_config: IndexConfig) -> Embedder:
+    del index_config
     from archex.index.embeddings.sentence_tf import SentenceTransformerEmbedder
 
     return SentenceTransformerEmbedder()
 
 
-def _coderank_factory() -> Embedder:
+def _coderank_factory(index_config: IndexConfig) -> Embedder:
     from archex.index.embeddings.coderank import CodeRankEmbedder
 
-    return CodeRankEmbedder()
+    return CodeRankEmbedder(allow_remote_code=index_config.allow_remote_code)
+
+
+def _call_factory(factory: EmbedderFactory, index_config: IndexConfig) -> Embedder:
+    signature = inspect.signature(factory)
+    required_positional = [
+        parameter
+        for parameter in signature.parameters.values()
+        if parameter.kind
+        in {
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        }
+        and parameter.default is inspect.Parameter.empty
+    ]
+    if not required_positional:
+        return cast("Callable[[], Embedder]", factory)()
+    return cast("Callable[[IndexConfig], Embedder]", factory)(index_config)
 
 
 class EmbedderRegistry:
@@ -72,13 +104,14 @@ class EmbedderRegistry:
     def __init__(self) -> None:
         self._factories: dict[str, EmbedderFactory] = {}
         self._entry_points_loaded: bool = False
-        self._instances: dict[str, Embedder] = {}
+        self._instances: dict[tuple[str, bool], Embedder] = {}
         self._entry_points_strict: bool = False
 
     def register(self, name: str, factory: EmbedderFactory) -> None:
         """Register an embedder factory by name."""
         self._factories[name] = factory
-        self._instances.pop(name, None)
+        for key in [key for key in self._instances if key[0] == name]:
+            self._instances.pop(key)
 
     def get(self, name: str) -> EmbedderFactory | None:
         """Return the factory for an embedder name, or None."""
@@ -92,14 +125,15 @@ class EmbedderRegistry:
         """
         if not index_config.embedder:
             return None
-        cached = self._instances.get(index_config.embedder)
+        cache_key = (index_config.embedder, index_config.allow_remote_code)
+        cached = self._instances.get(cache_key)
         if cached is not None:
             return cached
         factory = self._factories.get(index_config.embedder)
         if factory is None:
             raise ConfigError(f"Unknown embedder: {index_config.embedder!r}")
-        embedder = factory()
-        self._instances[index_config.embedder] = embedder
+        embedder = _call_factory(factory, index_config)
+        self._instances[cache_key] = embedder
         return embedder
 
     def load_entry_points(
@@ -115,7 +149,8 @@ class EmbedderRegistry:
             try:
                 factory = ep.load()
                 self._factories[ep.name] = factory
-                self._instances.pop(ep.name, None)
+                for key in [key for key in self._instances if key[0] == ep.name]:
+                    self._instances.pop(key)
                 logger.info("Loaded embedder %s from entry point", ep.name)
             except (ImportError, AttributeError, TypeError, ValueError) as exc:
                 if strict:

--- a/src/archex/index/embeddings/coderank.py
+++ b/src/archex/index/embeddings/coderank.py
@@ -7,11 +7,17 @@ import sys
 from typing import Any
 
 from archex.exceptions import ArchexIndexError
+from archex.index.model_policy import (
+    CODERANK_MODEL_ID,
+    CODERANK_MODEL_REVISION,
+    embedder_security_profile,
+    remote_code_trust_value,
+)
 
 logger = logging.getLogger(__name__)
 
-HF_MODEL_ID = "nomic-ai/CodeRankEmbed"
-HF_MODEL_REVISION = "3c4b60807d71f79b43f3c4363786d9493691f8b1"
+HF_MODEL_ID = CODERANK_MODEL_ID
+HF_MODEL_REVISION = CODERANK_MODEL_REVISION
 QUERY_PREFIX = "Represent this query for searching relevant code: "
 
 
@@ -44,9 +50,11 @@ class CodeRankEmbedder:
         self,
         model_name: str = HF_MODEL_ID,
         batch_size: int = 32,
+        allow_remote_code: bool = False,
     ) -> None:
         self._model_name = model_name
         self._batch_size = batch_size
+        self._allow_remote_code = allow_remote_code
         self._model: Any = None
         self._dimension: int | None = None
 
@@ -55,6 +63,11 @@ class CodeRankEmbedder:
         if self._model is not None:
             return
 
+        profile = embedder_security_profile("coderank")
+        trust_remote_code = remote_code_trust_value(
+            profile,
+            allow_remote_code=self._allow_remote_code,
+        )
         try:
             from sentence_transformers import SentenceTransformer
         except ImportError as e:
@@ -62,7 +75,6 @@ class CodeRankEmbedder:
                 "CodeRankEmbedder requires sentence-transformers. "
                 "Install with: uv add 'archex[vector-torch]'"
             ) from e
-
         device = _best_device()
         print(
             f"Loading embedding model '{self._model_name}' on {device} "
@@ -73,7 +85,7 @@ class CodeRankEmbedder:
         self._model = SentenceTransformer(
             self._model_name,
             revision=HF_MODEL_REVISION if self._model_name == HF_MODEL_ID else None,
-            trust_remote_code=True,
+            trust_remote_code=trust_remote_code,
             device=device,
         )
         self._dimension = self._model.get_sentence_embedding_dimension()

--- a/src/archex/index/embeddings/nomic.py
+++ b/src/archex/index/embeddings/nomic.py
@@ -7,10 +7,14 @@ import sys
 from typing import Any
 
 from archex.exceptions import ArchexIndexError
+from archex.index.model_policy import (
+    NOMIC_CODE_MODEL_ID,
+    NOMIC_CODE_MODEL_REVISION,
+    embedder_security_profile,
+    remote_code_trust_value,
+)
 
 logger = logging.getLogger(__name__)
-
-_HF_MODEL_ID = "nomic-ai/nomic-embed-code"
 
 
 def _best_device() -> str:
@@ -37,11 +41,15 @@ class NomicCodeEmbedder:
 
     def __init__(
         self,
-        model_name: str = _HF_MODEL_ID,
+        model_name: str = NOMIC_CODE_MODEL_ID,
         batch_size: int = 32,
+        allow_remote_code: bool = False,
+        revision: str | None = NOMIC_CODE_MODEL_REVISION,
     ) -> None:
         self._model_name = model_name
         self._batch_size = batch_size
+        self._allow_remote_code = allow_remote_code
+        self._revision = revision
         self._model: Any = None
         self._dimension: int | None = None
         self._backend: str | None = None
@@ -51,6 +59,11 @@ class NomicCodeEmbedder:
         if self._model is not None:
             return
 
+        profile = embedder_security_profile("nomic")
+        trust_remote_code = remote_code_trust_value(
+            profile,
+            allow_remote_code=self._allow_remote_code,
+        )
         try:
             from sentence_transformers import SentenceTransformer
 
@@ -62,7 +75,10 @@ class NomicCodeEmbedder:
                 flush=True,
             )
             self._model = SentenceTransformer(
-                self._model_name, trust_remote_code=True, device=device
+                self._model_name,
+                trust_remote_code=trust_remote_code,
+                revision=self._revision,
+                device=device,
             )
             self._dimension = self._model.get_sentence_embedding_dimension()
             self._backend = "sentence-transformers"

--- a/src/archex/index/embeddings/sentence_tf.py
+++ b/src/archex/index/embeddings/sentence_tf.py
@@ -7,6 +7,7 @@ from types import MappingProxyType
 from typing import Any
 
 from archex.exceptions import ArchexIndexError
+from archex.index.model_policy import custom_remote_code_profile, remote_code_trust_value
 
 
 class SentenceTransformerEmbedder:
@@ -20,6 +21,7 @@ class SentenceTransformerEmbedder:
         model_name: str = "all-MiniLM-L6-v2",
         batch_size: int = 32,
         trust_remote_code: bool = False,
+        allow_remote_code: bool = False,
         revision: str | None = None,
         local_files_only: bool = False,
         model_kwargs: Mapping[str, object] = MappingProxyType({}),
@@ -34,6 +36,18 @@ class SentenceTransformerEmbedder:
                 "Install with: uv add 'archex[vector-torch]'"
             ) from e
 
+        if trust_remote_code:
+            code_revision = config_kwargs.get("code_revision")
+            trust_remote_code = remote_code_trust_value(
+                custom_remote_code_profile(
+                    component="embedder",
+                    provider="sentence-transformers",
+                    model_name=model_name,
+                    model_revision=revision,
+                    code_revision=str(code_revision) if code_revision is not None else None,
+                ),
+                allow_remote_code=allow_remote_code,
+            )
         self._model_name = model_name
         self._batch_size = batch_size
         self._trust_remote_code = trust_remote_code

--- a/src/archex/index/model_policy.py
+++ b/src/archex/index/model_policy.py
@@ -1,0 +1,157 @@
+"""Central model-loading security policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from archex.exceptions import ConfigError
+
+ModelComponent = Literal["embedder", "reranker"]
+
+JINA_V2_MODEL_ID = "jinaai/jina-embeddings-v2-base-code"
+JINA_V2_MODEL_REVISION = "516f4baf13dec4ddddda8631e019b5737c8bc250"
+JINA_BERT_CODE_REVISION = "3baf9e3ac750e76e8edd3019170176884695fb94"
+JINA_V2_MAX_SEQ_LENGTH = 1024
+NOMIC_CODE_MODEL_ID = "nomic-ai/nomic-embed-code"
+NOMIC_CODE_MODEL_REVISION = "11114029805cee545ef111d5144b623787462a52"
+CODERANK_MODEL_ID = "nomic-ai/CodeRankEmbed"
+CODERANK_MODEL_REVISION = "3c4b60807d71f79b43f3c4363786d9493691f8b1"
+JINA_RERANKER_MODEL = "jinaai/jina-reranker-v3"
+JINA_RERANKER_REVISION = "10fb694fc21f7a710a563ff1eb977a460f3868e4"
+
+REMOTE_CODE_OPT_IN_HINT = (
+    "Set allow_remote_code = true under [index] in .archex/settings.toml, "
+    "export ARCHEX_ALLOW_REMOTE_CODE=true, or pass --allow-remote-code on supported CLI commands."
+)
+
+
+@dataclass(frozen=True)
+class ModelSecurityProfile:
+    component: ModelComponent
+    provider: str
+    model_name: str
+    requires_remote_code: bool
+    model_revision: str | None = None
+    code_revision: str | None = None
+
+    @property
+    def revision_label(self) -> str:
+        if self.model_revision is None and self.code_revision is None:
+            return "unpinned"
+        if self.code_revision is None:
+            return f"model={self.model_revision}"
+        return f"model={self.model_revision}; code={self.code_revision}"
+
+
+_EMBEDDER_PROFILES: dict[str, ModelSecurityProfile] = {
+    "fastembed": ModelSecurityProfile(
+        component="embedder",
+        provider="fastembed",
+        model_name="BAAI/bge-small-en-v1.5",
+        requires_remote_code=False,
+    ),
+    "sentence_transformers": ModelSecurityProfile(
+        component="embedder",
+        provider="sentence-transformers",
+        model_name="all-MiniLM-L6-v2",
+        requires_remote_code=False,
+    ),
+    "jina-v2": ModelSecurityProfile(
+        component="embedder",
+        provider="sentence-transformers",
+        model_name=JINA_V2_MODEL_ID,
+        requires_remote_code=True,
+        model_revision=JINA_V2_MODEL_REVISION,
+        code_revision=JINA_BERT_CODE_REVISION,
+    ),
+    "nomic": ModelSecurityProfile(
+        component="embedder",
+        provider="sentence-transformers",
+        model_name=NOMIC_CODE_MODEL_ID,
+        requires_remote_code=True,
+        model_revision=NOMIC_CODE_MODEL_REVISION,
+    ),
+    "coderank": ModelSecurityProfile(
+        component="embedder",
+        provider="sentence-transformers",
+        model_name=CODERANK_MODEL_ID,
+        requires_remote_code=True,
+        model_revision=CODERANK_MODEL_REVISION,
+    ),
+}
+
+_RERANKER_PROFILES: dict[str, ModelSecurityProfile] = {
+    JINA_RERANKER_MODEL: ModelSecurityProfile(
+        component="reranker",
+        provider="transformers",
+        model_name=JINA_RERANKER_MODEL,
+        requires_remote_code=True,
+        model_revision=JINA_RERANKER_REVISION,
+    ),
+}
+
+
+def embedder_security_profile(embedder: str | None) -> ModelSecurityProfile:
+    name = embedder or "sentence_transformers"
+    return _EMBEDDER_PROFILES.get(
+        name,
+        ModelSecurityProfile(
+            component="embedder",
+            provider="entry-point",
+            model_name=name,
+            requires_remote_code=False,
+        ),
+    )
+
+
+def reranker_security_profile(model_name: str) -> ModelSecurityProfile:
+    return _RERANKER_PROFILES.get(
+        model_name,
+        ModelSecurityProfile(
+            component="reranker",
+            provider="sentence-transformers",
+            model_name=model_name,
+            requires_remote_code=False,
+        ),
+    )
+
+
+def custom_remote_code_profile(
+    *,
+    component: ModelComponent,
+    provider: str,
+    model_name: str,
+    model_revision: str | None,
+    code_revision: str | None = None,
+) -> ModelSecurityProfile:
+    return ModelSecurityProfile(
+        component=component,
+        provider=provider,
+        model_name=model_name,
+        requires_remote_code=True,
+        model_revision=model_revision,
+        code_revision=code_revision,
+    )
+
+
+def require_remote_code_opt_in(
+    profile: ModelSecurityProfile,
+    *,
+    allow_remote_code: bool,
+) -> None:
+    """Reject remote-code model loading unless the caller explicitly opted in."""
+    if not profile.requires_remote_code or allow_remote_code:
+        return
+    raise ConfigError(
+        f"Remote code is disabled for {profile.component} provider "
+        f"'{profile.provider}' model '{profile.model_name}'. "
+        "This model path requires trust_remote_code=True. "
+        f"Pinned revisions: {profile.revision_label}. {REMOTE_CODE_OPT_IN_HINT}"
+    )
+
+
+def remote_code_trust_value(profile: ModelSecurityProfile, *, allow_remote_code: bool) -> bool:
+    """Return the trust_remote_code value after enforcing the opt-in policy."""
+    require_remote_code_opt_in(profile, allow_remote_code=allow_remote_code)
+    return profile.requires_remote_code and allow_remote_code

--- a/src/archex/index/rerank.py
+++ b/src/archex/index/rerank.py
@@ -8,14 +8,18 @@ from typing import TYPE_CHECKING, Any
 
 from archex.exceptions import ArchexIndexError
 from archex.index.huggingface import resolve_hf_model_path
+from archex.index.model_policy import (
+    JINA_RERANKER_MODEL,
+    JINA_RERANKER_REVISION,
+    remote_code_trust_value,
+    reranker_security_profile,
+)
 
 if TYPE_CHECKING:
     from archex.models import CodeChunk
 
 logger = logging.getLogger(__name__)
 
-JINA_RERANKER_MODEL = "jinaai/jina-reranker-v3"
-JINA_RERANKER_REVISION = "10fb694fc21f7a710a563ff1eb977a460f3868e4"
 DEFAULT_MODEL = JINA_RERANKER_MODEL
 MODEL_REVISIONS = {
     JINA_RERANKER_MODEL: JINA_RERANKER_REVISION,
@@ -100,8 +104,9 @@ class CrossEncoderReranker:
     candidates to improve precision without affecting recall.
     """
 
-    def __init__(self, model_name: str = DEFAULT_MODEL) -> None:
+    def __init__(self, model_name: str = DEFAULT_MODEL, *, allow_remote_code: bool = False) -> None:
         self._model_name = model_name
+        self._allow_remote_code = allow_remote_code
         self._model: Any = None
 
     def _uses_transformers_rerank_api(self) -> bool:
@@ -110,6 +115,12 @@ class CrossEncoderReranker:
     def _load_model(self) -> None:
         if self._model is not None:
             return
+
+        profile = reranker_security_profile(self._model_name)
+        trust_remote_code = remote_code_trust_value(
+            profile,
+            allow_remote_code=self._allow_remote_code,
+        )
 
         cached_model = _MODEL_CACHE.get(self._model_name)
         if cached_model is not None:
@@ -145,7 +156,7 @@ class CrossEncoderReranker:
                 model_path,
                 revision=revision,
                 dtype="auto",
-                trust_remote_code=True,
+                trust_remote_code=trust_remote_code,
             )
             if not hasattr(model, "rerank"):
                 raise ArchexIndexError(
@@ -167,7 +178,7 @@ class CrossEncoderReranker:
             cross_encoder: Any = CrossEncoder
             self._model = cross_encoder(
                 model_path,
-                trust_remote_code=True,
+                trust_remote_code=False,
                 device=device,
             )
             _ensure_padding_token(self._model)

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -167,6 +167,7 @@ class IndexConfig(BaseModel):
     chunk_max_tokens: int = 500
     chunk_min_tokens: int = 50
     token_encoding: str = "cl100k_base"
+    allow_remote_code: bool = False
 
     @model_validator(mode="after")
     def _validate_index_config(self) -> IndexConfig:

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -345,6 +345,7 @@ class TestRunCommand:
         assert "--rerank" in result.output
         assert "--splade" in result.output
         assert "--module-prefilter" in result.output
+        assert "--allow-remote-code" in result.output
         assert "--self-only" in result.output
         assert "--no-progress" in result.output
         assert "--embedder" in result.output
@@ -509,12 +510,26 @@ class TestRunCommand:
 
         monkeypatch.setattr("archex.cli.benchmark_cmd.load_selected_tasks", _empty_tasks)
         monkeypatch.setattr("archex.cli.benchmark_cmd.run_all", fake_run_all)
-        result = runner.invoke(benchmark_cmd, ["run", "--splade", "--module-prefilter"])
+        result = runner.invoke(
+            benchmark_cmd,
+            ["run", "--splade", "--module-prefilter", "--allow-remote-code"],
+        )
         assert result.exit_code == 0
         assert captured["retrieval_options"] == BenchmarkRetrievalOptions(
             splade=True,
             module_prefilter=True,
+            allow_remote_code=True,
         )
+
+    def test_run_reports_remote_code_preflight_error(
+        self,
+        runner: CliRunner,
+    ) -> None:
+        result = runner.invoke(benchmark_cmd, ["run", "--query-fusion"])
+
+        assert result.exit_code != 0
+        assert "Remote code is disabled" in result.output
+        assert "Traceback" not in result.output
 
     def test_run_passes_embedder_flag(
         self,

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -51,7 +51,8 @@ class TestBenchmarkPreflight:
             dimension = 768
 
         class RecordingReranker:
-            def __init__(self, model_name: str) -> None:
+            def __init__(self, model_name: str, *, allow_remote_code: bool = False) -> None:
+                del allow_remote_code
                 self._model_name = model_name
 
             def warm(self) -> None:

--- a/tests/index/embeddings/test_embeddings.py
+++ b/tests/index/embeddings/test_embeddings.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
-from archex.exceptions import ArchexIndexError
+from archex.exceptions import ArchexIndexError, ConfigError
 from archex.index.embeddings.base import Embedder
 
 
@@ -91,11 +91,18 @@ class TestNomicCodeEmbedder:
 
         from archex.index.embeddings.nomic import NomicCodeEmbedder
 
-        embedder = NomicCodeEmbedder()
+        embedder = NomicCodeEmbedder(allow_remote_code=True)
         with (
             patch("builtins.__import__", side_effect=mock_import),
             pytest.raises(ArchexIndexError, match="sentence-transformers"),
         ):
+            embedder._load_model()  # pyright: ignore[reportPrivateUsage]
+
+    def test_nomic_requires_remote_code_opt_in(self) -> None:
+        from archex.index.embeddings.nomic import NomicCodeEmbedder
+
+        embedder = NomicCodeEmbedder()
+        with pytest.raises(ConfigError, match="Remote code is disabled.*nomic-embed-code"):
             embedder._load_model()  # pyright: ignore[reportPrivateUsage]
 
     def test_load_model_success(self) -> None:
@@ -113,11 +120,17 @@ class TestNomicCodeEmbedder:
         with patch.dict("sys.modules", {"sentence_transformers": mock_st_module}):
             from archex.index.embeddings.nomic import NomicCodeEmbedder
 
-            embedder = NomicCodeEmbedder()
+            embedder = NomicCodeEmbedder(allow_remote_code=True)
             embedder._load_model()  # pyright: ignore[reportPrivateUsage]
 
         assert embedder._model is not None  # pyright: ignore[reportPrivateUsage]
         assert embedder._backend == "sentence-transformers"  # pyright: ignore[reportPrivateUsage]
+        mock_st_module.SentenceTransformer.assert_called_once_with(
+            "nomic-ai/nomic-embed-code",
+            trust_remote_code=True,
+            revision="11114029805cee545ef111d5144b623787462a52",
+            device=mock_st_module.SentenceTransformer.call_args.kwargs["device"],
+        )
 
     def test_default_model_name(self) -> None:
         """Default model name is nomic-ai/nomic-embed-code."""
@@ -237,6 +250,7 @@ class TestSentenceTransformerEmbedder:
             embedder = SentenceTransformerEmbedder(
                 model_name="test-model",
                 trust_remote_code=True,
+                allow_remote_code=True,
                 revision="model-revision",
                 local_files_only=True,
                 model_kwargs={"code_revision": "code-revision"},
@@ -357,6 +371,13 @@ class TestCodeRankEmbedder:
         assert embedder._model_name == HF_MODEL_ID  # pyright: ignore[reportPrivateUsage]
         assert embedder._model_name == "nomic-ai/CodeRankEmbed"  # pyright: ignore[reportPrivateUsage]
 
+    def test_coderank_requires_remote_code_opt_in(self) -> None:
+        from archex.index.embeddings.coderank import CodeRankEmbedder
+
+        embedder = CodeRankEmbedder()
+        with pytest.raises(ConfigError, match="Remote code is disabled.*CodeRankEmbed"):
+            embedder._load_model()  # pyright: ignore[reportPrivateUsage]
+
     def test_coderank_query_prefix_prepended(self) -> None:
         """encode_queries prepends the required prefix before calling encode."""
         from unittest.mock import MagicMock, patch
@@ -380,7 +401,7 @@ class TestCodeRankEmbedder:
             patch.dict("sys.modules", {"sentence_transformers": mock_st_module}),
             patch("archex.index.embeddings.coderank._best_device", return_value="cpu"),
         ):
-            embedder = CodeRankEmbedder()
+            embedder = CodeRankEmbedder(allow_remote_code=True)
             embedder._load_model()  # pyright: ignore[reportPrivateUsage]
 
         mock_st_module.SentenceTransformer.assert_called_once_with(
@@ -411,7 +432,7 @@ class TestCodeRankEmbedder:
         mock_st_module.SentenceTransformer.return_value = mock_model
 
         with patch.dict("sys.modules", {"sentence_transformers": mock_st_module}):
-            embedder = CodeRankEmbedder()
+            embedder = CodeRankEmbedder(allow_remote_code=True)
             embedder._load_model()  # pyright: ignore[reportPrivateUsage]
 
         queries = ["foo", "bar"]
@@ -432,10 +453,11 @@ class TestCodeRankEmbedder:
         """The coderank factory produces a CodeRankEmbedder instance."""
         from archex.index.embeddings import default_embedder_registry
         from archex.index.embeddings.coderank import CodeRankEmbedder
+        from archex.models import IndexConfig
 
-        factory = default_embedder_registry.get("coderank")
-        assert factory is not None
-        embedder = factory()
+        embedder = default_embedder_registry.create(
+            IndexConfig(vector=True, embedder="coderank", allow_remote_code=True)
+        )
         assert isinstance(embedder, CodeRankEmbedder)
 
     def test_coderank_import_error_raises_archex_index_error(self) -> None:
@@ -451,7 +473,7 @@ class TestCodeRankEmbedder:
 
         from archex.index.embeddings.coderank import CodeRankEmbedder
 
-        embedder = CodeRankEmbedder()
+        embedder = CodeRankEmbedder(allow_remote_code=True)
         with (
             patch("builtins.__import__", side_effect=mock_import),
             pytest.raises(ArchexIndexError, match="sentence-transformers"),
@@ -470,7 +492,7 @@ class TestCodeRankEmbedder:
         mock_st_module.SentenceTransformer.return_value = mock_model
 
         with patch.dict("sys.modules", {"sentence_transformers": mock_st_module}):
-            embedder = CodeRankEmbedder()
+            embedder = CodeRankEmbedder(allow_remote_code=True)
             embedder._load_model()  # pyright: ignore[reportPrivateUsage]
 
         assert embedder.dimension == 768
@@ -487,7 +509,7 @@ class TestCodeRankEmbedder:
         mock_st_module.SentenceTransformer.return_value = mock_model
 
         with patch.dict("sys.modules", {"sentence_transformers": mock_st_module}):
-            embedder = CodeRankEmbedder()
+            embedder = CodeRankEmbedder(allow_remote_code=True)
             embedder._load_model()  # pyright: ignore[reportPrivateUsage]
             embedder._load_model()  # pyright: ignore[reportPrivateUsage]
 

--- a/tests/index/test_embedder_registry.py
+++ b/tests/index/test_embedder_registry.py
@@ -19,7 +19,7 @@ from archex.index.embeddings.base import Embedder
 from archex.models import IndexConfig
 
 
-def _fake_factory() -> Embedder:
+def _fake_factory(_index_config: IndexConfig) -> Embedder:
     mock = MagicMock(spec=Embedder)
     mock.dimension = 384
     return mock
@@ -37,10 +37,10 @@ class TestEmbedderRegistry:
     def test_create_reuses_embedder_instance(self) -> None:
         call_count = 0
 
-        def factory() -> Embedder:
+        def factory(_index_config: IndexConfig) -> Embedder:
             nonlocal call_count
             call_count += 1
-            return _fake_factory()
+            return _fake_factory(_index_config)
 
         reg = EmbedderRegistry()
         reg.register("test_emb", factory)
@@ -74,16 +74,32 @@ class TestEmbedderRegistry:
         config = IndexConfig(vector=False, embedder="")
         assert reg.create(config) is None
 
+    def test_create_supports_zero_arg_embedder_factory(self) -> None:
+        def factory() -> Embedder:
+            return _fake_factory(IndexConfig(vector=True, embedder="test_emb"))
+
+        reg = EmbedderRegistry()
+        reg.register("test_emb", factory)
+
+        assert reg.create(IndexConfig(vector=True, embedder="test_emb")) is not None
+
     def test_default_registry_has_builtin_embedders(self) -> None:
         assert default_embedder_registry.get("nomic") is not None
         assert default_embedder_registry.get("sentence_transformers") is not None
         assert default_embedder_registry.get("jina-v2") is not None
         assert default_embedder_registry.get("coderank") is not None
 
-    def test_jina_v2_factory_pins_model_and_code_revisions(self) -> None:
+    def test_remote_code_embedder_requires_opt_in(self) -> None:
+        config = IndexConfig(vector=True, embedder="jina-v2")
+        with pytest.raises(ConfigError, match="Remote code is disabled.*jina-embeddings"):
+            default_embedder_registry.create(config)
+
+    def test_jina_v2_factory_pins_model_and_code_revisions_when_opted_in(self) -> None:
         from archex.index.embeddings.sentence_tf import SentenceTransformerEmbedder
 
-        embedder = default_embedder_registry.create(IndexConfig(vector=True, embedder="jina-v2"))
+        embedder = default_embedder_registry.create(
+            IndexConfig(vector=True, embedder="jina-v2", allow_remote_code=True)
+        )
         assert isinstance(embedder, SentenceTransformerEmbedder)
         assert embedder._model_name == JINA_V2_MODEL_ID  # pyright: ignore[reportPrivateUsage]
         assert embedder._revision == JINA_V2_MODEL_REVISION  # pyright: ignore[reportPrivateUsage]

--- a/tests/index/test_rerank.py
+++ b/tests/index/test_rerank.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+from archex.exceptions import ConfigError
 from archex.index import rerank as rerank_module
 from archex.index.rerank import (
     DEFAULT_MODEL,
@@ -142,6 +143,33 @@ class TestCrossEncoderReranker:
         reranker = CrossEncoderReranker(model_name="custom/model")
         assert reranker.rerank("query", []) == []
 
+    def test_default_load_requires_remote_code_opt_in(self) -> None:
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+        chunk = _make_chunk("a")
+
+        with pytest.raises(ConfigError, match="Remote code is disabled.*jina-reranker-v3"):
+            CrossEncoderReranker().rerank("query", [(chunk, 0.0)])
+
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+
+    def test_default_load_enforces_remote_code_opt_in_before_cache(self) -> None:
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+        chunk = _make_chunk("a")
+        fake_model = MagicMock()
+        fake_model.rerank.return_value = [{"index": 0, "relevance_score": 1.0}]
+
+        with (
+            patch("archex.index.rerank._best_device", return_value="cpu"),
+            patch("transformers.AutoModel") as auto_model,
+        ):
+            auto_model.from_pretrained.return_value = fake_model
+            CrossEncoderReranker(allow_remote_code=True).rerank("query", [(chunk, 0.0)])
+
+        with pytest.raises(ConfigError, match="Remote code is disabled.*jina-reranker-v3"):
+            CrossEncoderReranker().rerank("query", [(chunk, 0.0)])
+
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+
     def test_default_load_passes_pinned_jina_revision(self) -> None:
         rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
         chunk = _make_chunk("a")
@@ -153,7 +181,7 @@ class TestCrossEncoderReranker:
             patch("transformers.AutoModel") as auto_model,
         ):
             auto_model.from_pretrained.return_value = fake_model
-            CrossEncoderReranker().rerank("query", [(chunk, 0.0)])
+            CrossEncoderReranker(allow_remote_code=True).rerank("query", [(chunk, 0.0)])
 
         auto_model.from_pretrained.assert_called_once_with(
             JINA_RERANKER_MODEL,
@@ -178,7 +206,7 @@ class TestCrossEncoderReranker:
 
         cross_encoder.assert_called_once_with(
             "/cache/custom--model",
-            trust_remote_code=True,
+            trust_remote_code=False,
             device="cpu",
         )
         rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
@@ -194,7 +222,7 @@ class TestCrossEncoderReranker:
             patch("transformers.AutoModel") as auto_model,
         ):
             auto_model.from_pretrained.return_value = fake_model
-            CrossEncoderReranker().rerank("query", [(chunk, 0.0)])
+            CrossEncoderReranker(allow_remote_code=True).rerank("query", [(chunk, 0.0)])
 
         fake_model.to.assert_called_once_with("mps")
         rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -113,6 +113,7 @@ def test_index_command_uses_project_config(python_simple_repo: Path) -> None:
     assert index_config.vector is False
     assert index_config.splade is False
     assert index_config.module_prefilter is False
+    assert index_config.allow_remote_code is False
     assert store.closed is True
 
 
@@ -140,6 +141,20 @@ def test_index_command_module_prefilter_flag_enables_prefilter(
     assert result.exit_code == 0, result.output
     index_config = index_mock.call_args.kwargs["index_config"]
     assert index_config.module_prefilter is True
+
+
+def test_index_command_allow_remote_code_flag_enables_policy(
+    python_simple_repo: Path,
+) -> None:
+    store = FakeIndexStore()
+    runner = CliRunner()
+
+    with patch("archex.cli.index_cmd.index_repository", return_value=store) as index_mock:
+        result = runner.invoke(cli, ["index", str(python_simple_repo), "--allow-remote-code"])
+
+    assert result.exit_code == 0, result.output
+    index_config = index_mock.call_args.kwargs["index_config"]
+    assert index_config.allow_remote_code is True
 
 
 def test_index_command_json_output(python_simple_repo: Path) -> None:
@@ -335,6 +350,7 @@ def test_query_command_defaults_source_to_cwd(
     assert query_mock.call_args.args[0].local_path == "."
     assert query_mock.call_args.args[1] == "How does the query pipeline work?"
     assert query_mock.call_args.kwargs["refresh"] is True
+    assert query_mock.call_args.kwargs["index_config"].allow_remote_code is False
 
 
 def test_query_command_no_refresh_disables_inline_refresh(
@@ -357,6 +373,33 @@ def test_query_command_no_refresh_disables_inline_refresh(
 
     assert result.exit_code == 0, result.output
     assert query_mock.call_args.kwargs["refresh"] is False
+
+
+def test_query_command_allow_remote_code_flag_enables_policy(
+    python_simple_repo: Path,
+) -> None:
+    class FakeBundle:
+        chunks: list[object] = []
+        token_count = 0
+
+        def to_prompt(self, *, format: str) -> str:
+            return f"format={format}"
+
+    runner = CliRunner()
+
+    with patch("archex.cli.query_cmd.query", return_value=FakeBundle()) as query_mock:
+        result = runner.invoke(
+            cli,
+            [
+                "query",
+                str(python_simple_repo),
+                "How does search work?",
+                "--allow-remote-code",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert query_mock.call_args.kwargs["index_config"].allow_remote_code is True
 
 
 def test_analyze_tree_and_symbols_default_source_to_cwd(


### PR DESCRIPTION
## Stack

Stack-Id: `enterprise-clearance-20260615`
Base: `main`
Position: 2/4

1. `enterprise-clearance/security-policy` -> #240
2. `enterprise-clearance/remote-code-policy` -> this PR
3. `enterprise-clearance/doctor-security` -> #242
4. `enterprise-clearance/install-contract` -> #243

Depends on: #240
Upstack: #242

## Summary

- Add a central model-loading security policy for remote-code decisions and revision pins.
- Default user-facing model loading to remote-code disabled.
- Require `allow_remote_code` opt-in through config/env or CLI for built-in remote-code model paths.
- Pin Nomic, Jina embedding, CodeRank, and Jina reranker remote-code model revisions.
- Keep custom CrossEncoder rerank loading remote-code disabled by default.
- Surface benchmark remote-code preflight failures as clean Click errors instead of tracebacks.

## Validation

- `uv run pytest --no-cov tests/index/test_embedder_registry.py tests/index/embeddings/test_embeddings.py tests/index/test_rerank.py tests/benchmark/test_runner.py::TestBenchmarkPreflight tests/test_cli.py::test_index_command_uses_project_config tests/test_cli.py::test_index_command_allow_remote_code_flag_enables_policy tests/test_cli.py::test_query_command_defaults_source_to_cwd tests/test_cli.py::test_query_command_allow_remote_code_flag_enables_policy tests/benchmark/test_cli.py::TestRunCommand::test_run_help tests/benchmark/test_cli.py::TestRunCommand::test_run_passes_retrieval_measurement_flags tests/benchmark/test_cli.py::TestRunCommand::test_run_reports_remote_code_preflight_error`: passed
- `uv run ruff check src/archex/index/model_policy.py src/archex/index/embeddings/__init__.py src/archex/index/embeddings/sentence_tf.py src/archex/index/embeddings/nomic.py src/archex/index/embeddings/coderank.py src/archex/index/rerank.py src/archex/models.py src/archex/api.py src/archex/cli/index_cmd.py src/archex/cli/query_cmd.py src/archex/cli/benchmark_cmd.py src/archex/benchmark/models.py src/archex/benchmark/preflight.py src/archex/benchmark/strategies.py tests/index/test_embedder_registry.py tests/index/embeddings/test_embeddings.py tests/index/test_rerank.py tests/benchmark/test_runner.py tests/test_cli.py tests/benchmark/test_cli.py`: passed
- `uv run pyright src/archex/index/model_policy.py src/archex/index/embeddings/__init__.py src/archex/index/embeddings/sentence_tf.py src/archex/index/embeddings/nomic.py src/archex/index/embeddings/coderank.py src/archex/index/rerank.py src/archex/models.py src/archex/api.py src/archex/cli/index_cmd.py src/archex/cli/query_cmd.py src/archex/cli/benchmark_cmd.py src/archex/benchmark/models.py src/archex/benchmark/preflight.py src/archex/benchmark/strategies.py tests/index/test_embedder_registry.py tests/index/embeddings/test_embeddings.py tests/index/test_rerank.py tests/benchmark/test_runner.py tests/test_cli.py tests/benchmark/test_cli.py`: passed
- `/review` remote-code policy slice: passed after reranker-cache and zero-arg factory fixes
