### PR TITLE
Add Headroom compression-layer benchmark adapter

### DIFF
--- a/src/archex/benchmark/headroom.py
+++ b/src/archex/benchmark/headroom.py
@@ -1,0 +1,232 @@
+"""Headroom-style compression-layer adapter for the public comparison.
+
+Headroom is a context-compression / context-management layer, not a retrieval
+engine. This adapter applies a configured compression command to already-gathered
+context — either an archex-selected bundle (``archex_plus_headroom``) or raw/broad
+context (``headroom_only_on_raw_context``) — and records compression provenance.
+It never reframes Headroom as a retrieval system; ``CompressionLayerResult``
+fixes ``layer_type`` to ``compression`` and records which lane produced the source.
+
+Two run modes:
+
+* local — run the pinned binary on the source text and measure the result. Fails
+  with :class:`HeadroomUnavailableError` when the binary is absent, so an unavailable
+  tool is never silently skipped.
+* artifact — import operator-produced compression outputs (JSON) with pinned
+  provenance. Selected by setting ``compression_layers[].artifact_dir``. This is
+  the only mode that runs without the binary present.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from shutil import which
+
+from pydantic import Field, ValidationError
+
+from archex.benchmark.models import (
+    BenchmarkSpecModel,
+    ComparisonLayerType,
+    CompressionLayerConfig,
+    CompressionLayerMode,
+    CompressionLayerResult,
+)
+from archex.reporting import count_tokens
+
+
+class HeadroomUnavailableError(RuntimeError):
+    """Raised when a local compression-layer binary is required but not found."""
+
+
+class HeadroomAdapterError(RuntimeError):
+    """Raised when a compression-layer run or artifact cannot produce a result."""
+
+
+class HeadroomArtifactMode(BenchmarkSpecModel):
+    """One mode entry inside an operator-produced compression artifact."""
+
+    source_lane: str
+    source_passthrough: bool
+    bundle_tokens_uncompressed: int = Field(ge=0)
+    bundle_tokens_compressed: int = Field(ge=0)
+    command: str
+    compression_settings: dict[str, str] = {}
+
+
+class HeadroomArtifact(BenchmarkSpecModel):
+    """Schema for an operator-produced ``{task_id}.json`` compression artifact."""
+
+    task_id: str
+    headroom_version: str
+    modes: dict[CompressionLayerMode, HeadroomArtifactMode]
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _render_settings(settings: dict[str, str]) -> str:
+    return ";".join(f"{key}={settings[key]}" for key in sorted(settings))
+
+
+def _compression_ratio(uncompressed: int, compressed: int) -> float:
+    return (compressed / uncompressed) if uncompressed else 1.0
+
+
+def apply_headroom_layer_local(
+    config: CompressionLayerConfig,
+    mode: CompressionLayerMode,
+    *,
+    task_id: str,
+    source_lane: str,
+    source_text: str,
+) -> CompressionLayerResult:
+    """Run the pinned compression binary on ``source_text`` and measure the result.
+
+    Source text is fed on stdin; compressed text is read from stdout. Raises
+    :class:`HeadroomUnavailableError` when the binary is not on PATH so an unavailable
+    tool is reported, never silently skipped.
+    """
+    if which(config.command) is None:
+        raise HeadroomUnavailableError(
+            f"compression layer {config.name!r} command {config.command!r} not found; "
+            "set compression_layers[].artifact_dir to import operator artifacts instead"
+        )
+
+    command = [config.command, *config.args]
+    try:
+        completed = subprocess.run(
+            command,
+            input=source_text,
+            env={**os.environ, **config.env} if config.env else None,
+            capture_output=True,
+            text=True,
+            timeout=config.timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise HeadroomAdapterError(
+            f"compression layer {config.name!r} timed out after {config.timeout_seconds}s"
+        ) from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "no output"
+        raise HeadroomAdapterError(
+            f"compression layer {config.name!r} failed with exit {completed.returncode}: {detail}"
+        )
+
+    uncompressed = count_tokens(source_text)
+    compressed = count_tokens(completed.stdout)
+    return CompressionLayerResult(
+        task_id=task_id,
+        lane_label=mode.value,
+        layer_type=ComparisonLayerType.COMPRESSION,
+        mode=mode,
+        source_lane=source_lane,
+        source_passthrough=compressed >= uncompressed,
+        bundle_tokens_uncompressed=uncompressed,
+        bundle_tokens_compressed=compressed,
+        bundle_compression_ratio=_compression_ratio(uncompressed, compressed),
+        provenance={
+            "layer": config.name,
+            "version": config.version,
+            "command": " ".join(command),
+            "mode": mode.value,
+            "source_lane": source_lane,
+            "compression_settings": _render_settings(config.compression_settings),
+            "run_mode": "local",
+        },
+        timestamp=_now_iso(),
+    )
+
+
+def load_headroom_artifact(
+    config: CompressionLayerConfig,
+    mode: CompressionLayerMode,
+    *,
+    task_id: str,
+    artifact_dir: Path,
+) -> CompressionLayerResult:
+    """Import an operator-produced compression artifact for one task/mode.
+
+    The artifact's ``headroom_version`` must match the manifest-pinned version so
+    imported numbers carry pinned provenance. Records the artifact path and its
+    SHA-256 so the source of every imported number is traceable.
+    """
+    artifact_path = artifact_dir / f"{task_id}.json"
+    if not artifact_path.is_file():
+        raise HeadroomAdapterError(
+            f"compression layer {config.name!r} artifact not found: {artifact_path}"
+        )
+    raw = artifact_path.read_bytes()
+    try:
+        artifact = HeadroomArtifact.model_validate_json(raw)
+    except ValidationError as exc:
+        raise HeadroomAdapterError(
+            f"compression layer {config.name!r} artifact {artifact_path} is invalid: {exc}"
+        ) from exc
+
+    if artifact.headroom_version != config.version:
+        raise HeadroomAdapterError(
+            f"compression layer {config.name!r} artifact {artifact_path} version "
+            f"{artifact.headroom_version!r} does not match pinned version {config.version!r}"
+        )
+    if mode not in artifact.modes:
+        raise HeadroomAdapterError(
+            f"compression layer {config.name!r} artifact {artifact_path} is missing mode "
+            f"{mode.value!r}"
+        )
+
+    entry = artifact.modes[mode]
+    digest = hashlib.sha256(raw).hexdigest()
+    settings = _render_settings(entry.compression_settings)
+    return CompressionLayerResult(
+        task_id=task_id,
+        lane_label=mode.value,
+        layer_type=ComparisonLayerType.COMPRESSION,
+        mode=mode,
+        source_lane=entry.source_lane,
+        source_passthrough=entry.source_passthrough,
+        bundle_tokens_uncompressed=entry.bundle_tokens_uncompressed,
+        bundle_tokens_compressed=entry.bundle_tokens_compressed,
+        bundle_compression_ratio=_compression_ratio(
+            entry.bundle_tokens_uncompressed, entry.bundle_tokens_compressed
+        ),
+        provenance={
+            "layer": config.name,
+            "version": config.version,
+            "command": entry.command,
+            "mode": mode.value,
+            "source_lane": entry.source_lane,
+            "compression_settings": settings,
+            "run_mode": "artifact",
+            "artifact_path": str(artifact_path),
+            "artifact_sha256": digest,
+        },
+        timestamp=_now_iso(),
+    )
+
+
+def run_compression_layer(
+    config: CompressionLayerConfig,
+    mode: CompressionLayerMode,
+    *,
+    task_id: str,
+    source_lane: str,
+    source_text: str,
+) -> CompressionLayerResult:
+    """Produce a compression-layer result, choosing artifact or local mode.
+
+    Artifact mode is used when ``config.artifact_dir`` is set; otherwise the local
+    binary is required. ``source_text`` is ignored in artifact mode.
+    """
+    if config.artifact_dir is not None:
+        return load_headroom_artifact(
+            config, mode, task_id=task_id, artifact_dir=Path(config.artifact_dir)
+        )
+    return apply_headroom_layer_local(
+        config, mode, task_id=task_id, source_lane=source_lane, source_text=source_text
+    )

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -489,6 +489,30 @@ class BenchmarkReport(BaseModel):
     p95_latency_ms: float = 0.0
 
 
+class CompressionLayerResult(BaseModel):
+    """Result of applying a compression layer (Headroom-style) to a lane's context.
+
+    A compression layer is not a retrieval engine: ``layer_type`` is fixed to
+    ``compression`` and ``source_lane`` records which retrieval/baseline lane
+    produced the context that was compressed. ``source_passthrough`` records
+    whether the layer protected (passed through) the source/RAG content rather
+    than compressing it. Reuses the bundle compression-token fields so reports
+    can show compression ratio beside the retrieval lanes' token efficiency.
+    """
+
+    task_id: str
+    lane_label: str
+    layer_type: ComparisonLayerType = ComparisonLayerType.COMPRESSION
+    mode: CompressionLayerMode
+    source_lane: str
+    source_passthrough: bool
+    bundle_tokens_uncompressed: int
+    bundle_tokens_compressed: int
+    bundle_compression_ratio: float
+    provenance: dict[str, str] = {}
+    timestamp: str
+
+
 # ---------------------------------------------------------------------------
 # Delta benchmarking models
 # ---------------------------------------------------------------------------

--- a/tests/benchmark/test_headroom.py
+++ b/tests/benchmark/test_headroom.py
@@ -1,0 +1,207 @@
+"""Tests for the Headroom-style compression-layer adapter."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from archex.benchmark.headroom import (
+    HeadroomAdapterError,
+    HeadroomUnavailableError,
+    apply_headroom_layer_local,
+    load_headroom_artifact,
+    run_compression_layer,
+)
+from archex.benchmark.models import (
+    ComparisonLayerType,
+    CompressionLayerConfig,
+    CompressionLayerMode,
+)
+
+_COMPRESS_SCRIPT = """\
+import sys
+
+text = sys.stdin.read()
+lines = [line for line in text.splitlines() if line.strip()]
+kept = lines[: max(1, len(lines) // 2)]
+sys.stdout.write("\\n".join(kept))
+"""
+
+_PASSTHROUGH_SCRIPT = "import sys; sys.stdout.write(sys.stdin.read())"
+
+_SOURCE_TEXT = "\n".join(f"line {n} with content tokens here" for n in range(40))
+
+
+def _local_config(
+    script_path: Path, *, settings: dict[str, str] | None = None
+) -> CompressionLayerConfig:
+    return CompressionLayerConfig(
+        name="headroom",
+        version="0.4.1",
+        command=sys.executable,
+        args=[str(script_path)],
+        compression_settings=settings or {"profile": "balanced"},
+    )
+
+
+def _write_artifact(artifact_dir: Path, *, version: str = "0.4.1") -> Path:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "task_id": "task_a",
+        "headroom_version": version,
+        "modes": {
+            "archex_plus_headroom": {
+                "source_lane": "archex",
+                "source_passthrough": True,
+                "bundle_tokens_uncompressed": 1000,
+                "bundle_tokens_compressed": 1000,
+                "command": "headroom compress --profile balanced",
+                "compression_settings": {"profile": "balanced"},
+            },
+            "headroom_only_on_raw_context": {
+                "source_lane": "raw_files",
+                "source_passthrough": False,
+                "bundle_tokens_uncompressed": 5000,
+                "bundle_tokens_compressed": 2000,
+                "command": "headroom compress --profile aggressive",
+                "compression_settings": {"profile": "aggressive"},
+            },
+        },
+    }
+    path = artifact_dir / "task_a.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_apply_headroom_layer_local_records_provenance_and_metadata(tmp_path: Path) -> None:
+    script = tmp_path / "compress.py"
+    script.write_text(_COMPRESS_SCRIPT, encoding="utf-8")
+    config = _local_config(script)
+
+    result = apply_headroom_layer_local(
+        config,
+        CompressionLayerMode.HEADROOM_ONLY_ON_RAW_CONTEXT,
+        task_id="task_a",
+        source_lane="raw_files",
+        source_text=_SOURCE_TEXT,
+    )
+
+    assert result.lane_label == "headroom_only_on_raw_context"
+    assert result.layer_type is ComparisonLayerType.COMPRESSION
+    assert result.source_lane == "raw_files"
+    assert result.bundle_tokens_compressed < result.bundle_tokens_uncompressed
+    assert result.bundle_compression_ratio < 1.0
+    assert result.source_passthrough is False
+    assert result.provenance["version"] == "0.4.1"
+    assert result.provenance["run_mode"] == "local"
+    assert result.provenance["compression_settings"] == "profile=balanced"
+    assert script.name in result.provenance["command"]
+
+
+def test_apply_headroom_layer_local_marks_passthrough_when_unchanged(tmp_path: Path) -> None:
+    script = tmp_path / "passthrough.py"
+    script.write_text(_PASSTHROUGH_SCRIPT, encoding="utf-8")
+    config = _local_config(script)
+
+    result = apply_headroom_layer_local(
+        config,
+        CompressionLayerMode.ARCHEX_PLUS_HEADROOM,
+        task_id="task_a",
+        source_lane="archex",
+        source_text=_SOURCE_TEXT,
+    )
+
+    assert result.source_passthrough is True
+    assert result.bundle_compression_ratio == 1.0
+    assert result.bundle_tokens_compressed == result.bundle_tokens_uncompressed
+
+
+def test_apply_headroom_layer_local_raises_when_unavailable(tmp_path: Path) -> None:
+    config = CompressionLayerConfig(
+        name="headroom",
+        version="0.4.1",
+        command="archex-headroom-missing-binary",
+    )
+
+    with pytest.raises(HeadroomUnavailableError, match="not found"):
+        apply_headroom_layer_local(
+            config,
+            CompressionLayerMode.ARCHEX_PLUS_HEADROOM,
+            task_id="task_a",
+            source_lane="archex",
+            source_text=_SOURCE_TEXT,
+        )
+
+
+def test_run_compression_layer_uses_artifact_mode_without_binary(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "headroom-artifacts"
+    _write_artifact(artifact_dir)
+    config = CompressionLayerConfig(
+        name="headroom",
+        version="0.4.1",
+        command="archex-headroom-missing-binary",
+        artifact_dir=str(artifact_dir),
+    )
+
+    result = run_compression_layer(
+        config,
+        CompressionLayerMode.HEADROOM_ONLY_ON_RAW_CONTEXT,
+        task_id="task_a",
+        source_lane="ignored-in-artifact-mode",
+        source_text="ignored",
+    )
+
+    assert result.source_lane == "raw_files"
+    assert result.bundle_tokens_uncompressed == 5000
+    assert result.bundle_tokens_compressed == 2000
+    assert result.bundle_compression_ratio == pytest.approx(0.4)  # pyright: ignore[reportUnknownMemberType]
+    assert result.source_passthrough is False
+    assert result.provenance["run_mode"] == "artifact"
+    assert len(result.provenance["artifact_sha256"]) == 64
+    assert result.provenance["command"] == "headroom compress --profile aggressive"
+
+
+def test_load_headroom_artifact_rejects_version_mismatch(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "headroom-artifacts"
+    _write_artifact(artifact_dir, version="9.9.9")
+    config = CompressionLayerConfig(name="headroom", version="0.4.1", command="headroom")
+
+    with pytest.raises(HeadroomAdapterError, match="does not match pinned version"):
+        load_headroom_artifact(
+            config,
+            CompressionLayerMode.ARCHEX_PLUS_HEADROOM,
+            task_id="task_a",
+            artifact_dir=artifact_dir,
+        )
+
+
+def test_load_headroom_artifact_rejects_missing_mode(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "headroom-artifacts"
+    path = _write_artifact(artifact_dir)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    del payload["modes"]["archex_plus_headroom"]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    config = CompressionLayerConfig(name="headroom", version="0.4.1", command="headroom")
+
+    with pytest.raises(HeadroomAdapterError, match="missing mode 'archex_plus_headroom'"):
+        load_headroom_artifact(
+            config,
+            CompressionLayerMode.ARCHEX_PLUS_HEADROOM,
+            task_id="task_a",
+            artifact_dir=artifact_dir,
+        )
+
+
+def test_load_headroom_artifact_missing_file(tmp_path: Path) -> None:
+    config = CompressionLayerConfig(name="headroom", version="0.4.1", command="headroom")
+
+    with pytest.raises(HeadroomAdapterError, match="artifact not found"):
+        load_headroom_artifact(
+            config,
+            CompressionLayerMode.ARCHEX_PLUS_HEADROOM,
+            task_id="task_a",
+            artifact_dir=tmp_path / "missing",
+        )


### PR DESCRIPTION
## Stack

Stack-Id: `competitive-comparison-8da6d1`
Base: `main`
Position: 1/4

1. `bench/headroom-compression-adapter` -> this PR (#314)
2. `bench/competitive-report` -> #315
3. `bench/competitive-artifact-refresh` -> #316
4. `bench/competitive-docs` -> #317

Depends on: (none - root)
Upstack: #315

## Validation

- `uv run pytest tests/benchmark/test_headroom.py --no-cov -q`
- `uv run pytest tests/benchmark/test_headtohead.py tests/benchmark/test_headtohead_report.py --no-cov -q`
- `uv run ruff check src/archex/benchmark/models.py src/archex/benchmark/headroom.py tests/benchmark/test_headroom.py`
- `uv run ruff format --check src/archex/benchmark/models.py src/archex/benchmark/headroom.py tests/benchmark/test_headroom.py`
- `uv run pyright src/archex/benchmark/models.py src/archex/benchmark/headroom.py tests/benchmark/test_headroom.py`
