### PR TITLE
docs(mcp): document the MCP retrieval adoption surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - **README adoption refresh:** Reframed the opening around context-window burn, kept the quickstart as the one always-visible happy path, collapsed only the secondary Docker/extras blocks, and added a metric-anchored workflow translation under Measured results without changing product behavior or benchmark numbers.
 - **install-client default-global + `--dry-run`:** `archex install-client <client>` now installs at global (user) scope by default; pass a `[SOURCE]` repo path or `--scope project` for a repo-local install. Removed the `--write` flag — configs are written by default and `--dry-run` previews the exact target and config without touching the filesystem. Writes stay non-destructive (merge into existing config, never clobber unrelated sections) and are idempotent: re-running with an identical `archex` entry is a no-op, while a different existing entry is left untouched and refused. Updated the installation trust contract, compatibility matrix, and README to match.
+- **MCP adoption docs:** Documented the omp install target, the agent-file MCP guidance prompt and `--agent-file`, discovery-gated harnesses, the registration → surfacing → invocation distinction, and the CLI-vs-MCP surface split across the compatibility matrix, installation trust contract, README, and LOCAL_METRICS.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ archex does not ask the downstream agent to trust ranking alone. Every query/sco
 | Claude Code or MCP | [MCP and Claude Code](#mcp-and-claude-code) | Stdio MCP server, optional warm `--watch`, additive top-level receipts, and an in-repo skill that teaches doctor → scout → fetch. |
 | Python applications | [Python API](#python-api) | Deterministic `query()`, `analyze()`, `compare()`, and receipt-bearing bundles. |
 | Benchmark proof | [Measured results](#measured-results) and [archex vs. cocoindex-code](docs/ARCHEX_VS_COCOINDEX.md) | Same-task C1 report, raw-ripgrep/read baseline, bundle-only evaluator reports, required-file trust gates, and TurboQuant storage/recall evidence. |
-| Installation and clients | [Compatibility matrix](docs/CLIENT_COMPATIBILITY_MATRIX.md) | Client bootstrap paths for Claude Code, Codex, Pi, OpenCode, and Cursor (global/user scope by default; `--dry-run` previews). |
+| Installation and clients | [Compatibility matrix](docs/CLIENT_COMPATIBILITY_MATRIX.md) | Client bootstrap paths for Claude Code, Codex, Pi, OpenCode, Cursor, and oh-my-pi (`omp`); global/user scope by default, `--dry-run` previews. |
 
 ## 30-second quickstart
 
@@ -273,7 +273,7 @@ The mounted repository owns `.archex/`, so indexes survive container restarts an
 | Context receipts | Field contract, freshness/completeness semantics, output surfaces, and benchmark linkage live in [CONTEXT_RECEIPTS](docs/CONTEXT_RECEIPTS.md). |
 | Compatibility matrix | Tested vs unverified clients, exact config shapes, bootstrap commands, and verification steps live in [CLIENT_COMPATIBILITY_MATRIX](docs/CLIENT_COMPATIBILITY_MATRIX.md). |
 | Installation trust contract | Exact CLI, MCP, Docker, skill, cache, network, freshness, benchmark, and uninstall semantics live in [INSTALLATION_TRUST_CONTRACT](docs/INSTALLATION_TRUST_CONTRACT.md). |
-| `archex install-client` | Client config writer for Claude Code, Codex, Pi, OpenCode, and Cursor. Global/user scope by default; `--dry-run` previews without writing. |
+| `archex install-client` | Client config writer for Claude Code, Codex, Pi, OpenCode, Cursor, and oh-my-pi (`omp`). Global/user scope by default; `--dry-run` previews without writing. |
 | `archex doctor` | Text/JSON diagnostics for index health, staleness, local model cache presence, grammar availability by tier, MCP registration, model security, and `.archex/` disk usage. |
 | Repo-local `.archex/` | Generated state: settings, metadata, SQLite index, optional vectors, graph artifacts, dogfood history. Keep it uncommitted. |
 | Local usage metrics | Calculation rules, privacy boundaries, default-off versus opt-in behavior, export/delete controls, and retention live in [LOCAL_METRICS](docs/LOCAL_METRICS.md). |

--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ For warm local sessions, keep the MCP process alive and optionally watch the rep
 archex mcp --watch --watch-path .
 ```
 
+archex is a first-class `install-client` target for Claude Code, Codex, Cursor, OpenCode, Pi, and oh-my-pi (`omp` → `~/.omp/agent/mcp.json`). Registration alone is not enough: harnesses with on-demand tool discovery surface a registered server's tools only after the agent activates them, and agent guidance that names only the CLI never produces MCP calls. Append the ready-to-paste guidance prompt to a global or repo-specific agent file so agents reach for the MCP tools first:
+
+```bash
+archex install-client omp --agent-file ~/.omp/agent/AGENTS.md
+```
+
+`archex metrics` then reports a CLI-vs-MCP surface split so you can see whether agents actually route context through archex. The [compatibility matrix](docs/CLIENT_COMPATIBILITY_MATRIX.md) explains the registration → surfacing → invocation distinction.
+
 The in-repo Claude Code skill lives at [`skills/archex/`](skills/archex/). Its `/archex` command runs `archex doctor`, initializes/indexes when needed, scouts first for broad questions, then fetches exact `symbol:` or `chunk:` handles before a larger bundle query.
 
 Exact install, MCP, Docker, cache, uninstall, and trust semantics are documented in the [installation trust contract](docs/INSTALLATION_TRUST_CONTRACT.md). Client-specific config targets and bootstrap paths live in the [compatibility matrix](docs/CLIENT_COMPATIBILITY_MATRIX.md).

--- a/docs/CLIENT_COMPATIBILITY_MATRIX.md
+++ b/docs/CLIENT_COMPATIBILITY_MATRIX.md
@@ -14,6 +14,7 @@ This matrix separates config-shape verification from actual client smoke tests. 
 | Generic MCP stdio client | Unverified | Use a JSON config shaped like `{ "mcpServers": { "archex": { "command": "archex", "args": ["mcp"] }}}`. `archex install-client claude-code --dry-run` prints a compatible snippet. | Client-dependent | Same server-side freshness semantics as Claude Code / Cursor. | No live generic-client smoke in this stack. | 2026-06-16 |
 | Codex headless | Unverified | `archex install-client codex` writes `~/.codex/config.toml` (global); `archex install-client codex . --scope project` writes `.codex/config.toml`, appending `[mcp_servers.archex]`, `command = "archex"`, `args = ["mcp"]` without overwriting existing sections. `--dry-run` previews. | Yes — via `archex mcp --watch --watch-path .` after Codex launches the server. | Inline query refresh by default; warm watch is server-side, not Codex-specific. | Config shape verified against OpenAI Codex MCP docs; no Codex client smoke in this stack. | 2026-06-16 |
 | Pi | Config shape verified; client smoke unverified | `archex install-client pi` writes `~/.pi/agent/mcp.json` with a stdio `mcpServers.archex` entry (`--dry-run` previews). User scope only. | Client-dependent; server supports `--watch`. | Same server-side freshness semantics as other stdio clients. | No Pi client smoke in this stack. | 2026-06-16 |
+| oh-my-pi (omp) | Config shape verified; client smoke unverified | `archex install-client omp` writes `~/.omp/agent/mcp.json` (user scope only) with `mcpServers.archex.command = "archex"`, `args = ["mcp"]`, plus the oh-my-pi `$schema` (`--dry-run` previews). | Client-dependent; server supports `--watch`. | Same server-side freshness semantics as other stdio clients. | No oh-my-pi client smoke in this stack. Discovery-gated harness — tools must be activated before use (see below). | 2026-06-20 |
 | OpenCode | Config shape verified; client smoke unverified | `archex install-client opencode` writes `~/.config/opencode/opencode.json` (global); `archex install-client opencode . --scope project` writes `opencode.json`, setting `mcp.archex = { type = "local", command = ["archex", "mcp"], enabled = true }`. `--dry-run` previews. | Client-dependent; server supports `--watch`. | Same server-side freshness semantics as other stdio clients. | No OpenCode client smoke in this stack. | 2026-06-16 |
 | Cursor | Config shape verified; client smoke unverified | `archex install-client cursor` writes `~/.cursor/mcp.json` (global); `archex install-client cursor . --scope project` writes `.cursor/mcp.json` with `mcpServers.archex.command = "archex"`, `args = ["mcp"]`. `--dry-run` previews. | Yes — with a warm `archex mcp --watch --watch-path .` process. | Inline query refresh by default; watch keeps a warm process subscribed to file events. | No Cursor UI smoke in this stack. | 2026-06-16 |
 | Dockerized MCP server | Server path tested; client smoke unverified | Run `docker run -d --name archex-mcp -v "$PWD:/workspace" -w /workspace ghcr.io/mathews-tom/archex:slim sleep infinity` then point the client to `docker exec -i archex-mcp archex mcp`. | Yes — run the MCP process with `--watch`. | Same server-side freshness semantics as stdio. | Client-specific Docker registration varies; use the same client config shapes above, but replace the command with `docker` / `exec`. | 2026-06-16 |
@@ -28,6 +29,7 @@ archex install-client cursor
 archex install-client opencode
 archex install-client codex
 archex install-client pi
+archex install-client omp
 ```
 
 Preview any of them without writing:
@@ -49,7 +51,26 @@ archex install-client claude-code . --scope project
 - JSON clients merge an `archex` entry into the existing top-level server map without clobbering unrelated sections.
 - Codex appends one `[mcp_servers.archex]` section to `config.toml`.
 - Re-running an install with an identical `archex` entry already present is an idempotent no-op; a different existing `archex` entry is left untouched and the command fails instead of overwriting it.
-- Pi only supports `--scope user`.
+- Pi and oh-my-pi (omp) only support `--scope user`.
+
+## Registration is not surfacing is not invocation
+
+Registering an MCP server is necessary but not sufficient for an agent to actually use archex. Three distinct steps must all happen:
+
+- **Registration** — `install-client` writes the MCP server entry into the client config (this command).
+- **Surfacing** — the client/harness must expose the registered tools to the agent. Harnesses with on-demand tool discovery (e.g. oh-my-pi / Pi) treat a registered server's tools as *discoverable* but keep them out of the default tool set; the agent must activate them before the first call.
+- **Invocation** — the agent must choose to call `query_repo` / `scout_repo` / `analyze_repo` instead of reading files by hand.
+
+archex cannot change a harness's tool-gating, but it ships a ready-to-paste agent-file guidance prompt that names the MCP tools and the activation step. Append it to a global or repo-specific agent file (`CLAUDE.md`, `AGENTS.md`, ...):
+
+```bash
+archex install-client omp --agent-file ~/.omp/agent/AGENTS.md
+archex install-client claude-code . --scope project --agent-file ./CLAUDE.md --dry-run
+```
+
+The append is non-destructive and idempotent (a delimited `archex:mcp-guidance` block, never duplicated on re-run), and `--dry-run` previews the block without writing.
+
+To check whether agents actually route through MCP, `archex metrics` reports a CLI-vs-MCP surface split; a near-zero `mcp` count means the tools are registered but not being invoked.
 
 ## Verification commands
 
@@ -65,3 +86,4 @@ For Codex, open the TUI and run `/mcp` after writing `.codex/config.toml`.
 For Cursor, inspect `.cursor/mcp.json` or `~/.cursor/mcp.json` and restart the client.
 For OpenCode, inspect `opencode.json` and run `opencode mcp list` if available in your installed version.
 For Pi, inspect `~/.pi/agent/mcp.json` and open the MCP panel documented by your Pi build.
+For oh-my-pi, inspect `~/.omp/agent/mcp.json` and confirm the archex tools are activated in your session (discovery-gated harnesses require explicit activation).

--- a/docs/INSTALLATION_TRUST_CONTRACT.md
+++ b/docs/INSTALLATION_TRUST_CONTRACT.md
@@ -139,7 +139,7 @@ The command procedure runs `archex doctor`, initializes/indexes when needed, run
 
 Registering the MCP server is necessary but not sufficient. Three steps must all happen for an agent to use archex over MCP:
 
-- **Registration** — `archex install-client <client>` writes the server entry. The default scope is global (user); a `[SOURCE]` path or `--scope project` installs repo-local. Writes merge into existing config non-destructively and are idempotent; `--dry-run` previews the exact target and config with zero filesystem changes.
+- **Registration** — `archex install-client <client>` writes the server entry. The default scope is global (user); a `[SOURCE]` path or `--scope project` installs repo-local (except Pi and oh-my-pi, which are user-scope only). Writes merge into existing config non-destructively and are idempotent; `--dry-run` previews the exact target and config with zero filesystem changes.
 - **Surfacing** — the harness must expose the registered tools. Harnesses with on-demand tool discovery (e.g. oh-my-pi / Pi) keep a registered server's tools discoverable but out of the default tool set until the agent activates them.
 - **Invocation** — the agent must call `query_repo` / `scout_repo` / `analyze_repo` rather than reading files by hand.
 

--- a/docs/INSTALLATION_TRUST_CONTRACT.md
+++ b/docs/INSTALLATION_TRUST_CONTRACT.md
@@ -135,6 +135,23 @@ Then use:
 
 The command procedure runs `archex doctor`, initializes/indexes when needed, runs `archex scout`, and fetches exact `symbol:` or `chunk:` handles before a broader query.
 
+## MCP surfacing and agent guidance
+
+Registering the MCP server is necessary but not sufficient. Three steps must all happen for an agent to use archex over MCP:
+
+- **Registration** — `archex install-client <client>` writes the server entry. The default scope is global (user); a `[SOURCE]` path or `--scope project` installs repo-local. Writes merge into existing config non-destructively and are idempotent; `--dry-run` previews the exact target and config with zero filesystem changes.
+- **Surfacing** — the harness must expose the registered tools. Harnesses with on-demand tool discovery (e.g. oh-my-pi / Pi) keep a registered server's tools discoverable but out of the default tool set until the agent activates them.
+- **Invocation** — the agent must call `query_repo` / `scout_repo` / `analyze_repo` rather than reading files by hand.
+
+archex ships a ready-to-paste guidance prompt naming the MCP tools and the activation step. `install-client --agent-file <path>` appends it to a global or repo-specific agent file (`CLAUDE.md`, `AGENTS.md`, ...) inside a delimited, idempotent `archex:mcp-guidance` block; `--dry-run` previews it without writing:
+
+```bash
+archex install-client omp --agent-file ~/.omp/agent/AGENTS.md
+archex install-client claude-code . --scope project --agent-file ./CLAUDE.md --dry-run
+```
+
+The guidance prompt and agent-file append touch only the chosen agent file and make no network or LLM calls. Use `archex metrics` (the CLI-vs-MCP surface split) to confirm agents are actually invoking the MCP tools.
+
 ## What archex reads
 
 archex reads only paths you point it at or paths implied by the current repository:
@@ -172,6 +189,13 @@ Generated local state:
 - cache entries under the configured cache directory; before `archex init`, the default is `~/.archex/cache`; after repo-local initialization, the default project setting is `.archex`
 
 Do not commit `.archex/`. The project initializer adds `.archex/` to the repository gitignore path it manages.
+
+Explicit, user-initiated config writes happen only when you run `archex install-client`:
+
+- the selected client's MCP config (for example `~/.claude.json`, `.mcp.json`, `~/.codex/config.toml`, `~/.cursor/mcp.json`, `~/.config/opencode/opencode.json`, `~/.pi/agent/mcp.json`, or `~/.omp/agent/mcp.json`) — merged non-destructively, never clobbering unrelated entries
+- the agent file passed to `--agent-file` (for example `CLAUDE.md` or `AGENTS.md`) — a delimited `archex:mcp-guidance` block appended idempotently
+
+`--dry-run` previews both without writing.
 
 ## Network behavior by feature
 

--- a/docs/LOCAL_METRICS.md
+++ b/docs/LOCAL_METRICS.md
@@ -226,6 +226,13 @@ baseline is simply omitted (`whole_repo_tokens` becomes null) without latching a
 - raw-equivalent token total
 - percentage savings
 - whole-repo avoided tokens as context only
+- a per-surface event split (`cli` / `mcp` / `python_api`)
+
+The surface split shows how many events each surface contributed. A near-zero `mcp`
+count next to a healthy `cli` count means archex is registered but agents are not
+invoking the MCP tools — see the MCP surfacing notes in the
+[compatibility matrix](CLIENT_COMPATIBILITY_MATRIX.md). The JSON summary exposes the
+same split as `totals.by_surface`.
 
 `archex metrics inspect` reports recent event rows.
 


### PR DESCRIPTION
## Summary

Document the MCP retrieval adoption surface across the onboarding docs. Docs-only; no product behavior or benchmark numbers change.

- **Compatibility matrix:** added the oh-my-pi (`omp`) row, a "registration is not surfacing is not invocation" section, the agent-file guidance prompt, and an omp verification note.
- **Installation trust contract:** added an "MCP surfacing and agent guidance" section and disclosed the explicit `install-client` config / `--agent-file` writes.
- **README:** added the omp target, the agent-file guidance prompt, and the registration → surfacing → invocation distinction.
- **LOCAL_METRICS:** documented the CLI-vs-MCP surface split in the summary output.

## Stack

Stack-Id: `mcp-adoption-2026-06-20`
Base: `feat/metrics-surface-mix`
Position: 5/5 (leaf)

1. `feat/install-client-default-global` -> #330
2. `feat/install-client-omp-target` -> #331
3. `feat/install-client-agent-guidance` -> #332
4. `feat/metrics-surface-mix` -> #333
5. `docs/mcp-adoption` -> this PR

Depends on: #333

## Validation

- Docs-only diff; no Python changed in this PR.
- Verified no `--write` or "preview-first" references remain in README/docs/src/tests.
- Internal doc links and the canonical guidance prompt cross-checked against the design doc.
