### PR TITLE
Add archex_query_task_aware benchmark strategy

### DIFF
--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -28,6 +28,7 @@ class Strategy(StrEnum):
     ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT = "archex_query_hybrid_quantized_4bit"
     CROSS_LAYER_FUSION = "cross_layer_fusion"
     ARCHEX_QUERY_FUSION_RERANK = "archex_query_fusion_rerank"
+    ARCHEX_QUERY_TASK_AWARE = "archex_query_task_aware"
     EXTERNAL_MCP = "external_mcp"
 
 

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -47,6 +47,7 @@ AVAILABLE_STRATEGIES: list[Strategy] = [
     Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT,
     Strategy.ARCHEX_QUERY_FUSION_RERANK,
     Strategy.CROSS_LAYER_FUSION,
+    Strategy.ARCHEX_QUERY_TASK_AWARE,
 ]
 
 _VECTOR_STRATEGIES: frozenset[Strategy] = frozenset(

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -27,6 +27,7 @@ from archex.benchmark.region_metrics import (
     ReturnedRegion,
     compute_region_metrics,
 )
+from archex.benchmark.task_aware import DenseTrigger, TaskAwarePolicy, policy_for
 from archex.cache import CacheManager
 from archex.exceptions import ArchexError, ConfigError
 from archex.models import (
@@ -38,6 +39,7 @@ from archex.models import (
     RepoSource,
 )
 from archex.reporting import count_tokens
+from archex.serve.modality import classify_query
 
 logger = logging.getLogger(__name__)
 
@@ -1044,45 +1046,50 @@ def _region_result_fields(
     return metrics.as_result_fields() if metrics is not None else {}
 
 
-def _run_query_strategy(
+def _query_bundle(
     task: BenchmarkTask,
     repo_path: Path,
     *,
     strategy: Strategy,
     index_config: IndexConfig,
     cache: bool,
-    include_completion: bool = True,
-    measure_freshness: bool = False,
-) -> BenchmarkResult:
+) -> tuple[ContextBundle, IndexConfig, PipelineTiming]:
+    """Run the query pipeline once; return the bundle and effective index config."""
     from archex.api import query
     from archex.models import Config
 
-    t0 = time.perf_counter()
     timing = PipelineTiming()
     source = benchmark_repo_source(task, repo_path, strategy=strategy)
     config = Config(cache=cache, languages=task.languages)
-    index_config = benchmark_index_config(index_config, strategy=strategy)
+    effective_config = benchmark_index_config(index_config, strategy=strategy)
     bundle = query(
         source,
         task.question,
         token_budget=task.token_budget,
         explicit_token_budget=True,
         config=config,
-        index_config=index_config,
+        index_config=effective_config,
         timing=timing,
     )
+    return bundle, effective_config, timing
 
+
+def _assemble_query_result(
+    task: BenchmarkTask,
+    repo_path: Path,
+    *,
+    strategy: Strategy,
+    index_config: IndexConfig,
+    bundle: ContextBundle,
+    timing: PipelineTiming,
+    wall_ms: float,
+    include_completion: bool = True,
+    measure_freshness: bool = False,
+) -> BenchmarkResult:
+    """Build a BenchmarkResult from an already-retrieved bundle."""
     ranked_files = [chunk.chunk.file_path for chunk in bundle.chunks]
     unique_ranked = _deduplicate_ranked(ranked_files)
     result_files = set(unique_ranked)
-    wall_ms = (time.perf_counter() - t0) * 1000
-    logger.info(
-        "Strategy %s for %s: cached=%s, wall_time=%.1fms",
-        strategy.value,
-        task.task_id,
-        timing.cached,
-        wall_ms,
-    )
     recall = compute_recall(result_files, task.expected_files)
     precision = compute_precision(result_files, task.expected_files)
     required_metrics = compute_required_file_metrics(
@@ -1185,6 +1192,41 @@ def _run_query_strategy(
         )
     result_fields.update(_region_result_fields(bundle, task))
     return BenchmarkResult(**result_fields)
+
+
+def _run_query_strategy(
+    task: BenchmarkTask,
+    repo_path: Path,
+    *,
+    strategy: Strategy,
+    index_config: IndexConfig,
+    cache: bool,
+    include_completion: bool = True,
+    measure_freshness: bool = False,
+) -> BenchmarkResult:
+    t0 = time.perf_counter()
+    bundle, effective_config, timing = _query_bundle(
+        task, repo_path, strategy=strategy, index_config=index_config, cache=cache
+    )
+    wall_ms = (time.perf_counter() - t0) * 1000
+    logger.info(
+        "Strategy %s for %s: cached=%s, wall_time=%.1fms",
+        strategy.value,
+        task.task_id,
+        timing.cached,
+        wall_ms,
+    )
+    return _assemble_query_result(
+        task,
+        repo_path,
+        strategy=strategy,
+        index_config=effective_config,
+        bundle=bundle,
+        timing=timing,
+        wall_ms=wall_ms,
+        include_completion=include_completion,
+        measure_freshness=measure_freshness,
+    )
 
 
 def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
@@ -1564,6 +1606,171 @@ def run_cross_layer_fusion(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
     )
 
 
+def _vector_dependencies_available() -> bool:
+    """Return True when an embedding backend (fastembed/sentence-transformers) imports."""
+    try:
+        import fastembed as _fe  # noqa: F401  # pyright: ignore[reportUnusedImport]
+
+        return True
+    except ImportError:
+        pass
+    try:
+        import sentence_transformers as _st  # noqa: F401  # pyright: ignore[reportUnusedImport]
+
+        return True
+    except ImportError:
+        return False
+
+
+def _sparse_confidence(bundle: ContextBundle, *, window: int) -> tuple[float, float, int]:
+    """Return (top_score, relative_rank1_gap, candidate_count) over the top window.
+
+    The relative gap between the first and second scores is the cheap diffuseness
+    signal: a large gap means the top result clearly stands out (confident
+    sparse), a small gap means the top scores are diffuse.
+    """
+    scores = [chunk.final_score for chunk in bundle.chunks[:window]]
+    count = len(scores)
+    top = scores[0] if scores else 0.0
+    if count >= 2 and top > 0:
+        relative_gap = (scores[0] - scores[1]) / top
+    elif count == 1:
+        relative_gap = 1.0
+    else:
+        relative_gap = 0.0
+    return top, relative_gap, count
+
+
+def _should_expand_dense(
+    policy: TaskAwarePolicy, *, relative_gap: float, candidate_count: int
+) -> bool:
+    """Decide whether the conditional dense pass should run for a sparse-first policy.
+
+    Both conditional triggers — ``LOW_SPARSE_CONFIDENCE`` (pl_to_pl) and
+    ``DIFFUSE_TOP_SCORES`` (mixed) — share the same cheap signal: a small rank-1
+    relative gap means the top result does not clearly dominate, which is the
+    proxy for both "sparse confidence is low" and "top scores are diffuse". An
+    empty candidate set always expands. The absolute top score is recorded as a
+    diagnostic provenance signal but does not drive this decision.
+    """
+    if candidate_count == 0:
+        return True
+    return relative_gap < policy.diffuse_gap_threshold
+
+
+def _task_aware_index_config(policy: TaskAwarePolicy, *, vector: bool) -> IndexConfig:
+    """Bounded IndexConfig for a task-aware pass.
+
+    The cross-encoder reranker is disabled; confidence-aware fusion is governed by
+    the default retrieval policy when ``vector`` is True.
+    """
+    return IndexConfig(
+        vector=vector,
+        quantize_vectors=False,
+        rerank=False,
+        rerank_candidate_limit=policy.rerank_candidate_limit,
+    )
+
+
+def run_archex_query_task_aware(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
+    """Benchmark-only task-aware lane: route sparse/dense retrieval by modality + budget.
+
+    Classifies the query modality and budget tier, derives a deterministic
+    TaskAwarePolicy, and runs a sparse-first BM25 pass (or a bounded hybrid pass
+    for nl_to_pl). For pl_to_pl/mixed it may run one targeted dense expansion pass
+    when the top sparse scores are diffuse. The cross-encoder reranker is never
+    run; confidence-aware fusion runs only on the hybrid/dense pass. Work is
+    bounded to at most two retrieval passes. Strategy provenance records modality,
+    budget tier, the routing decision, candidate caps, skipped expensive steps,
+    and whether fusion ran. Product defaults are unchanged.
+    """
+    strategy = Strategy.ARCHEX_QUERY_TASK_AWARE
+    classification = classify_query(task.question, task.token_budget)
+    policy = policy_for(classification)
+    vector_available = _vector_dependencies_available()
+
+    t0 = time.perf_counter()
+    initial_vector = policy.use_vector_initial and vector_available
+    if policy.use_vector_initial and not vector_available:
+        initial_pass = "bm25_only(vector_unavailable_fallback)"
+    else:
+        initial_pass = "hybrid" if initial_vector else "bm25_only"
+    bundle, effective_config, timing = _query_bundle(
+        task,
+        repo_path,
+        strategy=strategy,
+        index_config=_task_aware_index_config(policy, vector=initial_vector),
+        cache=True,
+    )
+    initial_cached = timing.cached
+    initial_cache_state = _cache_state(timing)
+
+    top_score, relative_gap, candidate_count = _sparse_confidence(
+        bundle, window=policy.candidate_cap
+    )
+
+    if policy.dense_trigger is DenseTrigger.NEVER:
+        dense_expansion = "disabled"
+    elif policy.dense_trigger is DenseTrigger.ALWAYS:
+        dense_expansion = "initial_hybrid" if initial_vector else "skipped:vector_unavailable"
+    elif not _should_expand_dense(
+        policy, relative_gap=relative_gap, candidate_count=candidate_count
+    ):
+        dense_expansion = "skipped:confident_sparse"
+    elif not vector_available:
+        dense_expansion = "skipped:vector_unavailable"
+    else:
+        bundle, effective_config, timing = _query_bundle(
+            task,
+            repo_path,
+            strategy=strategy,
+            index_config=_task_aware_index_config(policy, vector=True),
+            cache=True,
+        )
+        # Report cache state across both passes: warm only if neither built work.
+        timing.cached = initial_cached and timing.cached
+        dense_expansion = "ran"
+
+    wall_ms = (time.perf_counter() - t0) * 1000
+    logger.info(
+        "Strategy %s for %s: modality=%s tier=%s dense=%s wall=%.1fms",
+        strategy.value,
+        task.task_id,
+        classification.modality.value,
+        classification.budget_tier.value,
+        dense_expansion,
+        wall_ms,
+    )
+    result = _assemble_query_result(
+        task,
+        repo_path,
+        strategy=strategy,
+        index_config=effective_config,
+        bundle=bundle,
+        timing=timing,
+        wall_ms=wall_ms,
+        include_completion=True,
+        measure_freshness=False,
+    )
+    routing_decision = (
+        f"{initial_pass}+dense_expansion" if dense_expansion == "ran" else initial_pass
+    )
+    fusion_used = initial_vector or dense_expansion == "ran"
+    runtime_provenance = {
+        "routing_decision": routing_decision,
+        "initial_pass": initial_pass,
+        "dense_expansion": dense_expansion,
+        "fusion_used": str(fusion_used).lower(),
+        "sparse_top_score": f"{top_score:.4f}",
+        "sparse_relative_gap": f"{relative_gap:.4f}",
+        "sparse_candidate_count": str(candidate_count),
+        "initial_cache_state": initial_cache_state,
+        "vector_dependencies_available": str(vector_available).lower(),
+    }
+    result.provenance = classification.to_provenance() | policy.to_provenance() | runtime_provenance
+    return result
+
+
 class StrategyRegistry:
     """Registry for benchmark strategy runners with entry-point support."""
 
@@ -1634,4 +1841,7 @@ default_strategy_registry.register(
     Strategy.ARCHEX_QUERY_FUSION_RERANK.value, run_archex_query_fusion_rerank
 )
 default_strategy_registry.register(Strategy.CROSS_LAYER_FUSION.value, run_cross_layer_fusion)
+default_strategy_registry.register(
+    Strategy.ARCHEX_QUERY_TASK_AWARE.value, run_archex_query_task_aware
+)
 default_strategy_registry.register(Strategy.EXTERNAL_MCP.value, _run_external_mcp_strategy)

--- a/tests/benchmark/test_task_aware_strategy.py
+++ b/tests/benchmark/test_task_aware_strategy.py
@@ -1,0 +1,273 @@
+"""Tests for the benchmark-only archex_query_task_aware strategy."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import archex.benchmark.strategies as strategies
+from archex.benchmark.models import BenchmarkTask, Strategy
+from archex.benchmark.runner import AVAILABLE_STRATEGIES, DEFAULT_STRATEGIES
+from archex.benchmark.strategies import (
+    _should_expand_dense,  # pyright: ignore[reportPrivateUsage]
+    _sparse_confidence,  # pyright: ignore[reportPrivateUsage]
+    run_archex_query_task_aware,
+)
+from archex.benchmark.task_aware import policy_for
+from archex.models import CodeChunk, ContextBundle, IndexConfig, PipelineTiming, RankedChunk
+from archex.serve.modality import BudgetTier, QueryModality, classify_query
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _ranked(chunk_id: str, score: float) -> RankedChunk:
+    chunk = CodeChunk(
+        id=chunk_id,
+        content=f"content {chunk_id}",
+        file_path=f"{chunk_id}.py",
+        start_line=1,
+        end_line=1,
+        language="python",
+        token_count=4,
+    )
+    return RankedChunk(chunk=chunk, final_score=score)
+
+
+def _bundle(*scores: float) -> ContextBundle:
+    chunks = [_ranked(f"c{i}", score) for i, score in enumerate(scores)]
+    return ContextBundle(query="q", chunks=chunks, token_count=0)
+
+
+class TestStrategyRegistry:
+    def test_runner_registered(self) -> None:
+        runner = strategies.default_strategy_registry.get(Strategy.ARCHEX_QUERY_TASK_AWARE)
+        assert runner is run_archex_query_task_aware
+
+    def test_name_in_registry(self) -> None:
+        names = strategies.default_strategy_registry.strategy_names
+        assert Strategy.ARCHEX_QUERY_TASK_AWARE.value in names
+
+    def test_not_a_product_default(self) -> None:
+        assert Strategy.ARCHEX_QUERY_TASK_AWARE not in DEFAULT_STRATEGIES
+
+    def test_is_available_strategy(self) -> None:
+        assert Strategy.ARCHEX_QUERY_TASK_AWARE in AVAILABLE_STRATEGIES
+
+    def test_default_strategy_list_unchanged(self) -> None:
+        assert DEFAULT_STRATEGIES == [
+            Strategy.RAW_FILES,
+            Strategy.RAW_RIPGREP,
+            Strategy.ARCHEX_QUERY,
+        ]
+
+
+class TestSparseConfidence:
+    def test_empty_bundle(self) -> None:
+        top, gap, count = _sparse_confidence(_bundle(), window=40)
+        assert top == 0.0
+        assert gap == 0.0
+        assert count == 0
+
+    def test_single_chunk_is_confident(self) -> None:
+        top, gap, count = _sparse_confidence(_bundle(0.8), window=40)
+        assert top == 0.8
+        assert gap == 1.0
+        assert count == 1
+
+    def test_diffuse_top_scores_small_gap(self) -> None:
+        _top, gap, count = _sparse_confidence(_bundle(1.0, 0.95, 0.9), window=40)
+        assert count == 3
+        assert abs(gap - 0.05) < 1e-9
+
+    def test_clear_top_score_large_gap(self) -> None:
+        _top, gap, _count = _sparse_confidence(_bundle(1.0, 0.2), window=40)
+        assert abs(gap - 0.8) < 1e-9
+
+    def test_window_caps_candidate_count(self) -> None:
+        _top, _gap, count = _sparse_confidence(_bundle(1.0, 0.9, 0.8, 0.7), window=2)
+        assert count == 2
+
+
+class TestShouldExpandDense:
+    def test_no_candidates_expands(self) -> None:
+        policy = policy_for(classify_query("AuthManager.validate_token refresh", 4096))
+        assert _should_expand_dense(policy, relative_gap=1.0, candidate_count=0) is True
+
+    def test_diffuse_gap_expands(self) -> None:
+        policy = policy_for(classify_query("AuthManager.validate_token refresh", 4096))
+        # standard tier threshold is 0.15
+        assert _should_expand_dense(policy, relative_gap=0.05, candidate_count=5) is True
+
+    def test_confident_gap_does_not_expand(self) -> None:
+        policy = policy_for(classify_query("AuthManager.validate_token refresh", 4096))
+        assert _should_expand_dense(policy, relative_gap=0.5, candidate_count=5) is False
+
+
+class TestRunTaskAwareFixture:
+    @pytest.fixture(autouse=True)
+    def _no_vector(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Keep the lane hermetic: never reach for embedding backends.
+        monkeypatch.setattr(strategies, "_vector_dependencies_available", lambda: False)
+
+    def _task(self, question: str, token_budget: int = 4096) -> BenchmarkTask:
+        return BenchmarkTask(
+            task_id="task_aware_test",
+            repo="test/repo",
+            commit="abc",
+            question=question,
+            expected_files=["main.py"],
+            token_budget=token_budget,
+        )
+
+    def test_pl_to_pl_runs_bm25_only(self, python_simple_repo: Path) -> None:
+        task = self._task("main.py main function module")
+        result = run_archex_query_task_aware(task, python_simple_repo)
+
+        assert result.strategy == Strategy.ARCHEX_QUERY_TASK_AWARE
+        assert result.tool_calls == 1
+        assert 0.0 <= result.required_file_recall <= 1.0
+        prov = result.provenance
+        assert prov["modality"] == QueryModality.PL_TO_PL.value
+        assert prov["budget_tier"] == BudgetTier.STANDARD.value
+        assert prov["initial_pass"] == "bm25_only"
+        assert prov["routing_decision"] == "bm25_only"
+        # vector unavailable: a diffuse sparse result cannot escalate to dense.
+        assert prov["dense_expansion"] in {"skipped:confident_sparse", "skipped:vector_unavailable"}
+        assert prov["fusion_used"] == "false"
+
+    def test_provenance_records_policy_and_routing(self, python_simple_repo: Path) -> None:
+        task = self._task("main.py main function module")
+        prov = run_archex_query_task_aware(task, python_simple_repo).provenance
+        for key in (
+            "modality",
+            "budget_tier",
+            "routing_decision",
+            "dense_expansion",
+            "initial_pass",
+            "policy_candidate_cap",
+            "policy_dense_candidate_cap",
+            "policy_skipped_steps",
+            "sparse_relative_gap",
+            "vector_dependencies_available",
+            "fusion_used",
+            "initial_cache_state",
+        ):
+            assert key in prov, key
+        assert "cross_encoder_rerank" in prov["policy_skipped_steps"]
+        assert prov["vector_dependencies_available"] == "false"
+
+    def test_nl_to_pl_falls_back_without_vector(self, python_simple_repo: Path) -> None:
+        task = self._task("How does the application start up and run overall?")
+        prov = run_archex_query_task_aware(task, python_simple_repo).provenance
+        assert prov["modality"] == QueryModality.NL_TO_PL.value
+        assert prov["initial_pass"] == "bm25_only(vector_unavailable_fallback)"
+        assert prov["dense_expansion"] == "skipped:vector_unavailable"
+
+
+def _install_query_stub(
+    monkeypatch: pytest.MonkeyPatch,
+    bundle: ContextBundle,
+    vector_flags: list[bool],
+) -> None:
+    def fake_query_bundle(
+        task: BenchmarkTask,
+        repo_path: Path,
+        *,
+        strategy: Strategy,
+        index_config: IndexConfig,
+        cache: bool,
+    ) -> tuple[ContextBundle, IndexConfig, PipelineTiming]:
+        # Core safety claim: a task-aware pass never enables the cross-encoder reranker.
+        assert index_config.rerank is False
+        vector_flags.append(index_config.vector)
+        return bundle, index_config, PipelineTiming()
+
+    monkeypatch.setattr(strategies, "_query_bundle", fake_query_bundle)
+
+
+def _stub_task(question: str, token_budget: int = 4096) -> BenchmarkTask:
+    return BenchmarkTask(
+        task_id="t",
+        repo="r",
+        commit="abc",
+        question=question,
+        expected_files=["main.py"],
+        token_budget=token_budget,
+    )
+
+
+class TestRunTaskAwareDenseRouting:
+    """Stub the retrieval pass to exercise dense routing deterministically."""
+
+    def test_dense_expansion_runs_when_diffuse(
+        self, monkeypatch: pytest.MonkeyPatch, python_simple_repo: Path
+    ) -> None:
+        monkeypatch.setattr(strategies, "_vector_dependencies_available", lambda: True)
+        vector_flags: list[bool] = []
+        _install_query_stub(monkeypatch, _bundle(1.0, 0.99, 0.98), vector_flags)
+
+        prov = run_archex_query_task_aware(
+            _stub_task("AuthManager.validate_token refresh_session handler"),
+            python_simple_repo,
+        ).provenance
+        assert prov["modality"] == QueryModality.PL_TO_PL.value
+        assert prov["dense_expansion"] == "ran"
+        assert prov["fusion_used"] == "true"
+        assert "+dense_expansion" in prov["routing_decision"]
+        # Initial sparse pass then a dense pass.
+        assert vector_flags == [False, True]
+
+    def test_dense_skipped_when_confident(
+        self, monkeypatch: pytest.MonkeyPatch, python_simple_repo: Path
+    ) -> None:
+        monkeypatch.setattr(strategies, "_vector_dependencies_available", lambda: True)
+        vector_flags: list[bool] = []
+        _install_query_stub(monkeypatch, _bundle(1.0, 0.1), vector_flags)
+
+        prov = run_archex_query_task_aware(
+            _stub_task("AuthManager.validate_token refresh_session handler"),
+            python_simple_repo,
+        ).provenance
+        assert prov["dense_expansion"] == "skipped:confident_sparse"
+        assert prov["fusion_used"] == "false"
+        # Only the initial sparse pass ran.
+        assert vector_flags == [False]
+
+    def test_nl_to_pl_initial_hybrid_single_pass(
+        self, monkeypatch: pytest.MonkeyPatch, python_simple_repo: Path
+    ) -> None:
+        monkeypatch.setattr(strategies, "_vector_dependencies_available", lambda: True)
+        vector_flags: list[bool] = []
+        _install_query_stub(monkeypatch, _bundle(1.0, 0.9), vector_flags)
+
+        prov = run_archex_query_task_aware(
+            _stub_task("How does the application start up and run overall?"),
+            python_simple_repo,
+        ).provenance
+        assert prov["modality"] == QueryModality.NL_TO_PL.value
+        assert prov["initial_pass"] == "hybrid"
+        assert prov["dense_expansion"] == "initial_hybrid"
+        assert prov["fusion_used"] == "true"
+        # A single hybrid pass; no separate dense pass.
+        assert vector_flags == [True]
+
+    def test_mixed_dense_expansion_when_diffuse(
+        self, monkeypatch: pytest.MonkeyPatch, python_simple_repo: Path
+    ) -> None:
+        monkeypatch.setattr(strategies, "_vector_dependencies_available", lambda: True)
+        vector_flags: list[bool] = []
+        _install_query_stub(monkeypatch, _bundle(1.0, 0.99, 0.98), vector_flags)
+
+        prov = run_archex_query_task_aware(
+            _stub_task(
+                "The session cache never clears even after logout, can you check why "
+                "`cache.invalidate(session_id)` is not being called here",
+                6144,
+            ),
+            python_simple_repo,
+        ).provenance
+        assert prov["modality"] == QueryModality.MIXED.value
+        assert prov["dense_expansion"] == "ran"
+        assert vector_flags == [False, True]


### PR DESCRIPTION
## Stack

Stack-Id: `task-aware-lane-cd265d`
Base: `bench/task-aware-policy`
Position: 3/4

1. `bench/task-aware-classifier` -> #295
2. `bench/task-aware-policy` -> #296
3. `bench/task-aware-strategy` -> this PR
4. `bench/task-aware-reports-docs` -> #298

Depends on: #296
Upstack: #298

## Summary

Adds `archex_query_task_aware`, a benchmark-only retrieval lane that consumes
the classifier (#295) and policy (#296):

- Classifies modality + budget tier, derives a `TaskAwarePolicy`.
- Runs a sparse-first BM25 pass (bounded hybrid for `nl_to_pl`).
- For `pl_to_pl`/`mixed`, runs **one** targeted dense expansion pass only when
  the top sparse scores are diffuse (cheap relative-gap signal) and an embedding
  backend is available; otherwise records why it was skipped.
- Confidence-aware fusion runs **only** on the hybrid/dense pass; the
  cross-encoder reranker is never run. Total work is bounded to at most two
  retrieval passes.
- Provenance records modality, budget tier, routing decision, candidate caps,
  the unconditionally-skipped step (cross-encoder rerank), whether fusion ran,
  the sparse-confidence signals, and combined cache state across both passes.

Registers the runner and adds `ARCHEX_QUERY_TASK_AWARE` to
`AVAILABLE_STRATEGIES` **without** touching `DEFAULT_STRATEGIES`, so the product
query path and default strategy list are unchanged. Extracts `_query_bundle`
and `_assemble_query_result` so the lane reuses existing result construction and
receipt handling. No hosted calls, telemetry, or mandatory network behaviour;
the dense pass degrades gracefully when embedding deps are absent.

## Validation

- `uv run pytest tests/benchmark/test_strategy_registry.py tests/benchmark/test_strategies.py tests/benchmark/test_task_aware.py tests/benchmark/test_task_aware_strategy.py tests/benchmark/test_runner.py tests/benchmark/test_reporter.py` — 204 passed
- `uv run pytest tests/benchmark/test_cli.py -k 'strategy or benchmark or report'` — 32 passed
- `uv run ruff check` / `uv run pyright` on changed files — clean
