### PR TITLE
Compression lane (3/4): archex_query_compressed benchmark strategy

### DIFF
--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -29,6 +29,7 @@ class Strategy(StrEnum):
     CROSS_LAYER_FUSION = "cross_layer_fusion"
     ARCHEX_QUERY_FUSION_RERANK = "archex_query_fusion_rerank"
     ARCHEX_QUERY_TASK_AWARE = "archex_query_task_aware"
+    ARCHEX_QUERY_COMPRESSED = "archex_query_compressed"
     EXTERNAL_MCP = "external_mcp"
 
 
@@ -385,6 +386,17 @@ class BenchmarkResult(BaseModel):
     useful_tokens: int | None = None
     wasted_tokens: int | None = None
     relevance_per_1k_tokens: float | None = None
+    # Optional post-retrieval compression metrics. Populated only by
+    # archex_query_compressed; None ("unknown") for every other strategy so
+    # archex_query and other lanes are unaffected. Retrieval metrics above stay
+    # attributable to the uncompressed retrieval set.
+    bundle_tokens_uncompressed: int | None = None
+    bundle_tokens_compressed: int | None = None
+    bundle_compression_ratio: float | None = None
+    required_context_compressed_tokens: int | None = None
+    required_context_passthrough_tokens: int | None = None
+    compression_hidden_required_region_count: int | None = None
+    token_efficiency_with_compression_and_completion: float | None = None
 
 
 class BenchmarkReport(BaseModel):

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -48,6 +48,7 @@ AVAILABLE_STRATEGIES: list[Strategy] = [
     Strategy.ARCHEX_QUERY_FUSION_RERANK,
     Strategy.CROSS_LAYER_FUSION,
     Strategy.ARCHEX_QUERY_TASK_AWARE,
+    Strategy.ARCHEX_QUERY_COMPRESSED,
 ]
 
 _VECTOR_STRATEGIES: frozenset[Strategy] = frozenset(

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -12,6 +12,7 @@ import tempfile
 import time
 from collections.abc import Callable
 from contextvars import ContextVar, Token
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -32,10 +33,13 @@ from archex.cache import CacheManager
 from archex.exceptions import ArchexError, ConfigError
 from archex.models import (
     ChunkerName,
+    CompressionMetadata,
+    CompressionMode,
     ContextBundle,
     ContextCompletenessStatus,
     IndexConfig,
     PipelineTiming,
+    RankedChunk,
     RepoSource,
 )
 from archex.reporting import count_tokens
@@ -1242,6 +1246,207 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     )
 
 
+_PASSTHROUGH_SCORE_FRACTION = 0.6
+
+
+def _passthrough_required(
+    rank_index: int,
+    ranked: RankedChunk,
+    *,
+    seed_paths: set[str],
+    expanded_paths: set[str],
+    top_score: float,
+) -> bool:
+    """Whether a region is required/direct/high-confidence and must not compress.
+
+    Graph-frontier expansions are the only regions eligible for compression. The
+    top hit, seed/direct retrievals, and any region scoring within
+    ``_PASSTHROUGH_SCORE_FRACTION`` of the best score are protected. Uses only
+    intrinsic retrieval signals — never benchmark ground truth.
+    """
+    path = ranked.chunk.file_path
+    if path in expanded_paths and path not in seed_paths:
+        return False
+    if rank_index == 0:
+        return True
+    if path in seed_paths:
+        return True
+    return top_score > 0.0 and ranked.final_score >= top_score * _PASSTHROUGH_SCORE_FRACTION
+
+
+@dataclass
+class _BundleCompression:
+    """Compressed bundle plus the benchmark result fields it produces."""
+
+    bundle: ContextBundle
+    result_fields: dict[str, float | int]
+    provenance: dict[str, str]
+
+
+def _compress_bundle(bundle: ContextBundle, *, question: str) -> _BundleCompression:
+    """Apply deterministic compression after assembly, preserving receipts.
+
+    Retrieval is untouched: this runs on an already-assembled bundle. Required,
+    direct, and high-confidence regions pass through; only lower-confidence
+    frontier regions are compressed. The original handle and hash for every
+    compressed region stay retrievable through the receipt and metadata.
+    """
+    from archex.receipt import region_content_hash
+    from archex.scout import chunk_handle
+    from archex.serve.compression import compress_region
+    from archex.serve.intent import QueryIntent, classify_intent
+
+    intent = classify_intent(question)
+    protect_code = intent == QueryIntent.DEBUGGING
+    meta = bundle.retrieval_metadata
+    seed_paths = set(meta.seed_file_paths)
+    expanded_paths = set(meta.expanded_file_paths)
+    top_score = max((rc.final_score for rc in bundle.chunks), default=0.0)
+
+    compressed = bundle.model_copy(deep=True)
+    receipt_items = (
+        {item.handle: item for item in compressed.receipt.returned_context}
+        if compressed.receipt is not None
+        else {}
+    )
+
+    uncompressed_tokens = 0
+    compressed_tokens = 0
+    passthrough_required_tokens = 0
+    compressed_required_tokens = 0
+    hidden_required = 0
+    compressed_regions = 0
+    passthrough_regions = 0
+
+    for index, ranked in enumerate(compressed.chunks):
+        chunk = ranked.chunk
+        handle = chunk_handle(chunk.id)
+        original = chunk.content
+        original_tokens = count_tokens(original)
+        uncompressed_tokens += original_tokens
+        required = _passthrough_required(
+            index,
+            ranked,
+            seed_paths=seed_paths,
+            expanded_paths=expanded_paths,
+            top_score=top_score,
+        )
+        outcome = compress_region(
+            original,
+            language=chunk.language,
+            fetch_original_handle=handle,
+            required=required,
+            protect_code=protect_code,
+        )
+        if outcome is None:
+            compressed_tokens += original_tokens
+            continue
+        new_tokens = count_tokens(outcome.content)
+        compressed_tokens += new_tokens
+        ratio = (new_tokens / original_tokens) if original_tokens else 1.0
+        chunk.content = outcome.content
+        chunk.token_count = new_tokens
+        item = receipt_items.get(handle)
+        if item is not None:
+            item.compression = CompressionMetadata(
+                compression_mode=outcome.mode,
+                original_tokens=original_tokens,
+                compressed_tokens=new_tokens,
+                compression_ratio=ratio,
+                original_content_hash=region_content_hash(
+                    chunk.file_path, chunk.start_line, chunk.end_line, original
+                ),
+                compressed_content_hash=region_content_hash(
+                    chunk.file_path, chunk.start_line, chunk.end_line, outcome.content
+                ),
+                fetch_original_handle=handle,
+                compression_loss_risk=outcome.loss_risk,
+            )
+        if outcome.mode is CompressionMode.PASSTHROUGH_REQUIRED:
+            passthrough_required_tokens += new_tokens
+            passthrough_regions += 1
+        else:
+            compressed_regions += 1
+            if required:
+                # Invariant guard: required regions never reach this branch.
+                compressed_required_tokens += new_tokens
+                hidden_required += 1
+
+    compressed.token_count = compressed_tokens
+    bundle_ratio = (compressed_tokens / uncompressed_tokens) if uncompressed_tokens else 1.0
+    result_fields: dict[str, float | int] = {
+        "bundle_tokens_uncompressed": uncompressed_tokens,
+        "bundle_tokens_compressed": compressed_tokens,
+        "bundle_compression_ratio": bundle_ratio,
+        "required_context_compressed_tokens": compressed_required_tokens,
+        "required_context_passthrough_tokens": passthrough_required_tokens,
+        "compression_hidden_required_region_count": hidden_required,
+    }
+    provenance = {
+        "query_intent": intent.value,
+        "protect_code": str(protect_code).lower(),
+        "compressed_region_count": str(compressed_regions),
+        "passthrough_region_count": str(passthrough_regions),
+        "bundle_compression_ratio": f"{bundle_ratio:.4f}",
+    }
+    return _BundleCompression(bundle=compressed, result_fields=result_fields, provenance=provenance)
+
+
+def run_archex_query_compressed(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
+    """Benchmark-only lane: archex query retrieval, then deterministic compression.
+
+    Runs the exact ``archex_query`` retrieval and packing path so retrieval
+    metrics stay attributable to the uncompressed set, then compresses the
+    assembled bundle. Compression metrics describe the compressed output.
+    Required/direct/high-confidence context passes through; the product default
+    is unchanged.
+    """
+    strategy = Strategy.ARCHEX_QUERY_COMPRESSED
+    t0 = time.perf_counter()
+    bundle, effective_config, timing = _query_bundle(
+        task,
+        repo_path,
+        strategy=strategy,
+        index_config=IndexConfig(vector=False),
+        cache=benchmark_cache_enabled(default=False),
+    )
+    wall_ms = (time.perf_counter() - t0) * 1000
+    result = _assemble_query_result(
+        task,
+        repo_path,
+        strategy=strategy,
+        index_config=effective_config,
+        bundle=bundle,
+        timing=timing,
+        wall_ms=wall_ms,
+        include_completion=True,
+        measure_freshness=False,
+    )
+    compression = _compress_bundle(bundle, question=task.question)
+    fields = dict(compression.result_fields)
+    # Completion penalty is identical to the uncompressed lane: compression
+    # cannot make incomplete retrieval complete. Scale measured output tokens by
+    # the region compression ratio so non-region overhead stays comparable.
+    ratio = float(compression.result_fields["bundle_compression_ratio"])
+    completion = result.bundle_completion_tokens
+    compressed_output = round(result.tokens_output * ratio)
+    fields["token_efficiency_with_compression_and_completion"] = compute_token_efficiency(
+        compressed_output + completion, result.tokens_input + completion
+    )
+    result = result.model_copy(update=fields)
+    result.provenance = compression.provenance
+    logger.info(
+        "Strategy %s for %s: ratio=%.4f compressed=%s passthrough=%s wall=%.1fms",
+        strategy.value,
+        task.task_id,
+        ratio,
+        compression.provenance["compressed_region_count"],
+        compression.provenance["passthrough_region_count"],
+        wall_ms,
+    )
+    return result
+
+
 def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Two-call scout map plus chunk-first exact fetch with direct-query guardrails."""
     from archex.api import query, scout_with_bundle
@@ -1843,5 +2048,8 @@ default_strategy_registry.register(
 default_strategy_registry.register(Strategy.CROSS_LAYER_FUSION.value, run_cross_layer_fusion)
 default_strategy_registry.register(
     Strategy.ARCHEX_QUERY_TASK_AWARE.value, run_archex_query_task_aware
+)
+default_strategy_registry.register(
+    Strategy.ARCHEX_QUERY_COMPRESSED.value, run_archex_query_compressed
 )
 default_strategy_registry.register(Strategy.EXTERNAL_MCP.value, _run_external_mcp_strategy)

--- a/src/archex/receipt.py
+++ b/src/archex/receipt.py
@@ -35,9 +35,14 @@ _MAX_RECEIPT_OMITTED_EDGES = 20
 _MAX_RECEIPT_INCLUDED_EDGES = 40
 
 
-def chunk_content_hash(chunk: CodeChunk) -> str:
-    payload = f"{chunk.file_path}\0{chunk.start_line}\0{chunk.end_line}\0{chunk.content}"
+def region_content_hash(file_path: str, start_line: int, end_line: int, content: str) -> str:
+    """Stable hash of a file region, used for receipt rows and compression provenance."""
+    payload = f"{file_path}\0{start_line}\0{end_line}\0{content}"
     return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def chunk_content_hash(chunk: CodeChunk) -> str:
+    return region_content_hash(chunk.file_path, chunk.start_line, chunk.end_line, chunk.content)
 
 
 def index_revision_from_store(store: IndexStore) -> str:

--- a/tests/benchmark/test_compression_strategy.py
+++ b/tests/benchmark/test_compression_strategy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from archex.benchmark.models import BenchmarkTask, Strategy
+from archex.benchmark.runner import AVAILABLE_STRATEGIES, DEFAULT_STRATEGIES
 from archex.benchmark.strategies import (
     _compress_bundle,
     _passthrough_required,
@@ -72,6 +73,11 @@ class TestStrategyRegistry:
     def test_strategy_value(self) -> None:
         assert Strategy.ARCHEX_QUERY_COMPRESSED.value == "archex_query_compressed"
         assert Strategy.ARCHEX_QUERY_COMPRESSED.value in default_strategy_registry.strategy_names
+
+    def test_available_but_not_default(self) -> None:
+        # Discoverable as a benchmark lane, but never part of the product default.
+        assert Strategy.ARCHEX_QUERY_COMPRESSED in AVAILABLE_STRATEGIES
+        assert Strategy.ARCHEX_QUERY_COMPRESSED not in DEFAULT_STRATEGIES
 
 
 class TestPassthroughRequired:

--- a/tests/benchmark/test_compression_strategy.py
+++ b/tests/benchmark/test_compression_strategy.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 from archex.benchmark.models import BenchmarkTask, Strategy
 from archex.benchmark.runner import AVAILABLE_STRATEGIES, DEFAULT_STRATEGIES
 from archex.benchmark.strategies import (
-    _compress_bundle,
-    _passthrough_required,
+    _compress_bundle,  # pyright: ignore[reportPrivateUsage]
+    _passthrough_required,  # pyright: ignore[reportPrivateUsage]
     default_strategy_registry,
     run_archex_query,
     run_archex_query_compressed,
@@ -141,6 +141,7 @@ class TestCompressBundle:
         bundle = _bundle(chunks)
         result = _compress_bundle(bundle, question="where is the widget rendered")
 
+        assert result.bundle.receipt is not None
         items = {item.file_path: item for item in result.bundle.receipt.returned_context}
         top = items["a.py"].compression
         assert top is not None
@@ -162,6 +163,7 @@ class TestCompressBundle:
         original_content = bundle.chunks[1].chunk.content
         _compress_bundle(bundle, question="where is the widget rendered")
         assert bundle.chunks[1].chunk.content == original_content
+        assert bundle.receipt is not None
         assert bundle.receipt.returned_context[0].compression is None
 
     def test_protect_code_skips_elision_for_debugging_intent(self) -> None:

--- a/tests/benchmark/test_compression_strategy.py
+++ b/tests/benchmark/test_compression_strategy.py
@@ -1,0 +1,217 @@
+"""Tests for the benchmark-only archex_query_compressed strategy."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from archex.benchmark.models import BenchmarkTask, Strategy
+from archex.benchmark.strategies import (
+    _compress_bundle,
+    _passthrough_required,
+    default_strategy_registry,
+    run_archex_query,
+    run_archex_query_compressed,
+)
+from archex.models import (
+    CodeChunk,
+    CompressionMode,
+    ContextBundle,
+    ContextReceipt,
+    ContextReceiptItem,
+    ContextReceiptTokenBudget,
+    RankedChunk,
+)
+from archex.receipt import chunk_content_hash
+from archex.scout import chunk_handle
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _chunk(chunk_id: str, *, score: float, body_lines: int = 40) -> RankedChunk:
+    body = "\n".join(f"    acc = acc + value_{i}" for i in range(body_lines))
+    content = f"def fn_{chunk_id}(value):\n    acc = 0\n{body}\n    return acc"
+    chunk = CodeChunk(
+        id=chunk_id,
+        content=content,
+        file_path=f"{chunk_id}.py",
+        start_line=1,
+        end_line=body_lines + 3,
+        language="python",
+    )
+    return RankedChunk(chunk=chunk, final_score=score)
+
+
+def _bundle(chunks: list[RankedChunk], *, query: str = "q") -> ContextBundle:
+    items = [
+        ContextReceiptItem(
+            handle=chunk_handle(rc.chunk.id),
+            file_path=rc.chunk.file_path,
+            start_line=rc.chunk.start_line,
+            end_line=rc.chunk.end_line,
+            content_hash=chunk_content_hash(rc.chunk),
+        )
+        for rc in chunks
+    ]
+    receipt = ContextReceipt(
+        query=query,
+        token_budget=ContextReceiptTokenBudget(requested=4096, consumed=100),
+        index_revision="rev",
+        returned_context=items,
+    )
+    return ContextBundle(query=query, chunks=chunks, token_count=300, receipt=receipt)
+
+
+class TestStrategyRegistry:
+    def test_runner_registered(self) -> None:
+        assert (
+            default_strategy_registry.get(Strategy.ARCHEX_QUERY_COMPRESSED)
+            is run_archex_query_compressed
+        )
+
+    def test_strategy_value(self) -> None:
+        assert Strategy.ARCHEX_QUERY_COMPRESSED.value == "archex_query_compressed"
+        assert Strategy.ARCHEX_QUERY_COMPRESSED.value in default_strategy_registry.strategy_names
+
+
+class TestPassthroughRequired:
+    def test_top_hit_always_passes_through(self) -> None:
+        ranked = _chunk("a", score=0.01)
+        assert (
+            _passthrough_required(
+                0, ranked, seed_paths=set(), expanded_paths=set(), top_score=1.0
+            )
+            is True
+        )
+
+    def test_graph_frontier_expansion_is_compressible(self) -> None:
+        ranked = _chunk("b", score=0.9)
+        assert (
+            _passthrough_required(
+                3, ranked, seed_paths=set(), expanded_paths={"b.py"}, top_score=1.0
+            )
+            is False
+        )
+
+    def test_seed_region_passes_through(self) -> None:
+        ranked = _chunk("c", score=0.01)
+        assert (
+            _passthrough_required(
+                2, ranked, seed_paths={"c.py"}, expanded_paths=set(), top_score=1.0
+            )
+            is True
+        )
+
+    def test_high_score_passes_through_low_score_compresses(self) -> None:
+        high = _chunk("d", score=0.7)
+        low = _chunk("e", score=0.2)
+        assert (
+            _passthrough_required(
+                1, high, seed_paths=set(), expanded_paths=set(), top_score=1.0
+            )
+            is True
+        )
+        assert (
+            _passthrough_required(
+                1, low, seed_paths=set(), expanded_paths=set(), top_score=1.0
+            )
+            is False
+        )
+
+
+class TestCompressBundle:
+    def test_compression_metrics_and_passthrough(self) -> None:
+        chunks = [_chunk("a", score=1.0), _chunk("b", score=0.1), _chunk("c", score=0.05)]
+        bundle = _bundle(chunks)
+        result = _compress_bundle(bundle, question="where is the widget rendered")
+
+        fields = result.result_fields
+        assert fields["bundle_tokens_uncompressed"] > fields["bundle_tokens_compressed"]
+        assert 0.0 < fields["bundle_compression_ratio"] < 1.0
+        # The top hit is required and passes through; its tokens are protected.
+        assert fields["required_context_passthrough_tokens"] > 0
+        # Required context is never compressed and nothing required is hidden.
+        assert fields["required_context_compressed_tokens"] == 0
+        assert fields["compression_hidden_required_region_count"] == 0
+        assert result.provenance["compressed_region_count"] == "2"
+        assert result.provenance["passthrough_region_count"] == "1"
+
+    def test_compressed_rows_expose_original_handle_and_hash(self) -> None:
+        chunks = [_chunk("a", score=1.0), _chunk("b", score=0.05)]
+        bundle = _bundle(chunks)
+        result = _compress_bundle(bundle, question="where is the widget rendered")
+
+        items = {item.file_path: item for item in result.bundle.receipt.returned_context}
+        top = items["a.py"].compression
+        assert top is not None
+        assert top.compression_mode == CompressionMode.PASSTHROUGH_REQUIRED
+        # Original hash matches the receipt's original content hash exactly.
+        assert top.original_content_hash == items["a.py"].content_hash
+
+        compressed = items["b.py"].compression
+        assert compressed is not None
+        assert compressed.compression_mode == CompressionMode.STRUCTURAL_CODE_ELISION
+        assert compressed.original_content_hash == items["b.py"].content_hash
+        assert compressed.fetch_original_handle == chunk_handle("b")
+        assert compressed.is_compressed is True
+        assert f"fetch original: {chunk_handle('b')}" in result.bundle.chunks[1].chunk.content
+
+    def test_does_not_mutate_original_bundle(self) -> None:
+        chunks = [_chunk("a", score=1.0), _chunk("b", score=0.05)]
+        bundle = _bundle(chunks)
+        original_content = bundle.chunks[1].chunk.content
+        _compress_bundle(bundle, question="where is the widget rendered")
+        assert bundle.chunks[1].chunk.content == original_content
+        assert bundle.receipt.returned_context[0].compression is None
+
+    def test_protect_code_skips_elision_for_debugging_intent(self) -> None:
+        chunks = [_chunk("a", score=1.0), _chunk("b", score=0.05)]
+        bundle = _bundle(chunks)
+        result = _compress_bundle(bundle, question="investigate the rendering bug")
+        assert result.provenance["protect_code"] == "true"
+        # Code bodies are protected during fix/debug/review; nothing compresses.
+        assert result.provenance["compressed_region_count"] == "0"
+        assert result.result_fields["bundle_compression_ratio"] == 1.0
+
+
+def _fixture_task(question: str, token_budget: int = 4096) -> BenchmarkTask:
+    return BenchmarkTask(
+        task_id="compression_test",
+        repo="test/repo",
+        commit="abc",
+        question=question,
+        expected_files=["main.py"],
+        token_budget=token_budget,
+    )
+
+
+class TestRunFixture:
+    def test_runs_and_reports_compression_fields(self, python_simple_repo: Path) -> None:
+        task = _fixture_task("main entry point function")
+        result = run_archex_query_compressed(task, python_simple_repo)
+
+        assert result.strategy == Strategy.ARCHEX_QUERY_COMPRESSED
+        # Compression fields are populated (not the None default of other lanes).
+        assert result.bundle_tokens_uncompressed is not None
+        assert result.bundle_tokens_compressed is not None
+        assert result.bundle_compression_ratio is not None
+        assert result.compression_hidden_required_region_count == 0
+        assert result.token_efficiency_with_compression_and_completion is not None
+        for key in ("query_intent", "compressed_region_count", "passthrough_region_count"):
+            assert key in result.provenance
+
+    def test_no_effect_on_archex_query_retrieval(self, python_simple_repo: Path) -> None:
+        task = _fixture_task("main entry point function")
+        plain = run_archex_query(task, python_simple_repo)
+        compressed = run_archex_query_compressed(task, python_simple_repo)
+
+        # Retrieval metrics are attributable to the same uncompressed retrieval set.
+        assert compressed.recall == plain.recall
+        assert compressed.precision == plain.precision
+        assert compressed.f1_score == plain.f1_score
+        assert compressed.result_files == plain.result_files
+        assert compressed.required_file_recall == plain.required_file_recall
+        assert compressed.token_efficiency_with_completion == plain.token_efficiency_with_completion
+        # archex_query never carries compression fields.
+        assert plain.bundle_compression_ratio is None
+        assert plain.bundle_tokens_compressed is None

--- a/tests/benchmark/test_compression_strategy.py
+++ b/tests/benchmark/test_compression_strategy.py
@@ -84,9 +84,7 @@ class TestPassthroughRequired:
     def test_top_hit_always_passes_through(self) -> None:
         ranked = _chunk("a", score=0.01)
         assert (
-            _passthrough_required(
-                0, ranked, seed_paths=set(), expanded_paths=set(), top_score=1.0
-            )
+            _passthrough_required(0, ranked, seed_paths=set(), expanded_paths=set(), top_score=1.0)
             is True
         )
 
@@ -112,15 +110,11 @@ class TestPassthroughRequired:
         high = _chunk("d", score=0.7)
         low = _chunk("e", score=0.2)
         assert (
-            _passthrough_required(
-                1, high, seed_paths=set(), expanded_paths=set(), top_score=1.0
-            )
+            _passthrough_required(1, high, seed_paths=set(), expanded_paths=set(), top_score=1.0)
             is True
         )
         assert (
-            _passthrough_required(
-                1, low, seed_paths=set(), expanded_paths=set(), top_score=1.0
-            )
+            _passthrough_required(1, low, seed_paths=set(), expanded_paths=set(), top_score=1.0)
             is False
         )
 


### PR DESCRIPTION
## Summary

Adds `archex_query_compressed` as a benchmark-only strategy. It runs the exact `archex_query` retrieval and packing path, then applies the deterministic post-retrieval compression primitives after bundle assembly. The product default is unchanged and `archex_query` is untouched.

- `Strategy.ARCHEX_QUERY_COMPRESSED = "archex_query_compressed"`, registered in the default registry.
- Retrieval metrics are assembled from the **uncompressed** bundle (same path as `archex_query`), so recall/region/F1/token-efficiency stay attributable to the uncompressed retrieval set.
- Compression runs on a deep copy: required/direct/high-confidence regions (top hit, seeds, high-score, non-frontier) pass through; only lower-confidence graph-frontier regions are eligible. The decision uses intrinsic retrieval signals only — never benchmark ground truth.
- New `region_content_hash` receipt helper guarantees a compressed row's `original_content_hash` equals the receipt row's original content hash; `fetch_original_handle` is the exact chunk handle.

## Result fields

`bundle_tokens_uncompressed`, `bundle_tokens_compressed`, `bundle_compression_ratio`, `required_context_compressed_tokens`, `required_context_passthrough_tokens`, `compression_hidden_required_region_count`, `token_efficiency_with_compression_and_completion`. All default to `None` for every other strategy.

The completion penalty is identical to the uncompressed lane (compression cannot make incomplete retrieval complete); the compressed efficiency scales measured output by the region ratio.

## Safety invariants

- Required/high-confidence code never compresses — `required_context_compressed_tokens` and `compression_hidden_required_region_count` are structural `0`.
- `protect_code` (fix/debug/review intent) disables code elision; clean code stays intact.

## Tests

```
uv run pytest tests/benchmark/test_compression_strategy.py tests/benchmark/test_strategy_registry.py
uv run pytest tests/benchmark/test_strategies.py tests/benchmark/test_runner.py tests/benchmark/test_reporter.py
```

Covers registry, passthrough predicate, compression metrics, required passthrough, exact handle/hash exposure, original-bundle immutability, protect_code, fixture run, and parity with `archex_query` (no effect on its retrieval metrics).

## Stack

Stack-Id: `compression-lane-501320`
Base: `bench/compression-primitives`
Position: 3/4

1. `bench/compression-metadata-model` -> #300
2. `bench/compression-primitives` -> #301
3. `bench/compression-strategy` -> this PR
4. `bench/compression-reports-docs` -> PR 4

Depends on: #301

## Validation

- Passed: `uv run pytest tests/benchmark/test_compression_strategy.py tests/benchmark/test_strategy_registry.py` (21 passed)
- Passed: `uv run pytest tests/benchmark/test_strategies.py tests/benchmark/test_runner.py tests/benchmark/test_reporter.py tests/benchmark/test_models.py tests/test_receipt.py tests/test_models.py` (273 passed)
