### PR TITLE
Split required-file miss benchmark semantics

### DIFF
--- a/src/archex/benchmark/external_mcp.py
+++ b/src/archex/benchmark/external_mcp.py
@@ -297,6 +297,7 @@ def run_external_mcp(
     (
         required_file_recall,
         missed_required_file_rate,
+        missed_required_task_rate,
         all_required_files_present,
         present,
         missing,
@@ -316,7 +317,7 @@ def run_external_mcp(
         result_files=unique_files,
         required_file_recall=required_file_recall,
         missed_required_file_rate=missed_required_file_rate,
-        missed_required_task_rate=0.0 if all_required_files_present else 1.0,
+        missed_required_task_rate=missed_required_task_rate,
         all_required_files_present=all_required_files_present,
         required_files_present=present,
         required_files_missing=missing,

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -291,13 +291,14 @@ def compute_bundle_completion_penalty(
 def compute_required_file_metrics(
     result_files: set[str],
     expected_files: list[str],
-) -> tuple[float, float, bool, list[str], list[str]]:
+) -> tuple[float, float, float, bool, list[str], list[str]]:
     present = [path for path in expected_files if path in result_files]
     missing = [path for path in expected_files if path not in result_files]
     recall = len(present) / len(expected_files) if expected_files else 0.0
     all_present = not missing
-    missed_rate = (len(missing) / len(expected_files)) if expected_files else 0.0
-    return recall, missed_rate, all_present, present, missing
+    missed_file_rate = (len(missing) / len(expected_files)) if expected_files else 0.0
+    missed_task_rate = 0.0 if all_present else 1.0
+    return recall, missed_file_rate, missed_task_rate, all_present, present, missing
 
 
 def compute_receipt_accuracy(
@@ -330,6 +331,7 @@ def run_raw_files(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     (
         required_file_recall,
         missed_required_file_rate,
+        missed_required_task_rate,
         all_required_files_present,
         present,
         missing,
@@ -345,7 +347,7 @@ def run_raw_files(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         result_files=list(task.expected_files),
         required_file_recall=required_file_recall,
         missed_required_file_rate=missed_required_file_rate,
-        missed_required_task_rate=0.0 if all_required_files_present else 1.0,
+        missed_required_task_rate=missed_required_task_rate,
         all_required_files_present=all_required_files_present,
         required_files_present=present,
         required_files_missing=missing,
@@ -426,6 +428,7 @@ def run_raw_grepped(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     (
         required_file_recall,
         missed_required_file_rate,
+        missed_required_task_rate,
         all_required_files_present,
         present,
         missing,
@@ -442,7 +445,7 @@ def run_raw_grepped(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         result_files=_deduplicate_ranked(matched_files_ordered),
         required_file_recall=required_file_recall,
         missed_required_file_rate=missed_required_file_rate,
-        missed_required_task_rate=0.0 if all_required_files_present else 1.0,
+        missed_required_task_rate=missed_required_task_rate,
         all_required_files_present=all_required_files_present,
         required_files_present=present,
         required_files_missing=missing,
@@ -548,6 +551,7 @@ def run_raw_ripgrep(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     (
         required_file_recall,
         missed_required_file_rate,
+        missed_required_task_rate,
         all_required_files_present,
         present,
         missing,
@@ -564,7 +568,7 @@ def run_raw_ripgrep(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         result_files=_deduplicate_ranked(matched_files_ordered),
         required_file_recall=required_file_recall,
         missed_required_file_rate=missed_required_file_rate,
-        missed_required_task_rate=0.0 if all_required_files_present else 1.0,
+        missed_required_task_rate=missed_required_task_rate,
         all_required_files_present=all_required_files_present,
         required_files_present=present,
         required_files_missing=missing,
@@ -1057,6 +1061,7 @@ def _run_query_strategy(
     (
         required_file_recall,
         missed_required_file_rate,
+        missed_required_task_rate,
         all_required_files_present,
         present,
         missing,
@@ -1103,7 +1108,7 @@ def _run_query_strategy(
         "required_file_recall": required_file_recall,
         "missed_required_file_rate": missed_required_file_rate,
         "all_required_files_present": all_required_files_present,
-        "missed_required_task_rate": 0.0 if all_required_files_present else 1.0,
+        "missed_required_task_rate": missed_required_task_rate,
         "required_files_present": present,
         "required_files_missing": missing,
         "receipt_accuracy": compute_receipt_accuracy(
@@ -1229,6 +1234,7 @@ def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
     (
         required_file_recall,
         missed_required_file_rate,
+        missed_required_task_rate,
         all_required_files_present,
         present,
         missing,
@@ -1273,7 +1279,7 @@ def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
         result_files=unique_ranked,
         required_file_recall=required_file_recall,
         missed_required_file_rate=missed_required_file_rate,
-        missed_required_task_rate=0.0 if all_required_files_present else 1.0,
+        missed_required_task_rate=missed_required_task_rate,
         all_required_files_present=all_required_files_present,
         required_files_present=present,
         required_files_missing=missing,

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -236,16 +236,44 @@ class TestBundleCompletionPenalty:
 
 class TestRequiredFileMetrics:
     def test_metrics_capture_missing_required_files(self) -> None:
-        recall, missed_rate, all_present, present, missing = compute_required_file_metrics(
+        (
+            recall,
+            missed_file_rate,
+            missed_task_rate,
+            all_present,
+            present,
+            missing,
+        ) = compute_required_file_metrics(
             {"a.py"},
             ["a.py", "b.py"],
         )
 
         assert recall == 0.5
-        assert missed_rate == 0.5
+        assert missed_file_rate == 0.5
+        assert missed_task_rate == 1.0
         assert all_present is False
         assert present == ["a.py"]
         assert missing == ["b.py"]
+
+    def test_file_and_task_miss_rates_are_separate(self) -> None:
+        (
+            recall,
+            missed_file_rate,
+            missed_task_rate,
+            all_present,
+            present,
+            missing,
+        ) = compute_required_file_metrics(
+            {"a.py", "b.py", "c.py"},
+            ["a.py", "b.py", "c.py", "d.py"],
+        )
+
+        assert recall == 0.75
+        assert missed_file_rate == 0.25
+        assert missed_task_rate == 1.0
+        assert all_present is False
+        assert present == ["a.py", "b.py", "c.py"]
+        assert missing == ["d.py"]
 
     def test_completion_result_from_missing_files(self) -> None:
         assert completion_result_from_missing([]).value == "pass"


### PR DESCRIPTION
## Summary

- Splits required-file misses into per-file and per-task semantics.
- Defines `missed_required_file_rate = missing_required_files / expected_required_files`.
- Defines `missed_required_task_rate = 0.0` when all required files are present, otherwise `1.0`.
- Preserves `required_file_recall` and `all_required_files_present` semantics across strategy and external MCP result construction.

## Stack

Stack-Id: ripgrep-trust-20260617
Position: 3/5
Base: `ripgrep-trust/public-baseline`
Head: `ripgrep-trust/required-miss-semantics`
Previous: #279 `ripgrep-trust/public-baseline`
Next: #281 `ripgrep-trust/report-gates`

Order:
1. #278 `ripgrep-trust/raw-ripgrep-strategy`
2. #279 `ripgrep-trust/public-baseline`
3. #280 `ripgrep-trust/required-miss-semantics`
4. #281 `ripgrep-trust/report-gates`
5. #282 `ripgrep-trust/artifacts-docs`

## Validation

- `uv run pytest tests/benchmark/test_models.py tests/benchmark/test_strategy_registry.py tests/benchmark/test_strategies.py tests/benchmark/test_runner.py tests/benchmark/test_cli.py tests/benchmark/test_reporter.py tests/benchmark/test_headtohead.py tests/benchmark/test_headtohead_report.py tests/benchmark/test_gate.py tests/benchmark/test_triage.py tests/benchmark/test_external_mcp.py tests/benchmark/test_readiness.py` — passed, 215 tests.
- `uv run ruff check src/archex/benchmark/strategies.py src/archex/benchmark/external_mcp.py src/archex/benchmark/gate.py src/archex/benchmark/readiness.py src/archex/benchmark/reporter.py src/archex/benchmark/triage.py tests/benchmark/test_strategies.py tests/benchmark/test_gate.py tests/benchmark/test_readiness.py tests/benchmark/test_reporter.py tests/benchmark/test_triage.py tests/benchmark/test_headtohead.py tests/benchmark/test_headtohead_report.py` — passed.
- `uv run pyright src/archex/benchmark tests/benchmark` — passed.
- `uv run archex benchmark headtohead report --input benchmarks/headtohead/results --format markdown` — passed.

## Review

Review status: passed. Individual PR review found no blocking findings for `ripgrep-trust/public-baseline..ripgrep-trust/required-miss-semantics`. Full-stack review found no blocking findings after PR4 receipt-accuracy gate fixes.