### PR TITLE
Surface region metrics in reporter, readiness, gate, and triage

### DIFF
--- a/src/archex/benchmark/gate.py
+++ b/src/archex/benchmark/gate.py
@@ -31,6 +31,13 @@ class QualityThresholds(BaseModel):
     min_receipt_accuracy: float = 0.0
     min_token_efficiency_with_completion: float = 0.0
     max_completion_efficiency_regression: float = 0.0
+    # Optional region/line retrieval-quality thresholds. Defaults are permissive
+    # so they never fire unless explicitly configured. Results whose optional
+    # region metric is None (no expected-region labels) are always ignored.
+    min_region_recall: float = 0.0
+    min_line_recall: float = 0.0
+    max_context_noise_ratio: float = 1.0
+    min_relevance_per_1k_tokens: float = 0.0
     # Latency: warn-only, does not fail the gate
     warn_latency_ms: float = 5000.0
     # Strategies exempt from gate checks (results are informational only)
@@ -88,6 +95,20 @@ def _minimum_gate_checks(t: QualityThresholds, strategy: str) -> list[tuple[str,
 
 def _maximum_gate_checks(t: QualityThresholds) -> list[tuple[str, float]]:
     return [("missed_required_task_rate", t.max_missed_required_task_rate)]
+
+
+def _optional_minimum_gate_checks(t: QualityThresholds) -> list[tuple[str, float]]:
+    """Minimum checks for optional region metrics; skipped when the value is None."""
+    return [
+        ("region_recall", t.min_region_recall),
+        ("line_recall", t.min_line_recall),
+        ("relevance_per_1k_tokens", t.min_relevance_per_1k_tokens),
+    ]
+
+
+def _optional_maximum_gate_checks(t: QualityThresholds) -> list[tuple[str, float]]:
+    """Maximum checks for optional region metrics; skipped when the value is None."""
+    return [("context_noise_ratio", t.max_context_noise_ratio)]
 
 
 def _receipt_accuracy_score(value: bool | None) -> float:
@@ -150,6 +171,34 @@ def check_gate(
                         actual=actual,
                     )
                 )
+            for metric_name, threshold_val in _optional_minimum_gate_checks(effective):
+                actual = getattr(r, metric_name)
+                if actual is None:
+                    continue
+                if actual < threshold_val:
+                    violations.append(
+                        GateViolation(
+                            task_id=r.task_id,
+                            strategy=strategy_val,
+                            metric=metric_name,
+                            threshold=threshold_val,
+                            actual=actual,
+                        )
+                    )
+            for metric_name, threshold_val in _optional_maximum_gate_checks(effective):
+                actual = getattr(r, metric_name)
+                if actual is None:
+                    continue
+                if actual > threshold_val:
+                    violations.append(
+                        GateViolation(
+                            task_id=r.task_id,
+                            strategy=strategy_val,
+                            metric=metric_name,
+                            threshold=threshold_val,
+                            actual=actual,
+                        )
+                    )
     return violations
 
 

--- a/src/archex/benchmark/readiness.py
+++ b/src/archex/benchmark/readiness.py
@@ -24,6 +24,15 @@ def _receipt_accuracy_score(value: bool | None) -> float:
     return 0.0 if value is None else 1.0 if value else 0.0
 
 
+def _mean_optional(values: list[float | None]) -> float | None:
+    present = [value for value in values if value is not None]
+    return (sum(present) / len(present)) if present else None
+
+
+def _format_optional(value: float | None) -> str:
+    return "unknown" if value is None else f"{value:.3f}"
+
+
 @dataclass(frozen=True)
 class ReadinessTargetStatus:
     """Pass/fail status for one readiness target."""
@@ -93,6 +102,14 @@ class ReadinessReport:
     targets: list[ReadinessTargetStatus]
     categories: list[CategoryReadiness]
     blocking_tasks: list[TriageFinding]
+    # Optional region/line-level retrieval-quality means over region-labelled
+    # tasks for this strategy; None when no labelled tasks ran.
+    mean_region_recall: float | None = None
+    mean_region_precision: float | None = None
+    mean_line_recall: float | None = None
+    mean_ranked_region_ndcg: float | None = None
+    mean_context_noise_ratio: float | None = None
+    mean_relevance_per_1k_tokens: float | None = None
 
     @property
     def ready(self) -> bool:
@@ -121,6 +138,12 @@ class ReadinessReport:
             "zero_recall_tasks": self.zero_recall_tasks,
             "low_f1_tasks": self.low_f1_tasks,
             "low_precision_tasks": self.low_precision_tasks,
+            "mean_region_recall": self.mean_region_recall,
+            "mean_region_precision": self.mean_region_precision,
+            "mean_line_recall": self.mean_line_recall,
+            "mean_ranked_region_ndcg": self.mean_ranked_region_ndcg,
+            "mean_context_noise_ratio": self.mean_context_noise_ratio,
+            "mean_relevance_per_1k_tokens": self.mean_relevance_per_1k_tokens,
             "targets": [target.to_json() for target in self.targets],
             "categories": [category.to_json() for category in self.categories],
             "blocking_tasks": [finding.to_json() for finding in self.blocking_tasks],
@@ -197,6 +220,19 @@ def build_readiness_report(
     low_f1_tasks = sum(1 for result in metric_results if result.f1_score < LOW_F1_THRESHOLD)
     low_precision_tasks = sum(
         1 for result in metric_results if result.precision < LOW_PRECISION_THRESHOLD
+    )
+    region_results = [result for result in metric_results if result.region_recall is not None]
+    mean_region_recall = _mean_optional([result.region_recall for result in region_results])
+    mean_region_precision = _mean_optional([result.region_precision for result in region_results])
+    mean_line_recall = _mean_optional([result.line_recall for result in region_results])
+    mean_ranked_region_ndcg = _mean_optional(
+        [result.ranked_region_ndcg for result in region_results]
+    )
+    mean_context_noise_ratio = _mean_optional(
+        [result.context_noise_ratio for result in region_results]
+    )
+    mean_relevance_per_1k_tokens = _mean_optional(
+        [result.relevance_per_1k_tokens for result in region_results]
     )
     targets = [
         ReadinessTargetStatus(
@@ -282,6 +318,12 @@ def build_readiness_report(
         targets=targets,
         categories=categories,
         blocking_tasks=blocking_tasks,
+        mean_region_recall=mean_region_recall,
+        mean_region_precision=mean_region_precision,
+        mean_line_recall=mean_line_recall,
+        mean_ranked_region_ndcg=mean_ranked_region_ndcg,
+        mean_context_noise_ratio=mean_context_noise_ratio,
+        mean_relevance_per_1k_tokens=mean_relevance_per_1k_tokens,
     )
 
 
@@ -323,6 +365,19 @@ def format_readiness_markdown(report: ReadinessReport) -> str:
         f"| {report.savings_vs_raw:.1f}% "
         f"| {report.median_latency_ms:.0f} ms | {report.p95_latency_ms:.0f} ms |"
     )
+    if report.mean_region_recall is not None:
+        lines.append("")
+        lines.append("## Region & Context Efficiency")
+        lines.append("")
+        lines.append(
+            f"- Mean region recall: `{_format_optional(report.mean_region_recall)}`\n"
+            f"- Mean region precision: `{_format_optional(report.mean_region_precision)}`\n"
+            f"- Mean line recall: `{_format_optional(report.mean_line_recall)}`\n"
+            f"- Mean ranked region nDCG: `{_format_optional(report.mean_ranked_region_ndcg)}`\n"
+            f"- Mean context noise ratio: `{_format_optional(report.mean_context_noise_ratio)}`\n"
+            "- Mean relevance per 1k tokens: "
+            f"`{_format_optional(report.mean_relevance_per_1k_tokens)}`"
+        )
     lines.append("")
     lines.append("## Summary")
     lines.append("")

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -84,6 +84,84 @@ def _all_required_label(value: bool) -> str:
     return "yes" if value else "no"
 
 
+def _has_region_metrics(reports: list[BenchmarkReport]) -> bool:
+    return any(result.region_recall is not None for report in reports for result in report.results)
+
+
+def _fmt_opt(value: float | None, *, digits: int = 3) -> str:
+    return "unknown" if value is None else f"{value:.{digits}f}"
+
+
+def _fmt_opt_int(value: int | None) -> str:
+    return "unknown" if value is None else f"{value:,}"
+
+
+def _mean_optional(values: list[float | None]) -> float | None:
+    present = [value for value in values if value is not None]
+    return (sum(present) / len(present)) if present else None
+
+
+def _region_quality_appendix(report: BenchmarkReport) -> list[str]:
+    """Per-task region + context-efficiency table, rendered only when labelled."""
+    rows = [result for result in report.results if result.region_recall is not None]
+    if not rows:
+        return []
+    lines = ["", "### Region & Context Efficiency", ""]
+    lines.append(
+        "| Strategy | Region Recall | Region Prec | Region F1 | Line Recall | Line Prec "
+        "| Ranked MRR | Ranked nDCG | Noise Ratio | Useful Tokens | Wasted Tokens | Rel/1k |"
+    )
+    lines.append(
+        "|----------|--------------:|------------:|----------:|------------:|----------:"
+        "|-----------:|------------:|------------:|--------------:|--------------:|-------:|"
+    )
+    for result in rows:
+        lines.append(
+            f"| {result.strategy.value} | {_fmt_opt(result.region_recall)} "
+            f"| {_fmt_opt(result.region_precision)} | {_fmt_opt(result.region_f1)} "
+            f"| {_fmt_opt(result.line_recall)} | {_fmt_opt(result.line_precision)} "
+            f"| {_fmt_opt(result.ranked_region_mrr)} | {_fmt_opt(result.ranked_region_ndcg)} "
+            f"| {_fmt_opt(result.context_noise_ratio)} | {_fmt_opt_int(result.useful_tokens)} "
+            f"| {_fmt_opt_int(result.wasted_tokens)} "
+            f"| {_fmt_opt(result.relevance_per_1k_tokens, digits=2)} |"
+        )
+    return lines
+
+
+def _region_quality_summary(reports: list[BenchmarkReport]) -> list[str]:
+    """Aggregated region + context-efficiency table, rendered only when labelled."""
+    if not _has_region_metrics(reports):
+        return []
+    by_strategy: dict[str, list[BenchmarkResult]] = defaultdict(list)
+    for report in reports:
+        for result in report.results:
+            if result.region_recall is not None:
+                by_strategy[result.strategy.value].append(result)
+    lines = ["## Region & Context Efficiency", ""]
+    lines.append(
+        "| Strategy | Region Recall | Region F1 | Line Recall | Ranked nDCG "
+        "| Noise Ratio | Rel/1k | Tasks |"
+    )
+    lines.append(
+        "|----------|--------------:|----------:|------------:|------------:"
+        "|------------:|-------:|------:|"
+    )
+    for name in sorted(by_strategy):
+        results = by_strategy[name]
+        lines.append(
+            f"| {name} "
+            f"| {_fmt_opt(_mean_optional([r.region_recall for r in results]))} "
+            f"| {_fmt_opt(_mean_optional([r.region_f1 for r in results]))} "
+            f"| {_fmt_opt(_mean_optional([r.line_recall for r in results]))} "
+            f"| {_fmt_opt(_mean_optional([r.ranked_region_ndcg for r in results]))} "
+            f"| {_fmt_opt(_mean_optional([r.context_noise_ratio for r in results]))} "
+            f"| {_fmt_opt(_mean_optional([r.relevance_per_1k_tokens for r in results]), digits=2)} "
+            f"| {len(results)} |"
+        )
+    lines.append("")
+    return lines
+
+
 def _aggregate_strategy_metrics(
     reports: list[BenchmarkReport],
     fields: tuple[str, ...],
@@ -141,6 +219,7 @@ def format_markdown(report: BenchmarkReport) -> str:
         )
     lines.extend(_missing_required_file_appendix(report))
     lines.extend(_bundle_only_eval_appendix(report))
+    lines.extend(_region_quality_appendix(report))
     lines.append("")
     return "\n".join(lines)
 
@@ -187,6 +266,7 @@ def format_summary(reports: list[BenchmarkReport]) -> str:
         )
 
     lines.append("")
+    lines.extend(_region_quality_summary(reports))
     return "\n".join(lines)
 
 

--- a/src/archex/benchmark/triage.py
+++ b/src/archex/benchmark/triage.py
@@ -12,6 +12,9 @@ from archex.benchmark.models import BenchmarkReport, BenchmarkResult, BenchmarkT
 LOW_F1_THRESHOLD = 0.40
 LOW_PRECISION_THRESHOLD = 0.35
 RAW_READ_GAP_THRESHOLD = 0.25
+LOW_REGION_RECALL_THRESHOLD = 0.40
+LOW_RANKED_REGION_MRR_THRESHOLD = 0.40
+HIGH_CONTEXT_NOISE_THRESHOLD = 0.75
 
 
 @dataclass(frozen=True)
@@ -48,6 +51,13 @@ class TriageFinding:
     raw_read_recall: float | None
     raw_read_precision: float | None
     raw_read_f1_score: float | None
+    region_recall: float | None
+    region_precision: float | None
+    line_recall: float | None
+    ranked_region_mrr: float | None
+    ranked_region_ndcg: float | None
+    context_noise_ratio: float | None
+    relevance_per_1k_tokens: float | None
     failure_bucket: str
     failure_reasons: list[str]
     rank_score: float
@@ -89,6 +99,15 @@ class TriageFinding:
                 "recall": self.raw_read_recall,
                 "precision": self.raw_read_precision,
                 "f1_score": self.raw_read_f1_score,
+            },
+            "region_metrics": {
+                "region_recall": self.region_recall,
+                "region_precision": self.region_precision,
+                "line_recall": self.line_recall,
+                "ranked_region_mrr": self.ranked_region_mrr,
+                "ranked_region_ndcg": self.ranked_region_ndcg,
+                "context_noise_ratio": self.context_noise_ratio,
+                "relevance_per_1k_tokens": self.relevance_per_1k_tokens,
             },
             "failure_bucket": self.failure_bucket,
             "failure_reasons": self.failure_reasons,
@@ -165,6 +184,13 @@ def triage_failures(
                 raw_read_recall=raw_read.recall if raw_read is not None else None,
                 raw_read_precision=raw_read.precision if raw_read is not None else None,
                 raw_read_f1_score=raw_read.f1_score if raw_read is not None else None,
+                region_recall=result.region_recall,
+                region_precision=result.region_precision,
+                line_recall=result.line_recall,
+                ranked_region_mrr=result.ranked_region_mrr,
+                ranked_region_ndcg=result.ranked_region_ndcg,
+                context_noise_ratio=result.context_noise_ratio,
+                relevance_per_1k_tokens=result.relevance_per_1k_tokens,
                 failure_bucket=bucket,
                 failure_reasons=reasons,
                 rank_score=_rank_score(result, raw_read, category, bucket),
@@ -216,6 +242,16 @@ def format_triage_markdown(findings: list[TriageFinding]) -> str:
                 f"recall `{finding.raw_read_recall:.3f}`, "
                 f"precision `{finding.raw_read_precision:.3f}`, "
                 f"F1 `{finding.raw_read_f1_score:.3f}`"
+            )
+        if finding.region_recall is not None:
+            lines.append(
+                "- Region metrics: "
+                f"region recall `{finding.region_recall:.3f}`, "
+                f"line recall `{_fmt_optional_metric(finding.line_recall)}`, "
+                f"ranked MRR `{_fmt_optional_metric(finding.ranked_region_mrr)}`, "
+                f"ranked nDCG `{_fmt_optional_metric(finding.ranked_region_ndcg)}`, "
+                f"context noise `{_fmt_optional_metric(finding.context_noise_ratio)}`, "
+                f"relevance/1k `{_fmt_optional_metric(finding.relevance_per_1k_tokens)}`"
             )
         lines.append(
             "- Expansion: "
@@ -312,6 +348,18 @@ def _failure_reasons(
         reasons.append("external_large_failure")
     if category == "framework-semantic" and result.f1_score < LOW_F1_THRESHOLD:
         reasons.append("framework_semantic_failure")
+    if result.region_recall is not None and result.region_recall < LOW_REGION_RECALL_THRESHOLD:
+        reasons.append("region_miss")
+    if (
+        result.ranked_region_mrr is not None
+        and result.ranked_region_mrr < LOW_RANKED_REGION_MRR_THRESHOLD
+    ):
+        reasons.append("ranking_miss")
+    if (
+        result.context_noise_ratio is not None
+        and result.context_noise_ratio > HIGH_CONTEXT_NOISE_THRESHOLD
+    ):
+        reasons.append("token_noise")
     return reasons
 
 
@@ -323,6 +371,18 @@ def _failure_bucket(
 ) -> str:
     if result.recall <= 0.0:
         return "zero_recall"
+    if result.region_recall is not None and result.region_recall < LOW_REGION_RECALL_THRESHOLD:
+        return "region_miss"
+    if (
+        result.ranked_region_mrr is not None
+        and result.ranked_region_mrr < LOW_RANKED_REGION_MRR_THRESHOLD
+    ):
+        return "ranking_miss"
+    if (
+        result.context_noise_ratio is not None
+        and result.context_noise_ratio > HIGH_CONTEXT_NOISE_THRESHOLD
+    ):
+        return "token_noise"
     if category == "external-large":
         return "large_repo_ambiguity"
     if category == "framework-semantic":
@@ -373,6 +433,12 @@ def _rank_score(
         score += 10.0
     if bucket == "expansion_noise":
         score += 5.0
+    if result.region_recall is not None:
+        score += max(0.0, LOW_REGION_RECALL_THRESHOLD - result.region_recall) * 15.0
+    if result.ranked_region_mrr is not None:
+        score += max(0.0, LOW_RANKED_REGION_MRR_THRESHOLD - result.ranked_region_mrr) * 8.0
+    if result.context_noise_ratio is not None:
+        score += max(0.0, result.context_noise_ratio - HIGH_CONTEXT_NOISE_THRESHOLD) * 8.0
     return score
 
 
@@ -384,6 +450,10 @@ def _inline_files(files: list[str]) -> str:
     if not files:
         return "none"
     return "<br>".join(f"`{path}`" for path in files)
+
+
+def _fmt_optional_metric(value: float | None) -> str:
+    return "unknown" if value is None else f"{value:.3f}"
 
 
 def _file_bullets(files: list[str]) -> list[str]:

--- a/tests/benchmark/test_gate.py
+++ b/tests/benchmark/test_gate.py
@@ -310,3 +310,87 @@ def test_check_gate_custom_exempt_set() -> None:
     )
     violations = check_gate(reports, thresholds)
     assert violations == []
+
+
+_REGION_METRICS = {
+    "region_recall",
+    "line_recall",
+    "context_noise_ratio",
+    "relevance_per_1k_tokens",
+}
+
+
+def _region_report(**fields: float) -> BenchmarkReport:
+    report = _make_report()
+    report.results[0] = report.results[0].model_copy(update=fields)
+    return report
+
+
+def test_gate_ignores_absent_region_labels() -> None:
+    # File-only result (region fields None): strict region thresholds must not fire.
+    reports = [_make_report()]
+    thresholds = QualityThresholds(
+        min_region_recall=0.9,
+        min_line_recall=0.9,
+        max_context_noise_ratio=0.1,
+        min_relevance_per_1k_tokens=100.0,
+    )
+    violations = check_gate(reports, thresholds)
+    assert not any(v.metric in _REGION_METRICS for v in violations)
+
+
+def test_gate_default_thresholds_pass_region_labeled_result() -> None:
+    reports = [
+        _region_report(
+            region_recall=0.5,
+            line_recall=0.5,
+            context_noise_ratio=0.5,
+            relevance_per_1k_tokens=5.0,
+        )
+    ]
+    violations = check_gate(reports)
+    assert not any(v.metric in _REGION_METRICS for v in violations)
+
+
+def test_gate_fails_region_recall_below_threshold() -> None:
+    reports = [
+        _region_report(
+            region_recall=0.2,
+            line_recall=0.5,
+            context_noise_ratio=0.3,
+            relevance_per_1k_tokens=5.0,
+        )
+    ]
+    thresholds = QualityThresholds(min_region_recall=0.5)
+    violations = check_gate(reports, thresholds)
+    assert any(v.metric == "region_recall" and v.actual == 0.2 for v in violations)
+
+
+def test_gate_fails_high_context_noise_ratio() -> None:
+    reports = [
+        _region_report(
+            region_recall=0.8,
+            line_recall=0.8,
+            context_noise_ratio=0.9,
+            relevance_per_1k_tokens=5.0,
+        )
+    ]
+    thresholds = QualityThresholds(max_context_noise_ratio=0.5)
+    violations = check_gate(reports, thresholds)
+    assert any(v.metric == "context_noise_ratio" and v.actual == 0.9 for v in violations)
+
+
+def test_gate_region_violations_are_advisory_warnings() -> None:
+    reports = [
+        _region_report(
+            region_recall=0.2,
+            line_recall=0.5,
+            context_noise_ratio=0.3,
+            relevance_per_1k_tokens=5.0,
+        )
+    ]
+    thresholds = QualityThresholds(min_region_recall=0.5)
+    violations = check_gate(reports, thresholds)
+    # Region failures are non-token quality warnings, not hard token failures.
+    assert any(v.metric == "region_recall" for v in non_token_quality_warnings(violations))
+    assert token_efficiency_violations(violations) == []

--- a/tests/benchmark/test_readiness.py
+++ b/tests/benchmark/test_readiness.py
@@ -245,3 +245,41 @@ def test_format_readiness_outputs_are_stable() -> None:
     assert payload["receipt_accuracy_rate"] == 1.0
     assert payload["token_efficiency_with_completion"] == 0.5
     assert payload["blocking_tasks"][0]["task_id"] == "miss"
+
+
+def test_readiness_includes_region_metrics_when_labeled() -> None:
+    result = _result("region", recall=1.0, precision=1.0, f1_score=1.0).model_copy(
+        update={
+            "region_recall": 0.6,
+            "region_precision": 0.5,
+            "line_recall": 0.4,
+            "ranked_region_ndcg": 0.7,
+            "context_noise_ratio": 0.3,
+            "relevance_per_1k_tokens": 4.0,
+        }
+    )
+    readiness = build_readiness_report(
+        [_report("region", result)],
+        {"region": _task("region", TaskCategory.SELF)},
+    )
+    assert readiness.mean_region_recall == 0.6
+    assert readiness.mean_line_recall == 0.4
+    md = format_readiness_markdown(readiness)
+    assert "Region & Context Efficiency" in md
+    payload = json.loads(format_readiness_json(readiness))
+    assert payload["mean_region_recall"] == 0.6
+    assert payload["mean_context_noise_ratio"] == 0.3
+
+
+def test_readiness_region_metrics_none_for_file_only_tasks() -> None:
+    result = _result("file", recall=1.0, precision=1.0, f1_score=1.0)
+    readiness = build_readiness_report(
+        [_report("file", result)],
+        {"file": _task("file", TaskCategory.SELF)},
+    )
+    assert readiness.mean_region_recall is None
+    assert readiness.mean_line_recall is None
+    md = format_readiness_markdown(readiness)
+    assert "Region & Context Efficiency" not in md
+    payload = json.loads(format_readiness_json(readiness))
+    assert payload["mean_region_recall"] is None

--- a/tests/benchmark/test_reporter.py
+++ b/tests/benchmark/test_reporter.py
@@ -297,3 +297,49 @@ class TestFormatChunkerFrontierTable:
         assert "archex_query_fusion_rerank | cast" in table
         assert "Chunk Count" in table
         assert "Mean Chunk Tokens" in table
+
+
+def _region_result(strategy: Strategy = Strategy.ARCHEX_QUERY) -> BenchmarkResult:
+    return _make_result(strategy).model_copy(
+        update={
+            "region_recall": 0.5,
+            "region_precision": 0.4,
+            "region_f1": 0.44,
+            "line_recall": 0.3,
+            "line_precision": 0.6,
+            "ranked_region_mrr": 0.5,
+            "ranked_region_ndcg": 0.7,
+            "context_noise_ratio": 0.25,
+            "useful_tokens": 75,
+            "wasted_tokens": 25,
+            "relevance_per_1k_tokens": 5.0,
+        }
+    )
+
+
+class TestRegionQualityReporting:
+    def test_markdown_shows_region_table_when_labeled(self) -> None:
+        md = format_markdown(_make_report([_region_result()]))
+        assert "Region & Context Efficiency" in md
+        assert "Noise Ratio" in md
+        assert "Rel/1k" in md
+
+    def test_markdown_omits_region_table_for_file_only_results(self) -> None:
+        md = format_markdown(_make_report([_make_result(Strategy.ARCHEX_QUERY)]))
+        assert "Region & Context Efficiency" not in md
+
+    def test_summary_shows_region_table_when_labeled(self) -> None:
+        summary = format_summary([_make_report([_region_result()])])
+        assert "Region & Context Efficiency" in summary
+
+    def test_summary_omits_region_table_for_file_only_results(self) -> None:
+        summary = format_summary([_make_report([_make_result(Strategy.ARCHEX_QUERY)])])
+        assert "Region & Context Efficiency" not in summary
+
+    def test_json_includes_region_fields(self) -> None:
+        import json
+
+        data = json.loads(format_json(_make_report([_region_result()])))
+        assert data["results"][0]["region_recall"] == 0.5
+        assert data["results"][0]["context_noise_ratio"] == 0.25
+        assert data["results"][0]["useful_tokens"] == 75

--- a/tests/benchmark/test_triage.py
+++ b/tests/benchmark/test_triage.py
@@ -237,3 +237,61 @@ def test_format_triage_json_serializes_expansion_diagnostics() -> None:
     assert payload[0]["expansion_ratio"] == 0.5
     assert payload[0]["expansion_diagnostics"]["eligible_seeds"] == 1
     assert payload[0]["expansion_diagnostics"]["candidates_found"] == 2
+
+
+def _region_result(**fields: float) -> BenchmarkResult:
+    base = _result(Strategy.ARCHEX_QUERY, recall=1.0, precision=1.0, f1_score=1.0)
+    return base.model_copy(update=fields)
+
+
+def test_triage_flags_region_miss_when_file_recall_ok() -> None:
+    result = _region_result(region_recall=0.1, ranked_region_mrr=0.9, context_noise_ratio=0.1)
+    findings = triage_failures(
+        [_report("rmiss", result)],
+        {"rmiss": _task("rmiss", TaskCategory.SELF)},
+    )
+    assert len(findings) == 1
+    assert findings[0].failure_bucket == "region_miss"
+    assert "region_miss" in findings[0].failure_reasons
+
+
+def test_triage_flags_ranking_miss() -> None:
+    result = _region_result(region_recall=0.9, ranked_region_mrr=0.1, context_noise_ratio=0.1)
+    findings = triage_failures(
+        [_report("rank", result)],
+        {"rank": _task("rank", TaskCategory.SELF)},
+    )
+    assert findings[0].failure_bucket == "ranking_miss"
+    assert "ranking_miss" in findings[0].failure_reasons
+
+
+def test_triage_flags_token_noise() -> None:
+    result = _region_result(region_recall=0.9, ranked_region_mrr=0.9, context_noise_ratio=0.95)
+    findings = triage_failures(
+        [_report("noise", result)],
+        {"noise": _task("noise", TaskCategory.SELF)},
+    )
+    assert findings[0].failure_bucket == "token_noise"
+    assert "token_noise" in findings[0].failure_reasons
+
+
+def test_triage_skips_healthy_region_labeled_result() -> None:
+    result = _region_result(region_recall=0.9, ranked_region_mrr=0.9, context_noise_ratio=0.1)
+    findings = triage_failures(
+        [_report("ok", result)],
+        {"ok": _task("ok", TaskCategory.SELF)},
+    )
+    assert findings == []
+
+
+def test_triage_json_includes_region_metrics() -> None:
+    result = _region_result(
+        region_recall=0.1, line_recall=0.2, ranked_region_mrr=0.9, context_noise_ratio=0.1
+    )
+    findings = triage_failures(
+        [_report("rmiss", result)],
+        {"rmiss": _task("rmiss", TaskCategory.SELF)},
+    )
+    payload = json.loads(format_triage_json(findings))
+    assert payload[0]["region_metrics"]["region_recall"] == 0.1
+    assert payload[0]["region_metrics"]["line_recall"] == 0.2


### PR DESCRIPTION
## Summary

Surfaces the region/line/ranking/context-efficiency metrics (PR2) across the benchmark reporting surfaces: reports, readiness, gate, and triage. Every addition is optional and additive — file-only results and tasks render exactly as before.

## Changes

- **Reporter**: per-task markdown and the aggregated summary render a `Region & Context Efficiency` table, shown only when a result carries region labels. JSON already serializes the optional fields (covered by a test).
- **Readiness**: adds mean region recall/precision, line recall, ranked nDCG, context noise, and relevance-per-1k over region-labelled tasks; surfaced in markdown + JSON when present, `None` otherwise.
- **Gate**: adds optional `min_region_recall`, `min_line_recall`, `max_context_noise_ratio`, `min_relevance_per_1k_tokens` thresholds with permissive defaults. Results whose optional metric is `None` (no labels) are ignored; thresholds are enforced only when the label exists. Region violations are advisory non-token warnings.
- **Triage**: adds `region_miss`, `ranking_miss`, and `token_noise` failure reasons/buckets so retrieval-quality regressions are identified separately from file misses; region metrics added to triage findings (JSON + markdown) and rank scoring.

## Validation

- `uv run pytest tests/benchmark/test_reporter.py tests/benchmark/test_gate.py tests/benchmark/test_readiness.py tests/benchmark/test_triage.py` — 66 passed
- `uv run pytest tests/benchmark/test_cli.py -k 'benchmark or report or gate or readiness'` — 32 passed
- `ruff check` / `ruff format --check` — clean

Covers: reporter region-labelled vs file-only output, gate ignore-when-absent + fail-when-present, readiness region means, and triage region/ranking/noise bucketing.

## Stack

Stack-Id: `retrieval-eval-frontier-de6e6a`
Base: `bench/eval-frontier-metrics`
Position: 3/4

1. `bench/eval-frontier-schema` -> #291
2. `bench/eval-frontier-metrics` -> #292
3. `bench/eval-frontier-reports` -> this PR
4. `bench/eval-frontier-fixtures-docs` -> fixtures + docs

Depends on: #292
