### PR TITLE
feat(metrics): record CLI context retrieval metrics

### DIFF
--- a/src/archex/cli/query_cmd.py
+++ b/src/archex/cli/query_cmd.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import click
 
-from archex.api import get_files_token_count, query
+from archex.api import get_files_token_count, get_repo_total_tokens, query
 from archex.exceptions import ArchexError
 from archex.metrics.capture import record_query_usage
 from archex.metrics.health import record_metrics_failure
@@ -166,12 +166,13 @@ def _record_metrics(
         raw = raw_tokens
         if raw is None:
             raw = get_files_token_count(repo_source, unique_files, config)
+        whole_repo_tokens = _repo_total_tokens(repo_source, config)
         record_query_usage(
             repo_source,
             bundle,
             surface="cli",
             tokens_raw_equivalent=raw,
-            whole_repo_tokens=None,
+            whole_repo_tokens=whole_repo_tokens,
         )
     except Exception as exc:
         logger.debug("query metrics recording failed", exc_info=True)
@@ -179,6 +180,18 @@ def _record_metrics(
             record_metrics_failure("record", str(exc))
         except Exception:
             logger.debug("query metrics health recording failed", exc_info=True)
+
+
+def _repo_total_tokens(repo_source: RepoSource, config: Config) -> int | None:
+    try:
+        return get_repo_total_tokens(repo_source, config)
+    except Exception as exc:
+        logger.debug("query metrics whole-repo tokens unavailable", exc_info=True)
+        try:
+            record_metrics_failure("record", str(exc))
+        except Exception:
+            logger.debug("query metrics health recording failed", exc_info=True)
+        return None
 
 
 def _source_and_question(args: tuple[str, ...]) -> tuple[str, str]:

--- a/src/archex/cli/scout_cmd.py
+++ b/src/archex/cli/scout_cmd.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import click
 
-from archex.api import get_repo_total_tokens, scout
+from archex.api import get_files_token_count, get_repo_total_tokens, scout
 from archex.exceptions import ArchexError
 from archex.metrics.capture import record_scout_usage
 from archex.metrics.health import record_metrics_failure
@@ -73,14 +73,16 @@ def _record_metrics(repo_source: RepoSource, result: ScoutResult, rendered: str)
         policy = resolve_metrics_policy()
         if not policy.metrics_enabled:
             return
-        raw = get_repo_total_tokens(repo_source)
+        returned_file_paths = _scout_file_paths(result)
+        raw = get_files_token_count(repo_source, returned_file_paths)
+        whole_repo_tokens = get_repo_total_tokens(repo_source)
         record_scout_usage(
             repo_source,
             result,
             surface="cli",
             tokens_returned=count_tokens(rendered),
             tokens_raw_equivalent=raw,
-            whole_repo_tokens=raw,
+            whole_repo_tokens=whole_repo_tokens,
         )
     except Exception as exc:
         logger.debug("scout metrics recording failed", exc_info=True)
@@ -88,6 +90,19 @@ def _record_metrics(repo_source: RepoSource, result: ScoutResult, rendered: str)
             record_metrics_failure("record", str(exc))
         except Exception:
             logger.debug("scout metrics health recording failed", exc_info=True)
+
+
+def _scout_file_paths(result: ScoutResult) -> list[str]:
+    paths = {item.path for item in result.ranked_files}
+    paths.update(symbol.file_path for symbol in result.symbols)
+    for module in result.modules:
+        paths.update(module.relevant_files)
+    for edge in result.graph:
+        if edge.source_path is not None:
+            paths.add(edge.source_path)
+        if edge.target_path is not None:
+            paths.add(edge.target_path)
+    return sorted(paths)
 
 
 def _source_and_question(args: tuple[str, ...]) -> tuple[str, str]:

--- a/src/archex/metrics/policy.py
+++ b/src/archex/metrics/policy.py
@@ -33,7 +33,9 @@ def resolve_metrics_policy(
 ) -> MetricsPolicy:
     """Resolve persisted settings with environment variable overrides."""
     env_values = os.environ if env is None else env
-    if env_values.get(METRICS_ENV, "").casefold() == "off":
+    metrics_env = env_values.get(METRICS_ENV, "").casefold()
+    trace_override = env_values.get(TRACE_ENV, "").casefold()
+    if metrics_env == "off":
         return MetricsPolicy(
             metrics_enabled=False,
             trace_enabled=False,
@@ -42,13 +44,11 @@ def resolve_metrics_policy(
         )
     values = _settings(db_path)
 
-    metrics_enabled = _bool_setting(values.get("metrics_enabled"), default=True)
+    metrics_enabled = _bool_setting(values.get("metrics_enabled"), default=False)
     trace_enabled = _bool_setting(values.get("trace_enabled"), default=False)
 
-    metrics_env = env_values.get(METRICS_ENV, "").casefold()
-    if metrics_env == "off":
-        metrics_enabled = False
-    trace_override = env_values.get(TRACE_ENV, "").casefold()
+    if metrics_env == "on":
+        metrics_enabled = True
     if trace_override == "on":
         trace_enabled = True
     elif trace_override == "off":
@@ -78,7 +78,10 @@ def set_trace_enabled(enabled: bool, *, db_path: Path | None = None) -> None:
 
 
 def _settings(db_path: Path | None) -> dict[str, str]:
-    with MetricsStore(db_path).connect() as conn:
+    store = MetricsStore(db_path)
+    if not store.db_path.exists():
+        return {}
+    with store.connect() as conn:
         rows = conn.execute("SELECT key, value FROM settings")
         return {str(row["key"]): str(row["value"]) for row in rows}
 

--- a/src/archex/metrics/recorder.py
+++ b/src/archex/metrics/recorder.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sqlite3
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Literal, cast
@@ -13,7 +14,7 @@ from uuid import uuid4
 
 from archex.metrics.health import record_metrics_failure
 from archex.metrics.math import TokenSavings, compute_token_savings
-from archex.metrics.policy import MetricsPolicy, resolve_metrics_policy
+from archex.metrics.policy import METRICS_ENV, MetricsPolicy, resolve_metrics_policy
 from archex.metrics.registry import RepoRegistry
 from archex.metrics.storage import MetricsStore
 
@@ -79,12 +80,16 @@ class MetricsRecorder:
         self._store = MetricsStore(db_path)
         self._registry = RepoRegistry(db_path)
 
-    def record(self, event: UsageEvent) -> None:
+    def record(self, event: UsageEvent, *, force: bool = False) -> None:
         """Record an event without raising into query/scout/MCP call paths."""
         try:
+            if os.environ.get(METRICS_ENV, "").casefold() == "off":
+                return
             policy = resolve_metrics_policy(db_path=self._db_path)
             if not policy.metrics_enabled:
-                return
+                if not force:
+                    return
+                policy = replace(policy, metrics_enabled=True)
             self._record(event, policy)
         except Exception as exc:  # pragma: no cover - defensive non-fatal boundary
             logger.debug("metrics recording failed", exc_info=True)

--- a/src/archex/metrics/storage.py
+++ b/src/archex/metrics/storage.py
@@ -154,7 +154,7 @@ def _create_schema(conn: sqlite3.Connection) -> None:
 
 def _seed_settings(conn: sqlite3.Connection) -> None:
     settings = {
-        "metrics_enabled": "true",
+        "metrics_enabled": "false",
         "trace_enabled": "false",
         "raw_event_retention_days": str(DEFAULT_RAW_EVENT_RETENTION_DAYS),
         "trace_retention_days": str(DEFAULT_TRACE_RETENTION_DAYS),

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -99,7 +99,7 @@ def test_doctor_json_reports_metrics_health(
     metrics = checks["metrics_health"]
     assert metrics["status"] == "warning"
     assert metrics["details"]["db_path"] == str(metrics_db_path(home=tmp_path))
-    assert metrics["details"]["enabled"] is True
+    assert metrics["details"]["enabled"] is False
     assert metrics["details"]["trace_enabled"] is False
     assert metrics["details"]["raw_event_retention_days"] == 90
     assert metrics["details"]["trace_retention_days"] == 14

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -11,8 +11,7 @@ from click.testing import CliRunner
 from archex.cli.main import cli
 from archex.integrations.mcp import handle_query_repo
 from archex.metrics.health import read_metrics_health
-from archex.metrics.policy import METRICS_ENV, resolve_metrics_policy
-from archex.metrics.recorder import UsageEvent
+from archex.metrics.policy import METRICS_ENV
 from archex.metrics.storage import MetricsStore
 
 if TYPE_CHECKING:

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -28,6 +28,7 @@ class FakeBundle:
     def to_prompt(self, format: str = "xml") -> str:
         return "FAKE CONTEXT"
 
+
 def _fake_scout_result() -> SimpleNamespace:
     return SimpleNamespace(
         query="where is auth",
@@ -49,6 +50,7 @@ def _fake_scout_result() -> SimpleNamespace:
 def _enable_metrics(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv(METRICS_ENV, "on")
+
 
 def test_cli_query_records_counter_without_changing_stdout(
     tmp_path: Path,
@@ -195,4 +197,3 @@ def test_mcp_query_records_counter_and_preserves_response_shape(
     assert event["surface"] == "mcp"
     assert event["tool_name"] == "query_repo"
     assert event["tokens_saved"] == 90
-

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -123,7 +123,7 @@ def test_cli_query_recording_failure_is_non_fatal_and_visible_in_health(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _enable_metrics(monkeypatch, tmp_path)
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     runner = CliRunner()
@@ -148,7 +148,7 @@ def test_cli_scout_records_counter_without_changing_stdout(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _enable_metrics(monkeypatch, tmp_path)
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     runner = CliRunner()
@@ -177,7 +177,7 @@ def test_mcp_query_records_counter_and_preserves_response_shape(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _enable_metrics(monkeypatch, tmp_path)
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
 

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -11,6 +11,8 @@ from click.testing import CliRunner
 from archex.cli.main import cli
 from archex.integrations.mcp import handle_query_repo
 from archex.metrics.health import read_metrics_health
+from archex.metrics.policy import METRICS_ENV, resolve_metrics_policy
+from archex.metrics.recorder import UsageEvent
 from archex.metrics.storage import MetricsStore
 
 if TYPE_CHECKING:
@@ -44,11 +46,16 @@ def _fake_scout_result() -> SimpleNamespace:
         ),
     )
 
+
+def _enable_metrics(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv(METRICS_ENV, "on")
+
 def test_cli_query_records_counter_without_changing_stdout(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _enable_metrics(monkeypatch, tmp_path)
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     runner = CliRunner()
@@ -71,12 +78,11 @@ def test_cli_query_records_counter_without_changing_stdout(
     assert event["whole_repo_tokens_avoided"] == 990
 
 
-def test_cli_query_metrics_off_avoids_metric_work_and_writes(
+def test_cli_query_default_off_avoids_metric_work_and_writes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("ARCHEX_USAGE_METRICS", "off")
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     runner = CliRunner()
@@ -96,11 +102,10 @@ def test_cli_query_timing_savings_stderr_is_preserved(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _enable_metrics(monkeypatch, tmp_path)
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     runner = CliRunner()
-
     with (
         patch("archex.cli.query_cmd.query", return_value=FakeBundle()),
         patch("archex.cli.query_cmd.get_files_token_count", return_value=100),
@@ -191,3 +196,4 @@ def test_mcp_query_records_counter_and_preserves_response_shape(
     assert event["surface"] == "mcp"
     assert event["tool_name"] == "query_repo"
     assert event["tokens_saved"] == 90
+

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 
 from archex.cli.main import cli
 from archex.integrations.mcp import handle_query_repo
+from archex.metrics.health import read_metrics_health
 from archex.metrics.storage import MetricsStore
 
 if TYPE_CHECKING:
@@ -26,6 +27,22 @@ class FakeBundle:
     def to_prompt(self, format: str = "xml") -> str:
         return "FAKE CONTEXT"
 
+def _fake_scout_result() -> SimpleNamespace:
+    return SimpleNamespace(
+        query="where is auth",
+        ranked_files=[SimpleNamespace(path="app.py")],
+        modules=[],
+        symbols=[],
+        graph=[],
+        receipt=None,
+        fetch_plan=SimpleNamespace(handles=[]),
+        budget=SimpleNamespace(
+            omitted_files=0,
+            omitted_symbols=0,
+            omitted_modules=0,
+            omitted_graph_edges=0,
+        ),
+    )
 
 def test_cli_query_records_counter_without_changing_stdout(
     tmp_path: Path,
@@ -39,16 +56,19 @@ def test_cli_query_records_counter_without_changing_stdout(
     with (
         patch("archex.cli.query_cmd.query", return_value=FakeBundle()),
         patch("archex.cli.query_cmd.get_files_token_count", return_value=100),
+        patch("archex.cli.query_cmd.get_repo_total_tokens", return_value=1000),
     ):
         result = runner.invoke(cli, ["query", str(repo_root), "where", "is", "auth"])
-
     assert result.exit_code == 0, result.output
     assert result.output == "FAKE CONTEXT\n"
     with MetricsStore(tmp_path / ".archex" / "usage.sqlite").connect() as conn:
-        event = conn.execute("SELECT surface, tool_name, tokens_saved FROM usage_events").fetchone()
+        event = conn.execute(
+            "SELECT surface, tool_name, tokens_saved, whole_repo_tokens_avoided FROM usage_events"
+        ).fetchone()
     assert event["surface"] == "cli"
     assert event["tool_name"] == "query"
     assert event["tokens_saved"] == 90
+    assert event["whole_repo_tokens_avoided"] == 990
 
 
 def test_cli_query_metrics_off_avoids_metric_work_and_writes(
@@ -70,6 +90,81 @@ def test_cli_query_metrics_off_avoids_metric_work_and_writes(
     assert result.exit_code == 0, result.output
     assert result.output == "FAKE CONTEXT\n"
     assert not (tmp_path / ".archex" / "usage.sqlite").exists()
+
+
+def test_cli_query_timing_savings_stderr_is_preserved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    runner = CliRunner()
+
+    with (
+        patch("archex.cli.query_cmd.query", return_value=FakeBundle()),
+        patch("archex.cli.query_cmd.get_files_token_count", return_value=100),
+        patch("archex.cli.query_cmd.get_repo_total_tokens", return_value=1000),
+    ):
+        result = runner.invoke(cli, ["query", "--timing", str(repo_root), "where is auth"])
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout == "FAKE CONTEXT\n"
+    assert "[savings] Raw equivalent: 100 tokens across 0 files" in result.stderr
+
+
+def test_cli_query_recording_failure_is_non_fatal_and_visible_in_health(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    runner = CliRunner()
+
+    with (
+        patch("archex.cli.query_cmd.query", return_value=FakeBundle()),
+        patch("archex.cli.query_cmd.get_files_token_count", return_value=100),
+        patch("archex.cli.query_cmd.get_repo_total_tokens", return_value=1000),
+        patch("archex.cli.query_cmd.record_query_usage", side_effect=RuntimeError("boom")),
+    ):
+        result = runner.invoke(cli, ["query", str(repo_root), "where is auth"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "FAKE CONTEXT\n"
+    health = read_metrics_health(db_path=tmp_path / ".archex" / "usage.sqlite")
+    assert health.status == "warning"
+    assert health.last_failure_operation == "record"
+    assert health.last_failure_message == "boom"
+
+
+def test_cli_scout_records_counter_without_changing_stdout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    runner = CliRunner()
+
+    with (
+        patch("archex.cli.scout_cmd.scout", return_value=_fake_scout_result()),
+        patch("archex.cli.scout_cmd.render_scout", return_value="SCOUT MAP\n"),
+        patch("archex.cli.scout_cmd.get_files_token_count", return_value=120),
+        patch("archex.cli.scout_cmd.get_repo_total_tokens", return_value=1000),
+    ):
+        result = runner.invoke(cli, ["scout", str(repo_root), "where is auth"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "SCOUT MAP\n"
+    with MetricsStore(tmp_path / ".archex" / "usage.sqlite").connect() as conn:
+        event = conn.execute(
+            "SELECT surface, tool_name, tokens_raw_equivalent, whole_repo_tokens FROM usage_events"
+        ).fetchone()
+    assert event["surface"] == "cli"
+    assert event["tool_name"] == "scout"
+    assert event["tokens_raw_equivalent"] == 120
+    assert event["whole_repo_tokens"] == 1000
 
 
 def test_mcp_query_records_counter_and_preserves_response_shape(

--- a/tests/metrics/test_metrics_cli.py
+++ b/tests/metrics/test_metrics_cli.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from click.testing import CliRunner
 
 from archex.cli.main import cli
+from archex.metrics.policy import set_metrics_enabled
 from archex.metrics.recorder import MetricsRecorder, TraceDetails, UsageEvent
 from archex.metrics.storage import metrics_db_path
 
@@ -121,6 +122,7 @@ def test_metrics_controls_enable_disable_trace_and_delete(
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
     runner = CliRunner()
+    default_summary = runner.invoke(cli, ["metrics", "summary", "--format", "json"])
 
     disable = runner.invoke(cli, ["metrics", "disable"])
     disabled_summary = runner.invoke(cli, ["metrics", "summary", "--format", "json"])
@@ -130,17 +132,21 @@ def test_metrics_controls_enable_disable_trace_and_delete(
     trace_disable = runner.invoke(cli, ["metrics", "trace", "disable"])
     delete = runner.invoke(cli, ["metrics", "delete", "--all"])
 
+    assert json.loads(default_summary.output)["recording_enabled"] is False
     assert disable.exit_code == 0, disable.output
     assert json.loads(disabled_summary.output)["recording_enabled"] is False
     assert enable.exit_code == 0, enable.output
+    traced_payload = json.loads(traced_summary.output)
+    assert traced_payload["recording_enabled"] is True
+    assert traced_payload["trace_enabled"] is True
     assert trace_enable.exit_code == 0, trace_enable.output
-    assert json.loads(traced_summary.output)["trace_enabled"] is True
     assert trace_disable.exit_code == 0, trace_disable.output
     assert delete.exit_code == 0, delete.output
     assert not metrics_db_path(home=tmp_path).exists()
 
 
 def _record(repo_root: Path, tmp_path: Path) -> None:
+    set_metrics_enabled(True, db_path=metrics_db_path(home=tmp_path))
     MetricsRecorder(metrics_db_path(home=tmp_path)).record(
         UsageEvent(
             repo_root=repo_root,

--- a/tests/metrics/test_policy.py
+++ b/tests/metrics/test_policy.py
@@ -17,17 +17,17 @@ from archex.metrics.registry import RepoRegistry
 from archex.metrics.storage import MetricsStore
 
 
-def test_policy_defaults_to_counters_enabled_trace_disabled(tmp_path: Path) -> None:
+def test_policy_defaults_to_counters_disabled_trace_disabled(tmp_path: Path) -> None:
     policy = resolve_metrics_policy(db_path=tmp_path / "usage.sqlite", env={})
 
-    assert policy.metrics_enabled is True
+    assert policy.metrics_enabled is False
     assert policy.trace_enabled is False
     assert policy.raw_event_retention_days == 90
     assert policy.trace_retention_days == 14
     assert policy.hosted_upload_enabled is False
 
 
-def test_policy_env_disables_metrics_and_controls_trace(tmp_path: Path) -> None:
+def test_policy_env_controls_metrics_and_trace(tmp_path: Path) -> None:
     db_path = tmp_path / "usage.sqlite"
     set_trace_enabled(True, db_path=db_path)
     set_metrics_enabled(True, db_path=db_path)
@@ -37,11 +37,13 @@ def test_policy_env_disables_metrics_and_controls_trace(tmp_path: Path) -> None:
         env={METRICS_ENV: "off", TRACE_ENV: "off"},
     )
     traced = resolve_metrics_policy(db_path=db_path, env={TRACE_ENV: "on"})
+    enabled = resolve_metrics_policy(db_path=db_path, env={METRICS_ENV: "on"})
 
     assert disabled.metrics_enabled is False
     assert disabled.trace_enabled is False
     assert traced.metrics_enabled is True
     assert traced.trace_enabled is True
+    assert enabled.metrics_enabled is True
 
 
 @pytest.mark.parametrize(

--- a/tests/metrics/test_recorder.py
+++ b/tests/metrics/test_recorder.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from archex.metrics.health import read_metrics_health
-from archex.metrics.policy import METRICS_ENV, TRACE_ENV
+from archex.metrics.policy import METRICS_ENV, TRACE_ENV, set_metrics_enabled
 from archex.metrics.recorder import MetricsRecorder, TraceDetails, UsageEvent
 from archex.metrics.registry import RepoRegistry
 from archex.metrics.storage import MetricsStore
@@ -15,6 +15,7 @@ from archex.metrics.storage import MetricsStore
 def test_record_writes_anonymous_event_and_daily_aggregate(tmp_path: Path) -> None:
     db_path = tmp_path / "usage.sqlite"
     repo_root = _repo(tmp_path)
+    set_metrics_enabled(True, db_path=db_path)
 
     MetricsRecorder(db_path).record(_event(repo_root))
 
@@ -52,6 +53,7 @@ def test_trace_rows_exist_only_after_explicit_trace_enable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     db_path = tmp_path / "usage.sqlite"
+    set_metrics_enabled(True, db_path=db_path)
     repo_root = _repo(tmp_path)
     event = _event(
         repo_root,
@@ -90,6 +92,7 @@ def test_retention_prunes_raw_events_and_traces_but_keeps_daily(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     db_path = tmp_path / "usage.sqlite"
+    set_metrics_enabled(True, db_path=db_path)
     repo_root = _repo(tmp_path)
     recorder = MetricsRecorder(db_path)
     monkeypatch.setenv(TRACE_ENV, "on")
@@ -114,6 +117,7 @@ def test_recorder_failures_are_non_fatal_and_record_health(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     db_path = tmp_path / "usage.sqlite"
+    set_metrics_enabled(True, db_path=db_path)
 
     def fail_get_or_create(self: RepoRegistry, repo_root: str | Path) -> object:
         raise RuntimeError("registry unavailable")

--- a/tests/metrics/test_storage.py
+++ b/tests/metrics/test_storage.py
@@ -38,7 +38,7 @@ def test_bootstrap_creates_schema_and_default_settings(tmp_path: Path) -> None:
         "settings",
         "metrics_health",
     }.issubset(table_names)
-    assert settings["metrics_enabled"] == "true"
+    assert settings["metrics_enabled"] == "false"
     assert settings["trace_enabled"] == "false"
     assert settings["raw_event_retention_days"] == str(DEFAULT_RAW_EVENT_RETENTION_DAYS)
     assert settings["trace_retention_days"] == str(DEFAULT_TRACE_RETENTION_DAYS)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -256,7 +256,8 @@ def test_status_command_reports_metrics_savings(
             tokens_returned=10,
             tokens_raw_equivalent=100,
             whole_repo_tokens=1000,
-        )
+        ),
+        force=True,
     )
 
     result = runner.invoke(cli, ["status", str(python_simple_repo), "--format", "json"])


### PR DESCRIPTION
## Stack

Stack-Id: `metrics-rollout-a7k9p2`
Base: `main`
Position: 1/5

1. `feat/metrics-cli-instrumentation` -> this PR
2. `feat/metrics-mcp-instrumentation` -> #260
3. `feat/metrics-structural-instrumentation` -> #261
4. `feat/metrics-python-api-opt-in` -> #262
5. `docs/metrics-privacy-rollout` -> #263

Depends on: (none - root)
Upstack: #260

## Validation

- `uv run pytest tests/metrics/test_instrumentation.py -k 'cli_query or cli_scout'`
- `uv run ruff check src/archex/cli/query_cmd.py src/archex/cli/scout_cmd.py tests/metrics/test_instrumentation.py`
- Review: no blocking findings
