### PR TITLE
feat(metrics): CLI-vs-MCP surface mix in summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **`omp` install-client target:** Added oh-my-pi (`omp`) as a first-class `archex install-client` client. `archex install-client omp` writes `~/.omp/agent/mcp.json` (user scope) with the standard `mcpServers.archex = {command: "archex", args: ["mcp"]}` payload plus the oh-my-pi `$schema`, merged non-destructively and idempotently.
 - **Agent-file MCP guidance prompt:** Added a ready-to-paste prompt that points an agent at the archex MCP tools (`scout_repo`, `query_repo`, `analyze_repo`, `search_symbols`, `get_symbol`) and the discovery/activation step for tool-gated harnesses. `archex install-client --agent-file <path>` appends it to a global or repo-specific agent file (`CLAUDE.md`, `AGENTS.md`, ...) inside a delimited block — non-destructive and idempotent — and `--dry-run` previews it without writing.
+- **CLI-vs-MCP surface mix in metrics:** `archex metrics` and `archex metrics summary` now report a per-surface event split (`cli`, `mcp`, `python_api`) so near-zero MCP adoption is observable at a glance. The split renders in the text summary and is exposed as `totals.by_surface` in the JSON summary; no event recording or token-savings math changed.
 
 ### Changed
 

--- a/src/archex/metrics/reporter.py
+++ b/src/archex/metrics/reporter.py
@@ -20,6 +20,9 @@ class TimeWindow:
     cutoff: str
 
 
+_SURFACES: tuple[str, ...] = ("cli", "mcp", "python_api")
+
+
 class MetricsReporter:
     """Builds summaries, repo lists, inspect rows, and export payloads."""
 
@@ -171,12 +174,16 @@ class MetricsReporter:
 
 def render_summary_text(payload: dict[str, Any]) -> str:
     totals = payload["totals"]
+    surface_mix = ", ".join(
+        f"{surface} {totals['by_surface'][surface]['event_count']}" for surface in _SURFACES
+    )
     lines = [
         "archex metrics",
         f"Window:                 {payload['window']}",
         f"Recording:              {_on_off(payload['recording_enabled'])}",
         f"Trace:                  {_on_off(payload['trace_enabled'])}",
         f"Events:                 {payload['event_count']}",
+        f"Surface mix:            {surface_mix}",
         f"Saved tokens:           {totals['tokens_saved']} vs returned full files",
         f"Returned tokens:        {totals['tokens_returned']}",
         f"Raw-equivalent tokens:  {totals['tokens_raw_equivalent']}",
@@ -291,6 +298,7 @@ def _totals(conn: Any, window: TimeWindow, repo_ids: list[str] | None) -> dict[s
         "whole_repo_tokens_avoided": int(row["whole_repo_tokens_avoided"]),
     }
     totals["savings_pct"] = _savings_pct(totals["tokens_saved"], totals["tokens_raw_equivalent"])
+    totals["by_surface"] = _surface_mix(conn, clauses, params)
     return totals
 
 
@@ -302,7 +310,35 @@ def _empty_totals() -> dict[str, Any]:
         "tokens_saved": 0,
         "whole_repo_tokens_avoided": 0,
         "savings_pct": 0.0,
+        "by_surface": _empty_surface_mix(),
     }
+
+
+def _surface_mix(conn: Any, clauses: list[str], params: list[object]) -> dict[str, dict[str, int]]:
+    rows = conn.execute(
+        f"""
+        SELECT surface, COUNT(*) AS event_count,
+            COALESCE(SUM(tokens_saved), 0) AS tokens_saved
+        FROM usage_events
+        WHERE {" AND ".join(clauses)}
+        GROUP BY surface
+        """,
+        params,
+    ).fetchall()
+    counts = {
+        str(row["surface"]): {
+            "event_count": int(row["event_count"]),
+            "tokens_saved": int(row["tokens_saved"]),
+        }
+        for row in rows
+    }
+    return {
+        surface: counts.get(surface, {"event_count": 0, "tokens_saved": 0}) for surface in _SURFACES
+    }
+
+
+def _empty_surface_mix() -> dict[str, dict[str, int]]:
+    return {surface: {"event_count": 0, "tokens_saved": 0} for surface in _SURFACES}
 
 
 def _repo_payload(row: Any) -> dict[str, Any]:

--- a/tests/metrics/test_metrics_cli.py
+++ b/tests/metrics/test_metrics_cli.py
@@ -164,6 +164,43 @@ def test_metrics_repair_clears_stale_warning(
     assert "nothing to repair" in repeated.output
 
 
+def test_metrics_summary_surface_mix_split(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_root = tmp_path / "workspace" / "repo-mix"
+    repo_root.mkdir(parents=True)
+    _record(repo_root, tmp_path)
+    MetricsRecorder(metrics_db_path(home=tmp_path)).record(
+        UsageEvent(
+            repo_root=repo_root,
+            surface="mcp",
+            tool_name="query_repo",
+            category="context_retrieval",
+            tokens_returned=20,
+            tokens_raw_equivalent=120,
+            whole_repo_tokens=1000,
+            occurred_at=datetime.now(UTC),
+            file_count=2,
+            freshness="clean",
+            index_revision="rev",
+        )
+    )
+    runner = CliRunner()
+
+    summary_json = runner.invoke(cli, ["metrics", "summary", str(repo_root), "--format", "json"])
+    summary_text = runner.invoke(cli, ["metrics", "summary", str(repo_root)])
+
+    assert summary_json.exit_code == 0, summary_json.output
+    assert summary_text.exit_code == 0, summary_text.output
+    by_surface = json.loads(summary_json.output)["totals"]["by_surface"]
+    assert by_surface["cli"]["event_count"] == 1
+    assert by_surface["mcp"]["event_count"] == 1
+    assert by_surface["python_api"]["event_count"] == 0
+    assert "Surface mix:            cli 1, mcp 1, python_api 0" in summary_text.output
+
+
 def _record(repo_root: Path, tmp_path: Path) -> None:
     set_metrics_enabled(True, db_path=metrics_db_path(home=tmp_path))
     MetricsRecorder(metrics_db_path(home=tmp_path)).record(

--- a/tests/metrics/test_metrics_cli.py
+++ b/tests/metrics/test_metrics_cli.py
@@ -198,6 +198,9 @@ def test_metrics_summary_surface_mix_split(
     assert by_surface["cli"]["event_count"] == 1
     assert by_surface["mcp"]["event_count"] == 1
     assert by_surface["python_api"]["event_count"] == 0
+    assert by_surface["cli"]["tokens_saved"] == 90
+    assert by_surface["mcp"]["tokens_saved"] == 100
+    assert by_surface["python_api"]["tokens_saved"] == 0
     assert "Surface mix:            cli 1, mcp 1, python_api 0" in summary_text.output
 
 


### PR DESCRIPTION
## Summary

Surface a CLI-vs-MCP event split in the metrics summary so near-zero MCP adoption is observable.

- `archex metrics` and `archex metrics summary` now print a `Surface mix:` line with per-surface event counts (`cli`, `mcp`, `python_api`).
- The same split is exposed as `totals.by_surface` in the JSON summary.
- Read-side reporting only: no event recording, no token-savings math, and no retrieval/ranking path changed.

## Stack

Stack-Id: `mcp-adoption-2026-06-20`
Base: `feat/install-client-agent-guidance`
Position: 4/5

1. `feat/install-client-default-global` -> #330
2. `feat/install-client-omp-target` -> #331
3. `feat/install-client-agent-guidance` -> #332
4. `feat/metrics-surface-mix` -> this PR
5. `docs/mcp-adoption`

Depends on: #332

## Validation

- `uv run ruff check` / `ruff format --check` / `uv run pyright` on changed files: pass
- `uv run pytest tests/metrics/test_metrics_cli.py --no-cov`: 7 passed; full `tests/metrics`: 46 passed
- Smoke: recorded mixed cli/mcp events; `archex metrics summary` shows `Surface mix: cli 1, mcp 2, python_api 0` and the JSON `totals.by_surface` matches.
