### PR TITLE
Expose receipts on output surfaces

### DIFF
--- a/docs/INSTALLATION_TRUST_CONTRACT.md
+++ b/docs/INSTALLATION_TRUST_CONTRACT.md
@@ -37,6 +37,14 @@ uv add archex
 
 Core CLI indexing and BM25 retrieval do not require hosted inference, API keys, vector model downloads, or Hugging Face remote code.
 
+## Context receipt output contract
+
+`archex query --format json` includes a top-level `receipt` object in the serialized `ContextBundle`. `archex query --format xml` includes a compact `<receipt>` block with freshness, index revision, completeness, recommended action, returned handles, skipped candidates, and omitted dependency-edge counts.
+
+`archex scout --format json` includes the same receipt fields on the scout result. `archex scout` markdown prints one compact receipt summary line before ranked files, while preserving fetch handles in the recommended-fetch section.
+
+MCP `query_repo` and `scout_repo` envelopes now include a top-level `receipt` field next to `content` and `_meta`. This is an intentional additive JSON-envelope change so MCP clients can inspect provenance and completeness without parsing prompt text.
+
 ## MCP setup
 
 Install the MCP extra:

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -115,7 +115,7 @@ def handle_query_repo(repo_url: str, question: str, budget: int | None = None) -
         explicit_token_budget=budget is not None,
     )
 
-    content = render_xml(bundle)
+    content = render_xml(bundle, include_receipt=False)
     metadata = bundle.retrieval_metadata
     raw_file_paths = sorted(
         {
@@ -137,7 +137,14 @@ def handle_query_repo(repo_url: str, question: str, budget: int | None = None) -
         query_time_ms=pt.total_ms,
         delta=pt.delta_meta,
     )
-    return json.dumps({"content": content, "_meta": meta.model_dump()}, indent=2)
+    return json.dumps(
+        {
+            "content": content,
+            "receipt": _receipt_payload(bundle.receipt),
+            "_meta": meta.model_dump(),
+        },
+        indent=2,
+    )
 
 
 def handle_scout_repo(
@@ -158,7 +165,7 @@ def handle_scout_repo(
         output_format=output_format,
         timing=pt,
     )
-    rendered = render_scout(result, output_format=output_format)
+    rendered = render_scout(result, output_format=output_format, include_receipt=False)
     content = json.loads(rendered) if output_format == "json" else rendered
     raw = get_repo_total_tokens(source)
     meta = compute_meta(
@@ -171,7 +178,11 @@ def handle_scout_repo(
         query_time_ms=pt.total_ms,
         delta=pt.delta_meta,
     )
-    return json.dumps({"content": content, "_meta": meta.model_dump()}, indent=2)
+    receipt = _receipt_payload(result.receipt)
+    return json.dumps(
+        {"content": content, "receipt": receipt, "_meta": meta.model_dump()},
+        indent=2,
+    )
 
 
 def handle_compare_repos(
@@ -504,6 +515,12 @@ def _graph_tool_response(
     meta["token_budget"] = token_budget
     meta["token_budget_truncated"] = budget_truncated
     return json.dumps({"content": content, "_meta": meta}, indent=2, sort_keys=True)
+
+
+def _receipt_payload(receipt: Any) -> dict[str, Any] | None:
+    if receipt is None:
+        return None
+    return receipt.model_dump(mode="json")
 
 
 def _validate_output_format(output_format: str) -> None:

--- a/src/archex/scout.py
+++ b/src/archex/scout.py
@@ -316,11 +316,22 @@ def enforce_scout_token_budget(result: ScoutResult, *, output_format: ScoutForma
         raise ValueError(msg)
 
 
-def render_scout(result: ScoutResult, *, output_format: ScoutFormat = "markdown") -> str:
+def render_scout(
+    result: ScoutResult,
+    *,
+    output_format: ScoutFormat = "markdown",
+    include_receipt: bool = True,
+) -> str:
     if output_format == "json":
-        return json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True) + "\n"
+        exclude = None if include_receipt else {"receipt"}
+        rendered = json.dumps(
+            result.model_dump(mode="json", exclude=exclude),
+            indent=2,
+            sort_keys=True,
+        )
+        return f"{rendered}\n"
     if output_format == "markdown":
-        return _render_markdown(result)
+        return _render_markdown(result, include_receipt=include_receipt)
     raise ValueError(f"Unsupported scout format {output_format!r}")
 
 
@@ -817,15 +828,25 @@ def _visibility_rank(visibility: str | None) -> int:
     return 2
 
 
-def _render_markdown(result: ScoutResult) -> str:
+def _render_markdown(result: ScoutResult, *, include_receipt: bool = True) -> str:
     lines = [
         "# archex scout",
         "",
         f"Query: {result.query}",
         f"Budget: {result.budget.token_count}/{result.budget.token_budget} tokens",
-        "",
-        "## Ranked files",
     ]
+    if include_receipt and result.receipt is not None:
+        receipt = result.receipt
+        lines.append(
+            "Receipt: "
+            f"freshness={receipt.freshness.value}, "
+            f"complete={receipt.context_complete.value}, "
+            f"reason={receipt.context_complete_reason.value}, "
+            f"action={receipt.recommended_next_action.value}, "
+            f"returned={len(receipt.returned_context)}, "
+            f"skipped={len(receipt.skipped_candidates)}"
+        )
+    lines.extend(["", "## Ranked files"])
     if result.ranked_files:
         for item in result.ranked_files:
             lines.append(

--- a/src/archex/serve/renderers/xml.py
+++ b/src/archex/serve/renderers/xml.py
@@ -6,10 +6,10 @@ from typing import TYPE_CHECKING
 from xml.sax.saxutils import escape
 
 if TYPE_CHECKING:
-    from archex.models import ContextBundle
+    from archex.models import ContextBundle, ContextReceipt
 
 
-def render_xml(bundle: ContextBundle) -> str:
+def render_xml(bundle: ContextBundle, *, include_receipt: bool = True) -> str:
     """Render a ContextBundle as an XML string suitable for LLM consumption."""
     lines: list[str] = []
     lines.append(f"<context query={_attr(bundle.query)}>")
@@ -63,6 +63,9 @@ def render_xml(bundle: ContextBundle) -> str:
             lines.append(f"    <external>{escape(item)}</external>")
         lines.append("  </dependencies>")
 
+    if include_receipt and bundle.receipt is not None:
+        lines.extend(_render_receipt_xml(bundle.receipt))
+
     lines.append("</context>")
     return "\n".join(lines)
 
@@ -112,6 +115,43 @@ def render_xml_envelope(bundle: ContextBundle) -> str:
 
     lines.append("</context>")
     return "\n".join(lines)
+
+
+def _render_receipt_xml(receipt: ContextReceipt) -> list[str]:
+    lines = [
+        "  <receipt"
+        f" freshness={_attr(receipt.freshness.value)}"
+        f" complete={_attr(receipt.context_complete.value)}"
+        f" reason={_attr(receipt.context_complete_reason.value)}"
+        f" action={_attr(receipt.recommended_next_action.value)}"
+        f" index_revision={_attr(receipt.index_revision)}"
+        f" budget_requested={_attr(str(receipt.token_budget.requested))}"
+        f" budget_consumed={_attr(str(receipt.token_budget.consumed))}"
+        f" returned={_attr(str(len(receipt.returned_context)))}"
+        f" skipped={_attr(str(len(receipt.skipped_candidates)))}"
+        f" omitted_edges={_attr(str(len(receipt.omitted_edges)))}"
+        ">",
+    ]
+    for item in receipt.returned_context[:8]:
+        lines.append(
+            "    <returned"
+            f" handle={_attr(item.handle)}"
+            f" file={_attr(item.file_path)}"
+            f" lines={_attr(f'{item.start_line}-{item.end_line}')}"
+            f" hash={_attr(item.content_hash)}"
+            f" score={_attr(f'{item.score:.4f}')}"
+            " />"
+        )
+    for item in receipt.skipped_candidates[:8]:
+        lines.append(
+            "    <skipped"
+            f" file={_attr(item.file_path)}"
+            f" reason={_attr(item.reason.value)}"
+            f" handle={_attr(item.handle or '')}"
+            " />"
+        )
+    lines.append("  </receipt>")
+    return lines
 
 
 def _attr(value: str) -> str:

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -40,6 +40,12 @@ from archex.models import (
     CodeChunk,
     ComparisonResult,
     ContextBundle,
+    ContextCompletenessReason,
+    ContextCompletenessStatus,
+    ContextFreshness,
+    ContextReceipt,
+    ContextReceiptTokenBudget,
+    ContextRecommendedAction,
     EdgeConfidence,
     RankedChunk,
     RepoMetadata,
@@ -59,7 +65,20 @@ def _make_arch_profile(local_path: str = "/fake/repo") -> ArchProfile:
 
 
 def _make_context_bundle(question: str = "how does auth work?") -> ContextBundle:
-    return ContextBundle(query=question, token_count=100, token_budget=8000)
+    return ContextBundle(
+        query=question,
+        token_count=100,
+        token_budget=8000,
+        receipt=ContextReceipt(
+            query=question,
+            token_budget=ContextReceiptTokenBudget(requested=8000, consumed=100),
+            index_revision="rev",
+            freshness=ContextFreshness.CLEAN,
+            context_complete=ContextCompletenessStatus.COMPLETE,
+            context_complete_reason=ContextCompletenessReason.COMPLETE,
+            recommended_next_action=ContextRecommendedAction.USE_BUNDLE,
+        ),
+    )
 
 
 def _make_comparison_result() -> ComparisonResult:
@@ -163,6 +182,9 @@ class TestHandleQueryRepo:
         assert "_meta" in parsed
         assert parsed["_meta"]["tool_name"] == "query_repo"
         assert parsed["_meta"]["strategy"] == "bm25+graph"
+        assert parsed["receipt"]["index_revision"] == "rev"
+        assert parsed["receipt"]["context_complete"] == "complete"
+        assert "<receipt" not in parsed["content"]
 
     def test_uses_adaptive_default_budget_when_omitted(self) -> None:
         bundle = _make_context_bundle()
@@ -296,6 +318,15 @@ class TestHandleScoutRepo:
                     handle=file_handle("src/archex/index/delta.py"),
                 )
             ],
+            receipt=ContextReceipt(
+                query="delta indexing",
+                token_budget=ContextReceiptTokenBudget(requested=120, consumed=80),
+                index_revision="rev",
+                freshness=ContextFreshness.CLEAN,
+                context_complete=ContextCompletenessStatus.COMPLETE,
+                context_complete_reason=ContextCompletenessReason.COMPLETE,
+                recommended_next_action=ContextRecommendedAction.USE_BUNDLE,
+            ),
             budget=ScoutBudget(token_budget=120),
         )
         with (
@@ -315,7 +346,34 @@ class TestHandleScoutRepo:
         assert parsed["_meta"]["tool_name"] == "scout_repo"
         assert parsed["_meta"]["strategy"] == "scout"
         assert scout_mock.call_args.kwargs["token_budget"] == 120
+        assert parsed["receipt"]["index_revision"] == "rev"
 
+
+    def test_returns_scout_json_without_duplicate_receipt(self) -> None:
+        from archex.scout import ScoutBudget, ScoutResult
+
+        result_model = ScoutResult(
+            query="delta indexing",
+            budget=ScoutBudget(token_budget=120),
+            receipt=ContextReceipt(
+                query="delta indexing",
+                token_budget=ContextReceiptTokenBudget(requested=120, consumed=80),
+                index_revision="rev",
+                freshness=ContextFreshness.CLEAN,
+                context_complete=ContextCompletenessStatus.COMPLETE,
+                context_complete_reason=ContextCompletenessReason.COMPLETE,
+                recommended_next_action=ContextRecommendedAction.USE_BUNDLE,
+            ),
+        )
+        with (
+            patch("archex.integrations.mcp.scout", return_value=result_model),
+            patch("archex.integrations.mcp.get_repo_total_tokens", return_value=1000),
+        ):
+            output = handle_scout_repo("/fake/repo", "delta indexing")
+
+        parsed = json.loads(output)
+        assert "receipt" not in parsed["content"]
+        assert parsed["receipt"]["index_revision"] == "rev"
 
 class TestHandleCompareRepos:
     def test_returns_json_with_meta(self) -> None:

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -348,7 +348,6 @@ class TestHandleScoutRepo:
         assert scout_mock.call_args.kwargs["token_budget"] == 120
         assert parsed["receipt"]["index_revision"] == "rev"
 
-
     def test_returns_scout_json_without_duplicate_receipt(self) -> None:
         from archex.scout import ScoutBudget, ScoutResult
 
@@ -374,6 +373,7 @@ class TestHandleScoutRepo:
         parsed = json.loads(output)
         assert "receipt" not in parsed["content"]
         assert parsed["receipt"]["index_revision"] == "rev"
+
 
 class TestHandleCompareRepos:
     def test_returns_json_with_meta(self) -> None:

--- a/tests/test_query_pipeline.py
+++ b/tests/test_query_pipeline.py
@@ -7,6 +7,7 @@ produces valid output in all three formats.
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 import pytest
@@ -22,6 +23,7 @@ from archex.models import (
     RepoSource,
     ScoringWeights,
 )
+from archex.scout import render_scout
 from archex.serve.renderers.json import render_json
 from archex.serve.renderers.markdown import render_markdown
 from archex.serve.renderers.xml import render_xml
@@ -55,6 +57,16 @@ class TestQueryPipelineEndToEnd:
         assert meta.candidates_found > 0
         assert meta.chunks_included > 0
 
+    def test_query_renderers_include_receipt(self, python_simple_repo: Path) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(cache=False)
+        bundle = query(source, "What models are defined?", config=config)
+
+        parsed = json.loads(render_json(bundle))
+        assert parsed["receipt"]["index_revision"] != "unknown"
+        assert parsed["receipt"]["freshness"] == "clean"
+        assert "<receipt " in render_xml(bundle)
+
     def test_query_receipt_records_unknown_freshness_when_refresh_skipped(
         self, python_simple_repo: Path
     ) -> None:
@@ -79,6 +91,7 @@ class TestQueryPipelineEndToEnd:
         assert result.receipt.returned_context
         assert result.receipt.returned_context[0].handle.startswith("file:")
         assert result.fetch_plan.handles
+        assert "Receipt: freshness=" in render_scout(result)
 
     def test_query_finds_relevant_files(self, python_simple_repo: Path) -> None:
         source = RepoSource(local_path=str(python_simple_repo))


### PR DESCRIPTION
## Stack

Stack-Id: `context-trust-benchmark-proof`
Base: `main`
Position: 3/6

1. `feat/context-receipt-model` -> #244
2. `feat/context-receipt-construction` -> #245
3. `feat/context-receipt-surfaces` -> this PR (#246)
4. `feat/benchmark-required-file-metrics` -> #247
5. `feat/client-compatibility-paths` -> #248
6. `feat/readme-trust-messaging` -> #249

Depends on: #245
Upstack: #247

## Validation

- `uv run ruff check src/archex/serve/renderers/xml.py src/archex/scout.py src/archex/integrations/mcp.py tests/test_query_pipeline.py tests/integrations/test_mcp.py`
- `uv run pyright src/archex/serve/renderers/xml.py src/archex/scout.py src/archex/integrations/mcp.py tests/test_query_pipeline.py tests/integrations/test_mcp.py`
- `uv run pytest tests/test_query_pipeline.py tests/integrations/test_mcp.py tests/test_scout.py -q --no-cov`
- Review: no blocking findings
