### PR TITLE
Add context receipt data model

### DIFF
--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -82,6 +82,57 @@ class LanguageTier(StrEnum):
     UNKNOWN = "unknown"
 
 
+class ContextFreshness(StrEnum):
+    CLEAN = "clean"
+    DIRTY = "dirty"
+    WATCH_ACTIVE = "watch_active"
+    WATCH_UNAVAILABLE = "watch_unavailable"
+    UNKNOWN = "unknown"
+
+
+class ContextCompletenessStatus(StrEnum):
+    COMPLETE = "complete"
+    INCOMPLETE = "incomplete"
+    UNKNOWN = "unknown"
+
+
+class ContextCompletenessReason(StrEnum):
+    COMPLETE = "complete"
+    BUDGET_EXHAUSTED = "budget_exhausted"
+    DEPENDENCY_FRONTIER_CUT = "dependency_frontier_cut"
+    DUPLICATE_SUPPRESSED = "duplicate_suppressed"
+    NO_CANDIDATES = "no_candidates"
+    STALE_INDEX = "stale_index"
+    UNSUPPORTED_GRAMMAR = "unsupported_grammar"
+    UNKNOWN = "unknown"
+
+
+class ContextRecommendedAction(StrEnum):
+    USE_BUNDLE = "use_bundle"
+    NARROW_QUERY = "narrow_query"
+    RAISE_BUDGET = "raise_budget"
+    REFRESH_INDEX = "refresh_index"
+    FETCH_SKIPPED_CANDIDATE = "fetch_skipped_candidate"
+    MANUAL_REVIEW = "manual_review"
+
+
+class ContextSkippedReason(StrEnum):
+    BELOW_THRESHOLD = "below_threshold"
+    DEPENDENCY_FRONTIER_CUT = "dependency_frontier_cut"
+    DUPLICATE = "duplicate"
+    OVER_BUDGET = "over_budget"
+    STALE_INDEX = "stale_index"
+    TEST_DEPRIORITIZED = "test_deprioritized"
+    UNSUPPORTED_GRAMMAR = "unsupported_grammar"
+
+
+class ContextOmittedEdgeReason(StrEnum):
+    OVER_BUDGET = "over_budget"
+    UNSUPPORTED_GRAMMAR = "unsupported_grammar"
+    STALE_INDEX = "stale_index"
+    BELOW_THRESHOLD = "below_threshold"
+
+
 # ---------------------------------------------------------------------------
 # Type aliases
 # ---------------------------------------------------------------------------
@@ -638,6 +689,63 @@ class RetrievalMetadata(BaseModel):
     mean_chunk_tokens: float = 0.0
 
 
+class ContextReceiptTokenBudget(BaseModel):
+    requested: int
+    consumed: int
+
+
+class ContextReceiptItem(BaseModel):
+    handle: str
+    file_path: str
+    start_line: int
+    end_line: int
+    content_hash: str
+    symbols: list[str] = []
+    score: float = 0.0
+    reason_codes: list[str] = []
+
+
+class ContextReceiptEdge(BaseModel):
+    source: str
+    target: str
+    kind: EdgeKind
+    source_path: str | None = None
+    target_path: str | None = None
+    confidence: EdgeConfidence | None = None
+    confidence_score: float | None = None
+    evidence: list[str] = []
+    reason: ContextOmittedEdgeReason | None = None
+
+    @model_validator(mode="after")
+    def _validate_confidence_score(self) -> ContextReceiptEdge:
+        if self.confidence_score is not None and not 0.0 <= self.confidence_score <= 1.0:
+            raise ValueError("confidence_score must be between 0.0 and 1.0")
+        return self
+
+
+class ContextSkippedCandidate(BaseModel):
+    file_path: str
+    reason: ContextSkippedReason
+    handle: str | None = None
+    symbol: str | None = None
+    score: float = 0.0
+    detail: str = ""
+
+
+class ContextReceipt(BaseModel):
+    query: str
+    token_budget: ContextReceiptTokenBudget
+    index_revision: str
+    freshness: ContextFreshness = ContextFreshness.UNKNOWN
+    returned_context: list[ContextReceiptItem] = []
+    included_edges: list[ContextReceiptEdge] = []
+    omitted_edges: list[ContextReceiptEdge] = []
+    skipped_candidates: list[ContextSkippedCandidate] = []
+    context_complete: ContextCompletenessStatus = ContextCompletenessStatus.UNKNOWN
+    context_complete_reason: ContextCompletenessReason = ContextCompletenessReason.UNKNOWN
+    recommended_next_action: ContextRecommendedAction = ContextRecommendedAction.MANUAL_REVIEW
+
+
 class ContextBundle(BaseModel):
     query: str
     chunks: list[RankedChunk] = []
@@ -648,6 +756,7 @@ class ContextBundle(BaseModel):
     token_budget: int = 0
     truncated: bool = False
     retrieval_metadata: RetrievalMetadata = RetrievalMetadata()
+    receipt: ContextReceipt | None = None
 
     def to_prompt(self, format: str = "xml") -> str:
         """Render the context bundle as an LLM prompt string."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,17 @@ from archex.models import (
     CodeChunk,
     Config,
     ContextBundle,
+    ContextCompletenessReason,
+    ContextCompletenessStatus,
+    ContextFreshness,
+    ContextOmittedEdgeReason,
+    ContextReceipt,
+    ContextReceiptEdge,
+    ContextReceiptItem,
+    ContextReceiptTokenBudget,
+    ContextRecommendedAction,
+    ContextSkippedCandidate,
+    ContextSkippedReason,
     DetectedPattern,
     Edge,
     EdgeConfidence,
@@ -84,6 +95,125 @@ def test_vector_mode_members() -> None:
 def test_retrieval_policy_members() -> None:
     assert RetrievalPolicy.AUTO == "auto"
     assert RetrievalPolicy.CROSS_LAYER == "cross_layer"
+
+
+def test_context_receipt_enum_members() -> None:
+    assert {member.name: member.value for member in ContextFreshness} == {
+        "CLEAN": "clean",
+        "DIRTY": "dirty",
+        "WATCH_ACTIVE": "watch_active",
+        "WATCH_UNAVAILABLE": "watch_unavailable",
+        "UNKNOWN": "unknown",
+    }
+    assert {member.name: member.value for member in ContextCompletenessStatus} == {
+        "COMPLETE": "complete",
+        "INCOMPLETE": "incomplete",
+        "UNKNOWN": "unknown",
+    }
+    assert {member.name: member.value for member in ContextCompletenessReason} == {
+        "COMPLETE": "complete",
+        "BUDGET_EXHAUSTED": "budget_exhausted",
+        "DEPENDENCY_FRONTIER_CUT": "dependency_frontier_cut",
+        "DUPLICATE_SUPPRESSED": "duplicate_suppressed",
+        "NO_CANDIDATES": "no_candidates",
+        "STALE_INDEX": "stale_index",
+        "UNSUPPORTED_GRAMMAR": "unsupported_grammar",
+        "UNKNOWN": "unknown",
+    }
+    assert {member.name: member.value for member in ContextRecommendedAction} == {
+        "USE_BUNDLE": "use_bundle",
+        "NARROW_QUERY": "narrow_query",
+        "RAISE_BUDGET": "raise_budget",
+        "REFRESH_INDEX": "refresh_index",
+        "FETCH_SKIPPED_CANDIDATE": "fetch_skipped_candidate",
+        "MANUAL_REVIEW": "manual_review",
+    }
+    assert {member.name: member.value for member in ContextSkippedReason} == {
+        "BELOW_THRESHOLD": "below_threshold",
+        "DEPENDENCY_FRONTIER_CUT": "dependency_frontier_cut",
+        "DUPLICATE": "duplicate",
+        "OVER_BUDGET": "over_budget",
+        "STALE_INDEX": "stale_index",
+        "TEST_DEPRIORITIZED": "test_deprioritized",
+        "UNSUPPORTED_GRAMMAR": "unsupported_grammar",
+    }
+    assert {member.name: member.value for member in ContextOmittedEdgeReason} == {
+        "OVER_BUDGET": "over_budget",
+        "UNSUPPORTED_GRAMMAR": "unsupported_grammar",
+        "STALE_INDEX": "stale_index",
+        "BELOW_THRESHOLD": "below_threshold",
+    }
+
+
+def test_context_receipt_instantiation_and_dump_are_deterministic() -> None:
+    receipt = ContextReceipt(
+        query="explain retrieval",
+        token_budget=ContextReceiptTokenBudget(requested=1000, consumed=250),
+        index_revision="abc123",
+        freshness=ContextFreshness.CLEAN,
+        returned_context=[
+            ContextReceiptItem(
+                handle="chunk:src/api.py::query",
+                file_path="src/api.py",
+                start_line=10,
+                end_line=20,
+                content_hash="hash-api-query",
+                symbols=["query"],
+                score=0.9,
+                reason_codes=["bm25", "graph_seed"],
+            )
+        ],
+        included_edges=[
+            ContextReceiptEdge(
+                source="src/api.py",
+                target="src/store.py",
+                kind=EdgeKind.IMPORTS,
+                source_path="src/api.py",
+                target_path="src/store.py",
+                confidence=EdgeConfidence.EXTRACTED,
+                confidence_score=1.0,
+                evidence=["import store"],
+            )
+        ],
+        omitted_edges=[
+            ContextReceiptEdge(
+                source="src/api.py",
+                target="src/optional.py",
+                kind=EdgeKind.IMPORTS,
+                reason=ContextOmittedEdgeReason.OVER_BUDGET,
+            )
+        ],
+        skipped_candidates=[
+            ContextSkippedCandidate(
+                file_path="tests/test_api.py",
+                reason=ContextSkippedReason.TEST_DEPRIORITIZED,
+                handle="file:tests/test_api.py",
+                score=0.2,
+                detail="support file without explicit test query",
+            )
+        ],
+        context_complete=ContextCompletenessStatus.INCOMPLETE,
+        context_complete_reason=ContextCompletenessReason.BUDGET_EXHAUSTED,
+        recommended_next_action=ContextRecommendedAction.RAISE_BUDGET,
+    )
+
+    first = receipt.model_dump(mode="json")
+    second = ContextReceipt.model_validate(first).model_dump(mode="json")
+    assert first == second
+    assert first["query"] == "explain retrieval"
+    assert first["token_budget"] == {"requested": 1000, "consumed": 250}
+    assert first["returned_context"][0]["reason_codes"] == ["bm25", "graph_seed"]
+    assert first["skipped_candidates"][0]["reason"] == "test_deprioritized"
+
+
+def test_context_receipt_edge_confidence_score_bounds() -> None:
+    with pytest.raises(ValueError, match="confidence_score must be between"):
+        ContextReceiptEdge(
+            source="src/api.py",
+            target="src/store.py",
+            kind=EdgeKind.IMPORTS,
+            confidence_score=1.1,
+        )
 
 
 def test_pattern_category_members() -> None:


### PR DESCRIPTION
## Stack

Stack-Id: `context-trust-benchmark-proof`
Base: `main`
Position: 1/6

1. `feat/context-receipt-model` -> this PR (#244)
2. `feat/context-receipt-construction` -> #245
3. `feat/context-receipt-surfaces` -> #246
4. `feat/benchmark-required-file-metrics` -> #247
5. `feat/client-compatibility-paths` -> #248
6. `feat/readme-trust-messaging` -> #249

Depends on: none
Upstack: #245

## Validation

- `uv run ruff check src/archex/models.py tests/test_models.py`
- `uv run pyright src/archex/models.py tests/test_models.py`
- `uv run pytest tests/test_models.py -q --no-cov`
- Review: no blocking findings
