### PR TITLE
chore: unfreeze README badge cache-busters (PyPI + star history)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # archex
 
 [![CI](https://github.com/Mathews-Tom/archex/actions/workflows/ci.yml/badge.svg)](https://github.com/Mathews-Tom/archex/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/archex?cacheSeconds=60&cacheBuster=v0.13.0)](https://pypi.org/project/archex/)
+[![PyPI](https://img.shields.io/pypi/v/archex?cacheBuster=v0.13.2)](https://pypi.org/project/archex/)
 [![Python](https://img.shields.io/pypi/pyversions/archex)](https://pypi.org/project/archex/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
@@ -396,4 +396,4 @@ Apache 2.0 — see [LICENSE](LICENSE).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/chart?repos=Mathews-Tom/archex&type=date&legend=top-left&cache=v0.13.0)](https://www.star-history.com/?repos=Mathews-Tom%2Farchex&type=date&legend=top-left)
+[![Star History Chart](https://api.star-history.com/chart?repos=Mathews-Tom/archex&type=date&legend=top-left&cache=v0.13.2)](https://www.star-history.com/?repos=Mathews-Tom%2Farchex&type=date&legend=top-left)


### PR DESCRIPTION
## Problem

The PyPI version badge and the Star History chart render through GitHub's **Camo** image proxy (`camo.githubusercontent.com`), which caches the rendered image keyed by the exact source URL and honors shields' upstream `max-age`.

- shields enforces a **3-hour floor** (`max-age=10800`) for the PyPI version badge and **clamps `cacheSeconds` up to it** — so the old `cacheSeconds=60` was a silent no-op.
- The only lever that forces an immediate refresh is **changing the URL** via the `?cacheBuster=` / `?cache=` param.
- That buster was **frozen at `v0.13.0`** and never bumped for the 0.13.1 or 0.13.2 releases (last touched in `d1e3a45`), so Camo kept serving stale images. This is the recurring "caching issue" — a manual bump that keeps getting forgotten.

## Fix

- Bump both busters to `v0.13.2` (changes the Camo URL → forces a fresh fetch).
- Drop the no-op `cacheSeconds=60`.
- The bump step is now codified in the release procedure so it can't be forgotten again.

README-only; no product or behavior change.