### PR TITLE
Compute region, line, ranking, and context-efficiency metrics

### DIFF
--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -371,6 +371,19 @@ class BenchmarkResult(BaseModel):
     chunker: ChunkerName = "default"
     index_chunk_count: int = 0
     mean_chunk_tokens: float = 0.0
+    # Optional region/line-level retrieval-quality metrics. Populated only when a
+    # task declares expected_regions; otherwise left as None ("unknown").
+    region_recall: float | None = None
+    region_precision: float | None = None
+    region_f1: float | None = None
+    line_recall: float | None = None
+    line_precision: float | None = None
+    ranked_region_mrr: float | None = None
+    ranked_region_ndcg: float | None = None
+    context_noise_ratio: float | None = None
+    useful_tokens: int | None = None
+    wasted_tokens: int | None = None
+    relevance_per_1k_tokens: float | None = None
 
 
 class BenchmarkReport(BaseModel):

--- a/src/archex/benchmark/region_metrics.py
+++ b/src/archex/benchmark/region_metrics.py
@@ -1,0 +1,283 @@
+"""Region, line, ranking, and context-efficiency metrics for benchmark results.
+
+These metrics extend the file-level retrieval signals toward block/line-level
+context quality, as motivated by ranked-region exploration benchmarks. They are
+computed only when a task declares ``expected_regions``; file-only tasks report
+``None`` for every region field so existing benchmark conventions are preserved.
+
+The computation is deterministic and local: it depends only on the returned
+context (in ranked order) and the task's ground-truth regions. No network, LLM,
+or hosted calls are involved.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from archex.benchmark.models import ExpectedRegion, RegionGranularity
+
+
+@dataclass(frozen=True)
+class ReturnedRegion:
+    """One returned context unit, in the order the bundle ranks it.
+
+    ``start_line``/``end_line`` are 1-indexed inclusive line bounds. Returned
+    context always carries a line range because it originates from concrete code
+    chunks; ``symbol`` is the chunk's symbol name when one applies.
+    """
+
+    path: str
+    start_line: int
+    end_line: int
+    symbol: str | None
+    tokens: int
+
+
+@dataclass(frozen=True)
+class RegionMetrics:
+    """Derived region/line/ranking/context-efficiency metrics for one result."""
+
+    region_recall: float
+    region_precision: float
+    region_f1: float
+    line_recall: float | None
+    line_precision: float | None
+    ranked_region_mrr: float
+    ranked_region_ndcg: float
+    context_noise_ratio: float
+    useful_tokens: int
+    wasted_tokens: int
+    relevance_per_1k_tokens: float
+
+    def as_result_fields(self) -> dict[str, float | int | None]:
+        """Map to ``BenchmarkResult`` keyword arguments."""
+        return {
+            "region_recall": self.region_recall,
+            "region_precision": self.region_precision,
+            "region_f1": self.region_f1,
+            "line_recall": self.line_recall,
+            "line_precision": self.line_precision,
+            "ranked_region_mrr": self.ranked_region_mrr,
+            "ranked_region_ndcg": self.ranked_region_ndcg,
+            "context_noise_ratio": self.context_noise_ratio,
+            "useful_tokens": self.useful_tokens,
+            "wasted_tokens": self.wasted_tokens,
+            "relevance_per_1k_tokens": self.relevance_per_1k_tokens,
+        }
+
+
+def _ranges_overlap(
+    r_start: int,
+    r_end: int,
+    e_start: int,
+    e_end: int,
+) -> bool:
+    return r_start <= e_end and e_start <= r_end
+
+
+def _symbol_matches(returned: str | None, expected: str | None) -> bool:
+    if not returned or not expected:
+        return False
+    if returned == expected:
+        return True
+    # Returned chunk symbols are often unqualified (``run``) while labels may be
+    # qualified (``Cli.run``). Match when the shorter dotted path is a trailing
+    # segment-sequence of the longer one, so ``run`` matches ``Cli.run`` but
+    # ``Server.run`` does not match ``Cli.run``.
+    r_parts = returned.split(".")
+    e_parts = expected.split(".")
+    shorter, longer = (r_parts, e_parts) if len(r_parts) <= len(e_parts) else (e_parts, r_parts)
+    return longer[-len(shorter) :] == shorter
+
+
+def _overlaps(returned: ReturnedRegion, expected: ExpectedRegion) -> bool:
+    """Whether a returned region covers an expected region at all."""
+    if returned.path != expected.path:
+        return False
+    if expected.granularity is RegionGranularity.FILE:
+        return True
+    if expected.granularity in (RegionGranularity.SYMBOL, RegionGranularity.BLOCK):
+        if _symbol_matches(returned.symbol, expected.symbol):
+            return True
+        # A symbol/block label may also pin explicit lines; fall through to a
+        # line-overlap match when it does, otherwise it is a miss.
+        if expected.start_line is None:
+            return False
+    if expected.start_line is None or expected.end_line is None:
+        return False
+    return _ranges_overlap(
+        returned.start_line, returned.end_line, expected.start_line, expected.end_line
+    )
+
+
+def _useful_fraction(returned: ReturnedRegion, expected_same_path: list[ExpectedRegion]) -> float:
+    """Fraction of a returned region's lines that fall inside expected regions.
+
+    The fraction is computed over the union of all overlapping expected regions
+    in the same file, so a chunk spanning several labeled regions is credited
+    for every covered line rather than only the single best-overlapping region.
+    """
+    r_lines = returned.end_line - returned.start_line + 1
+    if r_lines <= 0:
+        return 0.0
+    covered: set[int] = set()
+    for expected in expected_same_path:
+        if expected.granularity is RegionGranularity.FILE:
+            return 1.0
+        if expected.granularity in (RegionGranularity.SYMBOL, RegionGranularity.BLOCK):
+            if _symbol_matches(returned.symbol, expected.symbol):
+                return 1.0
+            if expected.start_line is None:
+                continue
+        if expected.start_line is None or expected.end_line is None:
+            continue
+        lo = max(returned.start_line, expected.start_line)
+        hi = min(returned.end_line, expected.end_line)
+        if hi >= lo:
+            covered.update(range(lo, hi + 1))
+    return len(covered) / r_lines
+
+
+def _line_set(region: ExpectedRegion) -> set[tuple[str, int]]:
+    if region.start_line is None or region.end_line is None:
+        return set()
+    return {(region.path, line) for line in range(region.start_line, region.end_line + 1)}
+
+
+def _f1(precision: float, recall: float) -> float:
+    if precision + recall == 0.0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+def _line_metrics(
+    returned_regions: list[ReturnedRegion],
+    expected_regions: list[ExpectedRegion],
+) -> tuple[float | None, float | None]:
+    """Line recall/precision over expected regions that pin explicit line ranges."""
+    expected_lines: set[tuple[str, int]] = set()
+    labeled_files: set[str] = set()
+    for expected in expected_regions:
+        lines = _line_set(expected)
+        if lines:
+            expected_lines |= lines
+            labeled_files.add(expected.path)
+    if not expected_lines:
+        return None, None
+    returned_lines: set[tuple[str, int]] = set()
+    for returned in returned_regions:
+        if returned.path not in labeled_files:
+            continue
+        for line in range(returned.start_line, returned.end_line + 1):
+            returned_lines.add((returned.path, line))
+    covered = expected_lines & returned_lines
+    line_recall = len(covered) / len(expected_lines)
+    line_precision = (len(covered) / len(returned_lines)) if returned_lines else 0.0
+    return line_recall, line_precision
+
+
+def _ranking_metrics(
+    returned_regions: list[ReturnedRegion],
+    expected_regions: list[ExpectedRegion],
+) -> tuple[float, float]:
+    """MRR and weighted nDCG over expected regions using returned context order.
+
+    nDCG credits each expected region at the rank of the first returned region
+    that covers it, and normalizes by the ideal ordering of *all* expected-region
+    weights (descending). Missing a heavily weighted region therefore lowers
+    nDCG even when the regions that were returned are well ordered. Regions that
+    are first surfaced by the same returned chunk are assigned distinct, adjacent
+    effective ranks so a single chunk covering several regions cannot push DCG
+    above the ideal (nDCG stays bounded in [0, 1]).
+    """
+    first_hit_rank = 0
+    for index, returned in enumerate(returned_regions):
+        if any(_overlaps(returned, expected) for expected in expected_regions):
+            first_hit_rank = index + 1
+            break
+    mrr = (1.0 / first_hit_rank) if first_hit_rank else 0.0
+
+    covered: list[tuple[int, float]] = []
+    for expected in expected_regions:
+        for rank_index, returned in enumerate(returned_regions):
+            if _overlaps(returned, expected):
+                covered.append((rank_index, expected.weight))
+                break
+    covered.sort(key=lambda item: (item[0], -item[1]))
+    dcg = 0.0
+    next_rank = 0
+    for first_index, weight in covered:
+        effective_rank = max(first_index, next_rank)
+        dcg += weight / math.log2(effective_rank + 2)
+        next_rank = effective_rank + 1
+    ideal_weights = sorted((expected.weight for expected in expected_regions), reverse=True)
+    idcg = sum(weight / math.log2(i + 2) for i, weight in enumerate(ideal_weights))
+    ndcg = (dcg / idcg) if idcg > 0 else 0.0
+    return mrr, ndcg
+
+
+def compute_region_metrics(
+    returned_regions: list[ReturnedRegion],
+    expected_regions: list[ExpectedRegion],
+) -> RegionMetrics | None:
+    """Compute region/line/ranking/context metrics, or ``None`` without labels.
+
+    ``returned_regions`` must be in the order the downstream model would see them
+    (ranked order), not path-sorted, so ranking metrics reflect early context.
+    """
+    if not expected_regions:
+        return None
+
+    covered_weight = 0.0
+    total_weight = 0.0
+    for expected in expected_regions:
+        total_weight += expected.weight
+        if any(_overlaps(returned, expected) for returned in returned_regions):
+            covered_weight += expected.weight
+    region_recall = (covered_weight / total_weight) if total_weight > 0 else 0.0
+
+    overlapping_returned = sum(
+        1
+        for returned in returned_regions
+        if any(_overlaps(returned, expected) for expected in expected_regions)
+    )
+    region_precision = (overlapping_returned / len(returned_regions)) if returned_regions else 0.0
+    region_f1 = _f1(region_precision, region_recall)
+
+    line_recall, line_precision = _line_metrics(returned_regions, expected_regions)
+    mrr, ndcg = _ranking_metrics(returned_regions, expected_regions)
+
+    by_path: dict[str, list[ExpectedRegion]] = {}
+    for expected in expected_regions:
+        by_path.setdefault(expected.path, []).append(expected)
+
+    # Token accounting is over returned chunk content only (the code context the
+    # model reads), not the result's headline tokens_total, which may also include
+    # scout maps or rendering. This keeps useful + wasted == returned-chunk tokens.
+    total_tokens = 0
+    useful_tokens = 0
+    for returned in returned_regions:
+        total_tokens += returned.tokens
+        same_path = by_path.get(returned.path)
+        if not same_path:
+            continue
+        useful_tokens += round(_useful_fraction(returned, same_path) * returned.tokens)
+    useful_tokens = min(useful_tokens, total_tokens)
+    wasted_tokens = total_tokens - useful_tokens
+    context_noise_ratio = (wasted_tokens / total_tokens) if total_tokens > 0 else 0.0
+    relevance_per_1k_tokens = (region_recall * 1000.0 / total_tokens) if total_tokens > 0 else 0.0
+
+    return RegionMetrics(
+        region_recall=region_recall,
+        region_precision=region_precision,
+        region_f1=region_f1,
+        line_recall=line_recall,
+        line_precision=line_precision,
+        ranked_region_mrr=mrr,
+        ranked_region_ndcg=ndcg,
+        context_noise_ratio=context_noise_ratio,
+        useful_tokens=useful_tokens,
+        wasted_tokens=wasted_tokens,
+        relevance_per_1k_tokens=relevance_per_1k_tokens,
+    )

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -23,6 +23,10 @@ from archex.benchmark.models import (
     Strategy,
     TaskCompletionResult,
 )
+from archex.benchmark.region_metrics import (
+    ReturnedRegion,
+    compute_region_metrics,
+)
 from archex.cache import CacheManager
 from archex.exceptions import ArchexError, ConfigError
 from archex.models import (
@@ -1017,6 +1021,29 @@ def measure_archex_freshness(task: BenchmarkTask, repo_path: Path) -> tuple[floa
         shutil.rmtree(workdir, ignore_errors=True)
 
 
+def _bundle_returned_regions(bundle: ContextBundle) -> list[ReturnedRegion]:
+    """Build ranked returned regions from a context bundle, preserving order."""
+    return [
+        ReturnedRegion(
+            path=ranked.chunk.file_path,
+            start_line=ranked.chunk.start_line,
+            end_line=ranked.chunk.end_line,
+            symbol=ranked.chunk.symbol_name,
+            tokens=count_tokens(ranked.chunk.content),
+        )
+        for ranked in bundle.chunks
+    ]
+
+
+def _region_result_fields(
+    bundle: ContextBundle,
+    task: BenchmarkTask,
+) -> dict[str, float | int | None]:
+    """Region/line/ranking/context-efficiency result fields, empty without labels."""
+    metrics = compute_region_metrics(_bundle_returned_regions(bundle), task.expected_regions)
+    return metrics.as_result_fields() if metrics is not None else {}
+
+
 def _run_query_strategy(
     task: BenchmarkTask,
     repo_path: Path,
@@ -1156,6 +1183,7 @@ def _run_query_strategy(
                 "freshness_correct": freshness_correct,
             }
         )
+    result_fields.update(_region_result_fields(bundle, task))
     return BenchmarkResult(**result_fields)
 
 
@@ -1273,7 +1301,7 @@ def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
         missing_from_fetch_reasons = {
             path: "direct_query_bundle_omission" for path in missing_from_fetch
         }
-    return BenchmarkResult(
+    result = BenchmarkResult(
         task_id=task.task_id,
         strategy=Strategy.ARCHEX_SCOUT_FETCH,
         tokens_total=tokens_total,
@@ -1351,6 +1379,7 @@ def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
             "intent_class": task.category.value if task.category is not None else "uncategorized",
         },
     )
+    return result.model_copy(update=_region_result_fields(bundle, task))
 
 
 def run_archex_query_vector(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -9,7 +9,14 @@ from unittest.mock import patch
 
 import pytest
 
-from archex.benchmark.models import BenchmarkRetrievalOptions, BenchmarkTask, Strategy
+from archex.benchmark.models import (
+    BenchmarkRetrievalOptions,
+    BenchmarkTask,
+    ExpectedRegion,
+    RegionGranularity,
+    Strategy,
+)
+from archex.benchmark.region_metrics import ReturnedRegion, compute_region_metrics
 from archex.benchmark.strategies import (
     _archex_fields,  # pyright: ignore[reportPrivateUsage]
     _deduplicate_ranked,  # pyright: ignore[reportPrivateUsage]
@@ -350,6 +357,150 @@ class TestComputeSymbolRecall:
         assert compute_symbol_recall(set(), ["foo"]) == 0.0
 
 
+class TestComputeRegionMetrics:
+    def test_returns_none_without_labels(self) -> None:
+        returned = [ReturnedRegion("a.py", 1, 10, None, 50)]
+        assert compute_region_metrics(returned, []) is None
+
+    def test_right_file_wrong_lines_fails_region_and_line(self) -> None:
+        # The file is returned (file recall would succeed) but the returned lines
+        # do not overlap the expected region (region/line recall must fail).
+        expected = [ExpectedRegion(path="a.py", start_line=10, end_line=20)]
+        returned = [ReturnedRegion("a.py", 100, 120, None, 200)]
+        metrics = compute_region_metrics(returned, expected)
+        assert metrics is not None
+        assert compute_recall({"a.py"}, ["a.py"]) == 1.0  # file-level success
+        assert metrics.region_recall == 0.0
+        assert metrics.line_recall == 0.0
+        assert metrics.context_noise_ratio == 1.0
+        assert metrics.useful_tokens == 0
+        assert metrics.wasted_tokens == 200
+
+    def test_overlapping_lines_succeed(self) -> None:
+        expected = [ExpectedRegion(path="a.py", start_line=10, end_line=20)]
+        returned = [ReturnedRegion("a.py", 8, 22, None, 150)]
+        metrics = compute_region_metrics(returned, expected)
+        assert metrics is not None
+        assert metrics.region_recall == 1.0
+        assert metrics.region_precision == 1.0
+        assert metrics.line_recall == 1.0  # all 11 expected lines covered
+        # 11 expected lines covered out of 15 returned lines.
+        assert metrics.line_precision == pytest.approx(11 / 15)  # pyright: ignore[reportUnknownMemberType]
+        assert metrics.useful_tokens == round(11 / 15 * 150)
+        assert metrics.ranked_region_mrr == 1.0
+        assert metrics.ranked_region_ndcg == 1.0
+
+    def test_ranking_respects_returned_order_not_path_sort(self) -> None:
+        # The relevant region ("a.py") is returned second; a path-sorted order
+        # would rank it first. MRR must reflect the returned position.
+        expected = [ExpectedRegion(path="z_relevant.py", start_line=10, end_line=20)]
+        returned = [
+            ReturnedRegion("a_irrelevant.py", 1, 5, None, 40),
+            ReturnedRegion("z_relevant.py", 10, 20, None, 40),
+        ]
+        metrics = compute_region_metrics(returned, expected)
+        assert metrics is not None
+        assert metrics.ranked_region_mrr == 0.5
+        # Putting the relevant region first scores a better nDCG.
+        reordered = compute_region_metrics(list(reversed(returned)), expected)
+        assert reordered is not None
+        assert reordered.ranked_region_ndcg > metrics.ranked_region_ndcg
+
+    def test_symbol_region_matches_unqualified_symbol(self) -> None:
+        expected = [
+            ExpectedRegion(path="a.py", granularity=RegionGranularity.SYMBOL, symbol="Cli.run")
+        ]
+        returned = [ReturnedRegion("a.py", 1, 9, "run", 80)]
+        metrics = compute_region_metrics(returned, expected)
+        assert metrics is not None
+        assert metrics.region_recall == 1.0
+        # No explicit expected line range -> line metrics stay unknown.
+        assert metrics.line_recall is None
+        assert metrics.line_precision is None
+        assert metrics.context_noise_ratio == 0.0
+
+    def test_file_granularity_region_covered_by_any_chunk(self) -> None:
+        expected = [ExpectedRegion(path="a.py", granularity=RegionGranularity.FILE)]
+        returned = [ReturnedRegion("a.py", 200, 240, None, 90)]
+        metrics = compute_region_metrics(returned, expected)
+        assert metrics is not None
+        assert metrics.region_recall == 1.0
+        assert metrics.line_recall is None
+        assert metrics.context_noise_ratio == 0.0
+
+    def test_weighted_recall_reflects_region_weight(self) -> None:
+        expected = [
+            ExpectedRegion(path="a.py", start_line=10, end_line=20, weight=3.0),
+            ExpectedRegion(path="b.py", start_line=10, end_line=20, weight=1.0),
+        ]
+        # Only the heavy region is covered: weighted recall = 3 / (3 + 1).
+        returned = [ReturnedRegion("a.py", 10, 20, None, 60)]
+        metrics = compute_region_metrics(returned, expected)
+        assert metrics is not None
+        assert metrics.region_recall == pytest.approx(0.75)  # pyright: ignore[reportUnknownMemberType]
+
+    def test_precision_penalizes_unmatched_returned_regions(self) -> None:
+        expected = [ExpectedRegion(path="a.py", start_line=10, end_line=20)]
+        returned = [
+            ReturnedRegion("a.py", 10, 20, None, 50),
+            ReturnedRegion("noise.py", 1, 5, None, 50),
+        ]
+        metrics = compute_region_metrics(returned, expected)
+        assert metrics is not None
+        assert metrics.region_precision == 0.5
+        assert metrics.context_noise_ratio == 0.5
+        assert metrics.relevance_per_1k_tokens == pytest.approx(1000.0 / 100)  # pyright: ignore[reportUnknownMemberType]
+
+    def test_useful_fraction_unions_multiple_regions_in_one_file(self) -> None:
+        # One chunk spanning two disjoint labeled regions is credited for the
+        # union of covered lines (20/100), not just the best single overlap.
+        expected = [
+            ExpectedRegion(path="a.py", start_line=1, end_line=10),
+            ExpectedRegion(path="a.py", start_line=91, end_line=100),
+        ]
+        returned = [ReturnedRegion("a.py", 1, 100, None, 1000)]
+        metrics = compute_region_metrics(returned, expected)
+        assert metrics is not None
+        assert metrics.useful_tokens == 200
+        assert metrics.wasted_tokens == 800
+        assert metrics.context_noise_ratio == pytest.approx(0.8)  # pyright: ignore[reportUnknownMemberType]
+
+    def test_ndcg_penalizes_missing_heavy_region(self) -> None:
+        # Heaviest region A is missed; only the light region B is returned, so
+        # nDCG must be well below 1.0 even though B is ranked first.
+        expected = [
+            ExpectedRegion(path="a.py", start_line=1, end_line=10, weight=5.0),
+            ExpectedRegion(path="a.py", start_line=100, end_line=110, weight=1.0),
+        ]
+        returned = [ReturnedRegion("a.py", 100, 110, None, 50)]
+        metrics = compute_region_metrics(returned, expected)
+        assert metrics is not None
+        assert metrics.ranked_region_ndcg < 0.5
+
+    def test_ndcg_bounded_when_one_chunk_covers_multiple_regions(self) -> None:
+        # A single returned chunk that covers two adjacent expected regions must
+        # not push nDCG above 1.0; both are surfaced as early as possible.
+        expected = [
+            ExpectedRegion(path="a.py", start_line=1, end_line=10),
+            ExpectedRegion(path="a.py", start_line=11, end_line=20),
+        ]
+        returned = [ReturnedRegion("a.py", 1, 20, None, 100)]
+        metrics = compute_region_metrics(returned, expected)
+        assert metrics is not None
+        assert metrics.ranked_region_ndcg == 1.0
+
+    def test_symbol_match_rejects_different_qualified_symbol(self) -> None:
+        # A qualified label must not be credited by a different qualified symbol
+        # that merely shares the trailing name in the same file.
+        expected = [
+            ExpectedRegion(path="a.py", granularity=RegionGranularity.SYMBOL, symbol="Cli.run")
+        ]
+        returned = [ReturnedRegion("a.py", 1, 9, "Server.run", 80)]
+        metrics = compute_region_metrics(returned, expected)
+        assert metrics is not None
+        assert metrics.region_recall == 0.0
+
+
 class TestRunRawFiles:
     def test_raw_files_strategy(self, python_simple_repo: Path) -> None:
         task = BenchmarkTask(
@@ -575,6 +726,58 @@ class TestRunArchexQuery:
         assert result.required_file_recall == 1.0
         assert result.all_required_files_present is True
         assert result.task_completion_result.value == "pass"
+
+    def test_archex_query_without_regions_leaves_region_fields_none(
+        self,
+        python_simple_repo: Path,
+    ) -> None:
+        task = BenchmarkTask(
+            task_id="test",
+            repo="test/repo",
+            commit="abc",
+            question="How does the main module work?",
+            expected_files=["main.py"],
+            token_budget=4096,
+        )
+        result = run_archex_query(task, python_simple_repo)
+        assert result.region_recall is None
+        assert result.region_precision is None
+        assert result.line_recall is None
+        assert result.ranked_region_mrr is None
+        assert result.context_noise_ratio is None
+        assert result.useful_tokens is None
+        assert result.relevance_per_1k_tokens is None
+
+    def test_archex_query_with_regions_populates_region_fields(
+        self,
+        python_simple_repo: Path,
+    ) -> None:
+        line_count = len((python_simple_repo / "main.py").read_text(encoding="utf-8").splitlines())
+        task = BenchmarkTask(
+            task_id="test",
+            repo="test/repo",
+            commit="abc",
+            question="How does the main module work?",
+            expected_files=["main.py"],
+            token_budget=4096,
+            expected_regions=[
+                ExpectedRegion(path="main.py", start_line=1, end_line=line_count),
+            ],
+        )
+        result = run_archex_query(task, python_simple_repo)
+        # File-level success is unchanged.
+        assert result.required_file_recall == 1.0
+        # Region fields are now populated (a whole-file region is covered when
+        # main.py is returned).
+        assert result.region_recall == 1.0
+        assert result.region_precision is not None
+        assert result.line_recall is not None
+        assert 0.0 <= result.line_recall <= 1.0
+        assert result.ranked_region_mrr is not None
+        assert result.context_noise_ratio is not None
+        assert result.useful_tokens is not None
+        assert result.wasted_tokens is not None
+        assert result.relevance_per_1k_tokens is not None
 
     def test_archex_query_reports_configured_chunker_metadata(
         self,


### PR DESCRIPTION
## Summary

Adds region/line/ranking/context-efficiency metric computation on top of the expected-region schema (PR1). Region metrics are optional and additive: file-level metrics are unchanged and file-only tasks report `None` for every region field.

## Changes

- New `archex.benchmark.region_metrics` module:
  - `ReturnedRegion` (one ranked returned context unit) and `RegionMetrics` (derived fields).
  - `compute_region_metrics(returned_regions, expected_regions)` returns `None` when no labels exist.
  - Region recall is weight-aware; region precision/F1 measure returned-region overlap.
  - Line recall/precision computed only over expected regions that pin explicit line ranges; otherwise `None`.
  - `ranked_region_mrr` and weighted `ranked_region_ndcg` use **returned context order**, not path-sorted order.
  - `context_noise_ratio`, `useful_tokens`, `wasted_tokens`, `relevance_per_1k_tokens` partition returned tokens by per-line overlap with expected regions.
- `BenchmarkResult` gains the 11 optional region fields (default `None`).
- Metrics are wired into every archex chunk-based query strategy (`_run_query_strategy`) and `run_archex_scout_fetch` via the bundle's ranked chunks. Completion-penalty token-efficiency fields are untouched.

## Validation

- `uv run pytest tests/benchmark/test_strategies.py::TestComputeRegionMetrics tests/benchmark/test_strategies.py::TestRunArchexQuery` — 23 passed
- `uv run pytest tests/benchmark/test_models.py tests/benchmark/test_runner.py` — 64 passed
- JSON round-trip confirms region fields serialize and default to `None`.
- `ruff check` / `ruff format --check` — clean

Key test: a task whose right file is returned with the **wrong lines** shows file recall success but region recall = 0 and line recall = 0.

## Stack

Stack-Id: `retrieval-eval-frontier-de6e6a`
Base: `bench/eval-frontier-schema`
Position: 2/4

1. `bench/eval-frontier-schema` -> #291
2. `bench/eval-frontier-metrics` -> this PR
3. `bench/eval-frontier-reports` -> reporter/readiness/gate/triage surfaces
4. `bench/eval-frontier-fixtures-docs` -> fixtures + docs

Depends on: #291
