### PR TITLE
Model competitive comparison lanes in the head-to-head manifest

### DIFF
--- a/src/archex/benchmark/headtohead.py
+++ b/src/archex/benchmark/headtohead.py
@@ -17,6 +17,7 @@ from archex.benchmark.models import (
     BenchmarkResult,
     BenchmarkRetrievalOptions,
     BenchmarkTask,
+    ComparisonLayerType,
     HeadToHeadManifest,
     Strategy,
     TaskCategory,
@@ -67,13 +68,62 @@ def _reject_empty_text(path: Path, field: str, value: str) -> None:
         raise HeadToHeadManifestError(f"Invalid head-to-head manifest in {path}: {field}: empty")
 
 
-def _reject_unpinned_version(path: Path, tool_name: str, version: str) -> None:
+def _reject_unpinned_version(path: Path, field: str, version: str) -> None:
     normalized = version.strip().lower()
     if normalized in {"", "latest", "head", "main", "operator-pinned"}:
         raise HeadToHeadManifestError(
-            f"Invalid head-to-head manifest in {path}: external_tools.{tool_name}.version "
-            "must pin an exact released version"
+            f"Invalid head-to-head manifest in {path}: {field} must pin an exact released version"
         )
+
+
+def _validate_archex_candidate_lanes(path: Path, manifest: HeadToHeadManifest) -> None:
+    seen: set[Strategy] = {manifest.archex.strategy}
+    for candidate in manifest.archex.candidate_strategies:
+        if not candidate.value.startswith("archex_query"):
+            raise HeadToHeadManifestError(
+                f"Invalid head-to-head manifest in {path}: archex.candidate_strategies entry "
+                f"{candidate.value!r} must be an archex_query lane"
+            )
+        if candidate in seen:
+            raise HeadToHeadManifestError(
+                f"Invalid head-to-head manifest in {path}: archex.candidate_strategies repeats "
+                f"lane {candidate.value!r}"
+            )
+        seen.add(candidate)
+
+
+def _validate_compression_layers(path: Path, manifest: HeadToHeadManifest) -> None:
+    seen: set[str] = set()
+    for layer in manifest.compression_layers:
+        _reject_empty_text(path, f"compression_layers.{layer.name}.name", layer.name)
+        _reject_empty_text(path, f"compression_layers.{layer.name}.command", layer.command)
+        _reject_unpinned_version(path, f"compression_layers.{layer.name}.version", layer.version)
+        if layer.layer_type is not ComparisonLayerType.COMPRESSION:
+            raise HeadToHeadManifestError(
+                f"Invalid head-to-head manifest in {path}: "
+                f"compression_layers.{layer.name}.layer_type must be compression"
+            )
+        if not layer.modes:
+            raise HeadToHeadManifestError(
+                f"Invalid head-to-head manifest in {path}: "
+                f"compression_layers.{layer.name}.modes must not be empty"
+            )
+        if len(set(layer.modes)) != len(layer.modes):
+            raise HeadToHeadManifestError(
+                f"Invalid head-to-head manifest in {path}: "
+                f"compression_layers.{layer.name}.modes contains duplicates"
+            )
+        if layer.artifact_dir is not None and not layer.artifact_dir.strip():
+            raise HeadToHeadManifestError(
+                f"Invalid head-to-head manifest in {path}: "
+                f"compression_layers.{layer.name}.artifact_dir must not be empty"
+            )
+        if layer.name in seen:
+            raise HeadToHeadManifestError(
+                f"Invalid head-to-head manifest in {path}: "
+                f"duplicate compression layer {layer.name!r}"
+            )
+        seen.add(layer.name)
 
 
 def _validate_manifest_shape(path: Path, manifest: HeadToHeadManifest) -> None:
@@ -112,12 +162,19 @@ def _validate_manifest_shape(path: Path, manifest: HeadToHeadManifest) -> None:
         _reject_empty_text(path, f"external_tools.{tool.name}.name", tool.name)
         _reject_empty_text(path, f"external_tools.{tool.name}.command", tool.command)
         _reject_empty_text(path, f"external_tools.{tool.name}.embedder", tool.embedder)
-        _reject_unpinned_version(path, tool.name, tool.version)
+        _reject_unpinned_version(path, f"external_tools.{tool.name}.version", tool.version)
+        if tool.layer_type is not ComparisonLayerType.RETRIEVAL:
+            raise HeadToHeadManifestError(
+                f"Invalid head-to-head manifest in {path}: external_tools.{tool.name}.layer_type "
+                "must be retrieval; model compression tools under compression_layers"
+            )
         if tool.name in seen_tools:
             raise HeadToHeadManifestError(
                 f"Invalid head-to-head manifest in {path}: duplicate external tool {tool.name!r}"
             )
         seen_tools.add(tool.name)
+    _validate_archex_candidate_lanes(path, manifest)
+    _validate_compression_layers(path, manifest)
 
 
 def load_headtohead_manifest(path: Path) -> HeadToHeadManifest:
@@ -125,6 +182,25 @@ def load_headtohead_manifest(path: Path) -> HeadToHeadManifest:
     manifest = _validate_yaml_model(path, HeadToHeadManifest)
     _validate_manifest_shape(path, manifest)
     return manifest
+
+
+def comparison_lane_layers(manifest: HeadToHeadManifest) -> dict[str, ComparisonLayerType]:
+    """Map each modeled comparison lane label to its layer type.
+
+    Distinguishes retrieval engines (archex default + candidate lanes, external
+    retrieval tools) from compression layers (Headroom modes) and the raw baseline,
+    so reports never present a compression layer as a retrieval engine.
+    """
+    layers: dict[str, ComparisonLayerType] = {"archex": ComparisonLayerType.RETRIEVAL}
+    for candidate in manifest.archex.candidate_strategies:
+        layers[candidate.value] = ComparisonLayerType.RETRIEVAL
+    for tool in manifest.external_tools:
+        layers[tool.name] = tool.layer_type
+    for layer in manifest.compression_layers:
+        for mode in layer.modes:
+            layers[mode.value] = layer.layer_type
+    layers["raw-ripgrep/read"] = ComparisonLayerType.BASELINE
+    return layers
 
 
 def select_headtohead_tasks(

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -262,6 +262,32 @@ class BenchmarkRetrievalOptions(BaseModel):
     summary_sidecar_path: str | None = None
 
 
+class ComparisonLayerType(StrEnum):
+    """Where a comparison lane operates.
+
+    ``retrieval`` lanes are retrieval/selection engines (archex, cocoindex-code).
+    ``compression`` lanes are post-selection context-management layers (Headroom);
+    they are not retrieval engines and the comparison must label the difference.
+    ``baseline`` is the raw filesystem read/grep lane.
+    """
+
+    RETRIEVAL = "retrieval"
+    COMPRESSION = "compression"
+    BASELINE = "baseline"
+
+
+class CompressionLayerMode(StrEnum):
+    """How a compression layer is composed with retrieval in the comparison.
+
+    ``headroom_only_on_raw_context`` compresses raw/broad context with no archex
+    selection (does compression alone rescue broad context?). ``archex_plus_headroom``
+    compresses an archex-selected bundle after selection (is the pair composable?).
+    """
+
+    HEADROOM_ONLY_ON_RAW_CONTEXT = "headroom_only_on_raw_context"
+    ARCHEX_PLUS_HEADROOM = "archex_plus_headroom"
+
+
 class ExternalToolCommandConfig(BenchmarkSpecModel):
     command: str
     args: list[str] = []
@@ -274,6 +300,10 @@ class ExternalToolBenchmarkConfig(BenchmarkSpecModel):
     command: str
     args: list[str] = []
     embedder: str
+    # External MCP tools modeled here are retrieval/selection engines. The layer
+    # type is explicit metadata so reports never frame a retrieval engine and a
+    # compression layer as the same kind of system.
+    layer_type: ComparisonLayerType = ComparisonLayerType.RETRIEVAL
     cwd: str | None = None
     env: dict[str, str] = {}
     search_tool: str = "search"
@@ -287,8 +317,38 @@ class ExternalToolBenchmarkConfig(BenchmarkSpecModel):
     bootstrap_commands: list[ExternalToolCommandConfig] = []
 
 
+class CompressionLayerConfig(BenchmarkSpecModel):
+    """A post-selection compression layer (Headroom-style) in the comparison.
+
+    This is a compression/context-management layer, not a retrieval engine, so
+    ``layer_type`` defaults to ``compression`` and the manifest validator rejects
+    any other value. ``artifact_dir`` selects artifact-adapter mode: operator-run
+    compression outputs are imported instead of running the binary in-session.
+    """
+
+    name: str
+    version: str
+    command: str
+    args: list[str] = []
+    layer_type: ComparisonLayerType = ComparisonLayerType.COMPRESSION
+    modes: list[CompressionLayerMode] = Field(
+        default_factory=lambda: [
+            CompressionLayerMode.HEADROOM_ONLY_ON_RAW_CONTEXT,
+            CompressionLayerMode.ARCHEX_PLUS_HEADROOM,
+        ]
+    )
+    compression_settings: dict[str, str] = {}
+    env: dict[str, str] = {}
+    timeout_seconds: float = 120.0
+    artifact_dir: str | None = None
+
+
 class HeadToHeadArchexConfig(BenchmarkSpecModel):
     strategy: Strategy = Strategy.ARCHEX_QUERY
+    # Improved/benchmark-only archex lanes compared beside the current default
+    # (e.g. archex_query_compressed, archex_query_efficiency_packed). Empty keeps
+    # the historical single-lane behavior.
+    candidate_strategies: list[Strategy] = []
     embedder: str = "jina-v2"
     local_models_only: bool = True
 
@@ -301,6 +361,7 @@ class HeadToHeadManifest(BenchmarkSpecModel):
     archex: HeadToHeadArchexConfig = Field(default_factory=HeadToHeadArchexConfig)
     raw_read_strategy: Strategy = Strategy.RAW_RIPGREP
     external_tools: list[ExternalToolBenchmarkConfig]
+    compression_layers: list[CompressionLayerConfig] = []
 
 
 class TaskCompletionResult(StrEnum):

--- a/tests/benchmark/test_headtohead.py
+++ b/tests/benchmark/test_headtohead.py
@@ -8,9 +8,11 @@ import pytest
 
 from archex.benchmark.headtohead import (
     HeadToHeadManifestError,
+    comparison_lane_layers,
     load_headtohead_manifest,
     load_headtohead_tasks,
 )
+from archex.benchmark.models import ComparisonLayerType
 
 
 def _write_task(path: Path, task_id: str, repo: str, category: str) -> None:
@@ -28,8 +30,17 @@ expected_files:
     )
 
 
-def _manifest_text(task_subset: list[str]) -> str:
+def _manifest_text(
+    task_subset: list[str],
+    *,
+    candidate_strategies: list[str] | None = None,
+    extra: str = "",
+) -> str:
     tasks_yaml = "\n".join(f"  - {task_id}" for task_id in task_subset)
+    candidates_yaml = ""
+    if candidate_strategies:
+        rendered = "\n".join(f"    - {name}" for name in candidate_strategies)
+        candidates_yaml = f"  candidate_strategies:\n{rendered}\n"
     return f"""\
 manifest_version: 1
 name: public-c1-comparison
@@ -38,7 +49,7 @@ task_subset:
 {tasks_yaml}
 archex:
   strategy: archex_query
-  embedder: jina-v2
+{candidates_yaml}  embedder: jina-v2
   local_models_only: true
 external_tools:
   - name: ccc
@@ -52,6 +63,20 @@ external_tools:
       - command: ccc
         args: [index]
 raw_read_strategy: raw_ripgrep
+{extra}"""
+
+
+_HEADROOM_LAYER_YAML = """\
+compression_layers:
+  - name: headroom
+    version: "0.4.1"
+    command: headroom
+    args: [compress]
+    modes:
+      - headroom_only_on_raw_context
+      - archex_plus_headroom
+    compression_settings:
+      profile: balanced
 """
 
 
@@ -111,3 +136,129 @@ def test_load_headtohead_tasks_rejects_self_repo_subset(tmp_path: Path) -> None:
 
     with pytest.raises(HeadToHeadManifestError, match="exclude self-repo"):
         load_headtohead_tasks(manifest_path, tasks_dir)
+
+
+def test_load_headtohead_manifest_accepts_pinned_compression_layer(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(
+        _manifest_text(["external_task"], extra=_HEADROOM_LAYER_YAML),
+        encoding="utf-8",
+    )
+
+    manifest = load_headtohead_manifest(manifest_path)
+
+    assert manifest.external_tools[0].layer_type is ComparisonLayerType.RETRIEVAL
+    layer = manifest.compression_layers[0]
+    assert layer.name == "headroom"
+    assert layer.version == "0.4.1"
+    assert layer.layer_type is ComparisonLayerType.COMPRESSION
+    assert layer.compression_settings == {"profile": "balanced"}
+
+
+def test_load_headtohead_manifest_rejects_unpinned_compression_version(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(
+        _manifest_text(
+            ["external_task"],
+            extra=_HEADROOM_LAYER_YAML.replace('version: "0.4.1"', "version: latest"),
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        HeadToHeadManifestError,
+        match="compression_layers.headroom.version must pin an exact released version",
+    ):
+        load_headtohead_manifest(manifest_path)
+
+
+def test_load_headtohead_manifest_rejects_compression_layer_labeled_retrieval(
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(
+        _manifest_text(
+            ["external_task"],
+            extra=_HEADROOM_LAYER_YAML.replace(
+                "    command: headroom\n",
+                "    command: headroom\n    layer_type: retrieval\n",
+            ),
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        HeadToHeadManifestError,
+        match="compression_layers.headroom.layer_type must be compression",
+    ):
+        load_headtohead_manifest(manifest_path)
+
+
+def test_load_headtohead_manifest_rejects_external_tool_labeled_compression(
+    tmp_path: Path,
+) -> None:
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(
+        _manifest_text(["external_task"]).replace(
+            "    command: ccc\n",
+            "    command: ccc\n    layer_type: compression\n",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        HeadToHeadManifestError,
+        match="external_tools.ccc.layer_type must be retrieval",
+    ):
+        load_headtohead_manifest(manifest_path)
+
+
+def test_load_headtohead_manifest_accepts_archex_candidate_lanes(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(
+        _manifest_text(
+            ["external_task"],
+            candidate_strategies=["archex_query_compressed", "archex_query_efficiency_packed"],
+        ),
+        encoding="utf-8",
+    )
+
+    manifest = load_headtohead_manifest(manifest_path)
+
+    assert [s.value for s in manifest.archex.candidate_strategies] == [
+        "archex_query_compressed",
+        "archex_query_efficiency_packed",
+    ]
+
+
+def test_load_headtohead_manifest_rejects_non_archex_candidate(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(
+        _manifest_text(["external_task"], candidate_strategies=["raw_ripgrep"]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(HeadToHeadManifestError, match="must be an archex_query lane"):
+        load_headtohead_manifest(manifest_path)
+
+
+def test_comparison_lane_layers_labels_each_lane(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.yaml"
+    manifest_path.write_text(
+        _manifest_text(
+            ["external_task"],
+            candidate_strategies=["archex_query_compressed"],
+            extra=_HEADROOM_LAYER_YAML,
+        ),
+        encoding="utf-8",
+    )
+
+    layers = comparison_lane_layers(load_headtohead_manifest(manifest_path))
+
+    assert layers["archex"] is ComparisonLayerType.RETRIEVAL
+    assert layers["archex_query_compressed"] is ComparisonLayerType.RETRIEVAL
+    assert layers["ccc"] is ComparisonLayerType.RETRIEVAL
+    assert layers["headroom_only_on_raw_context"] is ComparisonLayerType.COMPRESSION
+    assert layers["archex_plus_headroom"] is ComparisonLayerType.COMPRESSION
+    assert layers["raw-ripgrep/read"] is ComparisonLayerType.BASELINE


### PR DESCRIPTION
## Stack

Stack-Id: `competitive-comparison-8da6d1`
Base: `main`
Position: 1/5

1. `bench/competitive-manifest-lanes` -> this PR (#313)
2. `bench/headroom-compression-adapter` -> #314
3. `bench/competitive-report` -> #315
4. `bench/competitive-artifact-refresh` -> #316
5. `bench/competitive-docs` -> #317

Depends on: (none - root)
Upstack: #314

## Summary

Model competitive comparison lanes in the head-to-head manifest.

- add explicit comparison lane metadata: `retrieval`, `compression`, `baseline`
- add benchmark-only archex candidate lanes to the manifest model
- add `compression_layers` for Headroom-style lanes with pinned version validation
- reject unpinned versions, mislabeled layers, and non-archex candidate lanes

## Validation

- `uv run pytest tests/benchmark/test_headtohead.py tests/benchmark/test_headtohead_report.py -q`
- `uv run ruff check src/archex/benchmark/models.py src/archex/benchmark/headtohead.py tests/benchmark/test_headtohead.py`
- `uv run ruff format --check src/archex/benchmark/models.py src/archex/benchmark/headtohead.py tests/benchmark/test_headtohead.py`
- `uv run pyright src/archex/benchmark/models.py src/archex/benchmark/headtohead.py tests/benchmark/test_headtohead.py`
- `uv run python -c "from pathlib import Path; from archex.benchmark.headtohead import load_headtohead_manifest, comparison_lane_layers; m=load_headtohead_manifest(Path('benchmarks/headtohead/manifest.yaml')); print(m.name, comparison_lane_layers(m))"`
