### PR TITLE
Add archex_query_bounded_rerank benchmark lane

### DIFF
--- a/src/archex/benchmark/bounded_rerank.py
+++ b/src/archex/benchmark/bounded_rerank.py
@@ -1,0 +1,92 @@
+"""Deterministic symbolic evidence reranking for the bounded-rerank lane.
+
+Reranks a *compact* candidate set by cheap, local evidence — file-path matches,
+symbol-name matches, and query-term overlap — blended with the original
+retrieval rank. No model, no network: this symbolic pass is the always-available
+bounded rerank and guarantees a deterministic reordering. The benchmark lane may
+additionally reuse a local cross-encoder reranker when one is already loaded in
+process, but the symbolic pass is what bounds and grounds the result. Inspired by
+BLAgent's two-phase, evidence-grounded rerank over a compact candidate set
+(arXiv:2605.17965).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from archex.models import CodeChunk
+
+# Hard caps for the bounded rerank lane. The candidate cap bounds rerank work
+# structurally (only the top-N retrieved chunks are ever reranked); the latency
+# cap is the wall-clock budget a model rerank pass must stay under to be applied.
+DEFAULT_CANDIDATE_CAP = 8
+DEFAULT_LATENCY_CAP_MS = 750.0
+
+# Evidence weights (deterministic). A direct file-path match is the strongest
+# signal, then a symbol-name hit, then query-term overlap in the body, with the
+# original retrieval rank as a small tie-breaking prior.
+_PATH_WEIGHT = 2.0
+_SYMBOL_WEIGHT = 1.5
+_TERM_WEIGHT = 1.0
+_RANK_PRIOR_WEIGHT = 0.5
+
+_WORD_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]+")
+_PATH_RE = re.compile(
+    r"[\w.\-/]*[\w\-]+/[\w.\-/]*\.[A-Za-z]{1,6}"  # dir/.../file.ext
+    r"|\b[\w\-]+\.(?:py|js|ts|tsx|jsx|go|rs|java|kt|cs|rb|cpp|cc|c|h|hpp|swift|php"
+    r"|scala|sql|sh|yaml|yml|toml|json|md)\b"  # file.ext
+)
+
+
+@dataclass(frozen=True)
+class RerankCaps:
+    """Hard candidate and latency caps for the bounded rerank lane."""
+
+    candidate_cap: int = DEFAULT_CANDIDATE_CAP
+    latency_cap_ms: float = DEFAULT_LATENCY_CAP_MS
+
+
+@dataclass(frozen=True)
+class QuerySignals:
+    """Cheap deterministic signals extracted from the query for evidence scoring."""
+
+    terms: frozenset[str]
+    paths: tuple[str, ...]
+
+
+def query_signals(question: str) -> QuerySignals:
+    """Extract lowercase query terms and file-path mentions for evidence scoring."""
+    terms = frozenset(word.lower() for word in _WORD_RE.findall(question) if len(word) >= 2)
+    paths = tuple(path.lower() for path in _PATH_RE.findall(question))
+    return QuerySignals(terms=terms, paths=paths)
+
+
+def evidence_score(chunk: CodeChunk, signals: QuerySignals, *, rank: int, total: int) -> float:
+    """Deterministic evidence score for one candidate at a given retrieval rank."""
+    path = chunk.file_path.lower()
+    path_hit = 1.0 if any(p and (p in path or path.endswith(p)) for p in signals.paths) else 0.0
+    symbol_text = " ".join(part for part in (chunk.symbol_name, chunk.qualified_name) if part)
+    symbol_text = symbol_text.lower()
+    symbol_hit = 1.0 if any(term in symbol_text for term in signals.terms) else 0.0
+    content = chunk.content.lower()
+    overlap = sum(1 for term in signals.terms if term in content)
+    term_overlap = overlap / len(signals.terms) if signals.terms else 0.0
+    rank_prior = (total - rank) / total if total else 0.0
+    return (
+        _PATH_WEIGHT * path_hit
+        + _SYMBOL_WEIGHT * symbol_hit
+        + _TERM_WEIGHT * term_overlap
+        + _RANK_PRIOR_WEIGHT * rank_prior
+    )
+
+
+def symbolic_scores(chunks: list[CodeChunk], signals: QuerySignals) -> list[float]:
+    """Evidence scores for the compact candidate set, in candidate order."""
+    total = len(chunks)
+    return [
+        evidence_score(chunk, signals, rank=index, total=total)
+        for index, chunk in enumerate(chunks)
+    ]

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -32,6 +32,7 @@ class Strategy(StrEnum):
     ARCHEX_QUERY_COMPRESSED = "archex_query_compressed"
     ARCHEX_QUERY_EFFICIENCY_PACKED = "archex_query_efficiency_packed"
     ARCHEX_QUERY_DUAL_TRANSFORM = "archex_query_dual_transform"
+    ARCHEX_QUERY_BOUNDED_RERANK = "archex_query_bounded_rerank"
     EXTERNAL_MCP = "external_mcp"
 
 

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -51,6 +51,7 @@ AVAILABLE_STRATEGIES: list[Strategy] = [
     Strategy.ARCHEX_QUERY_COMPRESSED,
     Strategy.ARCHEX_QUERY_EFFICIENCY_PACKED,
     Strategy.ARCHEX_QUERY_DUAL_TRANSFORM,
+    Strategy.ARCHEX_QUERY_BOUNDED_RERANK,
 ]
 
 _VECTOR_STRATEGIES: frozenset[Strategy] = frozenset(

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -15,8 +15,13 @@ from contextvars import ContextVar, Token
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from archex.benchmark.bounded_rerank import (
+    RerankCaps,
+    query_signals,
+    symbolic_scores,
+)
 from archex.benchmark.models import (
     BenchmarkResult,
     BenchmarkRetrievalOptions,
@@ -54,6 +59,9 @@ from archex.serve.packing import (
     PackingSignals,
     pack_efficiently,
 )
+
+if TYPE_CHECKING:
+    from archex.index.rerank import CrossEncoderReranker
 
 logger = logging.getLogger(__name__)
 
@@ -1929,6 +1937,175 @@ def run_archex_query_dual_transform(task: BenchmarkTask, repo_path: Path) -> Ben
     return result
 
 
+_BOUNDED_RERANK_CAPS = RerankCaps()
+
+
+def _load_local_reranker() -> CrossEncoderReranker | None:
+    """Reuse an in-process cross-encoder reranker; never load or download a model.
+
+    Returns a warmed reranker only when one is already loaded in this process
+    (e.g. a prior fusion-rerank pass warmed it). When no local model is loaded, or
+    when warming the cached model is rejected (e.g. the model needs remote code and
+    the benchmark run did not opt in), returns None so the lane skips the model
+    rerank with explicit provenance. It never triggers a download, so it adds no
+    network behaviour; the remote-code opt-in mirrors the benchmark options.
+    """
+    from archex.index.rerank import CrossEncoderReranker, loaded_reranker_model_names
+
+    names = loaded_reranker_model_names()
+    if not names:
+        return None
+    options = current_benchmark_retrieval_options()
+    reranker = CrossEncoderReranker(names[0], allow_remote_code=options.allow_remote_code)
+    try:
+        reranker.warm()  # the model is already cached in-process; this never downloads
+    except ArchexError:
+        return None
+    return reranker
+
+
+def _normalize_ce_scores(results: list[tuple[CodeChunk, float]]) -> dict[str, float]:
+    """Min-max normalise cross-encoder scores into [0, 1] keyed by chunk id."""
+    if not results:
+        return {}
+    scores = [score for _, score in results]
+    low, high = min(scores), max(scores)
+    span = high - low
+    if span <= 0:
+        return {chunk.id: 1.0 for chunk, _ in results}
+    return {chunk.id: (score - low) / span for chunk, score in results}
+
+
+@dataclass
+class _BoundedRerank:
+    """Reordered bundle plus the provenance describing the bounded rerank."""
+
+    bundle: ContextBundle
+    provenance: dict[str, str]
+
+
+def _bounded_rerank_bundle(
+    bundle: ContextBundle, *, question: str, caps: RerankCaps
+) -> _BoundedRerank:
+    """Reorder a bounded compact candidate set by symbolic evidence (+ optional CE).
+
+    Only the top ``caps.candidate_cap`` retrieved chunks are reranked; chunks past
+    the cap keep their order. The deterministic symbolic evidence pass always runs.
+    A local cross-encoder is reused only when already loaded and only if its
+    measured pass stays under ``caps.latency_cap_ms``; otherwise the model rerank
+    is skipped/aborted and the symbolic order stands. Receipt rows are realigned to
+    the reordered chunk set so receipts stay aligned.
+    """
+    from archex.scout import chunk_handle
+
+    signals = query_signals(question)
+    compact = bundle.chunks[: caps.candidate_cap]
+    tail = bundle.chunks[caps.candidate_cap :]
+    candidate_count = len(compact)
+    scores = symbolic_scores([ranked.chunk for ranked in compact], signals)
+
+    reranker = _load_local_reranker()
+    rerank_ms = 0.0
+    if reranker is None:
+        cross_encoder_status = "skipped:unavailable"
+    elif not compact:
+        cross_encoder_status = "skipped:no_candidates"
+    else:
+        candidates = [(ranked.chunk, score) for ranked, score in zip(compact, scores, strict=True)]
+        t0 = time.perf_counter()
+        ce_results = reranker.rerank(question, candidates, top_k=candidate_count)
+        rerank_ms = (time.perf_counter() - t0) * 1000
+        if rerank_ms > caps.latency_cap_ms:
+            cross_encoder_status = "aborted:latency"
+        else:
+            ce_norm = _normalize_ce_scores(ce_results)
+            scores = [
+                score + ce_norm.get(ranked.chunk.id, 0.0)
+                for ranked, score in zip(compact, scores, strict=True)
+            ]
+            cross_encoder_status = "applied"
+
+    # Stable sort: higher score first, ties keep original retrieval order.
+    order = sorted(range(candidate_count), key=lambda index: -scores[index])
+    new_chunks = [compact[index] for index in order] + list(tail)
+
+    reordered = bundle.model_copy(update={"chunks": new_chunks})
+    if reordered.receipt is not None:
+        items_by_handle = {item.handle: item for item in reordered.receipt.returned_context}
+        ordered: list[ContextReceiptItem] = []
+        seen: set[str] = set()
+        for ranked in new_chunks:
+            handle = chunk_handle(ranked.chunk.id)
+            item = items_by_handle.get(handle)
+            if item is not None and handle not in seen:
+                ordered.append(item)
+                seen.add(handle)
+        # Preserve any receipt rows without a matching chunk (defensive).
+        ordered.extend(
+            item for item in reordered.receipt.returned_context if item.handle not in seen
+        )
+        reordered.receipt = reordered.receipt.model_copy(update={"returned_context": ordered})
+
+    rerank_method = "symbolic+cross_encoder" if cross_encoder_status == "applied" else "symbolic"
+    provenance = {
+        "candidate_cap": str(caps.candidate_cap),
+        "candidates_reranked": str(candidate_count),
+        "candidates_total": str(len(bundle.chunks)),
+        "latency_cap_ms": f"{caps.latency_cap_ms:.1f}",
+        "rerank_ms": f"{rerank_ms:.2f}",
+        "rerank_method": rerank_method,
+        "cross_encoder_status": cross_encoder_status,
+    }
+    return _BoundedRerank(bundle=reordered, provenance=provenance)
+
+
+def run_archex_query_bounded_rerank(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
+    """Benchmark-only lane: bounded symbolic/evidence rerank over a compact set.
+
+    Runs the ``archex_query`` BM25 retrieval path, then reranks only the top
+    ``candidate_cap`` chunks by deterministic symbolic evidence (path / symbol /
+    term overlap blended with the retrieval rank). A local cross-encoder reranker
+    is reused only when already loaded in process and only if its measured pass
+    stays within the latency cap; otherwise the model rerank is skipped or aborted
+    with explicit provenance. Hard candidate and latency caps prevent unbounded
+    rerank. The product default is unchanged.
+    """
+    strategy = Strategy.ARCHEX_QUERY_BOUNDED_RERANK
+    t0 = time.perf_counter()
+    bundle, effective_config, timing = _query_bundle(
+        task,
+        repo_path,
+        strategy=strategy,
+        index_config=IndexConfig(vector=False),
+        cache=benchmark_cache_enabled(default=False),
+    )
+    rerank = _bounded_rerank_bundle(bundle, question=task.question, caps=_BOUNDED_RERANK_CAPS)
+    wall_ms = (time.perf_counter() - t0) * 1000
+    result = _assemble_query_result(
+        task,
+        repo_path,
+        strategy=strategy,
+        index_config=effective_config,
+        bundle=rerank.bundle,
+        timing=timing,
+        wall_ms=wall_ms,
+        include_completion=True,
+        measure_freshness=False,
+    )
+    result.provenance = rerank.provenance
+    logger.info(
+        "Strategy %s for %s: reranked=%s/%s method=%s ce=%s wall=%.1fms",
+        strategy.value,
+        task.task_id,
+        rerank.provenance["candidates_reranked"],
+        rerank.provenance["candidates_total"],
+        rerank.provenance["rerank_method"],
+        rerank.provenance["cross_encoder_status"],
+        wall_ms,
+    )
+    return result
+
+
 def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Two-call scout map plus chunk-first exact fetch with direct-query guardrails."""
     from archex.api import query, scout_with_bundle
@@ -2539,5 +2716,8 @@ default_strategy_registry.register(
 )
 default_strategy_registry.register(
     Strategy.ARCHEX_QUERY_DUAL_TRANSFORM.value, run_archex_query_dual_transform
+)
+default_strategy_registry.register(
+    Strategy.ARCHEX_QUERY_BOUNDED_RERANK.value, run_archex_query_bounded_rerank
 )
 default_strategy_registry.register(Strategy.EXTERNAL_MCP.value, _run_external_mcp_strategy)

--- a/src/archex/index/rerank.py
+++ b/src/archex/index/rerank.py
@@ -45,6 +45,15 @@ RERANK_CANDIDATE_LIMIT = 4
 _MODEL_CACHE: dict[str, Any] = {}
 
 
+def loaded_reranker_model_names() -> list[str]:
+    """Return names of cross-encoder models already loaded in this process.
+
+    Lets callers reuse an in-process reranker without triggering a model load or
+    download: an empty list means no local reranker is available right now.
+    """
+    return list(_MODEL_CACHE)
+
+
 def _ensure_padding_token(cross_encoder: Any) -> None:
     tokenizer = getattr(cross_encoder, "tokenizer", None)
     if tokenizer is None:

--- a/tests/benchmark/test_bounded_rerank_strategy.py
+++ b/tests/benchmark/test_bounded_rerank_strategy.py
@@ -1,0 +1,337 @@
+"""Tests for the benchmark-only archex_query_bounded_rerank strategy."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import archex.benchmark.strategies as strategies
+from archex.benchmark.bounded_rerank import (
+    RerankCaps,
+    evidence_score,
+    query_signals,
+    symbolic_scores,
+)
+from archex.benchmark.models import BenchmarkTask, Strategy
+from archex.benchmark.runner import AVAILABLE_STRATEGIES, DEFAULT_STRATEGIES
+from archex.benchmark.strategies import (
+    _bounded_rerank_bundle,  # pyright: ignore[reportPrivateUsage]
+    _load_local_reranker,  # pyright: ignore[reportPrivateUsage]
+    default_strategy_registry,
+    run_archex_query_bounded_rerank,
+)
+from archex.models import (
+    CodeChunk,
+    ContextBundle,
+    ContextReceipt,
+    ContextReceiptItem,
+    ContextReceiptTokenBudget,
+    RankedChunk,
+)
+from archex.scout import chunk_handle
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def _chunk(
+    chunk_id: str,
+    *,
+    file_path: str | None = None,
+    content: str = "",
+    symbol: str | None = None,
+) -> CodeChunk:
+    return CodeChunk(
+        id=chunk_id,
+        content=content or f"body of {chunk_id}",
+        file_path=file_path or f"{chunk_id}.py",
+        start_line=1,
+        end_line=5,
+        language="python",
+        token_count=10,
+        symbol_name=symbol,
+    )
+
+
+def _ranked(chunk: CodeChunk, score: float) -> RankedChunk:
+    return RankedChunk(chunk=chunk, final_score=score)
+
+
+def _bundle(ranked: list[RankedChunk], *, query: str = "q") -> ContextBundle:
+    items = [
+        ContextReceiptItem(
+            handle=chunk_handle(rc.chunk.id),
+            file_path=rc.chunk.file_path,
+            start_line=rc.chunk.start_line,
+            end_line=rc.chunk.end_line,
+            content_hash=f"hash-{rc.chunk.id}",
+        )
+        for rc in ranked
+    ]
+    receipt = ContextReceipt(
+        query=query,
+        token_budget=ContextReceiptTokenBudget(requested=4096, consumed=0),
+        index_revision="rev",
+        returned_context=items,
+        returned_total=len(items),
+    )
+    return ContextBundle(query=query, chunks=ranked, token_count=0, receipt=receipt)
+
+
+class _SpyReranker:
+    """Fake local reranker recording candidate-set sizes and forcing a reorder."""
+
+    def __init__(self) -> None:
+        self.candidate_counts: list[int] = []
+
+    def rerank(
+        self, query: str, candidates: list[tuple[CodeChunk, float]], top_k: int
+    ) -> list[tuple[CodeChunk, float]]:
+        self.candidate_counts.append(len(candidates))
+        # Reverse order with descending scores so the last candidate scores best.
+        return [
+            (chunk, float(len(candidates) - i)) for i, (chunk, _) in enumerate(reversed(candidates))
+        ]
+
+
+class TestStrategyRegistry:
+    def test_runner_registered(self) -> None:
+        assert (
+            default_strategy_registry.get(Strategy.ARCHEX_QUERY_BOUNDED_RERANK)
+            is run_archex_query_bounded_rerank
+        )
+
+    def test_strategy_value(self) -> None:
+        assert Strategy.ARCHEX_QUERY_BOUNDED_RERANK.value == "archex_query_bounded_rerank"
+        assert (
+            Strategy.ARCHEX_QUERY_BOUNDED_RERANK.value in default_strategy_registry.strategy_names
+        )
+
+    def test_available_but_not_default(self) -> None:
+        assert Strategy.ARCHEX_QUERY_BOUNDED_RERANK in AVAILABLE_STRATEGIES
+        assert Strategy.ARCHEX_QUERY_BOUNDED_RERANK not in DEFAULT_STRATEGIES
+
+
+class TestEvidenceScoring:
+    def test_path_match_outranks_no_evidence(self) -> None:
+        signals = query_signals("bug in auth/session.py around validate_token")
+        unmatched = _chunk("a", file_path="util/io.py", content="unrelated body")
+        matched = _chunk("b", file_path="auth/session.py", symbol="validate_token")
+        # Evidence-rich chunk is placed LAST so its path/symbol weight must
+        # overcome the (higher) rank prior of the first position.
+        scored = symbolic_scores([unmatched, matched], signals)
+        assert scored[1] > scored[0]
+
+    def test_rank_prior_breaks_ties(self) -> None:
+        signals = query_signals("nothing matches here xyzzy")
+        first = _chunk("a")
+        second = _chunk("b")
+        # No path/symbol/term evidence: only the rank prior differs by position.
+        s_first = evidence_score(first, signals, rank=0, total=2)
+        s_second = evidence_score(second, signals, rank=1, total=2)
+        assert s_first > s_second
+
+
+class TestBoundedRerankBundle:
+    def test_symbolic_reorder_promotes_strong_evidence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(strategies, "_load_local_reranker", lambda: None)
+        weak = _ranked(_chunk("weak", file_path="util/io.py"), 9.0)
+        strong = _ranked(
+            _chunk("strong", file_path="auth/session.py", symbol="validate_token"), 1.0
+        )
+        bundle = _bundle([weak, strong])
+
+        result = _bounded_rerank_bundle(
+            bundle, question="auth/session.py validate_token", caps=RerankCaps()
+        )
+
+        # Despite a lower retrieval score, the evidence-rich chunk reranks first.
+        assert [rc.chunk.id for rc in result.bundle.chunks] == ["strong", "weak"]
+        assert result.provenance["cross_encoder_status"] == "skipped:unavailable"
+        assert result.provenance["rerank_method"] == "symbolic"
+
+    def test_candidate_cap_enforced(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(strategies, "_load_local_reranker", lambda: None)
+        ranked = [_ranked(_chunk(f"c{i}"), float(20 - i)) for i in range(12)]
+        bundle = _bundle(ranked)
+        caps = RerankCaps(candidate_cap=8, latency_cap_ms=750.0)
+
+        result = _bounded_rerank_bundle(bundle, question="c0 c1 module", caps=caps)
+
+        assert result.provenance["candidate_cap"] == "8"
+        assert result.provenance["candidates_reranked"] == "8"
+        assert result.provenance["candidates_total"] == "12"
+        # Chunks past the cap keep their original relative order (the tail).
+        tail_ids = [rc.chunk.id for rc in result.bundle.chunks[8:]]
+        assert tail_ids == ["c8", "c9", "c10", "c11"]
+        # The full chunk set is preserved, only reordered within the cap.
+        assert {rc.chunk.id for rc in result.bundle.chunks} == {f"c{i}" for i in range(12)}
+
+    def test_cross_encoder_never_sees_more_than_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        spy = _SpyReranker()
+        monkeypatch.setattr(strategies, "_load_local_reranker", lambda: spy)
+        ranked = [_ranked(_chunk(f"c{i}"), float(20 - i)) for i in range(12)]
+        bundle = _bundle(ranked)
+        caps = RerankCaps(candidate_cap=8, latency_cap_ms=10_000.0)
+
+        result = _bounded_rerank_bundle(bundle, question="c0 c1", caps=caps)
+
+        # The expensive model is invoked once, over exactly the compact set.
+        assert spy.candidate_counts == [8]
+        assert result.provenance["cross_encoder_status"] == "applied"
+        assert result.provenance["rerank_method"] == "symbolic+cross_encoder"
+
+    def test_unavailable_reranker_skips_with_provenance(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(strategies, "_load_local_reranker", lambda: None)
+        bundle = _bundle([_ranked(_chunk("a"), 1.0), _ranked(_chunk("b"), 0.5)])
+
+        result = _bounded_rerank_bundle(bundle, question="a b", caps=RerankCaps())
+
+        assert result.provenance["cross_encoder_status"] == "skipped:unavailable"
+        assert result.provenance["rerank_method"] == "symbolic"
+        assert result.provenance["rerank_ms"] == "0.00"
+
+    def test_latency_cap_aborts_cross_encoder(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ranked = [
+            _ranked(_chunk("a", file_path="auth/session.py", symbol="validate_token"), 1.0),
+            _ranked(_chunk("b", file_path="util/io.py"), 0.5),
+        ]
+        question = "auth/session.py validate_token"
+
+        # True symbolic-only order, with no cross-encoder in play.
+        monkeypatch.setattr(strategies, "_load_local_reranker", lambda: None)
+        symbolic_order = [
+            rc.chunk.id
+            for rc in _bounded_rerank_bundle(
+                bundle=_bundle(ranked), question=question, caps=RerankCaps(candidate_cap=8)
+            ).bundle.chunks
+        ]
+
+        # A spy cross-encoder would reverse the order, but a zero latency budget
+        # forces the measured pass to be discarded.
+        spy = _SpyReranker()
+        monkeypatch.setattr(strategies, "_load_local_reranker", lambda: spy)
+        result = _bounded_rerank_bundle(
+            bundle=_bundle(ranked),
+            question=question,
+            caps=RerankCaps(candidate_cap=8, latency_cap_ms=0.0),
+        )
+
+        assert result.provenance["cross_encoder_status"] == "aborted:latency"
+        # The cross-encoder was invoked (and measured) but its reorder is discarded.
+        assert spy.candidate_counts == [2]
+        assert [rc.chunk.id for rc in result.bundle.chunks] == symbolic_order
+
+    def test_receipt_realigned_to_reordered_chunks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(strategies, "_load_local_reranker", lambda: None)
+        weak = _ranked(_chunk("weak", file_path="util/io.py"), 9.0)
+        strong = _ranked(
+            _chunk("strong", file_path="auth/session.py", symbol="validate_token"), 1.0
+        )
+        bundle = _bundle([weak, strong])
+
+        result = _bounded_rerank_bundle(
+            bundle, question="auth/session.py validate_token", caps=RerankCaps()
+        )
+
+        assert result.bundle.receipt is not None
+        receipt_handles = [item.handle for item in result.bundle.receipt.returned_context]
+        chunk_handles = [chunk_handle(rc.chunk.id) for rc in result.bundle.chunks]
+        # Receipt order tracks the reordered chunk order.
+        assert receipt_handles == chunk_handles
+
+    def test_provenance_fields_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(strategies, "_load_local_reranker", lambda: None)
+        result = _bounded_rerank_bundle(
+            _bundle([_ranked(_chunk("a"), 1.0)]), question="a", caps=RerankCaps()
+        )
+        for key in (
+            "candidate_cap",
+            "candidates_reranked",
+            "candidates_total",
+            "latency_cap_ms",
+            "rerank_ms",
+            "rerank_method",
+            "cross_encoder_status",
+        ):
+            assert key in result.provenance, key
+
+
+class TestLoadLocalReranker:
+    def test_returns_none_without_loaded_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _no_models() -> list[str]:
+            return []
+
+        monkeypatch.setattr("archex.index.rerank.loaded_reranker_model_names", _no_models)
+        assert _load_local_reranker() is None
+
+    def test_reuses_cached_model_without_download(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from archex.benchmark.models import BenchmarkRetrievalOptions
+        from archex.benchmark.strategies import (
+            reset_benchmark_retrieval_options,
+            set_benchmark_retrieval_options,
+        )
+        from archex.index import rerank as rerank_mod
+
+        fake_model = object()
+        cache = rerank_mod._MODEL_CACHE  # pyright: ignore[reportPrivateUsage]
+        # Seed an already-loaded model under the transformers-rerank-API name so
+        # _load_model's cache short-circuit returns it without padding-token work.
+        monkeypatch.setitem(cache, rerank_mod.DEFAULT_MODEL, fake_model)
+
+        def _boom(*args: object, **kwargs: object) -> object:
+            raise AssertionError("must not resolve or download a model")
+
+        monkeypatch.setattr(rerank_mod, "resolve_hf_model_path", _boom)
+
+        # The default reranker requires remote code; mirror the opt-in so warming
+        # the already-cached model is allowed (it still never downloads).
+        token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions(allow_remote_code=True))
+        try:
+            reranker = _load_local_reranker()
+        finally:
+            reset_benchmark_retrieval_options(token)
+
+        assert reranker is not None
+        # The warmed reranker reuses the cached object; no download path was taken.
+        assert reranker._model is fake_model  # pyright: ignore[reportPrivateUsage]
+
+    def test_cached_model_skipped_without_remote_code_opt_in(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from archex.index import rerank as rerank_mod
+
+        cache = rerank_mod._MODEL_CACHE  # pyright: ignore[reportPrivateUsage]
+        # A remote-code model is cached, but the default benchmark options do not
+        # opt in, so warming is rejected and the lane treats it as unavailable.
+        monkeypatch.setitem(cache, rerank_mod.DEFAULT_MODEL, object())
+        assert _load_local_reranker() is None
+
+
+class TestRunBoundedRerankFixture:
+    def _task(self, question: str, token_budget: int = 4096) -> BenchmarkTask:
+        return BenchmarkTask(
+            task_id="bounded_rerank_test",
+            repo="test/repo",
+            commit="abc",
+            question=question,
+            expected_files=["main.py"],
+            token_budget=token_budget,
+        )
+
+    def test_runs_end_to_end(self, python_simple_repo: Path) -> None:
+        task = self._task("main.py main function module")
+        result = run_archex_query_bounded_rerank(task, python_simple_repo)
+
+        assert result.strategy == Strategy.ARCHEX_QUERY_BOUNDED_RERANK
+        assert result.tool_calls == 1
+        assert result.wall_time_ms >= 0.0
+        prov = result.provenance
+        # No model is loaded in a fresh benchmark process: the lane skips the CE.
+        assert prov["cross_encoder_status"] == "skipped:unavailable"
+        assert int(prov["candidates_reranked"]) <= int(prov["candidate_cap"])


### PR DESCRIPTION
## Stack

Stack-Id: `advanced-lanes-5619e8`
Position: 2/5 (base bench/dual-transform-strategy)

1. `bench/dual-transform-strategy` -> #308 (base `main`)
2. `bench/bounded-rerank-strategy` -> #309 (base `bench/dual-transform-strategy`)
3. `bench/summary-sidecar-strategy` -> #310 (base `bench/bounded-rerank-strategy`)
4. `bench/graph-multihop-strategy` -> #311 (base `bench/summary-sidecar-strategy`)
5. `bench/advanced-lane-reports-docs` -> #312 (base `bench/graph-multihop-strategy`)

Depends on: #308
Upstack: #310

## Summary

Part of the Workstream 5 "Advanced Retrieval Quality Lanes" stack. Each lane is in `AVAILABLE_STRATEGIES` only, never `DEFAULT_STRATEGIES`; no product default changes; no hosted calls / telemetry / mandatory network. See the per-lane commit messages for details and leaf PR #312 for the Advanced Quality Lanes report + docs.

## Validation

`ruff check` / `ruff format --check` / `pyright` (strict) on changed files — clean; lane + registry + (context/receipt/graph where relevant) tests pass.