### PR TITLE
Record local metrics events

### DIFF
--- a/src/archex/cli/query_cmd.py
+++ b/src/archex/cli/query_cmd.py
@@ -2,13 +2,24 @@
 
 from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING
+
 import click
 
 from archex.api import get_files_token_count, query
 from archex.exceptions import ArchexError
+from archex.metrics.capture import record_query_usage
+from archex.metrics.health import record_metrics_failure
+from archex.metrics.policy import resolve_metrics_policy
 from archex.reporting import print_savings, print_timing
 from archex.serve.intent import DEFAULT_TOKEN_BUDGET
 from archex.utils import resolve_source
+
+if TYPE_CHECKING:
+    from archex.models import Config, ContextBundle, RepoSource
+
+logger = logging.getLogger(__name__)
 
 
 @click.command("query")
@@ -114,12 +125,17 @@ def query_cmd(
 
     click.echo(bundle.to_prompt(format=output_format))
 
+    unique_files = list({c.chunk.file_path for c in bundle.chunks})
+    raw_tokens: int | None = None
     if timing and pt is not None:
         print_timing(pt)
-        unique_files = list({c.chunk.file_path for c in bundle.chunks})
-        raw = get_files_token_count(repo_source, unique_files, config)
+        raw_tokens = get_files_token_count(repo_source, unique_files, config)
         print_savings(
-            bundle.token_count, raw, pt.total_ms, budget=token_budget, file_count=len(unique_files)
+            bundle.token_count,
+            raw_tokens,
+            pt.total_ms,
+            budget=token_budget,
+            file_count=len(unique_files),
         )
 
     if metrics and pt is not None:
@@ -132,6 +148,37 @@ def query_cmd(
             dm = metrics_dict["delta_meta"]
             metrics_dict["delta_meta"] = {k: v for k, v in dm.items()}
         click.echo(json.dumps(metrics_dict, indent=2), err=True)
+
+    _record_metrics(repo_source, bundle, raw_tokens, unique_files, config)
+
+
+def _record_metrics(
+    repo_source: RepoSource,
+    bundle: ContextBundle,
+    raw_tokens: int | None,
+    unique_files: list[str],
+    config: Config,
+) -> None:
+    try:
+        policy = resolve_metrics_policy()
+        if not policy.metrics_enabled:
+            return
+        raw = raw_tokens
+        if raw is None:
+            raw = get_files_token_count(repo_source, unique_files, config)
+        record_query_usage(
+            repo_source,
+            bundle,
+            surface="cli",
+            tokens_raw_equivalent=raw,
+            whole_repo_tokens=None,
+        )
+    except Exception as exc:
+        logger.debug("query metrics recording failed", exc_info=True)
+        try:
+            record_metrics_failure("record", str(exc))
+        except Exception:
+            logger.debug("query metrics health recording failed", exc_info=True)
 
 
 def _source_and_question(args: tuple[str, ...]) -> tuple[str, str]:

--- a/src/archex/cli/scout_cmd.py
+++ b/src/archex/cli/scout_cmd.py
@@ -2,12 +2,24 @@
 
 from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING
+
 import click
 
-from archex.api import scout
+from archex.api import get_repo_total_tokens, scout
 from archex.exceptions import ArchexError
+from archex.metrics.capture import record_scout_usage
+from archex.metrics.health import record_metrics_failure
+from archex.metrics.policy import resolve_metrics_policy
+from archex.reporting import count_tokens
 from archex.scout import DEFAULT_SCOUT_TOKEN_BUDGET, ScoutFormat, render_scout
 from archex.utils import resolve_source
+
+logger = logging.getLogger(__name__)
+if TYPE_CHECKING:
+    from archex.models import RepoSource
+    from archex.scout import ScoutResult
 
 
 @click.command("scout")
@@ -51,7 +63,31 @@ def scout_cmd(
         )
     except (ArchexError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc
-    click.echo(render_scout(result, output_format=output_format), nl=False)
+    rendered = render_scout(result, output_format=output_format)
+    click.echo(rendered, nl=False)
+    _record_metrics(repo_source, result, rendered)
+
+
+def _record_metrics(repo_source: RepoSource, result: ScoutResult, rendered: str) -> None:
+    try:
+        policy = resolve_metrics_policy()
+        if not policy.metrics_enabled:
+            return
+        raw = get_repo_total_tokens(repo_source)
+        record_scout_usage(
+            repo_source,
+            result,
+            surface="cli",
+            tokens_returned=count_tokens(rendered),
+            tokens_raw_equivalent=raw,
+            whole_repo_tokens=raw,
+        )
+    except Exception as exc:
+        logger.debug("scout metrics recording failed", exc_info=True)
+        try:
+            record_metrics_failure("record", str(exc))
+        except Exception:
+            logger.debug("scout metrics health recording failed", exc_info=True)
 
 
 def _source_and_question(args: tuple[str, ...]) -> tuple[str, str]:

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -39,9 +39,12 @@ from archex.graph_query import (
     GraphQueryError,
     GraphStatsResult,
 )
-from archex.models import PipelineTiming, RepoSource
+from archex.metrics.capture import record_query_usage, record_scout_usage
+from archex.metrics.health import record_metrics_failure
+from archex.metrics.policy import resolve_metrics_policy
+from archex.models import ContextBundle, PipelineTiming, RepoSource
 from archex.reporting import compute_meta, count_tokens
-from archex.scout import DEFAULT_SCOUT_TOKEN_BUDGET, ScoutFormat, render_scout
+from archex.scout import DEFAULT_SCOUT_TOKEN_BUDGET, ScoutFormat, ScoutResult, render_scout
 from archex.serve.compare import validate_dimensions
 from archex.serve.intent import DEFAULT_TOKEN_BUDGET
 from archex.serve.renderers.xml import render_xml, render_xml_envelope
@@ -137,6 +140,7 @@ def handle_query_repo(repo_url: str, question: str, budget: int | None = None) -
         query_time_ms=pt.total_ms,
         delta=pt.delta_meta,
     )
+    _record_query_metrics(source, bundle, raw_tokens)
     return json.dumps(
         {
             "content": content,
@@ -179,10 +183,59 @@ def handle_scout_repo(
         delta=pt.delta_meta,
     )
     receipt = _receipt_payload(result.receipt)
+    _record_scout_metrics(source, result, rendered, raw)
     return json.dumps(
         {"content": content, "receipt": receipt, "_meta": meta.model_dump()},
         indent=2,
     )
+
+
+def _record_query_metrics(source: RepoSource, bundle: ContextBundle, raw_tokens: int) -> None:
+    try:
+        policy = resolve_metrics_policy()
+        if not policy.metrics_enabled:
+            return
+        record_query_usage(
+            source,
+            bundle,
+            surface="mcp",
+            tool_name="query_repo",
+            tokens_raw_equivalent=raw_tokens,
+            whole_repo_tokens=None,
+        )
+    except Exception as exc:
+        logger.debug("MCP query metrics recording failed", exc_info=True)
+        try:
+            record_metrics_failure("record", str(exc))
+        except Exception:
+            logger.debug("MCP query metrics health recording failed", exc_info=True)
+
+
+def _record_scout_metrics(
+    source: RepoSource,
+    result: ScoutResult,
+    rendered: str,
+    raw_tokens: int,
+) -> None:
+    try:
+        policy = resolve_metrics_policy()
+        if not policy.metrics_enabled:
+            return
+        record_scout_usage(
+            source,
+            result,
+            surface="mcp",
+            tool_name="scout_repo",
+            tokens_returned=count_tokens(rendered),
+            tokens_raw_equivalent=raw_tokens,
+            whole_repo_tokens=raw_tokens,
+        )
+    except Exception as exc:
+        logger.debug("MCP scout metrics recording failed", exc_info=True)
+        try:
+            record_metrics_failure("record", str(exc))
+        except Exception:
+            logger.debug("MCP scout metrics health recording failed", exc_info=True)
 
 
 def handle_compare_repos(

--- a/src/archex/metrics/__init__.py
+++ b/src/archex/metrics/__init__.py
@@ -2,17 +2,23 @@
 
 from __future__ import annotations
 
+from archex.metrics.health import MetricsHealth
 from archex.metrics.math import TokenSavings, compute_token_savings
 from archex.metrics.policy import MetricsPolicy, resolve_metrics_policy
+from archex.metrics.recorder import MetricsRecorder, TraceDetails, UsageEvent
 from archex.metrics.registry import RegisteredRepo, RepoRegistry
 from archex.metrics.storage import MetricsStore, metrics_db_path
 
 __all__ = [
+    "MetricsHealth",
     "MetricsPolicy",
     "MetricsStore",
+    "MetricsRecorder",
     "RegisteredRepo",
     "RepoRegistry",
     "TokenSavings",
+    "TraceDetails",
+    "UsageEvent",
     "compute_token_savings",
     "metrics_db_path",
     "resolve_metrics_policy",

--- a/src/archex/metrics/capture.py
+++ b/src/archex/metrics/capture.py
@@ -1,0 +1,109 @@
+"""Thin helpers that convert existing CLI/MCP outputs into UsageEvent inputs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from archex.metrics.recorder import MetricsRecorder, Surface, TraceDetails, UsageEvent
+
+if TYPE_CHECKING:
+    from archex.models import ContextBundle, ContextSkippedCandidate, RepoSource
+    from archex.scout import ScoutResult
+
+
+def record_query_usage(
+    source: RepoSource,
+    bundle: ContextBundle,
+    *,
+    surface: Surface,
+    tokens_raw_equivalent: int,
+    whole_repo_tokens: int | None,
+    tool_name: str = "query",
+    db_path: Path | None = None,
+) -> None:
+    repo_root = _local_repo_root(source)
+    if repo_root is None:
+        return
+    files = sorted({chunk.chunk.file_path for chunk in bundle.chunks})
+    symbols = sorted(
+        {chunk.chunk.symbol_name for chunk in bundle.chunks if chunk.chunk.symbol_name}
+    )
+    receipt = bundle.receipt
+    MetricsRecorder(db_path).record(
+        UsageEvent(
+            repo_root=repo_root,
+            surface=surface,
+            tool_name=tool_name,
+            category="context_retrieval",
+            tokens_returned=bundle.token_count,
+            tokens_raw_equivalent=tokens_raw_equivalent,
+            whole_repo_tokens=whole_repo_tokens,
+            file_count=len(files),
+            freshness=str(receipt.freshness) if receipt is not None else None,
+            index_revision=receipt.index_revision if receipt is not None else None,
+            trace=TraceDetails(
+                query_text=bundle.query,
+                returned_file_paths=files,
+                symbols=symbols,
+                skipped_counts=_skipped_counts(receipt.skipped_candidates if receipt else []),
+            ),
+        )
+    )
+
+
+def record_scout_usage(
+    source: RepoSource,
+    result: ScoutResult,
+    *,
+    surface: Surface,
+    tokens_returned: int,
+    tokens_raw_equivalent: int,
+    whole_repo_tokens: int | None,
+    tool_name: str = "scout",
+    db_path: Path | None = None,
+) -> None:
+    repo_root = _local_repo_root(source)
+    if repo_root is None:
+        return
+    receipt = result.receipt
+    MetricsRecorder(db_path).record(
+        UsageEvent(
+            repo_root=repo_root,
+            surface=surface,
+            tool_name=tool_name,
+            category="context_retrieval",
+            tokens_returned=tokens_returned,
+            tokens_raw_equivalent=tokens_raw_equivalent,
+            whole_repo_tokens=whole_repo_tokens,
+            file_count=len(result.ranked_files),
+            freshness=str(receipt.freshness) if receipt is not None else None,
+            index_revision=receipt.index_revision if receipt is not None else None,
+            trace=TraceDetails(
+                query_text=result.query,
+                returned_file_paths=[item.path for item in result.ranked_files],
+                symbols=[item.name for item in result.symbols],
+                handles=list(result.fetch_plan.handles),
+                skipped_counts={
+                    "omitted_files": result.budget.omitted_files,
+                    "omitted_symbols": result.budget.omitted_symbols,
+                    "omitted_modules": result.budget.omitted_modules,
+                    "omitted_graph_edges": result.budget.omitted_graph_edges,
+                },
+            ),
+        )
+    )
+
+
+def _local_repo_root(source: RepoSource) -> Path | None:
+    if source.local_path is None:
+        return None
+    return Path(source.local_path)
+
+
+def _skipped_counts(candidates: list[ContextSkippedCandidate]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for candidate in candidates:
+        reason = str(candidate.reason)
+        counts[reason] = counts.get(reason, 0) + 1
+    return counts

--- a/src/archex/metrics/health.py
+++ b/src/archex/metrics/health.py
@@ -1,0 +1,89 @@
+"""Metrics health state persisted in the local usage ledger."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from archex.metrics.storage import MetricsStore
+
+
+@dataclass(frozen=True)
+class MetricsHealth:
+    status: str
+    last_failure_at: str | None
+    last_failure_operation: str | None
+    last_failure_message: str | None
+
+    @property
+    def warning(self) -> str:
+        if self.status == "ok" or self.last_failure_message is None:
+            return ""
+        operation = self.last_failure_operation or "metrics"
+        return f"{operation}: {self.last_failure_message}"
+
+
+def read_metrics_health(*, db_path: Path | None = None) -> MetricsHealth:
+    with MetricsStore(db_path).connect() as conn:
+        row = conn.execute(
+            """
+            SELECT status, last_failure_at, last_failure_operation, last_failure_message
+            FROM metrics_health WHERE id = 1
+            """
+        ).fetchone()
+    if row is None:
+        return MetricsHealth("ok", None, None, None)
+    return MetricsHealth(
+        status=str(row["status"]),
+        last_failure_at=_optional_str(row["last_failure_at"]),
+        last_failure_operation=_optional_str(row["last_failure_operation"]),
+        last_failure_message=_optional_str(row["last_failure_message"]),
+    )
+
+
+def record_metrics_failure(
+    operation: str,
+    message: str,
+    *,
+    db_path: Path | None = None,
+) -> None:
+    with MetricsStore(db_path).connect() as conn, conn:
+        conn.execute(
+            """
+            INSERT INTO metrics_health(
+                id, status, last_failure_at, last_failure_operation,
+                last_failure_message, updated_at
+            ) VALUES (1, 'warning', ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(id) DO UPDATE SET
+                status = 'warning',
+                last_failure_at = excluded.last_failure_at,
+                last_failure_operation = excluded.last_failure_operation,
+                last_failure_message = excluded.last_failure_message,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (_utc_now(), operation, message[:500]),
+        )
+
+
+def clear_metrics_health(*, db_path: Path | None = None) -> None:
+    with MetricsStore(db_path).connect() as conn, conn:
+        conn.execute(
+            """
+            UPDATE metrics_health
+            SET status = 'ok',
+                last_failure_at = NULL,
+                last_failure_operation = NULL,
+                last_failure_message = NULL,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = 1
+            """
+        )
+
+
+def _optional_str(value: object) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")

--- a/src/archex/metrics/policy.py
+++ b/src/archex/metrics/policy.py
@@ -32,13 +32,21 @@ def resolve_metrics_policy(
     env: Mapping[str, str] | None = None,
 ) -> MetricsPolicy:
     """Resolve persisted settings with environment variable overrides."""
-    values = _settings(db_path)
     env_values = os.environ if env is None else env
+    if env_values.get(METRICS_ENV, "").casefold() == "off":
+        return MetricsPolicy(
+            metrics_enabled=False,
+            trace_enabled=False,
+            raw_event_retention_days=DEFAULT_RAW_EVENT_RETENTION_DAYS,
+            trace_retention_days=DEFAULT_TRACE_RETENTION_DAYS,
+        )
+    values = _settings(db_path)
 
     metrics_enabled = _bool_setting(values.get("metrics_enabled"), default=True)
     trace_enabled = _bool_setting(values.get("trace_enabled"), default=False)
 
-    if env_values.get(METRICS_ENV, "").casefold() == "off":
+    metrics_env = env_values.get(METRICS_ENV, "").casefold()
+    if metrics_env == "off":
         metrics_enabled = False
     trace_override = env_values.get(TRACE_ENV, "").casefold()
     if trace_override == "on":

--- a/src/archex/metrics/recorder.py
+++ b/src/archex/metrics/recorder.py
@@ -1,0 +1,307 @@
+"""Non-fatal metrics recorder for anonymous counters and opt-in traces."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Literal, cast
+from uuid import uuid4
+
+from archex.metrics.health import record_metrics_failure
+from archex.metrics.math import TokenSavings, compute_token_savings
+from archex.metrics.policy import MetricsPolicy, resolve_metrics_policy
+from archex.metrics.registry import RepoRegistry
+from archex.metrics.storage import MetricsStore
+
+logger = logging.getLogger(__name__)
+
+Surface = Literal["cli", "mcp", "python_api"]
+Category = Literal["context_retrieval", "structural_tools"]
+_ALLOWED_TRACE_KEYS = frozenset(
+    {
+        "query_text",
+        "returned_file_paths",
+        "symbols",
+        "handles",
+        "skipped_counts",
+    }
+)
+
+
+@dataclass(frozen=True)
+class TraceDetails:
+    query_text: str | None = None
+    returned_file_paths: list[str] = field(default_factory=lambda: [])
+    symbols: list[str] = field(default_factory=lambda: [])
+    handles: list[str] = field(default_factory=lambda: [])
+    skipped_counts: dict[str, int] = field(default_factory=lambda: {})
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, object]) -> TraceDetails:
+        extra = set(value) - _ALLOWED_TRACE_KEYS
+        if extra:
+            names = ", ".join(sorted(extra))
+            raise ValueError(f"trace details contain disallowed fields: {names}")
+        return cls(
+            query_text=_optional_str(value.get("query_text")),
+            returned_file_paths=_string_list(value.get("returned_file_paths")),
+            symbols=_string_list(value.get("symbols")),
+            handles=_string_list(value.get("handles")),
+            skipped_counts=_int_mapping(value.get("skipped_counts")),
+        )
+
+
+@dataclass(frozen=True)
+class UsageEvent:
+    repo_root: Path
+    surface: Surface
+    tool_name: str
+    category: Category
+    tokens_returned: int
+    tokens_raw_equivalent: int
+    whole_repo_tokens: int | None = None
+    occurred_at: datetime | None = None
+    file_count: int = 0
+    freshness: str | None = None
+    index_revision: str | None = None
+    trace: TraceDetails | None = None
+
+
+class MetricsRecorder:
+    """Single writer for metrics event rows, aggregates, traces, pruning, and health."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        self._db_path = db_path
+        self._store = MetricsStore(db_path)
+        self._registry = RepoRegistry(db_path)
+
+    def record(self, event: UsageEvent) -> None:
+        """Record an event without raising into query/scout/MCP call paths."""
+        try:
+            policy = resolve_metrics_policy(db_path=self._db_path)
+            if not policy.metrics_enabled:
+                return
+            self._record(event, policy)
+        except Exception as exc:  # pragma: no cover - defensive non-fatal boundary
+            logger.debug("metrics recording failed", exc_info=True)
+            self._record_failure("record", exc)
+
+    def prune(self) -> None:
+        """Prune expired raw events and traces without raising into readers."""
+        try:
+            policy = resolve_metrics_policy(db_path=self._db_path)
+            if not policy.metrics_enabled:
+                return
+            with self._store.connect() as conn, conn:
+                self._prune(conn, policy)
+        except Exception as exc:  # pragma: no cover - defensive non-fatal boundary
+            logger.debug("metrics pruning failed", exc_info=True)
+            self._record_failure("prune", exc)
+
+    def _record(self, event: UsageEvent, policy: MetricsPolicy) -> None:
+        registered = self._registry.get_or_create(event.repo_root)
+        savings = compute_token_savings(
+            tokens_returned=event.tokens_returned,
+            tokens_raw_equivalent=event.tokens_raw_equivalent,
+            whole_repo_tokens=event.whole_repo_tokens,
+        )
+        occurred_at = event.occurred_at or datetime.now(UTC)
+        event_id = str(uuid4())
+        trace_id = str(uuid4()) if policy.trace_enabled and event.trace is not None else None
+        with self._store.connect() as conn, conn:
+            self._insert_event(
+                conn,
+                event,
+                savings,
+                registered.repo_id,
+                event_id,
+                trace_id,
+                occurred_at,
+            )
+            self._upsert_daily_usage(conn, event, savings, registered.repo_id, occurred_at)
+            if trace_id is not None and event.trace is not None:
+                self._insert_trace(
+                    conn,
+                    event,
+                    event.trace,
+                    savings,
+                    registered.repo_id,
+                    event_id,
+                    trace_id,
+                    occurred_at + timedelta(days=policy.trace_retention_days),
+                )
+            self._prune(conn, policy, now=occurred_at)
+
+    def _record_failure(self, operation: str, exc: Exception) -> None:
+        try:
+            record_metrics_failure(operation, str(exc), db_path=self._db_path)
+        except Exception:
+            logger.debug("metrics health recording failed", exc_info=True)
+
+    @staticmethod
+    def _insert_event(
+        conn: sqlite3.Connection,
+        event: UsageEvent,
+        savings: TokenSavings,
+        repo_id: str,
+        event_id: str,
+        trace_id: str | None,
+        occurred_at: datetime,
+    ) -> None:
+        conn.execute(
+            """
+            INSERT INTO usage_events(
+                event_id, occurred_at, repo_id, surface, tool_name, category,
+                tokens_returned, tokens_raw_equivalent, tokens_saved, savings_pct,
+                whole_repo_tokens, whole_repo_tokens_avoided, baseline_type, file_count,
+                freshness, index_revision, trace_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event_id,
+                _format_dt(occurred_at),
+                repo_id,
+                event.surface,
+                event.tool_name,
+                event.category,
+                savings.tokens_returned,
+                savings.tokens_raw_equivalent,
+                savings.tokens_saved,
+                savings.savings_pct,
+                savings.whole_repo_tokens,
+                savings.whole_repo_tokens_avoided,
+                savings.baseline_type,
+                event.file_count,
+                event.freshness,
+                event.index_revision,
+                trace_id,
+            ),
+        )
+
+    @staticmethod
+    def _upsert_daily_usage(
+        conn: sqlite3.Connection,
+        event: UsageEvent,
+        savings: TokenSavings,
+        repo_id: str,
+        occurred_at: datetime,
+    ) -> None:
+        occurred = _format_dt(occurred_at)
+        conn.execute(
+            """
+            INSERT INTO daily_usage(
+                day, repo_id, surface, tool_name, category,
+                tokens_returned, tokens_raw_equivalent, tokens_saved,
+                whole_repo_tokens_avoided, event_count, first_event_at, last_event_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+            ON CONFLICT(day, repo_id, surface, tool_name, category) DO UPDATE SET
+                tokens_returned = tokens_returned + excluded.tokens_returned,
+                tokens_raw_equivalent = tokens_raw_equivalent + excluded.tokens_raw_equivalent,
+                tokens_saved = tokens_saved + excluded.tokens_saved,
+                whole_repo_tokens_avoided = (
+                    whole_repo_tokens_avoided + excluded.whole_repo_tokens_avoided
+                ),
+                event_count = event_count + 1,
+                first_event_at = min(first_event_at, excluded.first_event_at),
+                last_event_at = max(last_event_at, excluded.last_event_at)
+            """,
+            (
+                occurred_at.date().isoformat(),
+                repo_id,
+                event.surface,
+                event.tool_name,
+                event.category,
+                savings.tokens_returned,
+                savings.tokens_raw_equivalent,
+                savings.tokens_saved,
+                savings.whole_repo_tokens_avoided or 0,
+                occurred,
+                occurred,
+            ),
+        )
+
+    @staticmethod
+    def _insert_trace(
+        conn: sqlite3.Connection,
+        event: UsageEvent,
+        trace: TraceDetails,
+        savings: TokenSavings,
+        repo_id: str,
+        event_id: str,
+        trace_id: str,
+        expires_at: datetime,
+    ) -> None:
+        conn.execute(
+            """
+            INSERT INTO usage_traces(
+                trace_id, event_id, expires_at, query_text, returned_file_paths, symbols,
+                handles, skipped_counts, tokens_returned, tokens_raw_equivalent,
+                tokens_saved, savings_pct, whole_repo_tokens, whole_repo_tokens_avoided,
+                repo_id, index_revision
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                trace_id,
+                event_id,
+                _format_dt(expires_at),
+                trace.query_text,
+                json.dumps(trace.returned_file_paths, sort_keys=True),
+                json.dumps(trace.symbols, sort_keys=True),
+                json.dumps(trace.handles, sort_keys=True),
+                json.dumps(trace.skipped_counts, sort_keys=True),
+                savings.tokens_returned,
+                savings.tokens_raw_equivalent,
+                savings.tokens_saved,
+                savings.savings_pct,
+                savings.whole_repo_tokens,
+                savings.whole_repo_tokens_avoided,
+                repo_id,
+                event.index_revision,
+            ),
+        )
+
+    @staticmethod
+    def _prune(
+        conn: sqlite3.Connection,
+        policy: MetricsPolicy,
+        *,
+        now: datetime | None = None,
+    ) -> None:
+        current = now or datetime.now(UTC)
+        raw_cutoff = _format_dt(current - timedelta(days=policy.raw_event_retention_days))
+        conn.execute("DELETE FROM usage_traces WHERE expires_at < ?", (_format_dt(current),))
+        conn.execute("DELETE FROM usage_events WHERE occurred_at < ?", (raw_cutoff,))
+
+
+def _format_dt(value: datetime) -> str:
+    normalized = value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    return normalized.astimezone(UTC).isoformat(timespec="seconds")
+
+
+def _optional_str(value: object) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _string_list(value: object) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("trace list fields must be lists")
+    return [str(item) for item in cast("list[object]", value)]
+
+
+def _int_mapping(value: object) -> dict[str, int]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError("skipped_counts must be a mapping")
+    result: dict[str, int] = {}
+    for key, item in cast("dict[object, object]", value).items():
+        if not isinstance(item, int):
+            raise ValueError("skipped_counts values must be integers")
+        result[str(key)] = item
+    return result

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+from archex.integrations.mcp import handle_query_repo
+from archex.metrics.storage import MetricsStore
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class FakeBundle:
+    query = "where is auth"
+    token_count = 10
+    chunks: list[object] = []
+    receipt = None
+    retrieval_metadata = SimpleNamespace(seed_file_paths=[], expanded_file_paths=[])
+
+    def to_prompt(self, format: str = "xml") -> str:
+        return "FAKE CONTEXT"
+
+
+def test_cli_query_records_counter_without_changing_stdout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    runner = CliRunner()
+
+    with (
+        patch("archex.cli.query_cmd.query", return_value=FakeBundle()),
+        patch("archex.cli.query_cmd.get_files_token_count", return_value=100),
+    ):
+        result = runner.invoke(cli, ["query", str(repo_root), "where", "is", "auth"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "FAKE CONTEXT\n"
+    with MetricsStore(tmp_path / ".archex" / "usage.sqlite").connect() as conn:
+        event = conn.execute("SELECT surface, tool_name, tokens_saved FROM usage_events").fetchone()
+    assert event["surface"] == "cli"
+    assert event["tool_name"] == "query"
+    assert event["tokens_saved"] == 90
+
+
+def test_cli_query_metrics_off_avoids_metric_work_and_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("ARCHEX_USAGE_METRICS", "off")
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    runner = CliRunner()
+
+    with (
+        patch("archex.cli.query_cmd.query", return_value=FakeBundle()),
+        patch("archex.cli.query_cmd.get_files_token_count", side_effect=AssertionError("raw scan")),
+    ):
+        result = runner.invoke(cli, ["query", str(repo_root), "where", "is", "auth"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "FAKE CONTEXT\n"
+    assert not (tmp_path / ".archex" / "usage.sqlite").exists()
+
+
+def test_mcp_query_records_counter_and_preserves_response_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    with (
+        patch("archex.integrations.mcp.query", return_value=FakeBundle()),
+        patch("archex.integrations.mcp.render_xml", return_value="<context />"),
+        patch("archex.integrations.mcp.render_xml_envelope", return_value="<envelope />"),
+        patch("archex.integrations.mcp.get_files_token_count", return_value=100),
+        patch("archex.integrations.mcp.get_repo_total_tokens", return_value=1000),
+    ):
+        payload = json.loads(handle_query_repo(str(repo_root), "where is auth"))
+
+    assert sorted(payload) == ["_meta", "content", "receipt"]
+    assert payload["content"] == "<context />"
+    with MetricsStore(tmp_path / ".archex" / "usage.sqlite").connect() as conn:
+        event = conn.execute("SELECT surface, tool_name, tokens_saved FROM usage_events").fetchone()
+    assert event["surface"] == "mcp"
+    assert event["tool_name"] == "query_repo"
+    assert event["tokens_saved"] == 90

--- a/tests/metrics/test_recorder.py
+++ b/tests/metrics/test_recorder.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from archex.metrics.health import read_metrics_health
+from archex.metrics.policy import METRICS_ENV, TRACE_ENV
+from archex.metrics.recorder import MetricsRecorder, TraceDetails, UsageEvent
+from archex.metrics.registry import RepoRegistry
+from archex.metrics.storage import MetricsStore
+
+
+def test_record_writes_anonymous_event_and_daily_aggregate(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite"
+    repo_root = _repo(tmp_path)
+
+    MetricsRecorder(db_path).record(_event(repo_root))
+
+    with MetricsStore(db_path).connect() as conn:
+        event = conn.execute("SELECT * FROM usage_events").fetchone()
+        daily = conn.execute("SELECT * FROM daily_usage").fetchone()
+        traces = conn.execute("SELECT COUNT(*) FROM usage_traces").fetchone()[0]
+        repo = conn.execute("SELECT repo_id, repo_root FROM repos").fetchone()
+
+    assert event["repo_id"] == repo["repo_id"]
+    assert event["tokens_returned"] == 10
+    assert event["tokens_raw_equivalent"] == 100
+    assert event["tokens_saved"] == 90
+    assert event["savings_pct"] == 90.0
+    assert event["whole_repo_tokens_avoided"] == 990
+    assert event["trace_id"] is None
+    assert daily["tokens_returned"] == 10
+    assert daily["tokens_raw_equivalent"] == 100
+    assert daily["tokens_saved"] == 90
+    assert daily["event_count"] == 1
+    assert traces == 0
+
+
+def test_metrics_env_off_prevents_writes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db_path = tmp_path / "usage.sqlite"
+    monkeypatch.setenv(METRICS_ENV, "off")
+
+    MetricsRecorder(db_path).record(_event(_repo(tmp_path)))
+
+    assert not db_path.exists()
+
+
+def test_trace_rows_exist_only_after_explicit_trace_enable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "usage.sqlite"
+    repo_root = _repo(tmp_path)
+    event = _event(
+        repo_root,
+        trace=TraceDetails(
+            query_text="find auth flow",
+            returned_file_paths=["src/auth.py"],
+            symbols=["login"],
+            handles=["file:src/auth.py"],
+            skipped_counts={"below_threshold": 2},
+        ),
+    )
+
+    MetricsRecorder(db_path).record(event)
+    monkeypatch.setenv(TRACE_ENV, "on")
+    MetricsRecorder(db_path).record(event)
+
+    with MetricsStore(db_path).connect() as conn:
+        traces = conn.execute("SELECT * FROM usage_traces").fetchall()
+
+    assert len(traces) == 1
+    assert traces[0]["query_text"] == "find auth flow"
+    assert "src/auth.py" in traces[0]["returned_file_paths"]
+    assert "login" in traces[0]["symbols"]
+    assert "file:src/auth.py" in traces[0]["handles"]
+    assert "below_threshold" in traces[0]["skipped_counts"]
+
+
+def test_trace_filter_rejects_code_output_and_prompt_fields() -> None:
+    for key in ("source_code", "source_snippet", "rendered_output", "prompt_body"):
+        with pytest.raises(ValueError, match="disallowed fields"):
+            TraceDetails.from_mapping({key: "secret"})
+
+
+def test_retention_prunes_raw_events_and_traces_but_keeps_daily(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "usage.sqlite"
+    repo_root = _repo(tmp_path)
+    recorder = MetricsRecorder(db_path)
+    monkeypatch.setenv(TRACE_ENV, "on")
+    old = datetime.now(UTC) - timedelta(days=91)
+    event = _event(repo_root, occurred_at=old, trace=TraceDetails(query_text="old query"))
+
+    recorder.record(event)
+    recorder.prune()
+
+    with MetricsStore(db_path).connect() as conn:
+        event_count = conn.execute("SELECT COUNT(*) FROM usage_events").fetchone()[0]
+        trace_count = conn.execute("SELECT COUNT(*) FROM usage_traces").fetchone()[0]
+        daily_count = conn.execute("SELECT COUNT(*) FROM daily_usage").fetchone()[0]
+
+    assert event_count == 0
+    assert trace_count == 0
+    assert daily_count == 1
+
+
+def test_recorder_failures_are_non_fatal_and_record_health(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "usage.sqlite"
+
+    def fail_get_or_create(self: RepoRegistry, repo_root: str | Path) -> object:
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr(RepoRegistry, "get_or_create", fail_get_or_create)
+
+    MetricsRecorder(db_path).record(_event(_repo(tmp_path)))
+
+    health = read_metrics_health(db_path=db_path)
+    assert health.status == "warning"
+    assert health.last_failure_operation == "record"
+    assert health.last_failure_message == "registry unavailable"
+
+
+def _event(
+    repo_root: Path,
+    *,
+    occurred_at: datetime | None = None,
+    trace: TraceDetails | None = None,
+) -> UsageEvent:
+    return UsageEvent(
+        repo_root=repo_root,
+        surface="cli",
+        tool_name="query",
+        category="context_retrieval",
+        tokens_returned=10,
+        tokens_raw_equivalent=100,
+        whole_repo_tokens=1000,
+        occurred_at=occurred_at,
+        file_count=2,
+        freshness="clean",
+        index_revision="rev",
+        trace=trace,
+    )
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(exist_ok=True)
+    return repo_root


### PR DESCRIPTION
## Stack

Stack-Id: `local-metrics-foundation`
Base: `main`
Position: 3/5

1. `feat/metrics-storage-schema` -> #254
2. `feat/metrics-policy-registry` -> #255
3. `feat/metrics-recorder` -> this PR
4. `feat/metrics-cli` -> #257
5. `feat/metrics-visibility` -> #258

Depends on: #255
Upstack: #257

## Summary

- add `MetricsRecorder`, `UsageEvent`, trace filtering, retention pruning, and non-fatal metrics health recording
- make the recorder the only writer for events, aggregates, and traces
- instrument CLI `query`/`scout` and MCP `query_repo`/`scout_repo` counter events without changing response shape
- add tests for retention, trace opt-in, privacy filtering, disabled metrics, and instrumentation behavior

## Validation

- Passed: `uv run ruff check src/archex/metrics src/archex/cli/query_cmd.py src/archex/cli/scout_cmd.py src/archex/integrations/mcp.py tests/metrics`
- Passed: `uv run pyright src/archex/metrics src/archex/cli/query_cmd.py src/archex/cli/scout_cmd.py src/archex/integrations/mcp.py tests/metrics`
- Passed: `uv run pytest tests/metrics`
