### PR TITLE
Add efficiency-aware packer

### DIFF
--- a/src/archex/serve/packing.py
+++ b/src/archex/serve/packing.py
@@ -241,3 +241,217 @@ def order_candidates(scores: list[PackingScore]) -> list[PackingScore]:
             score.candidate_id,
         ),
     )
+
+
+# Pack decisions ordered richest-first; the packer downgrades a region along this
+# chain under budget pressure (INCLUDE -> COMPRESS -> ELIDE -> SKIP).
+_CHEAPER: dict[PackDecision, PackDecision] = {
+    PackDecision.INCLUDE: PackDecision.COMPRESS,
+    PackDecision.COMPRESS: PackDecision.ELIDE,
+    PackDecision.ELIDE: PackDecision.SKIP,
+}
+
+
+@dataclass(frozen=True)
+class PackingCandidate:
+    """A region offered to the packer: its intrinsic signals plus shaped costs.
+
+    ``compressed_token_count`` is the token count of the deterministic compressed
+    representation (equal to ``signals.token_count`` when the region is not
+    compressible); the packer reads it only when a COMPRESS decision is viable.
+    ``elided_token_count`` is the token count of the anchor that replaces the body
+    when a region is elided; the packer charges it (capped at the verbatim cost)
+    so budget admission reflects the real anchor size rather than a fixed guess.
+    """
+
+    signals: PackingSignals
+    compressed_token_count: int
+    elided_token_count: int
+
+
+@dataclass(frozen=True)
+class PackedRegion:
+    """Final pack decision for one candidate, with the score that produced it."""
+
+    candidate_id: str
+    decision: PackDecision
+    score: PackingScore
+    tokens_charged: int
+    retrieval_score: float
+
+
+@dataclass(frozen=True)
+class PackingPlan:
+    """Result of packing a candidate set under a token budget.
+
+    ``regions`` lists every candidate (including skipped ones) in packed order so
+    provenance can explain each include/compress/elide/skip decision.
+    """
+
+    regions: list[PackedRegion]
+    included_tokens: int
+    budget_tier: BudgetTier
+    token_budget: int
+
+    def kept(self) -> list[PackedRegion]:
+        """Regions that survived packing (everything except SKIP), in packed order."""
+        return [region for region in self.regions if region.decision is not PackDecision.SKIP]
+
+    def kept_ids(self) -> list[str]:
+        return [region.candidate_id for region in self.kept()]
+
+    def decision_for(self, candidate_id: str) -> PackDecision | None:
+        for region in self.regions:
+            if region.candidate_id == candidate_id:
+                return region.decision
+        return None
+
+    def relevance_per_1k_tokens(self) -> float:
+        """Delivered retrieval relevance per 1000 packed tokens (0 for an empty pack).
+
+        Only INCLUDE and COMPRESS regions deliver content; an ELIDE region keeps
+        an anchor/fetch handle but not the region body, so its retrieval mass is
+        excluded from the numerator (counting it would reward eliding evidence).
+        """
+        if self.included_tokens <= 0:
+            return 0.0
+        retained = sum(
+            region.retrieval_score
+            for region in self.regions
+            if region.decision in (PackDecision.INCLUDE, PackDecision.COMPRESS)
+        )
+        return retained / self.included_tokens * 1000.0
+
+    def to_provenance(self) -> dict[str, str]:
+        """Aggregate decision counts and efficiency for the strategy/report layer."""
+        counts = dict.fromkeys(PackDecision, 0)
+        direct = 0
+        for region in self.regions:
+            counts[region.decision] += 1
+            if region.score.direct_match:
+                direct += 1
+        return {
+            "budget_tier": self.budget_tier.value,
+            "token_budget": str(self.token_budget),
+            "packed_tokens": str(self.included_tokens),
+            "candidate_count": str(len(self.regions)),
+            "direct_match_count": str(direct),
+            "include_count": str(counts[PackDecision.INCLUDE]),
+            "compress_count": str(counts[PackDecision.COMPRESS]),
+            "elide_count": str(counts[PackDecision.ELIDE]),
+            "skip_count": str(counts[PackDecision.SKIP]),
+            "relevance_per_1k_tokens": f"{self.relevance_per_1k_tokens():.4f}",
+        }
+
+
+def _decision_cost(decision: PackDecision, candidate: PackingCandidate) -> int:
+    if decision is PackDecision.INCLUDE:
+        return candidate.signals.token_count
+    if decision is PackDecision.COMPRESS:
+        return candidate.compressed_token_count
+    if decision is PackDecision.ELIDE:
+        return min(candidate.elided_token_count, candidate.signals.token_count)
+    return 0  # SKIP
+
+
+def _compress_viable(candidate: PackingCandidate) -> bool:
+    """Whether the packer may represent a region as a deterministic compression.
+
+    Direct/high-confidence targets are never compressed (their content is the
+    evidence). Only genuinely low-risk, compressible, non-protected regions whose
+    compressed form is strictly smaller are eligible.
+    """
+    signals = candidate.signals
+    return (
+        not signals.direct_match
+        and signals.compression_eligible
+        and signals.compression_loss_risk in _COMPRESSIBLE_RISKS
+        and not signals.protect_code
+        and candidate.compressed_token_count < signals.token_count
+    )
+
+
+def _representation_chain(candidate: PackingCandidate, start: PackDecision) -> list[PackDecision]:
+    """Decisions from ``start`` down to SKIP, dropping non-viable representations."""
+    chain: list[PackDecision] = []
+    decision: PackDecision | None = start
+    while decision is not None:
+        if decision is not PackDecision.COMPRESS or _compress_viable(candidate):
+            chain.append(decision)
+        decision = _CHEAPER.get(decision)
+    return chain
+
+
+def _fit_decision(
+    candidate: PackingCandidate,
+    start: PackDecision,
+    remaining: int,
+    *,
+    allow_skip: bool,
+) -> PackDecision:
+    """Pick the richest representation at or below ``start`` that fits ``remaining``.
+
+    Optional context falls through to SKIP when nothing fits. A direct/high-
+    confidence target is never skipped: if even an anchor exceeds the remaining
+    budget it is still kept as an anchor so its fetch handle survives.
+    """
+    chain = _representation_chain(candidate, start)
+    cheapest_kept: PackDecision | None = None
+    for decision in chain:
+        if decision is PackDecision.SKIP:
+            if allow_skip:
+                return PackDecision.SKIP
+            continue
+        cheapest_kept = decision
+        if _decision_cost(decision, candidate) <= remaining:
+            return decision
+    if allow_skip:
+        return PackDecision.SKIP
+    return cheapest_kept if cheapest_kept is not None else PackDecision.ELIDE
+
+
+def pack_efficiently(
+    candidates: list[PackingCandidate],
+    *,
+    token_budget: int,
+    budget_tier: BudgetTier,
+) -> PackingPlan:
+    """Select and shape candidates to maximize relevance per token within budget.
+
+    Direct/high-confidence targets are packed before optional context and never
+    dropped below an anchor. Optional regions are admitted in efficiency order and
+    downgraded (compress -> elide -> skip) as the budget tightens. Whole-file and
+    low-value graph-distant context is shrunk or skipped per the score model.
+    """
+    by_id = {candidate.signals.candidate_id: candidate for candidate in candidates}
+    scores = [
+        score_candidate(candidate.signals, budget_tier=budget_tier) for candidate in candidates
+    ]
+    ordered = order_candidates(scores)
+
+    used = 0
+    regions: list[PackedRegion] = []
+    for score in ordered:
+        candidate = by_id[score.candidate_id]
+        allow_skip = not score.direct_match
+        decision = _fit_decision(
+            candidate, score.decision, token_budget - used, allow_skip=allow_skip
+        )
+        cost = _decision_cost(decision, candidate)
+        charged = 0 if decision is PackDecision.SKIP else cost
+        used += charged
+        regions.append(
+            PackedRegion(
+                candidate_id=score.candidate_id,
+                decision=decision,
+                score=score,
+                tokens_charged=charged,
+                retrieval_score=candidate.signals.retrieval_score,
+            )
+        )
+    return PackingPlan(
+        regions=regions,
+        included_tokens=used,
+        budget_tier=budget_tier,
+        token_budget=token_budget,
+    )

--- a/tests/serve/test_packing.py
+++ b/tests/serve/test_packing.py
@@ -11,8 +11,10 @@ from archex.models import CompressionLossRisk
 from archex.serve.modality import BudgetTier
 from archex.serve.packing import (
     PackDecision,
+    PackingCandidate,
     PackingSignals,
     order_candidates,
+    pack_efficiently,
     relevance_per_1k_tokens,
     score_candidate,
 )
@@ -309,3 +311,213 @@ class TestNoBenchmarkGroundTruthDependency:
         a = score_candidate(_signals("a"), budget_tier=BudgetTier.STANDARD)
         b = score_candidate(_signals("a"), budget_tier=BudgetTier.STANDARD)
         assert a == b
+
+
+def _candidate(
+    signals: PackingSignals,
+    compressed_token_count: int | None = None,
+    elided_token_count: int | None = None,
+) -> PackingCandidate:
+    return PackingCandidate(
+        signals=signals,
+        compressed_token_count=(
+            signals.token_count if compressed_token_count is None else compressed_token_count
+        ),
+        elided_token_count=(
+            min(12, signals.token_count) if elided_token_count is None else elided_token_count
+        ),
+    )
+
+
+class TestPackerDirectMatchWins:
+    def test_direct_match_packed_before_more_efficient_optional(self) -> None:
+        # The optional region is more efficient per token, but the budget only
+        # fits one region and the direct/high-confidence target must win.
+        direct = _candidate(
+            _signals("direct", direct_match=True, token_count=200, retrieval_score=0.2)
+        )
+        optional = _candidate(_signals("optional", token_count=60, retrieval_score=1.0))
+        plan = pack_efficiently([optional, direct], token_budget=200, budget_tier=BudgetTier.TIGHT)
+        assert plan.decision_for("direct") is PackDecision.INCLUDE
+        assert plan.decision_for("optional") is PackDecision.SKIP
+        assert plan.kept_ids() == ["direct"]
+        assert plan.included_tokens == 200
+
+
+class TestPackerGraphExpansion:
+    def _candidates(self) -> list[PackingCandidate]:
+        seed = _candidate(
+            _signals(
+                "seed", direct_match=True, graph_distance=0, token_count=100, retrieval_score=0.9
+            )
+        )
+        expanded = _candidate(
+            _signals(
+                "expanded",
+                graph_distance=1,
+                graph_edge_confidence=0.5,
+                token_count=100,
+                retrieval_score=0.4,
+            )
+        )
+        return [seed, expanded]
+
+    def test_graph_expansion_loses_under_tight_budget(self) -> None:
+        plan = pack_efficiently(self._candidates(), token_budget=100, budget_tier=BudgetTier.TIGHT)
+        assert plan.decision_for("seed") is PackDecision.INCLUDE
+        assert plan.decision_for("expanded") is PackDecision.SKIP
+        assert plan.kept_ids() == ["seed"]
+
+    def test_graph_expansion_included_when_budget_allows(self) -> None:
+        plan = pack_efficiently(self._candidates(), token_budget=400, budget_tier=BudgetTier.LARGE)
+        assert plan.decision_for("seed") is PackDecision.INCLUDE
+        assert plan.decision_for("expanded") is PackDecision.INCLUDE
+        assert set(plan.kept_ids()) == {"seed", "expanded"}
+
+
+class TestPackerWholeFilePreservation:
+    def test_whole_file_included_only_under_large_budget(self) -> None:
+        wf = _signals(
+            "wf", whole_file=True, file_evidence_regions=1, token_count=300, retrieval_score=0.5
+        )
+        large = pack_efficiently([_candidate(wf)], token_budget=2000, budget_tier=BudgetTier.LARGE)
+        standard = pack_efficiently(
+            [_candidate(wf)], token_budget=2000, budget_tier=BudgetTier.STANDARD
+        )
+        assert large.decision_for("wf") is PackDecision.INCLUDE
+        assert standard.decision_for("wf") is PackDecision.ELIDE
+
+
+class TestPackerCompressionRisk:
+    def test_high_risk_optional_is_never_compressed_under_pressure(self) -> None:
+        risky = _candidate(
+            _signals(
+                "risky",
+                token_count=300,
+                retrieval_score=0.6,
+                compression_eligible=True,
+                compression_loss_risk=CompressionLossRisk.HIGH,
+            ),
+            compressed_token_count=80,
+        )
+        plan = pack_efficiently([risky], token_budget=100, budget_tier=BudgetTier.TIGHT)
+        decision = plan.decision_for("risky")
+        assert decision is not PackDecision.COMPRESS
+        assert decision in (PackDecision.ELIDE, PackDecision.SKIP)
+
+    def test_low_risk_optional_is_compressed_under_pressure(self) -> None:
+        low = _candidate(
+            _signals(
+                "low",
+                token_count=300,
+                retrieval_score=0.6,
+                compression_eligible=True,
+                compression_loss_risk=CompressionLossRisk.LOW,
+            ),
+            compressed_token_count=80,
+        )
+        plan = pack_efficiently([low], token_budget=100, budget_tier=BudgetTier.TIGHT)
+        assert plan.decision_for("low") is PackDecision.COMPRESS
+        assert plan.included_tokens == 80
+
+
+class TestPackerInvariants:
+    def test_direct_match_kept_as_anchor_when_budget_exhausted(self) -> None:
+        first = _candidate(
+            _signals("first", direct_match=True, token_count=100, retrieval_score=0.9)
+        )
+        second = _candidate(
+            _signals("second", direct_match=True, token_count=100, retrieval_score=0.8)
+        )
+        plan = pack_efficiently([first, second], token_budget=100, budget_tier=BudgetTier.TIGHT)
+        assert plan.decision_for("first") is PackDecision.INCLUDE
+        # The second direct match no longer fits but is preserved as an anchor.
+        assert plan.decision_for("second") is PackDecision.ELIDE
+        assert "second" in plan.kept_ids()
+
+    def test_optional_regions_respect_budget(self) -> None:
+        candidates = [
+            _candidate(_signals(f"c{i}", token_count=100, retrieval_score=0.9 - i * 0.1))
+            for i in range(5)
+        ]
+        plan = pack_efficiently(candidates, token_budget=250, budget_tier=BudgetTier.STANDARD)
+        # Optional regions never overflow: the full packed total (include + anchors)
+        # stays within budget; only forced direct-match anchors may exceed it.
+        assert plan.included_tokens <= 250
+
+    def test_provenance_and_relevance_per_token(self) -> None:
+        seed = _candidate(_signals("seed", direct_match=True, token_count=100, retrieval_score=1.0))
+        opt = _candidate(_signals("opt", token_count=100, retrieval_score=0.5))
+        plan = pack_efficiently([seed, opt], token_budget=1000, budget_tier=BudgetTier.STANDARD)
+        prov = plan.to_provenance()
+        assert prov["include_count"] == "2"
+        assert prov["direct_match_count"] == "1"
+        assert prov["skip_count"] == "0"
+        assert prov["budget_tier"] == BudgetTier.STANDARD.value
+        # (1.0 + 0.5) retrieval mass over 200 packed tokens -> 7.5 per 1k tokens.
+        assert plan.relevance_per_1k_tokens() == 7.5
+        assert prov["relevance_per_1k_tokens"] == "7.5000"
+
+    def test_relevance_excludes_anchor_only_elided_regions(self) -> None:
+        # The elided region keeps only an anchor, so its retrieval mass must not
+        # count toward delivered relevance-per-token.
+        kept = _candidate(_signals("kept", direct_match=True, token_count=100, retrieval_score=1.0))
+        elided = _signals(
+            "wf", whole_file=True, file_evidence_regions=1, token_count=300, retrieval_score=0.9
+        )
+        plan = pack_efficiently(
+            [kept, _candidate(elided)], token_budget=2000, budget_tier=BudgetTier.STANDARD
+        )
+        assert plan.decision_for("wf") is PackDecision.ELIDE
+        # Only the INCLUDE region's mass (1.0) counts, over packed tokens (100 + 12).
+        assert plan.relevance_per_1k_tokens() == 1.0 / plan.included_tokens * 1000.0
+
+
+class TestPackerEdgeCases:
+    def test_empty_candidate_set(self) -> None:
+        plan = pack_efficiently([], token_budget=1000, budget_tier=BudgetTier.STANDARD)
+        assert plan.regions == []
+        assert plan.kept_ids() == []
+        assert plan.included_tokens == 0
+        assert plan.relevance_per_1k_tokens() == 0.0
+
+    def test_single_direct_match_larger_than_budget_is_anchored(self) -> None:
+        big = _candidate(_signals("big", direct_match=True, token_count=5000, retrieval_score=0.9))
+        plan = pack_efficiently([big], token_budget=100, budget_tier=BudgetTier.TIGHT)
+        # Cannot be INCLUDEd within budget, but a direct match is never dropped:
+        # it is preserved as an anchor even though that exceeds the budget.
+        assert plan.decision_for("big") is PackDecision.ELIDE
+        assert "big" in plan.kept_ids()
+
+    def test_zero_budget_skips_all_optional(self) -> None:
+        candidates = [_candidate(_signals(f"c{i}", token_count=100)) for i in range(3)]
+        plan = pack_efficiently(candidates, token_budget=0, budget_tier=BudgetTier.TIGHT)
+        assert plan.kept_ids() == []
+        assert plan.included_tokens == 0
+        assert plan.to_provenance()["skip_count"] == "3"
+
+    def test_packing_is_input_order_independent(self) -> None:
+        seed = _candidate(_signals("seed", direct_match=True, token_count=100, retrieval_score=0.9))
+        mid = _candidate(_signals("mid", token_count=100, retrieval_score=0.6))
+        low = _candidate(_signals("low", token_count=100, retrieval_score=0.2))
+        forward = pack_efficiently(
+            [seed, mid, low], token_budget=250, budget_tier=BudgetTier.STANDARD
+        )
+        shuffled = pack_efficiently(
+            [low, seed, mid], token_budget=250, budget_tier=BudgetTier.STANDARD
+        )
+        assert forward.kept_ids() == shuffled.kept_ids()
+        assert [r.decision for r in forward.regions] == [r.decision for r in shuffled.regions]
+
+    def test_elide_cost_uses_real_anchor_token_count(self) -> None:
+        # A whole-file region forced to an anchor is charged its real anchor cost
+        # (elided_token_count), not a fixed marker guess.
+        wf = _candidate(
+            _signals(
+                "wf", whole_file=True, file_evidence_regions=1, token_count=600, retrieval_score=0.4
+            ),
+            elided_token_count=30,
+        )
+        plan = pack_efficiently([wf], token_budget=2000, budget_tier=BudgetTier.STANDARD)
+        assert plan.decision_for("wf") is PackDecision.ELIDE
+        assert plan.included_tokens == 30


### PR DESCRIPTION
## Summary

Adds `pack_efficiently` (and its plan/candidate types) on top of the PR1 score model — the **efficiency-aware packer** for Workstream 4. It selects and shapes a candidate set under a token budget to maximize relevance per token while preserving required/high-confidence evidence.

- **Direct/high-confidence targets** are packed before optional context and are never dropped below an anchor (their fetch handle always survives).
- **Optional regions** are admitted in efficiency order and downgraded `INCLUDE → COMPRESS → ELIDE → SKIP` as the budget tightens.
- **Whole-file context** is preserved verbatim only at a large budget tier or when its file carries multiple high-confidence regions; otherwise it is shrunk to an enclosing-evidence representation.
- **Compression** is only ever a representation for genuinely low-risk, compressible, non-protected regions; a high/medium-risk region is included verbatim, elided to an anchor, or skipped — never compressed.

`PackingCandidate` carries the compressed token cost; `PackingPlan` records each decision, packed token total, aggregate relevance-per-1k-tokens, and flattened provenance counts.

No product code is wired to the packer; the default context-assembly path is unchanged (verified against `tests/serve/test_context.py`).

## Stack

Stack-Id: `packing-lane-82b485`
Base: `bench/packing-score-model`
Position: 2/4

1. `bench/packing-score-model` -> #304
2. `bench/efficiency-packer` -> this PR
3. `bench/efficiency-packed-strategy` (benchmark strategy)
4. `bench/packing-reports-docs` (reports + docs)

Depends on: #304
Upstack: (strategy PR, pending)

## Validation

- `uv run ruff check` / `ruff format --check` — pass
- `uv run pyright src/archex/serve/packing.py tests/serve/test_packing.py` — 0 errors
- `uv run pytest tests/serve/test_packing.py --no-cov` — 31 passed
- `uv run pytest tests/serve/test_context.py --no-cov` — 88 passed (default packing unchanged)
