### PR TITLE
feat(metrics): add Python API opt-in

### DIFF
--- a/src/archex/__init__.py
+++ b/src/archex/__init__.py
@@ -6,6 +6,6 @@ from importlib.metadata import version
 
 __version__ = version("archex")
 
-from archex.api import analyze, compare, query
+from archex.api import analyze, compare, query, record_usage_event
 
-__all__ = ["analyze", "query", "compare", "__version__"]
+__all__ = ["analyze", "query", "compare", "record_usage_event", "__version__"]

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -60,6 +60,7 @@ from archex.index.bm25 import BM25Index
 from archex.index.graph import DependencyGraph
 from archex.index.store import IndexStore
 from archex.languages import UNKNOWN_LANGUAGE_ID
+from archex.metrics.recorder import MetricsRecorder, UsageEvent
 from archex.models import (
     ArchProfile,
     ChunkSurrogate,
@@ -2513,6 +2514,11 @@ def get_symbols_batch(
 
 
 # ---------------------------------------------------------------------------
+def record_usage_event(event: UsageEvent, *, db_path: Path | None = None) -> None:
+    """Explicitly opt in to local usage recording for Python API callers."""
+    MetricsRecorder(db_path).record(event)
+
+
 # Token efficiency utilities
 # ---------------------------------------------------------------------------
 

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -2516,7 +2516,7 @@ def get_symbols_batch(
 # ---------------------------------------------------------------------------
 def record_usage_event(event: UsageEvent, *, db_path: Path | None = None) -> None:
     """Explicitly opt in to local usage recording for Python API callers."""
-    MetricsRecorder(db_path).record(event)
+    MetricsRecorder(db_path).record(event, force=True)
 
 
 # Token efficiency utilities

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -191,7 +191,6 @@ def test_mcp_query_records_counter_and_preserves_response_shape(
     _enable_metrics(monkeypatch, tmp_path)
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
-
     with (
         patch("archex.integrations.mcp.query", return_value=FakeBundle()),
         patch("archex.integrations.mcp.render_xml", return_value="<context />"),
@@ -248,7 +247,6 @@ def test_mcp_query_recording_failure_preserves_success_and_health(
     _enable_metrics(monkeypatch, tmp_path)
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
-
     with (
         patch("archex.integrations.mcp.query", return_value=FakeBundle()),
         patch("archex.integrations.mcp.render_xml", return_value="<context />"),
@@ -273,7 +271,6 @@ def test_mcp_scout_records_counter_and_preserves_meta(
     _enable_metrics(monkeypatch, tmp_path)
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
-
     with (
         patch("archex.integrations.mcp.scout", return_value=_fake_scout_result()),
         patch("archex.integrations.mcp.render_scout", return_value='{"ok": true}'),
@@ -336,7 +333,6 @@ def test_mcp_file_tree_records_structural_tool_counter(
     _enable_metrics(monkeypatch, tmp_path)
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
-
     with (
         patch("archex.integrations.mcp.file_tree", return_value=FakeTree()),
         patch("archex.integrations.mcp.get_repo_total_tokens", return_value=500),
@@ -399,3 +395,27 @@ def test_python_api_explicit_usage_event_records_metrics(
     assert event["tool_name"] == "query"
     assert event["tokens_saved"] == 75
     assert event["whole_repo_tokens_avoided"] == 975
+
+
+def test_python_api_explicit_usage_event_respects_env_off(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    python_simple_repo: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv(METRICS_ENV, "off")
+
+    record_usage_event(
+        UsageEvent(
+            repo_root=python_simple_repo,
+            surface="python_api",
+            tool_name="query",
+            category="context_retrieval",
+            tokens_returned=25,
+            tokens_raw_equivalent=100,
+            whole_repo_tokens=1000,
+            file_count=2,
+        )
+    )
+
+    assert not (tmp_path / ".archex" / "usage.sqlite").exists()

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -8,12 +8,14 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 
+from archex.api import query, record_usage_event
 from archex.cli.main import cli
 from archex.integrations.mcp import handle_get_file_tree, handle_query_repo, handle_scout_repo
 from archex.metrics.categories import category_for_tool
 from archex.metrics.health import read_metrics_health
 from archex.metrics.policy import METRICS_ENV, resolve_metrics_policy
 from archex.metrics.storage import MetricsStore
+from archex.models import Config, RepoSource
 
 if TYPE_CHECKING:
     import pytest
@@ -351,3 +353,49 @@ def test_mcp_file_tree_records_structural_tool_counter(
     assert event["tool_name"] == "get_file_tree"
     assert event["category"] == "structural_tools"
     assert event["tokens_raw_equivalent"] == 500
+
+
+def test_python_api_query_does_not_write_metrics_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    python_simple_repo: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    source = RepoSource(local_path=str(python_simple_repo))
+
+    bundle = query(source, "authentication", config=Config(cache=False, languages=["python"]))
+
+    assert bundle.chunks
+    assert not (tmp_path / ".archex" / "usage.sqlite").exists()
+
+
+def test_python_api_explicit_usage_event_records_metrics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    python_simple_repo: Path,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    source = RepoSource(local_path=str(python_simple_repo))
+
+    record_usage_event(
+        UsageEvent(
+            repo_root=python_simple_repo,
+            surface="python_api",
+            tool_name="query",
+            category="context_retrieval",
+            tokens_returned=25,
+            tokens_raw_equivalent=100,
+            whole_repo_tokens=1000,
+            file_count=2,
+        )
+    )
+
+    with MetricsStore(tmp_path / ".archex" / "usage.sqlite").connect() as conn:
+        event = conn.execute(
+            "SELECT surface, tool_name, tokens_saved, whole_repo_tokens_avoided FROM usage_events"
+        ).fetchone()
+    assert source.local_path == str(python_simple_repo)
+    assert event["surface"] == "python_api"
+    assert event["tool_name"] == "query"
+    assert event["tokens_saved"] == 75
+    assert event["whole_repo_tokens_avoided"] == 975

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -14,6 +14,7 @@ from archex.integrations.mcp import handle_get_file_tree, handle_query_repo, han
 from archex.metrics.categories import category_for_tool
 from archex.metrics.health import read_metrics_health
 from archex.metrics.policy import METRICS_ENV, resolve_metrics_policy
+from archex.metrics.recorder import UsageEvent
 from archex.metrics.storage import MetricsStore
 from archex.models import Config, RepoSource
 


### PR DESCRIPTION
## Stack

Stack-Id: `metrics-rollout-a7k9p2`
Base: `feat/metrics-structural-instrumentation`
Position: 4/5

1. `feat/metrics-cli-instrumentation` -> #259
2. `feat/metrics-mcp-instrumentation` -> #260
3. `feat/metrics-structural-instrumentation` -> #261
4. `feat/metrics-python-api-opt-in` -> this PR
5. `docs/metrics-privacy-rollout` -> #263

Depends on: #261
Upstack: #263

## Validation

- `uv run pytest tests/metrics/test_instrumentation.py -k 'python_api'`
- `uv run ruff check src/archex/api.py src/archex/__init__.py tests/metrics/test_instrumentation.py`
- `uv run pyright src/archex/api.py src/archex/__init__.py tests/metrics/test_instrumentation.py`
- Review: no blocking findings
