### PR TITLE
Add receipt totals and freshness fields

### DIFF
--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -737,10 +737,17 @@ class ContextReceipt(BaseModel):
     token_budget: ContextReceiptTokenBudget
     index_revision: str
     freshness: ContextFreshness = ContextFreshness.UNKNOWN
+    freshness_checked_at: str | None = None
+    index_fresh_at: str | None = None
+    watch_fresh_at: str | None = None
     returned_context: list[ContextReceiptItem] = []
     included_edges: list[ContextReceiptEdge] = []
     omitted_edges: list[ContextReceiptEdge] = []
     skipped_candidates: list[ContextSkippedCandidate] = []
+    returned_total: int = 0
+    skipped_total: int = 0
+    included_edges_total: int = 0
+    omitted_edges_total: int = 0
     context_complete: ContextCompletenessStatus = ContextCompletenessStatus.UNKNOWN
     context_complete_reason: ContextCompletenessReason = ContextCompletenessReason.UNKNOWN
     recommended_next_action: ContextRecommendedAction = ContextRecommendedAction.MANUAL_REVIEW

--- a/src/archex/receipt.py
+++ b/src/archex/receipt.py
@@ -67,13 +67,20 @@ def build_context_receipt(
     *,
     index_revision: str,
     freshness: ContextFreshness,
+    freshness_checked_at: str | None = None,
+    index_fresh_at: str | None = None,
+    watch_fresh_at: str | None = None,
     included_edges: Iterable[ContextReceiptEdge] = (),
     omitted_edges: Iterable[ContextReceiptEdge] = (),
     skipped_candidates: Iterable[ContextSkippedCandidate] = (),
 ) -> ContextReceipt:
-    skipped = sorted(skipped_candidates, key=_skipped_sort_key)[:_MAX_RECEIPT_SKIPPED]
+    returned = _returned_context(bundle)
+    skipped_all = list(skipped_candidates)
+    omitted_all = list(omitted_edges)
+    included_all = list(included_edges)
+    skipped = sorted(skipped_all, key=_skipped_sort_key)[:_MAX_RECEIPT_SKIPPED]
     omitted = sorted(
-        omitted_edges,
+        omitted_all,
         key=lambda item: (
             item.reason.value if item.reason else "",
             item.source,
@@ -82,7 +89,7 @@ def build_context_receipt(
         ),
     )[:_MAX_RECEIPT_OMITTED_EDGES]
     included = sorted(
-        included_edges,
+        included_all,
         key=lambda item: (item.source, item.target, item.kind.value),
     )[:_MAX_RECEIPT_INCLUDED_EDGES]
     return ContextReceipt(
@@ -93,10 +100,17 @@ def build_context_receipt(
         ),
         index_revision=index_revision,
         freshness=freshness,
-        returned_context=_returned_context(bundle),
+        freshness_checked_at=freshness_checked_at,
+        index_fresh_at=index_fresh_at,
+        watch_fresh_at=watch_fresh_at,
+        returned_context=returned,
         included_edges=included,
         omitted_edges=omitted,
         skipped_candidates=skipped,
+        returned_total=len(returned),
+        skipped_total=len(skipped_all),
+        included_edges_total=len(included_all),
+        omitted_edges_total=len(omitted_all),
         context_complete=_completion_status(bundle, freshness, omitted, skipped),
         context_complete_reason=_completion_reason(bundle, freshness, omitted, skipped),
         recommended_next_action=_recommended_action(bundle, freshness, omitted, skipped),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -151,6 +151,9 @@ def test_context_receipt_instantiation_and_dump_are_deterministic() -> None:
         token_budget=ContextReceiptTokenBudget(requested=1000, consumed=250),
         index_revision="abc123",
         freshness=ContextFreshness.CLEAN,
+        freshness_checked_at="2026-06-17T00:00:00Z",
+        index_fresh_at="2026-06-17T00:00:00Z",
+        watch_fresh_at=None,
         returned_context=[
             ContextReceiptItem(
                 handle="chunk:src/api.py::query",
@@ -192,6 +195,10 @@ def test_context_receipt_instantiation_and_dump_are_deterministic() -> None:
                 detail="support file without explicit test query",
             )
         ],
+        returned_total=1,
+        skipped_total=1,
+        included_edges_total=1,
+        omitted_edges_total=1,
         context_complete=ContextCompletenessStatus.INCOMPLETE,
         context_complete_reason=ContextCompletenessReason.BUDGET_EXHAUSTED,
         recommended_next_action=ContextRecommendedAction.RAISE_BUDGET,
@@ -204,6 +211,11 @@ def test_context_receipt_instantiation_and_dump_are_deterministic() -> None:
     assert first["token_budget"] == {"requested": 1000, "consumed": 250}
     assert first["returned_context"][0]["reason_codes"] == ["bm25", "graph_seed"]
     assert first["skipped_candidates"][0]["reason"] == "test_deprioritized"
+    assert first["returned_total"] == 1
+    assert first["skipped_total"] == 1
+    assert first["included_edges_total"] == 1
+    assert first["omitted_edges_total"] == 1
+    assert first["freshness_checked_at"] == "2026-06-17T00:00:00Z"
 
 
 def test_context_receipt_edge_confidence_score_bounds() -> None:

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -7,9 +7,11 @@ from archex.models import (
     ContextFreshness,
     ContextReceipt,
     ContextReceiptTokenBudget,
+    ContextReceiptEdge,
     ContextRecommendedAction,
     ContextSkippedCandidate,
     ContextSkippedReason,
+    EdgeKind,
 )
 from archex.receipt import (
     build_context_receipt,
@@ -48,6 +50,46 @@ def test_context_receipt_preserves_stale_marker_when_skipped_candidates_are_capp
     assert receipt.skipped_candidates[0].reason == ContextSkippedReason.STALE_INDEX
     assert receipt.context_complete_reason == ContextCompletenessReason.STALE_INDEX
     assert receipt.recommended_next_action == ContextRecommendedAction.REFRESH_INDEX
+
+
+def test_context_receipt_totals_preserve_uncapped_counts() -> None:
+    bundle = ContextBundle(query="q", token_count=10, token_budget=100, truncated=True)
+    skipped = [
+        ContextSkippedCandidate(
+            file_path=f"file_{index}.py",
+            reason=ContextSkippedReason.BELOW_THRESHOLD,
+        )
+        for index in range(25)
+    ]
+    included_edges = [
+        ContextReceiptEdge(source=f"src/{index}.py", target="src/shared.py", kind=EdgeKind.IMPORTS)
+        for index in range(45)
+    ]
+    omitted_edges = [
+        ContextReceiptEdge(source="src/root.py", target=f"src/{index}.py", kind=EdgeKind.IMPORTS)
+        for index in range(23)
+    ]
+
+    receipt = build_context_receipt(
+        bundle,
+        index_revision="rev",
+        freshness=ContextFreshness.CLEAN,
+        freshness_checked_at="2026-06-17T00:00:00Z",
+        index_fresh_at="2026-06-17T00:00:00Z",
+        included_edges=included_edges,
+        omitted_edges=omitted_edges,
+        skipped_candidates=skipped,
+    )
+
+    assert len(receipt.skipped_candidates) == 20
+    assert len(receipt.included_edges) == 40
+    assert len(receipt.omitted_edges) == 20
+    assert receipt.returned_total == 0
+    assert receipt.skipped_total == 25
+    assert receipt.included_edges_total == 45
+    assert receipt.omitted_edges_total == 23
+    assert receipt.freshness_checked_at == "2026-06-17T00:00:00Z"
+    assert receipt.index_fresh_at == "2026-06-17T00:00:00Z"
 
 
 def test_scout_receipt_does_not_mark_selected_handle_files_as_skipped() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "archex"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- add receipt total/count fields and freshness timestamp fields
- preserve uncapped receipt totals while keeping compact receipt lists
- sync uv.lock project version metadata

## Validation
- uv run pytest tests/test_models.py tests/test_receipt.py -q (assertions passed; coverage threshold fails for this narrow subset)