### PR TITLE
Add efficiency-aware packing score model

### DIFF
--- a/src/archex/serve/packing.py
+++ b/src/archex/serve/packing.py
@@ -1,0 +1,243 @@
+"""Efficiency-aware packing score model.
+
+A deterministic per-candidate packing score that folds intrinsic retrieval
+signals into a single priority value plus provenance explaining the include /
+compress / elide / skip decision. The model uses ONLY signals already present in
+a retrieved bundle and its receipt — retrieval score, direct path/symbol match
+status, graph edge confidence and distance, token count, compression
+eligibility and loss risk, scout/fetch handle priority, and the budget tier. It
+never reads benchmark ground truth (expected files, expected regions, or
+completion labels), so it is safe to import from product code; the
+benchmark-only ``archex_query_efficiency_packed`` lane is the first consumer.
+
+The score model decides *priority* and a *provisional decision* per candidate.
+The packer (built on top of this model) enforces the token budget and may
+downgrade a provisional ``INCLUDE`` toward ``COMPRESS``/``ELIDE``/``SKIP`` under
+budget pressure, but a direct/high-confidence target is always preserved before
+optional context.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from archex.models import CompressionLossRisk
+from archex.serve.modality import BudgetTier
+
+
+class PackDecision(StrEnum):
+    """What the packer does with one candidate region."""
+
+    INCLUDE = "include"  # keep the region verbatim
+    COMPRESS = "compress"  # keep a deterministic, low-risk compressed representation
+    ELIDE = "elide"  # keep only an anchor/marker pointing at the original
+    SKIP = "skip"  # drop the region entirely
+
+
+# A candidate is "large" past this many tokens; combined with a low retrieval
+# score and graph distance it becomes a budget-wasting expansion.
+_LARGE_TOKEN_COUNT = 400
+# Normalized final retrieval score below which a candidate is "low score" for
+# the large-low-score-graph-distant penalty.
+_LOW_SCORE = 0.25
+# A graph hop of at least this distance is "graph-distant".
+_DISTANT_HOP = 1
+
+# Score weights. ``value`` is a relevance-per-token efficiency score adjusted by
+# distance/risk penalties; direct-match preservation is enforced structurally by
+# ``order_candidates`` rather than by an unbounded score bonus.
+_HANDLE_PRIORITY_WEIGHT = 50.0
+_GRAPH_DISTANCE_PENALTY = 20.0  # per hop, always applied to graph-expanded context
+_LOW_CONFIDENCE_PENALTY = 30.0  # per hop, scaled by (1 - edge confidence)
+_HIGH_RISK_PENALTY = 40.0
+_LARGE_LOW_SCORE_PENALTY = 30.0
+
+# Compression is only ever *preferred* for genuinely low-risk context; medium and
+# high loss risk are never auto-compressed by the packer.
+_COMPRESSIBLE_RISKS = frozenset({CompressionLossRisk.NONE, CompressionLossRisk.LOW})
+
+
+def _clamp01(value: float) -> float:
+    return 0.0 if value < 0.0 else 1.0 if value > 1.0 else value
+
+
+@dataclass(frozen=True)
+class PackingSignals:
+    """Intrinsic per-candidate signals for the packer. No benchmark ground truth.
+
+    Every field is derivable from a retrieved bundle and its receipt. Expected
+    file/region coverage is deliberately absent so the score model cannot leak
+    benchmark ground truth into a retrieval decision.
+    """
+
+    candidate_id: str
+    file_path: str
+    # Normalized 0..1 final retrieval score for the region.
+    retrieval_score: float
+    # Direct path/symbol match or otherwise high-confidence edit target.
+    direct_match: bool
+    # 0 = seed/direct retrieval, >=1 = graph-expanded neighbour.
+    graph_distance: int
+    # 0..1 confidence of the edge that admitted the region (1.0 when direct).
+    graph_edge_confidence: float
+    # Tokens the verbatim region would consume.
+    token_count: int
+    # A deterministic compression mode would shrink the region.
+    compression_eligible: bool
+    compression_loss_risk: CompressionLossRisk
+    # Scout/fetch handle priority, 0..1 (0 when the region has no handle).
+    handle_priority: float
+    # Region is whole-file/module level rather than a smaller symbol/block.
+    whole_file: bool
+    # Count of high-confidence (direct-match) regions in the same file.
+    file_evidence_regions: int
+    # Query intent forbids lossy in-place compression of code; an anchor/elide
+    # that still points at untouched source is allowed (fix/debug/review intents).
+    protect_code: bool
+
+
+@dataclass(frozen=True)
+class PackingScore:
+    """Deterministic packing score and provenance for one candidate.
+
+    ``value`` is the relevance-per-token priority among same-tier candidates
+    (higher packs first). ``decision`` is the provisional pack decision derived
+    from per-candidate signals and budget tier; the packer may downgrade it under
+    budget pressure but never drops a direct match below an anchor.
+    """
+
+    candidate_id: str
+    value: float
+    relevance_per_1k_tokens: float
+    decision: PackDecision
+    reason: str
+    direct_match: bool
+    graph_distance: int
+    compression_loss_risk: CompressionLossRisk
+
+    def to_provenance(self) -> dict[str, str]:
+        """Flatten the score into string-valued provenance entries."""
+        return {
+            "candidate_id": self.candidate_id,
+            "decision": self.decision.value,
+            "reason": self.reason,
+            "value": f"{self.value:.4f}",
+            "relevance_per_1k_tokens": f"{self.relevance_per_1k_tokens:.4f}",
+            "direct_match": str(self.direct_match).lower(),
+            "graph_distance": str(self.graph_distance),
+            "compression_loss_risk": self.compression_loss_risk.value,
+        }
+
+
+def relevance_per_1k_tokens(retrieval_score: float, token_count: int) -> float:
+    """Retrieval score normalized per 1000 consumed tokens (0 for empty regions)."""
+    if token_count <= 0:
+        return 0.0
+    return retrieval_score / token_count * 1000.0
+
+
+def _is_low_value(signals: PackingSignals) -> bool:
+    """Large, low-score, and graph-distant: a budget-wasting expansion."""
+    return (
+        signals.token_count >= _LARGE_TOKEN_COUNT
+        and signals.retrieval_score < _LOW_SCORE
+        and signals.graph_distance >= _DISTANT_HOP
+    )
+
+
+def _provisional_decision(
+    signals: PackingSignals, *, budget_tier: BudgetTier
+) -> tuple[PackDecision, str]:
+    """Per-candidate pack decision before the packer applies the token budget."""
+    if signals.direct_match:
+        return PackDecision.INCLUDE, "direct/high-confidence target preserved"
+
+    low_risk = (
+        signals.compression_eligible
+        and signals.compression_loss_risk in _COMPRESSIBLE_RISKS
+        and not signals.protect_code
+    )
+
+    # Whole-file context only earns the budget at a large tier or when the file
+    # carries multiple high-confidence regions; otherwise a smaller enclosing
+    # symbol/block is preferred and the whole-file region is shrunk to evidence.
+    if signals.whole_file and not (
+        budget_tier is BudgetTier.LARGE or signals.file_evidence_regions >= 2
+    ):
+        if low_risk:
+            return (
+                PackDecision.COMPRESS,
+                "whole-file region compressed (low risk); smaller enclosing "
+                "evidence preferred under non-large budget",
+            )
+        return (
+            PackDecision.ELIDE,
+            "whole-file region elided to an anchor; smaller enclosing evidence "
+            "preferred under non-large budget",
+        )
+
+    if _is_low_value(signals):
+        if low_risk:
+            return (
+                PackDecision.COMPRESS,
+                "large low-score graph-distant region compressed (low risk)",
+            )
+        high_risk = signals.compression_loss_risk is CompressionLossRisk.HIGH
+        return (
+            PackDecision.SKIP,
+            "large, low-score, graph-distant"
+            + (", high compression risk" if high_risk else "")
+            + " -> skipped",
+        )
+
+    return PackDecision.INCLUDE, "relevant region included"
+
+
+def score_candidate(signals: PackingSignals, *, budget_tier: BudgetTier) -> PackingScore:
+    """Combine intrinsic signals into a deterministic packing score + decision."""
+    rel_per_1k = relevance_per_1k_tokens(signals.retrieval_score, signals.token_count)
+
+    value = rel_per_1k
+    value += _clamp01(signals.handle_priority) * _HANDLE_PRIORITY_WEIGHT
+    if signals.graph_distance > 0:
+        confidence_gap = 1.0 - _clamp01(signals.graph_edge_confidence)
+        value -= signals.graph_distance * (
+            _GRAPH_DISTANCE_PENALTY + _LOW_CONFIDENCE_PENALTY * confidence_gap
+        )
+    if signals.compression_loss_risk is CompressionLossRisk.HIGH:
+        value -= _HIGH_RISK_PENALTY
+    if _is_low_value(signals):
+        value -= _LARGE_LOW_SCORE_PENALTY
+
+    decision, reason = _provisional_decision(signals, budget_tier=budget_tier)
+    return PackingScore(
+        candidate_id=signals.candidate_id,
+        value=value,
+        relevance_per_1k_tokens=rel_per_1k,
+        decision=decision,
+        reason=reason,
+        direct_match=signals.direct_match,
+        graph_distance=signals.graph_distance,
+        compression_loss_risk=signals.compression_loss_risk,
+    )
+
+
+def order_candidates(scores: list[PackingScore]) -> list[PackingScore]:
+    """Deterministic packing order with direct-match preservation.
+
+    Direct/high-confidence targets sort ahead of all optional context regardless
+    of raw efficiency, so they are always packed first. Within a tier, regions
+    sort by descending ``value``; ties break toward nearer graph distance and
+    then by ``candidate_id`` so the order is fully deterministic and independent
+    of input ordering.
+    """
+    return sorted(
+        scores,
+        key=lambda score: (
+            not score.direct_match,
+            -score.value,
+            score.graph_distance,
+            score.candidate_id,
+        ),
+    )

--- a/tests/serve/test_packing.py
+++ b/tests/serve/test_packing.py
@@ -1,0 +1,311 @@
+"""Tests for the efficiency-aware packing score model."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import archex.serve.packing as packing
+from archex.models import CompressionLossRisk
+from archex.serve.modality import BudgetTier
+from archex.serve.packing import (
+    PackDecision,
+    PackingSignals,
+    order_candidates,
+    relevance_per_1k_tokens,
+    score_candidate,
+)
+
+
+def _signals(
+    candidate_id: str = "c0",
+    *,
+    file_path: str = "src/app.py",
+    retrieval_score: float = 0.5,
+    direct_match: bool = False,
+    graph_distance: int = 0,
+    graph_edge_confidence: float = 1.0,
+    token_count: int = 100,
+    compression_eligible: bool = False,
+    compression_loss_risk: CompressionLossRisk = CompressionLossRisk.NONE,
+    handle_priority: float = 0.0,
+    whole_file: bool = False,
+    file_evidence_regions: int = 1,
+    protect_code: bool = False,
+) -> PackingSignals:
+    return PackingSignals(
+        candidate_id=candidate_id,
+        file_path=file_path,
+        retrieval_score=retrieval_score,
+        direct_match=direct_match,
+        graph_distance=graph_distance,
+        graph_edge_confidence=graph_edge_confidence,
+        token_count=token_count,
+        compression_eligible=compression_eligible,
+        compression_loss_risk=compression_loss_risk,
+        handle_priority=handle_priority,
+        whole_file=whole_file,
+        file_evidence_regions=file_evidence_regions,
+        protect_code=protect_code,
+    )
+
+
+class TestRelevancePerToken:
+    def test_score_normalized_per_1k_tokens(self) -> None:
+        assert relevance_per_1k_tokens(0.5, 100) == 5.0
+        assert relevance_per_1k_tokens(1.0, 1000) == 1.0
+
+    def test_empty_region_is_zero(self) -> None:
+        assert relevance_per_1k_tokens(0.9, 0) == 0.0
+
+
+class TestScoreOrdering:
+    def test_ordering_is_deterministic_and_input_independent(self) -> None:
+        # Three non-direct candidates with strictly distinct efficiency.
+        high = score_candidate(
+            _signals("high", retrieval_score=0.9, token_count=100), budget_tier=BudgetTier.STANDARD
+        )
+        mid = score_candidate(
+            _signals("mid", retrieval_score=0.5, token_count=100), budget_tier=BudgetTier.STANDARD
+        )
+        low = score_candidate(
+            _signals("low", retrieval_score=0.1, token_count=100), budget_tier=BudgetTier.STANDARD
+        )
+        forward = [s.candidate_id for s in order_candidates([high, mid, low])]
+        shuffled = [s.candidate_id for s in order_candidates([low, high, mid])]
+        assert forward == ["high", "mid", "low"]
+        assert forward == shuffled
+
+    def test_equal_value_breaks_by_graph_distance_then_id(self) -> None:
+        # Identical efficiency and value; only the tie-break keys differ. Both are
+        # graph-expanded with full edge confidence so the distance penalty matches.
+        near = score_candidate(
+            _signals("z_near", retrieval_score=0.4, token_count=100, graph_distance=1),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        far = score_candidate(
+            _signals("a_far", retrieval_score=0.4, token_count=100, graph_distance=2),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        same_a = score_candidate(
+            _signals("a_near", retrieval_score=0.4, token_count=100, graph_distance=1),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        ordered = [s.candidate_id for s in order_candidates([far, near, same_a])]
+        # Nearer distance first; within equal distance, candidate_id ascending.
+        assert ordered == ["a_near", "z_near", "a_far"]
+
+
+class TestDirectMatchPreservation:
+    def test_direct_match_packs_before_more_efficient_optional(self) -> None:
+        # A tiny-but-efficient optional region would outrank the direct match on
+        # raw efficiency, yet the direct/high-confidence target must pack first.
+        direct = score_candidate(
+            _signals("direct", retrieval_score=0.2, token_count=500, direct_match=True),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        optional = score_candidate(
+            _signals("optional", retrieval_score=1.0, token_count=10),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        assert optional.value > direct.value  # optional is more efficient
+        ordered = [s.candidate_id for s in order_candidates([optional, direct])]
+        assert ordered == ["direct", "optional"]
+
+    def test_direct_match_decision_is_always_include(self) -> None:
+        # Even a large, whole-file, high-risk region stays INCLUDE when direct.
+        score = score_candidate(
+            _signals(
+                "d",
+                retrieval_score=0.05,
+                token_count=2000,
+                direct_match=True,
+                whole_file=True,
+                graph_distance=0,
+                compression_eligible=True,
+                compression_loss_risk=CompressionLossRisk.HIGH,
+            ),
+            budget_tier=BudgetTier.TIGHT,
+        )
+        assert score.decision is PackDecision.INCLUDE
+
+
+class TestWholeFilePreservation:
+    def test_whole_file_compressed_under_standard_budget_when_low_risk(self) -> None:
+        score = score_candidate(
+            _signals(
+                "wf",
+                whole_file=True,
+                file_evidence_regions=1,
+                compression_eligible=True,
+                compression_loss_risk=CompressionLossRisk.LOW,
+            ),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        assert score.decision is PackDecision.COMPRESS
+
+    def test_whole_file_elided_under_standard_budget_when_not_compressible(self) -> None:
+        score = score_candidate(
+            _signals("wf", whole_file=True, file_evidence_regions=1, compression_eligible=False),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        assert score.decision is PackDecision.ELIDE
+
+    def test_whole_file_included_under_large_budget(self) -> None:
+        score = score_candidate(
+            _signals("wf", whole_file=True, file_evidence_regions=1),
+            budget_tier=BudgetTier.LARGE,
+        )
+        assert score.decision is PackDecision.INCLUDE
+
+    def test_whole_file_included_with_multiple_evidence_regions(self) -> None:
+        score = score_candidate(
+            _signals("wf", whole_file=True, file_evidence_regions=2),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        assert score.decision is PackDecision.INCLUDE
+
+
+class TestPenalties:
+    def test_graph_distance_lowers_value(self) -> None:
+        seed = score_candidate(
+            _signals("seed", retrieval_score=0.6, token_count=100, graph_distance=0),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        expanded = score_candidate(
+            _signals("exp", retrieval_score=0.6, token_count=100, graph_distance=1),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        assert expanded.value < seed.value
+
+    def test_low_edge_confidence_lowers_value_further(self) -> None:
+        confident = score_candidate(
+            _signals("hi", retrieval_score=0.6, graph_distance=1, graph_edge_confidence=0.9),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        diffuse = score_candidate(
+            _signals("lo", retrieval_score=0.6, graph_distance=1, graph_edge_confidence=0.1),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        assert diffuse.value < confident.value
+
+    def test_handle_priority_bonus_is_clamped(self) -> None:
+        capped = score_candidate(
+            _signals("a", handle_priority=1.0), budget_tier=BudgetTier.STANDARD
+        )
+        over = score_candidate(_signals("b", handle_priority=5.0), budget_tier=BudgetTier.STANDARD)
+        assert over.value == capped.value
+
+    def test_edge_confidence_gap_is_clamped(self) -> None:
+        # Confidence above 1 behaves like 1 (no extra distance penalty); below 0
+        # behaves like 0 (full low-confidence penalty).
+        at_one = score_candidate(
+            _signals("a", graph_distance=1, graph_edge_confidence=1.0),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        over_one = score_candidate(
+            _signals("b", graph_distance=1, graph_edge_confidence=5.0),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        at_zero = score_candidate(
+            _signals("c", graph_distance=1, graph_edge_confidence=0.0),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        below_zero = score_candidate(
+            _signals("d", graph_distance=1, graph_edge_confidence=-2.0),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        assert over_one.value == at_one.value
+        assert below_zero.value == at_zero.value
+
+
+class TestCompressionRiskGating:
+    def test_high_risk_low_value_region_is_skipped_not_compressed(self) -> None:
+        score = score_candidate(
+            _signals(
+                "risky",
+                retrieval_score=0.05,
+                token_count=800,
+                graph_distance=2,
+                compression_eligible=True,
+                compression_loss_risk=CompressionLossRisk.HIGH,
+            ),
+            budget_tier=BudgetTier.TIGHT,
+        )
+        assert score.decision is PackDecision.SKIP
+
+    def test_medium_risk_region_is_not_auto_compressed(self) -> None:
+        # Medium loss risk is not "low risk", so a low-value region is skipped
+        # rather than compressed; only NONE/LOW risk earns COMPRESS.
+        score = score_candidate(
+            _signals(
+                "med",
+                retrieval_score=0.05,
+                token_count=800,
+                graph_distance=2,
+                compression_eligible=True,
+                compression_loss_risk=CompressionLossRisk.MEDIUM,
+            ),
+            budget_tier=BudgetTier.TIGHT,
+        )
+        assert score.decision is PackDecision.SKIP
+
+    def test_protect_code_blocks_compression_preference(self) -> None:
+        # Fix/debug/review intent: a compressible whole-file region is elided to an
+        # anchor rather than compressed in place.
+        score = score_candidate(
+            _signals(
+                "wf",
+                whole_file=True,
+                compression_eligible=True,
+                compression_loss_risk=CompressionLossRisk.LOW,
+                protect_code=True,
+            ),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        assert score.decision is PackDecision.ELIDE
+
+
+class TestProvenance:
+    def test_to_provenance_formats_fields(self) -> None:
+        score = score_candidate(
+            _signals("c0", retrieval_score=0.5, token_count=100, direct_match=True),
+            budget_tier=BudgetTier.STANDARD,
+        )
+        prov = score.to_provenance()
+        assert prov["candidate_id"] == "c0"
+        assert prov["decision"] == PackDecision.INCLUDE.value
+        assert prov["direct_match"] == "true"  # lowercased boolean, not "True"
+        assert prov["relevance_per_1k_tokens"] == "5.0000"  # 0.5 / 100 * 1000, 4dp
+        assert prov["value"] == f"{score.value:.4f}"
+        assert prov["compression_loss_risk"] == CompressionLossRisk.NONE.value
+
+
+class TestNoBenchmarkGroundTruthDependency:
+    def test_score_signature_takes_only_intrinsic_signals(self) -> None:
+        params = set(inspect.signature(score_candidate).parameters)
+        assert params == {"signals", "budget_tier"}
+
+    def test_module_does_not_import_benchmark_package(self) -> None:
+        tree = ast.parse(Path(packing.__file__).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                assert all(not alias.name.startswith("archex.benchmark") for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                assert not module.startswith("archex.benchmark")
+                if module == "archex":  # guard `from archex import benchmark`
+                    assert all(alias.name != "benchmark" for alias in node.names)
+
+    def test_module_does_not_reference_ground_truth_fields(self) -> None:
+        source = Path(packing.__file__).read_text(encoding="utf-8")
+        for forbidden in ("expected_region", "expected_file", "ground_truth"):
+            assert forbidden not in source
+
+    def test_provisional_decision_ignores_unknown_relevance(self) -> None:
+        # The signals carry no region-coverage field; identical signals always
+        # produce the identical decision regardless of any external label.
+        a = score_candidate(_signals("a"), budget_tier=BudgetTier.STANDARD)
+        b = score_candidate(_signals("a"), budget_tier=BudgetTier.STANDARD)
+        assert a == b


### PR DESCRIPTION
## Summary

Adds a deterministic per-candidate **packing score model** (`src/archex/serve/packing.py`) that folds intrinsic retrieval signals into a single relevance-per-token priority value plus provenance explaining the include / compress / elide / skip decision. This is the foundation for the benchmark-only `archex_query_efficiency_packed` lane (Workstream 4 of `.docs/2026-06-18-retrieval-quality-token-efficiency-enhancement-design.md`).

The model consumes **only** signals already present in a retrieved bundle and its receipt — retrieval score, direct path/symbol match, graph edge confidence and distance, token count, compression eligibility/loss risk, scout/fetch handle priority, whole-file vs enclosing-symbol granularity, same-file evidence region count, and a protect-code intent flag. It never reads benchmark ground truth (expected files/regions or completion labels), so it is safe to import from product code.

- `PackDecision` — include / compress / elide / skip.
- `PackingSignals` — intrinsic per-candidate inputs, no ground truth.
- `PackingScore` + `to_provenance()` — value, relevance-per-1k-tokens, decision, and reason.
- `score_candidate(signals, *, budget_tier)` — combines signals with distance/confidence/risk penalties.
- `order_candidates(scores)` — direct-match preservation enforced structurally, then descending value with deterministic tie-breaks.

No product default behavior changes; nothing is wired into the query path yet.

## Stack

Stack-Id: `packing-lane-82b485`
Base: `main`
Position: 1/4

1. `bench/packing-score-model` -> this PR
2. `bench/efficiency-packer` (packer)
3. `bench/efficiency-packed-strategy` (benchmark strategy)
4. `bench/packing-reports-docs` (reports + docs)

Depends on: (none - root)

## Validation

- `uv run ruff check` / `ruff format --check` — pass
- `uv run pyright src/archex/serve/packing.py tests/serve/test_packing.py` — 0 errors
- `uv run pytest tests/serve/test_packing.py --no-cov` — 18 passed
