### PR TITLE
Add task-aware retrieval policy model

### DIFF
--- a/src/archex/benchmark/task_aware.py
+++ b/src/archex/benchmark/task_aware.py
@@ -1,0 +1,193 @@
+"""Task-aware retrieval policy: map query modality + budget tier to choices.
+
+Benchmark-only. ``policy_for`` is a pure mapping from a
+:class:`~archex.serve.modality.ModalityClassification` to a deterministic
+retrieval plan: sparse-vs-dense routing, a conditional dense-expansion trigger,
+hard candidate caps, and the expensive steps this lane never runs. The benchmark
+``archex_query_task_aware`` strategy consumes this plan; nothing here touches the
+product query path, and no hosted calls, telemetry, or network behaviour are
+introduced.
+
+The mapping follows the research-backed rules in Workstream 2 of
+``.docs/2026-06-18-retrieval-quality-token-efficiency-enhancement-design.md``:
+BM25-heavy for PL-to-PL, bounded hybrid/dense for NL-to-PL, sparse-first with
+targeted dense expansion for mixed, scaled by the requested token budget.
+
+Whole-file/enclosing-block preservation and graph-expansion strictness are
+recorded as declared policy preferences, as are the candidate caps beyond the
+sparse confidence window. Mechanical retrieval-aware packing is intentionally
+deferred to Workstream 4. The only expensive step this lane unconditionally
+skips is the cross-encoder reranker; confidence-aware fusion runs only on the
+conditional hybrid/dense pass, and total work is bounded to at most two
+retrieval passes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from archex.models import RetrievalPolicy
+from archex.serve.modality import BudgetTier, ModalityClassification, QueryModality
+
+
+class DenseTrigger(StrEnum):
+    """When the lane may run a dense pass beyond the sparse-first default."""
+
+    NEVER = "never"
+    ALWAYS = "always"
+    LOW_SPARSE_CONFIDENCE = "low_sparse_confidence"
+    DIFFUSE_TOP_SCORES = "diffuse_top_scores"
+
+
+class GraphExpansion(StrEnum):
+    """Declared dependency-frontier expansion regime, scaled by budget."""
+
+    STRICT = "strict"
+    NORMAL = "normal"
+
+
+# The cross-encoder reranker is never run by this lane (recorded as skipped so
+# provenance shows the bounded retrieval surface). RRF/confidence-aware fusion is
+# NOT listed here: it is used on the conditional hybrid/dense pass and is recorded
+# per run in the strategy's runtime provenance, not as an always-skipped step.
+_SKIPPED_EXPENSIVE_STEPS = ("cross_encoder_rerank",)
+
+
+@dataclass(frozen=True)
+class TaskAwarePolicy:
+    """Deterministic retrieval plan for one modality + budget-tier combination."""
+
+    modality: QueryModality
+    budget_tier: BudgetTier
+    initial_retrieval_policy: RetrievalPolicy
+    use_vector_initial: bool
+    dense_trigger: DenseTrigger
+    candidate_cap: int
+    dense_candidate_cap: int
+    rerank_candidate_limit: int
+    allow_rerank: bool
+    graph_expansion: GraphExpansion
+    prefer_whole_file: bool
+    diffuse_gap_threshold: float
+    skipped_steps: tuple[str, ...]
+    reasons: tuple[str, ...]
+
+    def to_provenance(self) -> dict[str, str]:
+        """Flatten the policy into string-valued provenance entries."""
+        return {
+            "policy_initial_retrieval": self.initial_retrieval_policy.value,
+            "policy_use_vector_initial": str(self.use_vector_initial).lower(),
+            "policy_dense_trigger": self.dense_trigger.value,
+            "policy_candidate_cap": str(self.candidate_cap),
+            "policy_dense_candidate_cap": str(self.dense_candidate_cap),
+            "policy_rerank_candidate_limit": str(self.rerank_candidate_limit),
+            "policy_allow_rerank": str(self.allow_rerank).lower(),
+            "policy_graph_expansion": self.graph_expansion.value,
+            "policy_prefer_whole_file": str(self.prefer_whole_file).lower(),
+            "policy_diffuse_gap_threshold": f"{self.diffuse_gap_threshold:.2f}",
+            "policy_skipped_steps": ", ".join(self.skipped_steps),
+            "policy_reasons": "; ".join(self.reasons),
+        }
+
+
+@dataclass(frozen=True)
+class _ModalityRouting:
+    initial_retrieval_policy: RetrievalPolicy
+    use_vector_initial: bool
+    dense_trigger: DenseTrigger
+    reason: str
+
+
+@dataclass(frozen=True)
+class _BudgetRouting:
+    candidate_cap: int
+    dense_candidate_cap: int
+    rerank_candidate_limit: int
+    graph_expansion: GraphExpansion
+    prefer_whole_file: bool
+    diffuse_gap_threshold: float
+    reason: str
+
+
+_MODALITY_ROUTING: dict[QueryModality, _ModalityRouting] = {
+    QueryModality.PL_TO_PL: _ModalityRouting(
+        initial_retrieval_policy=RetrievalPolicy.BM25_ONLY,
+        use_vector_initial=False,
+        dense_trigger=DenseTrigger.LOW_SPARSE_CONFIDENCE,
+        reason="pl_to_pl: BM25-heavy; dense/fusion avoided unless sparse confidence is low",
+    ),
+    QueryModality.NL_TO_PL: _ModalityRouting(
+        initial_retrieval_policy=RetrievalPolicy.HYBRID,
+        use_vector_initial=True,
+        dense_trigger=DenseTrigger.ALWAYS,
+        reason="nl_to_pl: hybrid/dense expansion within strict candidate and latency caps",
+    ),
+    QueryModality.MIXED: _ModalityRouting(
+        initial_retrieval_policy=RetrievalPolicy.BM25_ONLY,
+        use_vector_initial=False,
+        dense_trigger=DenseTrigger.DIFFUSE_TOP_SCORES,
+        reason=(
+            "mixed: sparse first; targeted dense expansion only if top sparse scores are diffuse"
+        ),
+    ),
+}
+
+
+_BUDGET_ROUTING: dict[BudgetTier, _BudgetRouting] = {
+    BudgetTier.TIGHT: _BudgetRouting(
+        candidate_cap=20,
+        dense_candidate_cap=10,
+        rerank_candidate_limit=4,
+        graph_expansion=GraphExpansion.STRICT,
+        prefer_whole_file=False,
+        diffuse_gap_threshold=0.10,
+        reason=(
+            "tight budget: smaller candidate caps, stricter graph expansion, "
+            "reluctant dense expansion"
+        ),
+    ),
+    BudgetTier.STANDARD: _BudgetRouting(
+        candidate_cap=40,
+        dense_candidate_cap=20,
+        rerank_candidate_limit=6,
+        graph_expansion=GraphExpansion.NORMAL,
+        prefer_whole_file=False,
+        diffuse_gap_threshold=0.15,
+        reason="standard budget: default candidate caps and graph expansion",
+    ),
+    BudgetTier.LARGE: _BudgetRouting(
+        candidate_cap=80,
+        dense_candidate_cap=40,
+        rerank_candidate_limit=8,
+        graph_expansion=GraphExpansion.NORMAL,
+        prefer_whole_file=True,
+        diffuse_gap_threshold=0.25,
+        reason=(
+            "large budget: larger candidate caps and whole-file/enclosing-block "
+            "preservation preference for top files"
+        ),
+    ),
+}
+
+
+def policy_for(classification: ModalityClassification) -> TaskAwarePolicy:
+    """Map a modality + budget-tier classification to a deterministic policy."""
+    routing = _MODALITY_ROUTING[classification.modality]
+    budget = _BUDGET_ROUTING[classification.budget_tier]
+    return TaskAwarePolicy(
+        modality=classification.modality,
+        budget_tier=classification.budget_tier,
+        initial_retrieval_policy=routing.initial_retrieval_policy,
+        use_vector_initial=routing.use_vector_initial,
+        dense_trigger=routing.dense_trigger,
+        candidate_cap=budget.candidate_cap,
+        dense_candidate_cap=budget.dense_candidate_cap,
+        rerank_candidate_limit=budget.rerank_candidate_limit,
+        allow_rerank=False,
+        graph_expansion=budget.graph_expansion,
+        prefer_whole_file=budget.prefer_whole_file,
+        diffuse_gap_threshold=budget.diffuse_gap_threshold,
+        skipped_steps=_SKIPPED_EXPENSIVE_STEPS,
+        reasons=(routing.reason, budget.reason),
+    )

--- a/tests/benchmark/test_task_aware.py
+++ b/tests/benchmark/test_task_aware.py
@@ -1,0 +1,190 @@
+"""Tests for the benchmark-only task-aware retrieval policy mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from archex.benchmark.task_aware import (
+    DenseTrigger,
+    GraphExpansion,
+    TaskAwarePolicy,
+    policy_for,
+)
+from archex.models import RetrievalPolicy
+from archex.serve.intent import QueryIntent
+from archex.serve.modality import (
+    BudgetTier,
+    ModalityClassification,
+    ModalitySignals,
+    QueryModality,
+    classify_query,
+)
+
+
+def _classification(modality: QueryModality, tier: BudgetTier) -> ModalityClassification:
+    signals = ModalitySignals(
+        word_count=0,
+        identifier_count=0,
+        identifier_density=0.0,
+        has_code_fence=False,
+        has_stack_trace=False,
+        path_mentions=0,
+        symbol_mentions=0,
+        natural_language_word_count=0,
+        natural_language_ratio=0.0,
+        query_intent=QueryIntent.GENERAL,
+    )
+    return ModalityClassification(
+        modality=modality,
+        budget_tier=tier,
+        token_budget=4096,
+        signals=signals,
+        reasons=(),
+    )
+
+
+_MODALITY_EXPECTATIONS = {
+    QueryModality.PL_TO_PL: (RetrievalPolicy.BM25_ONLY, False, DenseTrigger.LOW_SPARSE_CONFIDENCE),
+    QueryModality.NL_TO_PL: (RetrievalPolicy.HYBRID, True, DenseTrigger.ALWAYS),
+    QueryModality.MIXED: (RetrievalPolicy.BM25_ONLY, False, DenseTrigger.DIFFUSE_TOP_SCORES),
+}
+
+_BUDGET_EXPECTATIONS = {
+    # tier: (candidate_cap, dense_candidate_cap, rerank_limit, graph, whole_file, gap)
+    BudgetTier.TIGHT: (20, 10, 4, GraphExpansion.STRICT, False, 0.10),
+    BudgetTier.STANDARD: (40, 20, 6, GraphExpansion.NORMAL, False, 0.15),
+    BudgetTier.LARGE: (80, 40, 8, GraphExpansion.NORMAL, True, 0.25),
+}
+
+
+class TestPolicyMapping:
+    @pytest.mark.parametrize("modality", list(QueryModality))
+    @pytest.mark.parametrize("tier", list(BudgetTier))
+    def test_policy_routes_each_combination(
+        self, modality: QueryModality, tier: BudgetTier
+    ) -> None:
+        policy = policy_for(_classification(modality, tier))
+        assert isinstance(policy, TaskAwarePolicy)
+        assert policy.modality is modality
+        assert policy.budget_tier is tier
+
+        retrieval, use_vector, trigger = _MODALITY_EXPECTATIONS[modality]
+        assert policy.initial_retrieval_policy is retrieval
+        assert policy.use_vector_initial is use_vector
+        assert policy.dense_trigger is trigger
+
+        cap, dense_cap, rerank_limit, graph, whole_file, gap = _BUDGET_EXPECTATIONS[tier]
+        assert policy.candidate_cap == cap
+        assert policy.dense_candidate_cap == dense_cap
+        assert policy.rerank_candidate_limit == rerank_limit
+        assert policy.graph_expansion is graph
+        assert policy.prefer_whole_file is whole_file
+        assert abs(policy.diffuse_gap_threshold - gap) < 1e-9
+
+    @pytest.mark.parametrize("modality", list(QueryModality))
+    @pytest.mark.parametrize("tier", list(BudgetTier))
+    def test_cross_encoder_rerank_always_skipped(
+        self, modality: QueryModality, tier: BudgetTier
+    ) -> None:
+        policy = policy_for(_classification(modality, tier))
+        # The cross-encoder reranker is never run. Fusion is conditional and is
+        # therefore not listed as an always-skipped step.
+        assert policy.allow_rerank is False
+        assert "cross_encoder_rerank" in policy.skipped_steps
+        assert "rrf_fusion" not in policy.skipped_steps
+
+    @pytest.mark.parametrize("tier", list(BudgetTier))
+    def test_cap_ordering_invariants(self, tier: BudgetTier) -> None:
+        policy = policy_for(_classification(QueryModality.NL_TO_PL, tier))
+        # The lane must never request more dense/rerank candidates than its
+        # overall candidate cap, or it would defeat the bound.
+        assert policy.dense_candidate_cap <= policy.candidate_cap
+        assert policy.rerank_candidate_limit <= policy.dense_candidate_cap
+
+    def test_caps_increase_with_budget(self) -> None:
+        tight = policy_for(_classification(QueryModality.NL_TO_PL, BudgetTier.TIGHT))
+        standard = policy_for(_classification(QueryModality.NL_TO_PL, BudgetTier.STANDARD))
+        large = policy_for(_classification(QueryModality.NL_TO_PL, BudgetTier.LARGE))
+        # Caps and dense willingness grow monotonically tight < standard < large.
+        assert tight.candidate_cap < standard.candidate_cap < large.candidate_cap
+        assert tight.dense_candidate_cap < standard.dense_candidate_cap < large.dense_candidate_cap
+        assert (
+            tight.rerank_candidate_limit
+            < standard.rerank_candidate_limit
+            < large.rerank_candidate_limit
+        )
+        assert (
+            tight.diffuse_gap_threshold
+            < standard.diffuse_gap_threshold
+            < large.diffuse_gap_threshold
+        )
+
+    def test_pl_to_pl_is_sparse_first(self) -> None:
+        policy = policy_for(_classification(QueryModality.PL_TO_PL, BudgetTier.STANDARD))
+        assert policy.initial_retrieval_policy is RetrievalPolicy.BM25_ONLY
+        assert policy.use_vector_initial is False
+
+    def test_nl_to_pl_allows_initial_dense(self) -> None:
+        policy = policy_for(_classification(QueryModality.NL_TO_PL, BudgetTier.STANDARD))
+        assert policy.initial_retrieval_policy is RetrievalPolicy.HYBRID
+        assert policy.use_vector_initial is True
+
+
+class TestPolicyProvenance:
+    def test_provenance_is_string_valued(self) -> None:
+        policy = policy_for(_classification(QueryModality.MIXED, BudgetTier.LARGE))
+        provenance = policy.to_provenance()
+        assert all(isinstance(k, str) and isinstance(v, str) for k, v in provenance.items())
+        assert provenance["policy_initial_retrieval"] == RetrievalPolicy.BM25_ONLY.value
+        assert provenance["policy_dense_trigger"] == DenseTrigger.DIFFUSE_TOP_SCORES.value
+        assert provenance["policy_candidate_cap"] == "80"
+        assert provenance["policy_dense_candidate_cap"] == "40"
+        assert provenance["policy_allow_rerank"] == "false"
+        assert provenance["policy_prefer_whole_file"] == "true"
+        assert "cross_encoder_rerank" in provenance["policy_skipped_steps"]
+        assert provenance["policy_diffuse_gap_threshold"] == "0.25"
+        assert set(provenance) == {
+            "policy_initial_retrieval",
+            "policy_use_vector_initial",
+            "policy_dense_trigger",
+            "policy_candidate_cap",
+            "policy_dense_candidate_cap",
+            "policy_rerank_candidate_limit",
+            "policy_allow_rerank",
+            "policy_graph_expansion",
+            "policy_prefer_whole_file",
+            "policy_diffuse_gap_threshold",
+            "policy_skipped_steps",
+            "policy_reasons",
+        }
+        assert provenance["policy_reasons"]
+
+
+class TestPolicyFromClassifier:
+    def test_code_query_tight_budget_is_bm25_only(self) -> None:
+        classification = classify_query("AuthManager.validate_token refresh_session", 2048)
+        policy = policy_for(classification)
+        assert policy.modality is QueryModality.PL_TO_PL
+        assert policy.budget_tier is BudgetTier.TIGHT
+        assert policy.initial_retrieval_policy is RetrievalPolicy.BM25_ONLY
+        assert policy.dense_trigger is DenseTrigger.LOW_SPARSE_CONFIDENCE
+
+    def test_natural_language_large_budget_allows_dense(self) -> None:
+        classification = classify_query("How does the authentication system work overall?", 16384)
+        policy = policy_for(classification)
+        assert policy.modality is QueryModality.NL_TO_PL
+        assert policy.budget_tier is BudgetTier.LARGE
+        assert policy.use_vector_initial is True
+        assert policy.prefer_whole_file is True
+
+    def test_mixed_issue_standard_budget_uses_diffuse_trigger(self) -> None:
+        classification = classify_query(
+            "The session cache never clears even after logout, can you check why "
+            "`cache.invalidate(session_id)` is not being called here",
+            6144,
+        )
+        policy = policy_for(classification)
+        assert policy.modality is QueryModality.MIXED
+        assert policy.budget_tier is BudgetTier.STANDARD
+        assert policy.use_vector_initial is False
+        assert policy.dense_trigger is DenseTrigger.DIFFUSE_TOP_SCORES


### PR DESCRIPTION
## Stack

Stack-Id: `task-aware-lane-cd265d`
Base: `bench/task-aware-classifier`
Position: 2/4

1. `bench/task-aware-classifier` -> #295
2. `bench/task-aware-policy` -> this PR
3. `bench/task-aware-strategy` -> #297
4. `bench/task-aware-reports-docs` -> (pending)

Depends on: #295
Upstack: #297

## Summary

Adds `archex.benchmark.task_aware`: a pure mapping from a
`ModalityClassification` (PR #295) to a deterministic, benchmark-only
retrieval plan (`TaskAwarePolicy`).

Routing rules (Workstream 2):
- `pl_to_pl`: BM25-only; dense expansion gated on low sparse confidence.
- `nl_to_pl`: bounded hybrid/dense initial pass.
- `mixed`: sparse first; targeted dense expansion only if top sparse scores
  are diffuse.
- Budget tier (`tight`/`standard`/`large`) scales hard candidate caps, the
  bounded rerank limit, the dense-trigger gap threshold, graph-expansion
  strictness, and a whole-file preservation preference.

RRF fusion and cross-encoder rerank are always recorded as skipped, bounding
the lane's retrieval surface. `to_provenance` flattens the plan for strategy
provenance. Mechanical whole-file packing is intentionally deferred to the
Workstream 4 retrieval-aware packing lane. No product path changes; no hosted
calls, telemetry, or network behaviour.

## Validation

- `uv run pytest tests/benchmark/test_task_aware.py` — 28 passed
- `uv run ruff check` on changed files — clean
- `uv run pyright` on changed files — clean
