### PR TITLE
Add required-file benchmark metrics

### DIFF
--- a/src/archex/benchmark/external_mcp.py
+++ b/src/archex/benchmark/external_mcp.py
@@ -20,6 +20,7 @@ from archex.benchmark.models import (
     Strategy,
 )
 from archex.benchmark.strategies import (
+    completion_result_from_missing,
     compute_bundle_completion_penalty,
     compute_f1,
     compute_map,
@@ -27,6 +28,7 @@ from archex.benchmark.strategies import (
     compute_ndcg,
     compute_precision,
     compute_recall,
+    compute_required_file_metrics,
     compute_token_efficiency,
     count_file_tokens,
     now_iso,
@@ -288,6 +290,17 @@ def run_external_mcp(
     completion_tokens, completion_files = compute_bundle_completion_penalty(
         repo_path, result_files, task.expected_files
     )
+    required_metrics = compute_required_file_metrics(
+        result_files,
+        task.expected_files,
+    )
+    (
+        required_file_recall,
+        missed_required_file_rate,
+        all_required_files_present,
+        present,
+        missing,
+    ) = required_metrics
     recall = compute_recall(result_files, task.expected_files)
     precision = compute_precision(result_files, task.expected_files)
     wall_ms = (time.perf_counter() - total_started) * 1000
@@ -300,6 +313,14 @@ def run_external_mcp(
         tokens_input=tokens_input,
         tokens_output=tokens_output,
         token_efficiency=compute_token_efficiency(tokens_output, tokens_input),
+        result_files=unique_files,
+        required_file_recall=required_file_recall,
+        missed_required_file_rate=missed_required_file_rate,
+        all_required_files_present=all_required_files_present,
+        required_files_present=present,
+        required_files_missing=missing,
+        post_bundle_read_turns=len(completion_files),
+        task_completion_result=completion_result_from_missing(completion_files),
         bundle_completion_tokens=completion_tokens,
         bundle_completion_files=completion_files,
         token_efficiency_with_completion=compute_token_efficiency(
@@ -320,7 +341,6 @@ def run_external_mcp(
         timestamp=now_iso(),
         unique_ranked_files=len(unique_files),
         seed_files=unique_files,
-        result_files=unique_files,
         cold_start_ms=cold_start_ms,
         warm_latency_ms=warm_latency_ms,
         cache_state="cold" if config.bootstrap_commands else "warm",

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -190,6 +190,12 @@ class HeadToHeadManifest(BenchmarkSpecModel):
     raw_read_strategy: Strategy = Strategy.RAW_GREPPED
 
 
+
+class TaskCompletionResult(StrEnum):
+    PASS = "pass"
+    FAIL = "fail"
+    UNKNOWN = "unknown"
+
 class BenchmarkResult(BaseModel):
     task_id: str
     strategy: Strategy
@@ -234,6 +240,16 @@ class BenchmarkResult(BaseModel):
     expansion_reason_counts: dict[str, int] = {}
     expanded_file_reasons: dict[str, list[str]] = {}
     result_files: list[str] = []
+    required_file_recall: float = 0.0
+    missed_required_file_rate: float = 0.0
+    all_required_files_present: bool = False
+    required_files_present: list[str] = []
+    required_files_missing: list[str] = []
+    post_bundle_search_turns: int | None = None
+    post_bundle_read_turns: int | None = None
+    task_completion_result: TaskCompletionResult = TaskCompletionResult.UNKNOWN
+    completion_preserved: bool | None = None
+    receipt_accuracy: bool | None = None
     bundle_completion_tokens: int = 0
     bundle_completion_files: list[str] = []
     token_efficiency_with_completion: float = 0.0

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -190,11 +190,11 @@ class HeadToHeadManifest(BenchmarkSpecModel):
     raw_read_strategy: Strategy = Strategy.RAW_GREPPED
 
 
-
 class TaskCompletionResult(StrEnum):
     PASS = "pass"
     FAIL = "fail"
     UNKNOWN = "unknown"
+
 
 class BenchmarkResult(BaseModel):
     task_id: str

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -14,6 +14,8 @@ _SUMMARY_FIELDS = (
     "savings_vs_raw",
     "token_efficiency",
     "recall",
+    "required_file_recall",
+    "missed_required_file_rate",
     "f1_score",
     "mrr",
     "ndcg",
@@ -22,6 +24,8 @@ _SUMMARY_FIELDS = (
 _BUCKET_FIELDS = (
     "recall",
     "precision",
+    "required_file_recall",
+    "missed_required_file_rate",
     "f1_score",
     "mrr",
     "ndcg",
@@ -32,6 +36,7 @@ _BUCKET_FIELDS = (
 _COMPARISON_METRICS = (
     "recall",
     "precision",
+    "required_file_recall",
     "f1_score",
     "mrr",
     "ndcg",
@@ -41,6 +46,7 @@ _COMPARISON_METRICS = (
 _COMPARISON_LABELS = {
     "recall": "Recall",
     "precision": "Precision",
+    "required_file_recall": "Required Recall",
     "f1_score": "F1",
     "mrr": "MRR",
     "ndcg": "nDCG",
@@ -64,6 +70,16 @@ def _percentile(values: list[float], quantile: float) -> float:
     upper = min(lower + 1, len(ordered) - 1)
     fraction = position - lower
     return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
+def _receipt_accuracy_label(value: bool | None) -> str:
+    if value is None:
+        return "unknown"
+    return "yes" if value else "no"
+
+
+def _all_required_label(value: bool) -> str:
+    return "yes" if value else "no"
 
 
 def _aggregate_strategy_metrics(
@@ -103,23 +119,25 @@ def format_markdown(report: BenchmarkReport) -> str:
     lines.append(f"**Baseline tokens:** {report.baseline_tokens:,}")
     lines.append("")
     header = (
-        "| Strategy | Tokens | Tokens In | Tokens Out | Efficiency | Savings "
-        "| Recall | Precision | F1 | MRR | nDCG | MAP | Files | Time (ms) |"
+        "| Strategy | Tokens | Required Recall | Missed Task Rate | All Required | "
+        "Post Reads | Completion | Receipt Accuracy | Recall | Precision | F1 | Time (ms) |"
     )
     lines.append(header)
     lines.append(
-        "|----------|--------|-----------|------------|------------|--------"
-        "|--------|-----------|------|------|------|------|-------|-----------|"
+        "|----------|--------|-----------------|------------------|--------------|"
+        "------------|------------|------------------|--------|-----------|------|-----------|"
     )
     for r in report.results:
+        receipt_accuracy = _receipt_accuracy_label(r.receipt_accuracy)
+        all_required = _all_required_label(r.all_required_files_present)
+        post_reads = r.post_bundle_read_turns if r.post_bundle_read_turns is not None else "—"
         lines.append(
-            f"| {r.strategy.value} | {r.tokens_total:,} "
-            f"| {r.tokens_input:,} | {r.tokens_output:,} | {r.token_efficiency:.2f} "
-            f"| {r.savings_vs_raw:.1f}% "
-            f"| {r.recall:.2f} | {r.precision:.2f} | {r.f1_score:.2f} | {r.mrr:.2f} "
-            f"| {r.ndcg:.2f} | {r.map_score:.2f} "
-            f"| {r.files_accessed} | {r.wall_time_ms:.0f} |"
+            f"| {r.strategy.value} | {r.tokens_total:,} | {r.required_file_recall:.2f} "
+            f"| {r.missed_required_file_rate:.2f} | {all_required} | {post_reads} "
+            f"| {r.task_completion_result.value} | {receipt_accuracy} | {r.recall:.2f} "
+            f"| {r.precision:.2f} | {r.f1_score:.2f} | {r.wall_time_ms:.0f} |"
         )
+    lines.extend(_missing_required_file_appendix(report))
     lines.append("")
     return "\n".join(lines)
 
@@ -142,12 +160,12 @@ def format_summary(reports: list[BenchmarkReport]) -> str:
     strategy_metrics = _aggregate_strategy_metrics(reports, _SUMMARY_FIELDS)
 
     lines.append(
-        "| Strategy | Avg Tokens | Avg Savings | Avg Efficiency | Avg Recall | Avg F1 "
-        "| Avg MRR | Avg nDCG | Avg MAP | Tasks |"
+        "| Strategy | Avg Tokens | Avg Savings | Avg Efficiency | Avg Recall | "
+        "Avg Required Recall | Missed Task Rate | Avg F1 | Avg MRR | Avg nDCG | Avg MAP | Tasks |"
     )
     lines.append(
-        "|----------|------------|-------------|----------------|------------|--------"
-        "|---------|----------|---------|-------|"
+        "|----------|------------|-------------|----------------|------------|"
+        "---------------------|------------------|--------|---------|----------|---------|-------|"
     )
 
     for name in sorted(strategy_metrics):
@@ -156,10 +174,11 @@ def format_summary(reports: list[BenchmarkReport]) -> str:
         lines.append(
             f"| {name} | {_mean(metrics['tokens_total']):,.0f} "
             f"| {_mean(metrics['savings_vs_raw']):.1f}% "
-            f"| {_mean(metrics['token_efficiency']):.2f} "
-            f"| {_mean(metrics['recall']):.2f} | {_mean(metrics['f1_score']):.2f} "
-            f"| {_mean(metrics['mrr']):.2f} | {_mean(metrics['ndcg']):.2f} "
-            f"| {_mean(metrics['map_score']):.2f} | {count} |"
+            f"| {_mean(metrics['token_efficiency']):.2f} | {_mean(metrics['recall']):.2f} "
+            f"| {_mean(metrics['required_file_recall']):.2f} "
+            f"| {_mean(metrics['missed_required_file_rate']):.2f} "
+            f"| {_mean(metrics['f1_score']):.2f} | {_mean(metrics['mrr']):.2f} "
+            f"| {_mean(metrics['ndcg']):.2f} | {_mean(metrics['map_score']):.2f} | {count} |"
         )
 
     lines.append("")
@@ -247,20 +266,24 @@ def format_strategy_comparison(reports: list[BenchmarkReport]) -> str:
         lines.append(f"## {report.task_id}")
         lines.append("")
         lines.append(
-            "| Strategy | Recall | Precision | F1 | MRR | nDCG | MAP | Tokens Total "
-            "| Token Efficiency | Savings vs Raw |"
+            "| Strategy | Required Recall | Missed Task Rate | All Required | "
+            "Completion | Receipt Accuracy | Recall | Precision | F1 | Tokens Total |"
         )
         lines.append(
-            "|----------|--------|-----------|------|------|------|------|-------------"
-            "|------------------|---------------|"
+            "|----------|-----------------|------------------|--------------|"
+            "------------|------------------|--------|-----------|------|-------------|"
         )
         for r in report.results:
+            receipt_accuracy = _receipt_accuracy_label(r.receipt_accuracy)
+            all_required = _all_required_label(r.all_required_files_present)
             lines.append(
-                f"| {r.strategy.value} | {r.recall:.2f} | {r.precision:.2f} "
-                f"| {r.f1_score:.2f} | {r.mrr:.2f} | {r.ndcg:.2f} "
-                f"| {r.map_score:.2f} | {r.tokens_total:,} "
-                f"| {r.token_efficiency:.2f} | {r.savings_vs_raw:.1f}% |"
+                f"| {r.strategy.value} | {r.required_file_recall:.2f} "
+                f"| {r.missed_required_file_rate:.2f} | {all_required} "
+                f"| {r.task_completion_result.value} | {receipt_accuracy} "
+                f"| {r.recall:.2f} | {r.precision:.2f} | {r.f1_score:.2f} "
+                f"| {r.tokens_total:,} |"
             )
+        lines.extend(_missing_required_file_appendix(report))
         lines.append("")
 
     # Head-to-head wins
@@ -297,6 +320,19 @@ def format_strategy_comparison(reports: list[BenchmarkReport]) -> str:
     lines.append("")
 
     return "\n".join(lines)
+
+
+def _missing_required_file_appendix(report: BenchmarkReport) -> list[str]:
+    lines: list[str] = []
+    failures = [result for result in report.results if result.required_files_missing]
+    if not failures:
+        return lines
+    lines.extend(["", "### Missing required files appendix"])
+    for result in failures:
+        lines.append(
+            f"- {result.strategy.value}: missing {', '.join(result.required_files_missing)}"
+        )
+    return lines
 
 
 def format_chunker_frontier_table(

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -17,6 +17,7 @@ from archex.benchmark.models import (
     BenchmarkRetrievalOptions,
     BenchmarkTask,
     Strategy,
+    TaskCompletionResult,
 )
 from archex.benchmark.strategies import (
     benchmark_index_config,
@@ -238,6 +239,16 @@ def run_benchmark(
                     result.savings_vs_raw = round(
                         (1 - result.tokens_total / baseline_tokens) * 100,
                         1,
+                    )
+        if raw_result is not None:
+            baseline_completion = raw_result.task_completion_result
+            for result in results:
+                if (
+                    baseline_completion != TaskCompletionResult.UNKNOWN
+                    and result.task_completion_result != TaskCompletionResult.UNKNOWN
+                ):
+                    result.completion_preserved = (
+                        result.task_completion_result == baseline_completion
                     )
 
         return BenchmarkReport(

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -21,10 +21,18 @@ from archex.benchmark.models import (
     BenchmarkRetrievalOptions,
     BenchmarkTask,
     Strategy,
+    TaskCompletionResult,
 )
 from archex.cache import CacheManager
 from archex.exceptions import ArchexError, ConfigError
-from archex.models import ChunkerName, IndexConfig, PipelineTiming, RepoSource
+from archex.models import (
+    ChunkerName,
+    ContextBundle,
+    ContextCompletenessStatus,
+    IndexConfig,
+    PipelineTiming,
+    RepoSource,
+)
 from archex.reporting import count_tokens
 
 logger = logging.getLogger(__name__)
@@ -280,11 +288,51 @@ def compute_bundle_completion_penalty(
     return count_file_tokens(repo_path, missing_files), missing_files
 
 
+def compute_required_file_metrics(
+    result_files: set[str],
+    expected_files: list[str],
+) -> tuple[float, float, bool, list[str], list[str]]:
+    present = [path for path in expected_files if path in result_files]
+    missing = [path for path in expected_files if path not in result_files]
+    recall = len(present) / len(expected_files) if expected_files else 0.0
+    all_present = not missing
+    missed_rate = 0.0 if all_present else 1.0
+    return recall, missed_rate, all_present, present, missing
+
+
+def compute_receipt_accuracy(
+    bundle: ContextBundle | None,
+    *,
+    all_required_files_present: bool,
+) -> bool | None:
+    if bundle is None or bundle.receipt is None:
+        return None
+    status = bundle.receipt.context_complete
+    if status == "unknown":
+        return None
+    predicted_complete = status == ContextCompletenessStatus.COMPLETE
+    return predicted_complete == all_required_files_present
+
+
+def completion_result_from_missing(missing_files: list[str]) -> TaskCompletionResult:
+    return TaskCompletionResult.PASS if not missing_files else TaskCompletionResult.FAIL
+
 def run_raw_files(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Baseline strategy: read all expected files, count tokens."""
     t0 = time.perf_counter()
     tokens = count_file_tokens(repo_path, task.expected_files)
     wall_ms = (time.perf_counter() - t0) * 1000
+    required_metrics = compute_required_file_metrics(
+        set(task.expected_files),
+        task.expected_files,
+    )
+    (
+        required_file_recall,
+        missed_required_file_rate,
+        all_required_files_present,
+        present,
+        missing,
+    ) = required_metrics
 
     return BenchmarkResult(
         task_id=task.task_id,
@@ -294,6 +342,15 @@ def run_raw_files(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         tokens_output=tokens,
         token_efficiency=compute_token_efficiency(tokens, tokens),
         result_files=list(task.expected_files),
+        required_file_recall=required_file_recall,
+        missed_required_file_rate=missed_required_file_rate,
+        all_required_files_present=all_required_files_present,
+        required_files_present=present,
+        required_files_missing=missing,
+        post_bundle_search_turns=0,
+        post_bundle_read_turns=0,
+        task_completion_result=TaskCompletionResult.PASS,
+        completion_preserved=True,
         token_efficiency_with_completion=compute_token_efficiency(tokens, tokens),
         tokens_raw_baseline=tokens,
         tool_calls=len(task.expected_files),
@@ -343,7 +400,6 @@ def run_raw_grepped(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         )
         if result.returncode == 0:
             for line in result.stdout.strip().splitlines():
-                # Strip leading ./ from grep output
                 path = line.lstrip("./")
                 if path and path not in matched_files_seen:
                     matched_files_seen.add(path)
@@ -361,6 +417,17 @@ def run_raw_grepped(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     completion_tokens, completion_files = compute_bundle_completion_penalty(
         repo_path, matched_files_seen, task.expected_files
     )
+    required_metrics = compute_required_file_metrics(
+        matched_files_seen,
+        task.expected_files,
+    )
+    (
+        required_file_recall,
+        missed_required_file_rate,
+        all_required_files_present,
+        present,
+        missing,
+    ) = required_metrics
     tokens_with_completion = tokens + completion_tokens
 
     return BenchmarkResult(
@@ -371,6 +438,13 @@ def run_raw_grepped(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         tokens_output=tokens,
         token_efficiency=compute_token_efficiency(tokens, tokens),
         result_files=_deduplicate_ranked(matched_files_ordered),
+        required_file_recall=required_file_recall,
+        missed_required_file_rate=missed_required_file_rate,
+        all_required_files_present=all_required_files_present,
+        required_files_present=present,
+        required_files_missing=missing,
+        post_bundle_read_turns=len(missing),
+        task_completion_result=completion_result_from_missing(missing),
         bundle_completion_tokens=completion_tokens,
         bundle_completion_files=completion_files,
         token_efficiency_with_completion=compute_token_efficiency(
@@ -385,7 +459,7 @@ def run_raw_grepped(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         mrr=mrr_val,
         ndcg=ndcg_val,
         map_score=map_val,
-        savings_vs_raw=0.0,  # backfilled by runner
+        savings_vs_raw=0.0,
         wall_time_ms=wall_ms,
         cached=False,
         timestamp=now_iso(),
@@ -762,10 +836,11 @@ def _freshness_target(task: BenchmarkTask, repo_path: Path) -> Path | None:
         candidate = repo_path / expected
         if candidate.is_file():
             return candidate
-    for candidate in repo_path.rglob("*"):
-        if candidate.is_file() and candidate.suffix.lower() in {".py", ".js", ".ts", ".go", ".rs"}:
-            return candidate
     return None
+
+
+
+
 
 
 def measure_archex_freshness(task: BenchmarkTask, repo_path: Path) -> tuple[float, bool]:
@@ -813,7 +888,7 @@ def _run_query_strategy(
     strategy: Strategy,
     index_config: IndexConfig,
     cache: bool,
-    include_completion: bool = False,
+    include_completion: bool = True,
     measure_freshness: bool = False,
 ) -> BenchmarkResult:
     from archex.api import query
@@ -847,6 +922,17 @@ def _run_query_strategy(
     )
     recall = compute_recall(result_files, task.expected_files)
     precision = compute_precision(result_files, task.expected_files)
+    required_metrics = compute_required_file_metrics(
+        result_files,
+        task.expected_files,
+    )
+    (
+        required_file_recall,
+        missed_required_file_rate,
+        all_required_files_present,
+        present,
+        missing,
+    ) = required_metrics
     af = _archex_fields(bundle, task, repo_path)
     result_fields: dict[str, Any] = {
         "task_id": task.task_id,
@@ -885,6 +971,16 @@ def _run_query_strategy(
         "expansion_zero_candidate_reason": af.expansion_zero_candidate_reason,
         "expansion_reason_counts": af.expansion_reason_counts,
         "expanded_file_reasons": af.expanded_file_reasons,
+        "result_files": unique_ranked,
+        "required_file_recall": required_file_recall,
+        "missed_required_file_rate": missed_required_file_rate,
+        "all_required_files_present": all_required_files_present,
+        "required_files_present": present,
+        "required_files_missing": missing,
+        "receipt_accuracy": compute_receipt_accuracy(
+            bundle,
+            all_required_files_present=all_required_files_present,
+        ),
         "chunker": af.chunker,
         "index_chunk_count": af.index_chunk_count,
         "mean_chunk_tokens": af.mean_chunk_tokens,
@@ -899,7 +995,8 @@ def _run_query_strategy(
         )
         result_fields.update(
             {
-                "result_files": unique_ranked,
+                "post_bundle_read_turns": len(completion_files),
+                "task_completion_result": completion_result_from_missing(completion_files),
                 "bundle_completion_tokens": completion_tokens,
                 "bundle_completion_files": completion_files,
                 "token_efficiency_with_completion": compute_token_efficiency(
@@ -996,6 +1093,17 @@ def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
     wall_ms = (time.perf_counter() - t0) * 1000
     recall = compute_recall(result_files, task.expected_files)
     precision = compute_precision(result_files, task.expected_files)
+    required_metrics = compute_required_file_metrics(
+        result_files,
+        task.expected_files,
+    )
+    (
+        required_file_recall,
+        missed_required_file_rate,
+        all_required_files_present,
+        present,
+        missing,
+    ) = required_metrics
     f1 = compute_f1(recall, precision)
     mrr_val = compute_mrr(ranked_files, task.expected_files)
     ndcg_val = compute_ndcg(ranked_files, task.expected_files)
@@ -1034,6 +1142,17 @@ def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
         tokens_output=tokens_total,
         token_efficiency=compute_token_efficiency(tokens_total, tokens_input),
         result_files=unique_ranked,
+        required_file_recall=required_file_recall,
+        missed_required_file_rate=missed_required_file_rate,
+        all_required_files_present=all_required_files_present,
+        required_files_present=present,
+        required_files_missing=missing,
+        post_bundle_read_turns=len(completion_files),
+        task_completion_result=completion_result_from_missing(completion_files),
+        receipt_accuracy=compute_receipt_accuracy(
+            bundle,
+            all_required_files_present=all_required_files_present,
+        ),
         bundle_completion_tokens=completion_tokens,
         bundle_completion_files=completion_files,
         token_efficiency_with_completion=compute_token_efficiency(

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -317,6 +317,7 @@ def compute_receipt_accuracy(
 def completion_result_from_missing(missing_files: list[str]) -> TaskCompletionResult:
     return TaskCompletionResult.PASS if not missing_files else TaskCompletionResult.FAIL
 
+
 def run_raw_files(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Baseline strategy: read all expected files, count tokens."""
     t0 = time.perf_counter()
@@ -837,10 +838,6 @@ def _freshness_target(task: BenchmarkTask, repo_path: Path) -> Path | None:
         if candidate.is_file():
             return candidate
     return None
-
-
-
-
 
 
 def measure_archex_freshness(task: BenchmarkTask, repo_path: Path) -> tuple[float, bool]:

--- a/tests/benchmark/test_reporter.py
+++ b/tests/benchmark/test_reporter.py
@@ -77,11 +77,10 @@ class TestFormatMarkdown:
     def test_contains_table_header(self) -> None:
         md = format_markdown(_make_report())
         assert "| Strategy |" in md
-        assert "Tokens In" in md
-        assert "Tokens Out" in md
-        assert "Efficiency" in md
-        assert "nDCG" in md
-        assert "MAP" in md
+        assert "Required Recall" in md
+        assert "Missed Task Rate" in md
+        assert "Completion" in md
+        assert "Receipt Accuracy" in md
 
     def test_contains_strategy_rows(self) -> None:
         md = format_markdown(_make_report())
@@ -124,8 +123,8 @@ class TestFormatSummary:
         assert "raw_files" in summary
         assert "archex_query" in summary
         assert "Avg Efficiency" in summary
-        assert "Avg nDCG" in summary
-        assert "Avg MAP" in summary
+        assert "Avg Required Recall" in summary
+        assert "Missed Task Rate" in summary
 
     def test_multi_report_aggregation(self) -> None:
         r1 = _make_report(
@@ -156,8 +155,21 @@ class TestFormatStrategyComparison:
         assert "raw_files" in result
         assert "archex_query" in result
         assert "Tokens Total" in result
-        assert "Token Efficiency" in result
-        assert "Savings vs Raw" in result
+        assert "Required Recall" in result
+        assert "Receipt Accuracy" in result
+
+    def test_includes_missing_required_file_appendix(self) -> None:
+        report = _make_report(
+            [
+                _make_result(Strategy.ARCHEX_QUERY),
+                _make_result(Strategy.ARCHEX_SCOUT_FETCH),
+            ]
+        )
+        report.results[0].required_files_missing = ["missing.py"]
+        report.results[0].missed_required_file_rate = 1.0
+        result = format_strategy_comparison([report])
+        assert "Missing required files appendix" in result
+        assert "missing.py" in result
 
     def test_contains_head_to_head(self) -> None:
         report = _make_report()

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -13,12 +13,14 @@ from archex.benchmark.strategies import (
     _deduplicate_ranked,  # pyright: ignore[reportPrivateUsage]
     benchmark_index_config,
     benchmark_repo_source,
+    completion_result_from_missing,
     compute_bundle_completion_penalty,
     compute_map,
     compute_mrr,
     compute_ndcg,
     compute_precision,
     compute_recall,
+    compute_required_file_metrics,
     compute_symbol_recall,
     compute_token_efficiency,
     count_file_tokens,
@@ -228,6 +230,24 @@ class TestBundleCompletionPenalty:
 
         assert tokens == count_file_tokens(tmp_path, ["missing.py"])
         assert files == ["missing.py"]
+
+
+class TestRequiredFileMetrics:
+    def test_metrics_capture_missing_required_files(self) -> None:
+        recall, missed_rate, all_present, present, missing = compute_required_file_metrics(
+            {"a.py"},
+            ["a.py", "b.py"],
+        )
+
+        assert recall == 0.5
+        assert missed_rate == 1.0
+        assert all_present is False
+        assert present == ["a.py"]
+        assert missing == ["b.py"]
+
+    def test_completion_result_from_missing_files(self) -> None:
+        assert completion_result_from_missing([]).value == "pass"
+        assert completion_result_from_missing(["b.py"]).value == "fail"
 
 
 class TestExtractKeywords:
@@ -451,6 +471,9 @@ class TestRunArchexQuery:
         assert result.tokens_input >= 0
         assert result.tokens_output >= 0
         assert result.tokens_raw_baseline >= 0
+        assert result.required_file_recall == 1.0
+        assert result.all_required_files_present is True
+        assert result.task_completion_result.value == "pass"
 
     def test_archex_query_reports_configured_chunker_metadata(
         self,
@@ -577,6 +600,8 @@ class TestRunArchexQuery:
         assert result.tool_calls == 2
         assert result.result_files == ["main.py"]
         assert result.provenance["scout_token_budget"] == "1000"
+        assert result.required_file_recall == 1.0
+        assert result.task_completion_result.value == "pass"
         assert result.provenance["fetch_mode"] == "chunk_first"
         assert result.provenance["missing_from_scout_map"] == "none"
         assert result.provenance["projected_coverage"] == "0.000"


### PR DESCRIPTION
## Stack

Stack-Id: `context-trust-benchmark-proof`
Base: `main`
Position: 4/6

1. `feat/context-receipt-model` -> #244
2. `feat/context-receipt-construction` -> #245
3. `feat/context-receipt-surfaces` -> #246
4. `feat/benchmark-required-file-metrics` -> this PR (#247)
5. `feat/client-compatibility-paths` -> #248
6. `feat/readme-trust-messaging` -> #249

Depends on: #246
Upstack: #248

## Validation

- `uv run ruff check src/archex/benchmark/models.py src/archex/benchmark/strategies.py src/archex/benchmark/external_mcp.py src/archex/benchmark/runner.py src/archex/benchmark/reporter.py tests/benchmark/test_models.py tests/benchmark/test_reporter.py tests/benchmark/test_strategies.py tests/benchmark/test_external_mcp.py tests/benchmark/test_runner.py`
- `uv run pyright src/archex/benchmark/models.py src/archex/benchmark/strategies.py src/archex/benchmark/external_mcp.py src/archex/benchmark/runner.py src/archex/benchmark/reporter.py tests/benchmark/test_models.py tests/benchmark/test_reporter.py tests/benchmark/test_strategies.py tests/benchmark/test_external_mcp.py tests/benchmark/test_runner.py`
- `uv run pytest tests/benchmark/test_models.py tests/benchmark/test_reporter.py tests/benchmark/test_strategies.py tests/benchmark/test_external_mcp.py tests/benchmark/test_runner.py -q --no-cov`
- Review: no blocking findings
