### PR TITLE
feat(benchmark): report bundle-only safety analysis

### DIFF
--- a/src/archex/benchmark/bundle_eval.py
+++ b/src/archex/benchmark/bundle_eval.py
@@ -105,6 +105,61 @@ def parse_bundle_only_evaluator_output(stdout: str) -> BundleOnlyEvaluatorOutput
         raise BundleOnlyEvaluatorError(msg) from exc
 
 
+def _returned_files(bundle: ContextBundle) -> set[str]:
+    if bundle.receipt is not None and bundle.receipt.returned_context:
+        return {item.file_path for item in bundle.receipt.returned_context if item.file_path}
+    return {chunk.chunk.file_path for chunk in bundle.chunks if chunk.chunk.file_path}
+
+
+def _frontier_files(bundle: ContextBundle) -> set[str]:
+    if bundle.receipt is None:
+        return set()
+    files = {
+        edge.target_path for edge in bundle.receipt.omitted_edges if edge.target_path is not None
+    }
+    files.update(
+        candidate.file_path
+        for candidate in bundle.receipt.skipped_candidates
+        if candidate.reason == "dependency_frontier_cut" and candidate.file_path
+    )
+    return files
+
+
+def _top_candidate_files(bundle: ContextBundle) -> set[str]:
+    if bundle.receipt is None:
+        return set()
+    return {
+        candidate.file_path
+        for candidate in bundle.receipt.skipped_candidates
+        if candidate.file_path
+    }
+
+
+def bundle_only_result_fields(
+    bundle: ContextBundle,
+    output: BundleOnlyEvaluatorOutput,
+) -> dict[str, object]:
+    """Derive benchmark result fields from evaluator output and receipt metadata."""
+    needed_files = list(dict.fromkeys(output.needed_files))
+    returned_files = _returned_files(bundle)
+    frontier_files = _frontier_files(bundle)
+    top_candidate_files = _top_candidate_files(bundle)
+    outside_returned = [path for path in needed_files if path not in returned_files]
+    in_frontier = [path for path in outside_returned if path in frontier_files]
+    in_top_candidates = [path for path in outside_returned if path in top_candidate_files]
+    receipt_claims_complete = (
+        bundle.receipt is not None and bundle.receipt.context_complete == "complete"
+    )
+    return {
+        "bundle_only_success": output.bundle_only_success or TaskCompletionResult.UNKNOWN,
+        "needed_files_outside_returned": outside_returned,
+        "needed_files_in_frontier_cut": in_frontier,
+        "needed_files_in_top_candidates": in_top_candidates,
+        "safe_to_act_false_positive": bool(receipt_claims_complete and outside_returned),
+        "post_bundle_read_turns": output.post_bundle_read_turns,
+    }
+
+
 def _with_expected_answer_success(
     task: BenchmarkTask,
     output: BundleOnlyEvaluatorOutput,

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -122,24 +122,21 @@ def format_markdown(report: BenchmarkReport) -> str:
     lines.append("")
     header = (
         "| Strategy | Tokens | Required Recall | Missed File Rate | Missed Task Rate | "
-        "All Required | Post Reads | Completion | Receipt Accuracy | Recall | Precision | "
-        "F1 | Time (ms) |"
+        "All Required | Completion | Receipt Accuracy | Recall | Precision | F1 | Time (ms) |"
     )
     lines.append(header)
     lines.append(
         "|----------|--------|-----------------|------------------|------------------|"
-        "--------------|------------|------------|------------------|--------|-----------|"
-        "------|-----------|"
+        "--------------|------------|------------------|--------|-----------|------|-----------|"
     )
     for r in report.results:
         receipt_accuracy = _receipt_accuracy_label(r.receipt_accuracy)
         all_required = _all_required_label(r.all_required_files_present)
-        post_reads = r.post_bundle_read_turns if r.post_bundle_read_turns is not None else "—"
         lines.append(
             f"| {r.strategy.value} | {r.tokens_total:,} | {r.required_file_recall:.2f} "
             f"| {r.missed_required_file_rate:.2f} | {r.missed_required_task_rate:.2f} "
-            f"| {all_required} | {post_reads} | {r.task_completion_result.value} "
-            f"| {receipt_accuracy} | {r.recall:.2f} | {r.precision:.2f} "
+            f"| {all_required} | {r.task_completion_result.value} | {receipt_accuracy} "
+            f"| {r.recall:.2f} | {r.precision:.2f} "
             f"| {r.f1_score:.2f} | {r.wall_time_ms:.0f} |"
         )
     lines.extend(_missing_required_file_appendix(report))

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -143,6 +143,7 @@ def format_markdown(report: BenchmarkReport) -> str:
             f"| {r.f1_score:.2f} | {r.wall_time_ms:.0f} |"
         )
     lines.extend(_missing_required_file_appendix(report))
+    lines.extend(_bundle_only_eval_appendix(report))
     lines.append("")
     return "\n".join(lines)
 
@@ -297,6 +298,7 @@ def format_strategy_comparison(reports: list[BenchmarkReport]) -> str:
                 f"| {r.tokens_total:,} |"
             )
         lines.extend(_missing_required_file_appendix(report))
+        lines.extend(_bundle_only_eval_appendix(report))
         lines.append("")
 
     # Head-to-head wins
@@ -344,6 +346,38 @@ def _missing_required_file_appendix(report: BenchmarkReport) -> list[str]:
     for result in failures:
         lines.append(
             f"- {result.strategy.value}: missing {', '.join(result.required_files_missing)}"
+        )
+    return lines
+
+
+def _bundle_only_eval_appendix(report: BenchmarkReport) -> list[str]:
+    evaluated = [result for result in report.results if result.bundle_only_success is not None]
+    if not evaluated:
+        return []
+
+    header = (
+        "| Strategy | Success | Outside returned | In frontier cut | "
+        "In top candidates | Safe-to-act false positive | Post reads |"
+    )
+    separator = (
+        "|----------|---------|------------------|-----------------|"
+        "-------------------|----------------------------|------------|"
+    )
+    lines = ["", "### Bundle-only evaluation", header, separator]
+    for result in evaluated:
+        outside = ", ".join(result.needed_files_outside_returned or []) or "none"
+        frontier = ", ".join(result.needed_files_in_frontier_cut or []) or "none"
+        top_candidates = ", ".join(result.needed_files_in_top_candidates or []) or "none"
+        false_positive = _receipt_accuracy_label(result.safe_to_act_false_positive)
+        post_reads = result.post_bundle_read_turns
+        if post_reads is None:
+            post_reads = "—"
+        if result.bundle_only_success is None:
+            continue
+        success = result.bundle_only_success.value
+        lines.append(
+            f"| {result.strategy.value} | {success} | {outside} | {frontier} | "
+            f"{top_candidates} | {false_positive} | {post_reads} |"
         )
     return lines
 

--- a/tests/benchmark/test_bundle_eval.py
+++ b/tests/benchmark/test_bundle_eval.py
@@ -9,7 +9,9 @@ import pytest
 
 from archex.benchmark.bundle_eval import (
     BundleOnlyEvaluatorError,
+    BundleOnlyEvaluatorOutput,
     build_bundle_only_evaluator_input,
+    bundle_only_result_fields,
     parse_bundle_only_evaluator_output,
     run_bundle_only_evaluator,
 )
@@ -24,7 +26,12 @@ from archex.models import (
     ContextBundle,
     ContextCompletenessStatus,
     ContextReceipt,
+    ContextReceiptEdge,
+    ContextReceiptItem,
     ContextReceiptTokenBudget,
+    ContextSkippedCandidate,
+    ContextSkippedReason,
+    EdgeKind,
 )
 
 
@@ -80,6 +87,71 @@ def test_build_evaluator_input_contains_bundle_receipt_and_policy() -> None:
         "needed_files",
         "attempted_more_context",
     ]
+
+
+def test_result_fields_attribute_needed_files_and_false_positive() -> None:
+    receipt = ContextReceipt(
+        query="Can the bundle answer this?",
+        token_budget=ContextReceiptTokenBudget(requested=1000, consumed=20),
+        index_revision="sha256:test",
+        context_complete=ContextCompletenessStatus.COMPLETE,
+        returned_context=[
+            ContextReceiptItem(
+                handle="src/main.py#1-10",
+                file_path="src/main.py",
+                start_line=1,
+                end_line=10,
+                content_hash="sha256:main",
+            )
+        ],
+        omitted_edges=[
+            ContextReceiptEdge(
+                source="src/main.py",
+                target="src/frontier.py",
+                kind=EdgeKind.IMPORTS,
+                target_path="src/frontier.py",
+            )
+        ],
+        skipped_candidates=[
+            ContextSkippedCandidate(
+                file_path="src/frontier.py",
+                reason=ContextSkippedReason.DEPENDENCY_FRONTIER_CUT,
+            ),
+            ContextSkippedCandidate(
+                file_path="src/skipped.py",
+                reason=ContextSkippedReason.BELOW_THRESHOLD,
+            ),
+        ],
+    )
+    output = BundleOnlyEvaluatorOutput(
+        answer="bundle contains receipt",
+        confidence=1.0,
+        needed_files=[
+            "src/main.py",
+            "src/frontier.py",
+            "src/skipped.py",
+            "src/absent.py",
+        ],
+        attempted_more_context=True,
+        post_bundle_read_turns=3,
+        bundle_only_success=TaskCompletionResult.FAIL,
+    )
+
+    fields = bundle_only_result_fields(
+        ContextBundle(query="q", token_count=20, token_budget=1000, receipt=receipt),
+        output,
+    )
+
+    assert fields["bundle_only_success"] is TaskCompletionResult.FAIL
+    assert fields["needed_files_outside_returned"] == [
+        "src/frontier.py",
+        "src/skipped.py",
+        "src/absent.py",
+    ]
+    assert fields["needed_files_in_frontier_cut"] == ["src/frontier.py"]
+    assert fields["needed_files_in_top_candidates"] == ["src/frontier.py", "src/skipped.py"]
+    assert fields["safe_to_act_false_positive"] is True
+    assert fields["post_bundle_read_turns"] == 3
 
 
 def test_run_evaluator_command_returns_structured_output(tmp_path: Path) -> None:

--- a/tests/benchmark/test_reporter.py
+++ b/tests/benchmark/test_reporter.py
@@ -124,6 +124,8 @@ class TestFormatMarkdown:
         assert "src/frontier.py, src/absent.py" in md
         assert "Safe-to-act false positive" in md
         assert "| archex_query | fail |" in md
+        assert "All Required | Post Reads | Completion" not in md
+        assert "Safe-to-act false positive | Post reads" in md
 
 
 class TestFormatJson:

--- a/tests/benchmark/test_reporter.py
+++ b/tests/benchmark/test_reporter.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from archex.benchmark.models import BenchmarkReport, BenchmarkResult, Strategy, TaskCategory
+from archex.benchmark.models import (
+    BenchmarkReport,
+    BenchmarkResult,
+    Strategy,
+    TaskCategory,
+    TaskCompletionResult,
+)
 from archex.benchmark.reporter import (
     format_bucketed_summary,
     format_chunker_frontier_table,
@@ -102,6 +108,23 @@ class TestFormatMarkdown:
         md = format_markdown(_make_report())
         assert "2,000" in md
 
+    def test_contains_bundle_only_eval_section_when_present(self) -> None:
+        report = _make_report([_make_result(Strategy.ARCHEX_QUERY)])
+        result = report.results[0]
+        result.bundle_only_success = TaskCompletionResult.FAIL
+        result.needed_files_outside_returned = ["src/frontier.py", "src/absent.py"]
+        result.needed_files_in_frontier_cut = ["src/frontier.py"]
+        result.needed_files_in_top_candidates = ["src/frontier.py"]
+        result.safe_to_act_false_positive = True
+        result.post_bundle_read_turns = 2
+
+        md = format_markdown(report)
+
+        assert "Bundle-only evaluation" in md
+        assert "src/frontier.py, src/absent.py" in md
+        assert "Safe-to-act false positive" in md
+        assert "| archex_query | fail |" in md
+
 
 class TestFormatJson:
     def test_valid_json(self) -> None:
@@ -177,6 +200,16 @@ class TestFormatStrategyComparison:
         result = format_strategy_comparison([report])
         assert "Missing required files appendix" in result
         assert "missing.py" in result
+
+    def test_strategy_comparison_includes_bundle_only_eval_section(self) -> None:
+        report = _make_report([_make_result(Strategy.ARCHEX_QUERY)])
+        report.results[0].bundle_only_success = TaskCompletionResult.PASS
+        report.results[0].needed_files_outside_returned = ["src/absent.py"]
+
+        result = format_strategy_comparison([report])
+
+        assert "Bundle-only evaluation" in result
+        assert "src/absent.py" in result
 
     def test_contains_head_to_head(self) -> None:
         report = _make_report()


### PR DESCRIPTION
## Stack

Stack-Id: `bundle-only-eval-k7p4q2`
Base: `main`
Position: 3/4

1. `feat/bundle-only-eval-model` -> #283
2. `feat/bundle-only-eval-runner` -> #284
3. `feat/bundle-only-eval-reporting` -> this PR (#285)
4. `feat/bundle-only-eval-cli-docs` -> #286

Depends on: #284
Upstack: #286

## Summary

- Adds bundle-only needed-file attribution for outside-returned, frontier-cut, and top-candidate files.
- Detects `safe_to_act_false_positive` when a complete receipt overclaims but evaluator output needs files outside returned context.
- Surfaces bundle-only results in report appendices separate from core retrieval summary and gate metrics.

## Validation

- `uv run ruff format --check .`: passed, 282 files already formatted
- `uv run ruff check src/archex/benchmark/models.py src/archex/benchmark/loader.py src/archex/benchmark/bundle_eval.py src/archex/benchmark/reporter.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_models.py tests/benchmark/test_loader.py tests/benchmark/test_bundle_eval.py tests/benchmark/test_reporter.py tests/benchmark/test_cli.py tests/fixtures/bundle_eval_command.py`: passed
- `uv run pyright src/archex/benchmark/models.py src/archex/benchmark/loader.py src/archex/benchmark/bundle_eval.py src/archex/benchmark/reporter.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_models.py tests/benchmark/test_loader.py tests/benchmark/test_bundle_eval.py tests/benchmark/test_reporter.py tests/benchmark/test_cli.py tests/fixtures/bundle_eval_command.py`: passed
- `uv run pytest tests/benchmark/test_models.py tests/benchmark/test_loader.py tests/benchmark/test_runner.py tests/benchmark/test_reporter.py tests/benchmark/test_cli.py tests/benchmark/test_bundle_eval.py`: passed, 153 tests
- GitHub checks: docker full build, docker slim build, test 3.11, test 3.12, and test 3.13 passed; #286 passed again after the default-policy fix.

## Review status

- Manual review finding fixed: local evaluator start failures and timeouts now raise `BundleOnlyEvaluatorError` with tests.
- Manual review finding fixed: evaluator output now requires `needed_files` and `attempted_more_context`, matching the advertised structured output schema, with tests.
- Manual review finding fixed: bundle-only post-read metrics now stay in the bundle-only appendix instead of the core retrieval summary table, with reporter coverage.
- Manual review finding fixed: bundle-only task execution now reuses the benchmark repo path helper so remote tasks with `include_paths` run against the same sliced corpus as core benchmark runs, with coverage.
- Manual review finding fixed: bundle-only evaluator input defaults to `bundle-only` policy when a task has no optional bundle-only config, so the explicit CLI lane can run ordinary benchmark tasks with a user-supplied evaluator command.
- `/review` command unavailable: provider rate limit 429 on individual PR review and full-stack review attempts. Latest post-default-policy-fix retry returned `retry-after-ms=101752000` for #286 and `retry-after-ms=101748000` for full-stack.
