### PR TITLE
Render receipt parity in markdown and XML

### DIFF
--- a/src/archex/scout.py
+++ b/src/archex/scout.py
@@ -837,15 +837,46 @@ def _render_markdown(result: ScoutResult, *, include_receipt: bool = True) -> st
     ]
     if include_receipt and result.receipt is not None:
         receipt = result.receipt
-        lines.append(
-            "Receipt: "
-            f"freshness={receipt.freshness.value}, "
-            f"complete={receipt.context_complete.value}, "
-            f"reason={receipt.context_complete_reason.value}, "
-            f"action={receipt.recommended_next_action.value}, "
-            f"returned={len(receipt.returned_context)}, "
-            f"skipped={len(receipt.skipped_candidates)}"
+        lines.extend(
+            [
+                "",
+                "## Receipt",
+                f"- Freshness: {receipt.freshness.value}",
+                f"- Index revision: {receipt.index_revision}",
+                (
+                    f"- Budget: {receipt.token_budget.consumed} / "
+                    f"{receipt.token_budget.requested} tokens"
+                ),
+                f"- Context complete: {receipt.context_complete.value}",
+                f"- Reason: {receipt.context_complete_reason.value}",
+                f"- Recommended action: {receipt.recommended_next_action.value}",
+                (
+                    f"- Returned: {len(receipt.returned_context)} shown / "
+                    f"{receipt.returned_total} total"
+                ),
+                (
+                    f"- Skipped: {len(receipt.skipped_candidates)} shown / "
+                    f"{receipt.skipped_total} total"
+                ),
+                (
+                    f"- Omitted dependency edges: {len(receipt.omitted_edges)} shown / "
+                    f"{receipt.omitted_edges_total} total"
+                ),
+            ]
         )
+        if receipt.skipped_candidates:
+            lines.extend(["", "### Skipped candidates"])
+            for item in receipt.skipped_candidates[:8]:
+                handle = f" `{item.handle}`" if item.handle else ""
+                lines.append(
+                    f"- {item.file_path or '(index)'}{handle}: "
+                    f"{item.reason.value}, score={item.score:.3f}"
+                )
+        if receipt.omitted_edges:
+            lines.extend(["", "### Omitted dependency edges"])
+            for edge in receipt.omitted_edges[:8]:
+                reason = edge.reason.value if edge.reason else "unknown"
+                lines.append(f"- {edge.source} --{edge.kind.value}--> {edge.target}: {reason}")
     lines.extend(["", "## Ranked files"])
     if result.ranked_files:
         for item in result.ranked_files:

--- a/src/archex/serve/renderers/markdown.py
+++ b/src/archex/serve/renderers/markdown.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from archex.models import ContextBundle
+    from archex.models import ContextBundle, ContextReceipt
 
 
 def render_markdown(bundle: ContextBundle) -> str:
@@ -69,4 +69,49 @@ def render_markdown(bundle: ContextBundle) -> str:
                 lines.append(f"- {item}")
             lines.append("")
 
+    if bundle.receipt is not None:
+        lines.extend(_receipt_lines(bundle.receipt))
+        lines.append("")
+
     return "\n".join(lines)
+
+
+def _receipt_lines(receipt: ContextReceipt) -> list[str]:
+    lines = [
+        "## Receipt",
+        "",
+        f"- Freshness: {receipt.freshness.value}",
+        f"- Index revision: {receipt.index_revision}",
+        (
+            f"- Budget: {receipt.token_budget.consumed} / "
+            f"{receipt.token_budget.requested} tokens"
+        ),
+        f"- Context complete: {receipt.context_complete.value}",
+        f"- Reason: {receipt.context_complete_reason.value}",
+        f"- Recommended action: {receipt.recommended_next_action.value}",
+        f"- Returned: {len(receipt.returned_context)} shown / {receipt.returned_total} total",
+        f"- Skipped: {len(receipt.skipped_candidates)} shown / {receipt.skipped_total} total",
+        (
+            f"- Omitted dependency edges: {len(receipt.omitted_edges)} shown / "
+            f"{receipt.omitted_edges_total} total"
+        ),
+    ]
+    if receipt.skipped_candidates:
+        lines.extend(["", "### Skipped candidates"])
+        for item in receipt.skipped_candidates[:8]:
+            handle = f" `{item.handle}`" if item.handle else ""
+            symbol = f" symbol={item.symbol}" if item.symbol else ""
+            detail = f" ({item.detail})" if item.detail else ""
+            lines.append(
+                f"- {item.file_path or '(index)'}{handle}: {item.reason.value}, "
+                f"score={item.score:.3f}{symbol}{detail}"
+            )
+    if receipt.omitted_edges:
+        lines.extend(["", "### Omitted dependency edges"])
+        for edge in receipt.omitted_edges[:8]:
+            reason = edge.reason.value if edge.reason else "unknown"
+            lines.append(
+                f"- {edge.source} --{edge.kind.value}--> {edge.target}: "
+                f"{reason}, confidence={edge.confidence_score or 0.0:.3f}"
+            )
+    return lines

--- a/src/archex/serve/renderers/xml.py
+++ b/src/archex/serve/renderers/xml.py
@@ -127,9 +127,12 @@ def _render_receipt_xml(receipt: ContextReceipt) -> list[str]:
         f" index_revision={_attr(receipt.index_revision)}"
         f" budget_requested={_attr(str(receipt.token_budget.requested))}"
         f" budget_consumed={_attr(str(receipt.token_budget.consumed))}"
-        f" returned={_attr(str(len(receipt.returned_context)))}"
-        f" skipped={_attr(str(len(receipt.skipped_candidates)))}"
-        f" omitted_edges={_attr(str(len(receipt.omitted_edges)))}"
+        f" returned_shown={_attr(str(len(receipt.returned_context)))}"
+        f" returned_total={_attr(str(receipt.returned_total))}"
+        f" skipped_shown={_attr(str(len(receipt.skipped_candidates)))}"
+        f" skipped_total={_attr(str(receipt.skipped_total))}"
+        f" omitted_edges_shown={_attr(str(len(receipt.omitted_edges)))}"
+        f" omitted_edges_total={_attr(str(receipt.omitted_edges_total))}"
         ">",
     ]
     for item in receipt.returned_context[:8]:

--- a/tests/serve/test_renderers.py
+++ b/tests/serve/test_renderers.py
@@ -5,7 +5,18 @@ from __future__ import annotations
 from archex.models import (
     CodeChunk,
     ContextBundle,
+    ContextCompletenessReason,
+    ContextCompletenessStatus,
+    ContextFreshness,
+    ContextOmittedEdgeReason,
+    ContextReceipt,
+    ContextReceiptEdge,
+    ContextReceiptTokenBudget,
+    ContextRecommendedAction,
+    ContextSkippedCandidate,
+    ContextSkippedReason,
     DependencySummary,
+    EdgeKind,
     RankedChunk,
     StructuralContext,
     SymbolKind,
@@ -73,6 +84,39 @@ def _base_bundle(**overrides: object) -> ContextBundle:
     return ContextBundle(**defaults)  # type: ignore[arg-type]
 
 
+def _receipt() -> ContextReceipt:
+    return ContextReceipt(
+        query="how does auth work?",
+        token_budget=ContextReceiptTokenBudget(requested=1000, consumed=250),
+        index_revision="rev",
+        freshness=ContextFreshness.CLEAN,
+        skipped_candidates=[
+            ContextSkippedCandidate(
+                file_path="src/extra.py",
+                reason=ContextSkippedReason.BELOW_THRESHOLD,
+                handle="file:src/extra.py",
+                score=0.25,
+            )
+        ],
+        omitted_edges=[
+            ContextReceiptEdge(
+                source="src/app.py",
+                target="src/db.py",
+                kind=EdgeKind.IMPORTS,
+                reason=ContextOmittedEdgeReason.OVER_BUDGET,
+                confidence_score=0.8,
+            )
+        ],
+        returned_total=3,
+        skipped_total=5,
+        omitted_edges_total=4,
+        context_complete=ContextCompletenessStatus.INCOMPLETE,
+        context_complete_reason=ContextCompletenessReason.DEPENDENCY_FRONTIER_CUT,
+        recommended_next_action=ContextRecommendedAction.FETCH_SKIPPED_CANDIDATE,
+    )
+
+
+
 # ---------------------------------------------------------------------------
 # Markdown renderer tests
 # ---------------------------------------------------------------------------
@@ -131,6 +175,18 @@ def test_markdown_both_internal_and_external_deps() -> None:
     assert "- httpx" in md
 
 
+def test_markdown_receipt_block_shows_totals_and_next_action() -> None:
+    md = render_markdown(_base_bundle(receipt=_receipt()))
+    assert "## Receipt" in md
+    assert "- Budget: 250 / 1000 tokens" in md
+    assert "- Recommended action: fetch_skipped_candidate" in md
+    assert "- Returned: 0 shown / 3 total" in md
+    assert "- Skipped: 1 shown / 5 total" in md
+    assert "- Omitted dependency edges: 1 shown / 4 total" in md
+    assert "src/extra.py" in md
+    assert "src/app.py --imports--> src/db.py" in md
+
+
 def test_markdown_no_file_tree_when_empty() -> None:
     bundle = _base_bundle(structural_context=StructuralContext(file_tree=""))
     md = render_markdown(bundle)
@@ -180,6 +236,16 @@ def test_xml_dependencies_block_rendered() -> None:
     assert "<internal>src/db.py</internal>" in xml
     assert "<external>sqlalchemy</external>" in xml
     assert "</dependencies>" in xml
+
+
+def test_xml_receipt_uses_shown_and_total_counts() -> None:
+    xml = render_xml(_base_bundle(receipt=_receipt()))
+    assert 'returned_shown="0"' in xml
+    assert 'returned_total="3"' in xml
+    assert 'skipped_shown="1"' in xml
+    assert 'skipped_total="5"' in xml
+    assert 'omitted_edges_shown="1"' in xml
+    assert 'omitted_edges_total="4"' in xml
 
 
 def test_xml_no_type_defs_or_deps_tags_when_empty() -> None:

--- a/tests/test_query_pipeline.py
+++ b/tests/test_query_pipeline.py
@@ -94,7 +94,7 @@ class TestQueryPipelineEndToEnd:
         assert result.receipt.token_budget.consumed == result.budget.token_count
         assert result.receipt.returned_context[0].content_hash
         assert result.fetch_plan.handles
-        assert "Receipt: freshness=" in render_scout(result)
+        assert "## Receipt" in render_scout(result)
 
     def test_query_finds_relevant_files(self, python_simple_repo: Path) -> None:
         source = RepoSource(local_path=str(python_simple_repo))


### PR DESCRIPTION
## Summary
- add receipt block to query markdown
- show receipt shown/total counts in XML
- expand scout markdown receipt details

## Validation
- uv run ruff check src/archex/serve/renderers/markdown.py src/archex/serve/renderers/xml.py src/archex/scout.py tests/serve/test_renderers.py tests/test_query_pipeline.py
- uv run pytest tests/serve/test_renderers.py tests/test_query_pipeline.py tests/test_cli.py -k 'query or scout or receipt' -q --no-cov