### PR TITLE
Add metrics policy and repo registry

### DIFF
--- a/src/archex/metrics/__init__.py
+++ b/src/archex/metrics/__init__.py
@@ -2,6 +2,18 @@
 
 from __future__ import annotations
 
+from archex.metrics.math import TokenSavings, compute_token_savings
+from archex.metrics.policy import MetricsPolicy, resolve_metrics_policy
+from archex.metrics.registry import RegisteredRepo, RepoRegistry
 from archex.metrics.storage import MetricsStore, metrics_db_path
 
-__all__ = ["MetricsStore", "metrics_db_path"]
+__all__ = [
+    "MetricsPolicy",
+    "MetricsStore",
+    "RegisteredRepo",
+    "RepoRegistry",
+    "TokenSavings",
+    "compute_token_savings",
+    "metrics_db_path",
+    "resolve_metrics_policy",
+]

--- a/src/archex/metrics/math.py
+++ b/src/archex/metrics/math.py
@@ -1,0 +1,52 @@
+"""Token savings calculations for local usage metrics."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+BASELINE_RETURNED_FULL_FILES = "returned_full_files"
+
+
+@dataclass(frozen=True)
+class TokenSavings:
+    tokens_returned: int
+    tokens_raw_equivalent: int
+    tokens_saved: int
+    savings_pct: float
+    whole_repo_tokens: int | None = None
+    whole_repo_tokens_avoided: int | None = None
+    baseline_type: str = BASELINE_RETURNED_FULL_FILES
+
+
+def compute_token_savings(
+    *,
+    tokens_returned: int,
+    tokens_raw_equivalent: int,
+    whole_repo_tokens: int | None = None,
+) -> TokenSavings:
+    """Compute conservative returned-full-files savings and context upper bound."""
+    _validate_non_negative("tokens_returned", tokens_returned)
+    _validate_non_negative("tokens_raw_equivalent", tokens_raw_equivalent)
+    if whole_repo_tokens is not None:
+        _validate_non_negative("whole_repo_tokens", whole_repo_tokens)
+
+    tokens_saved = max(tokens_raw_equivalent - tokens_returned, 0)
+    savings_pct = (
+        (tokens_saved / tokens_raw_equivalent * 100.0) if tokens_raw_equivalent > 0 else 0.0
+    )
+    whole_repo_tokens_avoided = (
+        max(whole_repo_tokens - tokens_returned, 0) if whole_repo_tokens is not None else None
+    )
+    return TokenSavings(
+        tokens_returned=tokens_returned,
+        tokens_raw_equivalent=tokens_raw_equivalent,
+        tokens_saved=tokens_saved,
+        savings_pct=savings_pct,
+        whole_repo_tokens=whole_repo_tokens,
+        whole_repo_tokens_avoided=whole_repo_tokens_avoided,
+    )
+
+
+def _validate_non_negative(name: str, value: int) -> None:
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative, got {value}")

--- a/src/archex/metrics/policy.py
+++ b/src/archex/metrics/policy.py
@@ -1,0 +1,114 @@
+"""Policy resolution for local metrics recording and detailed traces."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from archex.metrics.storage import (
+    DEFAULT_RAW_EVENT_RETENTION_DAYS,
+    DEFAULT_TRACE_RETENTION_DAYS,
+    MetricsStore,
+)
+
+METRICS_ENV = "ARCHEX_USAGE_METRICS"
+TRACE_ENV = "ARCHEX_USAGE_TRACE"
+
+
+@dataclass(frozen=True)
+class MetricsPolicy:
+    metrics_enabled: bool
+    trace_enabled: bool
+    raw_event_retention_days: int
+    trace_retention_days: int
+    hosted_upload_enabled: bool = False
+
+
+def resolve_metrics_policy(
+    *,
+    db_path: Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> MetricsPolicy:
+    """Resolve persisted settings with environment variable overrides."""
+    values = _settings(db_path)
+    env_values = os.environ if env is None else env
+
+    metrics_enabled = _bool_setting(values.get("metrics_enabled"), default=True)
+    trace_enabled = _bool_setting(values.get("trace_enabled"), default=False)
+
+    if env_values.get(METRICS_ENV, "").casefold() == "off":
+        metrics_enabled = False
+    trace_override = env_values.get(TRACE_ENV, "").casefold()
+    if trace_override == "on":
+        trace_enabled = True
+    elif trace_override == "off":
+        trace_enabled = False
+
+    return MetricsPolicy(
+        metrics_enabled=metrics_enabled,
+        trace_enabled=trace_enabled,
+        raw_event_retention_days=_int_setting(
+            values.get("raw_event_retention_days"),
+            default=DEFAULT_RAW_EVENT_RETENTION_DAYS,
+        ),
+        trace_retention_days=_int_setting(
+            values.get("trace_retention_days"),
+            default=DEFAULT_TRACE_RETENTION_DAYS,
+        ),
+        hosted_upload_enabled=_bool_setting(values.get("hosted_upload_enabled"), default=False),
+    )
+
+
+def set_metrics_enabled(enabled: bool, *, db_path: Path | None = None) -> None:
+    _set_setting("metrics_enabled", _bool_value(enabled), db_path=db_path)
+
+
+def set_trace_enabled(enabled: bool, *, db_path: Path | None = None) -> None:
+    _set_setting("trace_enabled", _bool_value(enabled), db_path=db_path)
+
+
+def _settings(db_path: Path | None) -> dict[str, str]:
+    with MetricsStore(db_path).connect() as conn:
+        rows = conn.execute("SELECT key, value FROM settings")
+        return {str(row["key"]): str(row["value"]) for row in rows}
+
+
+def _set_setting(key: str, value: str, *, db_path: Path | None) -> None:
+    with MetricsStore(db_path).connect() as conn, conn:
+        conn.execute(
+            """
+            INSERT INTO settings(key, value, updated_at)
+            VALUES (?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(key) DO UPDATE SET
+                value = excluded.value,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (key, value),
+        )
+
+
+def _bool_setting(value: str | None, *, default: bool) -> bool:
+    if value is None or value == "":
+        return default
+    normalized = value.casefold()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _int_setting(value: str | None, *, default: int) -> int:
+    if value is None or value == "":
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        return default
+    return parsed if parsed >= 0 else default
+
+
+def _bool_value(value: bool) -> str:
+    return "true" if value else "false"

--- a/src/archex/metrics/registry.py
+++ b/src/archex/metrics/registry.py
@@ -1,0 +1,58 @@
+"""Local repository registry for anonymized metrics rows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+from archex.metrics.storage import MetricsStore
+
+
+@dataclass(frozen=True)
+class RegisteredRepo:
+    repo_id: str
+    repo_root: Path
+    display_name: str
+
+
+class RepoRegistry:
+    """Maps local repo roots to random machine-local UUIDs."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        self._store = MetricsStore(db_path)
+
+    def get_or_create(self, repo_root: str | Path) -> RegisteredRepo:
+        root = Path(repo_root).expanduser().resolve()
+        now = _utc_now()
+        with self._store.connect() as conn, conn:
+            existing = conn.execute(
+                "SELECT repo_id, repo_root, display_name FROM repos WHERE repo_root = ?",
+                (str(root),),
+            ).fetchone()
+            if existing is not None:
+                conn.execute(
+                    "UPDATE repos SET last_seen_at = ? WHERE repo_id = ?",
+                    (now, str(existing["repo_id"])),
+                )
+                return RegisteredRepo(
+                    repo_id=str(existing["repo_id"]),
+                    repo_root=Path(str(existing["repo_root"])),
+                    display_name=str(existing["display_name"]),
+                )
+
+            repo_id = str(uuid4())
+            display_name = root.name or str(root)
+            conn.execute(
+                """
+                INSERT INTO repos(repo_id, repo_root, display_name, first_seen_at, last_seen_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (repo_id, str(root), display_name, now, now),
+            )
+            return RegisteredRepo(repo_id=repo_id, repo_root=root, display_name=display_name)
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")

--- a/tests/metrics/test_policy.py
+++ b/tests/metrics/test_policy.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from archex.metrics.math import BASELINE_RETURNED_FULL_FILES, compute_token_savings
+from archex.metrics.policy import (
+    METRICS_ENV,
+    TRACE_ENV,
+    resolve_metrics_policy,
+    set_metrics_enabled,
+    set_trace_enabled,
+)
+from archex.metrics.registry import RepoRegistry
+from archex.metrics.storage import MetricsStore
+
+
+def test_policy_defaults_to_counters_enabled_trace_disabled(tmp_path: Path) -> None:
+    policy = resolve_metrics_policy(db_path=tmp_path / "usage.sqlite", env={})
+
+    assert policy.metrics_enabled is True
+    assert policy.trace_enabled is False
+    assert policy.raw_event_retention_days == 90
+    assert policy.trace_retention_days == 14
+    assert policy.hosted_upload_enabled is False
+
+
+def test_policy_env_disables_metrics_and_controls_trace(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite"
+    set_trace_enabled(True, db_path=db_path)
+    set_metrics_enabled(True, db_path=db_path)
+
+    disabled = resolve_metrics_policy(
+        db_path=db_path,
+        env={METRICS_ENV: "off", TRACE_ENV: "off"},
+    )
+    traced = resolve_metrics_policy(db_path=db_path, env={TRACE_ENV: "on"})
+
+    assert disabled.metrics_enabled is False
+    assert disabled.trace_enabled is False
+    assert traced.metrics_enabled is True
+    assert traced.trace_enabled is True
+
+
+@pytest.mark.parametrize(
+    ("returned", "raw", "repo_total", "saved", "pct", "whole_repo_avoided"),
+    [
+        (40, 100, 1000, 60, 60.0, 960),
+        (120, 100, 1000, 0, 0.0, 880),
+        (0, 0, None, 0, 0.0, None),
+        (1200, 100, 1000, 0, 0.0, 0),
+    ],
+)
+def test_token_savings_math_matches_design(
+    returned: int,
+    raw: int,
+    repo_total: int | None,
+    saved: int,
+    pct: float,
+    whole_repo_avoided: int | None,
+) -> None:
+    result = compute_token_savings(
+        tokens_returned=returned,
+        tokens_raw_equivalent=raw,
+        whole_repo_tokens=repo_total,
+    )
+
+    assert result.tokens_returned == returned
+    assert result.tokens_raw_equivalent == raw
+    assert result.tokens_saved == saved
+    assert result.savings_pct == pct
+    assert result.whole_repo_tokens == repo_total
+    assert result.whole_repo_tokens_avoided == whole_repo_avoided
+    assert result.baseline_type == BASELINE_RETURNED_FULL_FILES
+
+
+def test_token_savings_rejects_negative_inputs() -> None:
+    with pytest.raises(ValueError, match="tokens_returned must be non-negative"):
+        compute_token_savings(tokens_returned=-1, tokens_raw_equivalent=1)
+
+
+def test_repo_registry_uses_stable_random_local_uuid(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite"
+    repo_root = tmp_path / "workspace" / "secret-repo-name"
+    repo_root.mkdir(parents=True)
+    registry = RepoRegistry(db_path)
+
+    first = registry.get_or_create(repo_root)
+    second = registry.get_or_create(repo_root)
+
+    assert first == second
+    assert UUID(first.repo_id).version == 4
+    assert first.repo_root == repo_root.resolve()
+    assert first.display_name == "secret-repo-name"
+
+
+def test_repo_registry_keeps_paths_only_in_repos_mapping(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite"
+    repo_root = tmp_path / "org-name" / "repo-name"
+    repo_root.mkdir(parents=True)
+    registered = RepoRegistry(db_path).get_or_create(repo_root)
+
+    with MetricsStore(db_path).connect() as conn, conn:
+        conn.execute(
+            """
+            INSERT INTO usage_events(
+                event_id, occurred_at, repo_id, surface, tool_name, category,
+                tokens_returned, tokens_raw_equivalent, tokens_saved, savings_pct,
+                whole_repo_tokens, whole_repo_tokens_avoided, baseline_type, file_count,
+                freshness, index_revision, trace_id
+            ) VALUES (
+                'event-1', '2026-06-16T00:00:00+00:00', ?, 'cli', 'query',
+                'context_retrieval', 10, 100, 90, 90.0, 1000, 990,
+                'returned_full_files', 2, 'clean', 'rev', NULL
+            )
+            """,
+            (registered.repo_id,),
+        )
+        event = conn.execute("SELECT * FROM usage_events WHERE event_id = 'event-1'").fetchone()
+        repo = conn.execute(
+            "SELECT repo_root, display_name FROM repos WHERE repo_id = ?",
+            (registered.repo_id,),
+        ).fetchone()
+
+    event_values = {str(value) for value in event if value is not None}
+    assert str(repo_root.resolve()) in str(repo["repo_root"])
+    assert repo["display_name"] == "repo-name"
+    assert str(repo_root.resolve()) not in event_values
+    assert "org-name" not in event_values
+    assert "repo-name" not in event_values
+
+
+def test_usage_event_rows_have_no_sensitive_default_columns(tmp_path: Path) -> None:
+    forbidden = {
+        "query_text",
+        "file_path",
+        "file_paths",
+        "path_hash",
+        "symbols",
+        "handles",
+        "source_snippet",
+        "rendered_output",
+        "prompt_body",
+        "remote_url",
+        "org_name",
+        "repo_name",
+    }
+    with MetricsStore(tmp_path / "usage.sqlite").connect() as conn:
+        event_columns = {row["name"] for row in conn.execute("PRAGMA table_info(usage_events)")}
+
+    assert event_columns.isdisjoint(forbidden)


### PR DESCRIPTION
## Stack

Stack-Id: `local-metrics-foundation`
Base: `main`
Position: 2/5

1. `feat/metrics-storage-schema` -> #254
2. `feat/metrics-policy-registry` -> this PR
3. `feat/metrics-recorder` -> #256
4. `feat/metrics-cli` -> #257
5. `feat/metrics-visibility` -> #258

Depends on: #254
Upstack: #256

## Summary

- resolve metrics policy from persisted settings plus `ARCHEX_USAGE_METRICS` and `ARCHEX_USAGE_TRACE`
- implement exact token-savings math for returned-file and whole-repo avoided metrics
- map repo roots to random machine-local UUIDs in the local registry
- add privacy tests proving default event rows contain no query/path/symbol/handle or remote metadata columns

## Validation

- Passed: `uv run ruff check src/archex/metrics tests/metrics`
- Passed: `uv run pyright src/archex/metrics tests/metrics`
- Passed: `uv run pytest tests/metrics/test_storage.py tests/metrics/test_policy.py`
