### PR TITLE
feat(benchmark): model bundle-only eval metadata

### DIFF
--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -41,6 +41,47 @@ class BenchmarkSpecModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class BundleOnlyAllowedContext(StrEnum):
+    BUNDLE_ONLY = "bundle-only"
+    BUNDLE_PLUS_FRONTIER = "bundle-plus-frontier"
+
+
+class BundleOnlyEvaluatorCommand(BenchmarkSpecModel):
+    command: str
+    args: list[str] = []
+    timeout_seconds: float = Field(default=600.0, gt=0)
+
+    @model_validator(mode="after")
+    def _validate_command(self) -> BundleOnlyEvaluatorCommand:
+        if not self.command.strip():
+            msg = "bundle-only evaluator command must not be empty"
+            raise ValueError(msg)
+        return self
+
+
+class BundleOnlyEvaluation(BenchmarkSpecModel):
+    expected_answer: str | None = None
+    deterministic_rubric: str | None = None
+    allowed_context_policy: BundleOnlyAllowedContext = BundleOnlyAllowedContext.BUNDLE_ONLY
+    evaluator_command: BundleOnlyEvaluatorCommand | None = None
+
+    @model_validator(mode="after")
+    def _validate_grader(self) -> BundleOnlyEvaluation:
+        has_expected_answer = self.expected_answer is not None and bool(
+            self.expected_answer.strip()
+        )
+        has_rubric = self.deterministic_rubric is not None and bool(
+            self.deterministic_rubric.strip()
+        )
+        if has_expected_answer == has_rubric:
+            msg = (
+                "bundle-only evaluation must define exactly one of "
+                "expected_answer or deterministic_rubric"
+            )
+            raise ValueError(msg)
+        return self
+
+
 class BenchmarkTask(BenchmarkSpecModel):
     task_id: str
     repo: str
@@ -53,6 +94,7 @@ class BenchmarkTask(BenchmarkSpecModel):
     languages: list[str] | None = None
     include_paths: list[str] = []
     category: TaskCategory | None = None
+    bundle_only_eval: BundleOnlyEvaluation | None = None
 
     @model_validator(mode="after")
     def _validate_include_paths(self) -> BenchmarkTask:
@@ -247,6 +289,11 @@ class BenchmarkResult(BaseModel):
     all_required_files_present: bool = False
     required_files_present: list[str] = []
     required_files_missing: list[str] = []
+    bundle_only_success: TaskCompletionResult | None = None
+    needed_files_outside_returned: list[str] | None = None
+    needed_files_in_frontier_cut: list[str] | None = None
+    needed_files_in_top_candidates: list[str] | None = None
+    safe_to_act_false_positive: bool | None = None
     post_bundle_search_turns: int | None = None
     post_bundle_read_turns: int | None = None
     task_completion_result: TaskCompletionResult = TaskCompletionResult.UNKNOWN

--- a/tests/benchmark/test_loader.py
+++ b/tests/benchmark/test_loader.py
@@ -77,6 +77,49 @@ expected_files:
         task = load_task(p)
         assert task.include_paths == ["src/pkg"]
 
+    def test_load_bundle_only_eval_fields(self, tmp_path: Path) -> None:
+        p = tmp_path / "bundle_eval.yaml"
+        p.write_text("""\
+task_id: bundle_eval
+repo: owner/repo
+commit: abc
+question: "How?"
+expected_files:
+  - src/pkg/main.py
+bundle_only_eval:
+  expected_answer: "It calls the renderer."
+  allowed_context_policy: bundle-plus-frontier
+  evaluator_command:
+    command: python
+    args:
+      - tests/fixtures/bundle_eval.py
+    timeout_seconds: 30
+""")
+
+        task = load_task(p)
+
+        assert task.bundle_only_eval is not None
+        assert task.bundle_only_eval.expected_answer == "It calls the renderer."
+        assert task.bundle_only_eval.allowed_context_policy == "bundle-plus-frontier"
+        assert task.bundle_only_eval.evaluator_command is not None
+        assert task.bundle_only_eval.evaluator_command.command == "python"
+
+    def test_load_rejects_bundle_eval_without_grader(self, tmp_path: Path) -> None:
+        p = tmp_path / "bundle_eval_without_grader.yaml"
+        p.write_text("""\
+task_id: bundle_eval_without_grader
+repo: owner/repo
+commit: abc
+question: "How?"
+expected_files:
+  - src/pkg/main.py
+bundle_only_eval:
+  allowed_context_policy: bundle-only
+""")
+
+        with pytest.raises(ValueError, match=r"bundle_eval_without_grader\.yaml.*bundle_only_eval"):
+            load_task(p)
+
     def test_load_missing_file(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):
             load_task(tmp_path / "nonexistent.yaml")

--- a/tests/benchmark/test_models.py
+++ b/tests/benchmark/test_models.py
@@ -14,7 +14,11 @@ from archex.benchmark.models import (
     BenchmarkReport,
     BenchmarkResult,
     BenchmarkTask,
+    BundleOnlyAllowedContext,
+    BundleOnlyEvaluation,
+    BundleOnlyEvaluatorCommand,
     Strategy,
+    TaskCompletionResult,
 )
 
 
@@ -54,6 +58,45 @@ class TestBenchmarkTask:
         assert task.keywords == []
         assert task.expected_symbols == []
         assert task.include_paths == []
+        assert task.bundle_only_eval is None
+
+    def test_bundle_only_eval_task_fields(self) -> None:
+        task = BenchmarkTask(
+            task_id="test_task",
+            repo="owner/repo",
+            commit="abc123",
+            question="How does X work?",
+            expected_files=["src/main.py"],
+            bundle_only_eval=BundleOnlyEvaluation(
+                expected_answer="It initializes the CLI.",
+                allowed_context_policy=BundleOnlyAllowedContext.BUNDLE_PLUS_FRONTIER,
+                evaluator_command=BundleOnlyEvaluatorCommand(
+                    command="python",
+                    args=["tests/fixtures/bundle_eval.py"],
+                    timeout_seconds=30.0,
+                ),
+            ),
+        )
+
+        assert task.bundle_only_eval is not None
+        assert task.bundle_only_eval.expected_answer == "It initializes the CLI."
+        assert task.bundle_only_eval.deterministic_rubric is None
+        assert (
+            task.bundle_only_eval.allowed_context_policy
+            is BundleOnlyAllowedContext.BUNDLE_PLUS_FRONTIER
+        )
+        assert task.bundle_only_eval.evaluator_command is not None
+        assert task.bundle_only_eval.evaluator_command.command == "python"
+
+    def test_bundle_only_eval_requires_one_grader(self) -> None:
+        with pytest.raises(ValidationError):
+            BundleOnlyEvaluation()
+
+        with pytest.raises(ValidationError):
+            BundleOnlyEvaluation(
+                expected_answer="answer",
+                deterministic_rubric="rubric",
+            )
 
     def test_include_paths_must_be_relative(self) -> None:
         with pytest.raises(ValidationError):
@@ -179,6 +222,39 @@ class TestBenchmarkResult:
         assert result.symbol_recall == 0.0
         assert result.vector_mode == "raw"
         assert result.cache_state == "cold"
+        assert result.bundle_only_success is None
+        assert result.needed_files_outside_returned is None
+        assert result.needed_files_in_frontier_cut is None
+        assert result.needed_files_in_top_candidates is None
+        assert result.safe_to_act_false_positive is None
+
+    def test_bundle_only_result_fields(self) -> None:
+        result = BenchmarkResult(
+            task_id="test",
+            strategy=Strategy.ARCHEX_QUERY,
+            tokens_total=1000,
+            tool_calls=3,
+            files_accessed=3,
+            recall=1.0,
+            precision=1.0,
+            savings_vs_raw=0.0,
+            wall_time_ms=50.0,
+            cached=False,
+            timestamp="2025-01-01T00:00:00Z",
+            bundle_only_success=TaskCompletionResult.PASS,
+            needed_files_outside_returned=["src/missing.py"],
+            needed_files_in_frontier_cut=["src/frontier.py"],
+            needed_files_in_top_candidates=["src/skipped.py"],
+            safe_to_act_false_positive=True,
+            post_bundle_read_turns=2,
+        )
+
+        assert result.bundle_only_success is TaskCompletionResult.PASS
+        assert result.needed_files_outside_returned == ["src/missing.py"]
+        assert result.needed_files_in_frontier_cut == ["src/frontier.py"]
+        assert result.needed_files_in_top_candidates == ["src/skipped.py"]
+        assert result.safe_to_act_false_positive is True
+        assert result.post_bundle_read_turns == 2
 
     def test_with_timing(self) -> None:
         from archex.models import PipelineTiming


### PR DESCRIPTION
## Stack

Stack-Id: `bundle-only-eval-k7p4q2`
Base: `main`
Position: 1/4

1. `feat/bundle-only-eval-model` -> this PR (#283)
2. `feat/bundle-only-eval-runner` -> #284
3. `feat/bundle-only-eval-reporting` -> #285
4. `feat/bundle-only-eval-cli-docs` -> #286

Depends on: (none - root)
Upstack: #284

## Summary

- Adds optional bundle-only eval task metadata and allowed-context policy modeling.
- Adds optional bundle-only result fields for success, needed-file attribution, safe-to-act false positives, and post-bundle reads.
- Keeps existing benchmark task YAML disabled by default.

## Validation

- `uv run ruff format --check .`: passed, 282 files already formatted
- `uv run ruff check src/archex/benchmark/models.py src/archex/benchmark/loader.py src/archex/benchmark/bundle_eval.py src/archex/benchmark/reporter.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_models.py tests/benchmark/test_loader.py tests/benchmark/test_bundle_eval.py tests/benchmark/test_reporter.py tests/benchmark/test_cli.py tests/fixtures/bundle_eval_command.py`: passed
- `uv run pyright src/archex/benchmark/models.py src/archex/benchmark/loader.py src/archex/benchmark/bundle_eval.py src/archex/benchmark/reporter.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_models.py tests/benchmark/test_loader.py tests/benchmark/test_bundle_eval.py tests/benchmark/test_reporter.py tests/benchmark/test_cli.py tests/fixtures/bundle_eval_command.py`: passed
- `uv run pytest tests/benchmark/test_models.py tests/benchmark/test_loader.py tests/benchmark/test_runner.py tests/benchmark/test_reporter.py tests/benchmark/test_cli.py tests/benchmark/test_bundle_eval.py`: passed, 153 tests
- GitHub checks: docker full build, docker slim build, test 3.11, test 3.12, and test 3.13 passed; #286 passed again after the default-policy fix.

## Review status

- Manual review finding fixed: local evaluator start failures and timeouts now raise `BundleOnlyEvaluatorError` with tests.
- Manual review finding fixed: evaluator output now requires `needed_files` and `attempted_more_context`, matching the advertised structured output schema, with tests.
- Manual review finding fixed: bundle-only post-read metrics now stay in the bundle-only appendix instead of the core retrieval summary table, with reporter coverage.
- Manual review finding fixed: bundle-only task execution now reuses the benchmark repo path helper so remote tasks with `include_paths` run against the same sliced corpus as core benchmark runs, with coverage.
- Manual review finding fixed: bundle-only evaluator input defaults to `bundle-only` policy when a task has no optional bundle-only config, so the explicit CLI lane can run ordinary benchmark tasks with a user-supplied evaluator command.
- `/review` command unavailable: provider rate limit 429 on individual PR review and full-stack review attempts. Latest post-default-policy-fix retry returned `retry-after-ms=101752000` for #286 and `retry-after-ms=101748000` for full-stack.
