### PR TITLE
Add archex_query_dual_transform benchmark lane

### DIFF
--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -31,6 +31,7 @@ class Strategy(StrEnum):
     ARCHEX_QUERY_TASK_AWARE = "archex_query_task_aware"
     ARCHEX_QUERY_COMPRESSED = "archex_query_compressed"
     ARCHEX_QUERY_EFFICIENCY_PACKED = "archex_query_efficiency_packed"
+    ARCHEX_QUERY_DUAL_TRANSFORM = "archex_query_dual_transform"
     EXTERNAL_MCP = "external_mcp"
 
 

--- a/src/archex/benchmark/query_transform.py
+++ b/src/archex/benchmark/query_transform.py
@@ -1,0 +1,194 @@
+"""Deterministic dual-perspective query transformation for the benchmark lane.
+
+Rewrites a user query into two subqueries from complementary perspectives:
+
+* a *structural* subquery that emphasises the code-shaped signals an exact
+  retriever keys on — file paths, dotted/CamelCase/snake_case identifiers, call
+  sites, class/function names, error/exception types, stack-trace frames, and
+  import targets;
+* a *behavioural* subquery that preserves the natural-language description — the
+  reported symptom, the expected behaviour, and the domain nouns — including the
+  domain nouns embedded inside identifiers (``parse_imports`` -> ``parse
+  imports``) so prose-leaning retrieval still sees them.
+
+Rule-based only: no hosted LLM calls, no network. Inspired by BLAgent's
+dual-perspective query transformation (arXiv:2605.17965). Used exclusively by the
+benchmark-only ``archex_query_dual_transform`` lane; product retrieval paths are
+unaffected.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Code-token shapes. These mirror the structural shapes in
+# ``archex.serve.modality``; they are duplicated locally (as
+# ``archex.serve.intent`` already duplicates the identifier shape) to keep this
+# benchmark lane decoupled from the product classifier's private internals.
+_PATH_RE = re.compile(
+    r"[\w.\-/]*[\w\-]+/[\w.\-/]*\.[A-Za-z]{1,6}"  # dir/.../file.ext
+    r"|\b[\w\-]+\.(?:py|js|ts|tsx|jsx|go|rs|java|kt|cs|rb|cpp|cc|c|h|hpp|swift|php"
+    r"|scala|sql|sh|yaml|yml|toml|json|md)\b"  # file.ext
+)
+_IDENTIFIER_RE = re.compile(
+    r"(?:"
+    r"[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_.]+"  # dotted.name (2+ char tail)
+    r"|[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)+"  # CamelCase (2+ parts)
+    r"|[a-z0-9]+_[a-z0-9_]+"  # snake_case
+    r"|[A-Z][A-Z0-9_]{2,}"  # UPPER_CASE (3+ chars)
+    r")"
+)
+# Call site: ``name(`` excluding the ``(s)``/``(es)`` plural prose forms.
+_CALL_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\((?!s\)|es\))")
+# Error/exception/warning type names, including bare single-word ones.
+_ERROR_RE = re.compile(r"\b[A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning)\b")
+# Code fences / inline snippets.
+_CODE_FENCE_RE = re.compile(r"```|`[^`]+`")
+# Stack-trace / traceback evidence across common ecosystems.
+_STACK_TRACE_RE = re.compile(
+    r"traceback \(most recent call last\)"
+    r'|file "[^"]+", line \d+'
+    r"|\bat [\w.$]+\([\w.: ]*\)"  # java/js frame
+    r"|(?-i:\b[A-Z]\w*(?:Error|Exception)\b) *:"  # ValueError:, NullPointerException:
+    r"|\b[\w/]+\.(?:py|js|ts|tsx|jsx|go|rs|java|kt|cs|rb|cpp|cc|c|h|hpp|swift|php"
+    r"|scala):\d+\b",  # path.ext:line
+    re.IGNORECASE,
+)
+# Import statements: ``from pkg.mod import a, b`` or ``import pkg.mod, other``.
+_FROM_IMPORT_RE = re.compile(r"^\s*from\s+([\w.]+)\s+import\s+(.+)$")
+_IMPORT_RE = re.compile(r"^\s*import\s+(.+)$")
+
+_NL_STRIP_CHARS = ".,;:!?()[]{}\"'`"
+# CamelCase split points: lower/digit -> upper, and the ACRONYMWord boundary.
+_CAMEL_BOUNDARY_RE = re.compile(r"(?<=[a-z0-9])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])")
+# Non-identifier-word separators (underscore included so snake_case splits).
+_NONWORD_RE = re.compile(r"[^A-Za-z0-9]+")
+
+
+def _ordered_unique(tokens: list[str]) -> list[str]:
+    """Deduplicate tokens preserving first-occurrence order, dropping blanks."""
+    return [token for token in dict.fromkeys(tokens) if token]
+
+
+def _strip_code_spans(question: str) -> str:
+    """Blank out code fences, stack-trace spans, and file paths for prose."""
+    stripped = _CODE_FENCE_RE.sub(" ", question)
+    stripped = _STACK_TRACE_RE.sub(" ", stripped)
+    return _PATH_RE.sub(" ", stripped)
+
+
+def _is_natural_language_word(token: str) -> bool:
+    """Return True for a plain English-style word (not a code identifier)."""
+    if len(token) < 2 or "_" in token or "." in token or "/" in token:
+        return False
+    if not token.isalpha():
+        return False
+    # CamelCase / ALLCAPS read as code, not prose.
+    return token == token.lower() or token == token.capitalize()
+
+
+def _split_import_names(clause: str) -> list[str]:
+    """Split an import clause into target names, dropping aliases and ``*``."""
+    names: list[str] = []
+    for raw in clause.split(","):
+        name = raw.strip().split(" as ", 1)[0].strip()
+        if name and name != "*":
+            names.append(name)
+    return names
+
+
+def _import_tokens(question: str) -> list[str]:
+    """Extract module/symbol names from import statements in the query."""
+    tokens: list[str] = []
+    for line in question.splitlines():
+        from_match = _FROM_IMPORT_RE.match(line)
+        if from_match:
+            tokens.append(from_match.group(1))
+            tokens.extend(_split_import_names(from_match.group(2)))
+            continue
+        import_match = _IMPORT_RE.match(line)
+        if import_match:
+            tokens.extend(_split_import_names(import_match.group(1)))
+    return tokens
+
+
+def _split_identifier(identifier: str) -> list[str]:
+    """Split an identifier into lowercase domain-noun words (length >= 2)."""
+    words: list[str] = []
+    for part in _NONWORD_RE.split(identifier):
+        words.extend(_CAMEL_BOUNDARY_RE.split(part))
+    return [word.lower() for word in words if len(word) >= 2]
+
+
+def _structural_tokens(question: str) -> list[str]:
+    """Code-shaped tokens emphasised by the structural subquery, in query order."""
+    tokens: list[str] = []
+    tokens.extend(_PATH_RE.findall(question))
+    tokens.extend(_ERROR_RE.findall(question))
+    tokens.extend(call.rstrip("(") for call in _CALL_RE.findall(question))
+    tokens.extend(_IDENTIFIER_RE.findall(question))
+    tokens.extend(_import_tokens(question))
+    return _ordered_unique(tokens)
+
+
+def _behavioral_tokens(question: str) -> list[str]:
+    """Natural-language words plus identifier-derived domain nouns, in order."""
+    prose = _strip_code_spans(question)
+    nl_words = [
+        core
+        for token in prose.split()
+        if (core := token.strip(_NL_STRIP_CHARS)) and _is_natural_language_word(core)
+    ]
+    domain_nouns: list[str] = []
+    for identifier in _IDENTIFIER_RE.findall(question):
+        domain_nouns.extend(_split_identifier(identifier))
+    return _ordered_unique([*nl_words, *domain_nouns])
+
+
+@dataclass(frozen=True)
+class DualQuery:
+    """A user query rewritten into structural and behavioural subqueries.
+
+    ``*_from_fallback`` is True when a perspective extracted no tokens and the
+    original query string is used verbatim so retrieval always has a query.
+    """
+
+    original: str
+    structural: str
+    behavioral: str
+    structural_token_count: int
+    behavioral_token_count: int
+    structural_from_fallback: bool
+    behavioral_from_fallback: bool
+    has_stack_trace: bool
+
+    def to_provenance(self) -> dict[str, str]:
+        """Flatten the dual query into string-valued provenance entries."""
+        return {
+            "subquery_structural": self.structural,
+            "subquery_behavioral": self.behavioral,
+            "structural_token_count": str(self.structural_token_count),
+            "behavioral_token_count": str(self.behavioral_token_count),
+            "structural_from_fallback": str(self.structural_from_fallback).lower(),
+            "behavioral_from_fallback": str(self.behavioral_from_fallback).lower(),
+            "has_stack_trace": str(self.has_stack_trace).lower(),
+        }
+
+
+def transform_query(question: str) -> DualQuery:
+    """Rewrite a query into deterministic structural and behavioural subqueries."""
+    structural_tokens = _structural_tokens(question)
+    behavioral_tokens = _behavioral_tokens(question)
+    structural = " ".join(structural_tokens)
+    behavioral = " ".join(behavioral_tokens)
+    return DualQuery(
+        original=question,
+        structural=structural or question,
+        behavioral=behavioral or question,
+        structural_token_count=len(structural_tokens),
+        behavioral_token_count=len(behavioral_tokens),
+        structural_from_fallback=not structural,
+        behavioral_from_fallback=not behavioral,
+        has_stack_trace=_STACK_TRACE_RE.search(question) is not None,
+    )

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -50,6 +50,7 @@ AVAILABLE_STRATEGIES: list[Strategy] = [
     Strategy.ARCHEX_QUERY_TASK_AWARE,
     Strategy.ARCHEX_QUERY_COMPRESSED,
     Strategy.ARCHEX_QUERY_EFFICIENCY_PACKED,
+    Strategy.ARCHEX_QUERY_DUAL_TRANSFORM,
 ]
 
 _VECTOR_STRATEGIES: frozenset[Strategy] = frozenset(

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -24,6 +24,7 @@ from archex.benchmark.models import (
     Strategy,
     TaskCompletionResult,
 )
+from archex.benchmark.query_transform import transform_query
 from archex.benchmark.region_metrics import (
     ReturnedRegion,
     compute_region_metrics,
@@ -1764,6 +1765,170 @@ def run_archex_query_efficiency_packed(task: BenchmarkTask, repo_path: Path) -> 
     return result
 
 
+def _fuse_dual_bundles(
+    structural: ContextBundle,
+    behavioral: ContextBundle,
+    *,
+    query: str,
+    token_budget: int,
+) -> tuple[ContextBundle, dict[str, int]]:
+    """Reciprocal-rank fuse two retrieved bundles into one budget-bounded bundle.
+
+    Both inputs already ran the full retrieval + packing path for their subquery.
+    Their ranked chunks are merged by reciprocal rank; the fused order is filled
+    greedily up to ``token_budget`` (the top chunk is always kept). The structural
+    bundle supplies receipt/metadata scaffolding; the receipt's returned_context
+    and the seed/expansion diagnostics are rebuilt to match the fused chunk set so
+    they stay aligned. Returns the fused bundle plus candidate-count stats.
+    """
+    from archex.index.fusion import reciprocal_rank_fusion
+    from archex.scout import chunk_handle
+
+    structural_ranked = [(rc.chunk, rc.final_score) for rc in structural.chunks]
+    behavioral_ranked = [(rc.chunk, rc.final_score) for rc in behavioral.chunks]
+    fused = reciprocal_rank_fusion(structural_ranked, behavioral_ranked)
+
+    ranked_by_id: dict[str, RankedChunk] = {}
+    for ranked in (*structural.chunks, *behavioral.chunks):
+        ranked_by_id.setdefault(ranked.chunk.id, ranked)
+
+    fused_chunks: list[RankedChunk] = []
+    total_tokens = 0
+    for chunk, rrf_score in fused:
+        tokens = chunk.token_count or count_tokens(chunk.content)
+        if fused_chunks and total_tokens + tokens > token_budget:
+            continue
+        base = ranked_by_id[chunk.id]
+        fused_chunks.append(base.model_copy(update={"final_score": rrf_score}))
+        total_tokens += tokens
+
+    receipt = None
+    if structural.receipt is not None:
+        items_by_handle: dict[str, ContextReceiptItem] = {}
+        for source in (structural, behavioral):
+            if source.receipt is not None:
+                for item in source.receipt.returned_context:
+                    items_by_handle.setdefault(item.handle, item)
+        returned = [
+            items_by_handle[handle]
+            for ranked in fused_chunks
+            if (handle := chunk_handle(ranked.chunk.id)) in items_by_handle
+        ]
+        receipt = structural.receipt.model_copy(
+            update={
+                "query": query,
+                "returned_context": returned,
+                "returned_total": len(returned),
+            }
+        )
+
+    # The fused selection has no single-pass "seed vs graph-expansion" split, so
+    # the structural pass's expansion diagnostics would misattribute to this lane.
+    # Reset them so every fused file reports as a direct seed with no expansion.
+    fused_files = _deduplicate_ranked([ranked.chunk.file_path for ranked in fused_chunks])
+    fused_metadata = structural.retrieval_metadata.model_copy(
+        update={
+            "seed_file_paths": [],
+            "expanded_file_paths": [],
+            "seed_files_found": len(fused_files),
+            "expansion_files_added": 0,
+            "expansion_eligible_seeds": 0,
+            "expansion_candidates_found": 0,
+            "expansion_import_neighbor_edges": 0,
+            "expansion_same_module_candidates": 0,
+            "expansion_hub_candidates": 0,
+            "expansion_test_candidates_skipped": 0,
+            "expansion_zero_candidate_reason": "",
+            "expansion_reason_counts": {},
+            "expanded_file_reasons": {},
+        }
+    )
+
+    fused_bundle = structural.model_copy(
+        update={
+            "query": query,
+            "chunks": fused_chunks,
+            "token_count": total_tokens,
+            "token_budget": token_budget,
+            "retrieval_metadata": fused_metadata,
+            "receipt": receipt,
+        }
+    )
+    stats = {
+        "structural_candidates": len(structural.chunks),
+        "behavioral_candidates": len(behavioral.chunks),
+        "fused_candidates": len(fused),
+        "fused_included": len(fused_chunks),
+    }
+    return fused_bundle, stats
+
+
+def run_archex_query_dual_transform(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
+    """Benchmark-only lane: deterministic dual-perspective query transformation.
+
+    Rewrites the query into a structural subquery (paths, identifiers, call
+    sites, errors, stack-trace and import signals) and a behavioural subquery
+    (natural-language symptoms and domain nouns) using rule-based transforms
+    only, runs the BM25 retrieval path once per subquery sharing one warm index,
+    then reciprocal-rank fuses the two results into one budget-bounded bundle.
+    Both subqueries and the fusion stats are recorded in strategy provenance. No
+    hosted LLM calls; the product default is unchanged.
+    """
+    strategy = Strategy.ARCHEX_QUERY_DUAL_TRANSFORM
+    dual = transform_query(task.question)
+    t0 = time.perf_counter()
+    structural_bundle, _, structural_timing = _query_bundle(
+        task.model_copy(update={"question": dual.structural}),
+        repo_path,
+        strategy=strategy,
+        index_config=IndexConfig(vector=False),
+        cache=True,
+    )
+    behavioral_bundle, effective_config, behavioral_timing = _query_bundle(
+        task.model_copy(update={"question": dual.behavioral}),
+        repo_path,
+        strategy=strategy,
+        index_config=IndexConfig(vector=False),
+        cache=True,
+    )
+    fused_bundle, fusion_stats = _fuse_dual_bundles(
+        structural_bundle,
+        behavioral_bundle,
+        query=task.question,
+        token_budget=task.token_budget,
+    )
+    wall_ms = (time.perf_counter() - t0) * 1000
+    # Report cache state across both passes: warm only if neither built work.
+    behavioral_timing.cached = structural_timing.cached and behavioral_timing.cached
+    result = _assemble_query_result(
+        task,
+        repo_path,
+        strategy=strategy,
+        index_config=effective_config,
+        bundle=fused_bundle,
+        timing=behavioral_timing,
+        wall_ms=wall_ms,
+        include_completion=True,
+        measure_freshness=False,
+    )
+    result.provenance = dual.to_provenance() | {
+        "structural_candidates": str(fusion_stats["structural_candidates"]),
+        "behavioral_candidates": str(fusion_stats["behavioral_candidates"]),
+        "fused_candidates": str(fusion_stats["fused_candidates"]),
+        "fused_included": str(fusion_stats["fused_included"]),
+    }
+    logger.info(
+        "Strategy %s for %s: structural=%d behavioral=%d fused=%d wall=%.1fms",
+        strategy.value,
+        task.task_id,
+        fusion_stats["structural_candidates"],
+        fusion_stats["behavioral_candidates"],
+        fusion_stats["fused_included"],
+        wall_ms,
+    )
+    return result
+
+
 def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Two-call scout map plus chunk-first exact fetch with direct-query guardrails."""
     from archex.api import query, scout_with_bundle
@@ -2371,5 +2536,8 @@ default_strategy_registry.register(
 )
 default_strategy_registry.register(
     Strategy.ARCHEX_QUERY_EFFICIENCY_PACKED.value, run_archex_query_efficiency_packed
+)
+default_strategy_registry.register(
+    Strategy.ARCHEX_QUERY_DUAL_TRANSFORM.value, run_archex_query_dual_transform
 )
 default_strategy_registry.register(Strategy.EXTERNAL_MCP.value, _run_external_mcp_strategy)

--- a/tests/benchmark/test_dual_transform_strategy.py
+++ b/tests/benchmark/test_dual_transform_strategy.py
@@ -1,0 +1,288 @@
+"""Tests for the benchmark-only archex_query_dual_transform strategy."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import archex.benchmark.strategies as strategies
+from archex.benchmark.models import BenchmarkTask, Strategy
+from archex.benchmark.query_transform import transform_query
+from archex.benchmark.runner import AVAILABLE_STRATEGIES, DEFAULT_STRATEGIES
+from archex.benchmark.strategies import (
+    _fuse_dual_bundles,  # pyright: ignore[reportPrivateUsage]
+    default_strategy_registry,
+    run_archex_query_dual_transform,
+)
+from archex.models import (
+    CodeChunk,
+    ContextBundle,
+    ContextReceipt,
+    ContextReceiptItem,
+    ContextReceiptTokenBudget,
+    IndexConfig,
+    PipelineTiming,
+    RankedChunk,
+)
+from archex.scout import chunk_handle
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _ranked(chunk_id: str, score: float, *, tokens: int = 10) -> RankedChunk:
+    chunk = CodeChunk(
+        id=chunk_id,
+        content=f"content for {chunk_id}",
+        file_path=f"{chunk_id}.py",
+        start_line=1,
+        end_line=5,
+        language="python",
+        token_count=tokens,
+    )
+    return RankedChunk(chunk=chunk, final_score=score)
+
+
+def _bundle_with_receipt(chunks: list[RankedChunk], *, query: str = "q") -> ContextBundle:
+    items = [
+        ContextReceiptItem(
+            handle=chunk_handle(rc.chunk.id),
+            file_path=rc.chunk.file_path,
+            start_line=rc.chunk.start_line,
+            end_line=rc.chunk.end_line,
+            content_hash=f"hash-{rc.chunk.id}",
+        )
+        for rc in chunks
+    ]
+    receipt = ContextReceipt(
+        query=query,
+        token_budget=ContextReceiptTokenBudget(requested=4096, consumed=0),
+        index_revision="rev",
+        returned_context=items,
+        returned_total=len(items),
+    )
+    total = sum(rc.chunk.token_count for rc in chunks)
+    return ContextBundle(query=query, chunks=chunks, token_count=total, receipt=receipt)
+
+
+class TestStrategyRegistry:
+    def test_runner_registered(self) -> None:
+        assert (
+            default_strategy_registry.get(Strategy.ARCHEX_QUERY_DUAL_TRANSFORM)
+            is run_archex_query_dual_transform
+        )
+
+    def test_strategy_value(self) -> None:
+        assert Strategy.ARCHEX_QUERY_DUAL_TRANSFORM.value == "archex_query_dual_transform"
+        assert (
+            Strategy.ARCHEX_QUERY_DUAL_TRANSFORM.value in default_strategy_registry.strategy_names
+        )
+
+    def test_available_but_not_default(self) -> None:
+        # Discoverable as a benchmark lane, but never part of the product default.
+        assert Strategy.ARCHEX_QUERY_DUAL_TRANSFORM in AVAILABLE_STRATEGIES
+        assert Strategy.ARCHEX_QUERY_DUAL_TRANSFORM not in DEFAULT_STRATEGIES
+
+    def test_default_strategies_unchanged(self) -> None:
+        assert DEFAULT_STRATEGIES == [
+            Strategy.RAW_FILES,
+            Strategy.RAW_RIPGREP,
+            Strategy.ARCHEX_QUERY,
+        ]
+
+
+class TestTransformQuery:
+    """Deterministic transformation across the five required query shapes."""
+
+    def test_bug_report(self) -> None:
+        dual = transform_query(
+            "The login button throws a NullPointerException when the session expires"
+        )
+        # Structural surfaces the error/exception type.
+        assert "NullPointerException" in dual.structural
+        # Behavioural preserves the natural-language symptom and domain nouns.
+        assert "login" in dual.behavioral
+        assert "session" in dual.behavioral
+        assert "expires" in dual.behavioral
+        assert not dual.structural_from_fallback
+        assert not dual.behavioral_from_fallback
+
+    def test_stack_trace(self) -> None:
+        dual = transform_query(
+            "Traceback (most recent call last):\n"
+            '  File "auth/session.py", line 42, in refresh\n'
+            "    raise TokenError(msg)\n"
+            "TokenError: token expired"
+        )
+        assert dual.has_stack_trace
+        # Structural surfaces the failing path and exception type.
+        assert "auth/session.py" in dual.structural
+        assert "TokenError" in dual.structural
+        # The trace frame is stripped from behavioural prose-noise counting.
+        assert "expired" in dual.behavioral
+
+    def test_api_question(self) -> None:
+        dual = transform_query(
+            "How do I use the query() function to retrieve a ContextBundle within a budget?"
+        )
+        # Structural captures the call site and the symbol.
+        assert "query" in dual.structural.split()
+        assert "ContextBundle" in dual.structural
+        # Behavioural keeps the how-to phrasing and the domain noun.
+        assert "How" in dual.behavioral
+        assert "retrieve" in dual.behavioral
+        assert "context" in dual.behavioral
+
+    def test_architecture_question(self) -> None:
+        dual = transform_query(
+            "How is the retrieval pipeline structured across the indexing and serving layers?"
+        )
+        # Pure natural language: no code tokens, so structural falls back to the
+        # original query while behavioural carries the architecture vocabulary.
+        assert dual.structural_from_fallback
+        assert dual.structural == dual.original
+        assert "retrieval" in dual.behavioral
+        assert "pipeline" in dual.behavioral
+        assert "structured" in dual.behavioral
+
+    def test_pure_code_query(self) -> None:
+        dual = transform_query("RankedChunk.final_score CodeChunk.token_count parse_imports")
+        # Structural keeps the dotted symbols and snake_case identifier verbatim.
+        assert "RankedChunk.final_score" in dual.structural
+        assert "CodeChunk.token_count" in dual.structural
+        assert "parse_imports" in dual.structural
+        # Behavioural recovers the domain nouns embedded in the identifiers.
+        assert "ranked" in dual.behavioral
+        assert "imports" in dual.behavioral
+        assert not dual.behavioral_from_fallback
+
+    def test_import_targets_in_structural(self) -> None:
+        dual = transform_query("import os\nfrom pkg.mod import helper, other")
+        structural_tokens = dual.structural.split()
+        assert "os" in structural_tokens
+        assert "pkg.mod" in structural_tokens
+        assert "helper" in structural_tokens
+        assert "other" in structural_tokens
+
+    def test_provenance_records_both_subqueries(self) -> None:
+        dual = transform_query("AuthManager.validate_token fails on logout")
+        prov = dual.to_provenance()
+        assert prov["subquery_structural"] == dual.structural
+        assert prov["subquery_behavioral"] == dual.behavioral
+        for key in (
+            "structural_token_count",
+            "behavioral_token_count",
+            "structural_from_fallback",
+            "behavioral_from_fallback",
+            "has_stack_trace",
+        ):
+            assert key in prov, key
+
+
+class TestFuseDualBundles:
+    def test_reciprocal_rank_fusion_dedups_and_reorders(self) -> None:
+        structural = _bundle_with_receipt([_ranked("a", 5.0), _ranked("b", 3.0)])
+        behavioral = _bundle_with_receipt([_ranked("b", 0.9), _ranked("c", 0.8)])
+
+        fused, stats = _fuse_dual_bundles(structural, behavioral, query="orig", token_budget=4096)
+
+        ids = [rc.chunk.id for rc in fused.chunks]
+        # b appears in both lists -> highest RRF score -> ranked first.
+        assert ids[0] == "b"
+        assert set(ids) == {"a", "b", "c"}
+        assert stats["structural_candidates"] == 2
+        assert stats["behavioral_candidates"] == 2
+        assert stats["fused_candidates"] == 3
+        assert stats["fused_included"] == 3
+        assert fused.query == "orig"
+
+    def test_budget_cap_keeps_top_even_when_it_alone_exceeds_budget(self) -> None:
+        # Top hit alone exceeds the budget; the guard must keep it, and the
+        # smaller second chunk must not slip in ahead of the dropped overflow.
+        structural = _bundle_with_receipt([_ranked("a", 5.0, tokens=50)])
+        behavioral = _bundle_with_receipt([_ranked("b", 0.9, tokens=10)])
+
+        fused, stats = _fuse_dual_bundles(structural, behavioral, query="orig", token_budget=30)
+
+        assert stats["fused_included"] == 1
+        assert [rc.chunk.id for rc in fused.chunks] == ["a"]
+        assert fused.token_count == 50
+
+    def test_receipt_realigned_to_fused_chunks(self) -> None:
+        structural = _bundle_with_receipt([_ranked("a", 5.0, tokens=30)])
+        behavioral = _bundle_with_receipt([_ranked("b", 0.9, tokens=30)])
+
+        fused, _ = _fuse_dual_bundles(structural, behavioral, query="orig", token_budget=30)
+
+        assert fused.receipt is not None
+        handles = {item.handle for item in fused.receipt.returned_context}
+        kept = {chunk_handle(rc.chunk.id) for rc in fused.chunks}
+        # Receipt rows describe exactly the chunks the fused bundle returned.
+        assert handles == kept
+        assert fused.receipt.returned_total == len(fused.chunks)
+
+
+class TestRunDualTransformFixture:
+    @pytest.fixture(autouse=True)
+    def _no_vector(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Keep the lane hermetic: BM25-only, never reach for embedding backends.
+        monkeypatch.setattr(strategies, "_vector_dependencies_available", lambda: False)
+
+    def _task(self, question: str, token_budget: int = 4096) -> BenchmarkTask:
+        return BenchmarkTask(
+            task_id="dual_transform_test",
+            repo="test/repo",
+            commit="abc",
+            question=question,
+            expected_files=["main.py"],
+            token_budget=token_budget,
+        )
+
+    def test_runs_end_to_end(self, python_simple_repo: Path) -> None:
+        task = self._task("How does main.py start the application and call main()?")
+        result = run_archex_query_dual_transform(task, python_simple_repo)
+
+        assert result.strategy == Strategy.ARCHEX_QUERY_DUAL_TRANSFORM
+        assert result.tool_calls == 1
+        assert 0.0 <= result.required_file_recall <= 1.0
+        # Added latency is reported like every other lane.
+        assert result.wall_time_ms >= 0.0
+        prov = result.provenance
+        assert prov["subquery_structural"]
+        assert prov["subquery_behavioral"]
+        for key in (
+            "structural_candidates",
+            "behavioral_candidates",
+            "fused_candidates",
+            "fused_included",
+        ):
+            assert key in prov, key
+
+    def test_index_config_never_enables_rerank(
+        self, monkeypatch: pytest.MonkeyPatch, python_simple_repo: Path
+    ) -> None:
+        seen: list[IndexConfig] = []
+        real_query_bundle = strategies._query_bundle  # pyright: ignore[reportPrivateUsage]
+
+        def spy(
+            task: BenchmarkTask,
+            repo_path: Path,
+            *,
+            strategy: Strategy,
+            index_config: IndexConfig,
+            cache: bool,
+        ) -> tuple[ContextBundle, IndexConfig, PipelineTiming]:
+            seen.append(index_config)
+            return real_query_bundle(
+                task, repo_path, strategy=strategy, index_config=index_config, cache=cache
+            )
+
+        monkeypatch.setattr(strategies, "_query_bundle", spy)
+        run_archex_query_dual_transform(
+            self._task("main.py main function module"), python_simple_repo
+        )
+
+        # Two retrieval passes (structural + behavioural), neither reranked.
+        assert len(seen) == 2
+        assert all(cfg.rerank is False for cfg in seen)


### PR DESCRIPTION
## Stack

Stack-Id: `advanced-lanes-5619e8`
Position: 1/5 (root, base main)

1. `bench/dual-transform-strategy` -> #308 (base `main`)
2. `bench/bounded-rerank-strategy` -> #309 (base `bench/dual-transform-strategy`)
3. `bench/summary-sidecar-strategy` -> #310 (base `bench/bounded-rerank-strategy`)
4. `bench/graph-multihop-strategy` -> #311 (base `bench/summary-sidecar-strategy`)
5. `bench/advanced-lane-reports-docs` -> #312 (base `bench/graph-multihop-strategy`)

Depends on: (none — root)
Upstack: #309

## Summary

Part of the Workstream 5 "Advanced Retrieval Quality Lanes" stack. Each lane is in `AVAILABLE_STRATEGIES` only, never `DEFAULT_STRATEGIES`; no product default changes; no hosted calls / telemetry / mandatory network. See the per-lane commit messages for details and leaf PR #312 for the Advanced Quality Lanes report + docs.

## Validation

`ruff check` / `ruff format --check` / `pyright` (strict) on changed files — clean; lane + registry + (context/receipt/graph where relevant) tests pass.