### PR TITLE
Tighten raw ripgrep benchmark strategy

### DIFF
--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -480,6 +480,7 @@ _RIPGREP_INCLUDE_GLOBS = (
     "*.cs",
     "*.swift",
 )
+_RIPGREP_TIMEOUT_SECONDS = 30
 
 
 def run_raw_ripgrep(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
@@ -488,13 +489,19 @@ def run_raw_ripgrep(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     rg_path = shutil.which("rg")
     if rg_path is None:
         raise RuntimeError("raw_ripgrep strategy requires ripgrep executable 'rg' on PATH")
-    version = subprocess.run(
-        [rg_path, "--version"],
-        capture_output=True,
-        text=True,
-        timeout=5,
-        check=True,
-    ).stdout.splitlines()[0]
+    try:
+        version = subprocess.run(
+            [rg_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        ).stdout.splitlines()[0]
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("raw_ripgrep timed out while reading rg --version") from exc
+    except subprocess.CalledProcessError as exc:
+        message = exc.stderr.strip() or exc.stdout.strip() or str(exc)
+        raise RuntimeError(f"raw_ripgrep failed to read rg --version: {message}") from exc
     keywords = extract_keywords(task.question, task.keywords)
     matched_files_seen: set[str] = set()
     matched_files_ordered: list[str] = []
@@ -507,13 +514,18 @@ def run_raw_ripgrep(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
             keyword,
             ".",
         ]
-        result = subprocess.run(
-            command,
-            cwd=repo_path,
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
+        try:
+            result = subprocess.run(
+                command,
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                timeout=_RIPGREP_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"raw_ripgrep timed out after {_RIPGREP_TIMEOUT_SECONDS}s for keyword {keyword!r}"
+            ) from exc
         if result.returncode == 1:
             continue
         if result.returncode != 0:
@@ -580,7 +592,7 @@ def run_raw_ripgrep(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
             "rg_version": version,
             "keyword_count": str(len(keywords)),
             "include_globs": ",".join(_RIPGREP_INCLUDE_GLOBS),
-            "timeout_seconds": "30",
+            "timeout_seconds": str(_RIPGREP_TIMEOUT_SECONDS),
             "matched_file_count": str(len(matched_files_seen)),
         },
     )

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import shutil
+import subprocess
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -361,9 +362,53 @@ def test_raw_ripgrep_missing_executable_fails(
         run_raw_ripgrep(sample_task, python_simple_repo)
 
 
+def test_raw_ripgrep_timeout_fails_loudly(
+    sample_task: BenchmarkTask,
+    python_simple_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def present_executable(_name: str) -> str:
+        return "rg"
+
+    monkeypatch.setattr("archex.benchmark.strategies.shutil.which", present_executable)
+    with (
+        patch(
+            "archex.benchmark.strategies.subprocess.run",
+            side_effect=[
+                subprocess.CompletedProcess(["rg", "--version"], 0, stdout="ripgrep 15.1.0\n"),
+                subprocess.TimeoutExpired(["rg"], timeout=30),
+            ],
+        ),
+        pytest.raises(RuntimeError, match="timed out after 30s"),
+    ):
+        run_raw_ripgrep(sample_task, python_simple_repo)
+
+
+def test_raw_ripgrep_error_fails_loudly(
+    sample_task: BenchmarkTask,
+    python_simple_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def present_executable(_name: str) -> str:
+        return "rg"
+
+    monkeypatch.setattr("archex.benchmark.strategies.shutil.which", present_executable)
+    with (
+        patch(
+            "archex.benchmark.strategies.subprocess.run",
+            side_effect=[
+                subprocess.CompletedProcess(["rg", "--version"], 0, stdout="ripgrep 15.1.0\n"),
+                subprocess.CompletedProcess(["rg"], 2, stderr="invalid regex\n"),
+            ],
+        ),
+        pytest.raises(RuntimeError, match="raw_ripgrep failed for keyword"),
+    ):
+        run_raw_ripgrep(sample_task, python_simple_repo)
+
+
 @REQUIRES_RG
-class TestRunRawGrepped:
-    def test_grep_finds_files(self, python_simple_repo: Path) -> None:
+class TestRunRawRipgrep:
+    def test_ripgrep_finds_files(self, python_simple_repo: Path) -> None:
         task = BenchmarkTask(
             task_id="test",
             repo="test/repo",
@@ -378,7 +423,7 @@ class TestRunRawGrepped:
         assert 0.0 <= result.recall <= 1.0
         assert 0.0 <= result.precision <= 1.0
 
-    def test_grep_no_matches(self, python_simple_repo: Path) -> None:
+    def test_ripgrep_no_matches(self, python_simple_repo: Path) -> None:
         task = BenchmarkTask(
             task_id="test",
             repo="test/repo",
@@ -393,7 +438,7 @@ class TestRunRawGrepped:
         assert result.files_accessed == 0
         assert result.recall == 0.0
 
-    def test_grep_result_fields(self, python_simple_repo: Path) -> None:
+    def test_ripgrep_result_fields_and_provenance(self, python_simple_repo: Path) -> None:
         task = BenchmarkTask(
             task_id="test",
             repo="test/repo",
@@ -412,6 +457,11 @@ class TestRunRawGrepped:
         assert result.tokens_output >= 0
         assert result.tokens_raw_baseline >= 0
         assert isinstance(result.mrr, float)
+        assert result.provenance["rg_version"].startswith("ripgrep ")
+        assert result.provenance["keyword_count"] == str(result.tool_calls)
+        assert "*.py" in result.provenance["include_globs"]
+        assert result.provenance["timeout_seconds"] == "30"
+        assert result.provenance["matched_file_count"] == str(result.files_accessed)
 
 
 class TestRunArchexQuery:


### PR DESCRIPTION
## Summary

- Tightens the `raw_ripgrep` benchmark strategy around the real `rg` executable.
- Records ripgrep version, keyword count, include globs, timeout, and matched file count in provenance.
- Fails loudly when ripgrep is missing, times out, or exits with an unexpected error. No grep fallback.

## Stack

Stack-Id: ripgrep-trust-20260617
Position: 1/5
Base: `main`
Head: `ripgrep-trust/raw-ripgrep-strategy`
Next: `ripgrep-trust/public-baseline`

Order:
1. #278 `ripgrep-trust/raw-ripgrep-strategy`
2. #279 `ripgrep-trust/public-baseline`
3. #280 `ripgrep-trust/required-miss-semantics`
4. #281 `ripgrep-trust/report-gates`
5. #282 `ripgrep-trust/artifacts-docs`

## Validation

- `uv run pytest tests/benchmark/test_models.py tests/benchmark/test_strategy_registry.py tests/benchmark/test_strategies.py tests/benchmark/test_runner.py tests/benchmark/test_cli.py tests/benchmark/test_reporter.py tests/benchmark/test_headtohead.py tests/benchmark/test_headtohead_report.py tests/benchmark/test_gate.py tests/benchmark/test_triage.py tests/benchmark/test_external_mcp.py tests/benchmark/test_readiness.py` — passed, 215 tests.
- `uv run ruff check src/archex/benchmark/strategies.py src/archex/benchmark/external_mcp.py src/archex/benchmark/gate.py src/archex/benchmark/readiness.py src/archex/benchmark/reporter.py src/archex/benchmark/triage.py tests/benchmark/test_strategies.py tests/benchmark/test_gate.py tests/benchmark/test_readiness.py tests/benchmark/test_reporter.py tests/benchmark/test_triage.py tests/benchmark/test_headtohead.py tests/benchmark/test_headtohead_report.py` — passed.
- `uv run pyright src/archex/benchmark tests/benchmark` — passed.
- `uv run archex benchmark headtohead report --input benchmarks/headtohead/results --format markdown` — passed.

## Review

Review status: passed. Individual PR review found no blocking findings for `main..ripgrep-trust/raw-ripgrep-strategy`. Full-stack review found no blocking findings after PR4 receipt-accuracy gate fixes.