### PR TITLE
Add competitive comparison report (per-family and aggregate)

### DIFF
--- a/src/archex/benchmark/competitive.py
+++ b/src/archex/benchmark/competitive.py
@@ -1,0 +1,318 @@
+"""Competitive comparison report across retrieval, baseline, and compression lanes.
+
+Renders the public head-to-head comparison as per-repo/task-family tables plus an
+aggregate, never as an aggregate-only winner claim. Lanes are labeled by layer
+type so a Headroom-style compression layer is never presented as a retrieval
+engine: retrieval/baseline lanes fill the quality columns; compression lanes
+contribute a compression ratio and are explicitly marked ``compression``.
+"""
+
+from __future__ import annotations
+
+from archex.benchmark.headtohead import (
+    HeadToHeadManifestError,
+    comparison_lane_layers,
+    lane_label,
+    result_provenance,
+)
+from archex.benchmark.models import (
+    BenchmarkReport,
+    BenchmarkResult,
+    ComparisonLayerType,
+    CompressionLayerResult,
+    HeadToHeadManifest,
+    Strategy,
+)
+
+_METRIC_HEADER = (
+    "| Lane | Layer | Recall | Required-file recall | Region recall | Line recall | "
+    "Precision | Context noise | Token eff. (compl.) | Compression ratio | Receipt acc. | "
+    "Freshness correct | Cold-start ms | Warm p50 ms | Warm p95 ms |"
+)
+_METRIC_DIVIDER = "| " + " | ".join(["---"] * 15) + " |"
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * quantile
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
+def _num(value: float, *, digits: int = 2) -> str:
+    return f"{value:.{digits}f}"
+
+
+def _optional_mean(values: list[float | None], *, digits: int = 2) -> str:
+    present = [v for v in values if v is not None]
+    return _num(_mean(present), digits=digits) if present else "n/a"
+
+
+def _optional_rate(flags: list[bool | None]) -> str:
+    present = [1.0 if flag else 0.0 for flag in flags if flag is not None]
+    return _num(_mean(present)) if present else "n/a"
+
+
+def _gated_rate(flags: list[bool], measured: list[bool]) -> str:
+    present = [1.0 if flag else 0.0 for flag, ok in zip(flags, measured, strict=True) if ok]
+    return _num(_mean(present)) if present else "n/a"
+
+
+def _warm_latency(results: list[BenchmarkResult]) -> list[float]:
+    return [r.warm_latency_ms or r.wall_time_ms for r in results]
+
+
+def _retrieval_row(label: str, layer: ComparisonLayerType, results: list[BenchmarkResult]) -> str:
+    latencies = _warm_latency(results)
+    cells = [
+        label,
+        layer.value,
+        _num(_mean([r.recall for r in results])),
+        _num(_mean([r.required_file_recall for r in results])),
+        _optional_mean([r.region_recall for r in results]),
+        _optional_mean([r.line_recall for r in results]),
+        _num(_mean([r.precision for r in results])),
+        _optional_mean([r.context_noise_ratio for r in results]),
+        _num(_mean([r.token_efficiency_with_completion for r in results])),
+        _optional_mean([r.bundle_compression_ratio for r in results]),
+        _optional_rate([r.receipt_accuracy for r in results]),
+        _gated_rate(
+            [r.freshness_correct for r in results],
+            [r.freshness_measured for r in results],
+        ),
+        _num(_mean([r.cold_start_ms for r in results]), digits=0),
+        _num(_percentile(latencies, 0.50), digits=0),
+        _num(_percentile(latencies, 0.95), digits=0),
+    ]
+    return "| " + " | ".join(cells) + " |"
+
+
+def _compression_row(
+    label: str, layer: ComparisonLayerType, results: list[CompressionLayerResult]
+) -> str:
+    # Compression lanes are not retrieval engines: every retrieval-quality column
+    # is n/a; the lane contributes only a compression ratio.
+    cells = [
+        label,
+        layer.value,
+        *(["n/a"] * 7),
+        _num(_mean([r.bundle_compression_ratio for r in results])),
+        *(["n/a"] * 5),
+    ]
+    return "| " + " | ".join(cells) + " |"
+
+
+def _retrieval_lanes(
+    manifest: HeadToHeadManifest, reports: list[BenchmarkReport]
+) -> dict[str, list[BenchmarkResult]]:
+    comparison: set[Strategy] = {
+        Strategy.ARCHEX_QUERY,
+        Strategy.EXTERNAL_MCP,
+        manifest.raw_read_strategy,
+        *manifest.archex.candidate_strategies,
+    }
+    lanes: dict[str, list[BenchmarkResult]] = {}
+    for report in reports:
+        for result in report.results:
+            if result.strategy in comparison:
+                lanes.setdefault(lane_label(result), []).append(result)
+    return lanes
+
+
+def _compression_lanes(
+    results: list[CompressionLayerResult],
+) -> dict[str, list[CompressionLayerResult]]:
+    lanes: dict[str, list[CompressionLayerResult]] = {}
+    for result in results:
+        lanes.setdefault(result.lane_label, []).append(result)
+    return lanes
+
+
+def _ordered_retrieval_labels(
+    manifest: HeadToHeadManifest, lanes: dict[str, list[BenchmarkResult]]
+) -> list[str]:
+    preferred = ["archex", *(s.value for s in manifest.archex.candidate_strategies)]
+    preferred += [tool.name for tool in manifest.external_tools]
+    preferred.append("raw-ripgrep/read")
+    ordered = [label for label in preferred if label in lanes]
+    ordered += sorted(label for label in lanes if label not in preferred)
+    return ordered
+
+
+def _compression_provenance(results: list[CompressionLayerResult]) -> str:
+    provenance = results[0].provenance
+    layer = provenance.get("layer", "compression")
+    version = provenance.get("version", "")
+    source_lane = provenance.get("source_lane", "")
+    run_mode = provenance.get("run_mode", "")
+    return f"layer={layer}; version={version}; source_lane={source_lane}; run_mode={run_mode}"
+
+
+def _metric_table(
+    retrieval_order: list[str],
+    retrieval_lanes: dict[str, list[BenchmarkResult]],
+    layers: dict[str, ComparisonLayerType],
+    compression_order: list[str],
+    compression_lanes: dict[str, list[CompressionLayerResult]],
+) -> list[str]:
+    rows = [_METRIC_HEADER, _METRIC_DIVIDER]
+    for label in retrieval_order:
+        layer = layers.get(label, ComparisonLayerType.RETRIEVAL)
+        rows.append(_retrieval_row(label, layer, retrieval_lanes[label]))
+    for label in compression_order:
+        layer = layers.get(label, ComparisonLayerType.COMPRESSION)
+        rows.append(_compression_row(label, layer, compression_lanes[label]))
+    return rows
+
+
+def format_competitive_markdown(
+    manifest: HeadToHeadManifest,
+    reports: list[BenchmarkReport],
+    compression_results: list[CompressionLayerResult] | None = None,
+) -> str:
+    """Render the competitive comparison: per-repo/task-family tables plus aggregate.
+
+    ``compression_results`` carries optional Headroom-style compression lanes. The
+    report never emits a single aggregate-only winner; every lane and cell is shown.
+    """
+    if not reports:
+        return "No competitive benchmark results."
+
+    compression_results = compression_results or []
+    layers = comparison_lane_layers(manifest)
+    retrieval_lanes = _retrieval_lanes(manifest, reports)
+    compression_lanes = _compression_lanes(compression_results)
+    retrieval_order = _ordered_retrieval_labels(manifest, retrieval_lanes)
+    compression_order = [
+        label
+        for label in (mode.value for layer in manifest.compression_layers for mode in layer.modes)
+        if label in compression_lanes
+    ]
+    compression_order += sorted(
+        label for label in compression_lanes if label not in compression_order
+    )
+
+    required_lanes = {"archex", manifest.external_tools[0].name, "raw-ripgrep/read"}
+    missing_lanes = sorted(required_lanes.difference(retrieval_lanes))
+    if missing_lanes:
+        raise HeadToHeadManifestError(
+            "Competitive report is missing lane(s): " + ", ".join(missing_lanes)
+        )
+
+    task_repo = {report.task_id: report.repo for report in reports}
+    lines: list[str] = [
+        "# archex Competitive Comparison",
+        "",
+        f"Manifest: `{manifest.name}`",
+        f"Tasks: `{len(reports)}` external-repo tasks across "
+        f"`{len({report.repo for report in reports})}` repos",
+        f"Hardware notes: {manifest.hardware_notes}",
+        "",
+        "Headroom is evaluated as a compression / context-management layer, not a "
+        "retrieval engine. Compression lanes contribute a compression ratio only; "
+        "retrieval-quality columns are `n/a` for them.",
+        "",
+        "Metrics are reported per repo/task family and in aggregate. No aggregate-only "
+        "winner is claimed; every lane and cell is shown.",
+        "",
+        "## Lanes and layer types",
+        "",
+        "| Lane | Layer type | Provenance |",
+        "| --- | --- | --- |",
+    ]
+    for label in retrieval_order:
+        layer = layers.get(label, ComparisonLayerType.RETRIEVAL)
+        provenance = result_provenance(retrieval_lanes[label][0], manifest)
+        lines.append(f"| {label} | {layer.value} | {provenance} |")
+    for label in compression_order:
+        layer = layers.get(label, ComparisonLayerType.COMPRESSION)
+        provenance = _compression_provenance(compression_lanes[label])
+        lines.append(f"| {label} | {layer.value} | {provenance} |")
+
+    lines.extend(["", f"## Aggregate ({len(reports)} tasks)", ""])
+    lines.extend(
+        _metric_table(
+            retrieval_order, retrieval_lanes, layers, compression_order, compression_lanes
+        )
+    )
+
+    repos = sorted({report.repo for report in reports})
+    lines.extend(["", "## By repo / task family", ""])
+    for repo in repos:
+        repo_reports = [report for report in reports if report.repo == repo]
+        repo_retrieval = _retrieval_lanes(manifest, repo_reports)
+        repo_retrieval_order = _ordered_retrieval_labels(manifest, repo_retrieval)
+        repo_compression = _compression_lanes(
+            [r for r in compression_results if task_repo.get(r.task_id) == repo]
+        )
+        repo_compression_order = [label for label in compression_order if label in repo_compression]
+        lines.extend([f"### `{repo}` ({len(repo_reports)} tasks)", ""])
+        lines.extend(
+            _metric_table(
+                repo_retrieval_order,
+                repo_retrieval,
+                layers,
+                repo_compression_order,
+                repo_compression,
+            )
+        )
+        lines.append("")
+
+    lines.extend(_operational_dimensions(manifest, retrieval_order, compression_order, layers))
+    return "\n".join(lines)
+
+
+def _operational_dimensions(
+    manifest: HeadToHeadManifest,
+    retrieval_order: list[str],
+    compression_order: list[str],
+    layers: dict[str, ComparisonLayerType],
+) -> list[str]:
+    tool_by_name = {tool.name: tool for tool in manifest.external_tools}
+    lines = [
+        "## Operational dimensions",
+        "",
+        "| Lane | Layer | Local/offline posture | Setup steps | Embedder |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for label in retrieval_order:
+        layer = layers.get(label, ComparisonLayerType.RETRIEVAL)
+        if label == "archex":
+            posture = "local models only" if manifest.archex.local_models_only else "configurable"
+            steps = "index build"
+            embedder = manifest.archex.embedder
+        elif label == "raw-ripgrep/read":
+            posture = "local files only"
+            steps = "none"
+            embedder = "n/a"
+        elif label in tool_by_name:
+            tool = tool_by_name[label]
+            posture = f"operator-configured (embedder={tool.embedder})"
+            steps = f"{len(tool.bootstrap_commands)} bootstrap command(s)"
+            embedder = tool.embedder
+        else:
+            posture = "local models only"
+            steps = "index build"
+            embedder = manifest.archex.embedder
+        lines.append(f"| {label} | {layer.value} | {posture} | {steps} | {embedder} |")
+    for label in compression_order:
+        layer = layers.get(label, ComparisonLayerType.COMPRESSION)
+        lines.append(f"| {label} | {layer.value} | post-selection compression layer | n/a | n/a |")
+    lines.extend(
+        [
+            "",
+            "Language coverage and qualitative operational complexity are documented in "
+            "`docs/ARCHEX_VS_COCOINDEX.md`; they are not claimed as benchmark numbers here.",
+        ]
+    )
+    return lines

--- a/src/archex/benchmark/competitive.py
+++ b/src/archex/benchmark/competitive.py
@@ -175,6 +175,13 @@ def _metric_table(
     return rows
 
 
+def _task_family(report: BenchmarkReport) -> str:
+    for result in report.results:
+        if result.category is not None:
+            return result.category.value
+    return "unknown"
+
+
 def format_competitive_markdown(
     manifest: HeadToHeadManifest,
     reports: list[BenchmarkReport],
@@ -246,8 +253,34 @@ def format_competitive_markdown(
         )
     )
 
+    task_family = {report.task_id: _task_family(report) for report in reports}
+
+    families = sorted({task_family[report.task_id] for report in reports})
+    lines.extend(["", "## By task family", ""])
+    for family in families:
+        family_reports = [report for report in reports if task_family[report.task_id] == family]
+        family_retrieval = _retrieval_lanes(manifest, family_reports)
+        family_retrieval_order = _ordered_retrieval_labels(manifest, family_retrieval)
+        family_compression = _compression_lanes(
+            [r for r in compression_results if task_family.get(r.task_id) == family]
+        )
+        family_compression_order = [
+            label for label in compression_order if label in family_compression
+        ]
+        lines.extend([f"### `{family}` ({len(family_reports)} tasks)", ""])
+        lines.extend(
+            _metric_table(
+                family_retrieval_order,
+                family_retrieval,
+                layers,
+                family_compression_order,
+                family_compression,
+            )
+        )
+        lines.append("")
+
     repos = sorted({report.repo for report in reports})
-    lines.extend(["", "## By repo / task family", ""])
+    lines.extend(["", "## By repo", ""])
     for repo in repos:
         repo_reports = [report for report in reports if report.repo == repo]
         repo_retrieval = _retrieval_lanes(manifest, repo_reports)

--- a/src/archex/benchmark/headtohead.py
+++ b/src/archex/benchmark/headtohead.py
@@ -288,7 +288,7 @@ def load_headtohead_results(input_dir: Path) -> list[BenchmarkReport]:
     return reports
 
 
-def _lane_label(result: BenchmarkResult) -> str:
+def lane_label(result: BenchmarkResult) -> str:
     if result.strategy is Strategy.ARCHEX_QUERY:
         return "archex"
     if result.strategy is Strategy.RAW_RIPGREP:
@@ -298,7 +298,7 @@ def _lane_label(result: BenchmarkResult) -> str:
     return result.strategy.value
 
 
-def _result_provenance(result: BenchmarkResult, manifest: HeadToHeadManifest) -> str:
+def result_provenance(result: BenchmarkResult, manifest: HeadToHeadManifest) -> str:
     if result.strategy is Strategy.ARCHEX_QUERY:
         return f"manifest={manifest.name}; lane=archex; embedder={manifest.archex.embedder}"
     if result.strategy is Strategy.RAW_RIPGREP:
@@ -341,7 +341,7 @@ def _results_by_lane(
     for report in reports:
         for result in report.results:
             if result.strategy in HEADTOHEAD_REPORT_STRATEGIES:
-                lanes.setdefault(_lane_label(result), []).append(result)
+                lanes.setdefault(lane_label(result), []).append(result)
     return lanes
 
 
@@ -379,7 +379,7 @@ def format_headtohead_markdown(
 
     for lane in sorted(lanes):
         results = lanes[lane]
-        provenance = _result_provenance(results[0], manifest) + f"; tasks={len(results)}"
+        provenance = result_provenance(results[0], manifest) + f"; tasks={len(results)}"
         lines.append(
             "| "
             + " | ".join(

--- a/src/archex/benchmark/headtohead.py
+++ b/src/archex/benchmark/headtohead.py
@@ -304,6 +304,13 @@ def result_provenance(result: BenchmarkResult, manifest: HeadToHeadManifest) -> 
     if result.strategy is Strategy.RAW_RIPGREP:
         version = result.provenance.get("rg_version", "")
         return f"manifest={manifest.name}; lane=raw-ripgrep/read; rg={version}"
+    if result.strategy is not Strategy.EXTERNAL_MCP and result.strategy.value.startswith(
+        "archex_query"
+    ):
+        return (
+            f"manifest={manifest.name}; lane={result.strategy.value}; "
+            f"embedder={manifest.archex.embedder}"
+        )
     tool = result.provenance.get("external_tool", result.strategy_label or "external")
     version = result.provenance.get("external_tool_version", "")
     embedder = result.provenance.get("external_tool_embedder", "")

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -17,6 +17,7 @@ from archex.benchmark.arch_quality import (
 )
 from archex.benchmark.baseline import compare_baseline, load_baseline, save_baseline
 from archex.benchmark.bundle_eval import BundleOnlyEvaluatorError, run_bundle_only_eval_all
+from archex.benchmark.competitive import format_competitive_markdown
 from archex.benchmark.delta_runner import run_all_delta
 from archex.benchmark.gate import (
     DeltaQualityThresholds,
@@ -1023,6 +1024,41 @@ def headtohead_report_cmd(input_dir: str, output_format: str) -> None:
         raise click.ClickException(f"No result files found in {input_dir}")
     try:
         click.echo(format_headtohead_markdown(manifest, reports))
+    except HeadToHeadManifestError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@headtohead_cmd.command("competitive")
+@click.option(
+    "--input",
+    "input_dir",
+    default=".archex/headtohead",
+    type=click.Path(exists=True, file_okay=False),
+    show_default=True,
+    help="Directory containing head-to-head result JSON files.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="markdown",
+    type=click.Choice(["markdown"]),
+    show_default=True,
+    help="Report format.",
+)
+def headtohead_competitive_cmd(input_dir: str, output_format: str) -> None:
+    """Render the competitive comparison report (per repo/task family plus aggregate)."""
+    del output_format
+    input_path = Path(input_dir)
+    manifest_path = input_path / "manifest.yaml"
+    try:
+        manifest = load_headtohead_manifest(manifest_path)
+    except (FileNotFoundError, HeadToHeadManifestError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    reports = load_headtohead_results(input_path)
+    if not reports:
+        raise click.ClickException(f"No result files found in {input_dir}")
+    try:
+        click.echo(format_competitive_markdown(manifest, reports))
     except HeadToHeadManifestError as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/tests/benchmark/test_competitive_report.py
+++ b/tests/benchmark/test_competitive_report.py
@@ -16,6 +16,7 @@ from archex.benchmark.models import (
     HeadToHeadArchexConfig,
     HeadToHeadManifest,
     Strategy,
+    TaskCategory,
 )
 
 
@@ -46,6 +47,7 @@ def _result(
     label: str | None = None,
     region_recall: float | None = None,
     compression_ratio: float | None = None,
+    category: TaskCategory | None = TaskCategory.EXTERNAL_FRAMEWORK,
 ) -> BenchmarkResult:
     return BenchmarkResult(
         task_id="task_a",
@@ -67,6 +69,7 @@ def _result(
         line_recall=region_recall,
         context_noise_ratio=0.2 if region_recall is not None else None,
         bundle_compression_ratio=compression_ratio,
+        category=category,
         savings_vs_raw=0.0,
         wall_time_ms=12.0,
         warm_latency_ms=10.0,
@@ -190,7 +193,9 @@ def test_competitive_report_groups_by_repo_and_aggregate() -> None:
     output = format_competitive_markdown(_manifest(), reports)
 
     assert "## Aggregate (2 tasks)" in output
-    assert "## By repo / task family" in output
+    assert "## By task family" in output
+    assert "### `external-framework`" in output
+    assert "## By repo" in output
     assert "### `owner/one`" in output
     assert "### `owner/two`" in output
 

--- a/tests/benchmark/test_competitive_report.py
+++ b/tests/benchmark/test_competitive_report.py
@@ -1,0 +1,220 @@
+"""Tests for the competitive comparison report."""
+
+from __future__ import annotations
+
+import pytest
+
+from archex.benchmark.competitive import format_competitive_markdown
+from archex.benchmark.headtohead import HeadToHeadManifestError
+from archex.benchmark.models import (
+    BenchmarkReport,
+    BenchmarkResult,
+    CompressionLayerConfig,
+    CompressionLayerMode,
+    CompressionLayerResult,
+    ExternalToolBenchmarkConfig,
+    HeadToHeadArchexConfig,
+    HeadToHeadManifest,
+    Strategy,
+)
+
+
+def _manifest() -> HeadToHeadManifest:
+    return HeadToHeadManifest(
+        name="competitive",
+        task_subset=["task_a", "task_b"],
+        hardware_notes="M1 Pro",
+        archex=HeadToHeadArchexConfig(candidate_strategies=[Strategy.ARCHEX_QUERY_COMPRESSED]),
+        external_tools=[
+            ExternalToolBenchmarkConfig(
+                name="ccc",
+                version="0.2.35",
+                command="ccc",
+                args=["mcp"],
+                embedder="Snowflake/snowflake-arctic-embed-xs",
+            )
+        ],
+        compression_layers=[
+            CompressionLayerConfig(name="headroom", version="0.4.1", command="headroom")
+        ],
+    )
+
+
+def _result(
+    strategy: Strategy,
+    *,
+    label: str | None = None,
+    region_recall: float | None = None,
+    compression_ratio: float | None = None,
+) -> BenchmarkResult:
+    return BenchmarkResult(
+        task_id="task_a",
+        strategy=strategy,
+        strategy_label=label,
+        tokens_total=100,
+        tokens_input=400,
+        tokens_output=100,
+        token_efficiency=0.75,
+        token_efficiency_with_completion=0.71,
+        bundle_completion_tokens=20,
+        tool_calls=1,
+        files_accessed=1,
+        recall=0.9,
+        precision=0.5,
+        f1_score=0.64,
+        required_file_recall=0.9,
+        region_recall=region_recall,
+        line_recall=region_recall,
+        context_noise_ratio=0.2 if region_recall is not None else None,
+        bundle_compression_ratio=compression_ratio,
+        savings_vs_raw=0.0,
+        wall_time_ms=12.0,
+        warm_latency_ms=10.0,
+        cold_start_ms=2.0,
+        cached=True,
+        timestamp="2026-06-19T00:00:00Z",
+        provenance={
+            "external_tool": label or strategy.value,
+            "external_tool_version": "0.2.35",
+            "external_tool_embedder": "Snowflake/snowflake-arctic-embed-xs",
+        },
+    )
+
+
+def _report(task_id: str, repo: str, results: list[BenchmarkResult]) -> BenchmarkReport:
+    for result in results:
+        result.task_id = task_id
+    return BenchmarkReport(
+        task_id=task_id,
+        repo=repo,
+        question="How?",
+        baseline_tokens=400,
+        results=results,
+    )
+
+
+def _compression(
+    mode: CompressionLayerMode, source_lane: str, ratio: float
+) -> CompressionLayerResult:
+    return CompressionLayerResult(
+        task_id="task_a",
+        lane_label=mode.value,
+        mode=mode,
+        source_lane=source_lane,
+        source_passthrough=ratio >= 1.0,
+        bundle_tokens_uncompressed=1000,
+        bundle_tokens_compressed=int(1000 * ratio),
+        bundle_compression_ratio=ratio,
+        provenance={
+            "layer": "headroom",
+            "version": "0.4.1",
+            "source_lane": source_lane,
+            "run_mode": "artifact",
+            "command": "headroom compress",
+        },
+        timestamp="2026-06-19T00:00:00Z",
+    )
+
+
+def _reports_one_repo() -> list[BenchmarkReport]:
+    return [
+        _report(
+            "task_a",
+            "owner/repo",
+            [
+                _result(Strategy.ARCHEX_QUERY, region_recall=0.8),
+                _result(Strategy.ARCHEX_QUERY_COMPRESSED, compression_ratio=0.85),
+                _result(Strategy.EXTERNAL_MCP, label="ccc"),
+                _result(Strategy.RAW_RIPGREP),
+            ],
+        )
+    ]
+
+
+def test_competitive_report_includes_all_lanes_and_layer_labels() -> None:
+    compression = [
+        _compression(CompressionLayerMode.HEADROOM_ONLY_ON_RAW_CONTEXT, "raw_files", 0.4),
+        _compression(CompressionLayerMode.ARCHEX_PLUS_HEADROOM, "archex", 0.92),
+    ]
+
+    output = format_competitive_markdown(_manifest(), _reports_one_repo(), compression)
+
+    # Retrieval, candidate, external, baseline, and both compression lanes present.
+    assert "| archex | retrieval |" in output
+    assert "| archex_query_compressed | retrieval |" in output
+    assert "| ccc | retrieval |" in output
+    assert "| raw-ripgrep/read | baseline |" in output
+    assert "| headroom_only_on_raw_context | compression |" in output
+    assert "| archex_plus_headroom | compression |" in output
+    # p95 latency and token-efficiency-after-completion columns.
+    assert "Warm p95 ms" in output
+    assert "Token eff. (compl.)" in output
+    # Provenance for retrieval and compression lanes.
+    assert "manifest=competitive" in output
+    assert "layer=headroom" in output
+
+
+def test_competitive_report_renders_region_metrics_when_available() -> None:
+    output = format_competitive_markdown(_manifest(), _reports_one_repo())
+
+    assert "Region recall" in output
+    # archex declared region_recall=0.8; rendered, not "n/a".
+    assert "0.80" in output
+
+
+def test_competitive_report_marks_compression_lane_not_retrieval() -> None:
+    compression = [
+        _compression(CompressionLayerMode.HEADROOM_ONLY_ON_RAW_CONTEXT, "raw_files", 0.4)
+    ]
+
+    output = format_competitive_markdown(_manifest(), _reports_one_repo(), compression)
+
+    assert "not a retrieval engine" in output
+    # Compression lane has n/a recall but a real compression ratio.
+    compression_row = next(
+        line
+        for line in output.splitlines()
+        if line.startswith("| headroom_only_on_raw_context |") and line.count("|") == 16
+    )
+    cells = [cell.strip() for cell in compression_row.strip("|").split("|")]
+    assert cells[2] == "n/a"  # recall column
+    assert cells[9] == "0.40"  # compression ratio column
+
+
+def test_competitive_report_groups_by_repo_and_aggregate() -> None:
+    reports = [
+        _report("task_a", "owner/one", _standard_results()),
+        _report("task_b", "owner/two", _standard_results()),
+    ]
+
+    output = format_competitive_markdown(_manifest(), reports)
+
+    assert "## Aggregate (2 tasks)" in output
+    assert "## By repo / task family" in output
+    assert "### `owner/one`" in output
+    assert "### `owner/two`" in output
+
+
+def test_competitive_report_rejects_missing_required_lane() -> None:
+    reports = [
+        _report(
+            "task_a",
+            "owner/repo",
+            [_result(Strategy.EXTERNAL_MCP, label="ccc"), _result(Strategy.RAW_RIPGREP)],
+        )
+    ]
+
+    with pytest.raises(HeadToHeadManifestError, match="missing lane.*archex"):
+        format_competitive_markdown(_manifest(), reports)
+
+
+def test_competitive_report_handles_no_results() -> None:
+    assert format_competitive_markdown(_manifest(), []) == "No competitive benchmark results."
+
+
+def _standard_results() -> list[BenchmarkResult]:
+    return [
+        _result(Strategy.ARCHEX_QUERY),
+        _result(Strategy.EXTERNAL_MCP, label="ccc"),
+        _result(Strategy.RAW_RIPGREP),
+    ]

--- a/tests/benchmark/test_competitive_report.py
+++ b/tests/benchmark/test_competitive_report.py
@@ -152,8 +152,9 @@ def test_competitive_report_includes_all_lanes_and_layer_labels() -> None:
     # p95 latency and token-efficiency-after-completion columns.
     assert "Warm p95 ms" in output
     assert "Token eff. (compl.)" in output
-    # Provenance for retrieval and compression lanes.
-    assert "manifest=competitive" in output
+    # Provenance for retrieval, candidate, and compression lanes.
+    assert "manifest=competitive; lane=archex; embedder=jina-v2" in output
+    assert "manifest=competitive; lane=archex_query_compressed; embedder=jina-v2" in output
     assert "layer=headroom" in output
 
 


### PR DESCRIPTION
## Stack

Stack-Id: `competitive-comparison-8da6d1`
Base: `main`
Position: 1/3

1. `bench/competitive-report` -> this PR (#315)
2. `bench/competitive-artifact-refresh` -> #316
3. `bench/competitive-docs` -> #317

Depends on: (none - root)
Upstack: #316

## Validation

- `uv run pytest tests/benchmark/test_competitive_report.py tests/benchmark/test_headtohead.py tests/benchmark/test_headtohead_report.py --no-cov -q`
- `uv run archex benchmark headtohead competitive --input benchmarks/headtohead/results --format markdown`
- `uv run ruff check src/archex/benchmark/competitive.py src/archex/benchmark/headtohead.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_competitive_report.py`
- `uv run ruff format --check src/archex/benchmark/competitive.py src/archex/benchmark/headtohead.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_competitive_report.py`
- `uv run pyright src/archex/benchmark/competitive.py src/archex/benchmark/headtohead.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_competitive_report.py`
