### PR TITLE
feat(install-client): default-global scope + --dry-run (replaces --write)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - **README adoption refresh:** Reframed the opening around context-window burn, kept the quickstart as the one always-visible happy path, collapsed only the secondary Docker/extras blocks, and added a metric-anchored workflow translation under Measured results without changing product behavior or benchmark numbers.
+- **install-client default-global + `--dry-run`:** `archex install-client <client>` now installs at global (user) scope by default; pass a `[SOURCE]` repo path or `--scope project` for a repo-local install. Removed the `--write` flag — configs are written by default and `--dry-run` previews the exact target and config without touching the filesystem. Writes stay non-destructive (merge into existing config, never clobber unrelated sections) and are idempotent: re-running with an identical `archex` entry is a no-op, while a different existing entry is left untouched and refused. Updated the installation trust contract, compatibility matrix, and README to match.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ archex does not ask the downstream agent to trust ranking alone. Every query/sco
 | Claude Code or MCP | [MCP and Claude Code](#mcp-and-claude-code) | Stdio MCP server, optional warm `--watch`, additive top-level receipts, and an in-repo skill that teaches doctor → scout → fetch. |
 | Python applications | [Python API](#python-api) | Deterministic `query()`, `analyze()`, `compare()`, and receipt-bearing bundles. |
 | Benchmark proof | [Measured results](#measured-results) and [archex vs. cocoindex-code](docs/ARCHEX_VS_COCOINDEX.md) | Same-task C1 report, raw-ripgrep/read baseline, bundle-only evaluator reports, required-file trust gates, and TurboQuant storage/recall evidence. |
-| Installation and clients | [Compatibility matrix](docs/CLIENT_COMPATIBILITY_MATRIX.md) | Preview-first client bootstrap paths for Claude Code, Codex, Pi, OpenCode, and Cursor. |
+| Installation and clients | [Compatibility matrix](docs/CLIENT_COMPATIBILITY_MATRIX.md) | Client bootstrap paths for Claude Code, Codex, Pi, OpenCode, and Cursor (global/user scope by default; `--dry-run` previews). |
 
 ## 30-second quickstart
 

--- a/README.md
+++ b/README.md
@@ -170,11 +170,12 @@ uv tool install "archex[mcp]"
 }
 ```
 
-Preview the exact client config before writing it:
+Install the client config (global/user scope by default; pass a SOURCE path or `--scope project` for a repo-local install). Add `--dry-run` to preview the exact target and config without writing:
 
 ```bash
-archex install-client claude-code .
-archex install-client claude-code . --write
+archex install-client claude-code            # global, writes immediately
+archex install-client claude-code --dry-run  # preview only, no changes
+archex install-client claude-code . --scope project
 ```
 
 For warm local sessions, keep the MCP process alive and optionally watch the repo:
@@ -185,7 +186,7 @@ archex mcp --watch --watch-path .
 
 The in-repo Claude Code skill lives at [`skills/archex/`](skills/archex/). Its `/archex` command runs `archex doctor`, initializes/indexes when needed, scouts first for broad questions, then fetches exact `symbol:` or `chunk:` handles before a larger bundle query.
 
-Exact install, MCP, Docker, cache, uninstall, and trust semantics are documented in the [installation trust contract](docs/INSTALLATION_TRUST_CONTRACT.md). Client-specific config targets and preview-first bootstrap paths live in the [compatibility matrix](docs/CLIENT_COMPATIBILITY_MATRIX.md).
+Exact install, MCP, Docker, cache, uninstall, and trust semantics are documented in the [installation trust contract](docs/INSTALLATION_TRUST_CONTRACT.md). Client-specific config targets and bootstrap paths live in the [compatibility matrix](docs/CLIENT_COMPATIBILITY_MATRIX.md).
 
 Local usage metrics are off by default. If a user explicitly enables them with `archex metrics enable`, `ARCHEX_USAGE_METRICS=on`, or the persisted metrics setting, archex writes a machine-local ledger at `~/.archex/usage.sqlite`. That ledger records anonymous counters only: tool name, category, token counts, file count, repo-local random ID, freshness, and index revision. It does not store query text, file paths, symbols, handles, rendered outputs, prompt bodies, remote URLs, org names, or repo names in event rows. Headline savings are always `tokens_saved = max(returned full-file baseline - returned tokens, 0)`. Whole-repo avoided tokens are tracked separately as an upper-bound/context metric when the indexed repo total is available.
 
@@ -262,9 +263,9 @@ The mounted repository owns `.archex/`, so indexes survive container restarts an
 | --- | --- |
 | Security policy | Supported versions, disclosure workflow, no-telemetry posture, secret-handling guidance, and model remote-code policy live in [SECURITY](SECURITY.md). |
 | Context receipts | Field contract, freshness/completeness semantics, output surfaces, and benchmark linkage live in [CONTEXT_RECEIPTS](docs/CONTEXT_RECEIPTS.md). |
-| Compatibility matrix | Tested vs unverified clients, exact config shapes, preview-first bootstrap commands, and verification steps live in [CLIENT_COMPATIBILITY_MATRIX](docs/CLIENT_COMPATIBILITY_MATRIX.md). |
+| Compatibility matrix | Tested vs unverified clients, exact config shapes, bootstrap commands, and verification steps live in [CLIENT_COMPATIBILITY_MATRIX](docs/CLIENT_COMPATIBILITY_MATRIX.md). |
 | Installation trust contract | Exact CLI, MCP, Docker, skill, cache, network, freshness, benchmark, and uninstall semantics live in [INSTALLATION_TRUST_CONTRACT](docs/INSTALLATION_TRUST_CONTRACT.md). |
-| `archex install-client` | Preview-first client config writer for Claude Code, Codex, Pi, OpenCode, and Cursor. |
+| `archex install-client` | Client config writer for Claude Code, Codex, Pi, OpenCode, and Cursor. Global/user scope by default; `--dry-run` previews without writing. |
 | `archex doctor` | Text/JSON diagnostics for index health, staleness, local model cache presence, grammar availability by tier, MCP registration, model security, and `.archex/` disk usage. |
 | Repo-local `.archex/` | Generated state: settings, metadata, SQLite index, optional vectors, graph artifacts, dogfood history. Keep it uncommitted. |
 | Local usage metrics | Calculation rules, privacy boundaries, default-off versus opt-in behavior, export/delete controls, and retention live in [LOCAL_METRICS](docs/LOCAL_METRICS.md). |

--- a/docs/CLIENT_COMPATIBILITY_MATRIX.md
+++ b/docs/CLIENT_COMPATIBILITY_MATRIX.md
@@ -1,51 +1,54 @@
 # Client Compatibility Matrix
 
-Last updated: 2026-06-16
+Last updated: 2026-06-20
 
-This matrix separates config-shape verification from actual client smoke tests. `archex install-client <client>` previews the exact config it would write. Add `--write` to persist it.
+This matrix separates config-shape verification from actual client smoke tests. `archex install-client <client>` writes the config by default (global/user scope; a SOURCE path or `--scope project` installs repo-local). Add `--dry-run` to preview the exact target and config without writing.
 
 ## Matrix
 
 | Client / path | Tested status | Setup command / config | Watch support | Freshness semantics | Known limitations | Last verified |
 | --- | --- | --- | --- | --- | --- | --- |
-| Claude Code MCP stdio | Config-path tested; client smoke unverified | `archex install-client claude-code .` then `archex install-client claude-code . --write` writes `.mcp.json` with `mcpServers.archex.command = "archex"` and `args = ["mcp"]`. | Yes — `archex mcp --watch --watch-path .` | Inline query refresh by default; `--no-refresh` leaves freshness `unknown`; watch keeps a warm process subscribed to file events. | This stack did not run a live Claude Code UI smoke. Skill and MCP are separate rows. | 2026-06-16 |
+| Claude Code MCP stdio | Config-path tested; client smoke unverified | `archex install-client claude-code` writes `~/.claude.json` (global); `archex install-client claude-code . --scope project` writes `.mcp.json` with `mcpServers.archex.command = "archex"` and `args = ["mcp"]`. `--dry-run` previews either. | Yes — `archex mcp --watch --watch-path .` | Inline query refresh by default; `--no-refresh` leaves freshness `unknown`; watch keeps a warm process subscribed to file events. | This stack did not run a live Claude Code UI smoke. Skill and MCP are separate rows. | 2026-06-16 |
 | Claude Code skill command | Existing skill path tested in-repo; client smoke unverified | Use `skills/archex/` and the `/archex` command flow. No config file is written by `install-client`; this is command-only onboarding. | Indirect — skill can target a warm MCP server. | Same as MCP/query/scout paths underneath. | Skill setup remains repo-local documentation, not a writable client config target. | 2026-06-16 |
 | CLI-only query/scout | Tested | No client config required. Run `archex doctor`, `archex scout`, `archex query`. | N/A | Query checks freshness inline unless `--no-refresh`; scout inherits query freshness in its receipt. | Not an MCP client. | 2026-06-16 |
-| Generic MCP stdio client | Unverified | Use a JSON config shaped like `{ "mcpServers": { "archex": { "command": "archex", "args": ["mcp"] }}}`. `archex install-client claude-code .` prints a compatible snippet. | Client-dependent | Same server-side freshness semantics as Claude Code / Cursor. | No live generic-client smoke in this stack. | 2026-06-16 |
-| Codex headless | Unverified | `archex install-client codex .` previews `.codex/config.toml`; `--write` appends `[mcp_servers.archex]`, `command = "archex"`, `args = ["mcp"]` without overwriting existing sections. | Yes — via `archex mcp --watch --watch-path .` after Codex launches the server. | Inline query refresh by default; warm watch is server-side, not Codex-specific. | Config shape verified against OpenAI Codex MCP docs; no Codex client smoke in this stack. | 2026-06-16 |
-| Pi | Config shape verified; client smoke unverified | `archex install-client pi .` previews `~/.pi/agent/mcp.json`; `--write` writes a stdio `mcpServers.archex` entry. User scope only. | Client-dependent; server supports `--watch`. | Same server-side freshness semantics as other stdio clients. | No Pi client smoke in this stack. | 2026-06-16 |
-| OpenCode | Config shape verified; client smoke unverified | `archex install-client opencode .` previews `opencode.json`; `--write` writes `mcp.archex = { type = "local", command = ["archex", "mcp"], enabled = true }`. | Client-dependent; server supports `--watch`. | Same server-side freshness semantics as other stdio clients. | No OpenCode client smoke in this stack. | 2026-06-16 |
-| Cursor | Config shape verified; client smoke unverified | `archex install-client cursor .` previews `.cursor/mcp.json`; `--write` writes `mcpServers.archex.command = "archex"`, `args = ["mcp"]`. | Yes — with a warm `archex mcp --watch --watch-path .` process. | Inline query refresh by default; watch keeps a warm process subscribed to file events. | No Cursor UI smoke in this stack. | 2026-06-16 |
+| Generic MCP stdio client | Unverified | Use a JSON config shaped like `{ "mcpServers": { "archex": { "command": "archex", "args": ["mcp"] }}}`. `archex install-client claude-code --dry-run` prints a compatible snippet. | Client-dependent | Same server-side freshness semantics as Claude Code / Cursor. | No live generic-client smoke in this stack. | 2026-06-16 |
+| Codex headless | Unverified | `archex install-client codex` writes `~/.codex/config.toml` (global); `archex install-client codex . --scope project` writes `.codex/config.toml`, appending `[mcp_servers.archex]`, `command = "archex"`, `args = ["mcp"]` without overwriting existing sections. `--dry-run` previews. | Yes — via `archex mcp --watch --watch-path .` after Codex launches the server. | Inline query refresh by default; warm watch is server-side, not Codex-specific. | Config shape verified against OpenAI Codex MCP docs; no Codex client smoke in this stack. | 2026-06-16 |
+| Pi | Config shape verified; client smoke unverified | `archex install-client pi` writes `~/.pi/agent/mcp.json` with a stdio `mcpServers.archex` entry (`--dry-run` previews). User scope only. | Client-dependent; server supports `--watch`. | Same server-side freshness semantics as other stdio clients. | No Pi client smoke in this stack. | 2026-06-16 |
+| OpenCode | Config shape verified; client smoke unverified | `archex install-client opencode` writes `~/.config/opencode/opencode.json` (global); `archex install-client opencode . --scope project` writes `opencode.json`, setting `mcp.archex = { type = "local", command = ["archex", "mcp"], enabled = true }`. `--dry-run` previews. | Client-dependent; server supports `--watch`. | Same server-side freshness semantics as other stdio clients. | No OpenCode client smoke in this stack. | 2026-06-16 |
+| Cursor | Config shape verified; client smoke unverified | `archex install-client cursor` writes `~/.cursor/mcp.json` (global); `archex install-client cursor . --scope project` writes `.cursor/mcp.json` with `mcpServers.archex.command = "archex"`, `args = ["mcp"]`. `--dry-run` previews. | Yes — with a warm `archex mcp --watch --watch-path .` process. | Inline query refresh by default; watch keeps a warm process subscribed to file events. | No Cursor UI smoke in this stack. | 2026-06-16 |
 | Dockerized MCP server | Server path tested; client smoke unverified | Run `docker run -d --name archex-mcp -v "$PWD:/workspace" -w /workspace ghcr.io/mathews-tom/archex:slim sleep infinity` then point the client to `docker exec -i archex-mcp archex mcp`. | Yes — run the MCP process with `--watch`. | Same server-side freshness semantics as stdio. | Client-specific Docker registration varies; use the same client config shapes above, but replace the command with `docker` / `exec`. | 2026-06-16 |
 
 ## First-party bootstrap command
 
-Preview first. Nothing is written unless `--write` is passed.
+Installs write by default; add `--dry-run` to preview the exact target and config first. The default scope is global (user); pass a SOURCE path or `--scope project` for a repo-local install.
 
 ```bash
-archex install-client claude-code .
-archex install-client cursor .
-archex install-client opencode .
-archex install-client codex .
-archex install-client pi .
+archex install-client claude-code
+archex install-client cursor
+archex install-client opencode
+archex install-client codex
+archex install-client pi
 ```
 
-Persist the config only after reviewing the preview:
+Preview any of them without writing:
 
 ```bash
-archex install-client claude-code . --write
-archex install-client cursor . --write
-archex install-client opencode . --write
-archex install-client codex . --write
-archex install-client pi . --write
+archex install-client claude-code --dry-run
+```
+
+Install repo-local instead of global:
+
+```bash
+archex install-client claude-code . --scope project
 ```
 
 ## Safe-write behavior
 
-- Preview is the default.
-- JSON clients merge an `archex` entry into the existing top-level server map.
+- Writes happen by default; `--dry-run` previews the target and config and changes nothing on disk.
+- The default scope is global (user); a SOURCE path or `--scope project` selects a repo-local target.
+- JSON clients merge an `archex` entry into the existing top-level server map without clobbering unrelated sections.
 - Codex appends one `[mcp_servers.archex]` section to `config.toml`.
-- If `archex` is already present, the command fails instead of overwriting it.
+- Re-running an install with an identical `archex` entry already present is an idempotent no-op; a different existing `archex` entry is left untouched and the command fails instead of overwriting it.
 - Pi only supports `--scope user`.
 
 ## Verification commands

--- a/docs/INSTALLATION_TRUST_CONTRACT.md
+++ b/docs/INSTALLATION_TRUST_CONTRACT.md
@@ -117,11 +117,15 @@ ln -s "$PWD/skills/archex" ~/.claude/skills/archex
 ```
 
 
-Preview or write a client config with:
+Install (or preview) a client config with:
 
 ```bash
-archex install-client claude-code .
-archex install-client claude-code . --write
+# Global (user-scope) install by default — writes immediately, non-destructively.
+archex install-client claude-code
+# Preview the exact target + config without writing anything.
+archex install-client claude-code --dry-run
+# Repo-local install: pass a SOURCE path or --scope project.
+archex install-client claude-code . --scope project
 ```
 Then use:
 

--- a/src/archex/cli/install_client_cmd.py
+++ b/src/archex/cli/install_client_cmd.py
@@ -20,31 +20,31 @@ from archex.client_setup import (
     "client",
     type=click.Choice(["claude-code", "codex", "cursor", "opencode", "pi"]),
 )
-@click.argument("source", required=False, default=".")
+@click.argument("source", required=False, default=None)
 @click.option(
     "--scope",
     type=click.Choice(["project", "user"]),
     default=None,
-    help="Install scope.",
+    help="Install scope. Default user/global; a SOURCE path or --scope project is repo-local.",
 )
 @click.option(
-    "--write",
+    "--dry-run",
     is_flag=True,
     default=False,
-    help="Write config instead of previewing it.",
+    help="Preview the target path and config without writing anything.",
 )
-def install_client_cmd(client: str, source: str, scope: str | None, write: bool) -> None:
-    """Preview or write MCP client configuration for archex."""
+def install_client_cmd(client: str, source: str | None, scope: str | None, dry_run: bool) -> None:
+    """Install MCP client configuration for archex (preview with --dry-run)."""
     try:
         plan = build_client_install_plan(
             cast("ClientName", client),
             source,
             scope=cast("ClientScope | None", scope),
         )
-        if write:
+        if dry_run:
+            click.echo(render_client_install_preview(plan), nl=False)
+        else:
             target = write_client_install_plan(plan)
             click.echo(f"Wrote {client} config: {target}")
-        else:
-            click.echo(render_client_install_preview(plan), nl=False)
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -10,6 +10,8 @@ from typing import Literal, cast
 ClientName = Literal["claude-code", "codex", "cursor", "opencode", "pi"]
 ClientScope = Literal["project", "user"]
 
+_USER_ONLY_CLIENTS: frozenset[ClientName] = frozenset({"pi"})
+
 
 @dataclass(frozen=True)
 class ClientInstallPlan:
@@ -24,14 +26,14 @@ class ClientInstallPlan:
 
 def build_client_install_plan(
     client: ClientName,
-    source: str | Path = ".",
+    source: str | Path | None = None,
     *,
     scope: ClientScope | None = None,
 ) -> ClientInstallPlan:
-    repo_root = Path(source).expanduser().resolve()
-    selected_scope = scope or _default_scope(client)
-    if client == "pi" and selected_scope != "user":
-        raise ValueError("pi client config supports only --scope user")
+    selected_scope = _resolve_scope(client, source, scope)
+    if client in _USER_ONLY_CLIENTS and selected_scope != "user":
+        raise ValueError(f"{client} client config supports only --scope user")
+    repo_root = Path(source if source is not None else ".").expanduser().resolve()
     target_path = _target_path(client, repo_root, selected_scope)
     content = _render_content(client)
     return ClientInstallPlan(
@@ -49,9 +51,12 @@ def write_client_install_plan(plan: ClientInstallPlan) -> Path:
     target = plan.target_path
     target.parent.mkdir(parents=True, exist_ok=True)
     if _is_toml_plan(plan):
+        block = plan.content.strip()
         if target.exists():
             existing = target.read_text(encoding="utf-8")
             if "[mcp_servers.archex]" in existing:
+                if block in existing:
+                    return target
                 raise ValueError(f"archex already configured in {target}")
             if existing.strip():
                 new_content = existing.rstrip() + "\n\n" + plan.content
@@ -90,7 +95,10 @@ def write_client_install_plan(plan: ClientInstallPlan) -> Path:
     if not isinstance(archex_entry_obj, dict):
         raise ValueError(f"expected archex entry in generated content for {plan.client}")
     archex_entry = cast("dict[str, object]", archex_entry_obj)
-    if "archex" in container:
+    existing_archex = container.get("archex")
+    if existing_archex is not None:
+        if existing_archex == archex_entry:
+            return target
         raise ValueError(f"archex already configured in {target}")
     container["archex"] = archex_entry
     if plan.client == "opencode" and "$schema" not in existing_payload:
@@ -108,17 +116,21 @@ def render_client_install_preview(plan: ClientInstallPlan) -> str:
         f"Last verified: {plan.last_verified}",
         f"Description: {plan.description}",
         "",
-        "Preview only. Re-run with --write to persist this config.",
+        "Dry run. Re-run without --dry-run to write this config.",
         "",
         plan.content.rstrip(),
     ]
     return "\n".join(lines) + "\n"
 
 
-def _default_scope(client: ClientName) -> ClientScope:
-    if client == "pi":
+def _resolve_scope(
+    client: ClientName, source: str | Path | None, scope: ClientScope | None
+) -> ClientScope:
+    if scope is not None:
+        return scope
+    if client in _USER_ONLY_CLIENTS:
         return "user"
-    return "project"
+    return "project" if source is not None else "user"
 
 
 def _target_path(client: ClientName, repo_root: Path, scope: ClientScope) -> Path:

--- a/tests/cli/test_install_client.py
+++ b/tests/cli/test_install_client.py
@@ -12,54 +12,115 @@ if TYPE_CHECKING:
     import pytest
 
 
-def test_install_client_preview_claude_code_project(tmp_path: Path) -> None:
-    result = CliRunner().invoke(cli, ["install-client", "claude-code", str(tmp_path)])
+def test_install_client_default_scope_is_global(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = CliRunner().invoke(cli, ["install-client", "claude-code", "--dry-run"])
 
     assert result.exit_code == 0, result.output
-    assert f"Target: {tmp_path / '.mcp.json'}" in result.output
-    assert '"mcpServers"' in result.output
+    assert "Scope: user" in result.output
+    assert f"Target: {tmp_path / '.claude.json'}" in result.output
     assert '"command": "archex"' in result.output
-    assert "Preview only." in result.output
 
 
-def test_install_client_write_claude_code_project(tmp_path: Path) -> None:
+def test_install_client_source_path_selects_project_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    result = CliRunner().invoke(cli, ["install-client", "claude-code", str(repo), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Scope: project" in result.output
+    assert f"Target: {repo / '.mcp.json'}" in result.output
+
+
+def test_install_client_scope_project_flag_selects_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
     result = CliRunner().invoke(
         cli,
-        ["install-client", "claude-code", str(tmp_path), "--write"],
+        ["install-client", "claude-code", str(tmp_path), "--scope", "project", "--dry-run"],
     )
 
     assert result.exit_code == 0, result.output
-    config_path = tmp_path / ".mcp.json"
-    payload = json.loads(config_path.read_text(encoding="utf-8"))
-    assert payload["mcpServers"]["archex"]["args"] == ["mcp"]
+    assert "Scope: project" in result.output
+    assert f"Target: {tmp_path / '.mcp.json'}" in result.output
 
 
-def test_install_client_refuses_existing_entry(tmp_path: Path) -> None:
-    config_path = tmp_path / ".mcp.json"
+def test_install_client_dry_run_makes_no_filesystem_changes(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    result = CliRunner().invoke(cli, ["install-client", "claude-code", str(repo), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Dry run." in result.output
+    assert not (repo / ".mcp.json").exists()
+
+
+def test_install_client_writes_by_default_non_destructive(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config_path = repo / ".mcp.json"
     config_path.write_text(
-        json.dumps({"mcpServers": {"archex": {"command": "archex", "args": ["mcp"]}}}),
+        json.dumps({"mcpServers": {"other": {"command": "other"}}}),
         encoding="utf-8",
     )
 
-    result = CliRunner().invoke(
-        cli,
-        ["install-client", "claude-code", str(tmp_path), "--write"],
+    result = CliRunner().invoke(cli, ["install-client", "claude-code", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["mcpServers"]["archex"]["args"] == ["mcp"]
+    assert payload["mcpServers"]["other"] == {"command": "other"}
+
+
+def test_install_client_idempotent_on_identical_entry(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config_path = repo / ".mcp.json"
+
+    first = CliRunner().invoke(cli, ["install-client", "claude-code", str(repo)])
+    after_first = config_path.read_text(encoding="utf-8")
+    second = CliRunner().invoke(cli, ["install-client", "claude-code", str(repo)])
+    after_second = config_path.read_text(encoding="utf-8")
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    assert after_first == after_second
+    assert json.loads(after_second)["mcpServers"]["archex"]["args"] == ["mcp"]
+
+
+def test_install_client_refuses_conflicting_entry(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    config_path = repo / ".mcp.json"
+    config_path.write_text(
+        json.dumps({"mcpServers": {"archex": {"command": "other", "args": []}}}),
+        encoding="utf-8",
     )
+
+    result = CliRunner().invoke(cli, ["install-client", "claude-code", str(repo)])
 
     assert result.exit_code != 0
     assert "already configured" in result.output
 
 
 def test_install_client_writes_codex_project_toml(tmp_path: Path) -> None:
-    codex_dir = tmp_path / ".codex"
+    repo = tmp_path / "repo"
+    codex_dir = repo / ".codex"
     codex_dir.mkdir(parents=True)
     config_path = codex_dir / "config.toml"
     config_path.write_text('default_model = "gpt-5"\n', encoding="utf-8")
 
-    result = CliRunner().invoke(
-        cli,
-        ["install-client", "codex", str(tmp_path), "--write"],
-    )
+    result = CliRunner().invoke(cli, ["install-client", "codex", str(repo)])
 
     assert result.exit_code == 0, result.output
     content = config_path.read_text(encoding="utf-8")
@@ -67,15 +128,20 @@ def test_install_client_writes_codex_project_toml(tmp_path: Path) -> None:
     assert "[mcp_servers.archex]" in content
     assert 'args = ["mcp"]' in content
 
+    second = CliRunner().invoke(cli, ["install-client", "codex", str(repo)])
+    assert second.exit_code == 0, second.output
+    assert config_path.read_text(encoding="utf-8") == content
+
 
 def test_install_client_pi_user_scope_uses_home(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
 
-    result = CliRunner().invoke(cli, ["install-client", "pi", str(tmp_path)])
+    result = CliRunner().invoke(cli, ["install-client", "pi", str(tmp_path), "--dry-run"])
 
     assert result.exit_code == 0, result.output
+    assert "Scope: user" in result.output
     assert f"Target: {tmp_path / '.pi' / 'agent' / 'mcp.json'}" in result.output
 
 

--- a/tests/cli/test_install_client.py
+++ b/tests/cli/test_install_client.py
@@ -133,6 +133,41 @@ def test_install_client_writes_codex_project_toml(tmp_path: Path) -> None:
     assert config_path.read_text(encoding="utf-8") == content
 
 
+def test_install_client_refuses_conflicting_codex_entry(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    codex_dir = repo / ".codex"
+    codex_dir.mkdir(parents=True)
+    config_path = codex_dir / "config.toml"
+    config_path.write_text(
+        '[mcp_servers.archex]\ncommand = "other"\nargs = []\n',
+        encoding="utf-8",
+    )
+    before = config_path.read_text(encoding="utf-8")
+
+    result = CliRunner().invoke(cli, ["install-client", "codex", str(repo)])
+
+    assert result.exit_code != 0
+    assert "already configured" in result.output
+    assert config_path.read_text(encoding="utf-8") == before
+
+
+def test_install_client_default_global_write_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    target = tmp_path / ".claude.json"
+
+    first = CliRunner().invoke(cli, ["install-client", "claude-code"])
+    after_first = target.read_text(encoding="utf-8")
+    second = CliRunner().invoke(cli, ["install-client", "claude-code"])
+    after_second = target.read_text(encoding="utf-8")
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    assert json.loads(after_first)["mcpServers"]["archex"]["args"] == ["mcp"]
+    assert after_first == after_second
+
+
 def test_install_client_pi_user_scope_uses_home(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Make `archex install-client` install at global (user) scope by default and replace the preview-first `--write` flag with write-by-default + `--dry-run`.

- Default scope is now global (user) for every client; a `[SOURCE]` repo path or `--scope project` selects a repo-local install.
- `--write` is removed. Configs are written by default; `--dry-run` previews the exact target and config and changes nothing on disk.
- Writes are non-destructive (merge into existing config, never clobber unrelated sections) and idempotent: an identical existing `archex` entry is a no-op; a conflicting one is refused.
- Installation trust contract, compatibility matrix, and README updated to the new posture.

No retrieval, ranking, scoring, fusion, packing, or benchmark code path is touched.

## Stack

Stack-Id: `mcp-adoption-2026-06-20`
Base: `main`
Position: 1/5

1. `feat/install-client-default-global` -> this PR
2. `feat/install-client-omp-target`
3. `feat/install-client-agent-guidance`
4. `feat/metrics-surface-mix`
5. `docs/mcp-adoption`

Depends on: (none - root)

## Validation

- `uv run ruff check` / `ruff format --check` / `uv run pyright` on changed files: pass
- `uv run pytest tests/cli/test_install_client.py --no-cov`: 10 passed
