### PR TITLE
Add metrics reporting CLI

### DIFF
--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -18,6 +18,7 @@ from archex.cli.index_cmd import index_cmd
 from archex.cli.init_cmd import init_cmd
 from archex.cli.install_client_cmd import install_client_cmd
 from archex.cli.mcp_cmd import mcp_cmd
+from archex.cli.metrics_cmd import metrics_cmd
 from archex.cli.onboard_cmd import onboard_cmd
 from archex.cli.outline_cmd import outline_cmd
 from archex.cli.query_cmd import query_cmd
@@ -48,6 +49,7 @@ cli.add_command(reset_cmd)
 cli.add_command(doctor_cmd)
 cli.add_command(dogfood_cmd)
 cli.add_command(mcp_cmd)
+cli.add_command(metrics_cmd)
 cli.add_command(tree_cmd)
 cli.add_command(outline_cmd)
 cli.add_command(scout_cmd)

--- a/src/archex/cli/metrics_cmd.py
+++ b/src/archex/cli/metrics_cmd.py
@@ -1,0 +1,168 @@
+"""Metrics command group for local token-savings reporting."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from archex.metrics.policy import set_metrics_enabled, set_trace_enabled
+from archex.metrics.reporter import (
+    MetricsReporter,
+    render_inspect_text,
+    render_repos_text,
+    render_summary_text,
+)
+from archex.metrics.storage import metrics_db_path
+
+
+@click.group("metrics", invoke_without_command=True)
+@click.pass_context
+def metrics_cmd(ctx: click.Context) -> None:
+    """Report and control local archex usage metrics."""
+    if ctx.invoked_subcommand is not None:
+        return
+    payload = MetricsReporter().summary(source=".")
+    click.echo(render_summary_text(payload), nl=False)
+
+
+@metrics_cmd.command("summary")
+@click.argument("source", required=False, default=".")
+@click.option("--global", "global_scope", is_flag=True, default=False, help="Summarize all repos.")
+@click.option("--workspace", type=click.Path(path_type=Path), help="Summarize repos under PATH.")
+@click.option("--since", default="7d", show_default=True, help="Time window, e.g. 24h or 7d.")
+@click.option(
+    "--format",
+    "output_format",
+    default="text",
+    type=click.Choice(["text", "json"]),
+    help="Output format.",
+)
+def summary_cmd(
+    source: str,
+    global_scope: bool,
+    workspace: Path | None,
+    since: str,
+    output_format: str,
+) -> None:
+    """Print current repo, global, or workspace savings summary."""
+    payload = MetricsReporter().summary(
+        source=source,
+        global_scope=global_scope,
+        workspace=workspace,
+        since=since,
+    )
+    _emit(payload, output_format, render_summary_text)
+
+
+@metrics_cmd.command("repos")
+@click.option("--since", default="30d", show_default=True, help="Time window, e.g. 24h or 30d.")
+@click.option(
+    "--format",
+    "output_format",
+    default="text",
+    type=click.Choice(["text", "json"]),
+    help="Output format.",
+)
+def repos_cmd(since: str, output_format: str) -> None:
+    """List known local repos with savings totals."""
+    payload = MetricsReporter().repos(since=since)
+    _emit(payload, output_format, render_repos_text)
+
+
+@metrics_cmd.command("inspect")
+@click.argument("source", required=False, default=".")
+@click.option("--since", default="24h", show_default=True, help="Time window, e.g. 24h or 7d.")
+@click.option(
+    "--format",
+    "output_format",
+    default="text",
+    type=click.Choice(["text", "json"]),
+    help="Output format.",
+)
+def inspect_cmd(source: str, since: str, output_format: str) -> None:
+    """Inspect recent local metrics events."""
+    payload = MetricsReporter().inspect(source=source, since=since)
+    _emit(payload, output_format, render_inspect_text)
+
+
+@metrics_cmd.command("export")
+@click.option(
+    "--output",
+    type=click.Path(path_type=Path, dir_okay=False),
+    default=Path("usage.json"),
+    show_default=True,
+    help="Destination JSON file.",
+)
+@click.option("--since", default="90d", show_default=True, help="Time window, e.g. 90d.")
+@click.option("--include-local-paths", is_flag=True, default=False, help="Include repo root paths.")
+def export_cmd(output: Path, since: str, include_local_paths: bool) -> None:
+    """Export local metrics JSON."""
+    payload = MetricsReporter().export(since=since, include_local_paths=include_local_paths)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    click.echo(f"Exported metrics to {output}")
+
+
+@metrics_cmd.command("enable")
+def enable_cmd() -> None:
+    """Enable anonymous local metrics counters."""
+    set_metrics_enabled(True)
+    click.echo("Metrics recording enabled")
+
+
+@metrics_cmd.command("disable")
+def disable_cmd() -> None:
+    """Disable anonymous local metrics counters."""
+    set_metrics_enabled(False)
+    click.echo("Metrics recording disabled")
+
+
+@metrics_cmd.command("delete")
+@click.option(
+    "--all",
+    "delete_all",
+    is_flag=True,
+    default=False,
+    help="Delete all local metrics state.",
+)
+def delete_cmd(delete_all: bool) -> None:
+    """Delete local metrics state."""
+    if not delete_all:
+        raise click.UsageError("metrics delete requires --all")
+    db_path = metrics_db_path()
+    sidecars = (
+        db_path.with_suffix(db_path.suffix + "-wal"),
+        db_path.with_suffix(db_path.suffix + "-shm"),
+    )
+    for path in (db_path, *sidecars):
+        if path.exists():
+            path.unlink()
+    click.echo("Deleted local metrics state")
+
+
+@metrics_cmd.group("trace")
+def trace_cmd() -> None:
+    """Control opt-in detailed local traces."""
+
+
+@trace_cmd.command("enable")
+def trace_enable_cmd() -> None:
+    """Enable detailed local traces."""
+    set_trace_enabled(True)
+    click.echo("Metrics trace enabled")
+
+
+@trace_cmd.command("disable")
+def trace_disable_cmd() -> None:
+    """Disable detailed local traces."""
+    set_trace_enabled(False)
+    click.echo("Metrics trace disabled")
+
+
+def _emit(payload: dict[str, object], output_format: str, renderer: object) -> None:
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    click.echo(renderer(payload), nl=False)  # type: ignore[operator]

--- a/src/archex/metrics/reporter.py
+++ b/src/archex/metrics/reporter.py
@@ -1,0 +1,410 @@
+"""Read-side reporting for the local usage metrics ledger."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, cast
+
+from archex.metrics.health import MetricsHealth, read_metrics_health
+from archex.metrics.policy import MetricsPolicy, resolve_metrics_policy
+from archex.metrics.recorder import MetricsRecorder
+from archex.metrics.storage import MetricsStore
+
+
+@dataclass(frozen=True)
+class TimeWindow:
+    label: str
+    cutoff: str
+
+
+class MetricsReporter:
+    """Builds summaries, repo lists, inspect rows, and export payloads."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        self._db_path = db_path
+        self._store = MetricsStore(db_path)
+
+    def summary(
+        self,
+        *,
+        source: str | Path | None = None,
+        global_scope: bool = False,
+        workspace: str | Path | None = None,
+        since: str = "7d",
+    ) -> dict[str, Any]:
+        window = _window(since)
+        MetricsRecorder(self._db_path).prune()
+        policy = resolve_metrics_policy(db_path=self._db_path)
+        health = read_metrics_health(db_path=self._db_path)
+        with self._store.connect() as conn:
+            repo_ids = _repo_ids(
+                conn,
+                source=source,
+                global_scope=global_scope,
+                workspace=workspace,
+            )
+            totals = _totals(conn, window, repo_ids)
+        return _summary_payload(totals, policy=policy, health=health, window=window)
+
+    def repos(self, *, since: str = "30d") -> dict[str, Any]:
+        window = _window(since)
+        MetricsRecorder(self._db_path).prune()
+        policy = resolve_metrics_policy(db_path=self._db_path)
+        health = read_metrics_health(db_path=self._db_path)
+        with self._store.connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT r.repo_id, r.display_name, r.repo_root,
+                    COUNT(e.event_id) AS event_count,
+                    COALESCE(SUM(e.tokens_returned), 0) AS tokens_returned,
+                    COALESCE(SUM(e.tokens_raw_equivalent), 0) AS tokens_raw_equivalent,
+                    COALESCE(SUM(e.tokens_saved), 0) AS tokens_saved,
+                    COALESCE(SUM(e.whole_repo_tokens_avoided), 0) AS whole_repo_tokens_avoided
+                FROM repos r
+                LEFT JOIN usage_events e
+                    ON e.repo_id = r.repo_id AND e.occurred_at >= ?
+                GROUP BY r.repo_id
+                ORDER BY tokens_saved DESC, r.display_name ASC, r.repo_id ASC
+                """,
+                (window.cutoff,),
+            ).fetchall()
+        repos = [_repo_payload(row) for row in rows]
+        return {
+            "recording_enabled": policy.metrics_enabled,
+            "trace_enabled": policy.trace_enabled,
+            "window": window.label,
+            "repo_count": len(repos),
+            "repos": repos,
+            "health_warning": health.warning,
+        }
+
+    def inspect(
+        self,
+        *,
+        source: str | Path | None = None,
+        since: str = "24h",
+    ) -> dict[str, Any]:
+        window = _window(since)
+        MetricsRecorder(self._db_path).prune()
+        policy = resolve_metrics_policy(db_path=self._db_path)
+        health = read_metrics_health(db_path=self._db_path)
+        with self._store.connect() as conn:
+            repo_ids = _repo_ids(conn, source=source, global_scope=source is None, workspace=None)
+            clauses = ["e.occurred_at >= ?"]
+            params: list[object] = [window.cutoff]
+            if repo_ids is not None:
+                clauses.append(f"e.repo_id IN ({_placeholders(repo_ids)})")
+                params.extend(repo_ids)
+            rows = conn.execute(
+                f"""
+                SELECT e.*, t.query_text, t.returned_file_paths, t.symbols, t.handles,
+                    t.skipped_counts
+                FROM usage_events e
+                LEFT JOIN usage_traces t ON t.event_id = e.event_id
+                WHERE {" AND ".join(clauses)}
+                ORDER BY e.occurred_at DESC, e.event_id ASC
+                """,
+                params,
+            ).fetchall()
+        return {
+            "recording_enabled": policy.metrics_enabled,
+            "trace_enabled": policy.trace_enabled,
+            "window": window.label,
+            "event_count": len(rows),
+            "events": [_event_payload(row) for row in rows],
+            "health_warning": health.warning,
+        }
+
+    def export(
+        self,
+        *,
+        since: str = "90d",
+        include_local_paths: bool = False,
+    ) -> dict[str, Any]:
+        window = _window(since)
+        MetricsRecorder(self._db_path).prune()
+        policy = resolve_metrics_policy(db_path=self._db_path)
+        health = read_metrics_health(db_path=self._db_path)
+        with self._store.connect() as conn:
+            repos = [
+                _export_repo(row, include_local_paths=include_local_paths)
+                for row in conn.execute("SELECT * FROM repos ORDER BY display_name, repo_id")
+            ]
+            events = [
+                _event_payload(row)
+                for row in conn.execute(
+                    """
+                    SELECT * FROM usage_events
+                    WHERE occurred_at >= ?
+                    ORDER BY occurred_at, event_id
+                    """,
+                    (window.cutoff,),
+                )
+            ]
+            daily = [
+                dict(row)
+                for row in conn.execute(
+                    "SELECT * FROM daily_usage WHERE last_event_at >= ? ORDER BY day, repo_id",
+                    (window.cutoff,),
+                )
+            ]
+            traces = [
+                dict(row)
+                for row in conn.execute("SELECT * FROM usage_traces ORDER BY expires_at, trace_id")
+            ]
+        return {
+            "recording_enabled": policy.metrics_enabled,
+            "trace_enabled": policy.trace_enabled,
+            "window": window.label,
+            "exported_at": datetime.now(UTC).isoformat(timespec="seconds"),
+            "local_paths_included": include_local_paths,
+            "repos": repos,
+            "usage_events": events,
+            "daily_usage": daily,
+            "usage_traces": traces,
+            "health_warning": health.warning,
+        }
+
+
+def render_summary_text(payload: dict[str, Any]) -> str:
+    totals = payload["totals"]
+    lines = [
+        "archex metrics",
+        f"Window:                 {payload['window']}",
+        f"Recording:              {_on_off(payload['recording_enabled'])}",
+        f"Trace:                  {_on_off(payload['trace_enabled'])}",
+        f"Events:                 {payload['event_count']}",
+        f"Saved tokens:           {totals['tokens_saved']} vs returned full files",
+        f"Returned tokens:        {totals['tokens_returned']}",
+        f"Raw-equivalent tokens:  {totals['tokens_raw_equivalent']}",
+        f"Savings:                {totals['savings_pct']:.1f}%",
+        f"Whole-repo avoided:     {totals['whole_repo_tokens_avoided']} upper-bound/context only",
+    ]
+    if payload["health_warning"]:
+        lines.append(f"Metrics warning:        {payload['health_warning']}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_repos_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "archex metrics repos",
+        f"Window: {payload['window']}",
+        f"Recording: {_on_off(payload['recording_enabled'])}",
+        f"Trace: {_on_off(payload['trace_enabled'])}",
+    ]
+    for repo in payload["repos"]:
+        lines.append(
+            f"- {repo['display_name']}: {repo['tokens_saved']} saved tokens, "
+            f"{repo['event_count']} events"
+        )
+    if payload["health_warning"]:
+        lines.append(f"Metrics warning: {payload['health_warning']}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_inspect_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "archex metrics inspect",
+        f"Window: {payload['window']}",
+        f"Events: {payload['event_count']}",
+        f"Recording: {_on_off(payload['recording_enabled'])}",
+        f"Trace: {_on_off(payload['trace_enabled'])}",
+    ]
+    for event in payload["events"]:
+        lines.append(
+            f"- {event['occurred_at']} {event['surface']}/{event['tool_name']}: "
+            f"{event['tokens_saved']} saved tokens"
+        )
+    if payload["health_warning"]:
+        lines.append(f"Metrics warning: {payload['health_warning']}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _summary_payload(
+    totals: dict[str, Any],
+    *,
+    policy: MetricsPolicy,
+    health: MetricsHealth,
+    window: TimeWindow,
+) -> dict[str, Any]:
+    return {
+        "recording_enabled": policy.metrics_enabled,
+        "trace_enabled": policy.trace_enabled,
+        "window": window.label,
+        "event_count": totals["event_count"],
+        "totals": totals,
+        "health_warning": health.warning,
+    }
+
+
+def _repo_ids(
+    conn: Any,
+    *,
+    source: str | Path | None,
+    global_scope: bool,
+    workspace: str | Path | None,
+) -> list[str] | None:
+    if global_scope:
+        return None
+    if workspace is not None:
+        root = Path(workspace).expanduser().resolve()
+        rows = conn.execute("SELECT repo_id, repo_root FROM repos").fetchall()
+        return [
+            str(row["repo_id"]) for row in rows if _is_relative_to(Path(row["repo_root"]), root)
+        ]
+    repo_root = Path("." if source is None else source).expanduser().resolve()
+    row = conn.execute(
+        "SELECT repo_id FROM repos WHERE repo_root = ?",
+        (str(repo_root),),
+    ).fetchone()
+    return [] if row is None else [str(row["repo_id"])]
+
+
+def _totals(conn: Any, window: TimeWindow, repo_ids: list[str] | None) -> dict[str, Any]:
+    clauses = ["occurred_at >= ?"]
+    params: list[object] = [window.cutoff]
+    if repo_ids is not None:
+        if not repo_ids:
+            return _empty_totals()
+        clauses.append(f"repo_id IN ({_placeholders(repo_ids)})")
+        params.extend(repo_ids)
+    row = conn.execute(
+        f"""
+        SELECT COUNT(*) AS event_count,
+            COALESCE(SUM(tokens_returned), 0) AS tokens_returned,
+            COALESCE(SUM(tokens_raw_equivalent), 0) AS tokens_raw_equivalent,
+            COALESCE(SUM(tokens_saved), 0) AS tokens_saved,
+            COALESCE(SUM(whole_repo_tokens_avoided), 0) AS whole_repo_tokens_avoided
+        FROM usage_events
+        WHERE {" AND ".join(clauses)}
+        """,
+        params,
+    ).fetchone()
+    totals: dict[str, Any] = {
+        "event_count": int(row["event_count"]),
+        "tokens_returned": int(row["tokens_returned"]),
+        "tokens_raw_equivalent": int(row["tokens_raw_equivalent"]),
+        "tokens_saved": int(row["tokens_saved"]),
+        "whole_repo_tokens_avoided": int(row["whole_repo_tokens_avoided"]),
+    }
+    totals["savings_pct"] = _savings_pct(totals["tokens_saved"], totals["tokens_raw_equivalent"])
+    return totals
+
+
+def _empty_totals() -> dict[str, Any]:
+    return {
+        "event_count": 0,
+        "tokens_returned": 0,
+        "tokens_raw_equivalent": 0,
+        "tokens_saved": 0,
+        "whole_repo_tokens_avoided": 0,
+        "savings_pct": 0.0,
+    }
+
+
+def _repo_payload(row: Any) -> dict[str, Any]:
+    raw = int(row["tokens_raw_equivalent"])
+    saved = int(row["tokens_saved"])
+    return {
+        "repo_id": str(row["repo_id"]),
+        "display_name": str(row["display_name"]),
+        "event_count": int(row["event_count"]),
+        "tokens_returned": int(row["tokens_returned"]),
+        "tokens_raw_equivalent": raw,
+        "tokens_saved": saved,
+        "savings_pct": _savings_pct(saved, raw),
+        "whole_repo_tokens_avoided": int(row["whole_repo_tokens_avoided"]),
+    }
+
+
+def _event_payload(row: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "event_id": str(row["event_id"]),
+        "occurred_at": str(row["occurred_at"]),
+        "repo_id": str(row["repo_id"]),
+        "surface": str(row["surface"]),
+        "tool_name": str(row["tool_name"]),
+        "category": str(row["category"]),
+        "tokens_returned": int(row["tokens_returned"]),
+        "tokens_raw_equivalent": int(row["tokens_raw_equivalent"]),
+        "tokens_saved": int(row["tokens_saved"]),
+        "savings_pct": float(row["savings_pct"]),
+        "whole_repo_tokens": _optional_int(row["whole_repo_tokens"]),
+        "whole_repo_tokens_avoided": _optional_int(row["whole_repo_tokens_avoided"]),
+        "baseline_type": str(row["baseline_type"]),
+        "file_count": int(row["file_count"]),
+        "freshness": _optional_str(row["freshness"]),
+        "index_revision": _optional_str(row["index_revision"]),
+        "trace_id": _optional_str(row["trace_id"]),
+    }
+    if _row_has_column(row, "query_text") and row["query_text"] is not None:
+        payload["trace"] = {
+            "query_text": row["query_text"],
+            "returned_file_paths": json.loads(row["returned_file_paths"]),
+            "symbols": json.loads(row["symbols"]),
+            "handles": json.loads(row["handles"]),
+            "skipped_counts": json.loads(row["skipped_counts"]),
+        }
+    return payload
+
+
+def _export_repo(row: Any, *, include_local_paths: bool) -> dict[str, Any]:
+    payload = {
+        "repo_id": str(row["repo_id"]),
+        "display_name": str(row["display_name"]),
+        "first_seen_at": str(row["first_seen_at"]),
+        "last_seen_at": str(row["last_seen_at"]),
+    }
+    if include_local_paths:
+        payload["repo_root"] = str(row["repo_root"])
+    return payload
+
+
+def _window(value: str) -> TimeWindow:
+    now = datetime.now(UTC)
+    amount = int(value[:-1]) if len(value) > 1 else 0
+    unit = value[-1:].lower()
+    if amount < 0:
+        raise ValueError("since must be non-negative")
+    if unit == "d":
+        delta = timedelta(days=amount)
+    elif unit == "h":
+        delta = timedelta(hours=amount)
+    else:
+        raise ValueError("since must use h or d suffix")
+    return TimeWindow(value, (now - delta).isoformat(timespec="seconds"))
+
+
+def _savings_pct(saved: int, raw: int) -> float:
+    return (saved / raw * 100.0) if raw > 0 else 0.0
+
+
+def _placeholders(values: list[str]) -> str:
+    return ",".join("?" for _ in values)
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _row_has_column(row: Any, key: str) -> bool:
+    return key in tuple(row.keys())
+
+
+def _optional_str(value: object) -> str | None:
+    return str(value) if value is not None else None
+
+
+def _optional_int(value: object) -> int | None:
+    return int(cast("str | int | float", value)) if value is not None else None
+
+
+def _on_off(value: object) -> str:
+    return "on" if value else "off"

--- a/tests/metrics/test_metrics_cli.py
+++ b/tests/metrics/test_metrics_cli.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+from archex.metrics.recorder import MetricsRecorder, TraceDetails, UsageEvent
+from archex.metrics.storage import metrics_db_path
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_bare_metrics_prints_current_repo_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    runner = CliRunner()
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as cwd:
+        repo_root = Path(cwd).resolve()
+        _record(repo_root, tmp_path)
+        result = runner.invoke(cli, ["metrics"])
+
+    assert result.exit_code == 0, result.output
+    assert "Saved tokens:           90 vs returned full files" in result.output
+    assert "Whole-repo avoided:     990 upper-bound/context only" in result.output
+    assert "Recording:              on" in result.output
+    assert "Trace:                  off" in result.output
+
+
+def test_metrics_summary_repos_inspect_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_root = tmp_path / "workspace" / "repo-a"
+    repo_root.mkdir(parents=True)
+    _record(repo_root, tmp_path)
+    runner = CliRunner()
+
+    summary = runner.invoke(
+        cli,
+        ["metrics", "summary", str(repo_root), "--format", "json"],
+    )
+    repos = runner.invoke(cli, ["metrics", "repos", "--format", "json"])
+    inspect = runner.invoke(cli, ["metrics", "inspect", str(repo_root), "--format", "json"])
+    workspace = runner.invoke(
+        cli,
+        ["metrics", "summary", "--workspace", str(tmp_path / "workspace"), "--format", "json"],
+    )
+
+    assert summary.exit_code == 0, summary.output
+    assert repos.exit_code == 0, repos.output
+    assert inspect.exit_code == 0, inspect.output
+    assert workspace.exit_code == 0, workspace.output
+    summary_payload = json.loads(summary.output)
+    repos_payload = json.loads(repos.output)
+    inspect_payload = json.loads(inspect.output)
+    workspace_payload = json.loads(workspace.output)
+    assert summary_payload["totals"]["tokens_saved"] == 90
+    assert workspace_payload["totals"]["tokens_saved"] == 90
+    assert repos_payload["repos"][0]["display_name"] == "repo-a"
+    assert inspect_payload["events"][0]["tool_name"] == "query"
+
+
+def test_metrics_inspect_json_includes_opt_in_trace_details(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    runner = CliRunner()
+    trace_enable = runner.invoke(cli, ["metrics", "trace", "enable"])
+    _record(repo_root, tmp_path)
+
+    inspect = runner.invoke(cli, ["metrics", "inspect", str(repo_root), "--format", "json"])
+
+    assert trace_enable.exit_code == 0, trace_enable.output
+    assert inspect.exit_code == 0, inspect.output
+    event = json.loads(inspect.output)["events"][0]
+    assert event["trace"]["query_text"] == "where is auth"
+    assert event["trace"]["returned_file_paths"] == []
+
+
+def test_metrics_export_redacts_paths_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_root = tmp_path / "secret-org" / "secret-repo"
+    repo_root.mkdir(parents=True)
+    _record(repo_root, tmp_path)
+    runner = CliRunner()
+    redacted = tmp_path / "redacted.json"
+    pathful = tmp_path / "pathful.json"
+
+    default_result = runner.invoke(cli, ["metrics", "export", "--output", str(redacted)])
+    included_result = runner.invoke(
+        cli,
+        ["metrics", "export", "--output", str(pathful), "--include-local-paths"],
+    )
+
+    assert default_result.exit_code == 0, default_result.output
+    assert included_result.exit_code == 0, included_result.output
+    redacted_payload = json.loads(redacted.read_text(encoding="utf-8"))
+    pathful_payload = json.loads(pathful.read_text(encoding="utf-8"))
+    assert "repo_root" not in redacted_payload["repos"][0]
+    assert pathful_payload["repos"][0]["repo_root"] == str(repo_root.resolve())
+
+
+def test_metrics_controls_enable_disable_trace_and_delete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    runner = CliRunner()
+
+    disable = runner.invoke(cli, ["metrics", "disable"])
+    disabled_summary = runner.invoke(cli, ["metrics", "summary", "--format", "json"])
+    enable = runner.invoke(cli, ["metrics", "enable"])
+    trace_enable = runner.invoke(cli, ["metrics", "trace", "enable"])
+    traced_summary = runner.invoke(cli, ["metrics", "summary", "--format", "json"])
+    trace_disable = runner.invoke(cli, ["metrics", "trace", "disable"])
+    delete = runner.invoke(cli, ["metrics", "delete", "--all"])
+
+    assert disable.exit_code == 0, disable.output
+    assert json.loads(disabled_summary.output)["recording_enabled"] is False
+    assert enable.exit_code == 0, enable.output
+    assert trace_enable.exit_code == 0, trace_enable.output
+    assert json.loads(traced_summary.output)["trace_enabled"] is True
+    assert trace_disable.exit_code == 0, trace_disable.output
+    assert delete.exit_code == 0, delete.output
+    assert not metrics_db_path(home=tmp_path).exists()
+
+
+def _record(repo_root: Path, tmp_path: Path) -> None:
+    MetricsRecorder(metrics_db_path(home=tmp_path)).record(
+        UsageEvent(
+            repo_root=repo_root,
+            surface="cli",
+            tool_name="query",
+            category="context_retrieval",
+            tokens_returned=10,
+            tokens_raw_equivalent=100,
+            whole_repo_tokens=1000,
+            occurred_at=datetime.now(UTC),
+            file_count=1,
+            freshness="clean",
+            index_revision="rev",
+            trace=TraceDetails(query_text="where is auth"),
+        )
+    )


### PR DESCRIPTION
## Stack

Stack-Id: `local-metrics-foundation`
Base: `main`
Position: 4/5

1. `feat/metrics-storage-schema` -> #254
2. `feat/metrics-policy-registry` -> #255
3. `feat/metrics-recorder` -> #256
4. `feat/metrics-cli` -> this PR
5. `feat/metrics-visibility` -> #258

Depends on: #256
Upstack: #258

## Summary

- add `MetricsReporter` read paths for summary, repo rollups, inspect, and export
- add the nested `archex metrics` command group with summary, repos, inspect, export, enable/disable, delete, and trace toggles
- render deterministic JSON and label whole-repo avoided tokens as upper-bound/context only
- redact local repo paths from export unless `--include-local-paths` is explicitly set

## Validation

- Passed: `uv run ruff check src/archex/metrics src/archex/cli/metrics_cmd.py src/archex/cli/main.py tests/metrics`
- Passed: `uv run pyright src/archex/metrics src/archex/cli/metrics_cmd.py src/archex/cli/main.py tests/metrics`
- Passed: `uv run pytest tests/metrics`
