### PR TITLE
Compression lane (2/4): deterministic compression primitives

### DIFF
--- a/src/archex/serve/compression.py
+++ b/src/archex/serve/compression.py
@@ -1,0 +1,389 @@
+"""Deterministic, low-risk post-retrieval content compression primitives.
+
+These operate purely on already-assembled returned-region text. They never call
+hosted services, local models, or semantic summarizers; every mode is a
+deterministic text transform that preserves stable anchors and points back to
+the original via an explicit ``fetch original`` marker. Required, direct, and
+high-confidence regions pass through unchanged.
+
+The primitives here are content-only. Token counts and content hashes for the
+:class:`~archex.models.CompressionMetadata` record are computed by the caller,
+where the file path and line range are known.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from archex.models import CompressionLossRisk, CompressionMode
+from archex.reporting import count_tokens
+
+# A run of at least this many non-blank lines is worth replacing with a marker.
+_ELISION_MIN_RUN = 2
+
+# Large-literal summarization keeps this many head/tail lines and only fires on
+# blocks of at least this many lines that look mostly like data entries.
+_LITERAL_MIN_LINES = 12
+_LITERAL_HEAD = 3
+_LITERAL_TAIL = 3
+_LITERAL_ITEM_FRACTION = 0.5
+
+# JSON/log crushing keeps head/tail plus every anomaly line, on blocks of at
+# least this many lines.
+_JSONLOG_MIN_LINES = 12
+_JSONLOG_HEAD = 3
+_JSONLOG_TAIL = 3
+
+_MARKER_TOKEN = "[archex"
+
+_HASH_COMMENT_LANGUAGES = frozenset(
+    {"python", "ruby", "shell", "bash", "sh", "yaml", "yml", "toml", "r", "perl"}
+)
+_CODE_LANGUAGES = frozenset(
+    {
+        "python",
+        "javascript",
+        "typescript",
+        "tsx",
+        "jsx",
+        "go",
+        "rust",
+        "java",
+        "kotlin",
+        "swift",
+        "c",
+        "cpp",
+        "c++",
+        "csharp",
+        "cs",
+        "ruby",
+        "php",
+        "scala",
+    }
+)
+_DATA_LANGUAGES = frozenset(
+    {"json", "jsonl", "ndjson", "yaml", "yml", "toml", "log", "text", "txt", "csv", "tsv", ""}
+)
+
+_IMPORT_PREFIXES = (
+    "import ",
+    "from ",
+    "#include",
+    "using ",
+    "package ",
+    "use ",
+    "require ",
+)
+_DECL_PREFIXES = (
+    "def ",
+    "async def ",
+    "class ",
+    "function ",
+    "func ",
+    "fn ",
+    "interface ",
+    "type ",
+    "struct ",
+    "impl ",
+    "trait ",
+    "enum ",
+    "module ",
+    "namespace ",
+    "export ",
+    "public ",
+    "private ",
+    "protected ",
+    "internal ",
+    "abstract ",
+    "const ",
+    "let ",
+    "var ",
+    "static ",
+    "final ",
+    "override ",
+)
+_COMMENT_PREFIXES = ("#", "//", "/*", "*")
+_BLOCK_OPENERS = (":", "{", "(", "[")
+_BLOCK_CLOSERS = ("}", ")", "]", "};", "});", "),")
+
+# A comment line made only of separator/decoration characters (banner rules).
+_DECORATION_COMMENT_RE = re.compile(r"^[#/*\-=_~. ]+$")
+# Anomaly tokens that must survive json/log crushing.
+_ANOMALY_RE = re.compile(
+    r"\b(error|err|warn|warning|exception|traceback|fail|failed|failure|fatal|"
+    r"critical|panic|denied|timeout|refused|unauthorized)\b",
+    re.IGNORECASE,
+)
+# Cheap code-signal fallback when language is unknown.
+_CODE_SIGNAL_RE = re.compile(r"(^|\n)\s*(def |class |function |func |fn |import |#include)")
+# key: value or key = value data lines for literal detection.
+_KEYVAL_RE = re.compile(r"""^\s*["']?[\w.\-]+["']?\s*[:=]\s*\S""")
+# Timestamp / level evidence for log-line detection.
+_LOG_LINE_RE = re.compile(
+    r"(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2})|(\b(DEBUG|INFO|WARN|WARNING|ERROR|TRACE|FATAL)\b)"
+)
+
+_MODE_PRIORITY = (
+    CompressionMode.STRUCTURAL_CODE_ELISION,
+    CompressionMode.LARGE_LITERAL_SUMMARIZATION,
+    CompressionMode.JSON_LOG_SMART_CRUSHING,
+    CompressionMode.COMMENT_AND_WHITESPACE_SLIMMING,
+)
+_MODE_RISK = {
+    CompressionMode.PASSTHROUGH_REQUIRED: CompressionLossRisk.NONE,
+    CompressionMode.STRUCTURAL_CODE_ELISION: CompressionLossRisk.LOW,
+    CompressionMode.COMMENT_AND_WHITESPACE_SLIMMING: CompressionLossRisk.LOW,
+    CompressionMode.LARGE_LITERAL_SUMMARIZATION: CompressionLossRisk.MEDIUM,
+    CompressionMode.JSON_LOG_SMART_CRUSHING: CompressionLossRisk.MEDIUM,
+}
+
+
+@dataclass(frozen=True)
+class RegionCompression:
+    """Result of compressing one returned region.
+
+    ``content`` is the text to display in place of the original. For
+    ``passthrough_required`` it equals the input unchanged.
+    """
+
+    mode: CompressionMode
+    content: str
+    loss_risk: CompressionLossRisk
+
+
+def _leading_ws(line: str) -> str:
+    return line[: len(line) - len(line.lstrip())]
+
+
+def _comment_prefix(language: str | None) -> str:
+    if language and language.lower() in _HASH_COMMENT_LANGUAGES:
+        return "#"
+    return "//"
+
+
+def _is_comment(stripped: str) -> bool:
+    return stripped.startswith(_COMMENT_PREFIXES)
+
+
+def _looks_like_code(language: str | None, content: str) -> bool:
+    lang = (language or "").lower()
+    if lang in _CODE_LANGUAGES:
+        return True
+    if lang in _DATA_LANGUAGES:
+        return False
+    return bool(_CODE_SIGNAL_RE.search(content))
+
+
+def _looks_like_json(content: str) -> bool:
+    stripped = content.strip()
+    return stripped.startswith(("{", "[")) and ('":' in stripped or ": " in stripped)
+
+
+def _looks_like_log(lines: list[str]) -> bool:
+    hits = sum(1 for line in lines if _LOG_LINE_RE.search(line))
+    return hits >= max(3, len(lines) // 4)
+
+
+def _is_structural_line(stripped: str) -> bool:
+    """Whether a line should survive structural code elision."""
+    if not stripped:
+        return False
+    if stripped.startswith("@"):  # decorator / annotation
+        return True
+    if _is_comment(stripped):
+        return True
+    if stripped.startswith(_IMPORT_PREFIXES):
+        return True
+    if stripped.startswith(_DECL_PREFIXES):
+        return True
+    if stripped.endswith(_BLOCK_OPENERS):  # signature / block opener
+        return True
+    return stripped in _BLOCK_CLOSERS
+
+
+def _elision_marker(indent: str, prefix: str, line_count: int, handle: str) -> str:
+    detail = f"elided {line_count} line(s); fetch original: {handle}"
+    return f"{indent}{prefix} {_MARKER_TOKEN} {detail}]"
+
+
+def _omission_marker(indent: str, unit: str, count: int, handle: str, *, suffix: str = "") -> str:
+    detail = f"{count} {unit} omitted{suffix}"
+    return f"{indent}... {_MARKER_TOKEN} {detail}; fetch original: {handle}] ..."
+
+
+def _elide_structural(content: str, *, language: str | None, handle: str) -> str | None:
+    """Keep imports/declarations/signatures/anchors, elide low-risk bodies."""
+    prefix = _comment_prefix(language)
+    lines = content.split("\n")
+    out: list[str] = []
+    body_run: list[str] = []
+
+    def flush() -> None:
+        if not body_run:
+            return
+        nonblank = [line for line in body_run if line.strip()]
+        if not nonblank:
+            out.append("")  # collapse a pure-blank run to a single blank line
+        elif len(nonblank) >= _ELISION_MIN_RUN:
+            out.append(_elision_marker(_leading_ws(nonblank[0]), prefix, len(body_run), handle))
+        else:
+            out.extend(body_run)
+        body_run.clear()
+
+    for line in lines:
+        if _is_structural_line(line.strip()):
+            flush()
+            out.append(line)
+        else:
+            body_run.append(line)
+    flush()
+
+    new = "\n".join(out)
+    return new if new != content else None
+
+
+def _slim_comments_whitespace(content: str) -> str | None:
+    """Collapse repeated blank lines, trim trailing whitespace, drop banners."""
+    lines = content.split("\n")
+    out: list[str] = []
+    previous_blank = False
+    for line in lines:
+        trimmed = line.rstrip()
+        stripped = trimmed.strip()
+        if stripped and _is_comment(stripped) and _DECORATION_COMMENT_RE.match(stripped):
+            continue  # banner / separator comment with no information
+        if not stripped:
+            if previous_blank:
+                continue
+            previous_blank = True
+            out.append("")
+        else:
+            previous_blank = False
+            out.append(trimmed)
+    new = "\n".join(out)
+    return new if new != content else None
+
+
+def _summarize_large_literal(content: str, *, handle: str) -> str | None:
+    """Keep first/last items and the omitted count for a long data literal.
+
+    Defers to :func:`_crush_json_log` for JSON objects/arrays and log streams so
+    each mode owns a distinct content shape.
+    """
+    lines = content.split("\n")
+    if len(lines) < _LITERAL_MIN_LINES:
+        return None
+    if _looks_like_json(content) or _looks_like_log(lines):
+        return None
+    item_like = sum(
+        1
+        for line in lines
+        if line.rstrip().endswith((",", "[", "{")) or _KEYVAL_RE.match(line)
+    )
+    if item_like < len(lines) * _LITERAL_ITEM_FRACTION:
+        return None
+    head = lines[:_LITERAL_HEAD]
+    tail = lines[-_LITERAL_TAIL:]
+    omitted = len(lines) - len(head) - len(tail)
+    if omitted < _ELISION_MIN_RUN:
+        return None
+    indent = _leading_ws(lines[_LITERAL_HEAD])
+    marker = _omission_marker(
+        indent, "item(s)", omitted, handle, suffix=f" (kept first {len(head)} / last {len(tail)})"
+    )
+    new = "\n".join([*head, marker, *tail])
+    return new if new != content else None
+
+
+def _crush_json_log(content: str, *, handle: str) -> str | None:
+    """Preserve anomalies, first/last examples, and omitted counts.
+
+    Fires only when the content actually looks like a JSON object/array or a log
+    stream. Plain sequence/table literals are handled by
+    :func:`_summarize_large_literal` instead.
+    """
+    lines = content.split("\n")
+    if len(lines) < _JSONLOG_MIN_LINES:
+        return None
+    if not _looks_like_json(content) and not _looks_like_log(lines):
+        return None
+    keep = set(range(min(_JSONLOG_HEAD, len(lines))))
+    keep |= set(range(max(0, len(lines) - _JSONLOG_TAIL), len(lines)))
+    for index, line in enumerate(lines):
+        if _ANOMALY_RE.search(line):
+            keep.add(index)
+    out: list[str] = []
+    omitted_total = 0
+    index = 0
+    while index < len(lines):
+        if index in keep:
+            out.append(lines[index])
+            index += 1
+            continue
+        run_start = index
+        while index < len(lines) and index not in keep:
+            index += 1
+        run = index - run_start
+        omitted_total += run
+        out.append(_omission_marker(_leading_ws(lines[run_start]), "line(s)", run, handle))
+    if omitted_total < _ELISION_MIN_RUN:
+        return None
+    new = "\n".join(out)
+    return new if new != content else None
+
+
+def compress_region(
+    content: str,
+    *,
+    language: str | None,
+    fetch_original_handle: str,
+    required: bool,
+    protect_code: bool = False,
+) -> RegionCompression | None:
+    """Compress one returned region deterministically, or return ``None``.
+
+    Required/direct/high-confidence regions always pass through unchanged. Other
+    regions are run through the applicable deterministic modes; the smallest
+    strictly-beneficial result wins (ties broken by a fixed mode priority). When
+    no mode yields fewer tokens than the original — including the
+    larger-than-original case — the function returns ``None`` and the caller
+    leaves the region uncompressed.
+
+    ``protect_code`` disables structural code elision (for fix/debug/review
+    intents) while still allowing low-risk whitespace/comment slimming.
+    """
+    if required:
+        return RegionCompression(
+            CompressionMode.PASSTHROUGH_REQUIRED, content, CompressionLossRisk.NONE
+        )
+
+    original_tokens = count_tokens(content)
+    if original_tokens == 0:
+        return None
+
+    candidates: list[tuple[CompressionMode, str]] = []
+    if _looks_like_code(language, content) and not protect_code:
+        elided = _elide_structural(content, language=language, handle=fetch_original_handle)
+        if elided is not None:
+            candidates.append((CompressionMode.STRUCTURAL_CODE_ELISION, elided))
+    literal = _summarize_large_literal(content, handle=fetch_original_handle)
+    if literal is not None:
+        candidates.append((CompressionMode.LARGE_LITERAL_SUMMARIZATION, literal))
+    crushed = _crush_json_log(content, handle=fetch_original_handle)
+    if crushed is not None:
+        candidates.append((CompressionMode.JSON_LOG_SMART_CRUSHING, crushed))
+    slimmed = _slim_comments_whitespace(content)
+    if slimmed is not None:
+        candidates.append((CompressionMode.COMMENT_AND_WHITESPACE_SLIMMING, slimmed))
+
+    scored = [
+        (count_tokens(new_content), _MODE_PRIORITY.index(mode), mode, new_content)
+        for mode, new_content in candidates
+    ]
+    beneficial = [entry for entry in scored if entry[0] < original_tokens]
+    if not beneficial:
+        return None
+    beneficial.sort(key=lambda entry: (entry[0], entry[1]))
+    _, _, mode, new_content = beneficial[0]
+    return RegionCompression(mode, new_content, _MODE_RISK[mode])

--- a/src/archex/serve/compression.py
+++ b/src/archex/serve/compression.py
@@ -267,9 +267,7 @@ def _summarize_large_literal(content: str, *, handle: str) -> str | None:
     if _looks_like_json(content) or _looks_like_log(lines):
         return None
     item_like = sum(
-        1
-        for line in lines
-        if line.rstrip().endswith((",", "[", "{")) or _KEYVAL_RE.match(line)
+        1 for line in lines if line.rstrip().endswith((",", "[", "{")) or _KEYVAL_RE.match(line)
     )
     if item_like < len(lines) * _LITERAL_ITEM_FRACTION:
         return None

--- a/src/archex/serve/compression.py
+++ b/src/archex/serve/compression.py
@@ -363,16 +363,21 @@ def compress_region(
         return None
 
     candidates: list[tuple[CompressionMode, str]] = []
-    if _looks_like_code(language, content) and not protect_code:
+    is_code = _looks_like_code(language, content)
+    if is_code and not protect_code:
         elided = _elide_structural(content, language=language, handle=fetch_original_handle)
         if elided is not None:
             candidates.append((CompressionMode.STRUCTURAL_CODE_ELISION, elided))
-    literal = _summarize_large_literal(content, handle=fetch_original_handle)
-    if literal is not None:
-        candidates.append((CompressionMode.LARGE_LITERAL_SUMMARIZATION, literal))
-    crushed = _crush_json_log(content, handle=fetch_original_handle)
-    if crushed is not None:
-        candidates.append((CompressionMode.JSON_LOG_SMART_CRUSHING, crushed))
+    # Literal and JSON/log modes target data payloads, not source code. Keeping
+    # them off code prevents data-shaped code (assignment-heavy bodies) from
+    # being summarized and keeps protect_code an effective guard for editors.
+    if not is_code:
+        literal = _summarize_large_literal(content, handle=fetch_original_handle)
+        if literal is not None:
+            candidates.append((CompressionMode.LARGE_LITERAL_SUMMARIZATION, literal))
+        crushed = _crush_json_log(content, handle=fetch_original_handle)
+        if crushed is not None:
+            candidates.append((CompressionMode.JSON_LOG_SMART_CRUSHING, crushed))
     slimmed = _slim_comments_whitespace(content)
     if slimmed is not None:
         candidates.append((CompressionMode.COMMENT_AND_WHITESPACE_SLIMMING, slimmed))

--- a/src/archex/serve/compression.py
+++ b/src/archex/serve/compression.py
@@ -40,30 +40,8 @@ _MARKER_TOKEN = "[archex"
 _HASH_COMMENT_LANGUAGES = frozenset(
     {"python", "ruby", "shell", "bash", "sh", "yaml", "yml", "toml", "r", "perl"}
 )
-_CODE_LANGUAGES = frozenset(
-    {
-        "python",
-        "javascript",
-        "typescript",
-        "tsx",
-        "jsx",
-        "go",
-        "rust",
-        "java",
-        "kotlin",
-        "swift",
-        "c",
-        "cpp",
-        "c++",
-        "csharp",
-        "cs",
-        "ruby",
-        "php",
-        "scala",
-    }
-)
 _DATA_LANGUAGES = frozenset(
-    {"json", "jsonl", "ndjson", "yaml", "yml", "toml", "log", "text", "txt", "csv", "tsv", ""}
+    {"json", "jsonl", "ndjson", "yaml", "yml", "toml", "log", "text", "txt", "csv", "tsv"}
 )
 
 _IMPORT_PREFIXES = (
@@ -106,6 +84,9 @@ _DECL_PREFIXES = (
 _COMMENT_PREFIXES = ("#", "//", "/*", "*")
 _BLOCK_OPENERS = (":", "{", "(", "[")
 _BLOCK_CLOSERS = ("}", ")", "]", "};", "});", "),")
+# Block-comment delimiters that look like decoration but must not be dropped, to
+# avoid leaving orphaned ``* text`` interior lines without their open/close.
+_BLOCK_COMMENT_DELIMITERS = frozenset({"/*", "*/", "/**", "**/"})
 
 # A comment line made only of separator/decoration characters (banner rules).
 _DECORATION_COMMENT_RE = re.compile(r"^[#/*\-=_~. ]+$")
@@ -168,10 +149,14 @@ def _is_comment(stripped: str) -> bool:
 
 def _looks_like_code(language: str | None, content: str) -> bool:
     lang = (language or "").lower()
-    if lang in _CODE_LANGUAGES:
-        return True
     if lang in _DATA_LANGUAGES:
         return False
+    if lang:
+        # Any known, non-empty language that is not a data format is treated as
+        # code so compression fails safe toward code protection: literal/JSON-log
+        # modes never fire on code, and protect_code stays effective for
+        # shell/sql/lua and any other source language.
+        return True
     return bool(_CODE_SIGNAL_RE.search(content))
 
 
@@ -251,7 +236,12 @@ def _slim_comments_whitespace(content: str) -> str | None:
     for line in lines:
         trimmed = line.rstrip()
         stripped = trimmed.strip()
-        if stripped and _is_comment(stripped) and _DECORATION_COMMENT_RE.match(stripped):
+        if (
+            stripped
+            and _is_comment(stripped)
+            and stripped not in _BLOCK_COMMENT_DELIMITERS
+            and _DECORATION_COMMENT_RE.match(stripped)
+        ):
             continue  # banner / separator comment with no information
         if not stripped:
             if previous_blank:

--- a/tests/serve/test_compression.py
+++ b/tests/serve/test_compression.py
@@ -55,9 +55,7 @@ def test_structural_code_elision_keeps_signatures_and_marks_handle() -> None:
 
 def test_large_literal_summary_keeps_first_last_and_count() -> None:
     region = _literal_region(items=30)
-    result = compress_region(
-        region, language="text", fetch_original_handle=_HANDLE, required=False
-    )
+    result = compress_region(region, language="text", fetch_original_handle=_HANDLE, required=False)
     assert result is not None
     assert result.mode == CompressionMode.LARGE_LITERAL_SUMMARIZATION
     assert result.loss_risk == CompressionLossRisk.MEDIUM
@@ -70,9 +68,7 @@ def test_large_literal_summary_keeps_first_last_and_count() -> None:
 
 def test_json_log_crushing_preserves_anomaly_lines() -> None:
     region = _log_region()
-    result = compress_region(
-        region, language="log", fetch_original_handle=_HANDLE, required=False
-    )
+    result = compress_region(region, language="log", fetch_original_handle=_HANDLE, required=False)
     assert result is not None
     assert result.mode == CompressionMode.JSON_LOG_SMART_CRUSHING
     # The error line must survive even though it sits in the omitted middle band.
@@ -85,9 +81,7 @@ def test_json_log_crushing_preserves_anomaly_lines() -> None:
 def test_json_object_routes_to_json_log_crushing() -> None:
     rows = "\n".join(f'  "key_{i}": {i},' for i in range(30))
     region = "{\n" + rows + "\n}"
-    result = compress_region(
-        region, language="json", fetch_original_handle=_HANDLE, required=False
-    )
+    result = compress_region(region, language="json", fetch_original_handle=_HANDLE, required=False)
     assert result is not None
     assert result.mode == CompressionMode.JSON_LOG_SMART_CRUSHING
 
@@ -103,9 +97,7 @@ def test_comment_and_whitespace_slimming_drops_banners() -> None:
         "# -------------------------\n"
         "value_c = 3\n"
     )
-    result = compress_region(
-        region, language="text", fetch_original_handle=_HANDLE, required=False
-    )
+    result = compress_region(region, language="text", fetch_original_handle=_HANDLE, required=False)
     assert result is not None
     assert result.mode == CompressionMode.COMMENT_AND_WHITESPACE_SLIMMING
     assert result.loss_risk == CompressionLossRisk.LOW
@@ -121,9 +113,7 @@ def test_compression_larger_than_original_falls_back_to_none() -> None:
     # than it saves, and nothing else applies, so the region stays uncompressed.
     region = "x = 1\ny = 2"
     assert (
-        compress_region(
-            region, language="python", fetch_original_handle=_HANDLE, required=False
-        )
+        compress_region(region, language="python", fetch_original_handle=_HANDLE, required=False)
         is None
     )
 

--- a/tests/serve/test_compression.py
+++ b/tests/serve/test_compression.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from archex.models import CompressionLossRisk, CompressionMode
 from archex.reporting import count_tokens
-from archex.serve.compression import compress_region
+from archex.serve.compression import _slim_comments_whitespace, compress_region
 
 _HANDLE = "chunk:abc123def456"
 
@@ -181,3 +181,42 @@ def test_protect_code_leaves_clean_code_uncompressed() -> None:
         protect_code=True,
     )
     assert result is None
+
+
+def _shell_region() -> str:
+    body = "\n".join(f"VAR_{i}=value_{i}" for i in range(30))
+    return f"#!/bin/bash\nset -e\n{body}\necho done"
+
+
+def test_non_python_code_language_is_not_literal_compressed() -> None:
+    # Shell is a source language, not data: assignment-heavy shell must route to
+    # code elision, never large-literal summarization.
+    result = compress_region(
+        _shell_region(), language="bash", fetch_original_handle=_HANDLE, required=False
+    )
+    assert result is not None
+    assert result.mode != CompressionMode.LARGE_LITERAL_SUMMARIZATION
+    assert result.mode != CompressionMode.JSON_LOG_SMART_CRUSHING
+
+
+def test_protect_code_holds_for_non_python_code_language() -> None:
+    # protect_code must guard every source language, not just the curated set.
+    assert (
+        compress_region(
+            _shell_region(),
+            language="bash",
+            fetch_original_handle=_HANDLE,
+            required=False,
+            protect_code=True,
+        )
+        is None
+    )
+
+
+def test_slimming_preserves_block_comment_delimiters() -> None:
+    region = "/*\n * note kept\n */\n\n\nint x = 1;"
+    slimmed = _slim_comments_whitespace(region)
+    assert slimmed is not None  # repeated blank lines collapsed
+    assert "/*" in slimmed
+    assert "*/" in slimmed
+    assert "* note kept" in slimmed

--- a/tests/serve/test_compression.py
+++ b/tests/serve/test_compression.py
@@ -1,0 +1,153 @@
+"""Tests for deterministic post-retrieval compression primitives."""
+
+from __future__ import annotations
+
+from archex.models import CompressionLossRisk, CompressionMode
+from archex.reporting import count_tokens
+from archex.serve.compression import compress_region
+
+_HANDLE = "chunk:abc123def456"
+
+
+def _code_region(body_lines: int = 40) -> str:
+    body = "\n".join(f"    accumulator = accumulator + value_{i}" for i in range(body_lines))
+    header = "import math\n\n\ndef compute(values):\n    accumulator = 0\n"
+    return f"{header}{body}\n    return accumulator"
+
+
+def _literal_region(items: int = 30) -> str:
+    rows = "\n".join(f'    "color_{i}",' for i in range(items))
+    return f"PALETTE = (\n{rows}\n)"
+
+
+def _log_region(lines: int = 24) -> str:
+    rows = [f"2026-06-18T10:00:{i:02d} INFO processed record {i}" for i in range(lines)]
+    rows[lines // 2] = "2026-06-18T10:00:12 ERROR boom: write failure on record 12"
+    return "\n".join(rows)
+
+
+def test_required_region_passes_through_unchanged() -> None:
+    region = _code_region()
+    result = compress_region(
+        region, language="python", fetch_original_handle=_HANDLE, required=True
+    )
+    assert result is not None
+    assert result.mode == CompressionMode.PASSTHROUGH_REQUIRED
+    assert result.content == region
+    assert result.loss_risk == CompressionLossRisk.NONE
+
+
+def test_structural_code_elision_keeps_signatures_and_marks_handle() -> None:
+    region = _code_region()
+    result = compress_region(
+        region, language="python", fetch_original_handle=_HANDLE, required=False
+    )
+    assert result is not None
+    assert result.mode == CompressionMode.STRUCTURAL_CODE_ELISION
+    assert result.loss_risk == CompressionLossRisk.LOW
+    # Imports and the signature survive; bodies become a marked, fetchable stub.
+    assert "import math" in result.content
+    assert "def compute(values):" in result.content
+    assert "[archex" in result.content
+    assert f"fetch original: {_HANDLE}" in result.content
+    assert count_tokens(result.content) < count_tokens(region)
+
+
+def test_large_literal_summary_keeps_first_last_and_count() -> None:
+    region = _literal_region(items=30)
+    result = compress_region(
+        region, language="text", fetch_original_handle=_HANDLE, required=False
+    )
+    assert result is not None
+    assert result.mode == CompressionMode.LARGE_LITERAL_SUMMARIZATION
+    assert result.loss_risk == CompressionLossRisk.MEDIUM
+    assert '"color_0"' in result.content  # first example preserved
+    assert '"color_29"' in result.content  # last example preserved
+    assert "item(s) omitted" in result.content
+    assert f"fetch original: {_HANDLE}" in result.content
+    assert count_tokens(result.content) < count_tokens(region)
+
+
+def test_json_log_crushing_preserves_anomaly_lines() -> None:
+    region = _log_region()
+    result = compress_region(
+        region, language="log", fetch_original_handle=_HANDLE, required=False
+    )
+    assert result is not None
+    assert result.mode == CompressionMode.JSON_LOG_SMART_CRUSHING
+    # The error line must survive even though it sits in the omitted middle band.
+    assert "ERROR boom: write failure on record 12" in result.content
+    assert "line(s) omitted" in result.content
+    assert f"fetch original: {_HANDLE}" in result.content
+    assert count_tokens(result.content) < count_tokens(region)
+
+
+def test_json_object_routes_to_json_log_crushing() -> None:
+    rows = "\n".join(f'  "key_{i}": {i},' for i in range(30))
+    region = "{\n" + rows + "\n}"
+    result = compress_region(
+        region, language="json", fetch_original_handle=_HANDLE, required=False
+    )
+    assert result is not None
+    assert result.mode == CompressionMode.JSON_LOG_SMART_CRUSHING
+
+
+def test_comment_and_whitespace_slimming_drops_banners() -> None:
+    region = (
+        "# =========================\n"
+        "value_a = 1\n"
+        "\n"
+        "\n"
+        "\n"
+        "value_b = 2\n"
+        "# -------------------------\n"
+        "value_c = 3\n"
+    )
+    result = compress_region(
+        region, language="text", fetch_original_handle=_HANDLE, required=False
+    )
+    assert result is not None
+    assert result.mode == CompressionMode.COMMENT_AND_WHITESPACE_SLIMMING
+    assert result.loss_risk == CompressionLossRisk.LOW
+    assert "=========================" not in result.content
+    assert "-------------------------" not in result.content
+    assert "\n\n\n" not in result.content  # repeated blanks collapsed
+    assert "value_a = 1" in result.content
+    assert "value_c = 3" in result.content
+
+
+def test_compression_larger_than_original_falls_back_to_none() -> None:
+    # Two trivial statements: any elision marker (with a handle) costs more tokens
+    # than it saves, and nothing else applies, so the region stays uncompressed.
+    region = "x = 1\ny = 2"
+    assert (
+        compress_region(
+            region, language="python", fetch_original_handle=_HANDLE, required=False
+        )
+        is None
+    )
+
+
+def test_protect_code_disables_structural_elision() -> None:
+    region = "# ======\n" + _code_region()
+    result = compress_region(
+        region,
+        language="python",
+        fetch_original_handle=_HANDLE,
+        required=False,
+        protect_code=True,
+    )
+    assert result is not None
+    # Elision is off for fix/debug/review; only low-risk slimming may run.
+    assert result.mode != CompressionMode.STRUCTURAL_CODE_ELISION
+
+
+def test_compression_is_deterministic() -> None:
+    region = _code_region()
+    first = compress_region(
+        region, language="python", fetch_original_handle=_HANDLE, required=False
+    )
+    second = compress_region(
+        region, language="python", fetch_original_handle=_HANDLE, required=False
+    )
+    assert first == second

--- a/tests/serve/test_compression.py
+++ b/tests/serve/test_compression.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from archex.models import CompressionLossRisk, CompressionMode
 from archex.reporting import count_tokens
-from archex.serve.compression import _slim_comments_whitespace, compress_region
+from archex.serve.compression import (
+    _slim_comments_whitespace,  # pyright: ignore[reportPrivateUsage]
+    compress_region,
+)
 
 _HANDLE = "chunk:abc123def456"
 

--- a/tests/serve/test_compression.py
+++ b/tests/serve/test_compression.py
@@ -151,3 +151,33 @@ def test_compression_is_deterministic() -> None:
         region, language="python", fetch_original_handle=_HANDLE, required=False
     )
     assert first == second
+
+
+def _assignment_heavy_code() -> str:
+    body = "\n".join(f"    total = total + delta_{i}" for i in range(40))
+    return f"def reduce(deltas):\n    total = 0\n{body}\n    return total"
+
+
+def test_large_literal_mode_does_not_fire_on_code() -> None:
+    # Assignment-heavy code superficially resembles key=value data, but code is
+    # routed to structural elision, never to literal summarization.
+    result = compress_region(
+        _assignment_heavy_code(),
+        language="python",
+        fetch_original_handle=_HANDLE,
+        required=False,
+    )
+    assert result is not None
+    assert result.mode == CompressionMode.STRUCTURAL_CODE_ELISION
+
+
+def test_protect_code_leaves_clean_code_uncompressed() -> None:
+    # With elision disabled and no data/banner content, clean code stays intact.
+    result = compress_region(
+        _assignment_heavy_code(),
+        language="python",
+        fetch_original_handle=_HANDLE,
+        required=False,
+        protect_code=True,
+    )
+    assert result is None


### PR DESCRIPTION
## Summary

Adds `serve/compression.py`: deterministic, low-risk post-retrieval compression primitives operating purely on assembled region text. No hosted calls, local models, or semantic summarization — every mode is a deterministic text transform that preserves stable anchors and a fetch-original marker.

`compress_region(content, *, language, fetch_original_handle, required, protect_code=False)` returns a `RegionCompression` (mode + content + loss risk) or `None` when no mode is beneficial.

## Modes

- `passthrough_required` — required/direct/high-confidence regions pass through unchanged (loss risk `none`).
- `structural_code_elision` — keeps imports, declarations, signatures, and anchors; replaces low-risk bodies with a marked stub that names the fetch-original handle (`low`). Disabled when `protect_code` (fix/debug/review).
- `comment_and_whitespace_slimming` — collapses repeated blank lines and drops banner/separator comments (`low`).
- `large_literal_summarization` — keeps first/last items and the omitted count for sequence/table literals (`medium`).
- `json_log_smart_crushing` — keeps anomalies (error/warn/exception/...), first/last examples, and omitted counts for JSON objects/arrays and log streams (`medium`).

## Selection

The smallest strictly-beneficial result wins; ties break on a fixed mode priority. Non-beneficial and larger-than-original results return `None` (region stays uncompressed). Literal vs JSON/log ownership is split by content shape so each mode is independently predictable.

## Tests

```
uv run pytest tests/serve/test_compression.py
```

Covers required passthrough, elision output shape, large-literal first/last/count, JSON/log anomaly preservation, JSON-object routing, comment/whitespace slimming, larger-than-original fallback, `protect_code` disabling elision, and determinism (9 passed).

## Stack

Stack-Id: `compression-lane-501320`
Base: `bench/compression-metadata-model`
Position: 2/4

1. `bench/compression-metadata-model` -> #300
2. `bench/compression-primitives` -> this PR
3. `bench/compression-strategy` -> PR 3
4. `bench/compression-reports-docs` -> PR 4

Depends on: #300

## Validation

- Passed: `uv run pytest tests/serve/test_compression.py` (9 passed)
- Passed: `uv run ruff check src/archex/serve/compression.py tests/serve/test_compression.py`
