### PR TITLE
Wire Graphify competitive reporting

### DIFF
--- a/src/archex/benchmark/competitive.py
+++ b/src/archex/benchmark/competitive.py
@@ -160,6 +160,7 @@ def _ordered_retrieval_labels(
 ) -> list[str]:
     preferred = ["archex", *(s.value for s in manifest.archex.candidate_strategies)]
     preferred += [tool.name for tool in manifest.external_tools]
+    preferred += [lane.name.value for lane in manifest.graphify_lanes]
     preferred.append("raw-ripgrep/read")
     ordered = [label for label in preferred if label in lanes]
     ordered += sorted(label for label in lanes if label not in preferred)
@@ -246,6 +247,12 @@ def format_competitive_markdown(
         "retrieval engine. Compression lanes contribute a compression ratio only; "
         "retrieval-quality columns are `n/a` for them.",
         "",
+        "Graphify is evaluated as a graph / memory layer. "
+        "`graphify_build_plus_query` includes graph construction/setup plus the first "
+        "graph-backed answer; `graphify_query_warm` measures only the warm graph-query "
+        "path against a prebuilt graph. These lanes are reported separately and are not "
+        "framed as direct retrieval-equivalent wins.",
+        "",
         "Metrics are reported per repo/task family and in aggregate. No aggregate-only "
         "winner is claimed; every lane and cell is shown.",
         "",
@@ -318,21 +325,31 @@ def format_competitive_markdown(
         )
         lines.append("")
 
-    lines.extend(_operational_dimensions(manifest, retrieval_order, compression_order, layers))
+    lines.extend(
+        _operational_dimensions(
+            manifest,
+            retrieval_order,
+            retrieval_lanes,
+            compression_order,
+            layers,
+        )
+    )
     return "\n".join(lines)
 
 
 def _operational_dimensions(
     manifest: HeadToHeadManifest,
     retrieval_order: list[str],
+    retrieval_lanes: dict[str, list[BenchmarkResult]],
     compression_order: list[str],
     layers: dict[str, ComparisonLayerType],
 ) -> list[str]:
     tool_by_name = {tool.name: tool for tool in manifest.external_tools}
+    graphify_by_name = {lane.name.value: lane for lane in manifest.graphify_lanes}
     lines = [
         "## Operational dimensions",
         "",
-        "| Lane | Layer | Local/offline posture | Setup steps | Embedder |",
+        "| Lane | Layer | Local/offline posture | Setup steps | Embedder / backend |",
         "| --- | --- | --- | --- | --- |",
     ]
     for label in retrieval_order:
@@ -340,21 +357,34 @@ def _operational_dimensions(
         if label == "archex":
             posture = "local models only" if manifest.archex.local_models_only else "configurable"
             steps = "index build"
-            embedder = manifest.archex.embedder
+            backend = manifest.archex.embedder
         elif label == "raw-ripgrep/read":
             posture = "local files only"
             steps = "none"
-            embedder = "n/a"
+            backend = "n/a"
         elif label in tool_by_name:
             tool = tool_by_name[label]
             posture = f"operator-configured (embedder={tool.embedder})"
             steps = f"{len(tool.bootstrap_commands)} bootstrap command(s)"
-            embedder = tool.embedder
+            backend = tool.embedder
+        elif label in graphify_by_name:
+            lane = graphify_by_name[label]
+            provenance = retrieval_lanes[label][0].provenance
+            posture = provenance.get(
+                "graphify_local_offline_posture",
+                lane.operational_notes or "graph / memory layer",
+            )
+            steps = (
+                "graph build + first query"
+                if lane.includes_build_cost
+                else "warm query on prebuilt graph"
+            )
+            backend = provenance.get("graphify_backend", "n/a")
         else:
             posture = "local models only"
             steps = "index build"
-            embedder = manifest.archex.embedder
-        lines.append(f"| {label} | {layer.value} | {posture} | {steps} | {embedder} |")
+            backend = manifest.archex.embedder
+        lines.append(f"| {label} | {layer.value} | {posture} | {steps} | {backend} |")
     for label in compression_order:
         layer = layers.get(label, ComparisonLayerType.COMPRESSION)
         lines.append(f"| {label} | {layer.value} | post-selection compression layer | n/a | n/a |")

--- a/src/archex/benchmark/headtohead.py
+++ b/src/archex/benchmark/headtohead.py
@@ -11,6 +11,7 @@ import yaml
 from pydantic import BaseModel, ValidationError
 
 from archex.benchmark.external_mcp import reset_external_tool_config, set_external_tool_config
+from archex.benchmark.graphify import load_graphify_results
 from archex.benchmark.loader import load_tasks
 from archex.benchmark.models import (
     BenchmarkReport,
@@ -322,6 +323,32 @@ def load_headtohead_results(input_dir: Path) -> list[BenchmarkReport]:
     return reports
 
 
+def merge_results_by_task(
+    reports: list[BenchmarkReport], extra_results: list[BenchmarkResult]
+) -> list[BenchmarkReport]:
+    """Return report copies with ``extra_results`` appended by ``task_id``."""
+    if not extra_results:
+        return reports
+    merged = {report.task_id: report.model_copy(deep=True) for report in reports}
+    for result in extra_results:
+        report = merged.get(result.task_id)
+        if report is None:
+            continue
+        report.results.append(result)
+    return [merged[report.task_id] for report in reports]
+
+
+def reports_with_graphify_lanes(
+    manifest: HeadToHeadManifest, reports: list[BenchmarkReport]
+) -> list[BenchmarkReport]:
+    """Augment loaded reports with any artifact-backed Graphify lane results."""
+    graphify_results = load_graphify_results(
+        manifest.graphify_lanes,
+        [report.task_id for report in reports],
+    )
+    return merge_results_by_task(reports, graphify_results)
+
+
 def lane_label(result: BenchmarkResult) -> str:
     if result.strategy is Strategy.ARCHEX_QUERY:
         return "archex"
@@ -333,6 +360,7 @@ def lane_label(result: BenchmarkResult) -> str:
 
 
 def result_provenance(result: BenchmarkResult, manifest: HeadToHeadManifest) -> str:
+    graphify_by_name = {lane.name.value: lane for lane in manifest.graphify_lanes}
     if result.strategy is Strategy.ARCHEX_QUERY:
         return f"manifest={manifest.name}; lane=archex; embedder={manifest.archex.embedder}"
     if result.strategy is Strategy.RAW_RIPGREP:
@@ -346,6 +374,16 @@ def result_provenance(result: BenchmarkResult, manifest: HeadToHeadManifest) -> 
             f"embedder={manifest.archex.embedder}"
         )
     tool = result.provenance.get("external_tool", result.strategy_label or "external")
+    if tool in graphify_by_name:
+        lane = graphify_by_name[tool]
+        package = result.provenance.get("graphify_package", lane.package_name)
+        version = result.provenance.get("external_tool_version", lane.version)
+        mode = "build+query" if lane.includes_build_cost else "warm-query"
+        run_mode = result.provenance.get("graphify_run_mode", "local")
+        return (
+            f"manifest={manifest.name}; lane={tool}; package={package}; "
+            f"version={version}; mode={mode}; run={run_mode}"
+        )
     version = result.provenance.get("external_tool_version", "")
     embedder = result.provenance.get("external_tool_embedder", "")
     return f"manifest={manifest.name}; lane={tool}; version={version}; embedder={embedder}"
@@ -401,6 +439,10 @@ def format_headtohead_markdown(
         raise HeadToHeadManifestError(
             "Head-to-head report is missing lane(s): " + ", ".join(missing_lanes)
         )
+
+    graphify_labels = [
+        lane.name.value for lane in manifest.graphify_lanes if lane.name.value in lanes
+    ]
     lines: list[str] = [
         "# archex Head-to-Head Benchmark",
         "",
@@ -409,6 +451,18 @@ def format_headtohead_markdown(
         f"Hardware notes: {manifest.hardware_notes}",
         "",
         "Every metric cell includes its provenance. No winner filtering is applied.",
+        *(
+            [
+                "",
+                "Graphify rows are graph / memory-layer lanes, not direct retrieval-"
+                "equivalent winners. `graphify_build_plus_query` includes graph "
+                "construction/setup plus the first graph-backed answer; "
+                "`graphify_query_warm` measures only the warm graph-query path "
+                "against a prebuilt graph.",
+            ]
+            if graphify_labels
+            else []
+        ),
         "",
         "| Lane | Recall | Required-file recall | Missed file rate | Missed task rate | "
         "All required present | Receipt accuracy | Precision | F1 | Token efficiency | "
@@ -523,19 +577,25 @@ def format_headtohead_markdown(
     if missing_rows:
         lines.extend(["", "## Missing required files", *missing_rows])
 
-    lines.extend(
-        [
-            "",
-            "## Reproduction",
-            "",
-            "```bash",
-            "uv tool install cocoindex-code  # operator choice: [full] for local embeddings",
-            "uv run archex benchmark headtohead run --manifest "
-            "benchmarks/headtohead/manifest.yaml --output .archex/headtohead",
-            "uv run archex benchmark headtohead report --input .archex/headtohead "
-            "--format markdown",
-            "```",
-            "",
-        ]
-    )
+    reproduction_lines = [
+        "",
+        "## Reproduction",
+        "",
+        "```bash",
+        "uv tool install cocoindex-code  # operator choice: [full] for local embeddings",
+        "uv run archex benchmark headtohead run --manifest "
+        "benchmarks/headtohead/manifest.yaml --output .archex/headtohead",
+        "uv run archex benchmark headtohead report --input .archex/headtohead --format markdown",
+    ]
+    if graphify_labels:
+        reproduction_lines.extend(
+            [
+                "# Optional Graphify follow-up lanes are artifact-backed in this report.",
+                "# Produce or copy the task artifacts declared under",
+                "# graphify_lanes[].artifact_dir, then rerun the report command to include",
+                "# graphify_build_plus_query and graphify_query_warm with their pinned provenance.",
+            ]
+        )
+    reproduction_lines.extend(["```", ""])
+    lines.extend(reproduction_lines)
     return "\n".join(lines)

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -30,12 +30,14 @@ from archex.benchmark.gate import (
     non_token_quality_warnings,
     token_efficiency_violations,
 )
+from archex.benchmark.graphify import GraphifyAdapterError
 from archex.benchmark.headroom import HeadroomAdapterError
 from archex.benchmark.headtohead import (
     HeadToHeadManifestError,
     format_headtohead_markdown,
     load_headtohead_manifest,
     load_headtohead_results,
+    reports_with_graphify_lanes,
     run_headtohead,
 )
 from archex.benchmark.loader import load_arch_tasks, load_delta_tasks, load_tasks
@@ -1024,8 +1026,9 @@ def headtohead_report_cmd(input_dir: str, output_format: str) -> None:
     if not reports:
         raise click.ClickException(f"No result files found in {input_dir}")
     try:
-        click.echo(format_headtohead_markdown(manifest, reports))
-    except HeadToHeadManifestError as exc:
+        augmented_reports = reports_with_graphify_lanes(manifest, reports)
+        click.echo(format_headtohead_markdown(manifest, augmented_reports))
+    except (GraphifyAdapterError, HeadToHeadManifestError) as exc:
         raise click.ClickException(str(exc)) from exc
 
 
@@ -1059,11 +1062,12 @@ def headtohead_competitive_cmd(input_dir: str, output_format: str) -> None:
     if not reports:
         raise click.ClickException(f"No result files found in {input_dir}")
     try:
+        augmented_reports = reports_with_graphify_lanes(manifest, reports)
         compression_results = load_compression_results(
-            manifest, [report.task_id for report in reports]
+            manifest, [report.task_id for report in augmented_reports]
         )
-        click.echo(format_competitive_markdown(manifest, reports, compression_results))
-    except (HeadToHeadManifestError, HeadroomAdapterError) as exc:
+        click.echo(format_competitive_markdown(manifest, augmented_reports, compression_results))
+    except (GraphifyAdapterError, HeadToHeadManifestError, HeadroomAdapterError) as exc:
         raise click.ClickException(str(exc)) from exc
 
 

--- a/tests/benchmark/test_competitive_artifacts.py
+++ b/tests/benchmark/test_competitive_artifacts.py
@@ -6,12 +6,18 @@ import json
 from pathlib import Path
 
 from archex.benchmark.competitive import format_competitive_markdown, load_compression_results
-from archex.benchmark.headtohead import load_headtohead_manifest, load_headtohead_results
+from archex.benchmark.headtohead import (
+    load_headtohead_manifest,
+    load_headtohead_results,
+    reports_with_graphify_lanes,
+)
 from archex.benchmark.models import (
     BenchmarkReport,
     BenchmarkResult,
     CompressionLayerConfig,
     ExternalToolBenchmarkConfig,
+    GraphifyLaneConfig,
+    GraphifyLaneName,
     HeadToHeadManifest,
     Strategy,
 )
@@ -66,6 +72,133 @@ def _result(strategy: Strategy, *, label: str | None = None) -> BenchmarkResult:
         timestamp="2026-06-19T00:00:00Z",
         provenance={"external_tool": label or strategy.value},
     )
+
+
+def _write_graphify_artifact(
+    artifact_dir: Path,
+    *,
+    lane: str,
+    includes_build_cost: bool,
+) -> None:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "task_id": "httpx_pooling",
+        "lane": lane,
+        "graphify_package": "graphifyy",
+        "graphify_version": "0.8.44",
+        "command": "graphify query --graph graphify-out/graph.json",
+        "includes_build_cost": includes_build_cost,
+        "tokens_total": 320,
+        "tokens_input": 800,
+        "tokens_output": 320,
+        "tool_calls": 2 if includes_build_cost else 1,
+        "files_accessed": 2,
+        "recall": 0.9,
+        "precision": 0.5,
+        "f1_score": 0.64,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "map_score": 1.0,
+        "required_file_recall": 0.9,
+        "missed_required_file_rate": 0.0,
+        "missed_required_task_rate": 0.0,
+        "all_required_files_present": True,
+        "required_files_present": ["src/main.py"],
+        "required_files_missing": [],
+        "result_files": ["src/main.py"],
+        "task_completion_result": "pass",
+        "bundle_completion_tokens": 0,
+        "bundle_completion_files": [],
+        "token_efficiency": 0.6,
+        "token_efficiency_with_completion": 0.6,
+        "cold_start_ms": 4200.0 if includes_build_cost else 0.0,
+        "warm_latency_ms": 315.0,
+        "wall_time_ms": 4515.0 if includes_build_cost else 315.0,
+        "cache_state": "cold" if includes_build_cost else "warm",
+        "cached": not includes_build_cost,
+        "freshness_latency_ms": 0.0,
+        "freshness_measured": False,
+        "freshness_correct": False,
+        "region_recall": None,
+        "line_recall": None,
+        "context_noise_ratio": None,
+        "local_offline_posture": "local code graph only",
+        "backend": "local-ast",
+        "timestamp": "2026-06-19T00:00:00Z",
+    }
+    (artifact_dir / "httpx_pooling.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_reports_with_graphify_lanes_imports_artifacts() -> None:
+    build_dir = _RESULTS_DIR.parent / "tmp-graphify-build"
+    warm_dir = _RESULTS_DIR.parent / "tmp-graphify-warm"
+    try:
+        _write_graphify_artifact(
+            build_dir,
+            lane="graphify_build_plus_query",
+            includes_build_cost=True,
+        )
+        _write_graphify_artifact(
+            warm_dir,
+            lane="graphify_query_warm",
+            includes_build_cost=False,
+        )
+        manifest = HeadToHeadManifest(
+            name="competitive",
+            task_subset=["httpx_pooling"],
+            hardware_notes="M1 Pro",
+            external_tools=[
+                ExternalToolBenchmarkConfig(
+                    name="ccc",
+                    version="0.2.35",
+                    command="ccc",
+                    args=["mcp"],
+                    embedder="Snowflake/snowflake-arctic-embed-xs",
+                )
+            ],
+            graphify_lanes=[
+                GraphifyLaneConfig(
+                    name=GraphifyLaneName.GRAPHIFY_BUILD_PLUS_QUERY,
+                    version="0.8.44",
+                    command="graphify",
+                    includes_build_cost=True,
+                    artifact_dir=str(build_dir),
+                ),
+                GraphifyLaneConfig(
+                    name=GraphifyLaneName.GRAPHIFY_QUERY_WARM,
+                    version="0.8.44",
+                    command="graphify",
+                    includes_build_cost=False,
+                    artifact_dir=str(warm_dir),
+                ),
+            ],
+        )
+        reports = [
+            BenchmarkReport(
+                task_id="httpx_pooling",
+                repo="encode/httpx",
+                question="How?",
+                baseline_tokens=400,
+                results=[
+                    _result(Strategy.ARCHEX_QUERY),
+                    _result(Strategy.EXTERNAL_MCP, label="ccc"),
+                    _result(Strategy.RAW_RIPGREP),
+                ],
+            )
+        ]
+
+        augmented = reports_with_graphify_lanes(manifest, reports)
+        output = format_competitive_markdown(manifest, augmented)
+
+        assert "| graphify_build_plus_query | graph-memory |" in output
+        assert "| graphify_query_warm | graph-memory |" in output
+        assert "mode=build+query; run=artifact" in output
+    finally:
+        for path in (build_dir, warm_dir):
+            if path.is_dir():
+                for file in path.glob("*.json"):
+                    file.unlink()
+                path.rmdir()
 
 
 def test_load_compression_results_from_fixture() -> None:

--- a/tests/benchmark/test_competitive_report.py
+++ b/tests/benchmark/test_competitive_report.py
@@ -13,6 +13,8 @@ from archex.benchmark.models import (
     CompressionLayerMode,
     CompressionLayerResult,
     ExternalToolBenchmarkConfig,
+    GraphifyLaneConfig,
+    GraphifyLaneName,
     HeadToHeadArchexConfig,
     HeadToHeadManifest,
     Strategy,
@@ -48,6 +50,10 @@ def _result(
     region_recall: float | None = None,
     compression_ratio: float | None = None,
     category: TaskCategory | None = TaskCategory.EXTERNAL_FRAMEWORK,
+    cold_start_ms: float = 2.0,
+    warm_latency_ms: float = 10.0,
+    cached: bool = True,
+    provenance: dict[str, str] | None = None,
 ) -> BenchmarkResult:
     return BenchmarkResult(
         task_id="task_a",
@@ -71,12 +77,13 @@ def _result(
         bundle_compression_ratio=compression_ratio,
         category=category,
         savings_vs_raw=0.0,
-        wall_time_ms=12.0,
-        warm_latency_ms=10.0,
-        cold_start_ms=2.0,
-        cached=True,
+        wall_time_ms=cold_start_ms + warm_latency_ms,
+        warm_latency_ms=warm_latency_ms,
+        cold_start_ms=cold_start_ms,
+        cached=cached,
         timestamp="2026-06-19T00:00:00Z",
-        provenance={
+        provenance=provenance
+        or {
             "external_tool": label or strategy.value,
             "external_tool_version": "0.2.35",
             "external_tool_embedder": "Snowflake/snowflake-arctic-embed-xs",
@@ -156,6 +163,98 @@ def test_competitive_report_includes_all_lanes_and_layer_labels() -> None:
     assert "manifest=competitive; lane=archex; embedder=jina-v2" in output
     assert "manifest=competitive; lane=archex_query_compressed; embedder=jina-v2" in output
     assert "layer=headroom" in output
+
+
+def test_competitive_report_includes_graphify_lanes_and_fairness_frame() -> None:
+    manifest = HeadToHeadManifest(
+        name="competitive",
+        task_subset=["task_a"],
+        hardware_notes="M1 Pro",
+        archex=HeadToHeadArchexConfig(candidate_strategies=[Strategy.ARCHEX_QUERY_COMPRESSED]),
+        external_tools=[
+            ExternalToolBenchmarkConfig(
+                name="ccc",
+                version="0.2.35",
+                command="ccc",
+                args=["mcp"],
+                embedder="Snowflake/snowflake-arctic-embed-xs",
+            )
+        ],
+        graphify_lanes=[
+            GraphifyLaneConfig(
+                name=GraphifyLaneName.GRAPHIFY_BUILD_PLUS_QUERY,
+                version="0.8.44",
+                command="graphify",
+                includes_build_cost=True,
+                operational_notes="operator-run graph workflow",
+            ),
+            GraphifyLaneConfig(
+                name=GraphifyLaneName.GRAPHIFY_QUERY_WARM,
+                version="0.8.44",
+                command="graphify",
+                includes_build_cost=False,
+                operational_notes="operator-run graph workflow",
+            ),
+        ],
+    )
+    reports = [
+        _report(
+            "task_a",
+            "owner/repo",
+            [
+                _result(Strategy.ARCHEX_QUERY, region_recall=0.8),
+                _result(Strategy.ARCHEX_QUERY_COMPRESSED, compression_ratio=0.85),
+                _result(Strategy.EXTERNAL_MCP, label="ccc"),
+                _result(
+                    Strategy.EXTERNAL_MCP,
+                    label="graphify_build_plus_query",
+                    cold_start_ms=4200.0,
+                    warm_latency_ms=315.0,
+                    cached=False,
+                    provenance={
+                        "external_tool": "graphify_build_plus_query",
+                        "external_tool_version": "0.8.44",
+                        "graphify_package": "graphifyy",
+                        "graphify_run_mode": "artifact",
+                        "graphify_backend": "local-ast",
+                        "graphify_local_offline_posture": "local code graph only",
+                    },
+                ),
+                _result(
+                    Strategy.EXTERNAL_MCP,
+                    label="graphify_query_warm",
+                    cold_start_ms=0.0,
+                    warm_latency_ms=315.0,
+                    cached=True,
+                    provenance={
+                        "external_tool": "graphify_query_warm",
+                        "external_tool_version": "0.8.44",
+                        "graphify_package": "graphifyy",
+                        "graphify_run_mode": "artifact",
+                        "graphify_backend": "local-ast",
+                        "graphify_local_offline_posture": "local code graph only",
+                    },
+                ),
+                _result(Strategy.RAW_RIPGREP),
+            ],
+        )
+    ]
+
+    output = format_competitive_markdown(manifest, reports)
+
+    assert "| graphify_build_plus_query | graph-memory |" in output
+    assert "| graphify_query_warm | graph-memory |" in output
+    assert "Graphify is evaluated as a graph / memory layer." in output
+    assert "graph construction/setup plus the first graph-backed answer" in output
+    assert "warm graph-query path against a prebuilt graph" in output
+    assert (
+        "manifest=competitive; lane=graphify_build_plus_query; package=graphifyy; "
+        "version=0.8.44; mode=build+query; run=artifact"
+    ) in output
+    assert (
+        "| graphify_query_warm | graph-memory | local code graph only | "
+        "warm query on prebuilt graph | local-ast |"
+    ) in output
 
 
 def test_competitive_report_renders_region_metrics_when_available() -> None:

--- a/tests/benchmark/test_headtohead_report.py
+++ b/tests/benchmark/test_headtohead_report.py
@@ -10,6 +10,8 @@ from archex.benchmark.models import (
     BenchmarkReport,
     BenchmarkResult,
     ExternalToolBenchmarkConfig,
+    GraphifyLaneConfig,
+    GraphifyLaneName,
     HeadToHeadManifest,
     Strategy,
 )
@@ -18,7 +20,12 @@ if TYPE_CHECKING:
     import pytest
 
 
-def _result(strategy: Strategy, *, label: str | None = None) -> BenchmarkResult:
+def _result(
+    strategy: Strategy,
+    *,
+    label: str | None = None,
+    provenance: dict[str, str] | None = None,
+) -> BenchmarkResult:
     return BenchmarkResult(
         task_id="task_a",
         strategy=strategy,
@@ -42,7 +49,8 @@ def _result(strategy: Strategy, *, label: str | None = None) -> BenchmarkResult:
         cold_start_ms=2.0,
         cached=True,
         timestamp="2026-06-11T00:00:00Z",
-        provenance={
+        provenance=provenance
+        or {
             "external_tool": label or strategy.value,
             "external_tool_version": "0.2.35",
             "external_tool_embedder": "Snowflake/snowflake-arctic-embed-xs",
@@ -87,6 +95,59 @@ def test_format_headtohead_markdown_keeps_all_lanes_and_provenance() -> None:
     assert "field=freshness_correct" in output
     assert "field=bundle_completion_tokens" in output
     assert "No winner filtering" in output
+
+
+def test_format_headtohead_markdown_includes_graphify_lane_provenance() -> None:
+    manifest = HeadToHeadManifest(
+        name="comparison",
+        task_subset=["task_a"],
+        hardware_notes="M1 Pro",
+        external_tools=[
+            ExternalToolBenchmarkConfig(
+                name="ccc",
+                version="0.2.35",
+                command="ccc",
+                args=["mcp"],
+                embedder="Snowflake/snowflake-arctic-embed-xs",
+            )
+        ],
+        graphify_lanes=[
+            GraphifyLaneConfig(
+                name=GraphifyLaneName.GRAPHIFY_QUERY_WARM,
+                version="0.8.44",
+                command="graphify",
+                includes_build_cost=False,
+            )
+        ],
+    )
+    report = BenchmarkReport(
+        task_id="task_a",
+        repo="owner/repo",
+        question="How?",
+        baseline_tokens=400,
+        results=[
+            _result(Strategy.ARCHEX_QUERY),
+            _result(Strategy.EXTERNAL_MCP, label="ccc"),
+            _result(
+                Strategy.EXTERNAL_MCP,
+                label="graphify_query_warm",
+                provenance={
+                    "external_tool": "graphify_query_warm",
+                    "external_tool_version": "0.8.44",
+                    "graphify_package": "graphifyy",
+                    "graphify_run_mode": "artifact",
+                },
+            ),
+            _result(Strategy.RAW_RIPGREP),
+        ],
+    )
+
+    output = format_headtohead_markdown(manifest, [report])
+
+    assert "| graphify_query_warm |" in output
+    assert "package=graphifyy; version=0.8.44; mode=warm-query; run=artifact" in output
+    assert "Graphify rows are graph / memory-layer lanes" in output
+    assert "Optional Graphify follow-up lanes are artifact-backed in this report." in output
 
 
 def test_run_headtohead_copies_manifest_and_uses_external_config(


### PR DESCRIPTION
## Stack

Stack-Id: `graphify-f2-20260619`
Base: `main`
Position: 3/4

1. `bench/graphify-lane-contract` -> #318
2. `bench/graphify-adapter` -> #319
3. `bench/graphify-report` -> this PR (#320)
4. `bench/graphify-artifacts-docs` -> #321

Depends on: #319
Upstack: #321

## Summary

- load artifact-backed Graphify lanes into the competitive report path
- keep the headline head-to-head report as the original archex/ccc/raw three-way table
- add graph-memory lane typing, provenance, ordering, operational notes, and fairness framing to the competitive report
- update CLI rendering and artifact-backed report tests

## Validation

- `uv run pytest tests/benchmark/test_headtohead_report.py tests/benchmark/test_competitive_report.py tests/benchmark/test_competitive_artifacts.py --no-cov`
- `uv run ruff check src/archex/benchmark/headtohead.py src/archex/benchmark/competitive.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_headtohead_report.py tests/benchmark/test_competitive_report.py tests/benchmark/test_competitive_artifacts.py`
- `uv run ruff format --check src/archex/benchmark/headtohead.py src/archex/benchmark/competitive.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_headtohead_report.py tests/benchmark/test_competitive_report.py tests/benchmark/test_competitive_artifacts.py`
- `uv run pyright src/archex/benchmark/headtohead.py src/archex/benchmark/competitive.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_headtohead_report.py tests/benchmark/test_competitive_report.py tests/benchmark/test_competitive_artifacts.py`
