### PR TITLE
Report model security in doctor

### DIFF
--- a/src/archex/cli/doctor_cmd.py
+++ b/src/archex/cli/doctor_cmd.py
@@ -19,10 +19,16 @@ from archex.doctor import inspect_doctor, render_doctor_text
     type=click.Choice(["text", "json"]),
     help="Output format.",
 )
-def doctor_cmd(source: str, output_format: str) -> None:
+@click.option(
+    "--security",
+    is_flag=True,
+    default=False,
+    help="Show only model-loading security diagnostics.",
+)
+def doctor_cmd(source: str, output_format: str, security: bool) -> None:
     """Run read-only diagnostics for an archex repo-local project."""
     try:
-        report = inspect_doctor(Path(source))
+        report = inspect_doctor(Path(source), security_only=security)
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/src/archex/doctor.py
+++ b/src/archex/doctor.py
@@ -10,6 +10,12 @@ from pathlib import Path
 from typing import Literal, cast
 
 from archex.config import load_index_config
+from archex.index.model_policy import (
+    JINA_RERANKER_MODEL,
+    ModelSecurityProfile,
+    embedder_security_profile,
+    reranker_security_profile,
+)
 from archex.languages import LANGUAGE_SUPPORT
 from archex.models import LanguageTier
 from archex.parse.engine import TreeSitterEngine
@@ -18,16 +24,14 @@ from archex.status import ProjectStatus, inspect_project_status
 
 CheckStatus = Literal["ok", "warning", "error"]
 
-_JINA_V2_MODEL_ID = "jinaai/jina-embeddings-v2-base-code"
-_DEFAULT_RERANK_MODEL = "jinaai/jina-reranker-v3"
 _DEFAULT_SPLADE_MODEL = "naver/splade-cocondenser-ensembledistil"
 
 _HF_EMBEDDER_MODELS: dict[str, str] = {
-    "fastembed": "BAAI/bge-small-en-v1.5",
-    "jina-v2": _JINA_V2_MODEL_ID,
-    "sentence_transformers": _JINA_V2_MODEL_ID,
-    "nomic": "nomic-ai/nomic-embed-code",
-    "coderank": "nomic-ai/CodeRankEmbed",
+    "fastembed": embedder_security_profile("fastembed").model_name,
+    "jina-v2": embedder_security_profile("jina-v2").model_name,
+    "sentence_transformers": embedder_security_profile("sentence_transformers").model_name,
+    "nomic": embedder_security_profile("nomic").model_name,
+    "coderank": embedder_security_profile("coderank").model_name,
 }
 
 
@@ -64,17 +68,19 @@ class DoctorReport:
         }
 
 
-def inspect_doctor(source: str | Path) -> DoctorReport:
+def inspect_doctor(source: str | Path, *, security_only: bool = False) -> DoctorReport:
     """Run read-only health diagnostics for a repo-local archex project."""
     project = ProjectState.resolve(source)
     checks: list[DoctorCheck] = []
-    status = inspect_project_status(project.repo_root)
-    checks.append(_index_health_check(status))
-    checks.append(_index_staleness_check(status))
-    checks.append(_model_cache_check(project.repo_root))
-    checks.append(_grammar_check())
-    checks.append(_mcp_registration_check(project.repo_root))
-    checks.append(_disk_usage_check(project.project_dir))
+    if not security_only:
+        status = inspect_project_status(project.repo_root)
+        checks.append(_index_health_check(status))
+        checks.append(_index_staleness_check(status))
+        checks.append(_model_cache_check(project.repo_root))
+        checks.append(_grammar_check())
+        checks.append(_mcp_registration_check(project.repo_root))
+        checks.append(_disk_usage_check(project.project_dir))
+    checks.append(_model_security_check(project.repo_root))
     return DoctorReport(
         repo_root=project.repo_root,
         status=_overall_status(checks),
@@ -94,6 +100,20 @@ def render_doctor_text(report: DoctorReport) -> str:
         if check.name == "disk_usage":
             total_bytes = check.details.get("total_bytes", 0)
             lines.append(f"  .archex size: {_format_bytes(_int_value(total_bytes))}")
+        if check.name == "model_security":
+            lines.append(f"  allow_remote_code: {check.details.get('allow_remote_code', False)}")
+            for label in ("embedding", "reranker", "splade"):
+                value = check.details.get(label, {})
+                if isinstance(value, dict):
+                    entry = cast("dict[str, object]", value)
+                    lines.append(
+                        "  "
+                        f"{label}: provider={entry.get('provider')} "
+                        f"model={entry.get('model')} "
+                        f"remote_code={entry.get('requires_remote_code')} "
+                        f"cache_present={entry.get('cache_present')}"
+                    )
+            lines.append(f"  network: {check.details.get('network_implications', '')}")
         if check.name == "grammars":
             full_value = check.details.get("full", {})
             chunk_value = check.details.get("chunk_only", {})
@@ -179,7 +199,7 @@ def _model_cache_check(repo_root: Path) -> DoctorCheck:
     if index_config.splade:
         required_models.append(_DEFAULT_SPLADE_MODEL)
     if index_config.rerank:
-        required_models.append(index_config.rerank_model or _DEFAULT_RERANK_MODEL)
+        required_models.append(index_config.rerank_model or JINA_RERANKER_MODEL)
 
     cache_dirs = _model_cache_dirs()
     model_paths = {model: _cached_model_paths(model, cache_dirs) for model in required_models}
@@ -215,6 +235,162 @@ def _model_cache_check(repo_root: Path) -> DoctorCheck:
         message="enabled local models are present in the cache",
         details=details,
     )
+
+
+def _model_security_check(repo_root: Path) -> DoctorCheck:
+    index_config = load_index_config(repo_root)
+    cache_dirs = _model_cache_dirs()
+    if index_config.embedder is None:
+        embedding = _disabled_model_entry(
+            provider="none",
+            vector_requested=index_config.vector,
+        )
+    else:
+        embedder_profile = embedder_security_profile(index_config.embedder)
+        embedding = _model_security_entry(
+            enabled=index_config.vector,
+            provider=index_config.embedder,
+            profile=embedder_profile,
+            allow_remote_code=index_config.allow_remote_code,
+            cache_dirs=cache_dirs,
+        )
+    rerank_model = index_config.rerank_model or JINA_RERANKER_MODEL
+    reranker_profile = reranker_security_profile(rerank_model)
+
+    reranker = _model_security_entry(
+        enabled=index_config.rerank,
+        provider=rerank_model,
+        profile=reranker_profile,
+        allow_remote_code=index_config.allow_remote_code,
+        cache_dirs=cache_dirs,
+    )
+    splade = _download_entry(
+        enabled=index_config.splade,
+        provider="splade",
+        model_name=_DEFAULT_SPLADE_MODEL,
+        cache_dirs=cache_dirs,
+    )
+
+    blocked = [
+        entry["provider"]
+        for entry in (embedding, reranker)
+        if entry["enabled"] and entry["requires_remote_code"] and not index_config.allow_remote_code
+    ]
+    downloads = [
+        entry["provider"]
+        for entry in (embedding, reranker, splade)
+        if entry["enabled"] and not entry["cache_present"]
+    ]
+    details: dict[str, object] = {
+        "allow_remote_code": index_config.allow_remote_code,
+        "offline": _offline_status(),
+        "embedding": embedding,
+        "reranker": reranker,
+        "splade": splade,
+        "cache_dirs": [str(path) for path in cache_dirs],
+        "network_downloads_required": downloads,
+        "network_implications": _network_implications(downloads),
+    }
+    if blocked:
+        return DoctorCheck(
+            name="model_security",
+            status="error",
+            message="remote-code model selected without allow_remote_code opt-in",
+            details=details,
+        )
+    if downloads:
+        return DoctorCheck(
+            name="model_security",
+            status="warning",
+            message="one or more selected local models may download before first use",
+            details=details,
+        )
+    return DoctorCheck(
+        name="model_security",
+        status="ok",
+        message="selected model-loading paths satisfy the remote-code policy",
+        details=details,
+    )
+
+
+def _disabled_model_entry(*, provider: str, vector_requested: bool) -> dict[str, object]:
+    return {
+        "enabled": False,
+        "provider": provider,
+        "model": None,
+        "requires_remote_code": False,
+        "allow_remote_code": False,
+        "remote_code_allowed": False,
+        "model_revision": None,
+        "code_revision": None,
+        "cache_present": False,
+        "cache_paths": [],
+        "network_download_required": False,
+        "vector_requested": vector_requested,
+    }
+
+
+def _model_security_entry(
+    *,
+    enabled: bool,
+    provider: str,
+    profile: ModelSecurityProfile,
+    allow_remote_code: bool,
+    cache_dirs: list[Path],
+) -> dict[str, object]:
+    cache_paths = _cached_model_paths(profile.model_name, cache_dirs)
+    cache_present = any(path.exists() for path in cache_paths)
+    return {
+        "enabled": enabled,
+        "provider": provider,
+        "model": profile.model_name,
+        "requires_remote_code": profile.requires_remote_code,
+        "allow_remote_code": allow_remote_code,
+        "remote_code_allowed": profile.requires_remote_code and allow_remote_code,
+        "model_revision": profile.model_revision,
+        "code_revision": profile.code_revision,
+        "cache_present": cache_present,
+        "cache_paths": [str(path) for path in cache_paths],
+        "network_download_required": enabled and not cache_present,
+    }
+
+
+def _download_entry(
+    *,
+    enabled: bool,
+    provider: str,
+    model_name: str,
+    cache_dirs: list[Path],
+) -> dict[str, object]:
+    cache_paths = _cached_model_paths(model_name, cache_dirs)
+    cache_present = any(path.exists() for path in cache_paths)
+    return {
+        "enabled": enabled,
+        "provider": provider,
+        "model": model_name,
+        "requires_remote_code": False,
+        "cache_present": cache_present,
+        "cache_paths": [str(path) for path in cache_paths],
+        "network_download_required": enabled and not cache_present,
+    }
+
+
+def _offline_status() -> dict[str, bool]:
+    return {
+        "HF_HUB_OFFLINE": os.environ.get("HF_HUB_OFFLINE", "").lower()
+        in {"1", "true", "yes", "on"},
+        "TRANSFORMERS_OFFLINE": os.environ.get("TRANSFORMERS_OFFLINE", "").lower()
+        in {"1", "true", "yes", "on"},
+    }
+
+
+def _network_implications(downloads: list[object]) -> str:
+    if downloads:
+        return (
+            "selected model-backed features may contact Hugging Face or provider caches "
+            "before first use"
+        )
+    return "no selected model-backed feature requires a model download from the current cache state"
 
 
 def _grammar_check() -> DoctorCheck:

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from click.testing import CliRunner
 
 from archex.cli.main import cli
 from archex.project import init_project
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_doctor_json_reports_healthy_project(python_simple_repo: Path) -> None:
@@ -26,6 +30,9 @@ def test_doctor_json_reports_healthy_project(python_simple_repo: Path) -> None:
     assert checks["model_cache"]["details"]["required"] is False
     assert checks["grammars"]["details"]["full"]["available"] > 0
     assert checks["disk_usage"]["details"]["total_bytes"] > 0
+    assert checks["model_security"]["status"] == "ok"
+    assert checks["model_security"]["details"]["allow_remote_code"] is False
+    assert checks["model_security"]["details"]["embedding"]["enabled"] is False
 
 
 def test_doctor_json_fails_on_corrupt_index(python_simple_repo: Path) -> None:
@@ -61,3 +68,101 @@ def test_doctor_text_includes_required_sections(python_simple_repo: Path) -> Non
     assert "grammars" in result.output
     assert "mcp_registration" in result.output
     assert "disk_usage" in result.output
+    assert "model_security" in result.output
+    assert "allow_remote_code: False" in result.output
+
+
+def test_doctor_security_reports_remote_code_block(
+    python_simple_repo: Path,
+) -> None:
+    init_project(python_simple_repo)
+    settings = python_simple_repo / ".archex" / "settings.toml"
+    settings.write_text(
+        """\
+[index]
+cache_dir = ".archex"
+vector = true
+embedder = "nomic"
+""",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["doctor", str(python_simple_repo), "--security", "--format", "json"],
+    )
+
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "error"
+    assert [check["name"] for check in payload["checks"]] == ["model_security"]
+    details = payload["checks"][0]["details"]
+    assert details["allow_remote_code"] is False
+    assert details["embedding"]["provider"] == "nomic"
+    assert details["embedding"]["requires_remote_code"] is True
+    assert details["embedding"]["model_revision"] == "11114029805cee545ef111d5144b623787462a52"
+
+
+def test_doctor_security_reports_remote_code_opt_in_and_cache_state(
+    python_simple_repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    init_project(python_simple_repo)
+    settings = python_simple_repo / ".archex" / "settings.toml"
+    settings.write_text(
+        """\
+[index]
+cache_dir = ".archex"
+vector = true
+embedder = "nomic"
+allow_remote_code = true
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HF_HOME", str(tmp_path / "hf"))
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["doctor", str(python_simple_repo), "--security", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "warning"
+    details = payload["checks"][0]["details"]
+    assert details["allow_remote_code"] is True
+    assert details["embedding"]["remote_code_allowed"] is True
+    assert details["embedding"]["cache_present"] is False
+    assert details["network_downloads_required"] == ["nomic"]
+
+
+def test_doctor_security_reports_vector_without_embedder_as_no_model(
+    python_simple_repo: Path,
+) -> None:
+    init_project(python_simple_repo)
+    settings = python_simple_repo / ".archex" / "settings.toml"
+    settings.write_text(
+        """\
+[index]
+cache_dir = ".archex"
+vector = true
+""",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["doctor", str(python_simple_repo), "--security", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    details = payload["checks"][0]["details"]
+    assert details["embedding"]["provider"] == "none"
+    assert details["embedding"]["model"] is None
+    assert details["embedding"]["vector_requested"] is True
+    assert details["network_downloads_required"] == []


### PR DESCRIPTION
## Stack

Stack-Id: `enterprise-clearance-20260615`
Base: `main`
Position: 3/4

1. `enterprise-clearance/security-policy` -> #240
2. `enterprise-clearance/remote-code-policy` -> #241
3. `enterprise-clearance/doctor-security` -> this PR
4. `enterprise-clearance/install-contract` -> #243

Depends on: #241
Upstack: #243

## Summary

- Add a `model_security` doctor check and `archex doctor --security` mode.
- Report embedding, reranker, and SPLADE provider/model selection, remote-code policy, revision pins, cache state, offline env flags, and network/download implications.
- Error when a configured remote-code model path lacks `allow_remote_code` opt-in.
- Add focused doctor/security tests for default, blocked remote code, explicit opt-in, and vector-without-embedder behavior.

## Validation

- `uv run pytest --no-cov tests/cli/test_doctor.py`: passed
- `uv run ruff check src/archex/doctor.py src/archex/cli/doctor_cmd.py tests/cli/test_doctor.py`: passed
- `uv run pyright src/archex/doctor.py src/archex/cli/doctor_cmd.py tests/cli/test_doctor.py`: passed
- `/review` doctor/security slice: passed after embedder-none and --security I/O fixes
