### PR TITLE
feat(install-client): first-class omp target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`omp` install-client target:** Added oh-my-pi (`omp`) as a first-class `archex install-client` client. `archex install-client omp` writes `~/.omp/agent/mcp.json` (user scope) with the standard `mcpServers.archex = {command: "archex", args: ["mcp"]}` payload plus the oh-my-pi `$schema`, merged non-destructively and idempotently.
+
 ### Changed
 
 - **README adoption refresh:** Reframed the opening around context-window burn, kept the quickstart as the one always-visible happy path, collapsed only the secondary Docker/extras blocks, and added a metric-anchored workflow translation under Measured results without changing product behavior or benchmark numbers.

--- a/src/archex/cli/install_client_cmd.py
+++ b/src/archex/cli/install_client_cmd.py
@@ -18,7 +18,7 @@ from archex.client_setup import (
 @click.command("install-client")
 @click.argument(
     "client",
-    type=click.Choice(["claude-code", "codex", "cursor", "opencode", "pi"]),
+    type=click.Choice(["claude-code", "codex", "cursor", "opencode", "pi", "omp"]),
 )
 @click.argument("source", required=False, default=None)
 @click.option(

--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -7,10 +7,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, cast
 
-ClientName = Literal["claude-code", "codex", "cursor", "opencode", "pi"]
+ClientName = Literal["claude-code", "codex", "cursor", "opencode", "pi", "omp"]
 ClientScope = Literal["project", "user"]
 
-_USER_ONLY_CLIENTS: frozenset[ClientName] = frozenset({"pi"})
+_USER_ONLY_CLIENTS: frozenset[ClientName] = frozenset({"pi", "omp"})
+_OMP_SCHEMA = (
+    "https://raw.githubusercontent.com/can1357/oh-my-pi/main/"
+    "packages/coding-agent/src/config/mcp-schema.json"
+)
+_CLIENT_SCHEMA: dict[ClientName, str] = {
+    "opencode": "https://opencode.ai/config.json",
+    "omp": _OMP_SCHEMA,
+}
 
 
 @dataclass(frozen=True)
@@ -101,8 +109,9 @@ def write_client_install_plan(plan: ClientInstallPlan) -> Path:
             return target
         raise ValueError(f"archex already configured in {target}")
     container["archex"] = archex_entry
-    if plan.client == "opencode" and "$schema" not in existing_payload:
-        existing_payload["$schema"] = "https://opencode.ai/config.json"
+    schema = _CLIENT_SCHEMA.get(plan.client)
+    if schema is not None and "$schema" not in existing_payload:
+        existing_payload["$schema"] = schema
     target.write_text(json.dumps(existing_payload, indent=2) + "\n", encoding="utf-8")
     return target
 
@@ -157,6 +166,8 @@ def _target_path(client: ClientName, repo_root: Path, scope: ClientScope) -> Pat
         )
     if client == "pi":
         return home / ".pi" / "agent" / "mcp.json"
+    if client == "omp":
+        return home / ".omp" / "agent" / "mcp.json"
     raise ValueError(f"unsupported client: {client}")
 
 
@@ -185,6 +196,17 @@ def _render_content(client: ClientName) -> str:
             }
         }
         return json.dumps(payload, indent=2) + "\n"
+    if client == "omp":
+        payload = {
+            "$schema": _OMP_SCHEMA,
+            "mcpServers": {
+                "archex": {
+                    "command": "archex",
+                    "args": ["mcp"],
+                }
+            },
+        }
+        return json.dumps(payload, indent=2) + "\n"
     payload = {
         "mcpServers": {
             "archex": {
@@ -211,6 +233,8 @@ def _description(client: ClientName, scope: ClientScope) -> str:
         return f"OpenCode {'project' if scope == 'project' else 'user'} config"
     if client == "pi":
         return "Pi agent MCP config"
+    if client == "omp":
+        return "oh-my-pi agent MCP config"
     if client == "cursor":
         return f"Cursor {'project' if scope == 'project' else 'user'} MCP config"
     return f"Claude Code {'project' if scope == 'project' else 'user'} MCP config"
@@ -225,4 +249,6 @@ def _tested_status(client: ClientName) -> str:
         return "config-shape verified; client smoke unverified"
     if client == "codex":
         return "unverified client smoke"
+    if client == "omp":
+        return "config-shape verified; client smoke unverified"
     return "config-shape verified; client smoke unverified"

--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -15,8 +15,9 @@ _OMP_SCHEMA = (
     "https://raw.githubusercontent.com/can1357/oh-my-pi/main/"
     "packages/coding-agent/src/config/mcp-schema.json"
 )
+_OPENCODE_SCHEMA = "https://opencode.ai/config.json"
 _CLIENT_SCHEMA: dict[ClientName, str] = {
-    "opencode": "https://opencode.ai/config.json",
+    "opencode": _OPENCODE_SCHEMA,
     "omp": _OMP_SCHEMA,
 }
 
@@ -176,7 +177,7 @@ def _render_content(client: ClientName) -> str:
         return '[mcp_servers.archex]\ncommand = "archex"\nargs = ["mcp"]\n'
     if client == "opencode":
         payload = {
-            "$schema": "https://opencode.ai/config.json",
+            "$schema": _OPENCODE_SCHEMA,
             "mcp": {
                 "archex": {
                     "type": "local",

--- a/tests/cli/test_install_client.py
+++ b/tests/cli/test_install_client.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from click.testing import CliRunner
 
 from archex.cli.main import cli
-from archex.client_setup import _OMP_SCHEMA  # pyright: ignore[reportPrivateUsage]
 
 if TYPE_CHECKING:
     import pytest
@@ -201,7 +200,7 @@ def test_install_client_omp_user_scope_target(
     assert result.exit_code == 0, result.output
     assert "Scope: user" in result.output
     assert f"Target: {tmp_path / '.omp' / 'agent' / 'mcp.json'}" in result.output
-    assert "oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json" in result.output
+    assert "mcp-schema.json" in result.output
 
 
 def test_install_client_omp_writes_expected_payload(
@@ -209,17 +208,26 @@ def test_install_client_omp_writes_expected_payload(
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
     target = tmp_path / ".omp" / "agent" / "mcp.json"
+    runner = CliRunner()
 
-    result = CliRunner().invoke(cli, ["install-client", "omp"])
+    preview = runner.invoke(cli, ["install-client", "omp", "--dry-run"])
+    written = runner.invoke(cli, ["install-client", "omp"])
     after_first = target.read_text(encoding="utf-8")
-    second = CliRunner().invoke(cli, ["install-client", "omp"])
+    rerun = runner.invoke(cli, ["install-client", "omp"])
     after_second = target.read_text(encoding="utf-8")
 
-    assert result.exit_code == 0, result.output
-    assert second.exit_code == 0, second.output
-    payload = json.loads(after_first)
-    assert payload["mcpServers"]["archex"] == {"command": "archex", "args": ["mcp"]}
-    assert payload["$schema"] == _OMP_SCHEMA
+    assert preview.exit_code == 0, preview.output
+    assert written.exit_code == 0, written.output
+    assert rerun.exit_code == 0, rerun.output
+    previewed_payload = json.loads(preview.output[preview.output.index("{") :])
+    written_payload = json.loads(after_first)
+    # The written file must agree with what --dry-run previewed (single source of truth).
+    assert written_payload["mcpServers"]["archex"] == previewed_payload["mcpServers"]["archex"]
+    assert written_payload["$schema"] == previewed_payload["$schema"]
+    # The payload is the standard archex stdio entry plus the oh-my-pi schema.
+    assert written_payload["mcpServers"]["archex"] == {"command": "archex", "args": ["mcp"]}
+    assert "oh-my-pi" in written_payload["$schema"]
+    # Writing is idempotent.
     assert after_first == after_second
 
 

--- a/tests/cli/test_install_client.py
+++ b/tests/cli/test_install_client.py
@@ -188,3 +188,63 @@ def test_install_client_pi_rejects_project_scope(tmp_path: Path) -> None:
 
     assert result.exit_code != 0
     assert "supports only --scope user" in result.output
+
+
+def test_install_client_omp_user_scope_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = CliRunner().invoke(cli, ["install-client", "omp", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Scope: user" in result.output
+    assert f"Target: {tmp_path / '.omp' / 'agent' / 'mcp.json'}" in result.output
+    assert "oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json" in result.output
+
+
+def test_install_client_omp_writes_expected_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    target = tmp_path / ".omp" / "agent" / "mcp.json"
+
+    result = CliRunner().invoke(cli, ["install-client", "omp"])
+    after_first = target.read_text(encoding="utf-8")
+    second = CliRunner().invoke(cli, ["install-client", "omp"])
+    after_second = target.read_text(encoding="utf-8")
+
+    assert result.exit_code == 0, result.output
+    assert second.exit_code == 0, second.output
+    payload = json.loads(after_first)
+    assert payload["mcpServers"]["archex"] == {"command": "archex", "args": ["mcp"]}
+    assert payload["$schema"].endswith("mcp-schema.json")
+    assert after_first == after_second
+
+
+def test_install_client_omp_rejects_project_scope(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        cli,
+        ["install-client", "omp", str(tmp_path), "--scope", "project"],
+    )
+
+    assert result.exit_code != 0
+    assert "supports only --scope user" in result.output
+
+
+def test_install_client_opencode_write_injects_schema(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / "opencode.json"
+
+    result = CliRunner().invoke(cli, ["install-client", "opencode", str(repo)])
+    after_first = target.read_text(encoding="utf-8")
+    second = CliRunner().invoke(cli, ["install-client", "opencode", str(repo)])
+    after_second = target.read_text(encoding="utf-8")
+
+    assert result.exit_code == 0, result.output
+    assert second.exit_code == 0, second.output
+    payload = json.loads(after_first)
+    assert payload["$schema"] == "https://opencode.ai/config.json"
+    assert payload["mcp"]["archex"]["command"] == ["archex", "mcp"]
+    assert after_first == after_second

--- a/tests/cli/test_install_client.py
+++ b/tests/cli/test_install_client.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from click.testing import CliRunner
 
 from archex.cli.main import cli
+from archex.client_setup import _OMP_SCHEMA  # pyright: ignore[reportPrivateUsage]
 
 if TYPE_CHECKING:
     import pytest
@@ -218,7 +219,7 @@ def test_install_client_omp_writes_expected_payload(
     assert second.exit_code == 0, second.output
     payload = json.loads(after_first)
     assert payload["mcpServers"]["archex"] == {"command": "archex", "args": ["mcp"]}
-    assert payload["$schema"].endswith("mcp-schema.json")
+    assert payload["$schema"] == _OMP_SCHEMA
     assert after_first == after_second
 
 
@@ -248,3 +249,22 @@ def test_install_client_opencode_write_injects_schema(tmp_path: Path) -> None:
     assert payload["$schema"] == "https://opencode.ai/config.json"
     assert payload["mcp"]["archex"]["command"] == ["archex", "mcp"]
     assert after_first == after_second
+
+
+def test_install_client_omp_preserves_existing_schema(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    target = tmp_path / ".omp" / "agent" / "mcp.json"
+    target.parent.mkdir(parents=True)
+    target.write_text(
+        json.dumps({"$schema": "https://example.com/custom.json", "mcpServers": {}}),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(cli, ["install-client", "omp"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["$schema"] == "https://example.com/custom.json"
+    assert payload["mcpServers"]["archex"] == {"command": "archex", "args": ["mcp"]}


### PR DESCRIPTION
## Summary

Add oh-my-pi (`omp`) as a first-class `archex install-client` target.

- `archex install-client omp` writes `~/.omp/agent/mcp.json` at user scope (the new global default) with `mcpServers.archex = {command: "archex", args: ["mcp"]}` plus the oh-my-pi `$schema`.
- The `$schema` injection on merge is generalized from an opencode special-case to a per-client `_CLIENT_SCHEMA` table (opencode + omp).
- Writes stay non-destructive and idempotent; existing client targets are unchanged.

No retrieval, ranking, scoring, fusion, packing, or benchmark code path is touched.

## Stack

Stack-Id: `mcp-adoption-2026-06-20`
Base: `feat/install-client-default-global`
Position: 2/5

1. `feat/install-client-default-global` -> #330
2. `feat/install-client-omp-target` -> this PR
3. `feat/install-client-agent-guidance`
4. `feat/metrics-surface-mix`
5. `docs/mcp-adoption`

Depends on: #330

## Validation

- `uv run ruff check` / `ruff format --check` / `uv run pyright` on changed files: pass
- `uv run pytest tests/cli/test_install_client.py --no-cov`: 16 passed
- Smoke: `archex install-client omp` writes the expected `~/.omp/agent/mcp.json`; `--dry-run` previews with no filesystem change.
