### PR TITLE
fix(metrics): self-heal sticky global metrics-health warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **README adoption refresh:** Reframed the opening around context-window burn, kept the quickstart as the one always-visible happy path, collapsed only the secondary Docker/extras blocks, and added a metric-anchored workflow translation under Measured results without changing product behavior or benchmark numbers.
 
+### Fixed
+
+- **Sticky global metrics-health warning:** `archex metrics` could surface a permanent `Metrics warning: record: Path does not exist: /repo` (or similar) on every repo, because the machine-local health flag in `~/.archex/usage.sqlite` is global and was never cleared once set. Two root causes are fixed: (1) successful recording now self-heals the health flag, so any later successful query/scout on any repo clears a stale warning; (2) expected source-unavailability when computing the optional whole-repo/raw token baselines (an `AcquireError`/missing path for a source that is not a usable local repo) is no longer latched as a metrics failure. Added `archex metrics repair` to clear a stale warning manually without deleting accumulated savings data.
+
 ## [0.13.2] - 2026-06-19
 
 ### Fixed

--- a/docs/LOCAL_METRICS.md
+++ b/docs/LOCAL_METRICS.md
@@ -203,8 +203,20 @@ Metrics recording must never break query, scout, or MCP operations.
 
 If recording fails:
 - the user-facing operation still succeeds
-- metrics health is updated with the failure
-- `archex metrics` surfaces the warning
+- a genuine metrics-subsystem failure (storage, registry, or writer error) latches a
+  warning that `archex metrics` surfaces
+- the warning is **self-healing**: because health reflects the current state of the
+  writer rather than its history, the next successful record on any repo clears it
+- `archex metrics repair` clears a stale warning manually once recording works again,
+  without deleting any accumulated savings data
+
+The health flag lives in the single machine-local ledger (`~/.archex/usage.sqlite`), so
+it is shared across every repo on the machine.
+
+Expected, non-actionable conditions are **not** treated as failures. The optional
+whole-repo and raw-equivalent token baselines are computed by walking the source tree;
+when a source is not a usable local repo (path gone, not a directory, no `.git`), that
+baseline is simply omitted (`whole_repo_tokens` becomes null) without latching a warning.
 
 ## Reading the output
 

--- a/src/archex/cli/analyze_cmd.py
+++ b/src/archex/cli/analyze_cmd.py
@@ -10,7 +10,7 @@ from archex.api import analyze, get_repo_total_tokens
 from archex.config import load_config
 from archex.exceptions import ArchexError
 from archex.metrics.capture import record_structural_usage
-from archex.metrics.health import record_metrics_failure
+from archex.metrics.health import note_metrics_recording_failure
 from archex.metrics.policy import resolve_metrics_policy
 from archex.models import Config, PipelineTiming, RepoSource
 from archex.reporting import count_tokens, print_savings, print_timing
@@ -83,8 +83,4 @@ def _record_metrics(
             whole_repo_tokens=raw,
         )
     except Exception as exc:
-        logger.debug("analyze metrics recording failed", exc_info=True)
-        try:
-            record_metrics_failure("record", str(exc))
-        except Exception:
-            logger.debug("analyze metrics health recording failed", exc_info=True)
+        note_metrics_recording_failure(exc)

--- a/src/archex/cli/compare_cmd.py
+++ b/src/archex/cli/compare_cmd.py
@@ -10,7 +10,7 @@ import click
 from archex.api import compare, get_repo_total_tokens
 from archex.exceptions import ArchexError
 from archex.metrics.capture import record_structural_usage
-from archex.metrics.health import record_metrics_failure
+from archex.metrics.health import note_metrics_recording_failure
 from archex.metrics.policy import resolve_metrics_policy
 from archex.models import Config, RepoSource
 from archex.reporting import count_tokens, print_savings
@@ -171,8 +171,4 @@ def _record_metrics(
             whole_repo_tokens=raw,
         )
     except Exception as exc:
-        logger.debug("compare metrics recording failed", exc_info=True)
-        try:
-            record_metrics_failure("record", str(exc))
-        except Exception:
-            logger.debug("compare metrics health recording failed", exc_info=True)
+        note_metrics_recording_failure(exc)

--- a/src/archex/cli/metrics_cmd.py
+++ b/src/archex/cli/metrics_cmd.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import click
 
+from archex.metrics.health import clear_metrics_health, read_metrics_health
 from archex.metrics.policy import set_metrics_enabled, set_trace_enabled
 from archex.metrics.reporter import (
     MetricsReporter,
@@ -117,6 +118,17 @@ def disable_cmd() -> None:
     """Disable anonymous local metrics counters."""
     set_metrics_enabled(False)
     click.echo("Metrics recording disabled")
+
+
+@metrics_cmd.command("repair")
+def repair_cmd() -> None:
+    """Clear a stale metrics health warning once recording is working again."""
+    health = read_metrics_health()
+    if health.status == "ok":
+        click.echo("Metrics health: ok (nothing to repair)")
+        return
+    clear_metrics_health()
+    click.echo("Cleared metrics health warning")
 
 
 @metrics_cmd.command("delete")

--- a/src/archex/cli/outline_cmd.py
+++ b/src/archex/cli/outline_cmd.py
@@ -10,7 +10,7 @@ import click
 from archex.api import file_outline
 from archex.exceptions import ArchexError
 from archex.metrics.capture import record_structural_usage
-from archex.metrics.health import record_metrics_failure
+from archex.metrics.health import note_metrics_recording_failure
 from archex.metrics.policy import resolve_metrics_policy
 from archex.models import PipelineTiming, RepoSource
 from archex.reporting import count_tokens, print_savings, print_timing
@@ -80,8 +80,4 @@ def _record_metrics(source: RepoSource, output: str, raw_tokens: int) -> None:
             file_count=1,
         )
     except Exception as exc:
-        logger.debug("outline metrics recording failed", exc_info=True)
-        try:
-            record_metrics_failure("record", str(exc))
-        except Exception:
-            logger.debug("outline metrics health recording failed", exc_info=True)
+        note_metrics_recording_failure(exc)

--- a/src/archex/cli/query_cmd.py
+++ b/src/archex/cli/query_cmd.py
@@ -10,7 +10,7 @@ import click
 from archex.api import get_files_token_count, get_repo_total_tokens, query
 from archex.exceptions import ArchexError
 from archex.metrics.capture import record_query_usage
-from archex.metrics.health import record_metrics_failure
+from archex.metrics.health import note_metrics_recording_failure
 from archex.metrics.policy import resolve_metrics_policy
 from archex.reporting import print_savings, print_timing
 from archex.serve.intent import DEFAULT_TOKEN_BUDGET
@@ -175,22 +175,14 @@ def _record_metrics(
             whole_repo_tokens=whole_repo_tokens,
         )
     except Exception as exc:
-        logger.debug("query metrics recording failed", exc_info=True)
-        try:
-            record_metrics_failure("record", str(exc))
-        except Exception:
-            logger.debug("query metrics health recording failed", exc_info=True)
+        note_metrics_recording_failure(exc)
 
 
 def _repo_total_tokens(repo_source: RepoSource, config: Config) -> int | None:
     try:
         return get_repo_total_tokens(repo_source, config)
-    except Exception as exc:
+    except Exception:
         logger.debug("query metrics whole-repo tokens unavailable", exc_info=True)
-        try:
-            record_metrics_failure("record", str(exc))
-        except Exception:
-            logger.debug("query metrics health recording failed", exc_info=True)
         return None
 
 

--- a/src/archex/cli/scout_cmd.py
+++ b/src/archex/cli/scout_cmd.py
@@ -10,7 +10,7 @@ import click
 from archex.api import get_files_token_count, get_repo_total_tokens, scout
 from archex.exceptions import ArchexError
 from archex.metrics.capture import record_scout_usage
-from archex.metrics.health import record_metrics_failure
+from archex.metrics.health import note_metrics_recording_failure
 from archex.metrics.policy import resolve_metrics_policy
 from archex.reporting import count_tokens
 from archex.scout import DEFAULT_SCOUT_TOKEN_BUDGET, ScoutFormat, render_scout
@@ -85,11 +85,7 @@ def _record_metrics(repo_source: RepoSource, result: ScoutResult, rendered: str)
             whole_repo_tokens=whole_repo_tokens,
         )
     except Exception as exc:
-        logger.debug("scout metrics recording failed", exc_info=True)
-        try:
-            record_metrics_failure("record", str(exc))
-        except Exception:
-            logger.debug("scout metrics health recording failed", exc_info=True)
+        note_metrics_recording_failure(exc)
 
 
 def _scout_file_paths(result: ScoutResult) -> list[str]:

--- a/src/archex/cli/symbol_cmd.py
+++ b/src/archex/cli/symbol_cmd.py
@@ -9,7 +9,7 @@ import click
 from archex.api import get_file_token_count, get_symbol
 from archex.exceptions import ArchexError
 from archex.metrics.capture import record_structural_usage
-from archex.metrics.health import record_metrics_failure
+from archex.metrics.health import note_metrics_recording_failure
 from archex.metrics.policy import resolve_metrics_policy
 from archex.models import PipelineTiming, RepoSource
 from archex.reporting import count_tokens, print_savings, print_timing
@@ -74,11 +74,7 @@ def _record_metrics(
             file_count=1,
         )
     except Exception as exc:
-        logger.debug("symbol metrics recording failed", exc_info=True)
-        try:
-            record_metrics_failure("record", str(exc))
-        except Exception:
-            logger.debug("symbol metrics health recording failed", exc_info=True)
+        note_metrics_recording_failure(exc)
 
 
 def _source_and_symbol_id(args: tuple[str, ...]) -> tuple[str, str]:

--- a/src/archex/cli/symbols_cmd.py
+++ b/src/archex/cli/symbols_cmd.py
@@ -10,7 +10,7 @@ import click
 from archex.api import get_files_token_count, search_symbols
 from archex.exceptions import ArchexError
 from archex.metrics.capture import record_structural_usage
-from archex.metrics.health import record_metrics_failure
+from archex.metrics.health import note_metrics_recording_failure
 from archex.metrics.policy import resolve_metrics_policy
 from archex.models import PipelineTiming, RepoSource, SymbolMatch
 from archex.reporting import count_tokens, print_savings, print_timing
@@ -98,11 +98,7 @@ def _record_metrics(
             file_count=len(unique_files),
         )
     except Exception as exc:
-        logger.debug("symbols metrics recording failed", exc_info=True)
-        try:
-            record_metrics_failure("record", str(exc))
-        except Exception:
-            logger.debug("symbols metrics health recording failed", exc_info=True)
+        note_metrics_recording_failure(exc)
 
 
 def _source_and_query(args: tuple[str, ...]) -> tuple[str, str]:

--- a/src/archex/cli/tree_cmd.py
+++ b/src/archex/cli/tree_cmd.py
@@ -10,7 +10,7 @@ import click
 from archex.api import file_tree, get_repo_total_tokens
 from archex.exceptions import ArchexError
 from archex.metrics.capture import record_structural_usage
-from archex.metrics.health import record_metrics_failure
+from archex.metrics.health import note_metrics_recording_failure
 from archex.metrics.policy import resolve_metrics_policy
 from archex.models import PipelineTiming, RepoSource
 from archex.reporting import count_tokens, print_savings, print_timing
@@ -90,8 +90,4 @@ def _record_metrics(source: RepoSource, output: str, raw_tokens: int | None) -> 
             whole_repo_tokens=raw,
         )
     except Exception as exc:
-        logger.debug("tree metrics recording failed", exc_info=True)
-        try:
-            record_metrics_failure("record", str(exc))
-        except Exception:
-            logger.debug("tree metrics health recording failed", exc_info=True)
+        note_metrics_recording_failure(exc)

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -40,7 +40,7 @@ from archex.graph_query import (
     GraphStatsResult,
 )
 from archex.metrics.capture import record_query_usage, record_scout_usage, record_structural_usage
-from archex.metrics.health import record_metrics_failure
+from archex.metrics.health import note_metrics_recording_failure
 from archex.metrics.policy import resolve_metrics_policy
 from archex.models import ContextBundle, PipelineTiming, RepoSource
 from archex.reporting import compute_meta, count_tokens
@@ -216,11 +216,7 @@ def _record_query_metrics(
             whole_repo_tokens=whole_repo_tokens,
         )
     except Exception as exc:
-        logger.debug("MCP query metrics recording failed", exc_info=True)
-        try:
-            record_metrics_failure("record", str(exc))
-        except Exception:
-            logger.debug("MCP query metrics health recording failed", exc_info=True)
+        note_metrics_recording_failure(exc)
 
 
 def _record_scout_metrics(
@@ -244,22 +240,14 @@ def _record_scout_metrics(
             whole_repo_tokens=whole_repo_tokens,
         )
     except Exception as exc:
-        logger.debug("MCP scout metrics recording failed", exc_info=True)
-        try:
-            record_metrics_failure("record", str(exc))
-        except Exception:
-            logger.debug("MCP scout metrics health recording failed", exc_info=True)
+        note_metrics_recording_failure(exc)
 
 
 def _whole_repo_tokens(source: RepoSource) -> int | None:
     try:
         return get_repo_total_tokens(source)
-    except Exception as exc:
+    except Exception:
         logger.debug("MCP metrics whole-repo tokens unavailable", exc_info=True)
-        try:
-            record_metrics_failure("record", str(exc))
-        except Exception:
-            logger.debug("MCP metrics health recording failed", exc_info=True)
         return None
 
 
@@ -299,11 +287,7 @@ def _record_structural_metrics(
             file_count=file_count,
         )
     except Exception as exc:
-        logger.debug("MCP structural metrics recording failed", exc_info=True)
-        try:
-            record_metrics_failure("record", str(exc))
-        except Exception:
-            logger.debug("MCP structural metrics health recording failed", exc_info=True)
+        note_metrics_recording_failure(exc)
 
 
 def handle_compare_repos(

--- a/src/archex/metrics/health.py
+++ b/src/archex/metrics/health.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+from archex.exceptions import AcquireError
 from archex.metrics.storage import MetricsStore
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -79,6 +83,26 @@ def clear_metrics_health(*, db_path: Path | None = None) -> None:
             WHERE id = 1
             """
         )
+
+
+_EXPECTED_BASELINE_FAILURES = (AcquireError, FileNotFoundError, NotADirectoryError)
+
+
+def note_metrics_recording_failure(exc: Exception, *, db_path: Path | None = None) -> None:
+    """Record a non-fatal metrics wrapper failure, suppressing expected source-unavailability.
+
+    CLI/MCP metrics wrappers compute token baselines by walking the source tree. When the
+    source is not a usable local repo (path gone, not a directory, no ``.git``), that is
+    expected degradation rather than a broken metrics subsystem, so it must not latch a
+    sticky, repo-global warning. Genuine failures still latch for the operator to see.
+    """
+    logger.debug("metrics recording failed", exc_info=True)
+    if isinstance(exc, _EXPECTED_BASELINE_FAILURES):
+        return
+    try:
+        record_metrics_failure("record", str(exc), db_path=db_path)
+    except Exception:  # pragma: no cover - health write is best-effort
+        logger.debug("metrics health recording failed", exc_info=True)
 
 
 def _optional_str(value: object) -> str | None:

--- a/src/archex/metrics/recorder.py
+++ b/src/archex/metrics/recorder.py
@@ -140,12 +140,28 @@ class MetricsRecorder:
                     occurred_at + timedelta(days=policy.trace_retention_days),
                 )
             self._prune(conn, policy, now=occurred_at)
+            self._clear_health(conn)
 
     def _record_failure(self, operation: str, exc: Exception) -> None:
         try:
             record_metrics_failure(operation, str(exc), db_path=self._db_path)
         except Exception:
             logger.debug("metrics health recording failed", exc_info=True)
+
+    @staticmethod
+    def _clear_health(conn: sqlite3.Connection) -> None:
+        """Reset a prior warning once recording succeeds so health reflects current state."""
+        conn.execute(
+            """
+            UPDATE metrics_health
+            SET status = 'ok',
+                last_failure_at = NULL,
+                last_failure_operation = NULL,
+                last_failure_message = NULL,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = 1 AND status != 'ok'
+            """
+        )
 
     @staticmethod
     def _insert_event(

--- a/tests/metrics/test_health.py
+++ b/tests/metrics/test_health.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from archex.exceptions import AcquireError
+from archex.metrics.health import note_metrics_recording_failure, read_metrics_health
+
+
+def test_expected_source_unavailability_does_not_latch_warning(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite"
+
+    note_metrics_recording_failure(AcquireError("Path does not exist: /repo"), db_path=db_path)
+
+    assert read_metrics_health(db_path=db_path).status == "ok"
+
+
+def test_missing_file_baseline_failure_does_not_latch_warning(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite"
+
+    note_metrics_recording_failure(FileNotFoundError("/repo"), db_path=db_path)
+
+    assert read_metrics_health(db_path=db_path).status == "ok"
+
+
+def test_unexpected_failure_latches_warning(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite"
+
+    note_metrics_recording_failure(RuntimeError("boom"), db_path=db_path)
+
+    health = read_metrics_health(db_path=db_path)
+    assert health.status == "warning"
+    assert health.last_failure_operation == "record"
+    assert health.last_failure_message == "boom"

--- a/tests/metrics/test_metrics_cli.py
+++ b/tests/metrics/test_metrics_cli.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from click.testing import CliRunner
 
 from archex.cli.main import cli
+from archex.metrics.health import read_metrics_health, record_metrics_failure
 from archex.metrics.policy import set_metrics_enabled
 from archex.metrics.recorder import MetricsRecorder, TraceDetails, UsageEvent
 from archex.metrics.storage import metrics_db_path
@@ -143,6 +144,24 @@ def test_metrics_controls_enable_disable_trace_and_delete(
     assert trace_disable.exit_code == 0, trace_disable.output
     assert delete.exit_code == 0, delete.output
     assert not metrics_db_path(home=tmp_path).exists()
+
+
+def test_metrics_repair_clears_stale_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    db_path = metrics_db_path(home=tmp_path)
+    record_metrics_failure("record", "Path does not exist: /repo", db_path=db_path)
+    runner = CliRunner()
+
+    cleared = runner.invoke(cli, ["metrics", "repair"])
+    repeated = runner.invoke(cli, ["metrics", "repair"])
+
+    assert cleared.exit_code == 0, cleared.output
+    assert "Cleared metrics health warning" in cleared.output
+    assert read_metrics_health(db_path=db_path).status == "ok"
+    assert "nothing to repair" in repeated.output
 
 
 def _record(repo_root: Path, tmp_path: Path) -> None:

--- a/tests/metrics/test_recorder.py
+++ b/tests/metrics/test_recorder.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from archex.metrics.health import read_metrics_health
+from archex.metrics.health import read_metrics_health, record_metrics_failure
 from archex.metrics.policy import METRICS_ENV, TRACE_ENV, set_metrics_enabled
 from archex.metrics.recorder import MetricsRecorder, TraceDetails, UsageEvent
 from archex.metrics.registry import RepoRegistry
@@ -130,6 +130,19 @@ def test_recorder_failures_are_non_fatal_and_record_health(
     assert health.status == "warning"
     assert health.last_failure_operation == "record"
     assert health.last_failure_message == "registry unavailable"
+
+
+def test_successful_record_clears_prior_health_warning(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite"
+    set_metrics_enabled(True, db_path=db_path)
+    record_metrics_failure("record", "Path does not exist: /repo", db_path=db_path)
+    assert read_metrics_health(db_path=db_path).status == "warning"
+
+    MetricsRecorder(db_path).record(_event(_repo(tmp_path)))
+
+    health = read_metrics_health(db_path=db_path)
+    assert health.status == "ok"
+    assert health.last_failure_message is None
 
 
 def _event(


### PR DESCRIPTION
## Summary

`archex metrics` could surface a permanent warning such as:

```
Metrics warning:        record: Path does not exist: /repo
```

on **every** repository, indefinitely. This PR fixes the two root causes, adds a
non-destructive escape hatch, and documents the behavior.

## Root cause

Local usage metrics live in a single machine-global SQLite ledger
(`~/.archex/usage.sqlite`). Its `metrics_health` table is **one row (`id = 1`)
shared across all repos**, so any health warning is global, not per-repo.

Two defects combined to make a one-time failure permanent and noisy:

1. **The health flag was sticky.** `record_metrics_failure()` latched
   `status = 'warning'`, but `clear_metrics_health()` existed and was **never
   called**. Once set, the warning persisted forever and appeared on every repo.
2. **An expected condition was treated as a failure.** The CLI/MCP metrics
   wrappers compute the *optional* whole-repo and raw-equivalent token baselines
   by walking the source tree. When a source is not a usable local repo (path
   gone, not a directory, no `.git`), `open_local()` raises `AcquireError`. That
   optional-baseline failure was latched as a metrics-subsystem warning even
   though the event records fine with `whole_repo_tokens = null`. The literal
   `/repo` came from an invocation against a path that did not resolve to a
   usable local repository on the machine.

## What changed

### 1. Self-healing health (`metrics/recorder.py`)
`MetricsRecorder._record` now resets a prior warning within the record
transaction whenever recording succeeds (idempotent
`UPDATE ... WHERE id = 1 AND status != 'ok'`). Health reflects the **current**
state of the writer rather than its history, so any later successful
query/scout on any repo clears a stale warning.

### 2. Stop latching expected source-unavailability (`metrics/health.py` + wrappers)
New `note_metrics_recording_failure(exc)` centralizes wrapper failure handling:
it **suppresses** expected baseline failures
(`AcquireError` / `FileNotFoundError` / `NotADirectoryError`) while still
**latching** genuine storage/registry/writer errors. Every CLI and MCP metrics
wrapper now routes through it, replacing the duplicated
`try/except → record_metrics_failure("record", ...)` blocks:

- `cli/{analyze,compare,outline,query,scout,symbol,symbols,tree}_cmd.py`
- `integrations/mcp.py`

The optional whole-repo helpers (`query_cmd._repo_total_tokens`,
`mcp._whole_repo_tokens`) now degrade silently to `None` with no health latch.

### 3. `archex metrics repair` (`cli/metrics_cmd.py`)
A non-destructive command to clear a stale warning once recording works again,
**without deleting accumulated savings data** (unlike `metrics delete --all`).
Reports `nothing to repair` when health is already `ok`.

### 4. Docs (`docs/LOCAL_METRICS.md`, `CHANGELOG.md`)
Documents the global health flag, self-healing, suppression of expected
source-unavailability, and the new repair command; adds a CHANGELOG entry.

## Behavior change

| | Before | After |
|---|---|---|
| One-time recording failure | Warning latched forever, shown on every repo | Cleared by the next successful record on any repo |
| Optional baseline can't be computed (non-repo source) | Latched as a global warning | Silently omitted (`whole_repo_tokens = null`), no warning |
| Genuine storage/registry/writer failure | Latched (correct) | Latched (unchanged) |
| Stale warning after the cause is fixed | No way to clear without wiping data | `archex metrics repair` |

Metrics recording remains strictly non-fatal to query/scout/MCP operations.

## Testing

- `tests/metrics/test_health.py` (new): `note_metrics_recording_failure`
  suppresses `AcquireError`/`FileNotFoundError`, latches `RuntimeError`.
- `tests/metrics/test_recorder.py`: successful record clears a prior warning.
- `tests/metrics/test_metrics_cli.py`: `metrics repair` clears a stale warning
  and is a no-op when healthy.
- Existing instrumentation tests (genuine `RuntimeError` still latches) remain green.

Local CI gate (matches `.github/workflows/ci.yml`) on changed files:

- `ruff check` — passed
- `ruff format --check` — clean
- `pyright` (strict, incl. tests) — 0 errors
- `pytest tests/metrics/ tests/cli/test_doctor.py` — all pass

## Compatibility / risk

- No schema change; uses the existing `metrics_health` table.
- No migration required. Existing installs self-heal on the next successful
  record; `archex metrics repair` (or upgrading) clears a stuck flag immediately.
- Purely local, opt-in metrics — no behavioral change to retrieval output.
