### PR TITLE
Construct receipts for query and scout

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -66,6 +66,7 @@ from archex.models import (
     CodeChunk,
     Config,
     ContextBundle,
+    ContextFreshness,
     FileOutline,
     FileTree,
     IndexConfig,
@@ -92,6 +93,14 @@ from archex.parse.adapters import LanguageAdapter, default_adapter_registry
 from archex.pipeline.chunker import Chunker, chunker_revision, create_chunker
 from archex.pipeline.service import build_chunk_surrogates
 from archex.project import uses_project_cache_layout
+from archex.receipt import (
+    build_context_receipt,
+    build_scout_receipt,
+    index_revision_from_store,
+    skipped_candidates_for_ranked,
+    stale_index_skipped_candidate,
+    unsupported_grammar_skipped_candidate,
+)
 from archex.scout import (
     DEFAULT_SCOUT_TOKEN_BUDGET,
     ScoutFormat,
@@ -1375,6 +1384,35 @@ def _attach_vector_metadata(bundle: ContextBundle, index_config: IndexConfig) ->
     )
 
 
+def _freshness_for_query(refresh: bool) -> ContextFreshness:
+    return ContextFreshness.CLEAN if refresh else ContextFreshness.UNKNOWN
+
+
+def _refresh_receipt(
+    bundle: ContextBundle,
+    *,
+    index_revision: str,
+    freshness: ContextFreshness,
+    metadata_timing: PipelineTiming | None,
+) -> None:
+    skipped = list(bundle.receipt.skipped_candidates) if bundle.receipt is not None else []
+    if freshness != ContextFreshness.CLEAN:
+        skipped.append(stale_index_skipped_candidate())
+    if metadata_timing is not None and metadata_timing.parse_failure_count > 0:
+        skipped.append(unsupported_grammar_skipped_candidate(metadata_timing.parse_failure_count))
+    included_edges = list(bundle.receipt.included_edges) if bundle.receipt is not None else []
+    omitted_edges = list(bundle.receipt.omitted_edges) if bundle.receipt is not None else []
+    bundle.receipt = build_context_receipt(
+        bundle,
+        index_revision=index_revision,
+        freshness=freshness,
+        included_edges=included_edges,
+        omitted_edges=omitted_edges,
+        skipped_candidates=skipped,
+    )
+
+
+
 def _finalize_context_bundle(
     bundle: ContextBundle,
     *,
@@ -1386,6 +1424,8 @@ def _finalize_context_bundle(
     chunk_count: int,
     total_repo_tokens: int,
     metadata_timing: PipelineTiming | None,
+    index_revision: str,
+    freshness: ContextFreshness,
 ) -> ContextBundle:
     _attach_vector_metadata(bundle, index_config)
     _attach_index_metadata(
@@ -1406,6 +1446,12 @@ def _finalize_context_bundle(
         trace.end_ns = time.perf_counter_ns()
         trace.log_summary()
     _attach_refresh_metadata(bundle, metadata_timing)
+    _refresh_receipt(
+        bundle,
+        index_revision=index_revision,
+        freshness=freshness,
+        metadata_timing=metadata_timing,
+    )
     return bundle
 
 
@@ -1434,6 +1480,7 @@ def _query_by_scout_handles(
         )
         stored_count = store.get_metadata("chunk_count")
         chunk_count = int(stored_count) if stored_count is not None else len(store.get_chunks())
+        index_revision = index_revision_from_store(store)
     finally:
         store.close()
     bundle = _context_bundle_for_handle_chunks(question, chunks, token_budget)
@@ -1442,6 +1489,12 @@ def _query_by_scout_handles(
         index_config,
         chunk_count=chunk_count,
         total_repo_tokens=total_repo_tokens,
+    )
+    _refresh_receipt(
+        bundle,
+        index_revision=index_revision,
+        freshness=ContextFreshness.CLEAN,
+        metadata_timing=timing,
     )
     bundle.retrieval_metadata.retrieval_time_ms = _elapsed_ms(t0)
     if timing is not None:
@@ -1495,7 +1548,7 @@ def _context_bundle_for_handle_chunks(
             continue
         included.append(RankedChunk(chunk=chunk, relevance_score=1.0, final_score=1.0))
         total_tokens += tokens
-    return ContextBundle(
+    bundle = ContextBundle(
         query=question,
         chunks=included,
         token_count=total_tokens,
@@ -1510,6 +1563,18 @@ def _context_bundle_for_handle_chunks(
             assembly_time_ms=_elapsed_ms(t0),
         ),
     )
+    bundle.receipt = build_context_receipt(
+        bundle,
+        index_revision="unknown",
+        freshness=ContextFreshness.UNKNOWN,
+        skipped_candidates=skipped_candidates_for_ranked(
+            [RankedChunk(chunk=chunk, relevance_score=1.0, final_score=1.0) for chunk in chunks],
+            included,
+            token_budget=token_budget,
+            total_tokens=total_tokens,
+        ),
+    )
+    return bundle
 
 
 def _chunk_token_count(chunk: CodeChunk) -> int:
@@ -1561,6 +1626,7 @@ def scout_with_bundle(
             direct_query_tokens=bundle.token_count,
             direct_query_file_paths=bundle_file_paths,
         )
+        scout_result.receipt = build_scout_receipt(scout_result, bundle.receipt)
     finally:
         store.close()
     return scout_result, bundle
@@ -1678,6 +1744,7 @@ def query(
                 chunk_count = (
                     int(stored_count) if stored_count is not None else len(store.get_chunks())
                 )
+                index_revision = index_revision_from_store(store)
                 effective_budget = _compute_dynamic_budget(
                     total_repo_tokens,
                     token_budget,
@@ -1706,6 +1773,12 @@ def query(
                         total_repo_tokens=total_repo_tokens,
                     )
                     _attach_refresh_metadata(pt, metadata_timing)
+                    _refresh_receipt(
+                        pt,
+                        index_revision=index_revision,
+                        freshness=_freshness_for_query(refresh),
+                        metadata_timing=metadata_timing,
+                    )
                     return pt
 
                 bm25 = BM25Index(store)
@@ -1863,6 +1936,8 @@ def query(
                     chunk_count=chunk_count,
                     total_repo_tokens=total_repo_tokens,
                     metadata_timing=metadata_timing,
+                    index_revision=index_revision,
+                    freshness=_freshness_for_query(refresh),
                 )
             finally:
                 store.close()
@@ -2072,6 +2147,7 @@ def query(
                     source_identity=identity,
                 )
 
+            index_revision = index_revision_from_store(store)
             # Passthrough: entire repo fits within budget
             if effective_budget >= total_repo_tokens:
                 pt = passthrough_context(all_chunks, question, effective_budget)
@@ -2091,6 +2167,12 @@ def query(
                     total_repo_tokens=total_repo_tokens,
                 )
                 _attach_refresh_metadata(pt, metadata_timing)
+                _refresh_receipt(
+                    pt,
+                    index_revision=index_revision,
+                    freshness=_freshness_for_query(refresh),
+                    metadata_timing=metadata_timing,
+                )
                 return pt
 
             t6 = time.perf_counter()
@@ -2225,6 +2307,8 @@ def query(
             chunk_count=len(all_chunks),
             total_repo_tokens=total_repo_tokens,
             metadata_timing=metadata_timing,
+            index_revision=index_revision,
+            freshness=_freshness_for_query(refresh),
         )
     finally:
         cleanup()

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1412,7 +1412,6 @@ def _refresh_receipt(
     )
 
 
-
 def _finalize_context_bundle(
     bundle: ContextBundle,
     *,

--- a/src/archex/receipt.py
+++ b/src/archex/receipt.py
@@ -149,9 +149,7 @@ def build_scout_receipt(
     completion_reason = _reason_from_skipped(merged_skipped)
     action = _action_from_reason(completion_reason, has_skipped=bool(merged_skipped))
     status = (
-        ContextCompletenessStatus.INCOMPLETE
-        if merged_skipped
-        else direct_receipt.context_complete
+        ContextCompletenessStatus.INCOMPLETE if merged_skipped else direct_receipt.context_complete
     )
     return direct_receipt.model_copy(
         update={

--- a/src/archex/receipt.py
+++ b/src/archex/receipt.py
@@ -1,0 +1,413 @@
+"""Deterministic context receipt construction."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+from archex.models import (
+    CodeChunk,
+    ContextCompletenessReason,
+    ContextCompletenessStatus,
+    ContextFreshness,
+    ContextOmittedEdgeReason,
+    ContextReceipt,
+    ContextReceiptEdge,
+    ContextReceiptItem,
+    ContextReceiptTokenBudget,
+    ContextRecommendedAction,
+    ContextSkippedCandidate,
+    ContextSkippedReason,
+    Edge,
+    RankedChunk,
+)
+from archex.scout import ScoutResult, chunk_handle, file_handle
+
+if TYPE_CHECKING:
+    from archex.index.graph import DependencyGraph
+    from archex.index.store import IndexStore
+    from archex.models import ContextBundle
+
+_MAX_RECEIPT_SKIPPED = 20
+_MAX_RECEIPT_OMITTED_EDGES = 20
+_MAX_RECEIPT_INCLUDED_EDGES = 40
+
+
+def chunk_content_hash(chunk: CodeChunk) -> str:
+    payload = f"{chunk.file_path}\0{chunk.start_line}\0{chunk.end_line}\0{chunk.content}"
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def index_revision_from_store(store: IndexStore) -> str:
+    states = store.get_file_states()
+    if states:
+        payload = json.dumps(
+            [
+                (path, str(state.get("sha256", "")))
+                for path, state in sorted(states.items(), key=lambda item: item[0])
+            ],
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()
+    metadata_parts = [
+        store.get_metadata("working_tree_signature") or "",
+        store.get_metadata("commit_hash") or "",
+        store.get_metadata("chunker") or "",
+        store.get_metadata("chunker_revision") or "",
+        store.get_metadata("chunk_count") or "",
+    ]
+    payload = "\0".join(metadata_parts)
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def build_context_receipt(
+    bundle: ContextBundle,
+    *,
+    index_revision: str,
+    freshness: ContextFreshness,
+    included_edges: Iterable[ContextReceiptEdge] = (),
+    omitted_edges: Iterable[ContextReceiptEdge] = (),
+    skipped_candidates: Iterable[ContextSkippedCandidate] = (),
+) -> ContextReceipt:
+    skipped = sorted(skipped_candidates, key=_skipped_sort_key)[:_MAX_RECEIPT_SKIPPED]
+    omitted = sorted(
+        omitted_edges,
+        key=lambda item: (
+            item.reason.value if item.reason else "",
+            item.source,
+            item.target,
+            item.kind.value,
+        ),
+    )[:_MAX_RECEIPT_OMITTED_EDGES]
+    included = sorted(
+        included_edges,
+        key=lambda item: (item.source, item.target, item.kind.value),
+    )[:_MAX_RECEIPT_INCLUDED_EDGES]
+    return ContextReceipt(
+        query=bundle.query,
+        token_budget=ContextReceiptTokenBudget(
+            requested=bundle.token_budget,
+            consumed=bundle.token_count,
+        ),
+        index_revision=index_revision,
+        freshness=freshness,
+        returned_context=_returned_context(bundle),
+        included_edges=included,
+        omitted_edges=omitted,
+        skipped_candidates=skipped,
+        context_complete=_completion_status(bundle, freshness, omitted, skipped),
+        context_complete_reason=_completion_reason(bundle, freshness, omitted, skipped),
+        recommended_next_action=_recommended_action(bundle, freshness, omitted, skipped),
+    )
+
+
+def build_scout_receipt(
+    result: ScoutResult,
+    direct_receipt: ContextReceipt | None,
+) -> ContextReceipt | None:
+    if direct_receipt is None:
+        return None
+    returned = [
+        ContextReceiptItem(
+            handle=item.handle,
+            file_path=item.path,
+            start_line=1,
+            end_line=item.lines,
+            content_hash="",
+            symbols=[symbol.name for symbol in result.symbols if symbol.file_path == item.path],
+            score=item.score,
+            reason_codes=[item.reason],
+        )
+        for item in sorted(result.ranked_files, key=lambda file: file.path)
+    ]
+    skipped = list(direct_receipt.skipped_candidates)
+    selected_handles = set(result.fetch_plan.handles)
+    for file_path, reason in sorted(result.fetch_plan.file_reasons.items()):
+        if reason.startswith("selected"):
+            continue
+        if file_handle(file_path) in selected_handles:
+            continue
+        if reason.startswith("duplicate_handle"):
+            code = ContextSkippedReason.DUPLICATE
+        elif reason.startswith("pruned_by_cap"):
+            code = ContextSkippedReason.OVER_BUDGET
+        elif reason.startswith("no_precise_handle") or reason == "missing_precise_handle":
+            code = ContextSkippedReason.UNSUPPORTED_GRAMMAR
+        else:
+            code = ContextSkippedReason.BELOW_THRESHOLD
+        skipped.append(
+            ContextSkippedCandidate(
+                file_path=file_path,
+                handle=file_handle(file_path),
+                reason=code,
+                detail=reason,
+            )
+        )
+    merged_skipped = sorted(skipped, key=_skipped_sort_key)[:_MAX_RECEIPT_SKIPPED]
+    completion_reason = _reason_from_skipped(merged_skipped)
+    action = _action_from_reason(completion_reason, has_skipped=bool(merged_skipped))
+    status = (
+        ContextCompletenessStatus.INCOMPLETE
+        if merged_skipped
+        else direct_receipt.context_complete
+    )
+    return direct_receipt.model_copy(
+        update={
+            "returned_context": returned,
+            "skipped_candidates": merged_skipped,
+            "context_complete": status,
+            "context_complete_reason": (
+                completion_reason or direct_receipt.context_complete_reason
+            ),
+            "recommended_next_action": action or direct_receipt.recommended_next_action,
+        }
+    )
+
+
+def receipt_edges_for_graph(
+    graph: DependencyGraph,
+    included_files: set[str],
+    skipped_reason_by_file: dict[str, ContextSkippedReason] | None = None,
+) -> tuple[list[ContextReceiptEdge], list[ContextReceiptEdge]]:
+    skipped_reason_by_file = skipped_reason_by_file or {}
+    included: list[ContextReceiptEdge] = []
+    omitted: list[ContextReceiptEdge] = []
+    for edge in sorted(
+        graph.file_edges(),
+        key=lambda item: (item.source, item.target, item.kind.value),
+    ):
+        receipt_edge = _receipt_edge(edge)
+        if edge.source in included_files and edge.target in included_files:
+            included.append(receipt_edge)
+        elif edge.source in included_files or edge.target in included_files:
+            missing_path = edge.target if edge.source in included_files else edge.source
+            reason = (
+                ContextOmittedEdgeReason.OVER_BUDGET
+                if skipped_reason_by_file.get(missing_path) == ContextSkippedReason.OVER_BUDGET
+                else ContextOmittedEdgeReason.BELOW_THRESHOLD
+            )
+            omitted.append(receipt_edge.model_copy(update={"reason": reason}))
+    return included, omitted
+
+
+def skipped_candidates_for_ranked(
+    ranked: list[RankedChunk],
+    included: list[RankedChunk],
+    *,
+    token_budget: int,
+    total_tokens: int,
+) -> list[ContextSkippedCandidate]:
+    included_ids = {item.chunk.id for item in included}
+    included_ranges: dict[str, list[tuple[int, int]]] = {}
+    for item in included:
+        included_ranges.setdefault(item.chunk.file_path, []).append(
+            (item.chunk.start_line, item.chunk.end_line)
+        )
+    skipped: list[ContextSkippedCandidate] = []
+    for item in ranked:
+        if item.chunk.id in included_ids:
+            continue
+        reason = _skip_reason(
+            item.chunk,
+            included_ranges,
+            token_budget=token_budget,
+            total_tokens=total_tokens,
+        )
+        skipped.append(
+            ContextSkippedCandidate(
+                file_path=item.chunk.file_path,
+                handle=chunk_handle(item.chunk.id),
+                symbol=item.chunk.symbol_name,
+                score=item.final_score,
+                reason=reason,
+            )
+        )
+    return skipped
+
+
+def stale_index_skipped_candidate() -> ContextSkippedCandidate:
+    return ContextSkippedCandidate(
+        file_path="",
+        reason=ContextSkippedReason.STALE_INDEX,
+        detail="index freshness is stale or unknown",
+    )
+
+
+def unsupported_grammar_skipped_candidate(count: int) -> ContextSkippedCandidate:
+    return ContextSkippedCandidate(
+        file_path="",
+        reason=ContextSkippedReason.UNSUPPORTED_GRAMMAR,
+        detail=f"parse failures: {count}",
+    )
+
+
+def _returned_context(bundle: ContextBundle) -> list[ContextReceiptItem]:
+    items: list[ContextReceiptItem] = []
+    seed_paths = set(bundle.retrieval_metadata.seed_file_paths)
+    expanded_paths = set(bundle.retrieval_metadata.expanded_file_paths)
+    for ranked in bundle.chunks:
+        chunk = ranked.chunk
+        reason_codes = [bundle.retrieval_metadata.strategy or "ranked"]
+        if chunk.file_path in seed_paths:
+            reason_codes.append("seed")
+        if chunk.file_path in expanded_paths:
+            reason_codes.append("expanded")
+        symbols = [value for value in (chunk.symbol_name, chunk.qualified_name) if value]
+        items.append(
+            ContextReceiptItem(
+                handle=chunk_handle(chunk.id),
+                file_path=chunk.file_path,
+                start_line=chunk.start_line,
+                end_line=chunk.end_line,
+                content_hash=chunk_content_hash(chunk),
+                symbols=list(dict.fromkeys(symbols)),
+                score=ranked.final_score,
+                reason_codes=reason_codes,
+            )
+        )
+    return sorted(
+        items,
+        key=lambda item: (item.file_path, item.start_line, item.end_line, item.handle),
+    )
+
+
+def _receipt_edge(edge: Edge) -> ContextReceiptEdge:
+    return ContextReceiptEdge(
+        source=edge.source,
+        target=edge.target,
+        kind=edge.kind,
+        confidence=edge.confidence,
+        confidence_score=edge.confidence_score,
+        evidence=edge.evidence,
+    )
+
+
+def _skip_reason(
+    chunk: CodeChunk,
+    included_ranges: dict[str, list[tuple[int, int]]],
+    *,
+    token_budget: int,
+    total_tokens: int,
+) -> ContextSkippedReason:
+    for start, end in included_ranges.get(chunk.file_path, []):
+        if start <= chunk.start_line and chunk.end_line <= end:
+            return ContextSkippedReason.DUPLICATE
+        if chunk.start_line <= start and end <= chunk.end_line:
+            return ContextSkippedReason.DUPLICATE
+    chunk_tokens = (
+        chunk.token_count if chunk.token_count > 0 else int(len(chunk.content.split()) * 1.3)
+    )
+    if total_tokens >= token_budget or total_tokens + chunk_tokens > token_budget:
+        return ContextSkippedReason.OVER_BUDGET
+    return ContextSkippedReason.BELOW_THRESHOLD
+
+
+def _completion_status(
+    bundle: ContextBundle,
+    freshness: ContextFreshness,
+    omitted_edges: list[ContextReceiptEdge],
+    skipped_candidates: list[ContextSkippedCandidate],
+) -> ContextCompletenessStatus:
+    if freshness in {ContextFreshness.DIRTY, ContextFreshness.UNKNOWN}:
+        return ContextCompletenessStatus.UNKNOWN
+    if bundle.truncated or omitted_edges or skipped_candidates:
+        return ContextCompletenessStatus.INCOMPLETE
+    return ContextCompletenessStatus.COMPLETE
+
+
+def _skipped_sort_key(item: ContextSkippedCandidate) -> tuple[int, str, str, str, str]:
+    priority = {
+        ContextSkippedReason.STALE_INDEX: 0,
+        ContextSkippedReason.UNSUPPORTED_GRAMMAR: 1,
+        ContextSkippedReason.OVER_BUDGET: 2,
+        ContextSkippedReason.DEPENDENCY_FRONTIER_CUT: 3,
+        ContextSkippedReason.DUPLICATE: 4,
+        ContextSkippedReason.BELOW_THRESHOLD: 5,
+        ContextSkippedReason.TEST_DEPRIORITIZED: 6,
+    }
+    return (
+        priority[item.reason],
+        item.reason.value,
+        item.file_path,
+        item.symbol or "",
+        item.handle or "",
+    )
+
+
+def _reason_from_skipped(
+    skipped_candidates: list[ContextSkippedCandidate],
+) -> ContextCompletenessReason | None:
+    if any(item.reason == ContextSkippedReason.STALE_INDEX for item in skipped_candidates):
+        return ContextCompletenessReason.STALE_INDEX
+    if any(item.reason == ContextSkippedReason.OVER_BUDGET for item in skipped_candidates):
+        return ContextCompletenessReason.BUDGET_EXHAUSTED
+    if any(item.reason == ContextSkippedReason.UNSUPPORTED_GRAMMAR for item in skipped_candidates):
+        return ContextCompletenessReason.UNSUPPORTED_GRAMMAR
+    if any(item.reason == ContextSkippedReason.DUPLICATE for item in skipped_candidates):
+        return ContextCompletenessReason.DUPLICATE_SUPPRESSED
+    if skipped_candidates:
+        return ContextCompletenessReason.UNKNOWN
+    return None
+
+
+def _action_from_reason(
+    reason: ContextCompletenessReason | None,
+    *,
+    has_skipped: bool,
+) -> ContextRecommendedAction | None:
+    if reason == ContextCompletenessReason.STALE_INDEX:
+        return ContextRecommendedAction.REFRESH_INDEX
+    if reason == ContextCompletenessReason.BUDGET_EXHAUSTED:
+        return ContextRecommendedAction.RAISE_BUDGET
+    if has_skipped:
+        return ContextRecommendedAction.FETCH_SKIPPED_CANDIDATE
+    if reason == ContextCompletenessReason.COMPLETE:
+        return ContextRecommendedAction.USE_BUNDLE
+    return None
+
+
+def _completion_reason(
+    bundle: ContextBundle,
+    freshness: ContextFreshness,
+    omitted_edges: list[ContextReceiptEdge],
+    skipped_candidates: list[ContextSkippedCandidate],
+) -> ContextCompletenessReason:
+    if freshness == ContextFreshness.DIRTY:
+        return ContextCompletenessReason.STALE_INDEX
+    if any(item.reason == ContextSkippedReason.STALE_INDEX for item in skipped_candidates):
+        return ContextCompletenessReason.STALE_INDEX
+    if omitted_edges:
+        return ContextCompletenessReason.DEPENDENCY_FRONTIER_CUT
+    skipped_reason = _reason_from_skipped(skipped_candidates)
+    if skipped_reason is not None:
+        return skipped_reason
+    if bundle.truncated:
+        return ContextCompletenessReason.BUDGET_EXHAUSTED
+    if not bundle.chunks:
+        return ContextCompletenessReason.NO_CANDIDATES
+    if freshness == ContextFreshness.UNKNOWN:
+        return ContextCompletenessReason.UNKNOWN
+    return ContextCompletenessReason.COMPLETE
+
+
+def _recommended_action(
+    bundle: ContextBundle,
+    freshness: ContextFreshness,
+    omitted_edges: list[ContextReceiptEdge],
+    skipped_candidates: list[ContextSkippedCandidate],
+) -> ContextRecommendedAction:
+    reason = _completion_reason(bundle, freshness, omitted_edges, skipped_candidates)
+    if reason == ContextCompletenessReason.DEPENDENCY_FRONTIER_CUT:
+        return (
+            ContextRecommendedAction.RAISE_BUDGET
+            if any(edge.reason == ContextOmittedEdgeReason.OVER_BUDGET for edge in omitted_edges)
+            else ContextRecommendedAction.FETCH_SKIPPED_CANDIDATE
+        )
+    action = _action_from_reason(reason, has_skipped=bool(skipped_candidates))
+    if action is not None:
+        return action
+    if reason == ContextCompletenessReason.COMPLETE:
+        return ContextRecommendedAction.USE_BUNDLE
+    return ContextRecommendedAction.MANUAL_REVIEW

--- a/src/archex/scout.py
+++ b/src/archex/scout.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Literal
 from pydantic import BaseModel
 
 from archex.graph_query import GraphQuery, GraphQueryError
-from archex.models import CodeChunk, Module, RankedChunk, SymbolKind
+from archex.models import CodeChunk, ContextReceipt, Module, RankedChunk, SymbolKind
 from archex.reporting import count_tokens
 from archex.serve.intent import QueryIntent, classify_intent
 
@@ -186,6 +186,7 @@ class ScoutResult(BaseModel):
     graph: list[ScoutGraphEdge] = []
     budget: ScoutBudget
     fetch_plan: ScoutFetchPlan = ScoutFetchPlan()
+    receipt: ContextReceipt | None = None
 
 
 def file_handle(file_path: str) -> str:

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from archex.models import (
     CodeChunk,
     ContextBundle,
+    ContextFreshness,
     Module,
     RankedChunk,
     RetrievalMetadata,
@@ -19,6 +20,11 @@ from archex.models import (
     TypeDefinition,
 )
 from archex.observe import PipelineTrace, StepTiming
+from archex.receipt import (
+    build_context_receipt,
+    receipt_edges_for_graph,
+    skipped_candidates_for_ranked,
+)
 
 if TYPE_CHECKING:
     from archex.index.graph import DependencyGraph
@@ -157,7 +163,7 @@ def passthrough_context(
         assembly_time_ms=assembly_ms,
     )
 
-    return ContextBundle(
+    bundle = ContextBundle(
         query=question,
         chunks=included,
         structural_context=structural_context,
@@ -167,6 +173,12 @@ def passthrough_context(
         truncated=False,
         retrieval_metadata=meta,
     )
+    bundle.receipt = build_context_receipt(
+        bundle,
+        index_revision="unknown",
+        freshness=ContextFreshness.UNKNOWN,
+    )
+    return bundle
 
 
 _QUERY_STOP = frozenset(
@@ -936,11 +948,17 @@ def assemble_context(
         strategy = "hybrid+splade+graph" if vector_results else "bm25+splade+graph"
 
     if not search_results and not vector_results and not splade_results:
-        return ContextBundle(
+        bundle = ContextBundle(
             query=question,
             token_budget=token_budget,
             retrieval_metadata=RetrievalMetadata(strategy=strategy),
         )
+        bundle.receipt = build_context_receipt(
+            bundle,
+            index_revision="unknown",
+            freshness=ContextFreshness.UNKNOWN,
+        )
+        return bundle
 
     # Merge BM25 + vector via confidence-weighted RRF when both are available
     fusion_bm25_weight: float | None = None
@@ -1583,7 +1601,7 @@ def assemble_context(
         splade_fusion_skip_reason=splade_fusion_skip_reason,
     )
 
-    return ContextBundle(
+    bundle = ContextBundle(
         query=question,
         chunks=included,
         structural_context=structural_context,
@@ -1593,3 +1611,27 @@ def assemble_context(
         truncated=truncated,
         retrieval_metadata=meta,
     )
+    skipped_receipt_candidates = skipped_candidates_for_ranked(
+        ranked,
+        included,
+        token_budget=token_budget,
+        total_tokens=total_tokens,
+    )
+    included_receipt_edges, omitted_receipt_edges = receipt_edges_for_graph(
+        graph,
+        set(included_files),
+        {
+            item.file_path: item.reason
+            for item in skipped_receipt_candidates
+            if item.file_path
+        },
+    )
+    bundle.receipt = build_context_receipt(
+        bundle,
+        index_revision="unknown",
+        freshness=ContextFreshness.UNKNOWN,
+        included_edges=included_receipt_edges,
+        omitted_edges=omitted_receipt_edges,
+        skipped_candidates=skipped_receipt_candidates,
+    )
+    return bundle

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -1620,11 +1620,7 @@ def assemble_context(
     included_receipt_edges, omitted_receipt_edges = receipt_edges_for_graph(
         graph,
         set(included_files),
-        {
-            item.file_path: item.reason
-            for item in skipped_receipt_candidates
-            if item.file_path
-        },
+        {item.file_path: item.reason for item in skipped_receipt_candidates if item.file_path},
     )
     bundle.receipt = build_context_receipt(
         bundle,

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -822,8 +822,7 @@ def test_receipt_records_dependency_frontier_cut() -> None:
 
     assert bundle.receipt is not None
     assert (
-        bundle.receipt.context_complete_reason
-        == ContextCompletenessReason.DEPENDENCY_FRONTIER_CUT
+        bundle.receipt.context_complete_reason == ContextCompletenessReason.DEPENDENCY_FRONTIER_CUT
     )
     assert bundle.receipt.omitted_edges[0].source == "seed.py"
     assert bundle.receipt.omitted_edges[0].target == "dep.py"

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -7,7 +7,13 @@ import xml.etree.ElementTree as ET
 
 from archex.index.graph import DependencyGraph
 from archex.index.rerank import DEFAULT_TOP_K, RERANK_CANDIDATE_LIMIT, CrossEncoderReranker
-from archex.models import CodeChunk, ContextBundle, Module, SymbolKind
+from archex.models import (
+    CodeChunk,
+    ContextCompletenessReason,
+    ContextBundle,
+    Module,
+    SymbolKind,
+)
 from archex.serve.context import assemble_context
 from archex.serve.intent import INTENT_TOKEN_BUDGETS, QueryIntent
 from archex.serve.renderers.json import render_json
@@ -758,6 +764,69 @@ def test_expansion_metadata_records_seed_and_expanded_file_paths() -> None:
     assert meta.expansion_candidates_found == 1
     assert meta.expansion_import_neighbor_edges == 1
     assert meta.expansion_zero_candidate_reason == ""
+
+
+def test_receipt_records_budget_exhausted_skipped_candidates() -> None:
+    graph = DependencyGraph()
+    first = make_chunk("first", "first.py", token_count=60)
+    second = make_chunk("second", "second.py", token_count=60)
+    graph.add_file_node("first.py")
+    graph.add_file_node("second.py")
+
+    bundle = assemble_context(
+        [(first, 5.0), (second, 4.0)],
+        graph,
+        [first, second],
+        "budget test",
+        token_budget=70,
+    )
+
+    assert bundle.receipt is not None
+    assert bundle.receipt.context_complete_reason == ContextCompletenessReason.BUDGET_EXHAUSTED
+    assert any(item.reason == "over_budget" for item in bundle.receipt.skipped_candidates)
+
+
+def test_receipt_records_duplicate_suppression() -> None:
+    graph = DependencyGraph()
+    parent = make_chunk("parent", "service.py", token_count=10, start_line=1, end_line=20)
+    child = make_chunk("child", "service.py", token_count=10, start_line=5, end_line=8)
+    graph.add_file_node("service.py")
+
+    bundle = assemble_context(
+        [(parent, 5.0), (child, 4.0)],
+        graph,
+        [parent, child],
+        "service",
+        token_budget=1000,
+    )
+
+    assert bundle.receipt is not None
+    assert any(item.reason == "duplicate" for item in bundle.receipt.skipped_candidates)
+
+
+def test_receipt_records_dependency_frontier_cut() -> None:
+    graph = DependencyGraph()
+    seed = make_chunk("seed", "seed.py", token_count=60)
+    dep = make_chunk("dep", "dep.py", token_count=60)
+    graph.add_file_node("seed.py")
+    graph.add_file_node("dep.py")
+    graph.add_file_edge("seed.py", "dep.py", kind="imports")
+
+    bundle = assemble_context(
+        [(seed, 5.0)],
+        graph,
+        [seed, dep],
+        "dependency frontier",
+        token_budget=70,
+    )
+
+    assert bundle.receipt is not None
+    assert (
+        bundle.receipt.context_complete_reason
+        == ContextCompletenessReason.DEPENDENCY_FRONTIER_CUT
+    )
+    assert bundle.receipt.omitted_edges[0].source == "seed.py"
+    assert bundle.receipt.omitted_edges[0].target == "dep.py"
 
 
 def test_expansion_metadata_records_file_reasons_without_changing_output() -> None:

--- a/tests/test_query_pipeline.py
+++ b/tests/test_query_pipeline.py
@@ -11,10 +11,12 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from archex.api import query
+from archex.api import query, scout
 from archex.models import (
     Config,
     ContextBundle,
+    ContextFreshness,
+    ContextSkippedReason,
     IndexConfig,
     PipelineTiming,
     RepoSource,
@@ -52,6 +54,31 @@ class TestQueryPipelineEndToEnd:
         assert meta.retrieval_time_ms > 0
         assert meta.candidates_found > 0
         assert meta.chunks_included > 0
+
+    def test_query_receipt_records_unknown_freshness_when_refresh_skipped(
+        self, python_simple_repo: Path
+    ) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(cache=False)
+        bundle = query(source, "What models are defined?", config=config, refresh=False)
+
+        assert bundle.receipt is not None
+        assert bundle.receipt.freshness == ContextFreshness.UNKNOWN
+        assert any(
+            item.reason == ContextSkippedReason.STALE_INDEX
+            for item in bundle.receipt.skipped_candidates
+        )
+        assert bundle.receipt.index_revision != "unknown"
+
+    def test_scout_receipt_exposes_fetch_handles(self, python_simple_repo: Path) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(cache=False)
+        result = scout(source, "What models are defined?", config=config, output_format="json")
+
+        assert result.receipt is not None
+        assert result.receipt.returned_context
+        assert result.receipt.returned_context[0].handle.startswith("file:")
+        assert result.fetch_plan.handles
 
     def test_query_finds_relevant_files(self, python_simple_repo: Path) -> None:
         source = RepoSource(local_path=str(python_simple_repo))

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from archex.models import (
+    ContextBundle,
+    ContextCompletenessReason,
+    ContextCompletenessStatus,
+    ContextFreshness,
+    ContextReceipt,
+    ContextReceiptTokenBudget,
+    ContextRecommendedAction,
+    ContextSkippedCandidate,
+    ContextSkippedReason,
+)
+from archex.receipt import (
+    build_context_receipt,
+    build_scout_receipt,
+    stale_index_skipped_candidate,
+)
+from archex.scout import (
+    ScoutBudget,
+    ScoutFetchPlan,
+    ScoutFile,
+    ScoutResult,
+    file_handle,
+    symbol_handle,
+)
+
+
+def test_context_receipt_preserves_stale_marker_when_skipped_candidates_are_capped() -> None:
+    bundle = ContextBundle(query="q", token_count=10, token_budget=100, truncated=True)
+    skipped = [
+        ContextSkippedCandidate(
+            file_path=f"file_{index}.py",
+            reason=ContextSkippedReason.BELOW_THRESHOLD,
+        )
+        for index in range(25)
+    ]
+    skipped.append(stale_index_skipped_candidate())
+
+    receipt = build_context_receipt(
+        bundle,
+        index_revision="rev",
+        freshness=ContextFreshness.UNKNOWN,
+        skipped_candidates=skipped,
+    )
+
+    assert len(receipt.skipped_candidates) == 20
+    assert receipt.skipped_candidates[0].reason == ContextSkippedReason.STALE_INDEX
+    assert receipt.context_complete_reason == ContextCompletenessReason.STALE_INDEX
+    assert receipt.recommended_next_action == ContextRecommendedAction.REFRESH_INDEX
+
+
+def test_scout_receipt_does_not_mark_selected_handle_files_as_skipped() -> None:
+    direct_receipt = ContextReceipt(
+        query="q",
+        token_budget=ContextReceiptTokenBudget(requested=100, consumed=20),
+        index_revision="rev",
+        freshness=ContextFreshness.CLEAN,
+        context_complete=ContextCompletenessStatus.COMPLETE,
+        context_complete_reason=ContextCompletenessReason.COMPLETE,
+        recommended_next_action=ContextRecommendedAction.USE_BUNDLE,
+    )
+    scout = ScoutResult(
+        query="q",
+        ranked_files=[
+            ScoutFile(
+                path="src/service.py",
+                language="python",
+                lines=12,
+                symbol_count=1,
+                handle=file_handle("src/service.py"),
+                score=1.0,
+            )
+        ],
+        budget=ScoutBudget(token_budget=100),
+        fetch_plan=ScoutFetchPlan(
+            handles=[symbol_handle("src/service.py::Service#class")],
+            file_reasons={
+                "src/service.py": (
+                    "selected_handle rank=1 score=1.000 coverage=1.000 "
+                    "reason=ranked handle=symbol:src/service.py::Service#class"
+                )
+            },
+        ),
+    )
+
+    receipt = build_scout_receipt(scout, direct_receipt)
+
+    assert receipt is not None
+    assert receipt.skipped_candidates == []
+    assert receipt.context_complete == ContextCompletenessStatus.COMPLETE
+    assert receipt.context_complete_reason == ContextCompletenessReason.COMPLETE
+    assert receipt.recommended_next_action == ContextRecommendedAction.USE_BUNDLE


### PR DESCRIPTION
## Stack

Stack-Id: `context-trust-benchmark-proof`
Base: `main`
Position: 2/6

1. `feat/context-receipt-model` -> #244
2. `feat/context-receipt-construction` -> this PR (#245)
3. `feat/context-receipt-surfaces` -> #246
4. `feat/benchmark-required-file-metrics` -> #247
5. `feat/client-compatibility-paths` -> #248
6. `feat/readme-trust-messaging` -> #249

Depends on: #244
Upstack: #246

## Validation

- `uv run ruff check src/archex/receipt.py src/archex/api.py src/archex/scout.py src/archex/serve/context.py tests/serve/test_context.py tests/test_query_pipeline.py tests/test_receipt.py`
- `uv run pyright src/archex/receipt.py src/archex/api.py src/archex/scout.py src/archex/serve/context.py tests/serve/test_context.py tests/test_query_pipeline.py tests/test_receipt.py`
- `uv run pytest tests/serve/test_context.py tests/test_query_pipeline.py tests/test_scout.py tests/test_receipt.py -q --no-cov`
- Review: no blocking findings
