### PR TITLE
Fix PyPI badge cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 archex turns a repository into a ranked, token-budgeted context bundle plus a context receipt with freshness, index revision, skipped candidates, omitted dependency edges, and a recommended next action. It runs locally, uses deterministic retrieval and analysis, and does not require hosted inference or an API key.
 
 [![CI](https://github.com/Mathews-Tom/archex/actions/workflows/ci.yml/badge.svg)](https://github.com/Mathews-Tom/archex/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/archex)](https://pypi.org/project/archex/)
+[![PyPI](https://img.shields.io/pypi/v/archex?cacheSeconds=300)](https://pypi.org/project/archex/)
 [![Python](https://img.shields.io/pypi/pyversions/archex)](https://pypi.org/project/archex/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -343,4 +343,4 @@ Apache 2.0 — see [LICENSE](LICENSE).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/chart?repos=Mathews-Tom/archex&type=date&legend=top-left)](https://www.star-history.com/?repos=Mathews-Tom%2Farchex&type=date&legend=top-left)
+[![Star History Chart](https://api.star-history.com/chart?repos=Mathews-Tom/archex&type=date&legend=top-left&cache=v0.11.0)](https://www.star-history.com/?repos=Mathews-Tom%2Farchex&type=date&legend=top-left)


### PR DESCRIPTION
## Summary
- Add a short Shields cache window to the PyPI version badge so GitHub refreshes after the v0.11.0 release.
- Add a v0.11.0 cache key to the Star History image URL so GitHub's image proxy fetches a fresh chart URL.

## Validation
- Fetched the PyPI badge URL and verified it renders `pypi: v0.11.0`.
- Fetched the Star History chart URL with the new cache key and verified the service returns an SVG response.
- Checked GitHub API: `Mathews-Tom/archex` currently reports 32 stars.
