### PR TITLE
Wire TurboQuant index configuration

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -138,14 +138,24 @@ def _cache_manager_for_source(source: RepoSource, config: Config) -> CacheManage
 
 
 def _index_config_metadata_matches(store: IndexStore, index_config: IndexConfig) -> bool:
-    return store.get_metadata("chunker") == index_config.chunker and store.get_metadata(
+    if store.get_metadata("chunker") != index_config.chunker or store.get_metadata(
         "chunker_revision"
-    ) == chunker_revision(index_config.chunker)
+    ) != chunker_revision(index_config.chunker):
+        return False
+    stored_quantize = store.get_metadata("quantize_vectors")
+    stored_quantize_enabled = stored_quantize == "True" if stored_quantize is not None else False
+    if stored_quantize_enabled != index_config.quantize_vectors:
+        return False
+    if index_config.quantize_vectors:
+        return store.get_metadata("quantize_bits") == str(index_config.quantize_bits)
+    return True
 
 
 def _set_index_config_metadata(store: IndexStore, index_config: IndexConfig) -> None:
     store.set_metadata("chunker", index_config.chunker)
     store.set_metadata("chunker_revision", chunker_revision(index_config.chunker))
+    store.set_metadata("quantize_vectors", str(index_config.quantize_vectors))
+    store.set_metadata("quantize_bits", str(index_config.quantize_bits))
 
 
 def _full_index(
@@ -227,7 +237,10 @@ def _full_index(
                     else None
                 )
                 vector_chunks = embedding_eligible_chunks(all_chunks)
-                vec_idx = VectorIndex()
+                vec_idx = VectorIndex(
+                    quantize=effective_index_config.quantize_vectors,
+                    quantize_bits=effective_index_config.quantize_bits,
+                )
                 cache_hits, cache_misses = vec_idx.build(
                     vector_chunks,
                     embedder,
@@ -488,7 +501,10 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
                     index_config,
                     embedder,
                 )
-                vec_idx = VectorIndex()
+                vec_idx = VectorIndex(
+                    quantize=index_config.quantize_vectors,
+                    quantize_bits=index_config.quantize_bits,
+                )
                 cache_hits, cache_misses = vec_idx.build(
                     vector_chunks,
                     embedder,
@@ -1136,7 +1152,10 @@ def _cached_vectors_by_content_hash(
         return {}
     from archex.index.vector import VectorIndex
 
-    vec_idx = VectorIndex()
+    vec_idx = VectorIndex(
+        quantize=index_config.quantize_vectors,
+        quantize_bits=index_config.quantize_bits,
+    )
     try:
         vec_idx.load(
             npz_path,
@@ -1172,7 +1191,10 @@ def _vector_search_precomputed(
         return None
     from archex.index.vector import VectorIndex
 
-    vec_idx = VectorIndex()
+    vec_idx = VectorIndex(
+        quantize=index_config.quantize_vectors,
+        quantize_bits=index_config.quantize_bits,
+    )
     try:
         vec_idx.load(
             npz_path,
@@ -2067,7 +2089,10 @@ def query(
 
                     t_vec_build = time.perf_counter()
                     vector_chunks = embedding_eligible_chunks(all_chunks)
-                    vec_idx = VectorIndex()
+                    vec_idx = VectorIndex(
+                        quantize=index_config.quantize_vectors,
+                        quantize_bits=index_config.quantize_bits,
+                    )
                     cache_hits, cache_misses = vec_idx.build(
                         vector_chunks,
                         embedder,
@@ -2385,7 +2410,10 @@ def _vector_search_in_memory(
     from archex.index.vector import VectorIndex
 
     t_vec = time.perf_counter()
-    vec_idx = VectorIndex()
+    vec_idx = VectorIndex(
+        quantize=index_config.quantize_vectors,
+        quantize_bits=index_config.quantize_bits,
+    )
     vec_idx.build(
         eligible_chunks,
         embedder,  # type: ignore[arg-type]

--- a/src/archex/cli/index_cmd.py
+++ b/src/archex/cli/index_cmd.py
@@ -10,7 +10,7 @@ import click
 
 from archex.api import index_repository
 from archex.cache import CacheManager
-from archex.config import load_config, load_index_config
+from archex.config import load_config, load_index_config, persist_project_index_settings
 from archex.exceptions import ArchexError
 from archex.models import PipelineTiming, RepoSource
 from archex.project import uses_project_cache_layout
@@ -46,12 +46,25 @@ def _language_counts(file_metadata: list[dict[str, str | int]]) -> dict[str, int
     default=False,
     help="Allow explicitly selected pinned model paths that require Hugging Face remote code.",
 )
+@click.option(
+    "--quantize-vectors/--no-quantize-vectors",
+    default=None,
+    help="Build vector indexes with TurboQuant compression.",
+)
+@click.option(
+    "--quantize-bits",
+    default=None,
+    type=click.Choice(["2", "4"]),
+    help="TurboQuant bit-width for vector indexes.",
+)
 def index_cmd(
     source: str,
     output_format: str,
     splade: bool,
     module_prefilter: bool,
     allow_remote_code: bool,
+    quantize_vectors: bool | None,
+    quantize_bits: str | None,
 ) -> None:
     """Build or refresh the index for SOURCE without running a query."""
     repo_source = RepoSource(local_path=source)
@@ -64,6 +77,18 @@ def index_cmd(
         index_config = index_config.model_copy(update={"splade": True})
     if module_prefilter:
         index_config = index_config.model_copy(update={"module_prefilter": True})
+    index_updates: dict[str, bool | int | str] = {}
+    if quantize_vectors is not None:
+        index_updates["quantize_vectors"] = quantize_vectors
+        if quantize_vectors:
+            index_updates["vector"] = True
+            if index_config.embedder is None:
+                index_updates["embedder"] = "jina-v2"
+    if quantize_bits is not None:
+        index_updates["quantize_bits"] = int(quantize_bits)
+    if index_updates:
+        index_config = index_config.model_copy(update=index_updates)
+        persist_project_index_settings(repo_source, index_updates)
     timing = PipelineTiming()
     started = time.perf_counter()
     try:

--- a/src/archex/config.py
+++ b/src/archex/config.py
@@ -150,3 +150,70 @@ def load_index_config(source: RepoSource | str | Path | None = None) -> IndexCon
     overrides.update(_env_overrides(IndexConfig.model_fields))
 
     return IndexConfig(**overrides) if overrides else IndexConfig()
+
+
+def _format_toml_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str):
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    if isinstance(value, list):
+        items = cast("list[Any]", value)
+        return "[" + ", ".join(_format_toml_value(item) for item in items) + "]"
+    raise TypeError(f"Unsupported TOML value type for project index settings: {type(value)!r}")
+
+
+def persist_project_index_settings(
+    source: RepoSource | str | Path,
+    updates: dict[str, Any],
+) -> Path | None:
+    """Persist supported IndexConfig keys into repo-local `.archex/settings.toml`."""
+    state = _project_state(source)
+    if state is None:
+        return None
+    filtered = {key: value for key, value in updates.items() if key in IndexConfig.model_fields}
+    if not filtered:
+        return state.settings_path
+
+    # Validate existing settings and the merged index config before writing.
+    _state, index_settings = _project_index_settings(source) or (state, {})
+    IndexConfig(**(index_settings | filtered))
+
+    lines = state.settings_path.read_text(encoding="utf-8").splitlines()
+    section_start: int | None = None
+    section_end = len(lines)
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == "[index]":
+            section_start = idx
+            continue
+        if section_start is not None and idx > section_start and stripped.startswith("["):
+            section_end = idx
+            break
+
+    if section_start is None:
+        if lines and lines[-1] != "":
+            lines.append("")
+        lines.append("[index]")
+        section_start = len(lines) - 1
+        section_end = len(lines)
+
+    remaining = dict(filtered)
+    for idx in range(section_start + 1, section_end):
+        stripped = lines[idx].strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key = stripped.split("=", 1)[0].strip()
+        if key in remaining:
+            lines[idx] = f"{key} = {_format_toml_value(remaining.pop(key))}"
+
+    insert_at = section_end
+    for key, value in remaining.items():
+        lines.insert(insert_at, f"{key} = {_format_toml_value(value)}")
+        insert_at += 1
+
+    state.settings_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return state.settings_path

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -8,6 +8,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, model_validator
 
+from archex.index.quantize import SUPPORTED_BITS
 from archex.integrations.lsap_models import LSAPEnrichment  # noqa: TCH001
 
 # ---------------------------------------------------------------------------
@@ -219,6 +220,8 @@ class IndexConfig(BaseModel):
     chunk_min_tokens: int = 50
     token_encoding: str = "cl100k_base"
     allow_remote_code: bool = False
+    quantize_vectors: bool = False
+    quantize_bits: int = 4
 
     @model_validator(mode="after")
     def _validate_index_config(self) -> IndexConfig:
@@ -236,6 +239,8 @@ class IndexConfig(BaseModel):
             raise ValueError("surrogate_version must not be empty")
         if self.rerank_candidate_limit < 1:
             raise ValueError("rerank_candidate_limit must be at least 1")
+        if self.quantize_bits not in SUPPORTED_BITS:
+            raise ValueError(f"quantize_bits must be one of {SUPPORTED_BITS}")
         return self
 
 

--- a/tests/cli/test_index_cmd.py
+++ b/tests/cli/test_index_cmd.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import tomllib
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+from archex.project import init_project
+
+
+class FakeStore:
+    db_path = Path("/tmp/archex-index.db")
+
+    def get_file_metadata(self) -> list[dict[str, str | int]]:
+        return []
+
+    def get_metadata(self, key: str) -> str | None:
+        if key == "commit_hash":
+            return "abc123"
+        return None
+
+    def get_file_count(self) -> int:
+        return 0
+
+    def get_chunk_count(self) -> int:
+        return 0
+
+    def close(self) -> None:
+        pass
+
+
+def test_index_quantize_flags_persist_project_settings(python_simple_repo: Path) -> None:
+    init_project(python_simple_repo)
+    runner = CliRunner()
+
+    with patch("archex.cli.index_cmd.index_repository", return_value=FakeStore()):
+        result = runner.invoke(
+            cli,
+            [
+                "index",
+                str(python_simple_repo),
+                "--quantize-vectors",
+                "--quantize-bits",
+                "2",
+                "--format",
+                "json",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    summary = json.loads(result.output)
+    assert summary["commit_hash"] == "abc123"
+
+    settings = tomllib.loads((python_simple_repo / ".archex" / "settings.toml").read_text())
+    assert settings["index"]["vector"] is True
+    assert settings["index"]["embedder"] == "jina-v2"
+    assert settings["index"]["quantize_vectors"] is True
+    assert settings["index"]["quantize_bits"] == 2
+
+
+def test_index_no_quantize_vectors_persists_false(python_simple_repo: Path) -> None:
+    init_project(python_simple_repo)
+    runner = CliRunner()
+
+    with patch("archex.cli.index_cmd.index_repository", return_value=FakeStore()):
+        result = runner.invoke(
+            cli,
+            [
+                "index",
+                str(python_simple_repo),
+                "--no-quantize-vectors",
+                "--format",
+                "json",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    settings = tomllib.loads((python_simple_repo / ".archex" / "settings.toml").read_text())
+    assert settings["index"]["quantize_vectors"] is False

--- a/tests/index/test_quantize.py
+++ b/tests/index/test_quantize.py
@@ -24,7 +24,7 @@ from archex.index.quantize import (
     unpack_codes,
 )
 from archex.index.vector import VectorIndex
-from archex.models import CodeChunk, SymbolKind
+from archex.models import CodeChunk, IndexConfig, SymbolKind
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -478,6 +478,38 @@ class TestVectorIndexQuantized:
         assert idx2.is_quantized
         results = idx2.search(SAMPLE_CHUNKS[0].content, embedder, top_k=5)
         assert len(results) > 0
+
+
+def test_index_config_metadata_tracks_quantization(tmp_path: Path) -> None:
+    from archex.api import (
+        _index_config_metadata_matches,  # pyright: ignore[reportPrivateUsage]
+        _set_index_config_metadata,  # pyright: ignore[reportPrivateUsage]
+    )
+    from archex.index.store import IndexStore
+
+    store = IndexStore(tmp_path / "index.db")
+    try:
+        _set_index_config_metadata(store, IndexConfig(vector=True))
+        assert _index_config_metadata_matches(store, IndexConfig(vector=True))
+        assert not _index_config_metadata_matches(
+            store,
+            IndexConfig(vector=True, quantize_vectors=True, quantize_bits=4),
+        )
+
+        _set_index_config_metadata(
+            store,
+            IndexConfig(vector=True, quantize_vectors=True, quantize_bits=4),
+        )
+        assert _index_config_metadata_matches(
+            store,
+            IndexConfig(vector=True, quantize_vectors=True, quantize_bits=4),
+        )
+        assert not _index_config_metadata_matches(
+            store,
+            IndexConfig(vector=True, quantize_vectors=True, quantize_bits=2),
+        )
+    finally:
+        store.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -653,6 +653,16 @@ class TestIndexConfigValidation:
         assert config.chunk_min_tokens == 50
         assert config.vector_mode == VectorMode.RAW
         assert config.retrieval_policy == RetrievalPolicy.AUTO
+        assert config.quantize_vectors is False
+        assert config.quantize_bits == 4
+
+    def test_quantize_bits_must_be_supported(self) -> None:
+        with pytest.raises(ValueError, match="quantize_bits must be one of"):
+            IndexConfig(quantize_bits=8)
+
+    def test_quantize_bits_supports_two_and_four(self) -> None:
+        assert IndexConfig(quantize_bits=2).quantize_bits == 2
+        assert IndexConfig(quantize_bits=4).quantize_bits == 4
 
     def test_surrogate_version_must_not_be_empty(self) -> None:
         with pytest.raises(ValueError, match="surrogate_version must not be empty"):


### PR DESCRIPTION
## Summary

- Adds `quantize_vectors` and `quantize_bits` to `IndexConfig` with supported-bit validation.
- Threads quantization config through stored `VectorIndex` build/load call sites while leaving transient rerank vectors unchanged.
- Adds `archex index --quantize-vectors/--no-quantize-vectors` and `--quantize-bits`, persisting project index settings for subsequent runs.

## Stack

Stack-Id: `turboquant-vector-quantization`
Base: `main`
Position: 1/2

1. `turboquant-index-config` -> this PR (#287)
2. `turboquant-benchmark-measurement` -> #288

Depends on: none
Upstack: #288

## Validation

- `uv run ruff format --check .` — passed.
- `uv run pyright src tests` — passed.
- `uv run pytest tests/test_models.py tests/index/test_quantize.py tests/cli/test_index_cmd.py -q --no-cov` — passed, 128 tests.
- `uv run ruff check src/archex/models.py src/archex/api.py src/archex/config.py src/archex/cli/index_cmd.py tests/test_models.py tests/index/test_quantize.py tests/cli/test_index_cmd.py` — passed.
- `uv run pytest -q` — passed, 2376 passed / 4 deselected, coverage 89.48%.
- Smoke: initialized a temporary repo, ran `uv run archex index <repo> --quantize-vectors --allow-remote-code --format json`, then `uv run archex query <repo> ... --allow-remote-code --format markdown`; verified repo-local settings persisted vector + TurboQuant config and `.archex/vectors/raw.vectors.npz` contained `quantize_meta`.
- GitHub checks — passed: test 3.11, 3.12, 3.13; Docker slim; Docker full.

## Review

- Root diff review completed after validation. Fixed finding: `--quantize-vectors` now enables vector indexing and persists the default Jina embedder when no embedder is configured, so the flag produces a quantized vector artifact instead of only toggling metadata.
- Re-review found no remaining blocking findings.
