### PR TITLE
Fix scout receipt budget and hashes

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1626,7 +1626,15 @@ def scout_with_bundle(
             direct_query_tokens=bundle.token_count,
             direct_query_file_paths=bundle_file_paths,
         )
-        scout_result.receipt = build_scout_receipt(scout_result, bundle.receipt)
+        file_hashes = {
+            path: str(state.get("sha256", ""))
+            for path, state in store.get_file_states().items()
+        }
+        scout_result.receipt = build_scout_receipt(
+            scout_result,
+            bundle.receipt,
+            file_hashes=file_hashes,
+        )
     finally:
         store.close()
     return scout_result, bundle

--- a/src/archex/receipt.py
+++ b/src/archex/receipt.py
@@ -23,7 +23,7 @@ from archex.models import (
     Edge,
     RankedChunk,
 )
-from archex.scout import ScoutResult, chunk_handle, file_handle
+from archex.scout import ScoutResult, chunk_handle, file_handle, parse_scout_handle
 
 if TYPE_CHECKING:
     from archex.index.graph import DependencyGraph
@@ -120,28 +120,37 @@ def build_context_receipt(
 def build_scout_receipt(
     result: ScoutResult,
     direct_receipt: ContextReceipt | None,
+    *,
+    file_hashes: dict[str, str] | None = None,
 ) -> ContextReceipt | None:
     if direct_receipt is None:
         return None
+    file_hashes = file_hashes or {}
+    selected_handles = set(result.fetch_plan.handles)
+    selected_file_paths = _selected_scout_file_paths(result)
     returned = [
         ContextReceiptItem(
             handle=item.handle,
             file_path=item.path,
             start_line=1,
             end_line=item.lines,
-            content_hash="",
+            content_hash=file_hashes.get(item.path, ""),
             symbols=[symbol.name for symbol in result.symbols if symbol.file_path == item.path],
             score=item.score,
             reason_codes=[item.reason],
         )
         for item in sorted(result.ranked_files, key=lambda file: file.path)
     ]
-    skipped = list(direct_receipt.skipped_candidates)
-    selected_handles = set(result.fetch_plan.handles)
+    skipped = [
+        item
+        for item in direct_receipt.skipped_candidates
+        if item.file_path not in selected_file_paths
+        and (item.handle is None or item.handle not in selected_handles)
+    ]
     for file_path, reason in sorted(result.fetch_plan.file_reasons.items()):
         if reason.startswith("selected"):
             continue
-        if file_handle(file_path) in selected_handles:
+        if file_path in selected_file_paths or file_handle(file_path) in selected_handles:
             continue
         if reason.startswith("duplicate_handle"):
             code = ContextSkippedReason.DUPLICATE
@@ -167,8 +176,14 @@ def build_scout_receipt(
     )
     return direct_receipt.model_copy(
         update={
+            "token_budget": ContextReceiptTokenBudget(
+                requested=result.budget.token_budget,
+                consumed=result.budget.token_count,
+            ),
             "returned_context": returned,
             "skipped_candidates": merged_skipped,
+            "returned_total": len(returned),
+            "skipped_total": len(skipped),
             "context_complete": status,
             "context_complete_reason": (
                 completion_reason or direct_receipt.context_complete_reason
@@ -176,6 +191,23 @@ def build_scout_receipt(
             "recommended_next_action": action or direct_receipt.recommended_next_action,
         }
     )
+
+
+def _selected_scout_file_paths(result: ScoutResult) -> set[str]:
+    paths = {
+        file_path
+        for file_path, reason in result.fetch_plan.file_reasons.items()
+        if reason.startswith("selected")
+    }
+    for handle_value in result.fetch_plan.handles:
+        handle = parse_scout_handle(handle_value)
+        if handle is None:
+            continue
+        if handle.kind == "file":
+            paths.add(handle.value)
+        elif handle.kind in {"chunk", "symbol"} and "::" in handle.value:
+            paths.add(handle.value.split("::", 1)[0])
+    return paths
 
 
 def receipt_edges_for_graph(

--- a/tests/test_query_pipeline.py
+++ b/tests/test_query_pipeline.py
@@ -90,6 +90,9 @@ class TestQueryPipelineEndToEnd:
         assert result.receipt is not None
         assert result.receipt.returned_context
         assert result.receipt.returned_context[0].handle.startswith("file:")
+        assert result.receipt.token_budget.requested == result.budget.token_budget
+        assert result.receipt.token_budget.consumed == result.budget.token_count
+        assert result.receipt.returned_context[0].content_hash
         assert result.fetch_plan.handles
         assert "Receipt: freshness=" in render_scout(result)
 

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -6,8 +6,8 @@ from archex.models import (
     ContextCompletenessStatus,
     ContextFreshness,
     ContextReceipt,
-    ContextReceiptTokenBudget,
     ContextReceiptEdge,
+    ContextReceiptTokenBudget,
     ContextRecommendedAction,
     ContextSkippedCandidate,
     ContextSkippedReason,
@@ -95,12 +95,20 @@ def test_context_receipt_totals_preserve_uncapped_counts() -> None:
 def test_scout_receipt_does_not_mark_selected_handle_files_as_skipped() -> None:
     direct_receipt = ContextReceipt(
         query="q",
-        token_budget=ContextReceiptTokenBudget(requested=100, consumed=20),
+        token_budget=ContextReceiptTokenBudget(requested=500, consumed=250),
         index_revision="rev",
         freshness=ContextFreshness.CLEAN,
         context_complete=ContextCompletenessStatus.COMPLETE,
         context_complete_reason=ContextCompletenessReason.COMPLETE,
         recommended_next_action=ContextRecommendedAction.USE_BUNDLE,
+        skipped_candidates=[
+            ContextSkippedCandidate(
+                file_path="src/service.py",
+                reason=ContextSkippedReason.BELOW_THRESHOLD,
+                handle=file_handle("src/service.py"),
+            )
+        ],
+        skipped_total=1,
     )
     scout = ScoutResult(
         query="q",
@@ -114,7 +122,7 @@ def test_scout_receipt_does_not_mark_selected_handle_files_as_skipped() -> None:
                 score=1.0,
             )
         ],
-        budget=ScoutBudget(token_budget=100),
+        budget=ScoutBudget(token_budget=100, token_count=64),
         fetch_plan=ScoutFetchPlan(
             handles=[symbol_handle("src/service.py::Service#class")],
             file_reasons={
@@ -126,10 +134,19 @@ def test_scout_receipt_does_not_mark_selected_handle_files_as_skipped() -> None:
         ),
     )
 
-    receipt = build_scout_receipt(scout, direct_receipt)
+    receipt = build_scout_receipt(
+        scout,
+        direct_receipt,
+        file_hashes={"src/service.py": "sha256-service"},
+    )
 
     assert receipt is not None
     assert receipt.skipped_candidates == []
+    assert receipt.token_budget.requested == 100
+    assert receipt.token_budget.consumed == 64
+    assert receipt.returned_context[0].content_hash == "sha256-service"
+    assert receipt.returned_total == 1
+    assert receipt.skipped_total == 0
     assert receipt.context_complete == ContextCompletenessStatus.COMPLETE
     assert receipt.context_complete_reason == ContextCompletenessReason.COMPLETE
     assert receipt.recommended_next_action == ContextRecommendedAction.USE_BUNDLE


### PR DESCRIPTION
## Summary
- report scout receipt requested/consumed tokens from the scout map budget
- populate scout returned-context hashes from indexed file state hashes
- exclude selected fetch-handle files from scout skipped candidates

## Validation
- uv run ruff check src/archex/api.py src/archex/receipt.py tests/test_query_pipeline.py tests/test_receipt.py
- uv run pytest tests/test_query_pipeline.py tests/test_receipt.py -q --no-cov