### PR TITLE
Remove build-time FastEmbed prewarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Two local-first images are built in CI:
 # BM25-only, no torch
 docker run --rm -v "$PWD:/workspace" -w /workspace ghcr.io/mathews-tom/archex:slim archex doctor
 
-# Full local-embedding image with FastEmbed prewarmed
+# Full local-embedding image with FastEmbed runtime
 docker run --rm -v "$PWD:/workspace" -w /workspace ghcr.io/mathews-tom/archex:full archex query "Where is cache invalidation handled?" --strategy hybrid
 ```
 

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -19,7 +19,6 @@ COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src ./src
 
 RUN uv sync --frozen --no-dev --no-editable --extra mcp --extra vector-fast
-RUN uv run python -c "from fastembed import TextEmbedding; next(TextEmbedding(model_name='BAAI/bge-small-en-v1.5').embed(['archex warmup']))"
 
 ENV PATH="/app/.venv/bin:$PATH"
 WORKDIR /workspace

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -956,7 +956,7 @@ Build evaluation datasets and assertions using Attest's graduated assertion pipe
 - `archex doctor` with text/JSON checks for index health, staleness, local model cache presence, grammar availability by tier, MCP registration, and `.archex/` disk usage
 - `skills/archex/SKILL.md` plus `/archex` command asset teaching doctor-first, scout→fetch usage
 - `docker/Dockerfile.slim` for BM25-only/no-torch onboarding
-- `docker/Dockerfile.full` for local FastEmbed with prewarmed model cache
+- `docker/Dockerfile.full` for local FastEmbed without build-time model prewarm
 - `.github/workflows/docker.yml` building both images and publishing GHCR tags on pushes to `main`
 - `docs/ARCHEX_VS_COCOINDEX.md` with C1-backed measured-results and capability tables
 - README Docker usage and comparison summary pointer

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -198,7 +198,7 @@ archex/
 - **CLI:** repo-local workflows run through `archex init/index/status/doctor/query/scout/...`.
 - **MCP server:** `archex mcp` wraps the stdio server implemented in `integrations/mcp.py`.
 - **Claude Code skill:** `skills/archex/` codifies the doctor-first, scout→fetch workflow for agents.
-- **Containers:** `docker/Dockerfile.slim` ships BM25-only onboarding; `docker/Dockerfile.full` ships local FastEmbed with a prewarmed cache.
+- **Containers:** `docker/Dockerfile.slim` ships BM25-only onboarding; `docker/Dockerfile.full` ships local FastEmbed without requiring a build-time model download.
 
 ### 1.2.2 Repo-Local Trust and Freshness
 


### PR DESCRIPTION
## Stack

Stack-Id: `context-trust-benchmark-proof`
Base: `main`
Position: 0/7

0. `fix/docker-full-build` -> this PR
1. `feat/context-receipt-model` -> #244
2. `feat/context-receipt-construction` -> #245
3. `feat/context-receipt-surfaces` -> #246
4. `feat/benchmark-required-file-metrics` -> #247
5. `feat/client-compatibility-paths` -> #248
6. `feat/readme-trust-messaging` -> #249
7. `feat/brand-assets` -> #250

Depends on: none
Upstack: #244

## Summary

- remove the build-time FastEmbed model warmup from `docker/Dockerfile.full`
- keep the full image local-FastEmbed capable without requiring a model download during CI image build
- update docs that incorrectly claimed the full image shipped with a prewarmed model cache

## Validation

- `docker build -f docker/Dockerfile.full .`
