### PR TITLE
Add archex_query_summary_sidecar benchmark lane

### DIFF
--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -33,6 +33,7 @@ class Strategy(StrEnum):
     ARCHEX_QUERY_EFFICIENCY_PACKED = "archex_query_efficiency_packed"
     ARCHEX_QUERY_DUAL_TRANSFORM = "archex_query_dual_transform"
     ARCHEX_QUERY_BOUNDED_RERANK = "archex_query_bounded_rerank"
+    ARCHEX_QUERY_SUMMARY_SIDECAR = "archex_query_summary_sidecar"
     EXTERNAL_MCP = "external_mcp"
 
 
@@ -255,6 +256,9 @@ class BenchmarkRetrievalOptions(BaseModel):
     bm25_chunker: ChunkerName | None = None
     vector_chunker: ChunkerName | None = None
     rerank_candidate_limit: int | None = None
+    # Explicit offline opt-in for the summary-sidecar lane: filesystem path of a
+    # prebuilt sidecar. None disables summary-first selection (no auto-generation).
+    summary_sidecar_path: str | None = None
 
 
 class ExternalToolCommandConfig(BenchmarkSpecModel):

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -52,6 +52,7 @@ AVAILABLE_STRATEGIES: list[Strategy] = [
     Strategy.ARCHEX_QUERY_EFFICIENCY_PACKED,
     Strategy.ARCHEX_QUERY_DUAL_TRANSFORM,
     Strategy.ARCHEX_QUERY_BOUNDED_RERANK,
+    Strategy.ARCHEX_QUERY_SUMMARY_SIDECAR,
 ]
 
 _VECTOR_STRATEGIES: frozenset[Strategy] = frozenset(

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -34,6 +34,7 @@ from archex.benchmark.region_metrics import (
     ReturnedRegion,
     compute_region_metrics,
 )
+from archex.benchmark.summary_sidecar import SummarySidecar, file_content_hash
 from archex.benchmark.task_aware import DenseTrigger, TaskAwarePolicy, policy_for
 from archex.cache import CacheManager
 from archex.exceptions import ArchexError, ConfigError
@@ -2106,6 +2107,208 @@ def run_archex_query_bounded_rerank(task: BenchmarkTask, repo_path: Path) -> Ben
     return result
 
 
+_SUMMARY_FILE_CAP = 10
+
+
+def _load_summary_sidecar() -> SummarySidecar | None:
+    """Load the opted-in summary sidecar; None when not opted in or unreadable.
+
+    The path comes from the benchmark retrieval options (the explicit offline
+    opt-in). The lane never generates summaries — absence means summary-first
+    selection is simply disabled.
+    """
+    path = current_benchmark_retrieval_options().summary_sidecar_path
+    if not path:
+        return None
+    sidecar_path = Path(path)
+    if not sidecar_path.is_file():
+        return None
+    try:
+        return SummarySidecar.load(sidecar_path)
+    except (OSError, ValueError):
+        return None
+
+
+@dataclass
+class _SummarySelection:
+    """Summary-first file selection plus stats for provenance."""
+
+    selected_files: list[str]
+    stats: dict[str, int]
+
+
+def _select_summary_files(
+    sidecar: SummarySidecar, repo_path: Path, *, question: str, file_cap: int
+) -> _SummarySelection:
+    """Rank non-stale sidecar entries by query overlap into selected source files.
+
+    Stale entries (source file changed or missing) are excluded so summaries that
+    no longer describe the current code never drive selection.
+    """
+    signals = query_signals(question)
+    fresh = 0
+    stale = 0
+    file_scores: dict[str, int] = {}
+    file_order: list[str] = []
+    # Hash each source file at most once; every entry for a path is checked
+    # against that single read rather than re-reading per symbol entry.
+    current_hash: dict[str, str | None] = {}
+    for entry in sidecar.entries:
+        path = entry.source_file_path
+        if path not in current_hash:
+            current_hash[path] = file_content_hash(repo_path, path)
+        live = current_hash[path]
+        if live is None or live != entry.source_content_hash:
+            stale += 1
+            continue
+        fresh += 1
+        haystack = f"{entry.summary} {entry.symbol_name or ''} {path}".lower()
+        overlap = sum(1 for term in signals.terms if term in haystack)
+        if overlap <= 0:
+            continue
+        if path not in file_scores:
+            file_order.append(path)
+        file_scores[path] = file_scores.get(path, 0) + overlap
+    ranked = sorted(file_order, key=lambda path: -file_scores[path])
+    selected = ranked[:file_cap]
+    stats = {
+        "entries_total": len(sidecar.entries),
+        "entries_fresh": fresh,
+        "entries_stale": stale,
+        "matched_files": len(file_scores),
+        "selected_files": len(selected),
+    }
+    return _SummarySelection(selected_files=selected, stats=stats)
+
+
+def _filter_bundle_to_files(bundle: ContextBundle, files: set[str]) -> ContextBundle:
+    """Keep only chunks whose file was summary-selected; realign receipt + metadata.
+
+    The kept chunks are the original retrieved code (the edit evidence); summaries
+    only gate which files are returned. Seed/expansion diagnostics are reset to the
+    gated set so they are not misattributed to the pre-filter retrieval.
+    """
+    from archex.scout import chunk_handle
+
+    kept = [ranked for ranked in bundle.chunks if ranked.chunk.file_path in files]
+    token_count = sum(
+        ranked.chunk.token_count or count_tokens(ranked.chunk.content) for ranked in kept
+    )
+    receipt = bundle.receipt
+    if receipt is not None:
+        kept_handles = {chunk_handle(ranked.chunk.id) for ranked in kept}
+        returned = [item for item in receipt.returned_context if item.handle in kept_handles]
+        receipt = receipt.model_copy(
+            update={"returned_context": returned, "returned_total": len(returned)}
+        )
+    kept_files = _deduplicate_ranked([ranked.chunk.file_path for ranked in kept])
+    metadata = bundle.retrieval_metadata.model_copy(
+        update={
+            "seed_file_paths": [],
+            "expanded_file_paths": [],
+            "seed_files_found": len(kept_files),
+            "expansion_files_added": 0,
+            "expansion_eligible_seeds": 0,
+            "expansion_candidates_found": 0,
+            "expansion_import_neighbor_edges": 0,
+            "expansion_same_module_candidates": 0,
+            "expansion_hub_candidates": 0,
+            "expansion_test_candidates_skipped": 0,
+            "expansion_zero_candidate_reason": "",
+            "expansion_reason_counts": {},
+            "expanded_file_reasons": {},
+        }
+    )
+    return bundle.model_copy(
+        update={
+            "chunks": kept,
+            "token_count": token_count,
+            "receipt": receipt,
+            "retrieval_metadata": metadata,
+        }
+    )
+
+
+def run_archex_query_summary_sidecar(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
+    """Benchmark-only lane: summary-first selection, then original-code retrieval.
+
+    Requires an explicit offline opt-in (a prebuilt sidecar path in the benchmark
+    retrieval options); summaries are never auto-generated. Loads the sidecar,
+    drops stale entries, ranks the rest by query overlap to select source files,
+    then returns the original retrieved code restricted to those files — summaries
+    gate selection but are never returned as edit evidence. Without an opt-in (or
+    when the selection excludes everything retrieved) the lane returns the plain
+    original-code bundle and records why. The product default is unchanged.
+    """
+    strategy = Strategy.ARCHEX_QUERY_SUMMARY_SIDECAR
+    t0 = time.perf_counter()
+    bundle, effective_config, timing = _query_bundle(
+        task,
+        repo_path,
+        strategy=strategy,
+        index_config=IndexConfig(vector=False),
+        cache=benchmark_cache_enabled(default=False),
+    )
+    current_revision = bundle.receipt.index_revision if bundle.receipt is not None else ""
+    sidecar = _load_summary_sidecar()
+    if sidecar is None:
+        final_bundle = bundle
+        provenance = {"sidecar": "absent", "summary_first": "false"}
+    else:
+        selection = _select_summary_files(
+            sidecar, repo_path, question=task.question, file_cap=_SUMMARY_FILE_CAP
+        )
+        selected = set(selection.selected_files)
+        gated = _filter_bundle_to_files(bundle, selected) if selected else bundle
+        if gated.chunks and selected:
+            final_bundle = gated
+            summary_first = "true"
+            fallback = "none"
+        else:
+            # Selection matched nothing retrievable; return the original-code
+            # bundle so the lane still yields editable evidence.
+            final_bundle = bundle
+            summary_first = "false"
+            fallback = "empty_selection"
+        provenance = {
+            "sidecar": "loaded",
+            "summary_first": summary_first,
+            "summary_fallback": fallback,
+            "sidecar_granularity": sidecar.granularity.value,
+            "sidecar_index_revision": sidecar.index_revision,
+            "index_revision_match": str(sidecar.index_revision == current_revision).lower(),
+            "entries_total": str(selection.stats["entries_total"]),
+            "entries_fresh": str(selection.stats["entries_fresh"]),
+            "entries_stale": str(selection.stats["entries_stale"]),
+            "summary_selected_file_count": str(selection.stats["selected_files"]),
+            "summary_selected_files": ", ".join(selection.selected_files) or "none",
+            "original_code_retrieved": "true",
+            "fetch_original_preserved": "true",
+        }
+    wall_ms = (time.perf_counter() - t0) * 1000
+    result = _assemble_query_result(
+        task,
+        repo_path,
+        strategy=strategy,
+        index_config=effective_config,
+        bundle=final_bundle,
+        timing=timing,
+        wall_ms=wall_ms,
+        include_completion=True,
+        measure_freshness=False,
+    )
+    result.provenance = provenance
+    logger.info(
+        "Strategy %s for %s: sidecar=%s summary_first=%s wall=%.1fms",
+        strategy.value,
+        task.task_id,
+        provenance["sidecar"],
+        provenance["summary_first"],
+        wall_ms,
+    )
+    return result
+
+
 def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Two-call scout map plus chunk-first exact fetch with direct-query guardrails."""
     from archex.api import query, scout_with_bundle
@@ -2719,5 +2922,8 @@ default_strategy_registry.register(
 )
 default_strategy_registry.register(
     Strategy.ARCHEX_QUERY_BOUNDED_RERANK.value, run_archex_query_bounded_rerank
+)
+default_strategy_registry.register(
+    Strategy.ARCHEX_QUERY_SUMMARY_SIDECAR.value, run_archex_query_summary_sidecar
 )
 default_strategy_registry.register(Strategy.EXTERNAL_MCP.value, _run_external_mcp_strategy)

--- a/src/archex/benchmark/summary_sidecar.py
+++ b/src/archex/benchmark/summary_sidecar.py
@@ -1,0 +1,167 @@
+"""Offline-built summary sidecars for the summary-first benchmark lane.
+
+A sidecar is an explicit, offline-generated artifact: per file/symbol summaries
+plus the provenance needed to detect staleness (source content hash + index
+revision + generation time) and to fetch the exact original code (file path +
+line range + fetch handle). Summaries are deterministic, rule-based digests of
+already-parsed symbol metadata — no hosted LLM calls, no network. They are built
+only on explicit offline opt-in and are NEVER auto-generated during a normal
+query. Inspired by Meta-RAG's summary-first retrieval lane (arXiv:2508.02611).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+from archex.scout import chunk_handle
+
+if TYPE_CHECKING:
+    from archex.models import CodeChunk
+
+# Max characters kept in a single summary digest; keeps sidecars compact and the
+# summary-first selection cheap while preserving the signal-bearing prefix.
+_SUMMARY_MAX_CHARS = 280
+
+
+class SummaryGranularity(StrEnum):
+    """Granularity a summary sidecar entry describes."""
+
+    FILE = "file"
+    SYMBOL = "symbol"
+    BLOCK = "block"
+
+
+class SummaryEntry(BaseModel):
+    """A single offline summary plus the provenance needed to trust and fetch it."""
+
+    source_file_path: str
+    source_content_hash: str
+    index_revision: str
+    generated_at: str
+    granularity: SummaryGranularity
+    summary: str
+    symbol_name: str | None = None
+    start_line: int
+    end_line: int
+    fetch_original_handle: str
+
+
+class SummarySidecar(BaseModel):
+    """An offline-built collection of summaries for one repository revision."""
+
+    sidecar_version: int = 1
+    repo: str
+    commit: str
+    index_revision: str
+    generated_at: str
+    granularity: SummaryGranularity
+    entries: list[SummaryEntry] = []
+
+    def save(self, path: str | Path) -> Path:
+        """Write the sidecar to ``path`` as JSON; returns the resolved path."""
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(self.model_dump_json(indent=2), encoding="utf-8")
+        return target
+
+    @classmethod
+    def load(cls, path: str | Path) -> SummarySidecar:
+        """Load a sidecar from a JSON file."""
+        return cls.model_validate_json(Path(path).read_text(encoding="utf-8"))
+
+
+def _first_meaningful_line(content: str) -> str:
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def summarize_chunk(chunk: CodeChunk) -> str:
+    """Deterministic rule-based digest of a chunk's parsed symbol metadata.
+
+    Composes breadcrumbs, signature (or symbol name), and the first docstring
+    line, falling back to the first non-blank source line. No model, no network.
+    """
+    parts: list[str] = []
+    if chunk.breadcrumbs:
+        parts.append(chunk.breadcrumbs)
+    if chunk.signature:
+        parts.append(chunk.signature)
+    elif chunk.symbol_name:
+        parts.append(chunk.symbol_name)
+    if chunk.docstring:
+        parts.append(_first_meaningful_line(chunk.docstring))
+    if not parts:
+        parts.append(_first_meaningful_line(chunk.content))
+    digest = " | ".join(part for part in parts if part)
+    return digest[:_SUMMARY_MAX_CHARS]
+
+
+def file_content_hash(repo_path: Path, file_path: str) -> str | None:
+    """SHA-256 of a repo file's bytes, or None when the file is missing."""
+    target = repo_path / file_path
+    if not target.is_file():
+        return None
+    return hashlib.sha256(target.read_bytes()).hexdigest()
+
+
+def build_summary_sidecar(
+    chunks: list[CodeChunk],
+    repo_path: Path,
+    *,
+    repo: str,
+    commit: str,
+    index_revision: str,
+    granularity: SummaryGranularity = SummaryGranularity.SYMBOL,
+    generated_at: str | None = None,
+) -> SummarySidecar:
+    """Build a summary sidecar from already-parsed chunks (explicit offline step).
+
+    The source content hash is the whole-file hash so any edit to a file marks all
+    of its summaries stale. Chunks whose file cannot be read are skipped.
+    """
+    now = generated_at or datetime.now(tz=UTC).isoformat()
+    hash_cache: dict[str, str | None] = {}
+    entries: list[SummaryEntry] = []
+    for chunk in chunks:
+        if chunk.file_path not in hash_cache:
+            hash_cache[chunk.file_path] = file_content_hash(repo_path, chunk.file_path)
+        source_hash = hash_cache[chunk.file_path]
+        if source_hash is None:
+            continue
+        entries.append(
+            SummaryEntry(
+                source_file_path=chunk.file_path,
+                source_content_hash=source_hash,
+                index_revision=index_revision,
+                generated_at=now,
+                granularity=granularity,
+                summary=summarize_chunk(chunk),
+                symbol_name=chunk.symbol_name,
+                start_line=chunk.start_line,
+                end_line=chunk.end_line,
+                fetch_original_handle=chunk_handle(chunk.id),
+            )
+        )
+    return SummarySidecar(
+        repo=repo,
+        commit=commit,
+        index_revision=index_revision,
+        generated_at=now,
+        granularity=granularity,
+        entries=entries,
+    )
+
+
+def is_entry_stale(entry: SummaryEntry, repo_path: Path) -> bool:
+    """True when the source file is gone or its content no longer matches the hash."""
+    current = file_content_hash(repo_path, entry.source_file_path)
+    return current is None or current != entry.source_content_hash

--- a/tests/benchmark/test_summary_sidecar_strategy.py
+++ b/tests/benchmark/test_summary_sidecar_strategy.py
@@ -1,0 +1,349 @@
+"""Tests for the benchmark-only archex_query_summary_sidecar strategy."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+from archex.benchmark.models import BenchmarkRetrievalOptions, BenchmarkTask, Strategy
+from archex.benchmark.runner import AVAILABLE_STRATEGIES, DEFAULT_STRATEGIES
+from archex.benchmark.strategies import (
+    _filter_bundle_to_files,  # pyright: ignore[reportPrivateUsage]
+    _select_summary_files,  # pyright: ignore[reportPrivateUsage]
+    default_strategy_registry,
+    reset_benchmark_retrieval_options,
+    run_archex_query_summary_sidecar,
+    set_benchmark_retrieval_options,
+)
+from archex.benchmark.summary_sidecar import (
+    SummaryEntry,
+    SummaryGranularity,
+    SummarySidecar,
+    build_summary_sidecar,
+    is_entry_stale,
+    summarize_chunk,
+)
+from archex.models import (
+    CodeChunk,
+    ContextBundle,
+    ContextReceipt,
+    ContextReceiptItem,
+    ContextReceiptTokenBudget,
+    RankedChunk,
+    RetrievalMetadata,
+)
+from archex.scout import CHUNK_HANDLE_PREFIX, chunk_handle
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _entry(
+    *,
+    file_path: str,
+    source_hash: str,
+    summary: str,
+    handle: str,
+    symbol: str | None = None,
+) -> SummaryEntry:
+    return SummaryEntry(
+        source_file_path=file_path,
+        source_content_hash=source_hash,
+        index_revision="rev1",
+        generated_at="2026-01-01T00:00:00+00:00",
+        granularity=SummaryGranularity.SYMBOL,
+        summary=summary,
+        symbol_name=symbol,
+        start_line=1,
+        end_line=3,
+        fetch_original_handle=handle,
+    )
+
+
+def _index_chunks(repo_path: Path) -> list[CodeChunk]:
+    from archex.api import index_repository
+    from archex.models import Config, IndexConfig, RepoSource
+
+    source = RepoSource(local_path=str(repo_path), stable_identity="summary-sidecar-test@1")
+    store = index_repository(
+        source, config=Config(cache=False), index_config=IndexConfig(vector=False)
+    )
+    return store.get_chunks()
+
+
+def _build_fixture_sidecar(repo_path: Path, dest: Path) -> SummarySidecar:
+    sidecar = build_summary_sidecar(
+        _index_chunks(repo_path),
+        repo_path,
+        repo="test",
+        commit="1",
+        index_revision="rev1",
+    )
+    sidecar.save(dest)
+    return sidecar
+
+
+class TestStrategyRegistry:
+    def test_runner_registered(self) -> None:
+        assert (
+            default_strategy_registry.get(Strategy.ARCHEX_QUERY_SUMMARY_SIDECAR)
+            is run_archex_query_summary_sidecar
+        )
+
+    def test_strategy_value(self) -> None:
+        assert Strategy.ARCHEX_QUERY_SUMMARY_SIDECAR.value == "archex_query_summary_sidecar"
+        assert (
+            Strategy.ARCHEX_QUERY_SUMMARY_SIDECAR.value in default_strategy_registry.strategy_names
+        )
+
+    def test_available_but_not_default(self) -> None:
+        assert Strategy.ARCHEX_QUERY_SUMMARY_SIDECAR in AVAILABLE_STRATEGIES
+        assert Strategy.ARCHEX_QUERY_SUMMARY_SIDECAR not in DEFAULT_STRATEGIES
+
+
+class TestSummarizeChunk:
+    def test_digest_prefers_signature_and_docstring(self) -> None:
+        chunk = CodeChunk(
+            id="c1",
+            content="def parse(): ...",
+            file_path="p.py",
+            start_line=1,
+            end_line=2,
+            language="python",
+            signature="def parse(path: str) -> AST",
+            docstring="Parse a file into an AST.\nMore detail.",
+            breadcrumbs="mod > parse",
+        )
+        digest = summarize_chunk(chunk)
+        assert "def parse(path: str) -> AST" in digest
+        assert "Parse a file into an AST." in digest
+        # Only the first docstring line is kept.
+        assert "More detail." not in digest
+
+    def test_digest_falls_back_to_first_code_line(self) -> None:
+        chunk = CodeChunk(
+            id="c2",
+            content="\n\nx = compute_total(items)\n",
+            file_path="p.py",
+            start_line=1,
+            end_line=3,
+            language="python",
+        )
+        assert summarize_chunk(chunk) == "x = compute_total(items)"
+
+
+class TestSidecarRoundTripAndStaleness:
+    def test_build_save_load_roundtrip(self, python_simple_repo: Path, tmp_path: Path) -> None:
+        dest = tmp_path / "sidecar.json"
+        built = _build_fixture_sidecar(python_simple_repo, dest)
+        assert built.entries, "expected at least one summary entry"
+
+        loaded = SummarySidecar.load(dest)
+        assert loaded.entries == built.entries
+        assert loaded.granularity is SummaryGranularity.SYMBOL
+        # Every entry carries the metadata needed to trust and fetch it.
+        for entry in loaded.entries:
+            assert entry.source_content_hash
+            assert entry.index_revision == "rev1"
+            assert entry.generated_at
+            assert entry.fetch_original_handle.startswith(CHUNK_HANDLE_PREFIX)
+
+    def test_stale_detection_after_edit(self, python_simple_repo: Path, tmp_path: Path) -> None:
+        built = _build_fixture_sidecar(python_simple_repo, tmp_path / "sidecar.json")
+        assert not any(is_entry_stale(e, python_simple_repo) for e in built.entries)
+
+        target = python_simple_repo / "models.py"
+        target.write_text(target.read_text() + "\n# drift\n", encoding="utf-8")
+
+        stale = [e for e in built.entries if is_entry_stale(e, python_simple_repo)]
+        assert stale, "edited file's summaries must be detected stale"
+        assert all(e.source_file_path == "models.py" for e in stale)
+
+    def test_missing_file_is_stale(self, tmp_path: Path) -> None:
+        entry = _entry(file_path="gone.py", source_hash="deadbeef", summary="x", handle="chunk:1")
+        assert is_entry_stale(entry, tmp_path) is True
+
+
+class TestSelectSummaryFiles:
+    def test_ranks_by_overlap_and_excludes_stale(self, tmp_path: Path) -> None:
+        real = tmp_path / "real.py"
+        real.write_text("def query(): pass", encoding="utf-8")
+        real_hash = hashlib.sha256(real.read_bytes()).hexdigest()
+
+        fresh = _entry(
+            file_path="real.py",
+            source_hash=real_hash,
+            summary="query function entrypoint",
+            handle="chunk:1",
+            symbol="query",
+        )
+        stale = _entry(
+            file_path="gone.py",
+            source_hash="stale",
+            summary="query helper",
+            handle="chunk:2",
+        )
+        sidecar = SummarySidecar(
+            repo="r",
+            commit="c",
+            index_revision="rev1",
+            generated_at="t",
+            granularity=SummaryGranularity.SYMBOL,
+            entries=[fresh, stale],
+        )
+
+        selection = _select_summary_files(sidecar, tmp_path, question="query", file_cap=10)
+
+        # The stale entry's file is excluded; only the fresh match is selected.
+        assert selection.selected_files == ["real.py"]
+        assert selection.stats["entries_fresh"] == 1
+        assert selection.stats["entries_stale"] == 1
+
+    def test_no_overlap_selects_nothing(self, tmp_path: Path) -> None:
+        real = tmp_path / "real.py"
+        real.write_text("def query(): pass", encoding="utf-8")
+        real_hash = hashlib.sha256(real.read_bytes()).hexdigest()
+        entry = _entry(
+            file_path="real.py", source_hash=real_hash, summary="auth login", handle="chunk:1"
+        )
+        sidecar = SummarySidecar(
+            repo="r",
+            commit="c",
+            index_revision="rev1",
+            generated_at="t",
+            granularity=SummaryGranularity.SYMBOL,
+            entries=[entry],
+        )
+        selection = _select_summary_files(
+            sidecar, tmp_path, question="database migration", file_cap=10
+        )
+        assert selection.selected_files == []
+
+
+def _ranked(chunk_id: str, file_path: str, content: str) -> RankedChunk:
+    chunk = CodeChunk(
+        id=chunk_id,
+        content=content,
+        file_path=file_path,
+        start_line=1,
+        end_line=3,
+        language="python",
+        token_count=10,
+    )
+    return RankedChunk(chunk=chunk, final_score=1.0)
+
+
+def _bundle_with(ranked: list[RankedChunk]) -> ContextBundle:
+    items = [
+        ContextReceiptItem(
+            handle=chunk_handle(rc.chunk.id),
+            file_path=rc.chunk.file_path,
+            start_line=1,
+            end_line=3,
+            content_hash=f"h-{rc.chunk.id}",
+        )
+        for rc in ranked
+    ]
+    receipt = ContextReceipt(
+        query="q",
+        token_budget=ContextReceiptTokenBudget(requested=4096, consumed=0),
+        index_revision="rev",
+        returned_context=items,
+        returned_total=len(items),
+    )
+    metadata = RetrievalMetadata(seed_file_paths=[rc.chunk.file_path for rc in ranked])
+    return ContextBundle(
+        query="q",
+        chunks=ranked,
+        token_count=sum(rc.chunk.token_count for rc in ranked),
+        retrieval_metadata=metadata,
+        receipt=receipt,
+    )
+
+
+class TestFilterBundleToFiles:
+    def test_keeps_selected_files_preserves_handles_and_resets_diagnostics(self) -> None:
+        keep = _ranked("a", "keep.py", "def keep():\n    return 1")
+        drop = _ranked("b", "drop.py", "def drop():\n    return 2")
+        bundle = _bundle_with([keep, drop])
+
+        filtered = _filter_bundle_to_files(bundle, {"keep.py"})
+
+        assert [rc.chunk.file_path for rc in filtered.chunks] == ["keep.py"]
+        # Returned content is the original code, never a summary digest.
+        assert filtered.chunks[0].chunk.content == "def keep():\n    return 1"
+        # Fetch-original handles are preserved and realigned to the kept set.
+        assert filtered.receipt is not None
+        assert [item.handle for item in filtered.receipt.returned_context] == [chunk_handle("a")]
+        assert filtered.receipt.returned_total == 1
+        # Seed diagnostics are reset to the kept set; the dropped file does not leak.
+        assert filtered.retrieval_metadata.seed_file_paths == []
+        assert filtered.retrieval_metadata.seed_files_found == 1
+        assert filtered.token_count == 10
+
+
+class TestRunSummarySidecarFixture:
+    def _task(self, question: str, token_budget: int = 4096) -> BenchmarkTask:
+        return BenchmarkTask(
+            task_id="summary_sidecar_test",
+            repo="test/repo",
+            commit="abc",
+            question=question,
+            expected_files=["main.py"],
+            token_budget=token_budget,
+        )
+
+    def test_absent_sidecar_falls_back_to_plain_retrieval(self, python_simple_repo: Path) -> None:
+        # No opt-in configured: summary-first is disabled, plain retrieval runs.
+        result = run_archex_query_summary_sidecar(
+            self._task("main.py main function module"), python_simple_repo
+        )
+        assert result.strategy == Strategy.ARCHEX_QUERY_SUMMARY_SIDECAR
+        assert result.provenance["sidecar"] == "absent"
+        assert result.provenance["summary_first"] == "false"
+
+    def test_summary_first_selection_and_handles(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        dest = tmp_path / "sidecar.json"
+        sidecar = _build_fixture_sidecar(python_simple_repo, dest)
+
+        token = set_benchmark_retrieval_options(
+            BenchmarkRetrievalOptions(summary_sidecar_path=str(dest))
+        )
+        try:
+            result = run_archex_query_summary_sidecar(
+                self._task("main entry point function module"), python_simple_repo
+            )
+        finally:
+            reset_benchmark_retrieval_options(token)
+
+        prov = result.provenance
+        assert prov["sidecar"] == "loaded"
+        assert prov["summary_first"] == "true"
+        assert prov["original_code_retrieved"] == "true"
+        assert prov["fetch_original_preserved"] == "true"
+        assert int(prov["entries_total"]) == len(sidecar.entries)
+        # Returned files are within the summary-selected set.
+        selected = set(prov["summary_selected_files"].split(", "))
+        assert set(result.result_files).issubset(selected)
+        assert result.result_files, "summary-first selection returned no files"
+
+    def test_stale_sidecar_entries_reported(self, python_simple_repo: Path, tmp_path: Path) -> None:
+        dest = tmp_path / "sidecar.json"
+        _build_fixture_sidecar(python_simple_repo, dest)
+        # Drift the source after the sidecar was built.
+        target = python_simple_repo / "models.py"
+        target.write_text(target.read_text() + "\n# drift\n", encoding="utf-8")
+
+        token = set_benchmark_retrieval_options(
+            BenchmarkRetrievalOptions(summary_sidecar_path=str(dest))
+        )
+        try:
+            result = run_archex_query_summary_sidecar(
+                self._task("models data class fields"), python_simple_repo
+            )
+        finally:
+            reset_benchmark_retrieval_options(token)
+
+        assert int(result.provenance["entries_stale"]) > 0


### PR DESCRIPTION
## Stack

Stack-Id: `advanced-lanes-5619e8`
Position: 3/5 (base bench/bounded-rerank-strategy)

1. `bench/dual-transform-strategy` -> #308 (base `main`)
2. `bench/bounded-rerank-strategy` -> #309 (base `bench/dual-transform-strategy`)
3. `bench/summary-sidecar-strategy` -> #310 (base `bench/bounded-rerank-strategy`)
4. `bench/graph-multihop-strategy` -> #311 (base `bench/summary-sidecar-strategy`)
5. `bench/advanced-lane-reports-docs` -> #312 (base `bench/graph-multihop-strategy`)

Depends on: #309
Upstack: #311

## Summary

Part of the Workstream 5 "Advanced Retrieval Quality Lanes" stack. Each lane is in `AVAILABLE_STRATEGIES` only, never `DEFAULT_STRATEGIES`; no product default changes; no hosted calls / telemetry / mandatory network. See the per-lane commit messages for details and leaf PR #312 for the Advanced Quality Lanes report + docs.

## Validation

`ruff check` / `ruff format --check` / `pyright` (strict) on changed files — clean; lane + registry + (context/receipt/graph where relevant) tests pass.