### PR TITLE
Compression lane (1/4): compression metadata model and receipt extension

### DIFF
--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -743,6 +743,11 @@ class CompressionMetadata(BaseModel):
             raise ValueError("token counts must be non-negative")
         if self.compression_ratio < 0.0:
             raise ValueError("compression_ratio must be non-negative")
+        if (
+            self.compression_mode is CompressionMode.PASSTHROUGH_REQUIRED
+            and self.compressed_content_hash != self.original_content_hash
+        ):
+            raise ValueError("passthrough_required rows must keep the original content hash")
         return self
 
     @property

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -134,6 +134,25 @@ class ContextOmittedEdgeReason(StrEnum):
     BELOW_THRESHOLD = "below_threshold"
 
 
+class CompressionMode(StrEnum):
+    """Deterministic post-retrieval compression mode applied to a returned region."""
+
+    PASSTHROUGH_REQUIRED = "passthrough_required"
+    STRUCTURAL_CODE_ELISION = "structural_code_elision"
+    COMMENT_AND_WHITESPACE_SLIMMING = "comment_and_whitespace_slimming"
+    LARGE_LITERAL_SUMMARIZATION = "large_literal_summarization"
+    JSON_LOG_SMART_CRUSHING = "json_log_smart_crushing"
+
+
+class CompressionLossRisk(StrEnum):
+    """How risky a compression mode is for an editing/debugging agent."""
+
+    NONE = "none"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
 # ---------------------------------------------------------------------------
 # Type aliases
 # ---------------------------------------------------------------------------
@@ -699,6 +718,39 @@ class ContextReceiptTokenBudget(BaseModel):
     consumed: int
 
 
+class CompressionMetadata(BaseModel):
+    """Optional provenance for a post-retrieval compression step on one region.
+
+    Absent on uncompressed rows. When present, the original region stays exactly
+    retrievable via ``fetch_original_handle`` + ``original_content_hash`` so
+    compression never hides editable evidence. ``compression_ratio`` is the
+    fraction of original tokens retained (1.0 means nothing was removed); a
+    ``passthrough_required`` row keeps the original content and hashes unchanged.
+    """
+
+    compression_mode: CompressionMode
+    original_tokens: int
+    compressed_tokens: int
+    compression_ratio: float
+    original_content_hash: str
+    compressed_content_hash: str
+    fetch_original_handle: str
+    compression_loss_risk: CompressionLossRisk = CompressionLossRisk.NONE
+
+    @model_validator(mode="after")
+    def _validate_compression(self) -> CompressionMetadata:
+        if self.original_tokens < 0 or self.compressed_tokens < 0:
+            raise ValueError("token counts must be non-negative")
+        if self.compression_ratio < 0.0:
+            raise ValueError("compression_ratio must be non-negative")
+        return self
+
+    @property
+    def is_compressed(self) -> bool:
+        """True when the displayed content differs from the original region."""
+        return self.compressed_content_hash != self.original_content_hash
+
+
 class ContextReceiptItem(BaseModel):
     handle: str
     file_path: str
@@ -708,6 +760,7 @@ class ContextReceiptItem(BaseModel):
     symbols: list[str] = []
     score: float = 0.0
     reason_codes: list[str] = []
+    compression: CompressionMetadata | None = None
 
 
 class ContextReceiptEdge(BaseModel):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -294,6 +294,11 @@ def test_compression_metadata_rejects_negative_counts() -> None:
         _compression_metadata(compressed_tokens=-1)
 
 
+def test_compression_metadata_passthrough_requires_matching_hash() -> None:
+    with pytest.raises(ValueError, match="passthrough_required rows must keep"):
+        _compression_metadata(compression_mode=CompressionMode.PASSTHROUGH_REQUIRED)
+
+
 def test_context_receipt_item_uncompressed_row_has_no_metadata() -> None:
     item = ContextReceiptItem(
         handle="chunk:x", file_path="a.py", start_line=1, end_line=10, content_hash="h"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,6 +6,9 @@ from archex.models import (
     ArchDecision,
     ArchProfile,
     CodeChunk,
+    CompressionLossRisk,
+    CompressionMetadata,
+    CompressionMode,
     Config,
     ContextBundle,
     ContextCompletenessReason,
@@ -226,6 +229,92 @@ def test_context_receipt_edge_confidence_score_bounds() -> None:
             kind=EdgeKind.IMPORTS,
             confidence_score=1.1,
         )
+
+
+# ---------------------------------------------------------------------------
+# CompressionMetadata model
+# ---------------------------------------------------------------------------
+
+
+def _compression_metadata(**overrides: object) -> CompressionMetadata:
+    fields: dict[str, object] = {
+        "compression_mode": CompressionMode.STRUCTURAL_CODE_ELISION,
+        "original_tokens": 120,
+        "compressed_tokens": 48,
+        "compression_ratio": 0.4,
+        "original_content_hash": "orig",
+        "compressed_content_hash": "comp",
+        "fetch_original_handle": "chunk:abc",
+        "compression_loss_risk": CompressionLossRisk.LOW,
+    }
+    fields.update(overrides)
+    return CompressionMetadata(**fields)  # type: ignore[arg-type]
+
+
+def test_compression_mode_and_loss_risk_members() -> None:
+    assert {member.value for member in CompressionMode} == {
+        "passthrough_required",
+        "structural_code_elision",
+        "comment_and_whitespace_slimming",
+        "large_literal_summarization",
+        "json_log_smart_crushing",
+    }
+    assert {member.value for member in CompressionLossRisk} == {"none", "low", "medium", "high"}
+
+
+def test_compression_metadata_round_trip_is_deterministic() -> None:
+    meta = _compression_metadata()
+    dumped = meta.model_dump_json()
+    restored = CompressionMetadata.model_validate_json(dumped)
+    assert restored == meta
+    assert restored.model_dump_json() == dumped
+
+
+def test_compression_metadata_compressed_row_is_marked() -> None:
+    meta = _compression_metadata()
+    assert meta.is_compressed is True
+    assert meta.compression_loss_risk == CompressionLossRisk.LOW
+
+
+def test_compression_metadata_passthrough_row_is_neutral() -> None:
+    meta = _compression_metadata(
+        compression_mode=CompressionMode.PASSTHROUGH_REQUIRED,
+        original_tokens=60,
+        compressed_tokens=60,
+        compression_ratio=1.0,
+        compressed_content_hash="orig",
+        compression_loss_risk=CompressionLossRisk.NONE,
+    )
+    assert meta.is_compressed is False
+    assert meta.original_tokens == meta.compressed_tokens
+
+
+def test_compression_metadata_rejects_negative_counts() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        _compression_metadata(compressed_tokens=-1)
+
+
+def test_context_receipt_item_uncompressed_row_has_no_metadata() -> None:
+    item = ContextReceiptItem(
+        handle="chunk:x", file_path="a.py", start_line=1, end_line=10, content_hash="h"
+    )
+    assert item.compression is None
+    assert item.model_dump()["compression"] is None
+
+
+def test_context_receipt_item_carries_compression_metadata() -> None:
+    item = ContextReceiptItem(
+        handle="chunk:x",
+        file_path="a.py",
+        start_line=1,
+        end_line=10,
+        content_hash="h",
+        compression=_compression_metadata(fetch_original_handle="chunk:x"),
+    )
+    restored = ContextReceiptItem.model_validate_json(item.model_dump_json())
+    assert restored == item
+    assert restored.compression is not None
+    assert restored.compression.is_compressed is True
 
 
 def test_pattern_category_members() -> None:

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from archex.models import (
+    CompressionLossRisk,
+    CompressionMetadata,
+    CompressionMode,
     ContextBundle,
     ContextCompletenessReason,
     ContextCompletenessStatus,
     ContextFreshness,
     ContextReceipt,
     ContextReceiptEdge,
+    ContextReceiptItem,
     ContextReceiptTokenBudget,
     ContextRecommendedAction,
     ContextSkippedCandidate,
@@ -150,3 +154,62 @@ def test_scout_receipt_does_not_mark_selected_handle_files_as_skipped() -> None:
     assert receipt.context_complete == ContextCompletenessStatus.COMPLETE
     assert receipt.context_complete_reason == ContextCompletenessReason.COMPLETE
     assert receipt.recommended_next_action == ContextRecommendedAction.USE_BUNDLE
+
+
+def _compressed_item(handle: str) -> ContextReceiptItem:
+    return ContextReceiptItem(
+        handle=handle,
+        file_path="src/widget.py",
+        start_line=1,
+        end_line=40,
+        content_hash="orig-hash",
+        compression=CompressionMetadata(
+            compression_mode=CompressionMode.STRUCTURAL_CODE_ELISION,
+            original_tokens=200,
+            compressed_tokens=70,
+            compression_ratio=0.35,
+            original_content_hash="orig-hash",
+            compressed_content_hash="elided-hash",
+            fetch_original_handle=handle,
+            compression_loss_risk=CompressionLossRisk.LOW,
+        ),
+    )
+
+
+def test_compression_metadata_does_not_upgrade_receipt_completeness() -> None:
+    receipt = ContextReceipt(
+        query="q",
+        token_budget=ContextReceiptTokenBudget(requested=500, consumed=250),
+        index_revision="rev",
+        freshness=ContextFreshness.CLEAN,
+        returned_context=[_compressed_item("chunk:widget")],
+        returned_total=1,
+        context_complete=ContextCompletenessStatus.INCOMPLETE,
+        context_complete_reason=ContextCompletenessReason.BUDGET_EXHAUSTED,
+        recommended_next_action=ContextRecommendedAction.RAISE_BUDGET,
+    )
+
+    # Compression metadata is orthogonal to completeness: an incomplete receipt
+    # stays incomplete and keeps its reason/action even when rows are compressed.
+    assert receipt.context_complete == ContextCompletenessStatus.INCOMPLETE
+    assert receipt.context_complete_reason == ContextCompletenessReason.BUDGET_EXHAUSTED
+    assert receipt.recommended_next_action == ContextRecommendedAction.RAISE_BUDGET
+    assert receipt.returned_context[0].compression is not None
+    assert receipt.returned_context[0].compression.is_compressed is True
+
+
+def test_receipt_round_trips_with_compressed_rows() -> None:
+    receipt = ContextReceipt(
+        query="q",
+        token_budget=ContextReceiptTokenBudget(requested=500, consumed=250),
+        index_revision="rev",
+        returned_context=[_compressed_item("chunk:widget")],
+        returned_total=1,
+        context_complete=ContextCompletenessStatus.COMPLETE,
+        context_complete_reason=ContextCompletenessReason.COMPLETE,
+        recommended_next_action=ContextRecommendedAction.USE_BUNDLE,
+    )
+    restored = ContextReceipt.model_validate_json(receipt.model_dump_json())
+    assert restored == receipt
+    # A compressed row never flips a complete receipt; completeness is preserved.
+    assert restored.context_complete == ContextCompletenessStatus.COMPLETE


### PR DESCRIPTION
## Summary

Adds the data model for the post-retrieval compression lane (Workstream 3 of the retrieval quality / token-efficiency design). This is the first PR in a benchmark-only compression stack; it changes no retrieval behavior.

- New enums `CompressionMode` (`passthrough_required`, `structural_code_elision`, `comment_and_whitespace_slimming`, `large_literal_summarization`, `json_log_smart_crushing`) and `CompressionLossRisk` (`none`/`low`/`medium`/`high`).
- New `CompressionMetadata` model carrying `compression_mode`, `original_tokens`, `compressed_tokens`, `compression_ratio`, `original_content_hash`, `compressed_content_hash`, `fetch_original_handle`, and `compression_loss_risk`.
- Optional `compression` field on `ContextReceiptItem`: absent (neutral) for uncompressed rows; present on compressed rows so the exact original handle and hash remain retrievable.

## Invariants

- Compression metadata is a passive carrier. It never participates in receipt completeness — a `passthrough_required` row keeps the original content and hashes unchanged, and an incomplete receipt stays incomplete even when rows are compressed.
- `is_compressed` is derived from a hash mismatch, so passthrough rows report `False`.

## Tests

- `tests/test_models.py`: enum membership, dump/load determinism, compressed vs passthrough row behavior, non-negative validation, uncompressed-row neutral default.
- `tests/test_receipt.py`: compression metadata never upgrades `context_complete`; receipts round-trip with compressed rows.

```
uv run pytest tests/test_models.py tests/test_receipt.py
```

## Stack

Stack-Id: `compression-lane-501320`
Base: `main`
Position: 1/4

1. `bench/compression-metadata-model` -> this PR
2. `bench/compression-primitives` -> PR 2
3. `bench/compression-strategy` -> PR 3
4. `bench/compression-reports-docs` -> PR 4

Depends on: (none - root)

## Validation

- Passed: `uv run pytest tests/test_models.py tests/test_receipt.py` (87 passed)
