### PR TITLE
feat(benchmark): run local bundle-only evaluators

### DIFF
--- a/src/archex/benchmark/bundle_eval.py
+++ b/src/archex/benchmark/bundle_eval.py
@@ -1,0 +1,172 @@
+"""Optional bundle-only benchmark evaluator runner."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from archex.benchmark.models import TaskCompletionResult  # noqa: TC001 — Pydantic needs at runtime
+
+if TYPE_CHECKING:
+    from archex.benchmark.models import BenchmarkTask, BundleOnlyEvaluatorCommand
+    from archex.models import ContextBundle
+
+
+class BundleOnlyEvaluatorError(RuntimeError):
+    """Raised when a bundle-only evaluator command cannot produce valid output."""
+
+
+class BundleOnlyEvaluatorInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    task_id: str
+    question: str
+    rendered_bundle: str
+    receipt_json: str
+    allowed_context_policy: str
+    output_schema: dict[str, Any]
+
+
+class BundleOnlyEvaluatorOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    answer: str
+    confidence: float = Field(ge=0.0, le=1.0)
+    needed_files: list[str]
+    attempted_more_context: bool
+    post_bundle_read_turns: int = Field(default=0, ge=0)
+    bundle_only_success: TaskCompletionResult | None = None
+
+    @model_validator(mode="after")
+    def _validate_needed_files(self) -> BundleOnlyEvaluatorOutput:
+        for path in self.needed_files:
+            if not path or path.startswith("/") or ".." in path.split("/"):
+                msg = f"needed_files entries must be relative paths: {path!r}"
+                raise ValueError(msg)
+        return self
+
+
+def bundle_only_output_schema() -> dict[str, Any]:
+    """Return the structured JSON contract evaluator commands must print."""
+    return {
+        "type": "object",
+        "required": ["answer", "confidence", "needed_files", "attempted_more_context"],
+        "properties": {
+            "answer": {"type": "string"},
+            "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+            "needed_files": {"type": "array", "items": {"type": "string"}},
+            "attempted_more_context": {"type": "boolean"},
+            "post_bundle_read_turns": {"type": "integer", "minimum": 0},
+            "bundle_only_success": {"enum": ["pass", "fail", "unknown", None]},
+        },
+        "additionalProperties": False,
+    }
+
+
+def build_bundle_only_evaluator_input(
+    task: BenchmarkTask,
+    bundle: ContextBundle,
+    *,
+    bundle_format: str = "markdown",
+) -> BundleOnlyEvaluatorInput:
+    if task.bundle_only_eval is None:
+        msg = "bundle-only evaluation is not configured for this task"
+        raise BundleOnlyEvaluatorError(msg)
+    receipt_json = "null"
+    if bundle.receipt is not None:
+        receipt_json = bundle.receipt.model_dump_json()
+    return BundleOnlyEvaluatorInput(
+        task_id=task.task_id,
+        question=task.question,
+        rendered_bundle=bundle.to_prompt(format=bundle_format),
+        receipt_json=receipt_json,
+        allowed_context_policy=task.bundle_only_eval.allowed_context_policy.value,
+        output_schema=bundle_only_output_schema(),
+    )
+
+
+def parse_bundle_only_evaluator_output(stdout: str) -> BundleOnlyEvaluatorOutput:
+    if not stdout.strip():
+        msg = "bundle-only evaluator produced no JSON output"
+        raise BundleOnlyEvaluatorError(msg)
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        msg = "bundle-only evaluator produced invalid JSON output"
+        raise BundleOnlyEvaluatorError(msg) from exc
+    try:
+        return BundleOnlyEvaluatorOutput.model_validate(payload)
+    except ValidationError as exc:
+        msg = "bundle-only evaluator output does not match the required schema"
+        raise BundleOnlyEvaluatorError(msg) from exc
+
+
+def _with_expected_answer_success(
+    task: BenchmarkTask,
+    output: BundleOnlyEvaluatorOutput,
+) -> BundleOnlyEvaluatorOutput:
+    if output.bundle_only_success is not None or task.bundle_only_eval is None:
+        return output
+    expected_answer = task.bundle_only_eval.expected_answer
+    if expected_answer is None:
+        return output.model_copy(update={"bundle_only_success": TaskCompletionResult.UNKNOWN})
+    expected = expected_answer.strip()
+    actual = output.answer.strip()
+    success = TaskCompletionResult.PASS if actual == expected else TaskCompletionResult.FAIL
+    return output.model_copy(update={"bundle_only_success": success})
+
+
+def _resolve_evaluator_command(
+    task: BenchmarkTask,
+    command: BundleOnlyEvaluatorCommand | None,
+) -> BundleOnlyEvaluatorCommand:
+    if command is not None:
+        return command
+    if task.bundle_only_eval is not None and task.bundle_only_eval.evaluator_command is not None:
+        return task.bundle_only_eval.evaluator_command
+    msg = "bundle-only evaluation requires an explicit evaluator command"
+    raise BundleOnlyEvaluatorError(msg)
+
+
+def run_bundle_only_evaluator(
+    task: BenchmarkTask,
+    bundle: ContextBundle,
+    *,
+    command: BundleOnlyEvaluatorCommand | None = None,
+    cwd: Path | None = None,
+    bundle_format: str = "markdown",
+) -> BundleOnlyEvaluatorOutput:
+    """Run a user-supplied local evaluator command with bundle-only inputs."""
+    evaluator_command = _resolve_evaluator_command(task, command)
+    evaluator_input = build_bundle_only_evaluator_input(
+        task,
+        bundle,
+        bundle_format=bundle_format,
+    )
+    try:
+        completed = subprocess.run(
+            [evaluator_command.command, *evaluator_command.args],
+            input=evaluator_input.model_dump_json(),
+            text=True,
+            capture_output=True,
+            cwd=cwd,
+            timeout=evaluator_command.timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        msg = (
+            "bundle-only evaluator command timed out after "
+            f"{evaluator_command.timeout_seconds:g} seconds"
+        )
+        raise BundleOnlyEvaluatorError(msg) from exc
+    except OSError as exc:
+        msg = f"bundle-only evaluator command could not be started: {exc}"
+        raise BundleOnlyEvaluatorError(msg) from exc
+    if completed.returncode != 0:
+        msg = f"bundle-only evaluator command failed with exit code {completed.returncode}"
+        raise BundleOnlyEvaluatorError(msg)
+    return _with_expected_answer_success(task, parse_bundle_only_evaluator_output(completed.stdout))

--- a/tests/benchmark/test_bundle_eval.py
+++ b/tests/benchmark/test_bundle_eval.py
@@ -1,0 +1,190 @@
+"""Tests for optional bundle-only evaluator commands."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from archex.benchmark.bundle_eval import (
+    BundleOnlyEvaluatorError,
+    build_bundle_only_evaluator_input,
+    parse_bundle_only_evaluator_output,
+    run_bundle_only_evaluator,
+)
+from archex.benchmark.models import (
+    BenchmarkTask,
+    BundleOnlyAllowedContext,
+    BundleOnlyEvaluation,
+    BundleOnlyEvaluatorCommand,
+    TaskCompletionResult,
+)
+from archex.models import (
+    ContextBundle,
+    ContextCompletenessStatus,
+    ContextReceipt,
+    ContextReceiptTokenBudget,
+)
+
+
+def _fixture_command(mode: str) -> BundleOnlyEvaluatorCommand:
+    command_path = Path(__file__).parents[1] / "fixtures" / "bundle_eval_command.py"
+    return BundleOnlyEvaluatorCommand(
+        command=sys.executable,
+        args=[str(command_path), mode],
+        timeout_seconds=10,
+    )
+
+
+def _task(command: BundleOnlyEvaluatorCommand | None = None) -> BenchmarkTask:
+    return BenchmarkTask(
+        task_id="bundle_eval_task",
+        repo="owner/repo",
+        commit="abc123",
+        question="Can the bundle answer this?",
+        expected_files=["src/main.py"],
+        bundle_only_eval=BundleOnlyEvaluation(
+            expected_answer="bundle contains receipt",
+            allowed_context_policy=BundleOnlyAllowedContext.BUNDLE_PLUS_FRONTIER,
+            evaluator_command=command,
+        ),
+    )
+
+
+def _bundle() -> ContextBundle:
+    receipt = ContextReceipt(
+        query="Can the bundle answer this?",
+        token_budget=ContextReceiptTokenBudget(requested=1000, consumed=20),
+        index_revision="sha256:test",
+        context_complete=ContextCompletenessStatus.COMPLETE,
+    )
+    return ContextBundle(
+        query="Can the bundle answer this?",
+        token_count=20,
+        token_budget=1000,
+        receipt=receipt,
+    )
+
+
+def test_build_evaluator_input_contains_bundle_receipt_and_policy() -> None:
+    evaluator_input = build_bundle_only_evaluator_input(_task(), _bundle())
+
+    assert evaluator_input.question == "Can the bundle answer this?"
+    assert "Can the bundle answer this?" in evaluator_input.rendered_bundle
+    assert "sha256:test" in evaluator_input.receipt_json
+    assert evaluator_input.allowed_context_policy == "bundle-plus-frontier"
+    assert evaluator_input.output_schema["required"] == [
+        "answer",
+        "confidence",
+        "needed_files",
+        "attempted_more_context",
+    ]
+
+
+def test_run_evaluator_command_returns_structured_output(tmp_path: Path) -> None:
+    output = run_bundle_only_evaluator(
+        _task(_fixture_command("pass")),
+        _bundle(),
+        cwd=tmp_path,
+    )
+
+    assert output.answer == "bundle contains receipt"
+    assert output.confidence == 0.95
+    assert output.needed_files == ["src/frontier.py"]
+    assert output.attempted_more_context is False
+    assert output.post_bundle_read_turns == 1
+    assert output.bundle_only_success is TaskCompletionResult.PASS
+
+
+def test_expected_answer_grades_missing_success_field(tmp_path: Path) -> None:
+    output = run_bundle_only_evaluator(
+        _task(_fixture_command("no-success")),
+        _bundle(),
+        cwd=tmp_path,
+    )
+
+    assert output.bundle_only_success is TaskCompletionResult.PASS
+
+
+def test_explicit_command_overrides_task_command(tmp_path: Path) -> None:
+    output = run_bundle_only_evaluator(
+        _task(_fixture_command("exit-2")),
+        _bundle(),
+        command=_fixture_command("pass"),
+        cwd=tmp_path,
+    )
+
+    assert output.bundle_only_success is TaskCompletionResult.PASS
+
+
+def test_invalid_evaluator_json_fails_loudly(tmp_path: Path) -> None:
+    with pytest.raises(BundleOnlyEvaluatorError, match="invalid JSON"):
+        run_bundle_only_evaluator(
+            _task(_fixture_command("invalid-json")),
+            _bundle(),
+            cwd=tmp_path,
+        )
+
+
+def test_invalid_evaluator_schema_fails_loudly() -> None:
+    with pytest.raises(BundleOnlyEvaluatorError, match="required schema"):
+        parse_bundle_only_evaluator_output('{"answer": "missing fields"}')
+
+
+def test_missing_required_evaluator_fields_fail_loudly() -> None:
+    with pytest.raises(BundleOnlyEvaluatorError, match="required schema"):
+        parse_bundle_only_evaluator_output(
+            """{
+                "answer": "a",
+                "confidence": 1.0
+            }"""
+        )
+
+
+def test_invalid_needed_file_path_fails_loudly() -> None:
+    with pytest.raises(BundleOnlyEvaluatorError, match="required schema"):
+        parse_bundle_only_evaluator_output(
+            """{
+                "answer": "a",
+                "confidence": 1.0,
+                "needed_files": ["../secret.py"],
+                "attempted_more_context": false
+            }"""
+        )
+
+
+def test_nonzero_evaluator_exit_fails_loudly(tmp_path: Path) -> None:
+    with pytest.raises(BundleOnlyEvaluatorError, match="exit code 2"):
+        run_bundle_only_evaluator(
+            _task(_fixture_command("exit-2")),
+            _bundle(),
+            cwd=tmp_path,
+        )
+
+
+def test_nonexistent_evaluator_command_fails_loudly(tmp_path: Path) -> None:
+    command = BundleOnlyEvaluatorCommand(command="definitely-not-archex-bundle-eval")
+
+    with pytest.raises(BundleOnlyEvaluatorError, match="could not be started"):
+        run_bundle_only_evaluator(
+            _task(command),
+            _bundle(),
+            cwd=tmp_path,
+        )
+
+
+def test_evaluator_timeout_fails_loudly(tmp_path: Path) -> None:
+    command = _fixture_command("sleep").model_copy(update={"timeout_seconds": 0.01})
+
+    with pytest.raises(BundleOnlyEvaluatorError, match="timed out"):
+        run_bundle_only_evaluator(
+            _task(command),
+            _bundle(),
+            cwd=tmp_path,
+        )
+
+
+def test_missing_command_fails_before_execution() -> None:
+    with pytest.raises(BundleOnlyEvaluatorError, match="explicit evaluator command"):
+        run_bundle_only_evaluator(_task(), _bundle())

--- a/tests/fixtures/bundle_eval_command.py
+++ b/tests/fixtures/bundle_eval_command.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+import sys
+import time
+
+
+def main() -> int:
+    mode = sys.argv[1]
+    if mode == "invalid-json":
+        sys.stdout.write("not json")
+        return 0
+    if mode == "bad-schema":
+        sys.stdout.write(json.dumps({"answer": "missing fields"}))
+        return 0
+    if mode == "sleep":
+        time.sleep(5)
+        return 0
+    payload = json.loads(sys.stdin.read())
+    if mode == "exit-2":
+        return 2
+    answer = "bundle contains receipt"
+    success = "pass" if payload["question"] and payload["receipt_json"] != "null" else "fail"
+    output = {
+        "answer": answer,
+        "confidence": 0.95,
+        "needed_files": ["src/frontier.py"],
+        "attempted_more_context": False,
+        "post_bundle_read_turns": 1,
+    }
+    if mode != "no-success":
+        output["bundle_only_success"] = success
+    sys.stdout.write(json.dumps(output))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Stack

Stack-Id: `bundle-only-eval-k7p4q2`
Base: `main`
Position: 2/4

1. `feat/bundle-only-eval-model` -> #283
2. `feat/bundle-only-eval-runner` -> this PR (#284)
3. `feat/bundle-only-eval-reporting` -> #285
4. `feat/bundle-only-eval-cli-docs` -> #286

Depends on: #283
Upstack: #285

## Summary

- Adds a local bundle-only evaluator runner that passes task question, rendered bundle, receipt JSON, allowed-context policy, and output schema over stdin.
- Requires structured JSON evaluator output and fails on malformed JSON, schema errors, missing required fields, invalid needed-file paths, missing commands, command start failures, timeouts, or nonzero exits.
- Adds deterministic fixture-command tests without hosted model calls.

## Validation

- `uv run ruff format --check .`: passed, 282 files already formatted
- `uv run ruff check src/archex/benchmark/models.py src/archex/benchmark/loader.py src/archex/benchmark/bundle_eval.py src/archex/benchmark/reporter.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_models.py tests/benchmark/test_loader.py tests/benchmark/test_bundle_eval.py tests/benchmark/test_reporter.py tests/benchmark/test_cli.py tests/fixtures/bundle_eval_command.py`: passed
- `uv run pyright src/archex/benchmark/models.py src/archex/benchmark/loader.py src/archex/benchmark/bundle_eval.py src/archex/benchmark/reporter.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_models.py tests/benchmark/test_loader.py tests/benchmark/test_bundle_eval.py tests/benchmark/test_reporter.py tests/benchmark/test_cli.py tests/fixtures/bundle_eval_command.py`: passed
- `uv run pytest tests/benchmark/test_models.py tests/benchmark/test_loader.py tests/benchmark/test_runner.py tests/benchmark/test_reporter.py tests/benchmark/test_cli.py tests/benchmark/test_bundle_eval.py`: passed, 153 tests
- GitHub checks: docker full build, docker slim build, test 3.11, test 3.12, and test 3.13 passed; #286 passed again after the default-policy fix.

## Review status

- Manual review finding fixed: local evaluator start failures and timeouts now raise `BundleOnlyEvaluatorError` with tests.
- Manual review finding fixed: evaluator output now requires `needed_files` and `attempted_more_context`, matching the advertised structured output schema, with tests.
- Manual review finding fixed: bundle-only post-read metrics now stay in the bundle-only appendix instead of the core retrieval summary table, with reporter coverage.
- Manual review finding fixed: bundle-only task execution now reuses the benchmark repo path helper so remote tasks with `include_paths` run against the same sliced corpus as core benchmark runs, with coverage.
- Manual review finding fixed: bundle-only evaluator input defaults to `bundle-only` policy when a task has no optional bundle-only config, so the explicit CLI lane can run ordinary benchmark tasks with a user-supplied evaluator command.
- `/review` command unavailable: provider rate limit 429 on individual PR review and full-stack review attempts. Latest post-default-policy-fix retry returned `retry-after-ms=101752000` for #286 and `retry-after-ms=101748000` for full-stack.
