### PR TITLE
Add archex_query_graph_multihop benchmark lane

### DIFF
--- a/src/archex/benchmark/graph_multihop.py
+++ b/src/archex/benchmark/graph_multihop.py
@@ -1,0 +1,156 @@
+"""Bounded multi-hop dependency-graph expansion for the graph-multihop lane.
+
+Explores the file dependency graph outward from seed files with explicit caps so
+expansion can never flood the bundle: an edge-confidence threshold suppresses
+low-confidence edges, a per-hop frontier cap limits breadth, a hop cap limits
+depth, and a token budget limits total expansion cost. Every decision — each
+expanded file and each cut (low-confidence / frontier / budget) — is recorded so
+receipts and provenance can explain the expansion. Pure and deterministic: it
+operates on a plain edge list, so it needs neither a graph object nor a store.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+@dataclass(frozen=True)
+class GraphEdge:
+    """A directed dependency edge with an extraction-confidence score in [0, 1]."""
+
+    source: str
+    target: str
+    confidence: float
+
+
+@dataclass(frozen=True)
+class MultihopCaps:
+    """Hard caps that bound multi-hop expansion against dependency flooding."""
+
+    hop_cap: int = 2
+    frontier_cap: int = 8
+    confidence_threshold: float = 0.5
+    token_budget: int = 1_000_000
+
+
+class ExpansionAction(StrEnum):
+    """Outcome recorded for one candidate file during expansion."""
+
+    EXPANDED = "expanded"
+    SUPPRESSED_LOW_CONFIDENCE = "suppressed_low_confidence"
+    CUT_FRONTIER = "cut_frontier"
+    CUT_BUDGET = "cut_budget"
+
+
+@dataclass(frozen=True)
+class ExpansionDecision:
+    """One candidate file's expansion outcome, with the edge that proposed it."""
+
+    file: str
+    hop: int
+    via: str
+    confidence: float
+    tokens: int
+    action: ExpansionAction
+
+
+@dataclass(frozen=True)
+class MultihopResult:
+    """Files added by expansion plus the full ordered decision log."""
+
+    added_files: list[str]
+    decisions: list[ExpansionDecision]
+    hops_run: int
+
+    def action_count(self, action: ExpansionAction) -> int:
+        """Number of decisions with the given action."""
+        return sum(1 for decision in self.decisions if decision.action is action)
+
+    def expanded_decisions(self) -> list[ExpansionDecision]:
+        """Decisions that added a file to the bundle, in expansion order."""
+        return [d for d in self.decisions if d.action is ExpansionAction.EXPANDED]
+
+
+def _undirected_adjacency(edges: list[GraphEdge]) -> dict[str, dict[str, float]]:
+    """Build symmetric adjacency keeping the max confidence per (node, neighbour)."""
+    adjacency: dict[str, dict[str, float]] = {}
+    for edge in edges:
+        if edge.source == edge.target:
+            continue
+        for a, b in ((edge.source, edge.target), (edge.target, edge.source)):
+            neighbours = adjacency.setdefault(a, {})
+            if edge.confidence > neighbours.get(b, float("-inf")):
+                neighbours[b] = edge.confidence
+    return adjacency
+
+
+def graph_multihop_expand(
+    edges: list[GraphEdge],
+    seed_files: list[str],
+    file_tokens: dict[str, int],
+    caps: MultihopCaps,
+) -> MultihopResult:
+    """Expand from seeds hop by hop under confidence, frontier, hop, and budget caps.
+
+    Candidates each hop are ranked by edge confidence (then file name) for
+    determinism. A candidate below the confidence threshold is suppressed; beyond
+    the per-hop frontier cap it is a frontier cut; if it would exceed the token
+    budget it is a budget cut. Each candidate is decided exactly once (decided
+    files are never reconsidered), so expansion always terminates and never floods.
+    Only expanded files advance the frontier to the next hop.
+    """
+    adjacency = _undirected_adjacency(edges)
+    visited: set[str] = set(seed_files)
+    frontier: list[str] = list(dict.fromkeys(seed_files))
+    spent = 0
+    added: list[str] = []
+    decisions: list[ExpansionDecision] = []
+    hops_run = 0
+
+    for hop in range(1, caps.hop_cap + 1):
+        if not frontier:
+            break
+        # Best (max-confidence) proposing edge per unvisited neighbour this hop.
+        candidates: dict[str, tuple[str, float]] = {}
+        for node in frontier:
+            for neighbour, confidence in adjacency.get(node, {}).items():
+                if neighbour in visited:
+                    continue
+                best = candidates.get(neighbour)
+                if best is None or confidence > best[1]:
+                    candidates[neighbour] = (node, confidence)
+        if not candidates:
+            break
+        hops_run = hop
+        ranked = sorted(candidates.items(), key=lambda item: (-item[1][1], item[0]))
+        accepted_this_hop = 0
+        next_frontier: list[str] = []
+        for neighbour, (via, confidence) in ranked:
+            visited.add(neighbour)  # decided this hop; never reconsider
+            tokens = file_tokens.get(neighbour, 0)
+            if confidence < caps.confidence_threshold:
+                action = ExpansionAction.SUPPRESSED_LOW_CONFIDENCE
+            elif accepted_this_hop >= caps.frontier_cap:
+                action = ExpansionAction.CUT_FRONTIER
+            elif spent + tokens > caps.token_budget:
+                action = ExpansionAction.CUT_BUDGET
+            else:
+                action = ExpansionAction.EXPANDED
+                spent += tokens
+                accepted_this_hop += 1
+                added.append(neighbour)
+                next_frontier.append(neighbour)
+            decisions.append(
+                ExpansionDecision(
+                    file=neighbour,
+                    hop=hop,
+                    via=via,
+                    confidence=confidence,
+                    tokens=tokens,
+                    action=action,
+                )
+            )
+        frontier = next_frontier
+
+    return MultihopResult(added_files=added, decisions=decisions, hops_run=hops_run)

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -34,6 +34,7 @@ class Strategy(StrEnum):
     ARCHEX_QUERY_DUAL_TRANSFORM = "archex_query_dual_transform"
     ARCHEX_QUERY_BOUNDED_RERANK = "archex_query_bounded_rerank"
     ARCHEX_QUERY_SUMMARY_SIDECAR = "archex_query_summary_sidecar"
+    ARCHEX_QUERY_GRAPH_MULTIHOP = "archex_query_graph_multihop"
     EXTERNAL_MCP = "external_mcp"
 
 

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -53,6 +53,7 @@ AVAILABLE_STRATEGIES: list[Strategy] = [
     Strategy.ARCHEX_QUERY_DUAL_TRANSFORM,
     Strategy.ARCHEX_QUERY_BOUNDED_RERANK,
     Strategy.ARCHEX_QUERY_SUMMARY_SIDECAR,
+    Strategy.ARCHEX_QUERY_GRAPH_MULTIHOP,
 ]
 
 _VECTOR_STRATEGIES: frozenset[Strategy] = frozenset(

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -22,6 +22,14 @@ from archex.benchmark.bounded_rerank import (
     query_signals,
     symbolic_scores,
 )
+from archex.benchmark.graph_multihop import (
+    ExpansionAction,
+    ExpansionDecision,
+    GraphEdge,
+    MultihopCaps,
+    MultihopResult,
+    graph_multihop_expand,
+)
 from archex.benchmark.models import (
     BenchmarkResult,
     BenchmarkRetrievalOptions,
@@ -46,7 +54,13 @@ from archex.models import (
     CompressionMode,
     ContextBundle,
     ContextCompletenessStatus,
+    ContextOmittedEdgeReason,
+    ContextReceiptEdge,
     ContextReceiptItem,
+    ContextSkippedCandidate,
+    ContextSkippedReason,
+    EdgeConfidence,
+    EdgeKind,
     IndexConfig,
     PipelineTiming,
     RankedChunk,
@@ -63,6 +77,7 @@ from archex.serve.packing import (
 
 if TYPE_CHECKING:
     from archex.index.rerank import CrossEncoderReranker
+    from archex.index.store import IndexStore
 
 logger = logging.getLogger(__name__)
 
@@ -2309,6 +2324,240 @@ def run_archex_query_summary_sidecar(task: BenchmarkTask, repo_path: Path) -> Be
     return result
 
 
+_MULTIHOP_HOP_CAP = 2
+_MULTIHOP_FRONTIER_CAP = 8
+_MULTIHOP_CONFIDENCE_THRESHOLD = 0.5
+# Fraction of the token budget retrieved as seeds; the remainder funds expansion.
+_MULTIHOP_SEED_BUDGET_FRACTION = 0.5
+
+
+def _file_token_map(store: IndexStore) -> dict[str, int]:
+    """Total token count per file across the indexed chunk set."""
+    totals: dict[str, int] = {}
+    for chunk in store.get_chunks():
+        totals[chunk.file_path] = totals.get(chunk.file_path, 0) + (
+            chunk.token_count or count_tokens(chunk.content)
+        )
+    return totals
+
+
+def _expansion_edge(
+    decision: ExpansionDecision, *, reason: ContextOmittedEdgeReason | None = None
+) -> ContextReceiptEdge:
+    return ContextReceiptEdge(
+        source=decision.via,
+        target=decision.file,
+        kind=EdgeKind.IMPORTS,
+        confidence=EdgeConfidence.EXTRACTED,
+        confidence_score=decision.confidence,
+        evidence=[
+            f"graph multihop hop {decision.hop} via {decision.via} "
+            f"(confidence {decision.confidence:.2f})"
+        ],
+        reason=reason,
+    )
+
+
+def _expansion_skip(
+    decision: ExpansionDecision, reason: ContextSkippedReason
+) -> ContextSkippedCandidate:
+    return ContextSkippedCandidate(
+        file_path=decision.file,
+        reason=reason,
+        score=decision.confidence,
+        detail=f"graph multihop hop {decision.hop} via {decision.via}",
+    )
+
+
+def _apply_multihop_expansion(
+    bundle: ContextBundle,
+    store: IndexStore,
+    *,
+    seed_files: list[str],
+    expansion: MultihopResult,
+) -> ContextBundle:
+    """Append expanded files' original chunks and record the expansion in receipts.
+
+    Expanded files contribute their original code (the edit evidence); every
+    expansion decision becomes a receipt edge (included) or a cut (omitted edge /
+    skipped candidate), and the seed/expansion diagnostics are set to the expanded
+    bundle so they describe what the lane actually returned.
+    """
+    from archex.receipt import chunk_content_hash
+    from archex.scout import chunk_handle
+
+    confidence_by_file = {d.file: d.confidence for d in expansion.expanded_decisions()}
+    chunks_by_file: dict[str, list[CodeChunk]] = {}
+    for chunk in store.get_chunks_for_files(expansion.added_files):
+        chunks_by_file.setdefault(chunk.file_path, []).append(chunk)
+
+    expanded_ranked: list[RankedChunk] = []
+    new_items: list[ContextReceiptItem] = []
+    added_tokens = 0
+    for file in expansion.added_files:
+        confidence = confidence_by_file.get(file, 0.0)
+        for chunk in sorted(chunks_by_file.get(file, []), key=lambda c: c.start_line):
+            expanded_ranked.append(RankedChunk(chunk=chunk, final_score=confidence))
+            added_tokens += chunk.token_count or count_tokens(chunk.content)
+            new_items.append(
+                ContextReceiptItem(
+                    handle=chunk_handle(chunk.id),
+                    file_path=chunk.file_path,
+                    start_line=chunk.start_line,
+                    end_line=chunk.end_line,
+                    content_hash=chunk_content_hash(chunk),
+                    reason_codes=["graph_multihop_expansion"],
+                )
+            )
+
+    new_chunks = list(bundle.chunks) + expanded_ranked
+    receipt = bundle.receipt
+    if receipt is not None:
+        included = list(receipt.included_edges)
+        omitted = list(receipt.omitted_edges)
+        skipped = list(receipt.skipped_candidates)
+        for decision in expansion.decisions:
+            if decision.action is ExpansionAction.EXPANDED:
+                included.append(_expansion_edge(decision))
+            elif decision.action is ExpansionAction.SUPPRESSED_LOW_CONFIDENCE:
+                omitted.append(
+                    _expansion_edge(decision, reason=ContextOmittedEdgeReason.BELOW_THRESHOLD)
+                )
+                skipped.append(_expansion_skip(decision, ContextSkippedReason.BELOW_THRESHOLD))
+            elif decision.action is ExpansionAction.CUT_FRONTIER:
+                skipped.append(
+                    _expansion_skip(decision, ContextSkippedReason.DEPENDENCY_FRONTIER_CUT)
+                )
+            elif decision.action is ExpansionAction.CUT_BUDGET:
+                omitted.append(
+                    _expansion_edge(decision, reason=ContextOmittedEdgeReason.OVER_BUDGET)
+                )
+                skipped.append(_expansion_skip(decision, ContextSkippedReason.OVER_BUDGET))
+        returned = list(receipt.returned_context) + new_items
+        receipt = receipt.model_copy(
+            update={
+                "returned_context": returned,
+                "returned_total": len(returned),
+                "included_edges": included,
+                "included_edges_total": len(included),
+                "omitted_edges": omitted,
+                "omitted_edges_total": len(omitted),
+                "skipped_candidates": skipped,
+                "skipped_total": len(skipped),
+            }
+        )
+
+    metadata = bundle.retrieval_metadata.model_copy(
+        update={
+            "seed_file_paths": list(seed_files),
+            "expanded_file_paths": list(expansion.added_files),
+            "seed_files_found": len(seed_files),
+            "expansion_files_added": len(expansion.added_files),
+            "expansion_candidates_found": len(expansion.decisions),
+            "expansion_import_neighbor_edges": expansion.action_count(ExpansionAction.EXPANDED),
+        }
+    )
+    return bundle.model_copy(
+        update={
+            "chunks": new_chunks,
+            "token_count": bundle.token_count + added_tokens,
+            "receipt": receipt,
+            "retrieval_metadata": metadata,
+        }
+    )
+
+
+def run_archex_query_graph_multihop(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
+    """Benchmark-only lane: bounded multi-hop dependency-graph expansion.
+
+    Retrieves seeds with a reduced budget, then expands the file dependency graph
+    outward from those seeds under hard caps — an edge-confidence threshold, a
+    per-hop frontier cap, a hop cap, and a token budget — so dependency expansion
+    cannot flood the bundle. Expanded files contribute their original code; every
+    expansion decision and cut is recorded in the receipt (included/omitted edges,
+    skipped candidates) and in provenance. The product default is unchanged.
+    """
+    from archex.api import index_repository
+    from archex.index.graph import DependencyGraph
+    from archex.models import Config
+
+    strategy = Strategy.ARCHEX_QUERY_GRAPH_MULTIHOP
+    t0 = time.perf_counter()
+    seed_budget = max(1, int(task.token_budget * _MULTIHOP_SEED_BUDGET_FRACTION))
+    seed_task = task.model_copy(update={"token_budget": seed_budget})
+    bundle, effective_config, timing = _query_bundle(
+        seed_task,
+        repo_path,
+        strategy=strategy,
+        index_config=IndexConfig(vector=False),
+        cache=True,
+    )
+    seed_files = _deduplicate_ranked([ranked.chunk.file_path for ranked in bundle.chunks])
+    expansion_budget = max(0, task.token_budget - bundle.token_count)
+
+    source = benchmark_repo_source(seed_task, repo_path, strategy=strategy)
+    store = index_repository(
+        source, config=Config(cache=True, languages=task.languages), index_config=effective_config
+    )
+    try:
+        graph = DependencyGraph.from_edges(store.get_edges())
+        edges = [
+            GraphEdge(edge.source, edge.target, edge.confidence_score)
+            for edge in graph.file_edges()
+        ]
+        file_tokens = _file_token_map(store)
+        caps = MultihopCaps(
+            hop_cap=_MULTIHOP_HOP_CAP,
+            frontier_cap=_MULTIHOP_FRONTIER_CAP,
+            confidence_threshold=_MULTIHOP_CONFIDENCE_THRESHOLD,
+            token_budget=expansion_budget,
+        )
+        expansion = graph_multihop_expand(edges, seed_files, file_tokens, caps)
+        expanded_bundle = _apply_multihop_expansion(
+            bundle, store, seed_files=seed_files, expansion=expansion
+        )
+    finally:
+        store.close()
+
+    wall_ms = (time.perf_counter() - t0) * 1000
+    result = _assemble_query_result(
+        task,
+        repo_path,
+        strategy=strategy,
+        index_config=effective_config,
+        bundle=expanded_bundle,
+        timing=timing,
+        wall_ms=wall_ms,
+        include_completion=True,
+        measure_freshness=False,
+    )
+    result.provenance = {
+        "hop_cap": str(_MULTIHOP_HOP_CAP),
+        "frontier_cap": str(_MULTIHOP_FRONTIER_CAP),
+        "confidence_threshold": f"{_MULTIHOP_CONFIDENCE_THRESHOLD:.2f}",
+        "expansion_token_budget": str(expansion_budget),
+        "seed_file_count": str(len(seed_files)),
+        "hops_run": str(expansion.hops_run),
+        "files_expanded": str(len(expansion.added_files)),
+        "suppressed_low_confidence": str(
+            expansion.action_count(ExpansionAction.SUPPRESSED_LOW_CONFIDENCE)
+        ),
+        "frontier_cuts": str(expansion.action_count(ExpansionAction.CUT_FRONTIER)),
+        "budget_cuts": str(expansion.action_count(ExpansionAction.CUT_BUDGET)),
+        "expanded_files": ", ".join(expansion.added_files) or "none",
+    }
+    logger.info(
+        "Strategy %s for %s: seeds=%d expanded=%d hops=%d wall=%.1fms",
+        strategy.value,
+        task.task_id,
+        len(seed_files),
+        len(expansion.added_files),
+        expansion.hops_run,
+        wall_ms,
+    )
+    return result
+
+
 def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Two-call scout map plus chunk-first exact fetch with direct-query guardrails."""
     from archex.api import query, scout_with_bundle
@@ -2925,5 +3174,8 @@ default_strategy_registry.register(
 )
 default_strategy_registry.register(
     Strategy.ARCHEX_QUERY_SUMMARY_SIDECAR.value, run_archex_query_summary_sidecar
+)
+default_strategy_registry.register(
+    Strategy.ARCHEX_QUERY_GRAPH_MULTIHOP.value, run_archex_query_graph_multihop
 )
 default_strategy_registry.register(Strategy.EXTERNAL_MCP.value, _run_external_mcp_strategy)

--- a/tests/benchmark/test_graph_multihop_strategy.py
+++ b/tests/benchmark/test_graph_multihop_strategy.py
@@ -1,0 +1,326 @@
+"""Tests for the benchmark-only archex_query_graph_multihop strategy."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import archex.benchmark.strategies as strategies
+from archex.benchmark.graph_multihop import (
+    ExpansionAction,
+    ExpansionDecision,
+    GraphEdge,
+    MultihopCaps,
+    MultihopResult,
+    graph_multihop_expand,
+)
+from archex.benchmark.models import BenchmarkTask, Strategy
+from archex.benchmark.runner import AVAILABLE_STRATEGIES, DEFAULT_STRATEGIES
+from archex.benchmark.strategies import (
+    _apply_multihop_expansion,  # pyright: ignore[reportPrivateUsage]
+    default_strategy_registry,
+    run_archex_query_graph_multihop,
+)
+from archex.models import (
+    CodeChunk,
+    ContextBundle,
+    ContextOmittedEdgeReason,
+    ContextReceipt,
+    ContextReceiptItem,
+    ContextReceiptTokenBudget,
+    ContextSkippedReason,
+    PipelineTiming,
+    RankedChunk,
+)
+from archex.scout import chunk_handle
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+    from archex.index.store import IndexStore
+
+
+# ---------------------------------------------------------------------------
+# Pure expansion algorithm
+# ---------------------------------------------------------------------------
+
+_LINEAR_TOKENS = {name: 10 for name in "bcdefghij"}
+
+
+class TestGraphMultihopExpand:
+    def test_high_confidence_edge_expands(self) -> None:
+        edges = [GraphEdge("a", "b", 0.9)]
+        result = graph_multihop_expand(edges, ["a"], _LINEAR_TOKENS, MultihopCaps())
+        assert result.added_files == ["b"]
+        assert result.expanded_decisions()[0].confidence == 0.9
+
+    def test_low_confidence_edge_suppressed(self) -> None:
+        edges = [GraphEdge("a", "b", 0.2)]
+        result = graph_multihop_expand(
+            edges, ["a"], _LINEAR_TOKENS, MultihopCaps(confidence_threshold=0.5)
+        )
+        assert result.added_files == []
+        assert result.action_count(ExpansionAction.SUPPRESSED_LOW_CONFIDENCE) == 1
+
+    def test_hop_cap_limits_depth(self) -> None:
+        # a -> b -> c -> d, all high confidence; hop_cap=2 stops before d.
+        edges = [GraphEdge("a", "b", 0.9), GraphEdge("b", "c", 0.9), GraphEdge("c", "d", 0.9)]
+        result = graph_multihop_expand(
+            edges, ["a"], _LINEAR_TOKENS, MultihopCaps(hop_cap=2, frontier_cap=8)
+        )
+        assert result.added_files == ["b", "c"]
+        assert result.hops_run == 2
+        assert "d" not in result.added_files
+
+    def test_frontier_cap_limits_breadth(self) -> None:
+        # Four high-confidence neighbours of the seed; frontier_cap=2 keeps the best two.
+        edges = [
+            GraphEdge("a", "b", 0.9),
+            GraphEdge("a", "c", 0.8),
+            GraphEdge("a", "d", 0.7),
+            GraphEdge("a", "e", 0.6),
+        ]
+        result = graph_multihop_expand(
+            edges, ["a"], _LINEAR_TOKENS, MultihopCaps(hop_cap=1, frontier_cap=2)
+        )
+        # Ranked by confidence: b, c expand; d, e are frontier cuts.
+        assert result.added_files == ["b", "c"]
+        assert result.action_count(ExpansionAction.CUT_FRONTIER) == 2
+
+    def test_token_budget_cuts_expansion(self) -> None:
+        edges = [GraphEdge("a", "b", 0.9), GraphEdge("a", "c", 0.8)]
+        # Budget fits one 10-token file only.
+        result = graph_multihop_expand(
+            edges, ["a"], {"b": 10, "c": 10}, MultihopCaps(hop_cap=1, token_budget=10)
+        )
+        assert result.added_files == ["b"]
+        assert result.action_count(ExpansionAction.CUT_BUDGET) == 1
+
+    def test_deterministic_ranking_alphabetical_tie_break(self) -> None:
+        # Genuinely equal confidence so only the name tie-break can order b before c;
+        # listing a->c first proves the sort (not insertion order) decides.
+        edges = [GraphEdge("a", "c", 0.7), GraphEdge("a", "b", 0.7)]
+        result = graph_multihop_expand(
+            edges, ["a"], _LINEAR_TOKENS, MultihopCaps(hop_cap=1, frontier_cap=8)
+        )
+        assert result.added_files == ["b", "c"]
+
+    def test_seed_never_readded_across_hops(self) -> None:
+        # b expands at hop 1 then points back to the seed; a must stay excluded at hop 2.
+        edges = [GraphEdge("a", "b", 0.9), GraphEdge("b", "a", 0.9)]
+        result = graph_multihop_expand(
+            edges, ["a"], _LINEAR_TOKENS, MultihopCaps(hop_cap=2, frontier_cap=8)
+        )
+        assert result.added_files == ["b"]
+
+    def test_empty_inputs(self) -> None:
+        result = graph_multihop_expand([], ["a"], {}, MultihopCaps())
+        assert result.added_files == []
+        assert result.hops_run == 0
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyRegistry:
+    def test_runner_registered(self) -> None:
+        assert (
+            default_strategy_registry.get(Strategy.ARCHEX_QUERY_GRAPH_MULTIHOP)
+            is run_archex_query_graph_multihop
+        )
+
+    def test_strategy_value(self) -> None:
+        assert Strategy.ARCHEX_QUERY_GRAPH_MULTIHOP.value == "archex_query_graph_multihop"
+        assert (
+            Strategy.ARCHEX_QUERY_GRAPH_MULTIHOP.value in default_strategy_registry.strategy_names
+        )
+
+    def test_available_but_not_default(self) -> None:
+        assert Strategy.ARCHEX_QUERY_GRAPH_MULTIHOP in AVAILABLE_STRATEGIES
+        assert Strategy.ARCHEX_QUERY_GRAPH_MULTIHOP not in DEFAULT_STRATEGIES
+
+
+# ---------------------------------------------------------------------------
+# Receipt / provenance integration
+# ---------------------------------------------------------------------------
+
+
+def _index_store(repo_path: Path) -> IndexStore:
+    from archex.api import index_repository
+    from archex.models import Config, IndexConfig, RepoSource
+
+    source = RepoSource(local_path=str(repo_path), stable_identity="graph-multihop-test@1")
+    return index_repository(
+        source, config=Config(cache=False), index_config=IndexConfig(vector=False)
+    )
+
+
+def _bundle_from_chunks(query: str, chunks: list[CodeChunk]) -> ContextBundle:
+    ranked = [RankedChunk(chunk=chunk, final_score=1.0) for chunk in chunks]
+    items = [
+        ContextReceiptItem(
+            handle=chunk_handle(chunk.id),
+            file_path=chunk.file_path,
+            start_line=chunk.start_line,
+            end_line=chunk.end_line,
+            content_hash=f"h-{chunk.id}",
+        )
+        for chunk in chunks
+    ]
+    receipt = ContextReceipt(
+        query=query,
+        token_budget=ContextReceiptTokenBudget(requested=4096, consumed=0),
+        index_revision="rev",
+        returned_context=items,
+        returned_total=len(items),
+    )
+    return ContextBundle(
+        query=query,
+        chunks=ranked,
+        token_count=sum(chunk.token_count for chunk in chunks),
+        receipt=receipt,
+    )
+
+
+class TestApplyMultihopExpansion:
+    def test_appends_chunks_and_records_decisions(self, python_simple_repo: Path) -> None:
+        store = _index_store(python_simple_repo)
+        try:
+            files = sorted({chunk.file_path for chunk in store.get_chunks()})
+            seed = files[0]
+            expand_file = next(path for path in files if path != seed)
+            seed_chunks = store.get_chunks_for_files([seed])
+            bundle = _bundle_from_chunks(seed, seed_chunks)
+
+            decisions = [
+                ExpansionDecision(
+                    file=expand_file,
+                    hop=1,
+                    via=seed,
+                    confidence=0.9,
+                    tokens=10,
+                    action=ExpansionAction.EXPANDED,
+                ),
+                ExpansionDecision(
+                    file="low.py",
+                    hop=1,
+                    via=seed,
+                    confidence=0.2,
+                    tokens=5,
+                    action=ExpansionAction.SUPPRESSED_LOW_CONFIDENCE,
+                ),
+                ExpansionDecision(
+                    file="wide.py",
+                    hop=1,
+                    via=seed,
+                    confidence=0.8,
+                    tokens=5,
+                    action=ExpansionAction.CUT_FRONTIER,
+                ),
+                ExpansionDecision(
+                    file="big.py",
+                    hop=1,
+                    via=seed,
+                    confidence=0.7,
+                    tokens=999,
+                    action=ExpansionAction.CUT_BUDGET,
+                ),
+            ]
+            expansion = MultihopResult(added_files=[expand_file], decisions=decisions, hops_run=1)
+
+            expanded = _apply_multihop_expansion(
+                bundle, store, seed_files=[seed], expansion=expansion
+            )
+
+            # Expanded file's original chunks are appended to the seed bundle.
+            files_in_bundle = {rc.chunk.file_path for rc in expanded.chunks}
+            assert expand_file in files_in_bundle
+            assert seed in files_in_bundle
+
+            assert expanded.receipt is not None
+            # The expanded edge is included; cuts are recorded as omitted edges.
+            assert len(expanded.receipt.included_edges) == 1
+            omit_reasons = {edge.reason for edge in expanded.receipt.omitted_edges}
+            assert ContextOmittedEdgeReason.BELOW_THRESHOLD in omit_reasons
+            assert ContextOmittedEdgeReason.OVER_BUDGET in omit_reasons
+            # All three cut kinds appear as skipped candidates.
+            skip_reasons = {cand.reason for cand in expanded.receipt.skipped_candidates}
+            assert ContextSkippedReason.DEPENDENCY_FRONTIER_CUT in skip_reasons
+            assert ContextSkippedReason.BELOW_THRESHOLD in skip_reasons
+            assert ContextSkippedReason.OVER_BUDGET in skip_reasons
+            # Seed/expansion diagnostics describe the returned bundle.
+            assert expanded.retrieval_metadata.seed_file_paths == [seed]
+            assert expanded.retrieval_metadata.expanded_file_paths == [expand_file]
+            assert expanded.retrieval_metadata.expansion_files_added == 1
+        finally:
+            store.close()
+
+
+class TestRunGraphMultihopFixture:
+    def _task(self, question: str, token_budget: int = 4096) -> BenchmarkTask:
+        return BenchmarkTask(
+            task_id="graph_multihop_test",
+            repo="test/repo",
+            commit="abc",
+            question=question,
+            expected_files=["main.py"],
+            token_budget=token_budget,
+        )
+
+    def test_runs_end_to_end_with_cap_provenance(self, python_simple_repo: Path) -> None:
+        result = run_archex_query_graph_multihop(
+            self._task("How does main call services and utils?"), python_simple_repo
+        )
+        assert result.strategy == Strategy.ARCHEX_QUERY_GRAPH_MULTIHOP
+        assert result.tool_calls == 1
+        prov = result.provenance
+        for key in (
+            "hop_cap",
+            "frontier_cap",
+            "confidence_threshold",
+            "expansion_token_budget",
+            "seed_file_count",
+            "hops_run",
+            "files_expanded",
+            "suppressed_low_confidence",
+            "frontier_cuts",
+            "budget_cuts",
+        ):
+            assert key in prov, key
+        assert prov["hop_cap"] == "2"
+        assert prov["frontier_cap"] == "8"
+
+    def test_expands_graph_neighbours_from_single_seed(
+        self, monkeypatch: pytest.MonkeyPatch, python_simple_repo: Path
+    ) -> None:
+        store = _index_store(python_simple_repo)
+        try:
+            seed_chunks = [c for c in store.get_chunks() if c.file_path == "main.py"][:1]
+        finally:
+            store.close()
+        assert seed_chunks, "fixture must contain main.py chunks"
+        seed_bundle = _bundle_from_chunks("main", seed_chunks)
+
+        def fake_query_bundle(
+            task: BenchmarkTask,
+            repo_path: Path,
+            *,
+            strategy: Strategy,
+            index_config: object,
+            cache: bool,
+        ) -> tuple[ContextBundle, object, PipelineTiming]:
+            return seed_bundle, index_config, PipelineTiming()
+
+        monkeypatch.setattr(strategies, "_query_bundle", fake_query_bundle)
+
+        result = run_archex_query_graph_multihop(
+            self._task("How does main import services and utils?"), python_simple_repo
+        )
+
+        # main.py depends on other fixture modules; with only main.py as a seed,
+        # the bounded multi-hop expansion must add at least one graph neighbour.
+        assert int(result.provenance["files_expanded"]) >= 1
+        assert int(result.provenance["seed_file_count"]) == 1


### PR DESCRIPTION
## Stack

Stack-Id: `advanced-lanes-5619e8`
Position: 4/5 (base bench/summary-sidecar-strategy)

1. `bench/dual-transform-strategy` -> #308 (base `main`)
2. `bench/bounded-rerank-strategy` -> #309 (base `bench/dual-transform-strategy`)
3. `bench/summary-sidecar-strategy` -> #310 (base `bench/bounded-rerank-strategy`)
4. `bench/graph-multihop-strategy` -> #311 (base `bench/summary-sidecar-strategy`)
5. `bench/advanced-lane-reports-docs` -> #312 (base `bench/graph-multihop-strategy`)

Depends on: #310
Upstack: #312

## Summary

Part of the Workstream 5 "Advanced Retrieval Quality Lanes" stack. Each lane is in `AVAILABLE_STRATEGIES` only, never `DEFAULT_STRATEGIES`; no product default changes; no hosted calls / telemetry / mandatory network. See the per-lane commit messages for details and leaf PR #312 for the Advanced Quality Lanes report + docs.

## Validation

`ruff check` / `ruff format --check` / `pyright` (strict) on changed files — clean; lane + registry + (context/receipt/graph where relevant) tests pass.