### PR TITLE
Expose metrics health in doctor and status

### DIFF
--- a/src/archex/cli/status_cmd.py
+++ b/src/archex/cli/status_cmd.py
@@ -52,6 +52,7 @@ def _status_payload(status: ProjectStatus) -> dict[str, object]:
             str(status.dogfood_latest_path) if status.dogfood_latest_path is not None else ""
         ),
         "error": status.error,
+        "metrics_savings": status.metrics_savings,
     }
 
 
@@ -71,6 +72,8 @@ def _render_text(status: ProjectStatus) -> None:
         languages = "none"
     click.echo(f"Languages:          {languages}")
     click.echo(f"Vector index:       {'yes' if status.vector_index_available else 'no'}")
+    if status.metrics_savings is not None and status.metrics_savings["event_count"] > 0:
+        click.echo(f"Metrics saved:      {status.metrics_savings['tokens_saved']} tokens")
     if status.dogfood_latest_path is not None:
         click.echo(f"Dogfood latest:     {status.dogfood_latest_path}")
     if status.error:

--- a/src/archex/doctor.py
+++ b/src/archex/doctor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, cast
@@ -17,6 +18,12 @@ from archex.index.model_policy import (
     reranker_security_profile,
 )
 from archex.languages import LANGUAGE_SUPPORT
+from archex.metrics.policy import METRICS_ENV, TRACE_ENV, MetricsPolicy
+from archex.metrics.storage import (
+    DEFAULT_RAW_EVENT_RETENTION_DAYS,
+    DEFAULT_TRACE_RETENTION_DAYS,
+    metrics_db_path,
+)
 from archex.models import LanguageTier
 from archex.parse.engine import TreeSitterEngine
 from archex.project import ProjectState
@@ -80,6 +87,7 @@ def inspect_doctor(source: str | Path, *, security_only: bool = False) -> Doctor
         checks.append(_grammar_check())
         checks.append(_mcp_registration_check(project.repo_root))
         checks.append(_disk_usage_check(project.project_dir))
+        checks.append(_metrics_health_check())
     checks.append(_model_security_check(project.repo_root))
     return DoctorReport(
         repo_root=project.repo_root,
@@ -100,6 +108,12 @@ def render_doctor_text(report: DoctorReport) -> str:
         if check.name == "disk_usage":
             total_bytes = check.details.get("total_bytes", 0)
             lines.append(f"  .archex size: {_format_bytes(_int_value(total_bytes))}")
+        if check.name == "metrics_health":
+            lines.append(f"  db_path: {check.details.get('db_path', '')}")
+            lines.append(f"  recording: {check.details.get('enabled', False)}")
+            lines.append(f"  trace: {check.details.get('trace_enabled', False)}")
+            if check.details.get("latest_failure"):
+                lines.append(f"  latest failure: {check.details.get('latest_failure')}")
         if check.name == "model_security":
             lines.append(f"  allow_remote_code: {check.details.get('allow_remote_code', False)}")
             for label in ("embedding", "reranker", "splade"):
@@ -510,6 +524,124 @@ def _disk_usage_check(project_dir: Path) -> DoctorCheck:
         message=f".archex uses {_format_bytes(total)}",
         details={"path": str(project_dir), "total_bytes": total},
     )
+
+
+def _metrics_health_check() -> DoctorCheck:
+    db_path = metrics_db_path()
+    policy = _default_metrics_policy()
+    latest_failure = ""
+    if db_path.exists():
+        try:
+            with sqlite3.connect(db_path) as conn:
+                conn.row_factory = sqlite3.Row
+                settings = {
+                    str(row["key"]): str(row["value"])
+                    for row in conn.execute("SELECT key, value FROM settings")
+                }
+                policy = _metrics_policy_from_settings(settings)
+                health_row = conn.execute(
+                    """
+                    SELECT status, last_failure_operation, last_failure_message
+                    FROM metrics_health
+                    WHERE id = 1
+                    """
+                ).fetchone()
+                latest_failure = _health_warning_from_row(health_row)
+        except sqlite3.Error as exc:
+            latest_failure = f"metrics: {exc}"
+    else:
+        policy = _metrics_policy_from_settings({})
+    details: dict[str, object] = {
+        "db_path": str(db_path),
+        "enabled": policy.metrics_enabled,
+        "trace_enabled": policy.trace_enabled,
+        "raw_event_retention_days": policy.raw_event_retention_days,
+        "trace_retention_days": policy.trace_retention_days,
+        "latest_failure": latest_failure,
+        "default_raw_event_retention_days": DEFAULT_RAW_EVENT_RETENTION_DAYS,
+        "default_trace_retention_days": DEFAULT_TRACE_RETENTION_DAYS,
+    }
+    if latest_failure:
+        return DoctorCheck(
+            name="metrics_health",
+            status="warning",
+            message=f"metrics recording warning: {latest_failure}",
+            details=details,
+        )
+    return DoctorCheck(
+        name="metrics_health",
+        status="ok",
+        message="local metrics storage is available",
+        details=details,
+    )
+
+
+def _default_metrics_policy() -> MetricsPolicy:
+    return MetricsPolicy(
+        metrics_enabled=True,
+        trace_enabled=False,
+        raw_event_retention_days=DEFAULT_RAW_EVENT_RETENTION_DAYS,
+        trace_retention_days=DEFAULT_TRACE_RETENTION_DAYS,
+    )
+
+
+def _metrics_policy_from_settings(settings: dict[str, str]) -> MetricsPolicy:
+    env_metrics = os.environ.get(METRICS_ENV, "").casefold()
+    env_trace = os.environ.get(TRACE_ENV, "").casefold()
+    if env_metrics == "off":
+        return MetricsPolicy(
+            metrics_enabled=False,
+            trace_enabled=False,
+            raw_event_retention_days=DEFAULT_RAW_EVENT_RETENTION_DAYS,
+            trace_retention_days=DEFAULT_TRACE_RETENTION_DAYS,
+        )
+    trace_enabled = _bool_setting(settings.get("trace_enabled"), default=False)
+    if env_trace == "on":
+        trace_enabled = True
+    elif env_trace == "off":
+        trace_enabled = False
+    return MetricsPolicy(
+        metrics_enabled=_bool_setting(settings.get("metrics_enabled"), default=True),
+        trace_enabled=trace_enabled,
+        raw_event_retention_days=_int_setting(
+            settings.get("raw_event_retention_days"),
+            default=DEFAULT_RAW_EVENT_RETENTION_DAYS,
+        ),
+        trace_retention_days=_int_setting(
+            settings.get("trace_retention_days"),
+            default=DEFAULT_TRACE_RETENTION_DAYS,
+        ),
+    )
+
+
+def _health_warning_from_row(row: sqlite3.Row | None) -> str:
+    if row is None:
+        return ""
+    if str(row["status"]) == "ok" or row["last_failure_message"] is None:
+        return ""
+    operation = str(row["last_failure_operation"] or "metrics")
+    return f"{operation}: {row['last_failure_message']}"
+
+
+def _bool_setting(value: str | None, *, default: bool) -> bool:
+    if value is None or value == "":
+        return default
+    normalized = value.casefold()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _int_setting(value: str | None, *, default: int) -> int:
+    if value is None or value == "":
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        return default
+    return parsed if parsed >= 0 else default
 
 
 def _status_details(status: ProjectStatus) -> dict[str, object]:

--- a/src/archex/status.py
+++ b/src/archex/status.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -9,6 +10,7 @@ from archex.cache import CacheManager
 from archex.config import load_config
 from archex.index.delta import compute_working_tree_signature
 from archex.index.store import IndexStore
+from archex.metrics.storage import metrics_db_path
 from archex.project import ProjectState
 
 
@@ -27,6 +29,7 @@ class ProjectStatus:
     vector_index_available: bool
     dogfood_latest_path: Path | None
     error: str = ""
+    metrics_savings: dict[str, int | float] | None = None
 
 
 def inspect_project_status(source: str | Path) -> ProjectStatus:
@@ -138,7 +141,48 @@ def inspect_project_status(source: str | Path) -> ProjectStatus:
         languages=languages,
         vector_index_available=_vector_index_available(project),
         dogfood_latest_path=dogfood_latest if dogfood_latest.exists() else None,
+        metrics_savings=_metrics_savings(project.repo_root),
     )
+
+
+def _metrics_savings(repo_root: Path) -> dict[str, int | float] | None:
+    db_path = metrics_db_path()
+    if not db_path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            repo = conn.execute(
+                "SELECT repo_id FROM repos WHERE repo_root = ?",
+                (str(repo_root.resolve()),),
+            ).fetchone()
+            if repo is None:
+                return None
+            row = conn.execute(
+                """
+                SELECT COUNT(*) AS event_count,
+                    COALESCE(SUM(tokens_saved), 0) AS tokens_saved,
+                    COALESCE(SUM(tokens_returned), 0) AS tokens_returned,
+                    COALESCE(SUM(tokens_raw_equivalent), 0) AS tokens_raw_equivalent
+                FROM usage_events
+                WHERE repo_id = ?
+                """,
+                (str(repo["repo_id"]),),
+            ).fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+    raw = int(row["tokens_raw_equivalent"])
+    saved = int(row["tokens_saved"])
+    return {
+        "event_count": int(row["event_count"]),
+        "tokens_saved": saved,
+        "tokens_returned": int(row["tokens_returned"]),
+        "tokens_raw_equivalent": raw,
+        "savings_pct": (saved / raw * 100.0) if raw > 0 else 0.0,
+    }
 
 
 def _language_counts(file_metadata: list[dict[str, str | int]]) -> dict[str, int]:

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -2,15 +2,22 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING
 
+import pytest
 from click.testing import CliRunner
 
 from archex.cli.main import cli
+from archex.metrics.health import record_metrics_failure
+from archex.metrics.storage import metrics_db_path
 from archex.project import init_project
 
-if TYPE_CHECKING:
-    import pytest
+
+@pytest.fixture(autouse=True)
+def _isolated_metrics_home(  # pyright: ignore[reportUnusedFunction]
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
 
 
 def test_doctor_json_reports_healthy_project(python_simple_repo: Path) -> None:
@@ -70,6 +77,33 @@ def test_doctor_text_includes_required_sections(python_simple_repo: Path) -> Non
     assert "disk_usage" in result.output
     assert "model_security" in result.output
     assert "allow_remote_code: False" in result.output
+
+
+def test_doctor_json_reports_metrics_health(
+    python_simple_repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    init_project(python_simple_repo)
+    record_metrics_failure("record", "disk full", db_path=metrics_db_path(home=tmp_path))
+    runner = CliRunner()
+    indexed = runner.invoke(cli, ["index", str(python_simple_repo), "--format", "json"])
+    assert indexed.exit_code == 0, indexed.output
+
+    result = runner.invoke(cli, ["doctor", str(python_simple_repo), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    checks = {check["name"]: check for check in payload["checks"]}
+    metrics = checks["metrics_health"]
+    assert metrics["status"] == "warning"
+    assert metrics["details"]["db_path"] == str(metrics_db_path(home=tmp_path))
+    assert metrics["details"]["enabled"] is True
+    assert metrics["details"]["trace_enabled"] is False
+    assert metrics["details"]["raw_event_retention_days"] == 90
+    assert metrics["details"]["trace_retention_days"] == 14
+    assert metrics["details"]["latest_failure"] == "record: disk full"
 
 
 def test_doctor_security_reports_remote_code_block(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,10 +59,19 @@ def implementation_gate_paths(args: Sequence[str]) -> bool:
             or path.startswith("tests/index/")
             for path in paths
         )
-    if any(path == "tests/metrics" or path.startswith("tests/metrics/") for path in paths):
-        return all(path == "tests/metrics" or path.startswith("tests/metrics/") for path in paths)
-    if any(path == "tests/cli" or path.startswith("tests/cli/") for path in paths):
-        return all(path == "tests/cli" or path.startswith("tests/cli/") for path in paths)
+    cli_metric_paths = (
+        "tests/metrics",
+        "tests/cli",
+        "tests/test_cli.py",
+    )
+
+    def _is_cli_metric_path(path: str) -> bool:
+        return path == "tests/test_cli.py" or any(
+            path == prefix or path.startswith(f"{prefix}/") for prefix in cli_metric_paths[:-1]
+        )
+
+    if any(_is_cli_metric_path(path) for path in paths):
+        return all(_is_cli_metric_path(path) for path in paths)
     if any(path in {"tests/test_graph_query.py", "tests/test_scout.py"} for path in paths):
         allowed_paths = {
             "tests/test_graph_query.py",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -233,6 +233,41 @@ def test_status_command_reports_fresh_index(python_simple_repo: Path) -> None:
     assert data["languages"]["python"] > 0
 
 
+def test_status_command_reports_metrics_savings(
+    python_simple_repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from archex.metrics.recorder import MetricsRecorder, UsageEvent
+    from archex.metrics.storage import metrics_db_path
+    from archex.project import init_project
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    init_project(python_simple_repo)
+    runner = CliRunner()
+    indexed = runner.invoke(cli, ["index", str(python_simple_repo), "--format", "json"])
+    assert indexed.exit_code == 0, indexed.output
+    MetricsRecorder(metrics_db_path(home=tmp_path)).record(
+        UsageEvent(
+            repo_root=python_simple_repo,
+            surface="cli",
+            tool_name="query",
+            category="context_retrieval",
+            tokens_returned=10,
+            tokens_raw_equivalent=100,
+            whole_repo_tokens=1000,
+        )
+    )
+
+    result = runner.invoke(cli, ["status", str(python_simple_repo), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    metrics = json.loads(result.output)["metrics_savings"]
+    assert metrics["event_count"] == 1
+    assert metrics["tokens_saved"] == 90
+    assert metrics["savings_pct"] == 90.0
+
+
 def test_status_command_strict_fails_on_dirty_index(python_simple_repo: Path) -> None:
     from archex.project import init_project
 


### PR DESCRIPTION
## Stack

Stack-Id: `local-metrics-foundation`
Base: `main`
Position: 5/5

1. `feat/metrics-storage-schema` -> #254
2. `feat/metrics-policy-registry` -> #255
3. `feat/metrics-recorder` -> #256
4. `feat/metrics-cli` -> #257
5. `feat/metrics-visibility` -> this PR

Depends on: #257
Upstack: (none - leaf)

## Summary

- add `metrics_health` details to `archex doctor` without making doctor mutate the metrics ledger
- expose lightweight current-repo savings totals in `archex status`
- keep `archex metrics` authoritative while surfacing useful visibility in doctor/status
- add focused doctor/status tests plus implementation-gate coverage handling for the new slices

## Validation

- Passed: `uv run ruff check src/archex/doctor.py src/archex/status.py src/archex/cli/status_cmd.py tests/cli/test_doctor.py tests/test_cli.py tests/conftest.py`
- Passed: `uv run pyright src/archex/doctor.py src/archex/status.py src/archex/cli/status_cmd.py tests/cli/test_doctor.py tests/test_cli.py`
- Passed: `uv run pytest tests/cli/test_doctor.py`
- Passed: `uv run pytest tests/test_cli.py -k status`
