### PR TITLE
Add scipy to core dependencies (fixes #266)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,28 @@ jobs:
         with:
           name: test-results-${{ matrix.python-version }}
           path: results.xml
+
+  smoke-min-install:
+    # Guard against missing runtime dependencies that the full --all-extras dev
+    # environment masks (e.g. networkx pagerank's transitive numpy/scipy). Install
+    # ONLY [project.dependencies] into a clean venv and exercise the core query
+    # path end-to-end; a missing core dependency fails here.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install core dependencies only (no extras, no dev group)
+        run: |
+          python -m venv .smoke-venv
+          .smoke-venv/bin/pip install --upgrade pip
+          .smoke-venv/bin/pip install .
+
+      - name: Exercise core query path on a clean install
+        run: |
+          .smoke-venv/bin/archex index .
+          .smoke-venv/bin/archex query "how does archex score and rank retrieval candidates"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.13.2] - 2026-06-19
+
+### Fixed
+
+- **Missing scipy dependency:** `scipy` was absent from `[project.dependencies]` (declared only in the dev group), causing `ModuleNotFoundError: No module named 'scipy'` when `archex query` ran on a plain `archex[mcp]` install. networkx ≥ 3.3 routes `nx.pagerank()` — used by `DependencyGraph.structural_centrality` on the core query path — through `_pagerank_scipy`, which does a bare `import numpy` then `import scipy` at call time. v0.12.1 promoted `numpy` but missed `scipy` on the very next line of the same function, and CI installs `--all-extras` (which always pulls scipy transitively), so the gap stayed invisible. Promoted `scipy>=1.11.2` to a declared core dependency and removed the redundant dev entry. Added a minimal-install CI smoke job that installs only core dependencies and runs `archex index`/`archex query` end-to-end so missing runtime dependencies fail CI. Fixes #266.
+
 ## [0.13.1] - 2026-06-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archex"
-version = "0.13.1"
+version = "0.13.2"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -31,6 +31,7 @@ dependencies = [
     "pydantic>=2.7",
     "networkx>=3.3",
     "numpy>=1.24",
+    "scipy>=1.11.2",
     "click>=8.1",
     "pyyaml>=6.0",
     "rich==14.3.3",
@@ -130,5 +131,4 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.0.0",
     "ruff>=0.5",
-    "scipy>=1.17.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "archex"
-version = "0.13.1"
+version = "0.13.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -183,6 +183,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "scipy" },
     { name = "tiktoken" },
     { name = "tree-sitter" },
     { name = "tree-sitter-c-sharp" },
@@ -250,7 +251,6 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "scipy" },
 ]
 
 [package.metadata]
@@ -269,6 +269,7 @@ requires-dist = [
     { name = "python-igraph", marker = "extra == 'graph'", specifier = ">=0.11" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = "==14.3.3" },
+    { name = "scipy", specifier = ">=1.11.2" },
     { name = "sentence-transformers", marker = "extra == 'vector-torch'", specifier = ">=5.2,<6" },
     { name = "tiktoken", specifier = ">=0.7" },
     { name = "torch", marker = "extra == 'splade'", specifier = ">=2.0" },
@@ -300,7 +301,6 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.5" },
-    { name = "scipy", specifier = ">=1.17.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fixes the reopened #266. On a clean `archex[mcp]` install, `archex query` still crashed:

```
File ".../networkx/algorithms/link_analysis/pagerank_alg.py", line 453, in _pagerank_scipy
    import scipy as sp
ModuleNotFoundError: No module named 'scipy'
```

Same root cause as the original numpy gap, one import line later. networkx ≥ 3.3
routes `nx.pagerank()` — called by `DependencyGraph.structural_centrality` on the
**core** query path (`assemble_context`) — through `_pagerank_scipy`, which does a
bare `import numpy` (line 452) then `import scipy` (line 453). v0.12.1 promoted
`numpy` but left `scipy` declared **only in the dev group**, so end users without
the dev/extra packages don't get it.

## Why CI didn't catch it

CI installs `uv sync --all-extras`, and scipy is always pulled transitively by
the extras/dev packages (scikit-learn, sentence-transformers, torch, …). So the
bare `import scipy` inside networkx always succeeded in dev and CI; the gap only
appears on a minimal end-user install. The v0.12.1 fix also patched the first
failing import (numpy) without auditing that the same networkx function imports
scipy on the next line.

## Fix

- Promote `scipy>=1.11.2` to `[project.dependencies]`; remove the redundant
  `[dependency-groups] dev` entry (mirrors the numpy fix).
- Bump version to `0.13.2`; CHANGELOG entry.
- **Regression guard:** new `smoke-min-install` CI job that installs only
  `[project.dependencies]` into a clean venv (no extras, no dev group) and runs
  `archex index` + `archex query` end-to-end — a missing core runtime dependency
  now fails CI instead of hiding behind `--all-extras`.

## Verification (local clean install)

- Reproduced the exact failure: fresh venv + `pip install .` (current main, core
  only) → `archex query` on a real codebase → `ModuleNotFoundError: No module
  named 'scipy'` at `_pagerank_scipy` line 453.
- With the fix: fresh venv + `pip install .` → `scipy 1.17.1` resolved → the same
  `archex query` returns a full context bundle, no error, no other missing dep.
- `uv lock` re-resolved (170 packages); `ci.yml` validates.
