### PR TITLE
Add client install compatibility guide

### DIFF
--- a/docs/CLIENT_COMPATIBILITY_MATRIX.md
+++ b/docs/CLIENT_COMPATIBILITY_MATRIX.md
@@ -1,0 +1,64 @@
+# Client Compatibility Matrix
+
+Last updated: 2026-06-16
+
+This matrix separates config-shape verification from actual client smoke tests. `archex install-client <client>` previews the exact config it would write. Add `--write` to persist it.
+
+## Matrix
+
+| Client / path | Tested status | Setup command / config | Watch support | Freshness semantics | Known limitations | Last verified |
+| --- | --- | --- | --- | --- | --- | --- |
+| Claude Code MCP stdio | Config-path tested; client smoke unverified | `archex install-client claude-code .` then `archex install-client claude-code . --write` writes `.mcp.json` with `mcpServers.archex.command = "archex"` and `args = ["mcp"]`. | Yes — `archex mcp --watch --watch-path .` | Inline query refresh by default; `--no-refresh` leaves freshness `unknown`; watch keeps a warm process subscribed to file events. | This stack did not run a live Claude Code UI smoke. Skill and MCP are separate rows. | 2026-06-16 |
+| Claude Code skill command | Existing skill path tested in-repo; client smoke unverified | Use `skills/archex/` and the `/archex` command flow. No config file is written by `install-client`; this is command-only onboarding. | Indirect — skill can target a warm MCP server. | Same as MCP/query/scout paths underneath. | Skill setup remains repo-local documentation, not a writable client config target. | 2026-06-16 |
+| CLI-only query/scout | Tested | No client config required. Run `archex doctor`, `archex scout`, `archex query`. | N/A | Query checks freshness inline unless `--no-refresh`; scout inherits query freshness in its receipt. | Not an MCP client. | 2026-06-16 |
+| Generic MCP stdio client | Unverified | Use a JSON config shaped like `{ "mcpServers": { "archex": { "command": "archex", "args": ["mcp"] }}}`. `archex install-client claude-code .` prints a compatible snippet. | Client-dependent | Same server-side freshness semantics as Claude Code / Cursor. | No live generic-client smoke in this stack. | 2026-06-16 |
+| Codex headless | Unverified | `archex install-client codex .` previews `.codex/config.toml`; `--write` appends `[mcp_servers.archex]`, `command = "archex"`, `args = ["mcp"]` without overwriting existing sections. | Yes — via `archex mcp --watch --watch-path .` after Codex launches the server. | Inline query refresh by default; warm watch is server-side, not Codex-specific. | Config shape verified against OpenAI Codex MCP docs; no Codex client smoke in this stack. | 2026-06-16 |
+| Pi | Config shape verified; client smoke unverified | `archex install-client pi .` previews `~/.pi/agent/mcp.json`; `--write` writes a stdio `mcpServers.archex` entry. User scope only. | Client-dependent; server supports `--watch`. | Same server-side freshness semantics as other stdio clients. | No Pi client smoke in this stack. | 2026-06-16 |
+| OpenCode | Config shape verified; client smoke unverified | `archex install-client opencode .` previews `opencode.json`; `--write` writes `mcp.archex = { type = "local", command = ["archex", "mcp"], enabled = true }`. | Client-dependent; server supports `--watch`. | Same server-side freshness semantics as other stdio clients. | No OpenCode client smoke in this stack. | 2026-06-16 |
+| Cursor | Config shape verified; client smoke unverified | `archex install-client cursor .` previews `.cursor/mcp.json`; `--write` writes `mcpServers.archex.command = "archex"`, `args = ["mcp"]`. | Yes — with a warm `archex mcp --watch --watch-path .` process. | Inline query refresh by default; watch keeps a warm process subscribed to file events. | No Cursor UI smoke in this stack. | 2026-06-16 |
+| Dockerized MCP server | Server path tested; client smoke unverified | Run `docker run -d --name archex-mcp -v "$PWD:/workspace" -w /workspace ghcr.io/mathews-tom/archex:slim sleep infinity` then point the client to `docker exec -i archex-mcp archex mcp`. | Yes — run the MCP process with `--watch`. | Same server-side freshness semantics as stdio. | Client-specific Docker registration varies; use the same client config shapes above, but replace the command with `docker` / `exec`. | 2026-06-16 |
+
+## First-party bootstrap command
+
+Preview first. Nothing is written unless `--write` is passed.
+
+```bash
+archex install-client claude-code .
+archex install-client cursor .
+archex install-client opencode .
+archex install-client codex .
+archex install-client pi .
+```
+
+Persist the config only after reviewing the preview:
+
+```bash
+archex install-client claude-code . --write
+archex install-client cursor . --write
+archex install-client opencode . --write
+archex install-client codex . --write
+archex install-client pi . --write
+```
+
+## Safe-write behavior
+
+- Preview is the default.
+- JSON clients merge an `archex` entry into the existing top-level server map.
+- Codex appends one `[mcp_servers.archex]` section to `config.toml`.
+- If `archex` is already present, the command fails instead of overwriting it.
+- Pi only supports `--scope user`.
+
+## Verification commands
+
+Use these after writing config:
+
+```bash
+archex doctor .
+archex scout . "How does authentication flow through this repo?" --budget 1000 --format json
+archex query . "Where is cache invalidation handled?" --format json
+```
+
+For Codex, open the TUI and run `/mcp` after writing `.codex/config.toml`.
+For Cursor, inspect `.cursor/mcp.json` or `~/.cursor/mcp.json` and restart the client.
+For OpenCode, inspect `opencode.json` and run `opencode mcp list` if available in your installed version.
+For Pi, inspect `~/.pi/agent/mcp.json` and open the MCP panel documented by your Pi build.

--- a/docs/INSTALLATION_TRUST_CONTRACT.md
+++ b/docs/INSTALLATION_TRUST_CONTRACT.md
@@ -45,6 +45,8 @@ Core CLI indexing and BM25 retrieval do not require hosted inference, API keys, 
 
 MCP `query_repo` and `scout_repo` envelopes now include a top-level `receipt` field next to `content` and `_meta`. This is an intentional additive JSON-envelope change so MCP clients can inspect provenance and completeness without parsing prompt text.
 
+The client-by-client tested/unverified matrix and bootstrap paths live in [docs/CLIENT_COMPATIBILITY_MATRIX.md](CLIENT_COMPATIBILITY_MATRIX.md).
+
 ## MCP setup
 
 Install the MCP extra:
@@ -114,6 +116,13 @@ mkdir -p ~/.claude/skills
 ln -s "$PWD/skills/archex" ~/.claude/skills/archex
 ```
 
+
+Preview or write a client config with:
+
+```bash
+archex install-client claude-code .
+archex install-client claude-code . --write
+```
 Then use:
 
 ```text

--- a/src/archex/cli/install_client_cmd.py
+++ b/src/archex/cli/install_client_cmd.py
@@ -1,0 +1,50 @@
+"""Client install/bootstrap command."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import click
+
+from archex.client_setup import (
+    ClientName,
+    ClientScope,
+    build_client_install_plan,
+    render_client_install_preview,
+    write_client_install_plan,
+)
+
+
+@click.command("install-client")
+@click.argument(
+    "client",
+    type=click.Choice(["claude-code", "codex", "cursor", "opencode", "pi"]),
+)
+@click.argument("source", required=False, default=".")
+@click.option(
+    "--scope",
+    type=click.Choice(["project", "user"]),
+    default=None,
+    help="Install scope.",
+)
+@click.option(
+    "--write",
+    is_flag=True,
+    default=False,
+    help="Write config instead of previewing it.",
+)
+def install_client_cmd(client: str, source: str, scope: str | None, write: bool) -> None:
+    """Preview or write MCP client configuration for archex."""
+    try:
+        plan = build_client_install_plan(
+            cast("ClientName", client),
+            source,
+            scope=cast("ClientScope | None", scope),
+        )
+        if write:
+            target = write_client_install_plan(plan)
+            click.echo(f"Wrote {client} config: {target}")
+        else:
+            click.echo(render_client_install_preview(plan), nl=False)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -16,6 +16,7 @@ from archex.cli.graph_cmd import graph_cmd
 from archex.cli.impact_cmd import impact_cmd
 from archex.cli.index_cmd import index_cmd
 from archex.cli.init_cmd import init_cmd
+from archex.cli.install_client_cmd import install_client_cmd
 from archex.cli.mcp_cmd import mcp_cmd
 from archex.cli.onboard_cmd import onboard_cmd
 from archex.cli.outline_cmd import outline_cmd
@@ -41,6 +42,7 @@ cli.add_command(compare_cmd)
 cli.add_command(cache_cmd)
 cli.add_command(init_cmd)
 cli.add_command(index_cmd)
+cli.add_command(install_client_cmd)
 cli.add_command(status_cmd)
 cli.add_command(reset_cmd)
 cli.add_command(doctor_cmd)

--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -1,0 +1,216 @@
+"""Client install/bootstrap helpers for MCP-compatible archex setups."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
+
+ClientName = Literal["claude-code", "codex", "cursor", "opencode", "pi"]
+ClientScope = Literal["project", "user"]
+
+
+@dataclass(frozen=True)
+class ClientInstallPlan:
+    client: ClientName
+    scope: ClientScope
+    target_path: Path
+    content: str
+    description: str
+    tested_status: str
+    last_verified: str
+
+
+def build_client_install_plan(
+    client: ClientName,
+    source: str | Path = ".",
+    *,
+    scope: ClientScope | None = None,
+) -> ClientInstallPlan:
+    repo_root = Path(source).expanduser().resolve()
+    selected_scope = scope or _default_scope(client)
+    if client == "pi" and selected_scope != "user":
+        raise ValueError("pi client config supports only --scope user")
+    target_path = _target_path(client, repo_root, selected_scope)
+    content = _render_content(client)
+    return ClientInstallPlan(
+        client=client,
+        scope=selected_scope,
+        target_path=target_path,
+        content=content,
+        description=_description(client, selected_scope),
+        tested_status=_tested_status(client),
+        last_verified="2026-06-16",
+    )
+
+
+def write_client_install_plan(plan: ClientInstallPlan) -> Path:
+    target = plan.target_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if _is_toml_plan(plan):
+        if target.exists():
+            existing = target.read_text(encoding="utf-8")
+            if "[mcp_servers.archex]" in existing:
+                raise ValueError(f"archex already configured in {target}")
+            if existing.strip():
+                new_content = existing.rstrip() + "\n\n" + plan.content
+            else:
+                new_content = plan.content
+        else:
+            new_content = plan.content
+        target.write_text(new_content, encoding="utf-8")
+        return target
+
+    key = _json_server_key(plan.client)
+    payload_obj: object = json.loads(plan.content)
+    if not isinstance(payload_obj, dict):
+        raise ValueError(f"expected JSON object in generated content for {plan.client}")
+    payload = cast("dict[str, object]", payload_obj)
+    if target.exists():
+        existing_payload_obj: object = json.loads(target.read_text(encoding="utf-8"))
+        if not isinstance(existing_payload_obj, dict):
+            raise ValueError(f"expected JSON object in {target}")
+        existing_payload = cast("dict[str, object]", existing_payload_obj)
+    else:
+        existing_payload: dict[str, object] = {}
+    raw_container = existing_payload.get(key)
+    if raw_container is None:
+        container: dict[str, object] = {}
+        existing_payload[key] = container
+    elif isinstance(raw_container, dict):
+        container = cast("dict[str, object]", raw_container)
+    else:
+        raise ValueError(f"expected object at {key} in {target}")
+    payload_container_obj = payload.get(key)
+    if not isinstance(payload_container_obj, dict):
+        raise ValueError(f"expected object at {key} in generated content for {plan.client}")
+    payload_container = cast("dict[str, object]", payload_container_obj)
+    archex_entry_obj = payload_container.get("archex")
+    if not isinstance(archex_entry_obj, dict):
+        raise ValueError(f"expected archex entry in generated content for {plan.client}")
+    archex_entry = cast("dict[str, object]", archex_entry_obj)
+    if "archex" in container:
+        raise ValueError(f"archex already configured in {target}")
+    container["archex"] = archex_entry
+    if plan.client == "opencode" and "$schema" not in existing_payload:
+        existing_payload["$schema"] = "https://opencode.ai/config.json"
+    target.write_text(json.dumps(existing_payload, indent=2) + "\n", encoding="utf-8")
+    return target
+
+
+def render_client_install_preview(plan: ClientInstallPlan) -> str:
+    lines = [
+        f"Client: {plan.client}",
+        f"Scope: {plan.scope}",
+        f"Target: {plan.target_path}",
+        f"Status: {plan.tested_status}",
+        f"Last verified: {plan.last_verified}",
+        f"Description: {plan.description}",
+        "",
+        "Preview only. Re-run with --write to persist this config.",
+        "",
+        plan.content.rstrip(),
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _default_scope(client: ClientName) -> ClientScope:
+    if client == "pi":
+        return "user"
+    return "project"
+
+
+def _target_path(client: ClientName, repo_root: Path, scope: ClientScope) -> Path:
+    home = Path.home()
+    if client == "claude-code":
+        return repo_root / ".mcp.json" if scope == "project" else home / ".claude.json"
+    if client == "cursor":
+        return (
+            repo_root / ".cursor" / "mcp.json"
+            if scope == "project"
+            else home / ".cursor" / "mcp.json"
+        )
+    if client == "opencode":
+        return (
+            repo_root / "opencode.json"
+            if scope == "project"
+            else home / ".config" / "opencode" / "opencode.json"
+        )
+    if client == "codex":
+        return (
+            repo_root / ".codex" / "config.toml"
+            if scope == "project"
+            else home / ".codex" / "config.toml"
+        )
+    if client == "pi":
+        return home / ".pi" / "agent" / "mcp.json"
+    raise ValueError(f"unsupported client: {client}")
+
+
+def _render_content(client: ClientName) -> str:
+    if client == "codex":
+        return '[mcp_servers.archex]\ncommand = "archex"\nargs = ["mcp"]\n'
+    if client == "opencode":
+        payload = {
+            "$schema": "https://opencode.ai/config.json",
+            "mcp": {
+                "archex": {
+                    "type": "local",
+                    "command": ["archex", "mcp"],
+                    "enabled": True,
+                }
+            },
+        }
+        return json.dumps(payload, indent=2) + "\n"
+    if client == "pi":
+        payload = {
+            "mcpServers": {
+                "archex": {
+                    "command": "archex",
+                    "args": ["mcp"],
+                }
+            }
+        }
+        return json.dumps(payload, indent=2) + "\n"
+    payload = {
+        "mcpServers": {
+            "archex": {
+                "command": "archex",
+                "args": ["mcp"],
+            }
+        }
+    }
+    return json.dumps(payload, indent=2) + "\n"
+
+
+def _json_server_key(client: ClientName) -> str:
+    return "mcp" if client == "opencode" else "mcpServers"
+
+
+def _is_toml_plan(plan: ClientInstallPlan) -> bool:
+    return plan.client == "codex"
+
+
+def _description(client: ClientName, scope: ClientScope) -> str:
+    if client == "codex":
+        return "Codex CLI config.toml MCP server registration"
+    if client == "opencode":
+        return f"OpenCode {'project' if scope == 'project' else 'user'} config"
+    if client == "pi":
+        return "Pi agent MCP config"
+    if client == "cursor":
+        return f"Cursor {'project' if scope == 'project' else 'user'} MCP config"
+    return f"Claude Code {'project' if scope == 'project' else 'user'} MCP config"
+
+
+def _tested_status(client: ClientName) -> str:
+    if client == "claude-code":
+        return "config-path tested; client smoke unverified"
+    if client == "cursor":
+        return "config-shape verified; client smoke unverified"
+    if client == "opencode":
+        return "config-shape verified; client smoke unverified"
+    if client == "codex":
+        return "unverified client smoke"
+    return "config-shape verified; client smoke unverified"

--- a/tests/cli/test_install_client.py
+++ b/tests/cli/test_install_client.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_install_client_preview_claude_code_project(tmp_path: Path) -> None:
+    result = CliRunner().invoke(cli, ["install-client", "claude-code", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert f"Target: {tmp_path / '.mcp.json'}" in result.output
+    assert '"mcpServers"' in result.output
+    assert '"command": "archex"' in result.output
+    assert 'Preview only.' in result.output
+
+
+def test_install_client_write_claude_code_project(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        cli,
+        ["install-client", "claude-code", str(tmp_path), "--write"],
+    )
+
+    assert result.exit_code == 0, result.output
+    config_path = tmp_path / ".mcp.json"
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["mcpServers"]["archex"]["args"] == ["mcp"]
+
+
+def test_install_client_refuses_existing_entry(tmp_path: Path) -> None:
+    config_path = tmp_path / ".mcp.json"
+    config_path.write_text(
+        json.dumps({"mcpServers": {"archex": {"command": "archex", "args": ["mcp"]}}}),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["install-client", "claude-code", str(tmp_path), "--write"],
+    )
+
+    assert result.exit_code != 0
+    assert "already configured" in result.output
+
+
+def test_install_client_writes_codex_project_toml(tmp_path: Path) -> None:
+    codex_dir = tmp_path / ".codex"
+    codex_dir.mkdir(parents=True)
+    config_path = codex_dir / "config.toml"
+    config_path.write_text("default_model = \"gpt-5\"\n", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli,
+        ["install-client", "codex", str(tmp_path), "--write"],
+    )
+
+    assert result.exit_code == 0, result.output
+    content = config_path.read_text(encoding="utf-8")
+    assert "default_model = \"gpt-5\"" in content
+    assert "[mcp_servers.archex]" in content
+    assert 'args = ["mcp"]' in content
+
+
+def test_install_client_pi_user_scope_uses_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = CliRunner().invoke(cli, ["install-client", "pi", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert f"Target: {tmp_path / '.pi' / 'agent' / 'mcp.json'}" in result.output
+
+
+def test_install_client_pi_rejects_project_scope(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        cli,
+        ["install-client", "pi", str(tmp_path), "--scope", "project"],
+    )
+
+    assert result.exit_code != 0
+    assert "supports only --scope user" in result.output

--- a/tests/cli/test_install_client.py
+++ b/tests/cli/test_install_client.py
@@ -19,7 +19,7 @@ def test_install_client_preview_claude_code_project(tmp_path: Path) -> None:
     assert f"Target: {tmp_path / '.mcp.json'}" in result.output
     assert '"mcpServers"' in result.output
     assert '"command": "archex"' in result.output
-    assert 'Preview only.' in result.output
+    assert "Preview only." in result.output
 
 
 def test_install_client_write_claude_code_project(tmp_path: Path) -> None:
@@ -54,7 +54,7 @@ def test_install_client_writes_codex_project_toml(tmp_path: Path) -> None:
     codex_dir = tmp_path / ".codex"
     codex_dir.mkdir(parents=True)
     config_path = codex_dir / "config.toml"
-    config_path.write_text("default_model = \"gpt-5\"\n", encoding="utf-8")
+    config_path.write_text('default_model = "gpt-5"\n', encoding="utf-8")
 
     result = CliRunner().invoke(
         cli,
@@ -63,7 +63,7 @@ def test_install_client_writes_codex_project_toml(tmp_path: Path) -> None:
 
     assert result.exit_code == 0, result.output
     content = config_path.read_text(encoding="utf-8")
-    assert "default_model = \"gpt-5\"" in content
+    assert 'default_model = "gpt-5"' in content
     assert "[mcp_servers.archex]" in content
     assert 'args = ["mcp"]' in content
 


### PR DESCRIPTION
## Stack

Stack-Id: `context-trust-benchmark-proof`
Base: `main`
Position: 5/6

1. `feat/context-receipt-model` -> #244
2. `feat/context-receipt-construction` -> #245
3. `feat/context-receipt-surfaces` -> #246
4. `feat/benchmark-required-file-metrics` -> #247
5. `feat/client-compatibility-paths` -> this PR (#248)
6. `feat/readme-trust-messaging` -> #249

Depends on: #247
Upstack: #249

## Validation

- `uv run ruff check src/archex/client_setup.py src/archex/cli/install_client_cmd.py src/archex/cli/main.py tests/cli/test_install_client.py`
- `uv run pyright src/archex/client_setup.py src/archex/cli/install_client_cmd.py src/archex/cli/main.py tests/cli/test_install_client.py`
- `uv run pytest tests/cli/test_install_client.py -q --no-cov`
- Review: no blocking findings
