### PR TITLE
Move public baseline to raw ripgrep

### DIFF
--- a/benchmarks/headtohead/README.md
+++ b/benchmarks/headtohead/README.md
@@ -1,6 +1,6 @@
 # Head-to-head benchmark harness
 
-This directory contains the pinned C1 public comparison manifest for running the same external-repo tasks across archex, cocoindex-code (`ccc`), and the raw grep/read baseline. The harness records cold-start timing, warm query latency, recall, precision, token efficiency, and bundle-completion penalty tokens for every lane.
+This directory contains the pinned C1 public comparison manifest for running the same external-repo tasks across archex, cocoindex-code (`ccc`), and the raw-ripgrep/read baseline. The harness records cold-start timing, warm query latency, recall, precision, token efficiency, required-file coverage, receipt accuracy, and bundle-completion penalty tokens for every lane.
 
 Run only by an operator outside this implementation session:
 

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -387,7 +387,7 @@ class TestRunBenchmark:
         finally:
             default_strategy_registry._runners[key] = removed  # pyright: ignore[reportPrivateUsage]
 
-        # RAW_GREPPED was skipped; only RAW_FILES ran
+        # RAW_RIPGREP was skipped; only RAW_FILES ran
         assert len(report.results) == 1
         assert report.results[0].strategy == Strategy.RAW_FILES
 


### PR DESCRIPTION
## Summary

- Moves public/default benchmark comparison to `raw_ripgrep`.
- Keeps historical `raw_grepped` loading compatibility out of public defaults and new benchmark claims.
- Labels the public raw lane as `raw-ripgrep/read`.

## Stack

Stack-Id: ripgrep-trust-20260617
Position: 2/5
Base: `ripgrep-trust/raw-ripgrep-strategy`
Head: `ripgrep-trust/public-baseline`
Previous: #278 `ripgrep-trust/raw-ripgrep-strategy`
Next: #280 `ripgrep-trust/required-miss-semantics`

Order:
1. #278 `ripgrep-trust/raw-ripgrep-strategy`
2. #279 `ripgrep-trust/public-baseline`
3. #280 `ripgrep-trust/required-miss-semantics`
4. #281 `ripgrep-trust/report-gates`
5. #282 `ripgrep-trust/artifacts-docs`

## Validation

- `uv run pytest tests/benchmark/test_models.py tests/benchmark/test_strategy_registry.py tests/benchmark/test_strategies.py tests/benchmark/test_runner.py tests/benchmark/test_cli.py tests/benchmark/test_reporter.py tests/benchmark/test_headtohead.py tests/benchmark/test_headtohead_report.py tests/benchmark/test_gate.py tests/benchmark/test_triage.py tests/benchmark/test_external_mcp.py tests/benchmark/test_readiness.py` — passed, 215 tests.
- `uv run ruff check src/archex/benchmark/strategies.py src/archex/benchmark/external_mcp.py src/archex/benchmark/gate.py src/archex/benchmark/readiness.py src/archex/benchmark/reporter.py src/archex/benchmark/triage.py tests/benchmark/test_strategies.py tests/benchmark/test_gate.py tests/benchmark/test_readiness.py tests/benchmark/test_reporter.py tests/benchmark/test_triage.py tests/benchmark/test_headtohead.py tests/benchmark/test_headtohead_report.py` — passed.
- `uv run pyright src/archex/benchmark tests/benchmark` — passed.
- `uv run archex benchmark headtohead report --input benchmarks/headtohead/results --format markdown` — passed.

## Review

Review status: passed. Individual PR review found no blocking findings for `ripgrep-trust/raw-ripgrep-strategy..ripgrep-trust/public-baseline`. Full-stack review found no blocking findings after PR4 receipt-accuracy gate fixes.