### PR TITLE
Surface required-file trust in benchmark gates

### DIFF
--- a/src/archex/benchmark/gate.py
+++ b/src/archex/benchmark/gate.py
@@ -26,6 +26,11 @@ class QualityThresholds(BaseModel):
     min_token_efficiency: float = 0.0
     product_default_strategy: str = PRODUCT_DEFAULT_STRATEGY
     product_default_min_token_efficiency: float = PRODUCT_DEFAULT_TOKEN_EFFICIENCY_FLOOR
+    min_required_file_recall: float = 0.0
+    max_missed_required_task_rate: float = 1.0
+    min_receipt_accuracy: float = 0.0
+    min_token_efficiency_with_completion: float = 0.0
+    max_completion_efficiency_regression: float = 0.0
     # Latency: warn-only, does not fail the gate
     warn_latency_ms: float = 5000.0
     # Strategies exempt from gate checks (results are informational only)
@@ -62,7 +67,7 @@ class LatencyWarning(BaseModel):
     actual_ms: float
 
 
-def _gate_checks(t: QualityThresholds, strategy: str) -> list[tuple[str, float]]:
+def _minimum_gate_checks(t: QualityThresholds, strategy: str) -> list[tuple[str, float]]:
     token_efficiency_floor = (
         t.product_default_min_token_efficiency
         if strategy == t.product_default_strategy
@@ -76,7 +81,17 @@ def _gate_checks(t: QualityThresholds, strategy: str) -> list[tuple[str, float]]
         ("ndcg", t.min_ndcg),
         ("map_score", t.min_map),
         ("token_efficiency", token_efficiency_floor),
+        ("required_file_recall", t.min_required_file_recall),
+        ("token_efficiency_with_completion", t.min_token_efficiency_with_completion),
     ]
+
+
+def _maximum_gate_checks(t: QualityThresholds) -> list[tuple[str, float]]:
+    return [("missed_required_task_rate", t.max_missed_required_task_rate)]
+
+
+def _receipt_accuracy_score(value: bool | None) -> float:
+    return 0.0 if value is None else 1.0 if value else 0.0
 
 
 def check_gate(
@@ -100,7 +115,7 @@ def check_gate(
             if strategy_val in thresholds.gate_exempt_strategies:
                 continue
             effective = thresholds.strategy_thresholds.get(strategy_val, thresholds)
-            for metric_name, threshold_val in _gate_checks(effective, strategy_val):
+            for metric_name, threshold_val in _minimum_gate_checks(effective, strategy_val):
                 actual = getattr(r, metric_name)
                 if actual < threshold_val:
                     violations.append(
@@ -112,6 +127,29 @@ def check_gate(
                             actual=actual,
                         )
                     )
+            for metric_name, threshold_val in _maximum_gate_checks(effective):
+                actual = getattr(r, metric_name)
+                if actual > threshold_val:
+                    violations.append(
+                        GateViolation(
+                            task_id=r.task_id,
+                            strategy=strategy_val,
+                            metric=metric_name,
+                            threshold=threshold_val,
+                            actual=actual,
+                        )
+                    )
+            actual = _receipt_accuracy_score(r.receipt_accuracy)
+            if actual < effective.min_receipt_accuracy:
+                violations.append(
+                    GateViolation(
+                        task_id=r.task_id,
+                        strategy=strategy_val,
+                        metric="receipt_accuracy",
+                        threshold=effective.min_receipt_accuracy,
+                        actual=actual,
+                    )
+                )
     return violations
 
 
@@ -159,6 +197,20 @@ def check_recall_regressions(
                         metric="recall",
                         baseline=baseline.recall,
                         actual=result.recall,
+                    )
+                )
+            completion_efficiency_floor = (
+                baseline.token_efficiency_with_completion
+                - thresholds.max_completion_efficiency_regression
+            )
+            if result.token_efficiency_with_completion < completion_efficiency_floor:
+                violations.append(
+                    BaselineGateViolation(
+                        task_id=report.task_id,
+                        strategy=strategy_val,
+                        metric="token_efficiency_with_completion",
+                        baseline=completion_efficiency_floor,
+                        actual=result.token_efficiency_with_completion,
                     )
                 )
     return violations

--- a/src/archex/benchmark/readiness.py
+++ b/src/archex/benchmark/readiness.py
@@ -14,6 +14,14 @@ TARGET_MEAN_F1 = 0.70
 TARGET_ZERO_RECALL_TASKS = 1
 LOW_F1_THRESHOLD = 0.40
 LOW_PRECISION_THRESHOLD = 0.35
+TARGET_REQUIRED_FILE_RECALL = 0.80
+TARGET_MISSED_REQUIRED_TASK_RATE = 0.00
+TARGET_RECEIPT_ACCURACY = 0.95
+TARGET_TOKEN_EFFICIENCY_WITH_COMPLETION = 0.08
+
+
+def _receipt_accuracy_score(value: bool | None) -> float:
+    return 0.0 if value is None else 1.0 if value else 0.0
 
 
 @dataclass(frozen=True)
@@ -72,7 +80,13 @@ class ReadinessReport:
     p95_latency_ms: float
     tokens_total: int
     token_efficiency: float
+    token_efficiency_with_completion: float
     savings_vs_raw: float
+    mean_required_file_recall: float
+    mean_missed_required_file_rate: float
+    missed_required_task_rate: float
+    all_required_present_rate: float
+    receipt_accuracy_rate: float
     zero_recall_tasks: int
     low_f1_tasks: int
     low_precision_tasks: int
@@ -97,7 +111,13 @@ class ReadinessReport:
             "p95_latency_ms": self.p95_latency_ms,
             "tokens_total": self.tokens_total,
             "token_efficiency": self.token_efficiency,
+            "token_efficiency_with_completion": self.token_efficiency_with_completion,
             "savings_vs_raw": self.savings_vs_raw,
+            "mean_required_file_recall": self.mean_required_file_recall,
+            "mean_missed_required_file_rate": self.mean_missed_required_file_rate,
+            "missed_required_task_rate": self.missed_required_task_rate,
+            "all_required_present_rate": self.all_required_present_rate,
+            "receipt_accuracy_rate": self.receipt_accuracy_rate,
             "zero_recall_tasks": self.zero_recall_tasks,
             "low_f1_tasks": self.low_f1_tasks,
             "low_precision_tasks": self.low_precision_tasks,
@@ -132,7 +152,13 @@ def build_readiness_report(
             p95_latency_ms=0.0,
             tokens_total=0,
             token_efficiency=0.0,
+            token_efficiency_with_completion=0.0,
             savings_vs_raw=0.0,
+            mean_required_file_recall=0.0,
+            mean_missed_required_file_rate=0.0,
+            missed_required_task_rate=0.0,
+            all_required_present_rate=0.0,
+            receipt_accuracy_rate=0.0,
             zero_recall_tasks=0,
             low_f1_tasks=0,
             low_precision_tasks=0,
@@ -151,6 +177,22 @@ def build_readiness_report(
     tokens_total = sum(result.tokens_total for result in metric_results)
     token_efficiency = _mean([result.token_efficiency for result in metric_results])
     savings_vs_raw = _mean([result.savings_vs_raw for result in metric_results])
+    token_efficiency_with_completion = _mean(
+        [result.token_efficiency_with_completion for result in metric_results]
+    )
+    mean_required_file_recall = _mean([result.required_file_recall for result in metric_results])
+    mean_missed_required_file_rate = _mean(
+        [result.missed_required_file_rate for result in metric_results]
+    )
+    missed_required_task_rate = _mean(
+        [result.missed_required_task_rate for result in metric_results]
+    )
+    all_required_present_rate = _mean(
+        [1.0 if result.all_required_files_present else 0.0 for result in metric_results]
+    )
+    receipt_accuracy_rate = _mean(
+        [_receipt_accuracy_score(result.receipt_accuracy) for result in metric_results]
+    )
     zero_recall_tasks = sum(1 for result in metric_results if result.recall <= 0.0)
     low_f1_tasks = sum(1 for result in metric_results if result.f1_score < LOW_F1_THRESHOLD)
     low_precision_tasks = sum(
@@ -185,6 +227,34 @@ def build_readiness_report(
             passed=zero_recall_tasks <= TARGET_ZERO_RECALL_TASKS,
             comparator="<=",
         ),
+        ReadinessTargetStatus(
+            name="mean_required_file_recall",
+            actual=mean_required_file_recall,
+            target=TARGET_REQUIRED_FILE_RECALL,
+            passed=mean_required_file_recall >= TARGET_REQUIRED_FILE_RECALL,
+            comparator=">=",
+        ),
+        ReadinessTargetStatus(
+            name="missed_required_task_rate",
+            actual=missed_required_task_rate,
+            target=TARGET_MISSED_REQUIRED_TASK_RATE,
+            passed=missed_required_task_rate <= TARGET_MISSED_REQUIRED_TASK_RATE,
+            comparator="<=",
+        ),
+        ReadinessTargetStatus(
+            name="receipt_accuracy_rate",
+            actual=receipt_accuracy_rate,
+            target=TARGET_RECEIPT_ACCURACY,
+            passed=receipt_accuracy_rate >= TARGET_RECEIPT_ACCURACY,
+            comparator=">=",
+        ),
+        ReadinessTargetStatus(
+            name="token_efficiency_with_completion",
+            actual=token_efficiency_with_completion,
+            target=TARGET_TOKEN_EFFICIENCY_WITH_COMPLETION,
+            passed=token_efficiency_with_completion >= TARGET_TOKEN_EFFICIENCY_WITH_COMPLETION,
+            comparator=">=",
+        ),
     ]
     categories = _category_readiness(results, tasks_by_id)
     blocking_tasks = triage_failures(reports, tasks_by_id, strategy=strategy)[:10]
@@ -200,7 +270,13 @@ def build_readiness_report(
         tokens_total=tokens_total,
         token_efficiency=token_efficiency,
         savings_vs_raw=savings_vs_raw,
+        token_efficiency_with_completion=token_efficiency_with_completion,
         zero_recall_tasks=zero_recall_tasks,
+        mean_required_file_recall=mean_required_file_recall,
+        mean_missed_required_file_rate=mean_missed_required_file_rate,
+        missed_required_task_rate=missed_required_task_rate,
+        all_required_present_rate=all_required_present_rate,
+        receipt_accuracy_rate=receipt_accuracy_rate,
         low_f1_tasks=low_f1_tasks,
         low_precision_tasks=low_precision_tasks,
         targets=targets,
@@ -231,14 +307,20 @@ def format_readiness_markdown(report: ReadinessReport) -> str:
     lines.append("## Strategy Metrics")
     lines.append("")
     lines.append(
-        "| Strategy | Tasks | Recall | F1 | Tokens Total | Token Efficiency "
-        "| Savings vs Raw | Median Latency | P95 Latency |"
+        "| Strategy | Tasks | Recall | Required Recall | Missed Task Rate "
+        "| Receipt Accuracy | F1 | Tokens Total | Token Efficiency "
+        "| Efficiency after Completion | Savings vs Raw | Median Latency | P95 Latency |"
     )
-    lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|")
+    lines.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
     lines.append(
         f"| `{report.strategy}` | {report.task_count} | {report.mean_recall:.3f} "
+        f"| {report.mean_required_file_recall:.3f} "
+        f"| {report.missed_required_task_rate:.3f} "
+        f"| {report.receipt_accuracy_rate:.3f} "
         f"| {report.mean_f1_score:.3f} | {report.tokens_total:,} "
-        f"| {report.token_efficiency:.3f} | {report.savings_vs_raw:.1f}% "
+        f"| {report.token_efficiency:.3f} "
+        f"| {report.token_efficiency_with_completion:.3f} "
+        f"| {report.savings_vs_raw:.1f}% "
         f"| {report.median_latency_ms:.0f} ms | {report.p95_latency_ms:.0f} ms |"
     )
     lines.append("")
@@ -253,6 +335,12 @@ def format_readiness_markdown(report: ReadinessReport) -> str:
         f"- P95 latency: `{report.p95_latency_ms:.0f} ms`\n"
         f"- Tokens total: `{report.tokens_total:,}`\n"
         f"- Token efficiency: `{report.token_efficiency:.3f}`\n"
+        f"- Token efficiency after completion: `{report.token_efficiency_with_completion:.3f}`\n"
+        f"- Required-file recall: `{report.mean_required_file_recall:.3f}`\n"
+        f"- Missed required-file rate: `{report.mean_missed_required_file_rate:.3f}`\n"
+        f"- Missed required-task rate: `{report.missed_required_task_rate:.3f}`\n"
+        f"- All-required-present rate: `{report.all_required_present_rate:.3f}`\n"
+        f"- Receipt accuracy: `{report.receipt_accuracy_rate:.3f}`\n"
         f"- Savings vs raw: `{report.savings_vs_raw:.1f}%`\n"
         f"- Zero-recall tasks: `{report.zero_recall_tasks}`\n"
         f"- Tasks below F1 {LOW_F1_THRESHOLD:.2f}: `{report.low_f1_tasks}`\n"

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -166,11 +166,12 @@ def format_summary(reports: list[BenchmarkReport]) -> str:
 
     lines.append(
         "| Strategy | Avg Tokens | Avg Savings | Avg Efficiency | Avg Recall | "
-        "Avg Required Recall | Missed Task Rate | Avg F1 | Avg MRR | Avg nDCG | Avg MAP | Tasks |"
+        "Avg Required Recall | Missed File Rate | Missed Task Rate | Avg F1 | "
+        "Avg MRR | Avg nDCG | Avg MAP | Tasks |"
     )
     lines.append(
         "|----------|------------|-------------|----------------|------------|"
-        "---------------------|------------------|--------|---------|----------|---------|-------|"
+        "---------------------|------------------|------------------|--------|---------|----------|---------|-------|"
     )
 
     for name in sorted(strategy_metrics):
@@ -182,6 +183,7 @@ def format_summary(reports: list[BenchmarkReport]) -> str:
             f"| {_mean(metrics['token_efficiency']):.2f} | {_mean(metrics['recall']):.2f} "
             f"| {_mean(metrics['required_file_recall']):.2f} "
             f"| {_mean(metrics['missed_required_file_rate']):.2f} "
+            f"| {_mean(metrics['missed_required_task_rate']):.2f} "
             f"| {_mean(metrics['f1_score']):.2f} | {_mean(metrics['mrr']):.2f} "
             f"| {_mean(metrics['ndcg']):.2f} | {_mean(metrics['map_score']):.2f} | {count} |"
         )
@@ -225,11 +227,12 @@ def format_bucketed_summary(reports: list[BenchmarkReport]) -> str:
         strategy_metrics = _aggregate_strategy_metrics(bucket_reports, _BUCKET_FIELDS)
 
         tbl.append(
-            "| Strategy | Recall | Precision | F1 | MRR | nDCG | MAP "
-            "| Seed Recall | Seed Precision | Tasks |"
+            "| Strategy | Recall | Precision | Required Recall | Missed File Rate "
+            "| Missed Task Rate | F1 | MRR | nDCG | MAP | Seed Recall "
+            "| Seed Precision | Tasks |"
         )
         tbl.append(
-            "|----------|--------|-----------|------|------|------|------"
+            "|----------|--------|-----------|-----------------|------------------|------------------|------|------|------|------"
             "|-------------|----------------|-------|"
         )
         for name in sorted(strategy_metrics):
@@ -238,6 +241,9 @@ def format_bucketed_summary(reports: list[BenchmarkReport]) -> str:
             tbl.append(
                 f"| {name} "
                 f"| {_mean(metrics['recall']):.2f} | {_mean(metrics['precision']):.2f} "
+                f"| {_mean(metrics['required_file_recall']):.2f} "
+                f"| {_mean(metrics['missed_required_file_rate']):.2f} "
+                f"| {_mean(metrics['missed_required_task_rate']):.2f} "
                 f"| {_mean(metrics['f1_score']):.2f} | {_mean(metrics['mrr']):.2f} "
                 f"| {_mean(metrics['ndcg']):.2f} | {_mean(metrics['map_score']):.2f} "
                 f"| {_mean(metrics['seed_recall']):.2f} "

--- a/src/archex/benchmark/triage.py
+++ b/src/archex/benchmark/triage.py
@@ -11,7 +11,7 @@ from archex.benchmark.models import BenchmarkReport, BenchmarkResult, BenchmarkT
 
 LOW_F1_THRESHOLD = 0.40
 LOW_PRECISION_THRESHOLD = 0.35
-RAW_GREPPED_GAP_THRESHOLD = 0.25
+RAW_READ_GAP_THRESHOLD = 0.25
 
 
 @dataclass(frozen=True)
@@ -45,9 +45,9 @@ class TriageFinding:
     expansion_zero_candidate_reason: str
     expansion_reason_counts: dict[str, int]
     expanded_file_reasons: dict[str, list[str]]
-    raw_grepped_recall: float | None
-    raw_grepped_precision: float | None
-    raw_grepped_f1_score: float | None
+    raw_read_recall: float | None
+    raw_read_precision: float | None
+    raw_read_f1_score: float | None
     failure_bucket: str
     failure_reasons: list[str]
     rank_score: float
@@ -85,10 +85,10 @@ class TriageFinding:
                 "reason_counts": self.expansion_reason_counts,
                 "file_reasons": self.expanded_file_reasons,
             },
-            "raw_grepped_metrics": {
-                "recall": self.raw_grepped_recall,
-                "precision": self.raw_grepped_precision,
-                "f1_score": self.raw_grepped_f1_score,
+            "raw_read_baseline_metrics": {
+                "recall": self.raw_read_recall,
+                "precision": self.raw_read_precision,
+                "f1_score": self.raw_read_f1_score,
             },
             "failure_bucket": self.failure_bucket,
             "failure_reasons": self.failure_reasons,
@@ -122,17 +122,17 @@ def triage_failures(
         result = _find_result(report, strategy)
         if result is None:
             continue
-        raw_grepped = _find_raw_read_result(report)
+        raw_read = _find_raw_read_result(report)
         task = tasks_by_id.get(report.task_id)
         expected_files = task.expected_files if task is not None else []
         category = _category(result, task)
-        reasons = _failure_reasons(result, raw_grepped, category)
+        reasons = _failure_reasons(result, raw_read, category)
         if not reasons:
             continue
         returned_files = _returned_files(result)
         missing_files = _missing_files(expected_files, returned_files, result)
         extra_files = [path for path in returned_files if path not in set(expected_files)]
-        bucket = _failure_bucket(result, raw_grepped, category, missing_files)
+        bucket = _failure_bucket(result, raw_read, category, missing_files)
         findings.append(
             TriageFinding(
                 task_id=report.task_id,
@@ -162,12 +162,12 @@ def triage_failures(
                 expansion_zero_candidate_reason=result.expansion_zero_candidate_reason,
                 expansion_reason_counts=result.expansion_reason_counts,
                 expanded_file_reasons=result.expanded_file_reasons,
-                raw_grepped_recall=raw_grepped.recall if raw_grepped is not None else None,
-                raw_grepped_precision=raw_grepped.precision if raw_grepped is not None else None,
-                raw_grepped_f1_score=raw_grepped.f1_score if raw_grepped is not None else None,
+                raw_read_recall=raw_read.recall if raw_read is not None else None,
+                raw_read_precision=raw_read.precision if raw_read is not None else None,
+                raw_read_f1_score=raw_read.f1_score if raw_read is not None else None,
                 failure_bucket=bucket,
                 failure_reasons=reasons,
-                rank_score=_rank_score(result, raw_grepped, category, bucket),
+                rank_score=_rank_score(result, raw_read, category, bucket),
             )
         )
     return sorted(findings, key=_finding_sort_key)
@@ -210,12 +210,12 @@ def format_triage_markdown(findings: list[TriageFinding]) -> str:
             f"token efficiency `{finding.token_efficiency:.3f}`, "
             f"savings vs raw `{finding.savings_vs_raw:.1f}%`"
         )
-        if finding.raw_grepped_f1_score is not None:
+        if finding.raw_read_f1_score is not None:
             lines.append(
-                "- Raw grepped: "
-                f"recall `{finding.raw_grepped_recall:.3f}`, "
-                f"precision `{finding.raw_grepped_precision:.3f}`, "
-                f"F1 `{finding.raw_grepped_f1_score:.3f}`"
+                "- Raw ripgrep/read baseline: "
+                f"recall `{finding.raw_read_recall:.3f}`, "
+                f"precision `{finding.raw_read_precision:.3f}`, "
+                f"F1 `{finding.raw_read_f1_score:.3f}`"
             )
         lines.append(
             "- Expansion: "
@@ -295,7 +295,7 @@ def _missing_files(
 
 def _failure_reasons(
     result: BenchmarkResult,
-    raw_grepped: BenchmarkResult | None,
+    raw_read: BenchmarkResult | None,
     category: str,
 ) -> list[str]:
     reasons: list[str] = []
@@ -305,8 +305,9 @@ def _failure_reasons(
         reasons.append("low_f1")
     if result.precision < LOW_PRECISION_THRESHOLD:
         reasons.append("low_precision")
-    if _raw_grepped_gap(result, raw_grepped):
-        reasons.append("raw_grepped_gap")
+    raw_read_gap_reason = _raw_read_gap_reason(result, raw_read)
+    if raw_read_gap_reason is not None:
+        reasons.append(raw_read_gap_reason)
     if category == "external-large" and result.f1_score < LOW_F1_THRESHOLD:
         reasons.append("external_large_failure")
     if category == "framework-semantic" and result.f1_score < LOW_F1_THRESHOLD:
@@ -316,7 +317,7 @@ def _failure_reasons(
 
 def _failure_bucket(
     result: BenchmarkResult,
-    raw_grepped: BenchmarkResult | None,
+    raw_read: BenchmarkResult | None,
     category: str,
     missing_files: list[str],
 ) -> str:
@@ -326,8 +327,9 @@ def _failure_bucket(
         return "large_repo_ambiguity"
     if category == "framework-semantic":
         return "semantic_gap"
-    if _raw_grepped_gap(result, raw_grepped):
-        return "raw_grepped_gap"
+    raw_read_gap_reason = _raw_read_gap_reason(result, raw_read)
+    if raw_read_gap_reason is not None:
+        return raw_read_gap_reason
     if result.expanded_files and missing_files and result.precision < LOW_PRECISION_THRESHOLD:
         return "expansion_noise"
     if result.precision < LOW_PRECISION_THRESHOLD:
@@ -339,20 +341,22 @@ def _find_raw_read_result(report: BenchmarkReport) -> BenchmarkResult | None:
     return _find_result(report, Strategy.RAW_RIPGREP) or _find_result(report, Strategy.RAW_GREPPED)
 
 
-def _raw_grepped_gap(
+def _raw_read_gap_reason(
     result: BenchmarkResult,
-    raw_grepped: BenchmarkResult | None,
-) -> bool:
-    if raw_grepped is None:
-        return False
-    recall_gap = raw_grepped.recall - result.recall
-    f1_gap = raw_grepped.f1_score - result.f1_score
-    return recall_gap >= RAW_GREPPED_GAP_THRESHOLD or f1_gap >= RAW_GREPPED_GAP_THRESHOLD
+    raw_read: BenchmarkResult | None,
+) -> str | None:
+    if raw_read is None:
+        return None
+    recall_gap = raw_read.recall - result.recall
+    f1_gap = raw_read.f1_score - result.f1_score
+    if recall_gap < RAW_READ_GAP_THRESHOLD and f1_gap < RAW_READ_GAP_THRESHOLD:
+        return None
+    return "raw_ripgrep_gap" if raw_read.strategy is Strategy.RAW_RIPGREP else "raw_grepped_gap"
 
 
 def _rank_score(
     result: BenchmarkResult,
-    raw_grepped: BenchmarkResult | None,
+    raw_read: BenchmarkResult | None,
     category: str,
     bucket: str,
 ) -> float:
@@ -361,7 +365,7 @@ def _rank_score(
         score += 100.0
     score += max(0.0, LOW_F1_THRESHOLD - result.f1_score) * 25.0
     score += max(0.0, LOW_PRECISION_THRESHOLD - result.precision) * 10.0
-    if _raw_grepped_gap(result, raw_grepped):
+    if _raw_read_gap_reason(result, raw_read) is not None:
         score += 20.0
     if category == "external-large":
         score += 12.0

--- a/tests/benchmark/test_gate.py
+++ b/tests/benchmark/test_gate.py
@@ -21,6 +21,10 @@ def _make_report(
     ndcg: float = 0.7,
     map_score: float = 0.6,
     token_efficiency: float = PRODUCT_DEFAULT_TOKEN_EFFICIENCY_FLOOR,
+    required_file_recall: float = 1.0,
+    missed_required_task_rate: float = 0.0,
+    receipt_accuracy: bool | None = True,
+    token_efficiency_with_completion: float = PRODUCT_DEFAULT_TOKEN_EFFICIENCY_FLOOR,
 ) -> BenchmarkReport:
     result = BenchmarkResult(
         task_id="test_task",
@@ -36,6 +40,10 @@ def _make_report(
         map_score=map_score,
         savings_vs_raw=50.0,
         token_efficiency=token_efficiency,
+        required_file_recall=required_file_recall,
+        missed_required_task_rate=missed_required_task_rate,
+        receipt_accuracy=receipt_accuracy,
+        token_efficiency_with_completion=token_efficiency_with_completion,
         wall_time_ms=100.0,
         cached=False,
         timestamp="2026-01-01T00:00:00Z",
@@ -119,6 +127,54 @@ def test_check_gate_token_efficiency_floor_passes_at_floor() -> None:
     assert "token_efficiency" not in violated_metrics
 
 
+def test_check_gate_trust_metrics_can_fail() -> None:
+    reports = [
+        _make_report(
+            required_file_recall=0.75,
+            missed_required_task_rate=1.0,
+            receipt_accuracy=False,
+            token_efficiency_with_completion=0.02,
+        )
+    ]
+    thresholds = QualityThresholds(
+        min_required_file_recall=0.9,
+        max_missed_required_task_rate=0.0,
+        min_receipt_accuracy=1.0,
+        min_token_efficiency_with_completion=0.05,
+    )
+
+    violations = check_gate(reports, thresholds)
+
+    assert {violation.metric for violation in violations} == {
+        "required_file_recall",
+        "missed_required_task_rate",
+        "receipt_accuracy",
+        "token_efficiency_with_completion",
+    }
+
+
+def test_check_gate_missing_receipt_accuracy_fails_when_required() -> None:
+    reports = [_make_report(receipt_accuracy=None)]
+    thresholds = QualityThresholds(min_receipt_accuracy=1.0)
+
+    violations = check_gate(reports, thresholds)
+
+    assert [(v.metric, v.threshold, v.actual) for v in violations] == [
+        ("receipt_accuracy", 1.0, 0.0)
+    ]
+
+
+def test_baseline_gate_flags_completion_efficiency_regression() -> None:
+    baseline = [_make_report(token_efficiency_with_completion=0.6)]
+    current = [_make_report(token_efficiency_with_completion=0.5)]
+
+    violations = check_recall_regressions(current, baseline)
+
+    assert [(v.metric, v.baseline, v.actual) for v in violations] == [
+        ("token_efficiency_with_completion", 0.6, 0.5)
+    ]
+
+
 def test_baseline_gate_flags_recall_regression() -> None:
     baseline = [_make_report(recall=0.8)]
     current = [_make_report(recall=0.6)]
@@ -167,6 +223,7 @@ def _make_report_for_strategy(
     f1_score: float = 0.05,
     mrr: float = 0.0,
     token_efficiency: float = 0.0,
+    token_efficiency_with_completion: float = 0.0,
 ) -> BenchmarkReport:
     result = BenchmarkResult(
         task_id="test_task",
@@ -180,6 +237,7 @@ def _make_report_for_strategy(
         mrr=mrr,
         savings_vs_raw=0.0,
         token_efficiency=token_efficiency,
+        token_efficiency_with_completion=token_efficiency_with_completion,
         wall_time_ms=100.0,
         cached=False,
         timestamp="2026-01-01T00:00:00Z",

--- a/tests/benchmark/test_readiness.py
+++ b/tests/benchmark/test_readiness.py
@@ -29,6 +29,12 @@ def _result(
     tokens_total: int = 100,
     token_efficiency: float = 0.5,
     savings_vs_raw: float = 25.0,
+    required_file_recall: float = 1.0,
+    missed_required_file_rate: float = 0.0,
+    missed_required_task_rate: float = 0.0,
+    all_required_files_present: bool = True,
+    receipt_accuracy: bool | None = True,
+    token_efficiency_with_completion: float = 0.5,
     category: TaskCategory | None = None,
     strategy: Strategy = Strategy.ARCHEX_QUERY,
 ) -> BenchmarkResult:
@@ -37,6 +43,12 @@ def _result(
         strategy=strategy,
         tokens_total=tokens_total,
         token_efficiency=token_efficiency,
+        token_efficiency_with_completion=token_efficiency_with_completion,
+        required_file_recall=required_file_recall,
+        missed_required_file_rate=missed_required_file_rate,
+        missed_required_task_rate=missed_required_task_rate,
+        all_required_files_present=all_required_files_present,
+        receipt_accuracy=receipt_accuracy,
         tool_calls=1,
         files_accessed=1,
         recall=recall,
@@ -123,7 +135,15 @@ def test_build_readiness_report_tracks_targets_and_counts() -> None:
         "mean_precision",
         "mean_f1_score",
         "zero_recall_tasks",
+        "mean_required_file_recall",
+        "missed_required_task_rate",
+        "receipt_accuracy_rate",
+        "token_efficiency_with_completion",
     ]
+    assert readiness.mean_required_file_recall == 1.0
+    assert readiness.missed_required_task_rate == 0.0
+    assert readiness.receipt_accuracy_rate == 1.0
+    assert readiness.token_efficiency_with_completion == 0.5
     assert readiness.blocking_tasks[0].task_id == "miss"
 
 
@@ -159,6 +179,28 @@ def test_build_readiness_report_handles_missing_strategy() -> None:
     assert readiness.blocking_tasks == []
 
 
+def test_readiness_missing_receipt_accuracy_fails_target() -> None:
+    report = _report(
+        "missing_receipt",
+        _result(
+            "missing_receipt",
+            recall=1.0,
+            precision=1.0,
+            f1_score=1.0,
+            receipt_accuracy=None,
+        ),
+    )
+
+    readiness = build_readiness_report(
+        [report],
+        {"missing_receipt": _task("missing_receipt", TaskCategory.SELF)},
+    )
+
+    target = next(target for target in readiness.targets if target.name == "receipt_accuracy_rate")
+    assert readiness.receipt_accuracy_rate == 0.0
+    assert target.passed is False
+
+
 def test_format_readiness_outputs_are_stable() -> None:
     report = _report(
         "miss",
@@ -183,6 +225,10 @@ def test_format_readiness_outputs_are_stable() -> None:
     assert "Tokens Total" in markdown
     assert "Token Efficiency" in markdown
     assert "Savings vs Raw" in markdown
+    assert "Required Recall" in markdown
+    assert "Missed Task Rate" in markdown
+    assert "Receipt Accuracy" in markdown
+    assert "Efficiency after Completion" in markdown
     assert "`miss`" in markdown
     assert "Expansion Reasons" in markdown
 
@@ -194,4 +240,8 @@ def test_format_readiness_outputs_are_stable() -> None:
     assert payload["tokens_total"] == 100
     assert payload["token_efficiency"] == 0.5
     assert payload["savings_vs_raw"] == 25.0
+    assert payload["mean_required_file_recall"] == 1.0
+    assert payload["missed_required_task_rate"] == 0.0
+    assert payload["receipt_accuracy_rate"] == 1.0
+    assert payload["token_efficiency_with_completion"] == 0.5
     assert payload["blocking_tasks"][0]["task_id"] == "miss"

--- a/tests/benchmark/test_reporter.py
+++ b/tests/benchmark/test_reporter.py
@@ -27,6 +27,9 @@ def _make_result(
     tokens_input: int = 2000,
     tokens_output: int = 1000,
     token_efficiency: float = 0.5,
+    required_file_recall: float = 1.0,
+    missed_required_file_rate: float = 0.0,
+    missed_required_task_rate: float = 0.0,
     chunker: ChunkerName = "default",
     index_chunk_count: int = 10,
     mean_chunk_tokens: float = 50.0,
@@ -39,6 +42,9 @@ def _make_result(
         tokens_input=tokens_input,
         tokens_output=tokens_output,
         token_efficiency=token_efficiency,
+        required_file_recall=required_file_recall,
+        missed_required_file_rate=missed_required_file_rate,
+        missed_required_task_rate=missed_required_task_rate,
         tool_calls=1,
         files_accessed=3,
         recall=recall,
@@ -124,6 +130,7 @@ class TestFormatSummary:
         assert "archex_query" in summary
         assert "Avg Efficiency" in summary
         assert "Avg Required Recall" in summary
+        assert "Missed File Rate" in summary
         assert "Missed Task Rate" in summary
 
     def test_multi_report_aggregation(self) -> None:
@@ -214,6 +221,9 @@ class TestFormatBucketedSummary:
         assert "external-framework (1 tasks)" in output
         assert "All Tasks (2 tasks)" in output
         assert "Seed Recall" in output
+        assert "Required Recall" in output
+        assert "Missed File Rate" in output
+        assert "Missed Task Rate" in output
 
 
 class TestFormatChunkerFrontierTable:

--- a/tests/benchmark/test_triage.py
+++ b/tests/benchmark/test_triage.py
@@ -66,13 +66,13 @@ def _result(
 def _report(
     task_id: str,
     result: BenchmarkResult,
-    raw_grepped: BenchmarkResult | None = None,
+    raw_read: BenchmarkResult | None = None,
 ) -> BenchmarkReport:
     result.task_id = task_id
     results = [result]
-    if raw_grepped is not None:
-        raw_grepped.task_id = task_id
-        results.insert(0, raw_grepped)
+    if raw_read is not None:
+        raw_read.task_id = task_id
+        results.insert(0, raw_read)
     return BenchmarkReport(
         task_id=task_id,
         repo="owner/repo",
@@ -121,7 +121,7 @@ def test_triage_ranks_zero_recall_before_low_precision() -> None:
     assert findings[0].extra_files == ["src/noise.py"]
 
 
-def test_triage_detects_raw_grepped_gap() -> None:
+def test_triage_detects_raw_ripgrep_gap() -> None:
     archex = _result(
         Strategy.ARCHEX_QUERY,
         recall=0.4,
@@ -130,18 +130,18 @@ def test_triage_detects_raw_grepped_gap() -> None:
         category=TaskCategory.ARCHITECTURE_BROAD,
         seed_files=["src/task.py"],
     )
-    raw_grepped = _result(
+    raw_read = _result(
         Strategy.RAW_RIPGREP,
         recall=0.9,
         precision=0.1,
         f1_score=0.18,
     )
-    findings = triage_failures([_report("gap", archex, raw_grepped)], {"gap": _task("gap")})
+    findings = triage_failures([_report("gap", archex, raw_read)], {"gap": _task("gap")})
 
     assert len(findings) == 1
-    assert findings[0].failure_bucket == "raw_grepped_gap"
-    assert "raw_grepped_gap" in findings[0].failure_reasons
-    assert findings[0].raw_grepped_recall == 0.9
+    assert findings[0].failure_bucket == "raw_ripgrep_gap"
+    assert "raw_ripgrep_gap" in findings[0].failure_reasons
+    assert findings[0].raw_read_recall == 0.9
 
 
 def test_triage_uses_task_category_when_result_category_missing() -> None:
@@ -192,6 +192,7 @@ def test_format_triage_outputs_are_stable() -> None:
     assert "Token Efficiency" in markdown
     assert "Savings vs Raw" in markdown
     assert "Expansion:" in markdown
+    assert "raw_grepped" not in markdown
 
     payload = json.loads(format_triage_json(findings))
     assert payload[0]["task_id"] == "zero"
@@ -200,6 +201,7 @@ def test_format_triage_outputs_are_stable() -> None:
     assert payload[0]["metrics"]["token_efficiency"] == 0.5
     assert payload[0]["metrics"]["savings_vs_raw"] == 25.0
     assert payload[0]["expansion_diagnostics"]["eligible_seeds"] == 0
+    assert "raw_grepped_metrics" not in payload[0]
 
 
 def test_format_triage_json_serializes_expansion_diagnostics() -> None:


### PR DESCRIPTION
## Summary

- Adds unambiguous missed file rate and missed task rate reporting.
- Surfaces required-file recall, missed-file rate, missed-task rate, all-required-present rate, receipt accuracy, completion penalty tokens, and token efficiency after completion in head-to-head reports.
- Adds gate and readiness thresholds for trust and completion-adjusted efficiency.
- Treats missing receipt accuracy as a failed receipt target when a receipt-accuracy threshold is required.
- Renames triage raw baseline gap language to raw ripgrep/read.

## Stack

Stack-Id: ripgrep-trust-20260617
Position: 4/5
Base: `ripgrep-trust/required-miss-semantics`
Head: `ripgrep-trust/report-gates`
Previous: #280 `ripgrep-trust/required-miss-semantics`
Next: #282 `ripgrep-trust/artifacts-docs`

Order:
1. #278 `ripgrep-trust/raw-ripgrep-strategy`
2. #279 `ripgrep-trust/public-baseline`
3. #280 `ripgrep-trust/required-miss-semantics`
4. #281 `ripgrep-trust/report-gates`
5. #282 `ripgrep-trust/artifacts-docs`

## Validation

- `uv run pytest tests/benchmark/test_models.py tests/benchmark/test_strategy_registry.py tests/benchmark/test_strategies.py tests/benchmark/test_runner.py tests/benchmark/test_cli.py tests/benchmark/test_reporter.py tests/benchmark/test_headtohead.py tests/benchmark/test_headtohead_report.py tests/benchmark/test_gate.py tests/benchmark/test_triage.py tests/benchmark/test_external_mcp.py tests/benchmark/test_readiness.py` — passed, 215 tests.
- `uv run ruff check src/archex/benchmark/strategies.py src/archex/benchmark/external_mcp.py src/archex/benchmark/gate.py src/archex/benchmark/readiness.py src/archex/benchmark/reporter.py src/archex/benchmark/triage.py tests/benchmark/test_strategies.py tests/benchmark/test_gate.py tests/benchmark/test_readiness.py tests/benchmark/test_reporter.py tests/benchmark/test_triage.py tests/benchmark/test_headtohead.py tests/benchmark/test_headtohead_report.py` — passed.
- `uv run pyright src/archex/benchmark tests/benchmark` — passed.
- `uv run archex benchmark headtohead report --input benchmarks/headtohead/results --format markdown` — passed.

## Review

Review status: passed after fixes. Individual PR review found receipt-accuracy gate/readiness missing-data blockers; fixed by scoring missing receipt accuracy as `0.0` when receipt accuracy is required. Rerun PR review found no blocking findings. Full-stack review found no blocking findings.