### PR TITLE
Invert the README opening hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@
 
 **Verified local code context for agents.**
 
-archex turns a repository into a ranked, token-budgeted context bundle plus a context receipt with freshness, index revision, skipped candidates, omitted dependency edges, and a recommended next action. It runs locally, uses deterministic retrieval and analysis, and does not require hosted inference or an API key. The v0.13 line adds stronger benchmark trust surfaces, bundle-only evaluator support, and default 4-bit TurboQuant vector storage for local vector indexes.
+AI coding agents usually start by opening a file, following an import, checking a type definition, and backtracking through the repo until the context window is partly spent before the real task starts. archex does that retrieval and structural expansion up front and returns a ranked, token-budgeted context bundle plus a receipt that records what was included, what was skipped, and whether the bundle is complete enough to act on.
+
+It runs locally, uses deterministic retrieval and analysis, and does not require hosted inference or an API key. The v0.13 line adds stronger benchmark trust surfaces, bundle-only evaluator support, and default 4-bit TurboQuant vector storage for local vector indexes.
 
 **Start:** [30-second quickstart](#30-second-quickstart) · [MCP and Claude Code](#mcp-and-claude-code) · [Python API](#python-api) · [Local metrics](docs/LOCAL_METRICS.md) · [Compatibility matrix](docs/CLIENT_COMPATIBILITY_MATRIX.md) · [Installation trust contract](docs/INSTALLATION_TRUST_CONTRACT.md) · [Security policy](SECURITY.md)
 


### PR DESCRIPTION
## Summary
- invert the README opening so the what-it-is tagline stays first and the context-window problem lands before the dense capability paragraph
- keep the existing local/deterministic/no-hosted-inference capability paragraph, but demote it below the new hook
- leave the rest of the README content untouched in this slice

## Stack

Stack-Id: `readme-adoption-refresh-a1f9`
Base: `main`
Position: 1/4

1. `docs/readme-hook-refresh` -> this PR (#322)
2. `docs/readme-setup-refresh` -> #323
3. `docs/readme-results-translation` -> #324
4. `docs/readme-nav-changelog` -> #325

Depends on: (none - root)
Upstack: #323

## Validation

- `python` README guardrail checks: in-page anchors resolve; workflow-block banned words absent; details blocks present; benchmark figures match the README table and `docs/ARCHEX_VS_COCOINDEX.md`
- GitHub branch preview confirms the top hook renders as tagline -> problem -> mechanism
- `/review` result: clean
