### PR TITLE
feat(metrics): record structural tool metrics

### DIFF
--- a/src/archex/cli/analyze_cmd.py
+++ b/src/archex/cli/analyze_cmd.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+import logging
+
 import click
 
 from archex.api import analyze, get_repo_total_tokens
 from archex.config import load_config
 from archex.exceptions import ArchexError
-from archex.models import PipelineTiming
+from archex.metrics.capture import record_structural_usage
+from archex.metrics.health import record_metrics_failure
+from archex.metrics.policy import resolve_metrics_policy
+from archex.models import Config, PipelineTiming, RepoSource
 from archex.reporting import count_tokens, print_savings, print_timing
 from archex.utils import resolve_source
+
+logger = logging.getLogger(__name__)
+
 
 
 @click.command("analyze")
@@ -44,14 +52,40 @@ def analyze_cmd(source: str, output_format: str, languages: tuple[str, ...], tim
     except ArchexError as exc:
         raise click.ClickException(str(exc)) from exc
 
-    if output_format == "json":
-        click.echo(profile.to_json())
-    else:
-        click.echo(profile.to_markdown())
+    output = profile.to_json() if output_format == "json" else profile.to_markdown()
+    click.echo(output)
 
+    raw_tokens: int | None = None
     if timing and pt is not None:
         print_timing(pt)
-        output = profile.to_json() if output_format == "json" else profile.to_markdown()
         returned = count_tokens(output)
-        raw = get_repo_total_tokens(source_obj, config)
-        print_savings(returned, raw, pt.total_ms)
+        raw_tokens = get_repo_total_tokens(source_obj, config)
+        print_savings(returned, raw_tokens, pt.total_ms)
+    _record_metrics(source_obj, output, raw_tokens, config)
+
+
+def _record_metrics(
+    source: RepoSource,
+    output: str,
+    raw_tokens: int | None,
+    config: Config,
+) -> None:
+    try:
+        policy = resolve_metrics_policy()
+        if not policy.metrics_enabled:
+            return
+        raw = raw_tokens if raw_tokens is not None else get_repo_total_tokens(source, config)
+        record_structural_usage(
+            source,
+            surface="cli",
+            tool_name="analyze",
+            tokens_returned=count_tokens(output),
+            tokens_raw_equivalent=raw,
+            whole_repo_tokens=raw,
+        )
+    except Exception as exc:
+        logger.debug("analyze metrics recording failed", exc_info=True)
+        try:
+            record_metrics_failure("record", str(exc))
+        except Exception:
+            logger.debug("analyze metrics health recording failed", exc_info=True)

--- a/src/archex/cli/analyze_cmd.py
+++ b/src/archex/cli/analyze_cmd.py
@@ -19,7 +19,6 @@ from archex.utils import resolve_source
 logger = logging.getLogger(__name__)
 
 
-
 @click.command("analyze")
 @click.argument("source", required=False, default=".")
 @click.option(

--- a/src/archex/cli/compare_cmd.py
+++ b/src/archex/cli/compare_cmd.py
@@ -20,7 +20,6 @@ from archex.utils import resolve_source
 logger = logging.getLogger(__name__)
 
 
-
 def render_comparison_markdown(result: object) -> str:
     """Render a ComparisonResult as markdown."""
     from archex.models import ComparisonResult

--- a/src/archex/cli/compare_cmd.py
+++ b/src/archex/cli/compare_cmd.py
@@ -2,16 +2,23 @@
 
 from __future__ import annotations
 
+import logging
 import time
 
 import click
 
 from archex.api import compare, get_repo_total_tokens
 from archex.exceptions import ArchexError
-from archex.models import Config
+from archex.metrics.capture import record_structural_usage
+from archex.metrics.health import record_metrics_failure
+from archex.metrics.policy import resolve_metrics_policy
+from archex.models import Config, RepoSource
 from archex.reporting import count_tokens, print_savings
 from archex.serve.compare import SUPPORTED_DIMENSIONS
 from archex.utils import resolve_source
+
+logger = logging.getLogger(__name__)
+
 
 
 def render_comparison_markdown(result: object) -> str:
@@ -132,9 +139,41 @@ def compare_cmd(
         output = render_comparison_markdown(result)
         click.echo(output)
 
+    raw_tokens: int | None = None
     if timing:
         returned = count_tokens(output)
-        raw = get_repo_total_tokens(source_a_obj, config) + get_repo_total_tokens(
+        raw_tokens = get_repo_total_tokens(source_a_obj, config) + get_repo_total_tokens(
             source_b_obj, config
         )
-        print_savings(returned, raw, elapsed_ms)
+        print_savings(returned, raw_tokens, elapsed_ms)
+    _record_metrics(source_a_obj, source_b_obj, output, raw_tokens, config)
+
+
+def _record_metrics(
+    source_a: RepoSource,
+    source_b: RepoSource,
+    output: str,
+    raw_tokens: int | None,
+    config: Config,
+) -> None:
+    try:
+        policy = resolve_metrics_policy()
+        if not policy.metrics_enabled:
+            return
+        raw = raw_tokens
+        if raw is None:
+            raw = get_repo_total_tokens(source_a, config) + get_repo_total_tokens(source_b, config)
+        record_structural_usage(
+            source_a,
+            surface="cli",
+            tool_name="compare",
+            tokens_returned=count_tokens(output),
+            tokens_raw_equivalent=raw,
+            whole_repo_tokens=raw,
+        )
+    except Exception as exc:
+        logger.debug("compare metrics recording failed", exc_info=True)
+        try:
+            record_metrics_failure("record", str(exc))
+        except Exception:
+            logger.debug("compare metrics health recording failed", exc_info=True)

--- a/src/archex/cli/outline_cmd.py
+++ b/src/archex/cli/outline_cmd.py
@@ -2,18 +2,24 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import click
 
 from archex.api import file_outline
 from archex.exceptions import ArchexError
-from archex.models import PipelineTiming
+from archex.metrics.capture import record_structural_usage
+from archex.metrics.health import record_metrics_failure
+from archex.metrics.policy import resolve_metrics_policy
+from archex.models import PipelineTiming, RepoSource
 from archex.reporting import count_tokens, print_savings, print_timing
 from archex.utils import resolve_source
 
 if TYPE_CHECKING:
     from archex.models import SymbolOutline
+
+logger = logging.getLogger(__name__)
 
 
 def _render_symbols(symbols: list[SymbolOutline], indent: int = 0) -> list[str]:
@@ -42,25 +48,40 @@ def outline_cmd(source: str, file_path: str, output_json: bool, timing: bool) ->
         raise click.ClickException(str(exc)) from exc
 
     if output_json:
-        click.echo(result.model_dump_json(indent=2))
+        output = result.model_dump_json(indent=2)
     else:
-        click.echo(f"file: {result.file_path}")
-        click.echo(f"language: {result.language}")
-        click.echo(f"lines: {result.lines}")
-        for line in _render_symbols(result.symbols):
-            click.echo(line)
+        lines = [
+            f"file: {result.file_path}",
+            f"language: {result.language}",
+            f"lines: {result.lines}",
+        ]
+        lines.extend(_render_symbols(result.symbols))
+        output = "\n".join(lines)
+    click.echo(output)
 
     if timing and pt is not None:
         print_timing(pt)
-        if output_json:
-            output = result.model_dump_json(indent=2)
-        else:
-            lines = [
-                f"file: {result.file_path}",
-                f"language: {result.language}",
-                f"lines: {result.lines}",
-            ]
-            lines.extend(_render_symbols(result.symbols))
-            output = "\n".join(lines)
         returned = count_tokens(output)
         print_savings(returned, result.token_count_raw, pt.total_ms)
+    _record_metrics(source_obj, output, result.token_count_raw)
+
+
+def _record_metrics(source: RepoSource, output: str, raw_tokens: int) -> None:
+    try:
+        policy = resolve_metrics_policy()
+        if not policy.metrics_enabled:
+            return
+        record_structural_usage(
+            source,
+            surface="cli",
+            tool_name="outline",
+            tokens_returned=count_tokens(output),
+            tokens_raw_equivalent=raw_tokens,
+            file_count=1,
+        )
+    except Exception as exc:
+        logger.debug("outline metrics recording failed", exc_info=True)
+        try:
+            record_metrics_failure("record", str(exc))
+        except Exception:
+            logger.debug("outline metrics health recording failed", exc_info=True)

--- a/src/archex/cli/symbol_cmd.py
+++ b/src/archex/cli/symbol_cmd.py
@@ -18,7 +18,6 @@ from archex.utils import resolve_source
 logger = logging.getLogger(__name__)
 
 
-
 @click.command("symbol")
 @click.argument("args", nargs=-1, required=True)
 @click.option("--json", "output_json", is_flag=True, default=False, help="Output as JSON.")

--- a/src/archex/cli/symbol_cmd.py
+++ b/src/archex/cli/symbol_cmd.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import logging
+
 import click
 
 from archex.api import get_file_token_count, get_symbol
 from archex.exceptions import ArchexError
-from archex.models import PipelineTiming
-from archex.reporting import print_savings, print_timing
+from archex.metrics.capture import record_structural_usage
+from archex.metrics.health import record_metrics_failure
+from archex.metrics.policy import resolve_metrics_policy
+from archex.models import PipelineTiming, RepoSource
+from archex.reporting import count_tokens, print_savings, print_timing
 from archex.utils import resolve_source
+
+logger = logging.getLogger(__name__)
+
 
 
 @click.command("symbol")
@@ -30,16 +38,48 @@ def symbol_cmd(args: tuple[str, ...], output_json: bool, timing: bool) -> None:
         raise click.ClickException(f"Symbol not found: {symbol_id}")
 
     if output_json:
-        click.echo(result.model_dump_json(indent=2))
+        output = result.model_dump_json(indent=2)
+        click.echo(output)
     else:
         loc = f"{result.file_path}:{result.start_line}-{result.end_line}"
+        output = f"# {result.name} ({result.kind}) — {loc}\n{result.source}"
         click.echo(f"# {result.name} ({result.kind}) — {loc}")
         click.echo(result.source)
 
+    raw_tokens: int | None = None
     if timing and pt is not None:
         print_timing(pt)
-        raw = get_file_token_count(source_obj, result.file_path)
-        print_savings(result.token_count, raw, pt.total_ms)
+        raw_tokens = get_file_token_count(source_obj, result.file_path)
+        print_savings(result.token_count, raw_tokens, pt.total_ms)
+    _record_metrics(source_obj, output, result.token_count, raw_tokens, result.file_path)
+
+
+def _record_metrics(
+    source: RepoSource,
+    output: str,
+    returned_tokens: int,
+    raw_tokens: int | None,
+    file_path: str,
+) -> None:
+    try:
+        policy = resolve_metrics_policy()
+        if not policy.metrics_enabled:
+            return
+        raw = raw_tokens if raw_tokens is not None else get_file_token_count(source, file_path)
+        record_structural_usage(
+            source,
+            surface="cli",
+            tool_name="symbol",
+            tokens_returned=returned_tokens if returned_tokens > 0 else count_tokens(output),
+            tokens_raw_equivalent=raw,
+            file_count=1,
+        )
+    except Exception as exc:
+        logger.debug("symbol metrics recording failed", exc_info=True)
+        try:
+            record_metrics_failure("record", str(exc))
+        except Exception:
+            logger.debug("symbol metrics health recording failed", exc_info=True)
 
 
 def _source_and_symbol_id(args: tuple[str, ...]) -> tuple[str, str]:

--- a/src/archex/cli/symbols_cmd.py
+++ b/src/archex/cli/symbols_cmd.py
@@ -19,7 +19,6 @@ from archex.utils import resolve_source
 logger = logging.getLogger(__name__)
 
 
-
 @click.command("symbols")
 @click.argument("args", nargs=-1, required=True)
 @click.option("--kind", default=None, help="Filter by kind: function, class, method, etc.")
@@ -73,9 +72,7 @@ def _render_symbols(results: list[SymbolMatch]) -> str:
     lines = [hdr, "-" * len(hdr)]
     for m in results:
         lines.append(
-            f"{m.kind:<{ck}}  {m.name:<{cn}}  "
-            f"{m.file_path:<{cf}}  {m.start_line:<6}  "
-            f"{m.symbol_id}"
+            f"{m.kind:<{ck}}  {m.name:<{cn}}  {m.file_path:<{cf}}  {m.start_line:<6}  {m.symbol_id}"
         )
     return "\n".join(lines)
 

--- a/src/archex/cli/symbols_cmd.py
+++ b/src/archex/cli/symbols_cmd.py
@@ -3,14 +3,21 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import click
 
 from archex.api import get_files_token_count, search_symbols
 from archex.exceptions import ArchexError
-from archex.models import PipelineTiming
+from archex.metrics.capture import record_structural_usage
+from archex.metrics.health import record_metrics_failure
+from archex.metrics.policy import resolve_metrics_policy
+from archex.models import PipelineTiming, RepoSource, SymbolMatch
 from archex.reporting import count_tokens, print_savings, print_timing
 from archex.utils import resolve_source
+
+logger = logging.getLogger(__name__)
+
 
 
 @click.command("symbols")
@@ -41,31 +48,64 @@ def symbols_cmd(
         raise click.ClickException(str(exc)) from exc
 
     if output_json:
-        click.echo(json.dumps([m.model_dump() for m in results], indent=2))
+        output = json.dumps([m.model_dump() for m in results], indent=2)
     else:
-        if not results:
-            click.echo("No symbols found.")
-        else:
-            ck = max((len(m.kind) for m in results), default=4)
-            cn = max((len(m.name) for m in results), default=4)
-            cf = max((len(m.file_path) for m in results), default=9)
-            hdr = f"{'kind':<{ck}}  {'name':<{cn}}  {'file_path':<{cf}}  {'line':<6}  symbol_id"
-            click.echo(hdr)
-            click.echo("-" * len(hdr))
-            for m in results:
-                click.echo(
-                    f"{m.kind:<{ck}}  {m.name:<{cn}}  "
-                    f"{m.file_path:<{cf}}  {m.start_line:<6}  "
-                    f"{m.symbol_id}"
-                )
+        output = _render_symbols(results)
+    click.echo(output)
 
+    raw_tokens: int | None = None
+    unique_files = list({m.file_path for m in results})
     if timing and pt is not None:
         print_timing(pt)
-        output_text = json.dumps([m.model_dump() for m in results], indent=2) if output_json else ""
-        returned = count_tokens(output_text) if output_text else len(results)
-        unique_files = list({m.file_path for m in results})
-        raw = get_files_token_count(source_obj, unique_files)
-        print_savings(returned, raw, pt.total_ms, file_count=len(unique_files))
+        returned = count_tokens(output) if output_json else len(results)
+        raw_tokens = get_files_token_count(source_obj, unique_files)
+        print_savings(returned, raw_tokens, pt.total_ms, file_count=len(unique_files))
+    _record_metrics(source_obj, output, raw_tokens, unique_files)
+
+
+def _render_symbols(results: list[SymbolMatch]) -> str:
+    if not results:
+        return "No symbols found."
+    ck = max((len(m.kind) for m in results), default=4)
+    cn = max((len(m.name) for m in results), default=4)
+    cf = max((len(m.file_path) for m in results), default=9)
+    hdr = f"{'kind':<{ck}}  {'name':<{cn}}  {'file_path':<{cf}}  {'line':<6}  symbol_id"
+    lines = [hdr, "-" * len(hdr)]
+    for m in results:
+        lines.append(
+            f"{m.kind:<{ck}}  {m.name:<{cn}}  "
+            f"{m.file_path:<{cf}}  {m.start_line:<6}  "
+            f"{m.symbol_id}"
+        )
+    return "\n".join(lines)
+
+
+def _record_metrics(
+    source: RepoSource,
+    output: str,
+    raw_tokens: int | None,
+    unique_files: list[str],
+) -> None:
+    try:
+        policy = resolve_metrics_policy()
+        if not policy.metrics_enabled:
+            return
+        raw = raw_tokens if raw_tokens is not None else get_files_token_count(source, unique_files)
+        returned = count_tokens(output)
+        record_structural_usage(
+            source,
+            surface="cli",
+            tool_name="symbols",
+            tokens_returned=returned,
+            tokens_raw_equivalent=raw,
+            file_count=len(unique_files),
+        )
+    except Exception as exc:
+        logger.debug("symbols metrics recording failed", exc_info=True)
+        try:
+            record_metrics_failure("record", str(exc))
+        except Exception:
+            logger.debug("symbols metrics health recording failed", exc_info=True)
 
 
 def _source_and_query(args: tuple[str, ...]) -> tuple[str, str]:

--- a/src/archex/cli/tree_cmd.py
+++ b/src/archex/cli/tree_cmd.py
@@ -2,18 +2,24 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import click
 
 from archex.api import file_tree, get_repo_total_tokens
 from archex.exceptions import ArchexError
-from archex.models import PipelineTiming
+from archex.metrics.capture import record_structural_usage
+from archex.metrics.health import record_metrics_failure
+from archex.metrics.policy import resolve_metrics_policy
+from archex.models import PipelineTiming, RepoSource
 from archex.reporting import count_tokens, print_savings, print_timing
 from archex.utils import resolve_source
 
 if TYPE_CHECKING:
     from archex.models import FileTreeEntry
+
+logger = logging.getLogger(__name__)
 
 
 def _render_tree(
@@ -55,18 +61,37 @@ def tree_cmd(
         raise click.ClickException(str(exc)) from exc
 
     if output_json:
-        click.echo(result.model_dump_json(indent=2))
+        output = result.model_dump_json(indent=2)
     else:
-        click.echo(result.root)
-        for line in _render_tree(result.entries):
-            click.echo(line)
+        output = "\n".join([result.root, *_render_tree(result.entries)])
+    click.echo(output)
 
+    raw_tokens: int | None = None
     if timing and pt is not None:
         print_timing(pt)
-        if output_json:
-            output = result.model_dump_json(indent=2)
-        else:
-            output = "\n".join([result.root, *_render_tree(result.entries)])
         returned = count_tokens(output)
-        raw = get_repo_total_tokens(source_obj)
-        print_savings(returned, raw, pt.total_ms)
+        raw_tokens = get_repo_total_tokens(source_obj)
+        print_savings(returned, raw_tokens, pt.total_ms)
+    _record_metrics(source_obj, output, raw_tokens)
+
+
+def _record_metrics(source: RepoSource, output: str, raw_tokens: int | None) -> None:
+    try:
+        policy = resolve_metrics_policy()
+        if not policy.metrics_enabled:
+            return
+        raw = raw_tokens if raw_tokens is not None else get_repo_total_tokens(source)
+        record_structural_usage(
+            source,
+            surface="cli",
+            tool_name="tree",
+            tokens_returned=count_tokens(output),
+            tokens_raw_equivalent=raw,
+            whole_repo_tokens=raw,
+        )
+    except Exception as exc:
+        logger.debug("tree metrics recording failed", exc_info=True)
+        try:
+            record_metrics_failure("record", str(exc))
+        except Exception:
+            logger.debug("tree metrics health recording failed", exc_info=True)

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -39,7 +39,7 @@ from archex.graph_query import (
     GraphQueryError,
     GraphStatsResult,
 )
-from archex.metrics.capture import record_query_usage, record_scout_usage
+from archex.metrics.capture import record_query_usage, record_scout_usage, record_structural_usage
 from archex.metrics.health import record_metrics_failure
 from archex.metrics.policy import resolve_metrics_policy
 from archex.models import ContextBundle, PipelineTiming, RepoSource
@@ -86,6 +86,13 @@ def handle_analyze_repo(repo_url: str, output_format: str = "json") -> str:
         cached=pt.cached,
         index_time_ms=pt.index_ms,
         query_time_ms=pt.total_ms,
+    )
+    _record_structural_metrics(
+        source,
+        "analyze_repo",
+        content,
+        raw_tokens,
+        whole_repo_tokens=raw_tokens,
     )
     return json.dumps({"content": content, "_meta": meta.model_dump()}, indent=2)
 
@@ -269,6 +276,36 @@ def _scout_file_paths(result: ScoutResult) -> list[str]:
     return sorted(paths)
 
 
+def _record_structural_metrics(
+    source: RepoSource,
+    tool_name: str,
+    response_text: str,
+    raw_tokens: int,
+    *,
+    whole_repo_tokens: int | None = None,
+    file_count: int = 0,
+) -> None:
+    try:
+        policy = resolve_metrics_policy()
+        if not policy.metrics_enabled:
+            return
+        record_structural_usage(
+            source,
+            surface="mcp",
+            tool_name=tool_name,
+            tokens_returned=count_tokens(response_text),
+            tokens_raw_equivalent=raw_tokens,
+            whole_repo_tokens=whole_repo_tokens,
+            file_count=file_count,
+        )
+    except Exception as exc:
+        logger.debug("MCP structural metrics recording failed", exc_info=True)
+        try:
+            record_metrics_failure("record", str(exc))
+        except Exception:
+            logger.debug("MCP structural metrics health recording failed", exc_info=True)
+
+
 def handle_compare_repos(
     repo_a: str,
     repo_b: str,
@@ -301,12 +338,20 @@ def handle_compare_repos(
     content = result.model_dump_json(indent=2)
     raw_a = get_repo_total_tokens(source_a)
     raw_b = get_repo_total_tokens(source_b)
+    raw_tokens = raw_a + raw_b
     meta = compute_meta(
         tool_name="compare_repos",
         response_text=content,
-        raw_file_tokens=max(raw_a + raw_b, 1),
+        raw_file_tokens=max(raw_tokens, 1),
         strategy="full_comparison",
         query_time_ms=elapsed_ms,
+    )
+    _record_structural_metrics(
+        source_a,
+        "compare_repos",
+        content,
+        raw_tokens,
+        whole_repo_tokens=raw_tokens,
     )
     return json.dumps({"content": json.loads(content), "_meta": meta.model_dump()}, indent=2)
 
@@ -326,6 +371,13 @@ def handle_get_file_tree(repo_url: str, max_depth: int = 5, language: str | None
         index_time_ms=pt.index_ms,
         query_time_ms=pt.total_ms,
     )
+    _record_structural_metrics(
+        source,
+        "get_file_tree",
+        content,
+        raw_tokens,
+        whole_repo_tokens=raw_tokens,
+    )
     return json.dumps({"content": json.loads(content), "_meta": meta.model_dump()}, indent=2)
 
 
@@ -342,6 +394,13 @@ def handle_get_file_outline(repo_url: str, file_path: str) -> str:
         cached=pt.cached,
         index_time_ms=pt.index_ms,
         query_time_ms=pt.total_ms,
+    )
+    _record_structural_metrics(
+        source,
+        "get_file_outline",
+        content,
+        result.token_count_raw,
+        file_count=1,
     )
     return json.dumps({"content": json.loads(content), "_meta": meta.model_dump()}, indent=2)
 
@@ -371,6 +430,13 @@ def handle_search_symbols(
         index_time_ms=pt.index_ms,
         query_time_ms=pt.total_ms,
     )
+    _record_structural_metrics(
+        source,
+        "search_symbols",
+        content,
+        raw_tokens,
+        file_count=len(unique_files),
+    )
     return json.dumps({"content": match_data, "_meta": meta.model_dump()}, indent=2)
 
 
@@ -390,6 +456,13 @@ def handle_get_symbol(repo_url: str, symbol_id: str) -> str:
         cached=pt.cached,
         index_time_ms=pt.index_ms,
         query_time_ms=pt.total_ms,
+    )
+    _record_structural_metrics(
+        source,
+        "get_symbol",
+        content,
+        raw_tokens,
+        file_count=1,
     )
     return json.dumps({"content": json.loads(content), "_meta": meta.model_dump()}, indent=2)
 
@@ -412,6 +485,13 @@ def handle_get_symbols_batch(repo_url: str, symbol_ids: list[str]) -> str:
         cached=pt.cached,
         index_time_ms=pt.index_ms,
         query_time_ms=pt.total_ms,
+    )
+    _record_structural_metrics(
+        source,
+        "get_symbols_batch",
+        content,
+        raw_tokens,
+        file_count=len(unique_files),
     )
     return json.dumps({"content": result_data, "_meta": meta.model_dump()}, indent=2)
 

--- a/src/archex/metrics/capture.py
+++ b/src/archex/metrics/capture.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from archex.metrics.categories import category_for_tool
 from archex.metrics.recorder import MetricsRecorder, Surface, TraceDetails, UsageEvent
 
 if TYPE_CHECKING:
@@ -35,7 +36,7 @@ def record_query_usage(
             repo_root=repo_root,
             surface=surface,
             tool_name=tool_name,
-            category="context_retrieval",
+            category=category_for_tool(tool_name),
             tokens_returned=bundle.token_count,
             tokens_raw_equivalent=tokens_raw_equivalent,
             whole_repo_tokens=whole_repo_tokens,
@@ -72,7 +73,7 @@ def record_scout_usage(
             repo_root=repo_root,
             surface=surface,
             tool_name=tool_name,
-            category="context_retrieval",
+            category=category_for_tool(tool_name),
             tokens_returned=tokens_returned,
             tokens_raw_equivalent=tokens_raw_equivalent,
             whole_repo_tokens=whole_repo_tokens,
@@ -91,6 +92,34 @@ def record_scout_usage(
                     "omitted_graph_edges": result.budget.omitted_graph_edges,
                 },
             ),
+        )
+    )
+
+
+def record_structural_usage(
+    source: RepoSource,
+    *,
+    surface: Surface,
+    tool_name: str,
+    tokens_returned: int,
+    tokens_raw_equivalent: int,
+    whole_repo_tokens: int | None = None,
+    file_count: int = 0,
+    db_path: Path | None = None,
+) -> None:
+    repo_root = _local_repo_root(source)
+    if repo_root is None:
+        return
+    MetricsRecorder(db_path).record(
+        UsageEvent(
+            repo_root=repo_root,
+            surface=surface,
+            tool_name=tool_name,
+            category=category_for_tool(tool_name),
+            tokens_returned=tokens_returned,
+            tokens_raw_equivalent=tokens_raw_equivalent,
+            whole_repo_tokens=whole_repo_tokens,
+            file_count=file_count,
         )
     )
 

--- a/src/archex/metrics/categories.py
+++ b/src/archex/metrics/categories.py
@@ -1,0 +1,39 @@
+"""Central metrics category mapping for instrumented archex surfaces."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from archex.metrics.recorder import Category
+
+CONTEXT_RETRIEVAL = "context_retrieval"
+STRUCTURAL_TOOLS = "structural_tools"
+
+_CONTEXT_RETRIEVAL_TOOLS = frozenset({"query", "scout", "query_repo", "scout_repo"})
+_STRUCTURAL_TOOLS = frozenset(
+    {
+        "analyze",
+        "analyze_repo",
+        "compare",
+        "compare_repos",
+        "get_file_outline",
+        "get_file_tree",
+        "get_symbol",
+        "get_symbols_batch",
+        "outline",
+        "search_symbols",
+        "symbol",
+        "symbols",
+        "tree",
+    }
+)
+
+
+def category_for_tool(tool_name: str) -> Category:
+    """Return the metrics category for a known instrumented tool name."""
+    if tool_name in _CONTEXT_RETRIEVAL_TOOLS:
+        return CONTEXT_RETRIEVAL
+    if tool_name in _STRUCTURAL_TOOLS:
+        return STRUCTURAL_TOOLS
+    raise ValueError(f"unknown metrics tool category for {tool_name!r}")

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -36,6 +36,8 @@ class FakeTree:
 
     def model_dump_json(self, indent: int | None = None) -> str:
         return '{\n  "root": "repo",\n  "entries": []\n}'
+
+
 def _fake_scout_result() -> SimpleNamespace:
     return SimpleNamespace(
         query="where is auth",

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -9,7 +9,8 @@ from unittest.mock import patch
 from click.testing import CliRunner
 
 from archex.cli.main import cli
-from archex.integrations.mcp import handle_query_repo, handle_scout_repo
+from archex.integrations.mcp import handle_get_file_tree, handle_query_repo, handle_scout_repo
+from archex.metrics.categories import category_for_tool
 from archex.metrics.health import read_metrics_health
 from archex.metrics.policy import METRICS_ENV, resolve_metrics_policy
 from archex.metrics.storage import MetricsStore
@@ -29,6 +30,12 @@ class FakeBundle:
         return "FAKE CONTEXT"
 
 
+class FakeTree:
+    root = "repo"
+    entries: list[object] = []
+
+    def model_dump_json(self, indent: int | None = None) -> str:
+        return '{\n  "root": "repo",\n  "entries": []\n}'
 def _fake_scout_result() -> SimpleNamespace:
     return SimpleNamespace(
         query="where is auth",
@@ -282,3 +289,63 @@ def test_mcp_scout_records_counter_and_preserves_meta(
     assert event["tool_name"] == "scout_repo"
     assert event["tokens_raw_equivalent"] == 120
     assert event["whole_repo_tokens"] == 1000
+
+
+def test_metrics_category_mapping_is_centralized() -> None:
+    assert category_for_tool("query") == "context_retrieval"
+    assert category_for_tool("scout_repo") == "context_retrieval"
+    assert category_for_tool("tree") == "structural_tools"
+    assert category_for_tool("get_file_tree") == "structural_tools"
+
+
+def test_cli_tree_records_structural_tool_counter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    runner = CliRunner()
+
+    with (
+        patch("archex.cli.tree_cmd.file_tree", return_value=FakeTree()),
+        patch("archex.cli.tree_cmd.get_repo_total_tokens", return_value=500),
+    ):
+        result = runner.invoke(cli, ["tree", str(repo_root)])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "repo\n"
+    with MetricsStore(tmp_path / ".archex" / "usage.sqlite").connect() as conn:
+        event = conn.execute(
+            "SELECT surface, tool_name, category, tokens_raw_equivalent FROM usage_events"
+        ).fetchone()
+    assert event["surface"] == "cli"
+    assert event["tool_name"] == "tree"
+    assert event["category"] == "structural_tools"
+    assert event["tokens_raw_equivalent"] == 500
+
+
+def test_mcp_file_tree_records_structural_tool_counter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    with (
+        patch("archex.integrations.mcp.file_tree", return_value=FakeTree()),
+        patch("archex.integrations.mcp.get_repo_total_tokens", return_value=500),
+    ):
+        payload = json.loads(handle_get_file_tree(str(repo_root)))
+
+    assert payload["content"] == {"root": "repo", "entries": []}
+    assert payload["_meta"]["tool_name"] == "get_file_tree"
+    with MetricsStore(tmp_path / ".archex" / "usage.sqlite").connect() as conn:
+        event = conn.execute(
+            "SELECT surface, tool_name, category, tokens_raw_equivalent FROM usage_events"
+        ).fetchone()
+    assert event["surface"] == "mcp"
+    assert event["tool_name"] == "get_file_tree"
+    assert event["category"] == "structural_tools"
+    assert event["tokens_raw_equivalent"] == 500

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -302,7 +302,7 @@ def test_cli_tree_records_structural_tool_counter(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _enable_metrics(monkeypatch, tmp_path)
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     runner = CliRunner()
@@ -329,7 +329,7 @@ def test_mcp_file_tree_records_structural_tool_counter(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    _enable_metrics(monkeypatch, tmp_path)
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
 


### PR DESCRIPTION
## Stack

Stack-Id: `metrics-rollout-a7k9p2`
Base: `feat/metrics-mcp-instrumentation`
Position: 3/5

1. `feat/metrics-cli-instrumentation` -> #259
2. `feat/metrics-mcp-instrumentation` -> #260
3. `feat/metrics-structural-instrumentation` -> this PR
4. `feat/metrics-python-api-opt-in` -> #262
5. `docs/metrics-privacy-rollout` -> #263

Depends on: #260
Upstack: #262

## Validation

- `uv run pytest tests/metrics/test_instrumentation.py -k 'category or tree'`
- `uv run pytest tests/test_cli.py --cov-fail-under=0`
- `uv run pytest tests/integrations/test_mcp.py --cov-fail-under=0`
- `uv run pyright src/archex/metrics/categories.py src/archex/metrics/capture.py src/archex/cli/analyze_cmd.py src/archex/cli/compare_cmd.py src/archex/cli/symbol_cmd.py src/archex/cli/symbols_cmd.py src/archex/cli/outline_cmd.py src/archex/cli/tree_cmd.py src/archex/integrations/mcp.py tests/metrics/test_instrumentation.py`
- Review: no blocking findings
