### PR TITLE
Measure TurboQuant retrieval impact

### DIFF
--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -225,6 +225,7 @@ Unknown files fall back to line-window chunking so they can still be found by BM
 - **Bundle-only eval lane:** `archex benchmark bundle-eval` is explicit opt-in and separate from retrieval gates. It invokes only an operator-supplied local command with the task question, rendered bundle, receipt JSON, and allowed-context policy, then reports bundle-only success and missing-needed-file attribution.
 - **Comparison page:** `docs/ARCHEX_VS_COCOINDEX.md` publishes accepted C1 cells and capability evidence without re-measuring inside docs work.
 - **Chunking A/B:** the benchmark runner records the chunker axis (`default` or `cast`) so stores and benchmark outputs built with different chunkers are not compared silently.
+- **TurboQuant vector A/B:** `archex_query_hybrid_quantized_4bit` builds a separate 4-bit TurboQuant vector artifact and records measured `.npz` sizes, compression ratio, recall/MRR/F1 deltas, required-file recall delta, and query latency delta against `archex_query_hybrid`.
 
 ### 1.3 Dependency Architecture
 
@@ -321,6 +322,8 @@ class IndexConfig:
     chunk_max_tokens: int = 500
     chunk_min_tokens: int = 50
     token_encoding: str = "cl100k_base"
+    quantize_vectors: bool = True               # Enable 4-bit TurboQuant vector storage by default
+    quantize_bits: int = 4                      # Supported TurboQuant bit widths: 2 or 4
 ```
 
 ### 2.2 Intermediate Models (Pipeline Outputs)
@@ -864,35 +867,101 @@ LIMIT ?;
 
 #### 3.3.4 Vector Index
 
-Optional, activated via `IndexConfig(vector=True)`.
+Optional, activated via `IndexConfig(vector=True)`. Stored vector artifacts use TurboQuant
+by default through `IndexConfig(quantize_vectors=True, quantize_bits=4)`.
+TurboQuant applies a random orthogonal rotation, 4-bit Beta-distribution scalar
+quantization, and QJL dot products in rotated space. `VectorIndex.load()` reads
+artifact metadata so old unquantized `.npz` files and new quantized `.npz` files
+remain self-describing.
 
 ```python
 class VectorIndex:
-    """Simple embedding-based similarity search."""
+    """Embedding-based similarity search with optional TurboQuant storage."""
 
-    def __init__(self, embedder: Embedder):
+    def __init__(
+        self,
+        embedder: Embedder,
+        *,
+        quantize: bool = False,
+        quantize_bits: int = 4,
+    ):
         self.embedder = embedder
-        self.vectors: np.ndarray | None = None  # (n_chunks, dim)
+        self.quantize = quantize
+        self.quantize_bits = quantize_bits
+        self.vectors: np.ndarray | None = None
+        self.quantized_vectors: QuantizedVectors | None = None
         self.chunk_ids: list[str] = []
 
     def build(self, chunks: list[CodeChunk]) -> None:
         texts = [c.imports_context + "\n" + c.content for c in chunks]
-        self.vectors = self.embedder.embed(texts)
+        vectors = self.embedder.embed(texts)
+        self.vectors = vectors
+        self.quantized_vectors = quantize_vectors(vectors, bits=self.quantize_bits) if self.quantize else None
         self.chunk_ids = [c.id for c in chunks]
 
     def search(self, query: str, top_k: int = 20) -> list[tuple[str, float]]:
         query_vec = self.embedder.embed([query])[0]
-        similarities = self.vectors @ query_vec  # Cosine sim (vectors are normalized)
-        top_indices = np.argsort(similarities)[::-1][:top_k]
-        return [(self.chunk_ids[i], float(similarities[i])) for i in top_indices]
+        if self.quantized_vectors is not None:
+            scores = self.quantized_vectors.dot(query_vec)
+        else:
+            scores = self.vectors @ query_vec
+        top_indices = np.argsort(scores)[::-1][:top_k]
+        return [(self.chunk_ids[i], float(scores[i])) for i in top_indices]
 
     def save(self, path: Path) -> None:
-        np.save(path / "vectors.npy", self.vectors)
-        (path / "chunk_ids.json").write_text(json.dumps(self.chunk_ids))
+        # Writes vectors.npz with quantize_meta when quantized.
+        ...
 
     @classmethod
     def load(cls, path: Path, embedder: Embedder) -> "VectorIndex": ...
 ```
+
+2026-06-18 local benchmark comparison:
+
+- Candidate: `uv run archex benchmark run --strategy archex_query_hybrid_quantized_4bit --output .archex/e2e-quantized --allow-remote-code --no-progress`
+- Baseline: `uv run archex benchmark run --strategy archex_query_hybrid --output .archex/e2e-baseline --allow-remote-code --no-progress`
+- Report: `uv run archex benchmark report --input .archex/e2e-quantized --baseline .archex/e2e-baseline --format markdown`
+- Corpus: 35 benchmark tasks under `benchmarks/tasks`.
+- Aggregate result: 7.07× mean vector `.npz` compression, 6.98× minimum compression, recall Δ +0.000, MRR Δ +0.000, F1 Δ +0.000, required-file recall Δ +0.000, mean query latency Δ +110 ms.
+- Default decision: enable 4-bit TurboQuant by default. The Workstream 6 gate passed because aggregate recall and MRR did not regress by more than 0.02, and measured compression stayed above the 6× threshold.
+
+| Task | Recall Δ | MRR Δ | F1 Δ | Required Recall Δ | Latency Δ ms | Compression |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `archex_adapter_registry` | +0.000 | +0.000 | +0.000 | +0.000 | +73 | 7.04x |
+| `archex_benchmark_gate_lifecycle` | +0.000 | +0.000 | +0.000 | +0.000 | +342 | 7.04x |
+| `archex_delta_index_lifecycle` | +0.000 | +0.000 | +0.000 | +0.000 | +113 | 7.04x |
+| `archex_delta_indexing` | +0.000 | +0.000 | +0.000 | +0.000 | +75 | 7.04x |
+| `archex_graph_expansion` | +0.000 | +0.000 | +0.000 | +0.000 | +73 | 7.04x |
+| `archex_mcp_query_lifecycle` | +0.000 | +0.000 | +0.000 | +0.000 | +29 | 7.04x |
+| `archex_pattern_detection` | +0.000 | +0.000 | +0.000 | +0.000 | +648 | 7.04x |
+| `archex_project_config_resolution` | +0.000 | +0.000 | +0.000 | +0.000 | +228 | 7.04x |
+| `archex_project_index` | +0.000 | +0.000 | +0.000 | +0.000 | +172 | 7.04x |
+| `archex_project_init` | +0.000 | +0.000 | +0.000 | +0.000 | +119 | 7.04x |
+| `archex_project_reset` | +0.000 | +0.000 | +0.000 | +0.000 | +833 | 7.04x |
+| `archex_project_status` | +0.000 | +0.000 | +0.000 | +0.000 | +197 | 7.04x |
+| `archex_query_cache_lifecycle` | +0.000 | +0.000 | +0.000 | +0.000 | +65 | 7.04x |
+| `archex_query_pipeline` | +0.000 | +0.000 | +0.000 | +0.000 | +52 | 7.04x |
+| `archex_scoring` | +0.000 | +0.000 | +0.000 | +0.000 | +39 | 7.04x |
+| `archex_vector_cache_lifecycle` | +0.000 | +0.000 | +0.000 | +0.000 | +307 | 7.04x |
+| `celery_task_dispatch` | +0.000 | +0.000 | +0.000 | +0.000 | +26 | 7.11x |
+| `click_decorators` | +0.000 | +0.000 | +0.000 | +0.000 | +37 | 7.07x |
+| `django_middleware` | +0.000 | +0.000 | +0.000 | +0.000 | +60 | 7.03x |
+| `django_orm_queries` | +0.000 | +0.000 | +0.000 | +0.000 | +53 | 7.13x |
+| `express_error_handling` | +0.000 | +0.000 | +0.000 | +0.000 | +20 | 6.98x |
+| `express_middleware` | +0.000 | +0.000 | +0.000 | +0.000 | +24 | 6.98x |
+| `fastapi_dependency_injection` | +0.000 | +0.000 | +0.000 | +0.000 | +25 | 7.35x |
+| `fastapi_routing` | +0.000 | +0.000 | +0.000 | +0.000 | +17 | 7.48x |
+| `flask_blueprints` | +0.000 | +0.000 | +0.000 | +0.000 | +12 | 7.04x |
+| `gin_routing` | +0.000 | +0.000 | +0.000 | +0.000 | +30 | 7.04x |
+| `go_gin_middleware` | +0.000 | +0.000 | +0.000 | +0.000 | +18 | 7.04x |
+| `httpx_pooling` | +0.000 | +0.000 | +0.000 | +0.000 | +22 | 7.09x |
+| `mini_redis_async` | +0.000 | +0.000 | +0.000 | +0.000 | +14 | 7.02x |
+| `pydantic_validators` | +0.000 | +0.000 | +0.000 | +0.000 | +16 | 7.10x |
+| `pytest_fixtures` | +0.000 | +0.000 | +0.000 | +0.000 | +71 | 7.04x |
+| `react_hooks` | +0.000 | +0.000 | +0.000 | +0.000 | +3 | 7.12x |
+| `requests_sessions` | +0.000 | +0.000 | +0.000 | +0.000 | -8 | 7.03x |
+| `rust_tokio_runtime` | +0.000 | +0.000 | +0.000 | +0.000 | +17 | 7.04x |
+| `sqlalchemy_sessions` | +0.000 | +0.000 | +0.000 | +0.000 | +14 | 7.11x |
 
 #### 3.3.5 Index Persistence (SQLite)
 
@@ -1182,7 +1251,7 @@ graph TD
 
 ### 4.3 Cache Identity Strategy
 
-Repo-local mode uses the repository root plus `.archex/settings.toml` as the durable identity. Benchmark and remote-repo cache identities include the source identity, target path, retrieval strategy, embedder, vector mode, chunker, chunker revision, and config hash. The chunker axis is part of the identity so `default` and `cast` stores are never reused across each other silently.
+Repo-local mode uses the repository root plus `.archex/settings.toml` as the durable identity. Benchmark and remote-repo cache identities include the source identity, target path, retrieval strategy, embedder, vector mode, chunker, chunker revision, quantization mode and bit width, and config hash. The chunker and quantization axes are part of the identity so `default`/`cast` stores and quantized/unquantized vector artifacts are never reused across each other silently.
 
 ---
 

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -24,6 +24,8 @@ class Strategy(StrEnum):
     ARCHEX_QUERY_VECTOR = "archex_query_vector"
     SURROGATE_VECTOR = "surrogate_vector"
     ARCHEX_QUERY_FUSION = "archex_query_fusion"
+    ARCHEX_QUERY_HYBRID = "archex_query_hybrid"
+    ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT = "archex_query_hybrid_quantized_4bit"
     CROSS_LAYER_FUSION = "cross_layer_fusion"
     ARCHEX_QUERY_FUSION_RERANK = "archex_query_fusion_rerank"
     EXTERNAL_MCP = "external_mcp"

--- a/src/archex/benchmark/preflight.py
+++ b/src/archex/benchmark/preflight.py
@@ -11,6 +11,8 @@ _VECTOR_MODEL_STRATEGIES: frozenset[Strategy] = frozenset(
         Strategy.ARCHEX_QUERY_VECTOR,
         Strategy.SURROGATE_VECTOR,
         Strategy.ARCHEX_QUERY_FUSION,
+        Strategy.ARCHEX_QUERY_HYBRID,
+        Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT,
         Strategy.ARCHEX_QUERY_FUSION_RERANK,
         Strategy.CROSS_LAYER_FUSION,
     }

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from archex.benchmark.models import BenchmarkReport, DeltaBenchmarkResult
+    from archex.benchmark.models import BenchmarkReport, BenchmarkResult, DeltaBenchmarkResult
 
 
 _SUMMARY_FIELDS = (
@@ -258,6 +258,97 @@ def format_bucketed_summary(reports: list[BenchmarkReport]) -> str:
     for cat in sorted(buckets.keys()):
         lines.extend(_summary_table(cat, buckets[cat]))
 
+    return "\n".join(lines)
+
+
+def _result_for_strategy(report: BenchmarkReport, strategy: str) -> BenchmarkResult | None:
+    for result in report.results:
+        if result.strategy.value == strategy:
+            return result
+    return None
+
+
+def format_baseline_comparison(
+    candidate_reports: list[BenchmarkReport],
+    baseline_reports: list[BenchmarkReport],
+    *,
+    candidate_strategy: str,
+    baseline_strategy: str,
+) -> str:
+    """Render per-task and aggregate deltas between two result directories."""
+    if not candidate_reports or not baseline_reports:
+        return "No baseline comparison available."
+
+    baseline_by_task = {report.task_id: report for report in baseline_reports}
+    rows: list[tuple[str, float, float, float, float, float, float]] = []
+    compression_ratios: list[float] = []
+    for candidate_report in candidate_reports:
+        baseline_report = baseline_by_task.get(candidate_report.task_id)
+        if baseline_report is None:
+            continue
+        candidate = _result_for_strategy(candidate_report, candidate_strategy)
+        baseline = _result_for_strategy(baseline_report, baseline_strategy)
+        if candidate is None or baseline is None:
+            continue
+        compression_ratio = float(candidate.provenance.get("vector_compression_ratio", "0") or 0)
+        if compression_ratio:
+            compression_ratios.append(compression_ratio)
+        rows.append(
+            (
+                candidate_report.task_id,
+                candidate.recall - baseline.recall,
+                candidate.mrr - baseline.mrr,
+                candidate.f1_score - baseline.f1_score,
+                candidate.required_file_recall - baseline.required_file_recall,
+                candidate.wall_time_ms - baseline.wall_time_ms,
+                compression_ratio,
+            )
+        )
+
+    if not rows:
+        return "No matching strategy results found for baseline comparison."
+
+    lines = [
+        "# Baseline Comparison",
+        "",
+        f"Candidate: `{candidate_strategy}`",
+        f"Baseline: `{baseline_strategy}`",
+        "",
+        "| Task | Recall Δ | MRR Δ | F1 Δ | Required Recall Δ | Latency Δ ms | Compression |",
+        "|------|----------|-------|------|-------------------|--------------|-------------|",
+    ]
+    for (
+        task_id,
+        recall_delta,
+        mrr_delta,
+        f1_delta,
+        required_delta,
+        latency_delta,
+        compression,
+    ) in rows:
+        compression_cell = f"{compression:.2f}x" if compression else "n/a"
+        lines.append(
+            f"| {task_id} | {recall_delta:+.3f} | {mrr_delta:+.3f} "
+            f"| {f1_delta:+.3f} | {required_delta:+.3f} "
+            f"| {latency_delta:+.0f} | {compression_cell} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Aggregate",
+            "",
+            f"- Recall Δ: {_mean([row[1] for row in rows]):+.3f}",
+            f"- MRR Δ: {_mean([row[2] for row in rows]):+.3f}",
+            f"- F1 Δ: {_mean([row[3] for row in rows]):+.3f}",
+            f"- Required recall Δ: {_mean([row[4] for row in rows]):+.3f}",
+            f"- Latency Δ ms: {_mean([row[5] for row in rows]):+.0f}",
+            f"- Compression: {_mean(compression_ratios):.2f}x"
+            if compression_ratios
+            else "- Compression: n/a",
+            "",
+        ]
+    )
     return "\n".join(lines)
 
 

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -43,6 +43,8 @@ AVAILABLE_STRATEGIES: list[Strategy] = [
     *DEFAULT_STRATEGIES,
     Strategy.ARCHEX_SCOUT_FETCH,
     Strategy.ARCHEX_QUERY_FUSION,
+    Strategy.ARCHEX_QUERY_HYBRID,
+    Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT,
     Strategy.ARCHEX_QUERY_FUSION_RERANK,
     Strategy.CROSS_LAYER_FUSION,
 ]
@@ -53,6 +55,8 @@ _VECTOR_STRATEGIES: frozenset[Strategy] = frozenset(
         Strategy.SURROGATE_VECTOR,
         Strategy.ARCHEX_QUERY_FUSION,
         Strategy.ARCHEX_QUERY_FUSION_RERANK,
+        Strategy.ARCHEX_QUERY_HYBRID,
+        Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT,
         Strategy.CROSS_LAYER_FUSION,
     }
 )
@@ -79,7 +83,7 @@ def _warm_repo_index(
     repo_path: Path,
     retrieval_options: BenchmarkRetrievalOptions | None = None,
     *,
-    warm_rerank: bool = False,
+    warm_strategy: Strategy = Strategy.ARCHEX_QUERY_FUSION,
 ) -> None:
     """Pre-build the shared vector index so every vector strategy runs warm.
 
@@ -95,15 +99,19 @@ def _warm_repo_index(
     from archex.models import Config, IndexConfig
 
     retrieval_options = retrieval_options or BenchmarkRetrievalOptions()
-    warm_strategy = (
-        Strategy.ARCHEX_QUERY_FUSION_RERANK if warm_rerank else Strategy.ARCHEX_QUERY_FUSION
-    )
+    warm_rerank = warm_strategy is Strategy.ARCHEX_QUERY_FUSION_RERANK
+    if warm_strategy is Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT:
+        base_config = IndexConfig(vector=True, quantize_vectors=True, quantize_bits=4)
+    elif warm_strategy in {Strategy.ARCHEX_QUERY_HYBRID, Strategy.ARCHEX_QUERY_FUSION}:
+        base_config = IndexConfig(vector=True, quantize_vectors=False)
+    else:
+        base_config = IndexConfig(vector=True, rerank=warm_rerank, quantize_vectors=False)
     token = set_benchmark_retrieval_options(retrieval_options)
     try:
         source = benchmark_repo_source(task, repo_path, strategy=warm_strategy)
         config = Config(cache=True, languages=task.languages)
         index_config = benchmark_index_config(
-            IndexConfig(vector=True, rerank=warm_rerank),
+            base_config,
             strategy=warm_strategy,
         )
     finally:
@@ -187,18 +195,25 @@ def run_benchmark(
     retrieval_options = retrieval_options or BenchmarkRetrievalOptions()
     token = set_benchmark_retrieval_options(retrieval_options)
     try:
-        should_warm = _check_vector_available() and any(s in _VECTOR_STRATEGIES for s in strategies)
-        should_warm_rerank = Strategy.ARCHEX_QUERY_FUSION_RERANK in strategies
-        if should_warm:
+        warm_strategies: list[Strategy] = []
+        if _check_vector_available() and any(s in _VECTOR_STRATEGIES for s in strategies):
+            warm_rerank = Strategy.ARCHEX_QUERY_FUSION_RERANK in strategies
+            warm_strategies.append(
+                Strategy.ARCHEX_QUERY_FUSION_RERANK if warm_rerank else Strategy.ARCHEX_QUERY_FUSION
+            )
+            if Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT in strategies:
+                warm_strategies.append(Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT)
+        if warm_strategies:
             _log_progress(progress, f"  warming vector index for {task.task_id}...")
             if progress is not None:
                 progress.start_warmup()
-            _warm_repo_index(
-                task,
-                repo_path,
-                retrieval_options,
-                warm_rerank=should_warm_rerank,
-            )
+            for warm_strategy in warm_strategies:
+                _warm_repo_index(
+                    task,
+                    repo_path,
+                    retrieval_options,
+                    warm_strategy=warm_strategy,
+                )
         if progress is not None:
             progress.finish_warmup(strategies)
 

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -816,6 +816,8 @@ _VECTOR_CHUNKER_STRATEGIES = frozenset(
         Strategy.SURROGATE_VECTOR,
         Strategy.ARCHEX_QUERY_FUSION,
         Strategy.ARCHEX_QUERY_FUSION_RERANK,
+        Strategy.ARCHEX_QUERY_HYBRID,
+        Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT,
         Strategy.CROSS_LAYER_FUSION,
     }
 )
@@ -872,6 +874,8 @@ def _retrieval_cache_suffix(
             enabled.append(f"vector-chunker={vector_chunker}")
     else:
         enabled.append(f"chunker={_chunker_for_strategy(strategy, options)}")
+    if strategy is Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT:
+        enabled.append("quantize=4bit")
     if options.splade:
         enabled.append("splade")
     if options.module_prefilter:
@@ -1355,7 +1359,7 @@ def run_archex_query_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
         task,
         repo_path,
         strategy=Strategy.ARCHEX_QUERY_VECTOR,
-        index_config=IndexConfig(bm25=False, vector=True),
+        index_config=IndexConfig(bm25=False, vector=True, quantize_vectors=False),
         cache=True,
     )
 
@@ -1385,9 +1389,121 @@ def run_archex_query_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRe
         task,
         repo_path,
         strategy=Strategy.ARCHEX_QUERY_FUSION,
-        index_config=IndexConfig(vector=True),
+        index_config=IndexConfig(vector=True, quantize_vectors=False),
         cache=True,
     )
+
+
+def run_archex_query_hybrid(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
+    """Alias for the BM25 + independent vector hybrid retrieval strategy."""
+    result = _run_query_strategy(
+        task,
+        repo_path,
+        strategy=Strategy.ARCHEX_QUERY_HYBRID,
+        index_config=IndexConfig(vector=True, quantize_vectors=False),
+        cache=True,
+    )
+    return result
+
+
+def _vector_artifact_matches_config(path: Path, index_config: IndexConfig) -> bool:
+    if not path.exists():
+        return False
+
+    try:
+        import numpy as np
+
+        with np.load(str(path), allow_pickle=False) as data:
+            quantized = "quantize_meta" in data
+            if not index_config.quantize_vectors:
+                return not quantized
+            if not quantized:
+                return False
+            meta = list(data["quantize_meta"])
+            return int(meta[0]) == index_config.quantize_bits
+    except (OSError, ValueError, KeyError, IndexError, TypeError):
+        return False
+
+
+def _ensure_vector_artifact(
+    task: BenchmarkTask,
+    repo_path: Path,
+    *,
+    strategy: Strategy,
+    index_config: IndexConfig,
+) -> Path:
+    source = benchmark_repo_source(task, repo_path, strategy=strategy)
+    effective_config = benchmark_index_config(index_config, strategy=strategy)
+    cache = CacheManager()
+    key = cache.cache_key(source)
+    path = cache.vector_path(
+        key,
+        vector_mode=effective_config.vector_mode,
+        surrogate_version=effective_config.surrogate_version,
+    )
+    if _vector_artifact_matches_config(path, effective_config):
+        return path
+    if path.exists():
+        path.unlink()
+
+    from archex.api import query
+    from archex.models import Config
+
+    cache.invalidate(key)
+    timing = PipelineTiming()
+    query(
+        source,
+        task.question,
+        token_budget=task.token_budget,
+        explicit_token_budget=True,
+        config=Config(cache=True, languages=task.languages),
+        index_config=effective_config,
+        timing=timing,
+    )
+    return path
+
+
+def _quantized_storage_provenance(task: BenchmarkTask, repo_path: Path) -> dict[str, str]:
+    unquantized_path = _ensure_vector_artifact(
+        task,
+        repo_path,
+        strategy=Strategy.ARCHEX_QUERY_HYBRID,
+        index_config=IndexConfig(vector=True, quantize_vectors=False),
+    )
+    quantized_path = _ensure_vector_artifact(
+        task,
+        repo_path,
+        strategy=Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT,
+        index_config=IndexConfig(vector=True, quantize_vectors=True, quantize_bits=4),
+    )
+    unquantized_bytes = unquantized_path.stat().st_size if unquantized_path.exists() else 0
+    quantized_bytes = quantized_path.stat().st_size if quantized_path.exists() else 0
+    compression_ratio = (
+        unquantized_bytes / quantized_bytes if unquantized_bytes and quantized_bytes else 0.0
+    )
+    size_ratio = (
+        quantized_bytes / unquantized_bytes if unquantized_bytes and quantized_bytes else 0.0
+    )
+    return {
+        "unquantized_vector_npz_bytes": str(unquantized_bytes),
+        "quantized_vector_npz_bytes": str(quantized_bytes),
+        "vector_compression_ratio": f"{compression_ratio:.6f}",
+        "quantized_vector_size_ratio": f"{size_ratio:.6f}",
+    }
+
+
+def run_archex_query_hybrid_quantized_4bit(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
+    """Hybrid retrieval with 4-bit TurboQuant vector storage."""
+    provenance = _quantized_storage_provenance(task, repo_path)
+    result = _run_query_strategy(
+        task,
+        repo_path,
+        strategy=Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT,
+        index_config=IndexConfig(vector=True, quantize_vectors=True, quantize_bits=4),
+        cache=True,
+    )
+    result.provenance = result.provenance | provenance
+    return result
 
 
 def run_archex_query_fusion_rerank(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
@@ -1396,7 +1512,7 @@ def run_archex_query_fusion_rerank(task: BenchmarkTask, repo_path: Path) -> Benc
         task,
         repo_path,
         strategy=Strategy.ARCHEX_QUERY_FUSION_RERANK,
-        index_config=IndexConfig(vector=True, rerank=True),
+        index_config=IndexConfig(vector=True, rerank=True, quantize_vectors=False),
         cache=True,
     )
 
@@ -1480,6 +1596,11 @@ default_strategy_registry.register(Strategy.ARCHEX_SCOUT_FETCH.value, run_archex
 default_strategy_registry.register(Strategy.ARCHEX_QUERY_VECTOR.value, run_archex_query_vector)
 default_strategy_registry.register(Strategy.SURROGATE_VECTOR.value, run_surrogate_vector)
 default_strategy_registry.register(Strategy.ARCHEX_QUERY_FUSION.value, run_archex_query_fusion)
+default_strategy_registry.register(Strategy.ARCHEX_QUERY_HYBRID.value, run_archex_query_hybrid)
+default_strategy_registry.register(
+    Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT.value,
+    run_archex_query_hybrid_quantized_4bit,
+)
 default_strategy_registry.register(
     Strategy.ARCHEX_QUERY_FUSION_RERANK.value, run_archex_query_fusion_rerank
 )

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -53,6 +53,7 @@ from archex.benchmark.readiness import (
     format_readiness_markdown,
 )
 from archex.benchmark.reporter import (
+    format_baseline_comparison,
     format_bucketed_summary,
     format_chunker_frontier_table,
     format_delta_summary,
@@ -365,7 +366,14 @@ def bundle_eval_cmd(
     type=click.Path(exists=True),
     help="Directory containing result JSON files.",
 )
-def report_cmd(output_format: str, input_dir: str) -> None:
+@click.option(
+    "--baseline",
+    "baseline_dir",
+    default=None,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+    help="Optional baseline result directory for strategy delta reporting.",
+)
+def report_cmd(output_format: str, input_dir: str, baseline_dir: str | None) -> None:
     """Generate formatted reports from benchmark results."""
     input_path = Path(input_dir)
     reports: list[BenchmarkReport] = []
@@ -373,6 +381,13 @@ def report_cmd(output_format: str, input_dir: str) -> None:
     for json_file in sorted(input_path.glob("*.json")):
         data = json.loads(json_file.read_text(encoding="utf-8"))
         reports.append(BenchmarkReport.model_validate(data))
+    baseline_reports: list[BenchmarkReport] = []
+    if baseline_dir is not None:
+        for json_file in sorted(Path(baseline_dir).glob("*.json")):
+            data = json.loads(json_file.read_text(encoding="utf-8"))
+            baseline_reports.append(BenchmarkReport.model_validate(data))
+        if not baseline_reports:
+            raise click.ClickException(f"No baseline result files found in {baseline_dir}")
 
     if not reports:
         raise click.ClickException(f"No result files found in {input_dir}")
@@ -385,6 +400,15 @@ def report_cmd(output_format: str, input_dir: str) -> None:
             click.echo(format_markdown(report))
         click.echo(format_summary(reports))
         click.echo(format_bucketed_summary(reports))
+        if baseline_reports:
+            click.echo(
+                format_baseline_comparison(
+                    reports,
+                    baseline_reports,
+                    candidate_strategy=Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT.value,
+                    baseline_strategy=Strategy.ARCHEX_QUERY_HYBRID.value,
+                )
+            )
 
 
 @benchmark_cmd.command("triage")

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -220,7 +220,7 @@ class IndexConfig(BaseModel):
     chunk_min_tokens: int = 50
     token_encoding: str = "cl100k_base"
     allow_remote_code: bool = False
-    quantize_vectors: bool = False
+    quantize_vectors: bool = True
     quantize_bits: int = 4
 
     @model_validator(mode="after")

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -100,6 +100,71 @@ class TestReportCommand:
         data = json.loads(result.output)
         assert data["task_id"] == "test"
 
+    def test_markdown_output_with_baseline_comparison(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        candidate_dir = tmp_path / "candidate"
+        baseline_dir = tmp_path / "baseline"
+        candidate_dir.mkdir()
+        baseline_dir.mkdir()
+        baseline = BenchmarkReport(
+            task_id="test",
+            repo="owner/repo",
+            question="How?",
+            results=[
+                BenchmarkResult(
+                    task_id="test",
+                    strategy=Strategy.ARCHEX_QUERY_HYBRID,
+                    tokens_total=100,
+                    tool_calls=1,
+                    files_accessed=1,
+                    recall=0.8,
+                    precision=1.0,
+                    f1_score=0.89,
+                    mrr=0.5,
+                    savings_vs_raw=0.0,
+                    wall_time_ms=10.0,
+                    cached=True,
+                    timestamp="2025-01-01T00:00:00Z",
+                )
+            ],
+            baseline_tokens=100,
+        )
+        candidate = baseline.model_copy(
+            update={
+                "results": [
+                    BenchmarkResult(
+                        task_id="test",
+                        strategy=Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT,
+                        tokens_total=100,
+                        tool_calls=1,
+                        files_accessed=1,
+                        recall=0.79,
+                        precision=1.0,
+                        f1_score=0.88,
+                        mrr=0.5,
+                        savings_vs_raw=0.0,
+                        wall_time_ms=12.0,
+                        cached=True,
+                        timestamp="2025-01-01T00:00:00Z",
+                        provenance={"vector_compression_ratio": "7.5"},
+                    )
+                ]
+            }
+        )
+        (baseline_dir / "test.json").write_text(baseline.model_dump_json(indent=2))
+        (candidate_dir / "test.json").write_text(candidate.model_dump_json(indent=2))
+
+        result = runner.invoke(
+            benchmark_cmd,
+            ["report", "--input", str(candidate_dir), "--baseline", str(baseline_dir)],
+        )
+
+        assert result.exit_code == 0
+        assert "# Baseline Comparison" in result.output
+        assert "| test | -0.010 | +0.000 | -0.010" in result.output
+        assert "- Compression: 7.50x" in result.output
+
     def test_no_results_error(self, runner: CliRunner, tmp_path: Path) -> None:
         empty_dir = tmp_path / "empty"
         empty_dir.mkdir()

--- a/tests/benchmark/test_models.py
+++ b/tests/benchmark/test_models.py
@@ -32,6 +32,8 @@ class TestStrategy:
         assert Strategy.ARCHEX_QUERY_VECTOR == "archex_query_vector"
         assert Strategy.SURROGATE_VECTOR == "surrogate_vector"
         assert Strategy.ARCHEX_QUERY_FUSION == "archex_query_fusion"
+        assert Strategy.ARCHEX_QUERY_HYBRID == "archex_query_hybrid"
+        assert Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT == "archex_query_hybrid_quantized_4bit"
         assert Strategy.CROSS_LAYER_FUSION == "cross_layer_fusion"
         assert Strategy.ARCHEX_QUERY_FUSION_RERANK == "archex_query_fusion_rerank"
         assert Strategy.EXTERNAL_MCP == "external_mcp"

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -44,6 +44,8 @@ class TestAvailableStrategies:
         assert Strategy.ARCHEX_SCOUT_FETCH in AVAILABLE_STRATEGIES
         assert Strategy.ARCHEX_QUERY_FUSION in AVAILABLE_STRATEGIES
         assert Strategy.CROSS_LAYER_FUSION in AVAILABLE_STRATEGIES
+        assert Strategy.ARCHEX_QUERY_HYBRID in AVAILABLE_STRATEGIES
+        assert Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT in AVAILABLE_STRATEGIES
 
 
 class TestBenchmarkPreflight:
@@ -183,16 +185,16 @@ class TestRunBenchmark:
         from archex.benchmark.strategies import default_strategy_registry
         from archex.exceptions import ArchexIndexError
 
-        warmed: list[tuple[Path, BenchmarkRetrievalOptions | None, bool]] = []
+        warmed: list[tuple[Path, BenchmarkRetrievalOptions | None, Strategy]] = []
 
         def _record(
             _task: BenchmarkTask,
             path: Path,
             options: BenchmarkRetrievalOptions | None = None,
             *,
-            warm_rerank: bool = False,
+            warm_strategy: Strategy = Strategy.ARCHEX_QUERY_FUSION,
         ) -> None:
-            warmed.append((path, options, warm_rerank))
+            warmed.append((path, options, warm_strategy))
 
         def _raise(_task: BenchmarkTask, _path: Path) -> None:
             raise ArchexIndexError("no vector backend in test")
@@ -209,7 +211,13 @@ class TestRunBenchmark:
             repo_path=repo_path,
             retrieval_options=BenchmarkRetrievalOptions(embedder="coderank"),
         )
-        assert warmed == [(repo_path, BenchmarkRetrievalOptions(embedder="coderank"), False)]
+        assert warmed == [
+            (
+                repo_path,
+                BenchmarkRetrievalOptions(embedder="coderank"),
+                Strategy.ARCHEX_QUERY_FUSION,
+            )
+        ]
 
     def test_warms_reranker_when_rerank_strategy_present(
         self,
@@ -221,16 +229,16 @@ class TestRunBenchmark:
         from archex.exceptions import ArchexIndexError
 
         task, repo_path = fixture_task
-        warmed: list[tuple[Path, BenchmarkRetrievalOptions | None, bool]] = []
+        warmed: list[tuple[Path, BenchmarkRetrievalOptions | None, Strategy]] = []
 
         def _record(
             _task: BenchmarkTask,
             path: Path,
             options: BenchmarkRetrievalOptions | None = None,
             *,
-            warm_rerank: bool = False,
+            warm_strategy: Strategy = Strategy.ARCHEX_QUERY_FUSION,
         ) -> None:
-            warmed.append((path, options, warm_rerank))
+            warmed.append((path, options, warm_strategy))
 
         def _raise(_task: BenchmarkTask, _path: Path) -> None:
             raise ArchexIndexError("no vector backend in test")
@@ -248,7 +256,7 @@ class TestRunBenchmark:
             repo_path=repo_path,
             retrieval_options=options,
         )
-        assert warmed == [(repo_path, options, True)]
+        assert warmed == [(repo_path, options, Strategy.ARCHEX_QUERY_FUSION_RERANK)]
 
     def test_warm_repo_index_uses_configured_embedder(
         self,
@@ -258,7 +266,7 @@ class TestRunBenchmark:
         from archex.models import ContextBundle, IndexConfig
 
         task, repo_path = fixture_task
-        captured: list[tuple[str | None, bool, str | None, str, int]] = []
+        captured: list[tuple[str | None, bool, str | None, str, int, bool, int]] = []
 
         def fake_query(
             _source: object,
@@ -278,6 +286,8 @@ class TestRunBenchmark:
                     index_config.rerank_model,
                     index_config.chunker,
                     index_config.rerank_candidate_limit,
+                    index_config.quantize_vectors,
+                    index_config.quantize_bits,
                 )
             )
             return ContextBundle(
@@ -305,12 +315,22 @@ class TestRunBenchmark:
                     rerank_model="cross-encoder/ms-marco-MiniLM-L-6-v2",
                     rerank_candidate_limit=3,
                 ),
-                warm_rerank=True,
+                warm_strategy=Strategy.ARCHEX_QUERY_FUSION_RERANK,
+            )
+            runner_mod._warm_repo_index(  # pyright: ignore[reportPrivateUsage]
+                task,
+                repo_path,
+                BenchmarkRetrievalOptions(
+                    embedder="coderank",
+                    vector_chunker="cast",
+                ),
+                warm_strategy=Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT,
             )
 
         assert captured == [
-            ("coderank", False, None, "cast", 4),
-            ("coderank", True, "cross-encoder/ms-marco-MiniLM-L-6-v2", "cast", 3),
+            ("coderank", False, None, "cast", 4, False, 4),
+            ("coderank", True, "cross-encoder/ms-marco-MiniLM-L-6-v2", "cast", 3, False, 4),
+            ("coderank", False, None, "cast", 4, True, 4),
         ]
 
     @REQUIRES_RG

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -32,6 +32,8 @@ from archex.benchmark.strategies import (
     run_archex_query,
     run_archex_query_fusion,
     run_archex_query_fusion_rerank,
+    run_archex_query_hybrid,
+    run_archex_query_hybrid_quantized_4bit,
     run_archex_query_vector,
     run_archex_scout_fetch,
     run_cross_layer_fusion,
@@ -1029,6 +1031,8 @@ def test_vector_strategies_read_configured_embedder(
                 run_archex_query_vector,
                 run_surrogate_vector,
                 run_archex_query_fusion,
+                run_archex_query_hybrid,
+                run_archex_query_hybrid_quantized_4bit,
                 run_cross_layer_fusion,
                 run_archex_query_fusion_rerank,
             ):
@@ -1036,7 +1040,7 @@ def test_vector_strategies_read_configured_embedder(
     finally:
         reset_benchmark_retrieval_options(token)
 
-    assert captured == ["coderank"] * 5
+    assert captured == ["coderank"] * 9
 
 
 class TestRunArchexQueryVector:
@@ -1104,6 +1108,29 @@ class TestRunArchexQueryFusion:
         )
         with patch("archex.api._get_embedder", _stub_get_embedder):
             result = run_archex_query_fusion(task, python_simple_repo)
+        assert result.files_accessed >= 0
+        assert isinstance(result.recall, float)
+        assert isinstance(result.precision, float)
+
+
+class TestRunArchexQueryHybridQuantized4Bit:
+    def test_quantized_strategy_records_storage_provenance(self, python_simple_repo: Path) -> None:
+        task = BenchmarkTask(
+            task_id="test",
+            repo="test/repo",
+            commit="abc",
+            question="How does the main module work?",
+            expected_files=["main.py"],
+            token_budget=4096,
+        )
+        with patch("archex.api._get_embedder", _stub_get_embedder):
+            result = run_archex_query_hybrid_quantized_4bit(task, python_simple_repo)
+
+        assert result.strategy == Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT
+        assert result.provenance["unquantized_vector_npz_bytes"] != "0"
+        assert result.provenance["quantized_vector_npz_bytes"] != "0"
+        assert float(result.provenance["vector_compression_ratio"]) > 1.0
+
         assert result.files_accessed >= 0
         assert isinstance(result.recall, float)
         assert isinstance(result.precision, float)

--- a/tests/benchmark/test_strategy_registry.py
+++ b/tests/benchmark/test_strategy_registry.py
@@ -49,6 +49,8 @@ class TestStrategyRegistry:
         assert Strategy.ARCHEX_QUERY_VECTOR.value in names
         assert Strategy.SURROGATE_VECTOR.value in names
         assert Strategy.ARCHEX_QUERY_FUSION.value in names
+        assert Strategy.ARCHEX_QUERY_HYBRID.value in names
+        assert Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT.value in names
         assert Strategy.CROSS_LAYER_FUSION.value in names
         assert Strategy.ARCHEX_QUERY_FUSION_RERANK.value in names
 

--- a/tests/index/test_quantize.py
+++ b/tests/index/test_quantize.py
@@ -489,8 +489,10 @@ def test_index_config_metadata_tracks_quantization(tmp_path: Path) -> None:
 
     store = IndexStore(tmp_path / "index.db")
     try:
-        _set_index_config_metadata(store, IndexConfig(vector=True))
-        assert _index_config_metadata_matches(store, IndexConfig(vector=True))
+        _set_index_config_metadata(store, IndexConfig(vector=True, quantize_vectors=False))
+        assert _index_config_metadata_matches(
+            store, IndexConfig(vector=True, quantize_vectors=False)
+        )
         assert not _index_config_metadata_matches(
             store,
             IndexConfig(vector=True, quantize_vectors=True, quantize_bits=4),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -653,7 +653,7 @@ class TestIndexConfigValidation:
         assert config.chunk_min_tokens == 50
         assert config.vector_mode == VectorMode.RAW
         assert config.retrieval_policy == RetrievalPolicy.AUTO
-        assert config.quantize_vectors is False
+        assert config.quantize_vectors is True
         assert config.quantize_bits == 4
 
     def test_quantize_bits_must_be_supported(self) -> None:


### PR DESCRIPTION
## Stack

Stack-Id: `turboquant-vector-quantization`
Base: `main`
Position: 2/2

1. `turboquant-index-config` -> #287 (merged)
2. `turboquant-benchmark-measurement` -> this PR

Depends on: #287 (merged)
Upstack: (none - leaf)

## Summary

Measures 4-bit TurboQuant retrieval impact against the unquantized hybrid baseline, records vector storage provenance, and documents the default decision.

## Validation

- GitHub checks after retargeting to `main`: passed.
- Local validation before publishing: passed.
- Benchmark corpus: 35 tasks completed for baseline and quantized strategy.
- Measured mean vector `.npz` compression: 7.07x.
- Aggregate recall delta: 0.000.
- Aggregate MRR delta: 0.000.

## Review status

- Slice review completed; no remaining blocking findings.
- Full stack review completed after #287; no remaining blocking findings.
