### PR TITLE
revert: remove subagent commits from main

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1626,15 +1626,7 @@ def scout_with_bundle(
             direct_query_tokens=bundle.token_count,
             direct_query_file_paths=bundle_file_paths,
         )
-        file_hashes = {
-            path: str(state.get("sha256", ""))
-            for path, state in store.get_file_states().items()
-        }
-        scout_result.receipt = build_scout_receipt(
-            scout_result,
-            bundle.receipt,
-            file_hashes=file_hashes,
-        )
+        scout_result.receipt = build_scout_receipt(scout_result, bundle.receipt)
     finally:
         store.close()
     return scout_result, bundle

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -737,17 +737,10 @@ class ContextReceipt(BaseModel):
     token_budget: ContextReceiptTokenBudget
     index_revision: str
     freshness: ContextFreshness = ContextFreshness.UNKNOWN
-    freshness_checked_at: str | None = None
-    index_fresh_at: str | None = None
-    watch_fresh_at: str | None = None
     returned_context: list[ContextReceiptItem] = []
     included_edges: list[ContextReceiptEdge] = []
     omitted_edges: list[ContextReceiptEdge] = []
     skipped_candidates: list[ContextSkippedCandidate] = []
-    returned_total: int = 0
-    skipped_total: int = 0
-    included_edges_total: int = 0
-    omitted_edges_total: int = 0
     context_complete: ContextCompletenessStatus = ContextCompletenessStatus.UNKNOWN
     context_complete_reason: ContextCompletenessReason = ContextCompletenessReason.UNKNOWN
     recommended_next_action: ContextRecommendedAction = ContextRecommendedAction.MANUAL_REVIEW

--- a/src/archex/receipt.py
+++ b/src/archex/receipt.py
@@ -23,7 +23,7 @@ from archex.models import (
     Edge,
     RankedChunk,
 )
-from archex.scout import ScoutResult, chunk_handle, file_handle, parse_scout_handle
+from archex.scout import ScoutResult, chunk_handle, file_handle
 
 if TYPE_CHECKING:
     from archex.index.graph import DependencyGraph
@@ -120,37 +120,28 @@ def build_context_receipt(
 def build_scout_receipt(
     result: ScoutResult,
     direct_receipt: ContextReceipt | None,
-    *,
-    file_hashes: dict[str, str] | None = None,
 ) -> ContextReceipt | None:
     if direct_receipt is None:
         return None
-    file_hashes = file_hashes or {}
-    selected_handles = set(result.fetch_plan.handles)
-    selected_file_paths = _selected_scout_file_paths(result)
     returned = [
         ContextReceiptItem(
             handle=item.handle,
             file_path=item.path,
             start_line=1,
             end_line=item.lines,
-            content_hash=file_hashes.get(item.path, ""),
+            content_hash="",
             symbols=[symbol.name for symbol in result.symbols if symbol.file_path == item.path],
             score=item.score,
             reason_codes=[item.reason],
         )
         for item in sorted(result.ranked_files, key=lambda file: file.path)
     ]
-    skipped = [
-        item
-        for item in direct_receipt.skipped_candidates
-        if item.file_path not in selected_file_paths
-        and (item.handle is None or item.handle not in selected_handles)
-    ]
+    skipped = list(direct_receipt.skipped_candidates)
+    selected_handles = set(result.fetch_plan.handles)
     for file_path, reason in sorted(result.fetch_plan.file_reasons.items()):
         if reason.startswith("selected"):
             continue
-        if file_path in selected_file_paths or file_handle(file_path) in selected_handles:
+        if file_handle(file_path) in selected_handles:
             continue
         if reason.startswith("duplicate_handle"):
             code = ContextSkippedReason.DUPLICATE
@@ -176,14 +167,8 @@ def build_scout_receipt(
     )
     return direct_receipt.model_copy(
         update={
-            "token_budget": ContextReceiptTokenBudget(
-                requested=result.budget.token_budget,
-                consumed=result.budget.token_count,
-            ),
             "returned_context": returned,
             "skipped_candidates": merged_skipped,
-            "returned_total": len(returned),
-            "skipped_total": len(skipped),
             "context_complete": status,
             "context_complete_reason": (
                 completion_reason or direct_receipt.context_complete_reason
@@ -191,23 +176,6 @@ def build_scout_receipt(
             "recommended_next_action": action or direct_receipt.recommended_next_action,
         }
     )
-
-
-def _selected_scout_file_paths(result: ScoutResult) -> set[str]:
-    paths = {
-        file_path
-        for file_path, reason in result.fetch_plan.file_reasons.items()
-        if reason.startswith("selected")
-    }
-    for handle_value in result.fetch_plan.handles:
-        handle = parse_scout_handle(handle_value)
-        if handle is None:
-            continue
-        if handle.kind == "file":
-            paths.add(handle.value)
-        elif handle.kind in {"chunk", "symbol"} and "::" in handle.value:
-            paths.add(handle.value.split("::", 1)[0])
-    return paths
 
 
 def receipt_edges_for_graph(

--- a/src/archex/receipt.py
+++ b/src/archex/receipt.py
@@ -67,20 +67,13 @@ def build_context_receipt(
     *,
     index_revision: str,
     freshness: ContextFreshness,
-    freshness_checked_at: str | None = None,
-    index_fresh_at: str | None = None,
-    watch_fresh_at: str | None = None,
     included_edges: Iterable[ContextReceiptEdge] = (),
     omitted_edges: Iterable[ContextReceiptEdge] = (),
     skipped_candidates: Iterable[ContextSkippedCandidate] = (),
 ) -> ContextReceipt:
-    returned = _returned_context(bundle)
-    skipped_all = list(skipped_candidates)
-    omitted_all = list(omitted_edges)
-    included_all = list(included_edges)
-    skipped = sorted(skipped_all, key=_skipped_sort_key)[:_MAX_RECEIPT_SKIPPED]
+    skipped = sorted(skipped_candidates, key=_skipped_sort_key)[:_MAX_RECEIPT_SKIPPED]
     omitted = sorted(
-        omitted_all,
+        omitted_edges,
         key=lambda item: (
             item.reason.value if item.reason else "",
             item.source,
@@ -89,7 +82,7 @@ def build_context_receipt(
         ),
     )[:_MAX_RECEIPT_OMITTED_EDGES]
     included = sorted(
-        included_all,
+        included_edges,
         key=lambda item: (item.source, item.target, item.kind.value),
     )[:_MAX_RECEIPT_INCLUDED_EDGES]
     return ContextReceipt(
@@ -100,17 +93,10 @@ def build_context_receipt(
         ),
         index_revision=index_revision,
         freshness=freshness,
-        freshness_checked_at=freshness_checked_at,
-        index_fresh_at=index_fresh_at,
-        watch_fresh_at=watch_fresh_at,
-        returned_context=returned,
+        returned_context=_returned_context(bundle),
         included_edges=included,
         omitted_edges=omitted,
         skipped_candidates=skipped,
-        returned_total=len(returned),
-        skipped_total=len(skipped_all),
-        included_edges_total=len(included_all),
-        omitted_edges_total=len(omitted_all),
         context_complete=_completion_status(bundle, freshness, omitted, skipped),
         context_complete_reason=_completion_reason(bundle, freshness, omitted, skipped),
         recommended_next_action=_recommended_action(bundle, freshness, omitted, skipped),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -151,9 +151,6 @@ def test_context_receipt_instantiation_and_dump_are_deterministic() -> None:
         token_budget=ContextReceiptTokenBudget(requested=1000, consumed=250),
         index_revision="abc123",
         freshness=ContextFreshness.CLEAN,
-        freshness_checked_at="2026-06-17T00:00:00Z",
-        index_fresh_at="2026-06-17T00:00:00Z",
-        watch_fresh_at=None,
         returned_context=[
             ContextReceiptItem(
                 handle="chunk:src/api.py::query",
@@ -195,10 +192,6 @@ def test_context_receipt_instantiation_and_dump_are_deterministic() -> None:
                 detail="support file without explicit test query",
             )
         ],
-        returned_total=1,
-        skipped_total=1,
-        included_edges_total=1,
-        omitted_edges_total=1,
         context_complete=ContextCompletenessStatus.INCOMPLETE,
         context_complete_reason=ContextCompletenessReason.BUDGET_EXHAUSTED,
         recommended_next_action=ContextRecommendedAction.RAISE_BUDGET,
@@ -211,11 +204,6 @@ def test_context_receipt_instantiation_and_dump_are_deterministic() -> None:
     assert first["token_budget"] == {"requested": 1000, "consumed": 250}
     assert first["returned_context"][0]["reason_codes"] == ["bm25", "graph_seed"]
     assert first["skipped_candidates"][0]["reason"] == "test_deprioritized"
-    assert first["returned_total"] == 1
-    assert first["skipped_total"] == 1
-    assert first["included_edges_total"] == 1
-    assert first["omitted_edges_total"] == 1
-    assert first["freshness_checked_at"] == "2026-06-17T00:00:00Z"
 
 
 def test_context_receipt_edge_confidence_score_bounds() -> None:

--- a/tests/test_query_pipeline.py
+++ b/tests/test_query_pipeline.py
@@ -90,9 +90,6 @@ class TestQueryPipelineEndToEnd:
         assert result.receipt is not None
         assert result.receipt.returned_context
         assert result.receipt.returned_context[0].handle.startswith("file:")
-        assert result.receipt.token_budget.requested == result.budget.token_budget
-        assert result.receipt.token_budget.consumed == result.budget.token_count
-        assert result.receipt.returned_context[0].content_hash
         assert result.fetch_plan.handles
         assert "Receipt: freshness=" in render_scout(result)
 

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -7,11 +7,9 @@ from archex.models import (
     ContextFreshness,
     ContextReceipt,
     ContextReceiptTokenBudget,
-    ContextReceiptEdge,
     ContextRecommendedAction,
     ContextSkippedCandidate,
     ContextSkippedReason,
-    EdgeKind,
 )
 from archex.receipt import (
     build_context_receipt,
@@ -50,46 +48,6 @@ def test_context_receipt_preserves_stale_marker_when_skipped_candidates_are_capp
     assert receipt.skipped_candidates[0].reason == ContextSkippedReason.STALE_INDEX
     assert receipt.context_complete_reason == ContextCompletenessReason.STALE_INDEX
     assert receipt.recommended_next_action == ContextRecommendedAction.REFRESH_INDEX
-
-
-def test_context_receipt_totals_preserve_uncapped_counts() -> None:
-    bundle = ContextBundle(query="q", token_count=10, token_budget=100, truncated=True)
-    skipped = [
-        ContextSkippedCandidate(
-            file_path=f"file_{index}.py",
-            reason=ContextSkippedReason.BELOW_THRESHOLD,
-        )
-        for index in range(25)
-    ]
-    included_edges = [
-        ContextReceiptEdge(source=f"src/{index}.py", target="src/shared.py", kind=EdgeKind.IMPORTS)
-        for index in range(45)
-    ]
-    omitted_edges = [
-        ContextReceiptEdge(source="src/root.py", target=f"src/{index}.py", kind=EdgeKind.IMPORTS)
-        for index in range(23)
-    ]
-
-    receipt = build_context_receipt(
-        bundle,
-        index_revision="rev",
-        freshness=ContextFreshness.CLEAN,
-        freshness_checked_at="2026-06-17T00:00:00Z",
-        index_fresh_at="2026-06-17T00:00:00Z",
-        included_edges=included_edges,
-        omitted_edges=omitted_edges,
-        skipped_candidates=skipped,
-    )
-
-    assert len(receipt.skipped_candidates) == 20
-    assert len(receipt.included_edges) == 40
-    assert len(receipt.omitted_edges) == 20
-    assert receipt.returned_total == 0
-    assert receipt.skipped_total == 25
-    assert receipt.included_edges_total == 45
-    assert receipt.omitted_edges_total == 23
-    assert receipt.freshness_checked_at == "2026-06-17T00:00:00Z"
-    assert receipt.index_fresh_at == "2026-06-17T00:00:00Z"
 
 
 def test_scout_receipt_does_not_mark_selected_handle_files_as_skipped() -> None:

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -6,8 +6,8 @@ from archex.models import (
     ContextCompletenessStatus,
     ContextFreshness,
     ContextReceipt,
-    ContextReceiptEdge,
     ContextReceiptTokenBudget,
+    ContextReceiptEdge,
     ContextRecommendedAction,
     ContextSkippedCandidate,
     ContextSkippedReason,
@@ -95,20 +95,12 @@ def test_context_receipt_totals_preserve_uncapped_counts() -> None:
 def test_scout_receipt_does_not_mark_selected_handle_files_as_skipped() -> None:
     direct_receipt = ContextReceipt(
         query="q",
-        token_budget=ContextReceiptTokenBudget(requested=500, consumed=250),
+        token_budget=ContextReceiptTokenBudget(requested=100, consumed=20),
         index_revision="rev",
         freshness=ContextFreshness.CLEAN,
         context_complete=ContextCompletenessStatus.COMPLETE,
         context_complete_reason=ContextCompletenessReason.COMPLETE,
         recommended_next_action=ContextRecommendedAction.USE_BUNDLE,
-        skipped_candidates=[
-            ContextSkippedCandidate(
-                file_path="src/service.py",
-                reason=ContextSkippedReason.BELOW_THRESHOLD,
-                handle=file_handle("src/service.py"),
-            )
-        ],
-        skipped_total=1,
     )
     scout = ScoutResult(
         query="q",
@@ -122,7 +114,7 @@ def test_scout_receipt_does_not_mark_selected_handle_files_as_skipped() -> None:
                 score=1.0,
             )
         ],
-        budget=ScoutBudget(token_budget=100, token_count=64),
+        budget=ScoutBudget(token_budget=100),
         fetch_plan=ScoutFetchPlan(
             handles=[symbol_handle("src/service.py::Service#class")],
             file_reasons={
@@ -134,19 +126,10 @@ def test_scout_receipt_does_not_mark_selected_handle_files_as_skipped() -> None:
         ),
     )
 
-    receipt = build_scout_receipt(
-        scout,
-        direct_receipt,
-        file_hashes={"src/service.py": "sha256-service"},
-    )
+    receipt = build_scout_receipt(scout, direct_receipt)
 
     assert receipt is not None
     assert receipt.skipped_candidates == []
-    assert receipt.token_budget.requested == 100
-    assert receipt.token_budget.consumed == 64
-    assert receipt.returned_context[0].content_hash == "sha256-service"
-    assert receipt.returned_total == 1
-    assert receipt.skipped_total == 0
     assert receipt.context_complete == ContextCompletenessStatus.COMPLETE
     assert receipt.context_complete_reason == ContextCompletenessReason.COMPLETE
     assert receipt.recommended_next_action == ContextRecommendedAction.USE_BUNDLE

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "archex"
-version = "0.12.1"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Reverts two commits that landed directly on main without going through the PR workflow:

- `46d7fa5` Fix scout receipt budget and hashes
- `499537e` Add receipt totals and freshness fields

Neither was reviewed or intentionally merged. This restores main to `d76742e` (v0.12.1).