### PR TITLE
Sync README refresh navigation and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **README adoption refresh:** Reframed the opening around context-window burn, kept the quickstart as the one always-visible happy path, collapsed only the secondary Docker/extras blocks, and added a metric-anchored workflow translation under Measured results without changing product behavior or benchmark numbers.
+
 ## [0.13.2] - 2026-06-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ archex metrics trace enable
 ARCHEX_USAGE_METRICS=on archex query "Where is auth handled?"
 ```
 
-Detailed traces stay opt-in via `archex metrics trace enable` or `ARCHEX_USAGE_TRACE=on`. Traces remain local-only and still never store source code or rendered outputs. Metrics code paths make no LLM calls, no hosted upload calls, and no background network calls in v1.
+Detailed traces stay opt-in via `archex metrics trace enable` or `ARCHEX_USAGE_TRACE=on`. Traces remain local-only and still do not store source code or rendered outputs. Metrics code paths make no LLM calls, no hosted upload calls, and no background network calls in v1.
 ### Python API
 
 ```python


### PR DESCRIPTION
## Summary
- keep README navigation and authority-chain anchors aligned with the refreshed presentation pass
- remove the last banned overclaim word from README so the repo-wide README wording check passes cleanly
- add a docs-only changelog entry for the README adoption refresh

## Stack

Stack-Id: `readme-adoption-refresh-a1f9`
Base: `main`
Position: 4/4

1. `docs/readme-hook-refresh` -> #322
2. `docs/readme-setup-refresh` -> #323
3. `docs/readme-results-translation` -> #324
4. `docs/readme-nav-changelog` -> this PR (#325)

Depends on: #324
Upstack: (none - leaf)

## Validation

- `python` README guardrail checks: in-page anchors resolve; repo-wide README banned-word search returns zero hits; details blocks present; benchmark figures match the README table and `docs/ARCHEX_VS_COCOINDEX.md`
- GitHub branch preview confirms the refreshed README still renders with working nav anchors and collapsible secondary blocks
- `/review` result: clean on this PR and clean on the full stack/leaf diff
