### PR TITLE
feat(metrics): record MCP context retrieval metrics

### DIFF
--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -190,18 +190,23 @@ def handle_scout_repo(
     )
 
 
-def _record_query_metrics(source: RepoSource, bundle: ContextBundle, raw_tokens: int) -> None:
+def _record_query_metrics(
+    source: RepoSource,
+    bundle: ContextBundle,
+    raw_tokens: int,
+) -> None:
     try:
         policy = resolve_metrics_policy()
         if not policy.metrics_enabled:
             return
+        whole_repo_tokens = _whole_repo_tokens(source)
         record_query_usage(
             source,
             bundle,
             surface="mcp",
             tool_name="query_repo",
             tokens_raw_equivalent=raw_tokens,
-            whole_repo_tokens=None,
+            whole_repo_tokens=whole_repo_tokens,
         )
     except Exception as exc:
         logger.debug("MCP query metrics recording failed", exc_info=True)
@@ -215,12 +220,13 @@ def _record_scout_metrics(
     source: RepoSource,
     result: ScoutResult,
     rendered: str,
-    raw_tokens: int,
+    whole_repo_tokens: int | None,
 ) -> None:
     try:
         policy = resolve_metrics_policy()
         if not policy.metrics_enabled:
             return
+        raw_tokens = get_files_token_count(source, _scout_file_paths(result))
         record_scout_usage(
             source,
             result,
@@ -228,7 +234,7 @@ def _record_scout_metrics(
             tool_name="scout_repo",
             tokens_returned=count_tokens(rendered),
             tokens_raw_equivalent=raw_tokens,
-            whole_repo_tokens=raw_tokens,
+            whole_repo_tokens=whole_repo_tokens,
         )
     except Exception as exc:
         logger.debug("MCP scout metrics recording failed", exc_info=True)
@@ -236,6 +242,31 @@ def _record_scout_metrics(
             record_metrics_failure("record", str(exc))
         except Exception:
             logger.debug("MCP scout metrics health recording failed", exc_info=True)
+
+
+def _whole_repo_tokens(source: RepoSource) -> int | None:
+    try:
+        return get_repo_total_tokens(source)
+    except Exception as exc:
+        logger.debug("MCP metrics whole-repo tokens unavailable", exc_info=True)
+        try:
+            record_metrics_failure("record", str(exc))
+        except Exception:
+            logger.debug("MCP metrics health recording failed", exc_info=True)
+        return None
+
+
+def _scout_file_paths(result: ScoutResult) -> list[str]:
+    paths = {item.path for item in result.ranked_files}
+    paths.update(symbol.file_path for symbol in result.symbols)
+    for module in result.modules:
+        paths.update(module.relevant_files)
+    for edge in result.graph:
+        if edge.source_path is not None:
+            paths.add(edge.source_path)
+        if edge.target_path is not None:
+            paths.add(edge.target_path)
+    return sorted(paths)
 
 
 def handle_compare_repos(

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from archex.cli.main import cli
-from archex.integrations.mcp import handle_query_repo
+from archex.integrations.mcp import handle_query_repo, handle_scout_repo
 from archex.metrics.health import read_metrics_health
 from archex.metrics.policy import METRICS_ENV
 from archex.metrics.storage import MetricsStore
@@ -193,7 +193,92 @@ def test_mcp_query_records_counter_and_preserves_response_shape(
     assert sorted(payload) == ["_meta", "content", "receipt"]
     assert payload["content"] == "<context />"
     with MetricsStore(tmp_path / ".archex" / "usage.sqlite").connect() as conn:
-        event = conn.execute("SELECT surface, tool_name, tokens_saved FROM usage_events").fetchone()
+        event = conn.execute(
+            "SELECT surface, tool_name, tokens_saved, whole_repo_tokens_avoided FROM usage_events"
+        ).fetchone()
     assert event["surface"] == "mcp"
     assert event["tool_name"] == "query_repo"
     assert event["tokens_saved"] == 90
+    assert event["whole_repo_tokens_avoided"] == 990
+    assert payload["_meta"]["tokens_raw_equivalent"] == 100
+    assert "upload" not in payload["_meta"]
+    policy = resolve_metrics_policy(db_path=tmp_path / ".archex" / "usage.sqlite")
+    assert not policy.hosted_upload_enabled
+
+
+def test_mcp_query_default_off_prevents_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    with (
+        patch("archex.integrations.mcp.query", return_value=FakeBundle()),
+        patch("archex.integrations.mcp.render_xml", return_value="<context />"),
+        patch("archex.integrations.mcp.render_xml_envelope", return_value="<envelope />"),
+        patch("archex.integrations.mcp.get_files_token_count", return_value=100),
+        patch(
+            "archex.integrations.mcp.get_repo_total_tokens",
+            side_effect=AssertionError("repo scan"),
+        ),
+    ):
+        payload = json.loads(handle_query_repo(str(repo_root), "where is auth"))
+
+    assert payload["content"] == "<context />"
+    assert not (tmp_path / ".archex" / "usage.sqlite").exists()
+
+
+def test_mcp_query_recording_failure_preserves_success_and_health(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_metrics(monkeypatch, tmp_path)
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    with (
+        patch("archex.integrations.mcp.query", return_value=FakeBundle()),
+        patch("archex.integrations.mcp.render_xml", return_value="<context />"),
+        patch("archex.integrations.mcp.render_xml_envelope", return_value="<envelope />"),
+        patch("archex.integrations.mcp.get_files_token_count", return_value=100),
+        patch("archex.integrations.mcp.get_repo_total_tokens", return_value=1000),
+        patch("archex.integrations.mcp.record_query_usage", side_effect=RuntimeError("boom")),
+    ):
+        payload = json.loads(handle_query_repo(str(repo_root), "where is auth"))
+
+    assert payload["content"] == "<context />"
+    health = read_metrics_health(db_path=tmp_path / ".archex" / "usage.sqlite")
+    assert health.status == "warning"
+    assert health.last_failure_operation == "record"
+    assert health.last_failure_message == "boom"
+
+
+def test_mcp_scout_records_counter_and_preserves_meta(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_metrics(monkeypatch, tmp_path)
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    with (
+        patch("archex.integrations.mcp.scout", return_value=_fake_scout_result()),
+        patch("archex.integrations.mcp.render_scout", return_value='{"ok": true}'),
+        patch("archex.integrations.mcp.get_repo_total_tokens", return_value=1000),
+        patch("archex.integrations.mcp.get_files_token_count", return_value=120),
+    ):
+        payload = json.loads(handle_scout_repo(str(repo_root), "where is auth"))
+
+    assert sorted(payload) == ["_meta", "content", "receipt"]
+    assert payload["content"] == {"ok": True}
+    assert payload["_meta"]["tokens_raw_equivalent"] == 1000
+    with MetricsStore(tmp_path / ".archex" / "usage.sqlite").connect() as conn:
+        event = conn.execute(
+            "SELECT surface, tool_name, tokens_raw_equivalent, whole_repo_tokens FROM usage_events"
+        ).fetchone()
+    assert event["surface"] == "mcp"
+    assert event["tool_name"] == "scout_repo"
+    assert event["tokens_raw_equivalent"] == 120
+    assert event["whole_repo_tokens"] == 1000

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -11,7 +11,7 @@ from click.testing import CliRunner
 from archex.cli.main import cli
 from archex.integrations.mcp import handle_query_repo, handle_scout_repo
 from archex.metrics.health import read_metrics_health
-from archex.metrics.policy import METRICS_ENV
+from archex.metrics.policy import METRICS_ENV, resolve_metrics_policy
 from archex.metrics.storage import MetricsStore
 
 if TYPE_CHECKING:


### PR DESCRIPTION
## Stack

Stack-Id: `metrics-rollout-a7k9p2`
Base: `feat/metrics-cli-instrumentation`
Position: 2/5

1. `feat/metrics-cli-instrumentation` -> #259
2. `feat/metrics-mcp-instrumentation` -> this PR
3. `feat/metrics-structural-instrumentation` -> #261
4. `feat/metrics-python-api-opt-in` -> #262
5. `docs/metrics-privacy-rollout` -> #263

Depends on: #259
Upstack: #261

## Validation

- `uv run pytest tests/metrics/test_instrumentation.py -k 'mcp'`
- `uv run pytest tests/integrations/test_mcp.py --cov-fail-under=0`
- `uv run ruff check src/archex/integrations/mcp.py tests/metrics/test_instrumentation.py`
- Review: no blocking findings
