### PR TITLE
docs(metrics): document local metrics privacy controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ archex turns a repository into a ranked, token-budgeted context bundle plus a co
 
 [![archex banner](assets/archex-banner.png)](assets/archex-banner.svg)
 
-**Start:** [30-second quickstart](#30-second-quickstart) · [MCP and Claude Code](#mcp-and-claude-code) · [Python API](#python-api) · [Compatibility matrix](docs/CLIENT_COMPATIBILITY_MATRIX.md) · [Installation trust contract](docs/INSTALLATION_TRUST_CONTRACT.md) · [Security policy](SECURITY.md)
+**Start:** [30-second quickstart](#30-second-quickstart) · [MCP and Claude Code](#mcp-and-claude-code) · [Python API](#python-api) · [Local metrics](docs/LOCAL_METRICS.md) · [Compatibility matrix](docs/CLIENT_COMPATIBILITY_MATRIX.md) · [Installation trust contract](docs/INSTALLATION_TRUST_CONTRACT.md) · [Security policy](SECURITY.md)
 
 **Quick links:** [Proof bar](#proof-bar) · [Fast paths](#fast-paths) · [What archex returns](#what-archex-returns) · [Use it your way](#use-it-your-way) · [Trust and operations](#trust-and-operations) · [Measured results](#measured-results) · [Installation details](#installation-details) · [Language support](#language-support) · [Development](#development) · [Documentation map](#documentation-map)
 
@@ -119,7 +119,7 @@ Small receipt example:
 }
 ```
 
-Use [docs/CONTEXT_RECEIPTS.md](docs/CONTEXT_RECEIPTS.md) for the full field contract.
+Use [CONTEXT_RECEIPTS](docs/CONTEXT_RECEIPTS.md) for the full field contract.
 
 
 ## Why archex is different
@@ -177,6 +177,22 @@ The in-repo Claude Code skill lives at [`skills/archex/`](skills/archex/). Its `
 
 Exact install, MCP, Docker, cache, uninstall, and trust semantics are documented in the [installation trust contract](docs/INSTALLATION_TRUST_CONTRACT.md). Client-specific config targets and preview-first bootstrap paths live in the [compatibility matrix](docs/CLIENT_COMPATIBILITY_MATRIX.md).
 
+Local usage metrics are off by default. If a user explicitly enables them with `archex metrics enable`, `ARCHEX_USAGE_METRICS=on`, or the persisted metrics setting, archex writes a machine-local ledger at `~/.archex/usage.sqlite`. That ledger records anonymous counters only: tool name, category, token counts, file count, repo-local random ID, freshness, and index revision. It does not store query text, file paths, symbols, handles, rendered outputs, prompt bodies, remote URLs, org names, or repo names in event rows. Headline savings are always `tokens_saved = max(returned full-file baseline - returned tokens, 0)`. Whole-repo avoided tokens are tracked separately as an upper-bound/context metric when the indexed repo total is available.
+
+Important boundary: archex ships with no telemetry by default. Optional local metrics are separate from telemetry, stay on the machine, and require explicit enablement. Detailed traces remain a second explicit opt-in on top of metrics enablement. The exact calculation rules, privacy boundary, and controls live in [LOCAL_METRICS](docs/LOCAL_METRICS.md).
+
+`archex metrics` is the control surface:
+
+```bash
+archex metrics enable
+archex metrics
+archex metrics export --output usage.json
+archex metrics delete --all
+archex metrics trace enable
+ARCHEX_USAGE_METRICS=on archex query "Where is auth handled?"
+```
+
+Detailed traces stay opt-in via `archex metrics trace enable` or `ARCHEX_USAGE_TRACE=on`. Traces remain local-only and still never store source code or rendered outputs. Metrics code paths make no LLM calls, no hosted upload calls, and no background network calls in v1.
 ### Python API
 
 ```python
@@ -230,13 +246,14 @@ The mounted repository owns `.archex/`, so indexes survive container restarts an
 
 | Surface | Contract |
 | --- | --- |
-| Security policy | Supported versions, disclosure workflow, no-telemetry posture, secret-handling guidance, and model remote-code policy live in [SECURITY.md](SECURITY.md). |
-| Context receipts | Field contract, freshness/completeness semantics, output surfaces, and benchmark linkage live in [docs/CONTEXT_RECEIPTS.md](docs/CONTEXT_RECEIPTS.md). |
-| Compatibility matrix | Tested vs unverified clients, exact config shapes, preview-first bootstrap commands, and verification steps live in [docs/CLIENT_COMPATIBILITY_MATRIX.md](docs/CLIENT_COMPATIBILITY_MATRIX.md). |
-| Installation trust contract | Exact CLI, MCP, Docker, skill, cache, network, freshness, benchmark, and uninstall semantics live in [docs/INSTALLATION_TRUST_CONTRACT.md](docs/INSTALLATION_TRUST_CONTRACT.md). |
+| Security policy | Supported versions, disclosure workflow, no-telemetry posture, secret-handling guidance, and model remote-code policy live in [SECURITY](SECURITY.md). |
+| Context receipts | Field contract, freshness/completeness semantics, output surfaces, and benchmark linkage live in [CONTEXT_RECEIPTS](docs/CONTEXT_RECEIPTS.md). |
+| Compatibility matrix | Tested vs unverified clients, exact config shapes, preview-first bootstrap commands, and verification steps live in [CLIENT_COMPATIBILITY_MATRIX](docs/CLIENT_COMPATIBILITY_MATRIX.md). |
+| Installation trust contract | Exact CLI, MCP, Docker, skill, cache, network, freshness, benchmark, and uninstall semantics live in [INSTALLATION_TRUST_CONTRACT](docs/INSTALLATION_TRUST_CONTRACT.md). |
 | `archex install-client` | Preview-first client config writer for Claude Code, Codex, Pi, OpenCode, and Cursor. |
 | `archex doctor` | Text/JSON diagnostics for index health, staleness, local model cache presence, grammar availability by tier, MCP registration, model security, and `.archex/` disk usage. |
 | Repo-local `.archex/` | Generated state: settings, metadata, SQLite index, optional vectors, graph artifacts, dogfood history. Keep it uncommitted. |
+| Local usage metrics | Calculation rules, privacy boundaries, default-off versus opt-in behavior, export/delete controls, and retention live in [LOCAL_METRICS](docs/LOCAL_METRICS.md). |
 
 ## Measured results
 
@@ -335,6 +352,7 @@ Authority chain: README → [System Design](docs/SYSTEM_DESIGN.md) / [archex vs.
 - [System Design](docs/SYSTEM_DESIGN.md) — shipped architecture, graph query, scout, language tiers, and distribution surfaces
 - [archex vs. cocoindex-code](docs/ARCHEX_VS_COCOINDEX.md) — evidence-backed C1 comparison
 - [Retrieval Default Decisions](docs/RETRIEVAL_DEFAULT_DECISIONS.md) — default-strategy evidence gate
+- [Local Metrics](docs/LOCAL_METRICS.md) — token-savings math, privacy boundary, and default-off versus opt-in behavior
 - [Roadmap](docs/ROADMAP.md) — historical execution record
 
 ## License

--- a/docs/INSTALLATION_TRUST_CONTRACT.md
+++ b/docs/INSTALLATION_TRUST_CONTRACT.md
@@ -45,7 +45,7 @@ Core CLI indexing and BM25 retrieval do not require hosted inference, API keys, 
 
 MCP `query_repo` and `scout_repo` envelopes now include a top-level `receipt` field next to `content` and `_meta`. This is an intentional additive JSON-envelope change so MCP clients can inspect provenance and completeness without parsing prompt text.
 
-The client-by-client tested/unverified matrix and bootstrap paths live in [docs/CLIENT_COMPATIBILITY_MATRIX.md](CLIENT_COMPATIBILITY_MATRIX.md).
+The client-by-client tested/unverified matrix and bootstrap paths live in [CLIENT_COMPATIBILITY_MATRIX](CLIENT_COMPATIBILITY_MATRIX.md).
 
 ## MCP setup
 
@@ -144,6 +144,17 @@ archex reads only paths you point it at or paths implied by the current reposito
 
 archex does not need hosted API keys for core CLI, Python API, MCP, Docker slim, or BM25 retrieval.
 
+Local usage metrics are part of the core local-first contract:
+
+- CLI `query`/`scout` do not record metrics unless the user explicitly enables local metrics.
+- MCP `query_repo`/`scout_repo` do not record metrics unless the user explicitly enables local metrics.
+- Structural CLI/MCP tools do not record metrics unless the user explicitly enables local metrics; when enabled, archex only records tools that already have a cheap returned-token and raw-equivalent baseline.
+- Python API calls do not write the metrics ledger unless the caller explicitly opts in with `record_usage_event(...)`.
+- The local ledger path is `~/.archex/usage.sqlite`.
+- No metrics code path makes LLM calls.
+- No hosted upload exists in v1.
+
+The exact token-savings math and enablement boundary are documented in [LOCAL_METRICS.md](LOCAL_METRICS.md).
 ## What archex writes
 
 Generated local state:
@@ -172,6 +183,56 @@ Do not commit `.archex/`. The project initializer adds `.archex/` to the reposit
 | `archex mcp --watch` | Watches local filesystem events; no network by itself. |
 | Telemetry | No telemetry is sent by core CLI, Python API, MCP, or Docker slim workflows. |
 
+## Local metrics privacy and controls
+
+For exact token-savings formulas, summary-field interpretation, and enablement rules, see [LOCAL_METRICS.md](LOCAL_METRICS.md).
+
+When local metrics are enabled, default metrics rows contain:
+
+- tool name
+- category (`context_retrieval` or `structural_tools`)
+- returned tokens
+- raw-equivalent tokens
+- saved tokens and savings percent
+- optional whole-repo avoided tokens as an upper-bound/context metric
+- file count
+- freshness
+- index revision
+- repo-local random UUID reference
+
+When local metrics are enabled, default metrics rows do not contain:
+
+- query text
+- file paths
+- symbols
+- scout handles
+- source snippets
+- rendered outputs
+- prompt bodies
+- Git remote URLs
+- org names
+- repo names in event rows
+
+Controls:
+
+```bash
+archex metrics enable
+archex metrics disable
+archex metrics export --output usage.json
+archex metrics delete --all
+archex metrics trace enable
+archex metrics trace disable
+ARCHEX_USAGE_METRICS=on
+ARCHEX_USAGE_METRICS=off
+ARCHEX_USAGE_TRACE=on
+ARCHEX_USAGE_TRACE=off
+```
+
+`archex metrics enable` or `ARCHEX_USAGE_METRICS=on` turns on local metrics recording. `ARCHEX_USAGE_METRICS=off` prevents writes. `ARCHEX_USAGE_TRACE=on|off` overrides detailed trace recording. `archex metrics export` redacts local repo paths by default unless `--include-local-paths` is passed. `archex metrics delete --all` removes the local metrics ledger.
+
+Detailed traces are local-only and opt-in. They may store query text, returned file paths, symbols, handles, skipped counts, token math, repo ID, and index revision. They never store source code, rendered output bodies, or prompt bodies.
+
+Headline savings always mean saved tokens versus returned full files. Whole-repo avoided tokens are stored separately and must be treated as an upper-bound/context metric, not the headline savings number.
 Run `archex doctor --security --format json` to inspect selected providers, remote-code policy, revision pins, cache state, offline environment flags, and model-download implications.
 
 ## Remote-code policy

--- a/docs/LOCAL_METRICS.md
+++ b/docs/LOCAL_METRICS.md
@@ -1,0 +1,220 @@
+# Local Metrics
+
+This document explains what archex records in the local metrics ledger, how token savings are calculated, and which parts of the system are default-off versus explicitly opt-in.
+
+## The boundary
+
+archex ships with no telemetry by default.
+
+Local metrics are optional and default-off.
+
+What requires explicit enablement:
+- CLI `query` and `scout`
+- MCP `query_repo` and `scout_repo`
+- Structural CLI and MCP tools that already have a reliable raw-equivalent token baseline without adding expensive new work
+
+What is explicitly opt-in on top of metrics enablement:
+- Detailed traces via `archex metrics trace enable` or `ARCHEX_USAGE_TRACE=on`
+- Python API writes via `record_usage_event(...)`
+
+What does not exist in v1:
+- Hosted upload
+- Team or SaaS metrics service
+- Any metrics code path that makes LLM calls
+
+To turn local metrics on, use `archex metrics enable`, `ARCHEX_USAGE_METRICS=on`, or the persisted metrics setting. To turn them off everywhere for the current process, use `ARCHEX_USAGE_METRICS=off`.
+
+## Where the ledger lives
+
+The machine-local SQLite ledger lives at:
+
+```text
+~/.archex/usage.sqlite
+```
+
+This is separate from repo-local `.archex/` state.
+
+## What gets stored when metrics are enabled
+
+When metrics are enabled, default event rows store anonymous counters only:
+- surface
+- tool name
+- category
+- returned tokens
+- raw-equivalent tokens
+- saved tokens
+- savings percent
+- optional whole-repo avoided tokens
+- file count
+- freshness
+- index revision
+- machine-local repo UUID
+
+Default event rows do not store:
+- query text
+- file paths
+- symbol names
+- scout handles
+- source snippets
+- rendered outputs
+- prompt bodies
+- Git remote URLs
+- org names
+- repo names in event rows
+
+The local `repos` table does map the machine-local repo UUID back to a local path so repo summaries and exports can work on the same machine. Default exports include the repo `display_name` (the local directory basename). The full `repo_root` path stays out of export output unless you opt in with `--include-local-paths`.
+
+## Savings calculation
+
+The metrics ledger tracks three token views:
+
+1. Returned tokens
+   - The size of the actual archex response delivered to the caller.
+
+2. Raw-equivalent tokens
+   - The cost of returning the same result as full-file access for the files archex actually returned.
+   - This is the baseline used for the headline savings number.
+   - `baseline_type` is currently `returned_full_files`.
+
+3. Whole-repo tokens
+   - The token count for the indexed repository when archex already has that number cheaply.
+   - This is not the headline baseline. It is context only.
+
+The formulas are:
+
+```text
+tokens_saved = max(tokens_raw_equivalent - tokens_returned, 0)
+savings_pct = 0 if tokens_raw_equivalent <= 0 else (tokens_saved / tokens_raw_equivalent) * 100
+whole_repo_tokens_avoided = null if whole_repo_tokens is unavailable
+whole_repo_tokens_avoided = max(whole_repo_tokens - tokens_returned, 0) otherwise
+```
+
+Example:
+
+```text
+returned tokens = 6,132
+raw-equivalent tokens = 13,120
+whole-repo tokens = 1,302,860
+
+tokens_saved = 13,120 - 6,132 = 6,988
+savings_pct = 6,988 / 13,120 = 53.3%
+whole_repo_tokens_avoided = 1,302,860 - 6,132 = 1,296,728
+```
+
+Interpretation:
+- `tokens_saved` is the headline savings number.
+- `whole_repo_tokens_avoided` is an upper-bound/context metric, not the headline number.
+
+## Surface defaults
+
+| Surface | Default | Notes |
+| --- | --- | --- |
+| CLI `query` / `scout` | Not recorded | Recorded only after explicit metrics enablement. |
+| MCP `query_repo` / `scout_repo` | Not recorded | Response shape stays unchanged; recording failures are non-fatal once enabled. |
+| Structural CLI/MCP tools | Not recorded | After metrics enablement, archex records only tools with a cheap reliable baseline. |
+| Python API `query()` / `analyze()` / `compare()` | Not recorded | No ledger write unless the caller explicitly calls `record_usage_event(...)`. |
+| Detailed traces | Off by default | Local-only, opt-in on top of metrics enablement. |
+| Hosted upload | Not available | Reserved for possible future work, not implemented in v1. |
+
+## Detailed traces
+
+Detailed traces are local-only and opt-in.
+
+When enabled, a trace may store:
+- query text
+- returned file paths
+- symbol names
+- scout handles
+- skipped-count metadata
+- token math
+- repo UUID
+- index revision
+
+Detailed traces never store:
+- source code
+- rendered output bodies
+- prompt bodies
+
+## Commands and controls
+
+```bash
+archex metrics enable
+archex metrics disable
+archex metrics
+archex metrics summary --format json
+archex metrics inspect --format json
+archex metrics export --output usage.json
+archex metrics delete --all
+archex metrics trace enable
+archex metrics trace disable
+```
+
+Environment overrides:
+
+```bash
+ARCHEX_USAGE_METRICS=on
+ARCHEX_USAGE_METRICS=off
+ARCHEX_USAGE_TRACE=on
+ARCHEX_USAGE_TRACE=off
+```
+
+Notes:
+- `archex metrics enable` or `ARCHEX_USAGE_METRICS=on` turns on local metrics recording.
+- `ARCHEX_USAGE_METRICS=off` prevents writes.
+- `ARCHEX_USAGE_TRACE=on|off` overrides trace recording.
+- `archex metrics export` redacts local repo paths by default.
+- `archex metrics export --include-local-paths` includes them explicitly.
+- `archex metrics delete --all` removes the local metrics ledger.
+
+## Python API opt-in
+
+Python API calls do not write the metrics ledger by default.
+
+If a Python caller wants to record usage, it must opt in explicitly:
+
+```python
+from pathlib import Path
+
+from archex import record_usage_event
+from archex.metrics.recorder import UsageEvent
+
+record_usage_event(
+    UsageEvent(
+        repo_root=Path("."),
+        surface="python_api",
+        tool_name="query",
+        category="context_retrieval",
+        tokens_returned=250,
+        tokens_raw_equivalent=1000,
+    )
+)
+```
+
+## Retention
+
+Current local retention policy:
+- raw anonymous events: 90 days
+- detailed traces: 14 days
+- daily aggregates: retained indefinitely
+
+## Failure behavior
+
+Metrics recording must never break query, scout, or MCP operations.
+
+If recording fails:
+- the user-facing operation still succeeds
+- metrics health is updated with the failure
+- `archex metrics` surfaces the warning
+
+## Reading the output
+
+`archex metrics summary` reports:
+- headline saved tokens versus returned full files
+- returned token total
+- raw-equivalent token total
+- percentage savings
+- whole-repo avoided tokens as context only
+
+`archex metrics inspect` reports recent event rows.
+
+`archex metrics repos` ranks known local repos by saved tokens over the selected time window.

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -14,6 +14,7 @@ from archex.integrations.mcp import handle_get_file_tree, handle_query_repo, han
 from archex.metrics.categories import category_for_tool
 from archex.metrics.health import read_metrics_health
 from archex.metrics.policy import METRICS_ENV, resolve_metrics_policy
+from archex.metrics.recorder import UsageEvent
 from archex.metrics.storage import MetricsStore
 from archex.models import Config, RepoSource
 

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -14,7 +14,6 @@ from archex.integrations.mcp import handle_get_file_tree, handle_query_repo, han
 from archex.metrics.categories import category_for_tool
 from archex.metrics.health import read_metrics_health
 from archex.metrics.policy import METRICS_ENV, resolve_metrics_policy
-from archex.metrics.recorder import UsageEvent
 from archex.metrics.storage import MetricsStore
 from archex.models import Config, RepoSource
 


### PR DESCRIPTION
## Stack

Stack-Id: `metrics-rollout-a7k9p2`
Base: `feat/metrics-python-api-opt-in`
Position: 5/5

1. `feat/metrics-cli-instrumentation` -> #259
2. `feat/metrics-mcp-instrumentation` -> #260
3. `feat/metrics-structural-instrumentation` -> #261
4. `feat/metrics-python-api-opt-in` -> #262
5. `docs/metrics-privacy-rollout` -> this PR

Depends on: #262
Upstack: (none - leaf)

## Validation

- `uv run python -c "from archex import record_usage_event; print('record_usage_event ok')"`
- `uv run archex metrics --help`
- `uv run archex metrics export --help`
- `uv run archex metrics delete --help`
- `uv run archex metrics trace --help`
- Review: no blocking findings
