### PR TITLE
chore: drop hardcoded version cache-busters from README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # archex
 
 [![CI](https://github.com/Mathews-Tom/archex/actions/workflows/ci.yml/badge.svg)](https://github.com/Mathews-Tom/archex/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/archex?cacheBuster=v0.13.2)](https://pypi.org/project/archex/)
+[![PyPI](https://img.shields.io/pypi/v/archex)](https://pypi.org/project/archex/)
 [![Python](https://img.shields.io/pypi/pyversions/archex)](https://pypi.org/project/archex/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
@@ -396,4 +396,4 @@ Apache 2.0 — see [LICENSE](LICENSE).
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/chart?repos=Mathews-Tom/archex&type=date&legend=top-left&cache=v0.13.2)](https://www.star-history.com/?repos=Mathews-Tom%2Farchex&type=date&legend=top-left)
+[![Star History Chart](https://api.star-history.com/chart?repos=Mathews-Tom/archex&type=date&legend=top-left)](https://www.star-history.com/?repos=Mathews-Tom%2Farchex&type=date&legend=top-left)


### PR DESCRIPTION
Follow-up to #328. The version-pinned `?cacheBuster=vX.Y.Z` / `?cache=vX.Y.Z` params are a **hardcoded version dependency** that must be hand-bumped every release — the exact toil that caused the recurring "stale badge" issue (it was frozen at `v0.13.0` across the 0.13.1 and 0.13.2 releases).

They're also unnecessary: the badges render through GitHub's Camo proxy, which honors shields' `max-age=10800` (3h) and revalidates on its own, so the badge self-heals within hours of any release with zero action. For star-history the version coupling is especially meaningless — star count has nothing to do with the release version.

This removes both busters in favor of the canonical, dependency-free badge URLs. No per-release upkeep, no hardcoded version. Accepts a self-healing ≤3h refresh window after a release (vs. an instant-but-manual bump).

README-only; no behavior change.