### PR TITLE
feat(install-client): archex MCP agent-file guidance prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **`omp` install-client target:** Added oh-my-pi (`omp`) as a first-class `archex install-client` client. `archex install-client omp` writes `~/.omp/agent/mcp.json` (user scope) with the standard `mcpServers.archex = {command: "archex", args: ["mcp"]}` payload plus the oh-my-pi `$schema`, merged non-destructively and idempotently.
+- **Agent-file MCP guidance prompt:** Added a ready-to-paste prompt that points an agent at the archex MCP tools (`scout_repo`, `query_repo`, `analyze_repo`, `search_symbols`, `get_symbol`) and the discovery/activation step for tool-gated harnesses. `archex install-client --agent-file <path>` appends it to a global or repo-specific agent file (`CLAUDE.md`, `AGENTS.md`, ...) inside a delimited block — non-destructive and idempotent — and `--dry-run` previews it without writing.
 
 ### Changed
 

--- a/src/archex/cli/install_client_cmd.py
+++ b/src/archex/cli/install_client_cmd.py
@@ -69,5 +69,5 @@ def install_client_cmd(
                     click.echo(f"Appended archex MCP guidance: {resolved}")
                 else:
                     click.echo(f"archex MCP guidance already present: {resolved}")
-    except ValueError as exc:
+    except (ValueError, OSError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/archex/cli/install_client_cmd.py
+++ b/src/archex/cli/install_client_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import cast
 
 import click
@@ -9,7 +10,9 @@ import click
 from archex.client_setup import (
     ClientName,
     ClientScope,
+    append_agent_guidance,
     build_client_install_plan,
+    render_agent_guidance_preview,
     render_client_install_preview,
     write_client_install_plan,
 )
@@ -33,7 +36,19 @@ from archex.client_setup import (
     default=False,
     help="Preview the target path and config without writing anything.",
 )
-def install_client_cmd(client: str, source: str | None, scope: str | None, dry_run: bool) -> None:
+@click.option(
+    "--agent-file",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Append the archex MCP guidance prompt to this agent file (CLAUDE.md, AGENTS.md).",
+)
+def install_client_cmd(
+    client: str,
+    source: str | None,
+    scope: str | None,
+    dry_run: bool,
+    agent_file: Path | None,
+) -> None:
     """Install MCP client configuration for archex (preview with --dry-run)."""
     try:
         plan = build_client_install_plan(
@@ -43,8 +58,16 @@ def install_client_cmd(client: str, source: str | None, scope: str | None, dry_r
         )
         if dry_run:
             click.echo(render_client_install_preview(plan), nl=False)
+            if agent_file is not None:
+                click.echo(render_agent_guidance_preview(agent_file.expanduser()), nl=False)
         else:
             target = write_client_install_plan(plan)
             click.echo(f"Wrote {client} config: {target}")
+            if agent_file is not None:
+                resolved = agent_file.expanduser()
+                if append_agent_guidance(resolved):
+                    click.echo(f"Appended archex MCP guidance: {resolved}")
+                else:
+                    click.echo(f"archex MCP guidance already present: {resolved}")
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc

--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -21,6 +21,27 @@ _CLIENT_SCHEMA: dict[ClientName, str] = {
     "omp": _OMP_SCHEMA,
 }
 
+AGENT_GUIDANCE_START = "<!-- archex:mcp-guidance start -->"
+AGENT_GUIDANCE_END = "<!-- archex:mcp-guidance end -->"
+AGENT_GUIDANCE_PROMPT = "\n".join(
+    [
+        "## Repository context via archex (MCP)",
+        (
+            'For architecture, ownership, dependency, or "where is X" questions, use '
+            "the archex MCP tools before reading files by hand:"
+        ),
+        "- `scout_repo` — compact structural map",
+        "- `query_repo` — ranked code context for a question",
+        "- `analyze_repo` — module/package architecture",
+        "- `search_symbols` / `get_symbol` — exact symbol lookup",
+        (
+            "Pass the repository path as `repo_url`. In harnesses with on-demand tool "
+            "discovery, activate the archex tools first. Treat archex output as context "
+            "selection, not proof — verify with reads/tests before editing."
+        ),
+    ]
+)
+
 
 @dataclass(frozen=True)
 class ClientInstallPlan:
@@ -131,6 +152,42 @@ def render_client_install_preview(plan: ClientInstallPlan) -> str:
         plan.content.rstrip(),
     ]
     return "\n".join(lines) + "\n"
+
+
+def render_agent_guidance_block() -> str:
+    return f"{AGENT_GUIDANCE_START}\n{AGENT_GUIDANCE_PROMPT}\n{AGENT_GUIDANCE_END}\n"
+
+
+def append_agent_guidance(agent_file: Path) -> bool:
+    """Append the archex MCP guidance block to ``agent_file`` exactly once.
+
+    Returns True if the block was written, False if it was already present.
+    The append is non-destructive: existing content is preserved and the block
+    is never duplicated on re-run.
+    """
+    block = render_agent_guidance_block()
+    if agent_file.exists():
+        existing = agent_file.read_text(encoding="utf-8")
+        if AGENT_GUIDANCE_START in existing:
+            return False
+        new_content = existing.rstrip("\n") + "\n\n" + block if existing.strip() else block
+    else:
+        agent_file.parent.mkdir(parents=True, exist_ok=True)
+        new_content = block
+    agent_file.write_text(new_content, encoding="utf-8")
+    return True
+
+
+def render_agent_guidance_preview(agent_file: Path) -> str:
+    already_present = agent_file.exists() and AGENT_GUIDANCE_START in agent_file.read_text(
+        encoding="utf-8"
+    )
+    status = (
+        "archex MCP guidance already present; no change."
+        if already_present
+        else "Append archex MCP guidance block (idempotent):"
+    )
+    return f"Agent file: {agent_file}\n{status}\n\n{render_agent_guidance_block()}"
 
 
 def _resolve_scope(

--- a/tests/cli/test_install_client.py
+++ b/tests/cli/test_install_client.py
@@ -361,3 +361,19 @@ def test_install_client_agent_file_preview_already_present(
     assert result.exit_code == 0, result.output
     assert "already present; no change." in result.output
     assert agent_file.read_text(encoding="utf-8") == seeded
+
+
+def test_install_client_agent_file_directory_errors_cleanly(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    agent_path = repo / "AGENTS.md"
+    agent_path.mkdir()  # a directory where an agent file is expected
+
+    result = CliRunner().invoke(
+        cli,
+        ["install-client", "claude-code", str(repo), "--agent-file", str(agent_path)],
+    )
+
+    assert result.exit_code != 0
+    assert "Error" in result.output
+    assert "Traceback" not in result.output

--- a/tests/cli/test_install_client.py
+++ b/tests/cli/test_install_client.py
@@ -341,3 +341,23 @@ def test_install_client_agent_file_global_write_creates_parents(
     assert _GUIDANCE_MARKER in content
     for tool in _MCP_TOOLS:
         assert tool in content
+
+
+def test_install_client_agent_file_preview_already_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    agent_file = repo / "AGENTS.md"
+    seeded = f"# Repo\n\n{_GUIDANCE_MARKER}\nseeded block\n"
+    agent_file.write_text(seeded, encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli,
+        ["install-client", "claude-code", str(repo), "--agent-file", str(agent_file), "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "already present; no change." in result.output
+    assert agent_file.read_text(encoding="utf-8") == seeded

--- a/tests/cli/test_install_client.py
+++ b/tests/cli/test_install_client.py
@@ -276,3 +276,68 @@ def test_install_client_omp_preserves_existing_schema(
     payload = json.loads(target.read_text(encoding="utf-8"))
     assert payload["$schema"] == "https://example.com/custom.json"
     assert payload["mcpServers"]["archex"] == {"command": "archex", "args": ["mcp"]}
+
+
+_MCP_TOOLS = ("query_repo", "scout_repo", "analyze_repo", "search_symbols", "get_symbol")
+_GUIDANCE_MARKER = "<!-- archex:mcp-guidance start -->"
+
+
+def test_install_client_agent_file_preview_under_dry_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    agent_file = tmp_path / "AGENTS.md"
+
+    result = CliRunner().invoke(
+        cli,
+        ["install-client", "claude-code", "--agent-file", str(agent_file), "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    for tool in _MCP_TOOLS:
+        assert tool in result.output
+    assert f"Agent file: {agent_file}" in result.output
+    assert not agent_file.exists()
+    assert not (tmp_path / ".claude.json").exists()
+
+
+def test_install_client_agent_file_appends_once_non_destructive(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    agent_file = repo / "CLAUDE.md"
+    agent_file.write_text("# Project\n\nExisting guidance.\n", encoding="utf-8")
+
+    first = CliRunner().invoke(
+        cli, ["install-client", "claude-code", str(repo), "--agent-file", str(agent_file)]
+    )
+    after_first = agent_file.read_text(encoding="utf-8")
+    second = CliRunner().invoke(
+        cli, ["install-client", "claude-code", str(repo), "--agent-file", str(agent_file)]
+    )
+    after_second = agent_file.read_text(encoding="utf-8")
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    assert "Existing guidance." in after_first
+    assert after_first.count(_GUIDANCE_MARKER) == 1
+    assert after_second == after_first
+    assert "query_repo" in after_first
+    assert "Appended archex MCP guidance" in first.output
+    assert "already present" in second.output
+
+
+def test_install_client_agent_file_global_write_creates_parents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    agent_file = tmp_path / ".claude" / "CLAUDE.md"
+
+    result = CliRunner().invoke(
+        cli, ["install-client", "claude-code", "--agent-file", str(agent_file)]
+    )
+
+    assert result.exit_code == 0, result.output
+    content = agent_file.read_text(encoding="utf-8")
+    assert _GUIDANCE_MARKER in content
+    for tool in _MCP_TOOLS:
+        assert tool in content


### PR DESCRIPTION
## Summary

Ship a ready-to-paste archex-MCP guidance prompt and let `install-client` add it to an agent file.

- New `AGENT_GUIDANCE_PROMPT` names the archex MCP tools (`scout_repo`, `query_repo`, `analyze_repo`, `search_symbols`, `get_symbol`), the `repo_url` argument, and the discovery/activation step for tool-gated harnesses — the canonical text from the design doc.
- `archex install-client --agent-file <path>` appends the prompt to a global or repo-specific agent file (`CLAUDE.md`, `AGENTS.md`, ...) inside a delimited block. The append is non-destructive (existing content preserved) and idempotent (never duplicated on re-run). `--dry-run` previews it with zero filesystem changes.

No retrieval, ranking, scoring, fusion, packing, or benchmark code path is touched.

## Stack

Stack-Id: `mcp-adoption-2026-06-20`
Base: `feat/install-client-omp-target`
Position: 3/5

1. `feat/install-client-default-global` -> #330
2. `feat/install-client-omp-target` -> #331
3. `feat/install-client-agent-guidance` -> this PR
4. `feat/metrics-surface-mix`
5. `docs/mcp-adoption`

Depends on: #331

## Validation

- `uv run ruff check` / `ruff format --check` / `uv run pyright` on changed files: pass
- `uv run pytest tests/cli/test_install_client.py --no-cov`: 20 passed
- Smoke: `--dry-run` previews the prompt (no write); a real run appends exactly once and a re-run is a no-op; existing agent-file content is preserved.
