### PR TITLE
Add self-repo benchmark region labels

### DIFF
--- a/benchmarks/tasks/archex_adapter_registry.yaml
+++ b/benchmarks/tasks/archex_adapter_registry.yaml
@@ -12,6 +12,31 @@ expected_symbols:
   - AdapterRegistry
   - PythonAdapter
   - LanguageAdapter
+expected_regions:
+  - path: src/archex/parse/adapters/__init__.py
+    granularity: symbol
+    symbol: AdapterRegistry
+    start_line: 24
+    end_line: 79
+    notes: "Registry construction, lookup, instantiation, and entry-point loading."
+  - path: src/archex/parse/adapters/__init__.py
+    granularity: block
+    symbol: default_adapter_registry
+    start_line: 82
+    end_line: 94
+    notes: "Built-in adapter registration table."
+  - path: src/archex/parse/adapters/python.py
+    granularity: symbol
+    symbol: PythonAdapter
+    start_line: 331
+    end_line: 451
+    notes: "Concrete Python language adapter implementation."
+  - path: src/archex/parse/adapters/base.py
+    granularity: symbol
+    symbol: LanguageAdapter
+    start_line: 12
+    end_line: 48
+    notes: "Adapter protocol contract."
 token_budget: 8192
 keywords:
   - adapter

--- a/benchmarks/tasks/archex_delta_indexing.yaml
+++ b/benchmarks/tasks/archex_delta_indexing.yaml
@@ -11,6 +11,19 @@ expected_symbols:
   - compute_delta
   - apply_delta
   - DeltaManifest
+expected_regions:
+  - path: src/archex/index/delta.py
+    granularity: symbol
+    symbol: compute_delta
+    start_line: 282
+    end_line: 334
+    notes: "Git commit delta detection and manifest construction."
+  - path: src/archex/index/delta.py
+    granularity: symbol
+    symbol: apply_delta
+    start_line: 337
+    end_line: 490
+    notes: "Delta application against store, graph, and cache metadata."
 token_budget: 8192
 keywords:
   - delta

--- a/benchmarks/tasks/archex_graph_expansion.yaml
+++ b/benchmarks/tasks/archex_graph_expansion.yaml
@@ -21,7 +21,7 @@ expected_regions:
     granularity: symbol
     symbol: assemble_context
     start_line: 904
-    end_line: 1538
+    end_line: 1633
     notes: "Context assembly, graph expansion, ranking, and packing."
 token_budget: 8192
 keywords:

--- a/benchmarks/tasks/archex_graph_expansion.yaml
+++ b/benchmarks/tasks/archex_graph_expansion.yaml
@@ -10,6 +10,19 @@ expected_files:
 expected_symbols:
   - DependencyGraph.from_parsed_files
   - assemble_context
+expected_regions:
+  - path: src/archex/index/graph.py
+    granularity: symbol
+    symbol: DependencyGraph.from_parsed_files
+    start_line: 84
+    end_line: 118
+    notes: "Dependency graph construction from parsed files and resolved imports."
+  - path: src/archex/serve/context.py
+    granularity: symbol
+    symbol: assemble_context
+    start_line: 904
+    end_line: 1538
+    notes: "Context assembly, graph expansion, ranking, and packing."
 token_budget: 8192
 keywords:
   - graph

--- a/benchmarks/tasks/archex_pattern_detection.yaml
+++ b/benchmarks/tasks/archex_pattern_detection.yaml
@@ -28,7 +28,7 @@ expected_regions:
     granularity: symbol
     symbol: DetectedPattern
     start_line: 506
-    end_line: 518
+    end_line: 512
     notes: "Pattern result model corresponding to the task's pattern-match expectation."
 token_budget: 8192
 keywords:

--- a/benchmarks/tasks/archex_pattern_detection.yaml
+++ b/benchmarks/tasks/archex_pattern_detection.yaml
@@ -11,6 +11,25 @@ expected_symbols:
   - detect_patterns
   - PatternRegistry
   - PatternMatch
+expected_regions:
+  - path: src/archex/analyze/patterns.py
+    granularity: symbol
+    symbol: PatternRegistry
+    start_line: 30
+    end_line: 72
+    notes: "Pattern detector registry and entry-point loading."
+  - path: src/archex/analyze/patterns.py
+    granularity: symbol
+    symbol: detect_patterns
+    start_line: 496
+    end_line: 518
+    notes: "Public pattern-detection entry point."
+  - path: src/archex/models.py
+    granularity: symbol
+    symbol: DetectedPattern
+    start_line: 506
+    end_line: 518
+    notes: "Pattern result model corresponding to the task's pattern-match expectation."
 token_budget: 8192
 keywords:
   - pattern

--- a/benchmarks/tasks/archex_project_init.yaml
+++ b/benchmarks/tasks/archex_project_init.yaml
@@ -16,6 +16,31 @@ expected_symbols:
   - init_cmd
   - init_project
   - load_config
+expected_regions:
+  - path: src/archex/cli/main.py
+    granularity: symbol
+    symbol: cli
+    start_line: 34
+    end_line: 36
+    notes: "Root command group that registers project lifecycle commands."
+  - path: src/archex/cli/init_cmd.py
+    granularity: symbol
+    symbol: init_cmd
+    start_line: 18
+    end_line: 37
+    notes: "CLI option handling and init result rendering."
+  - path: src/archex/project.py
+    granularity: symbol
+    symbol: init_project
+    start_line: 122
+    end_line: 159
+    notes: "Repo-local state creation, settings writing, and gitignore update."
+  - path: src/archex/config.py
+    granularity: symbol
+    symbol: load_config
+    start_line: 115
+    end_line: 138
+    notes: "Runtime config loading from user, project, and environment settings."
 token_budget: 8192
 keywords:
   - init

--- a/benchmarks/tasks/archex_project_init.yaml
+++ b/benchmarks/tasks/archex_project_init.yaml
@@ -26,7 +26,7 @@ expected_regions:
   - path: src/archex/cli/init_cmd.py
     granularity: symbol
     symbol: init_cmd
-    start_line: 18
+    start_line: 10
     end_line: 37
     notes: "CLI option handling and init result rendering."
   - path: src/archex/project.py

--- a/benchmarks/tasks/archex_project_status.yaml
+++ b/benchmarks/tasks/archex_project_status.yaml
@@ -16,6 +16,31 @@ expected_symbols:
   - inspect_project_status
   - ProjectState
   - compute_working_tree_signature
+expected_regions:
+  - path: src/archex/cli/status_cmd.py
+    granularity: symbol
+    symbol: status_cmd
+    start_line: 22
+    end_line: 73
+    notes: "Status CLI rendering and strict-mode exit behavior."
+  - path: src/archex/status.py
+    granularity: symbol
+    symbol: inspect_project_status
+    start_line: 35
+    end_line: 145
+    notes: "Fresh, stale, missing, and corrupt index-state inspection."
+  - path: src/archex/project.py
+    granularity: symbol
+    symbol: ProjectState
+    start_line: 37
+    end_line: 100
+    notes: "Repo-local state path resolution."
+  - path: src/archex/index/delta.py
+    granularity: symbol
+    symbol: compute_working_tree_signature
+    start_line: 51
+    end_line: 93
+    notes: "Working-tree content signature for freshness checks."
 token_budget: 8192
 keywords:
   - status

--- a/benchmarks/tasks/archex_project_status.yaml
+++ b/benchmarks/tasks/archex_project_status.yaml
@@ -21,8 +21,20 @@ expected_regions:
     granularity: symbol
     symbol: status_cmd
     start_line: 22
-    end_line: 73
-    notes: "Status CLI rendering and strict-mode exit behavior."
+    end_line: 35
+    notes: "Status command dispatch, output-format selection, and strict-mode exit behavior."
+  - path: src/archex/cli/status_cmd.py
+    granularity: symbol
+    symbol: _status_payload
+    start_line: 38
+    end_line: 56
+    notes: "JSON status payload rendering."
+  - path: src/archex/cli/status_cmd.py
+    granularity: symbol
+    symbol: _render_text
+    start_line: 59
+    end_line: 80
+    notes: "Human-readable status output rendering."
   - path: src/archex/status.py
     granularity: symbol
     symbol: inspect_project_status

--- a/benchmarks/tasks/archex_query_pipeline.yaml
+++ b/benchmarks/tasks/archex_query_pipeline.yaml
@@ -29,7 +29,7 @@ expected_regions:
     granularity: symbol
     symbol: assemble_context
     start_line: 904
-    end_line: 1538
+    end_line: 1633
     notes: "Bundle assembly and ranked context packing."
 token_budget: 8192
 keywords:

--- a/benchmarks/tasks/archex_query_pipeline.yaml
+++ b/benchmarks/tasks/archex_query_pipeline.yaml
@@ -12,6 +12,25 @@ expected_symbols:
   - query
   - BM25Index
   - assemble_context
+expected_regions:
+  - path: src/archex/api.py
+    granularity: symbol
+    symbol: query
+    start_line: 1689
+    end_line: 2346
+    notes: "Public query orchestration from indexing through retrieval and context finalization."
+  - path: src/archex/index/bm25.py
+    granularity: symbol
+    symbol: BM25Index
+    start_line: 127
+    end_line: 344
+    notes: "BM25 FTS index build and search behavior."
+  - path: src/archex/serve/context.py
+    granularity: symbol
+    symbol: assemble_context
+    start_line: 904
+    end_line: 1538
+    notes: "Bundle assembly and ranked context packing."
 token_budget: 8192
 keywords:
   - query

--- a/benchmarks/tasks/archex_vector_cache_lifecycle.yaml
+++ b/benchmarks/tasks/archex_vector_cache_lifecycle.yaml
@@ -34,13 +34,13 @@ expected_regions:
     granularity: symbol
     symbol: VectorIndex
     start_line: 60
-    end_line: 284
+    end_line: 419
     notes: "Dense vector index build, save/load, and search."
   - path: src/archex/index/embeddings/base.py
     granularity: symbol
     symbol: Embedder
     start_line: 9
-    end_line: 12
+    end_line: 15
     notes: "Embedding-provider protocol used by vector retrieval."
 token_budget: 8192
 keywords:

--- a/benchmarks/tasks/archex_vector_cache_lifecycle.yaml
+++ b/benchmarks/tasks/archex_vector_cache_lifecycle.yaml
@@ -17,6 +17,31 @@ expected_symbols:
   - vector_path
   - VectorIndex
   - Embedder
+expected_regions:
+  - path: src/archex/api.py
+    granularity: symbol
+    symbol: _vector_search_precomputed
+    start_line: 1173
+    end_line: 1209
+    notes: "Reloads and searches persisted vector indexes."
+  - path: src/archex/cache.py
+    granularity: symbol
+    symbol: CacheManager.vector_path
+    start_line: 134
+    end_line: 151
+    notes: "Vector-cache path derivation."
+  - path: src/archex/index/vector.py
+    granularity: symbol
+    symbol: VectorIndex
+    start_line: 60
+    end_line: 284
+    notes: "Dense vector index build, save/load, and search."
+  - path: src/archex/index/embeddings/base.py
+    granularity: symbol
+    symbol: Embedder
+    start_line: 9
+    end_line: 12
+    notes: "Embedding-provider protocol used by vector retrieval."
 token_budget: 8192
 keywords:
   - vector

--- a/tests/benchmark/test_loader.py
+++ b/tests/benchmark/test_loader.py
@@ -356,10 +356,13 @@ expected_regions:
 
         assert task.expected_regions
         assert {region.path for region in task.expected_regions} <= set(task.expected_files)
-        assert any(
-            region.symbol == "compute_delta" and region.start_line == 282 and region.end_line == 334
-            for region in task.expected_regions
-        )
+        compute_delta_regions = [
+            region for region in task.expected_regions if region.symbol == "compute_delta"
+        ]
+        assert len(compute_delta_regions) == 1
+        assert compute_delta_regions[0].start_line is not None
+        assert compute_delta_regions[0].end_line is not None
+        assert compute_delta_regions[0].start_line <= compute_delta_regions[0].end_line
 
     def test_real_task_rejects_malformed_region(self, tmp_path: Path) -> None:
         malformed = tmp_path / LABELED_SELF_TASK.name

--- a/tests/benchmark/test_loader.py
+++ b/tests/benchmark/test_loader.py
@@ -22,6 +22,9 @@ from archex.benchmark.models import (
     ExpectedRegion,
 )
 
+TASKS_DIR = Path(__file__).resolve().parents[2] / "benchmarks" / "tasks"
+LABELED_SELF_TASK = TASKS_DIR / "archex_delta_indexing.yaml"
+
 
 @pytest.fixture
 def sample_yaml(tmp_path: Path) -> Path:
@@ -347,6 +350,30 @@ expected_regions:
 
         with pytest.raises(ValueError, match=r"region_bad_gran\.yaml.*granularity"):
             load_task(p)
+
+    def test_load_real_self_task_regions(self) -> None:
+        task = load_task(LABELED_SELF_TASK)
+
+        assert task.expected_regions
+        assert {region.path for region in task.expected_regions} <= set(task.expected_files)
+        assert any(
+            region.symbol == "compute_delta" and region.start_line == 282 and region.end_line == 334
+            for region in task.expected_regions
+        )
+
+    def test_real_task_rejects_malformed_region(self, tmp_path: Path) -> None:
+        malformed = tmp_path / LABELED_SELF_TASK.name
+        malformed.write_text(
+            LABELED_SELF_TASK.read_text(encoding="utf-8").replace(
+                "    end_line: 334",
+                "    end_line: 281",
+                1,
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match=r"archex_delta_indexing\.yaml.*end_line"):
+            load_task(malformed)
 
 
 class TestLoadArchTask:

--- a/tests/benchmark/test_region_fixtures.py
+++ b/tests/benchmark/test_region_fixtures.py
@@ -13,6 +13,17 @@ from archex.benchmark.loader import load_tasks, validate_task
 from archex.benchmark.strategies import run_archex_query
 
 REGION_TASKS_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "region_tasks"
+REAL_TASKS_DIR = Path(__file__).resolve().parents[2] / "benchmarks" / "tasks"
+LABELED_SELF_TASK_IDS = (
+    "archex_adapter_registry",
+    "archex_delta_indexing",
+    "archex_graph_expansion",
+    "archex_pattern_detection",
+    "archex_project_init",
+    "archex_project_status",
+    "archex_query_pipeline",
+    "archex_vector_cache_lifecycle",
+)
 
 
 def test_region_fixture_tasks_load_with_regions() -> None:
@@ -26,6 +37,26 @@ def test_region_fixture_tasks_validate_against_fixture_repo(python_simple_repo: 
     for task in load_tasks(REGION_TASKS_DIR):
         errors = validate_task(task, python_simple_repo)
         assert errors == [], f"{task.task_id}: {errors}"
+
+
+def test_labeled_self_repo_tasks_load_with_regions() -> None:
+    tasks = {task.task_id: task for task in load_tasks(REAL_TASKS_DIR)}
+
+    for task_id in LABELED_SELF_TASK_IDS:
+        task = tasks[task_id]
+        assert task.expected_regions, f"{task_id} declares no expected_regions"
+        assert {region.path for region in task.expected_regions} <= set(task.expected_files)
+        assert all(region.start_line is not None for region in task.expected_regions)
+        assert all(region.end_line is not None for region in task.expected_regions)
+
+
+def test_labeled_self_repo_tasks_validate_against_current_repo() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    tasks = {task.task_id: task for task in load_tasks(REAL_TASKS_DIR)}
+
+    for task_id in LABELED_SELF_TASK_IDS:
+        errors = validate_task(tasks[task_id], repo_root)
+        assert errors == [], f"{task_id}: {errors}"
 
 
 def test_region_fixture_task_computes_region_metrics(python_simple_repo: Path) -> None:


### PR DESCRIPTION
## Summary

Adds expected-region labels to a defensible self-repo benchmark subset in `benchmarks/tasks/archex_*.yaml` and covers loading/validation in benchmark tests.

## Stack

Stack-Id: `r0-region-labels-20260620`
Base: `main`
Position: 1/3

1. `r0-region-labels-self` -> this PR (#335)
2. `r0-region-labels-external` -> #336
3. `r0-region-labeled-baseline` -> #337

Depends on: none
Upstack: #336

## Validation

- `uv run pytest tests/benchmark/test_loader.py tests/benchmark/test_region_fixtures.py --no-cov` — passed
- `uv run ruff check tests/benchmark/test_loader.py tests/benchmark/test_region_fixtures.py` — passed
- `uv run ruff format --check tests/benchmark/test_loader.py tests/benchmark/test_region_fixtures.py` — passed
- `uv run pyright tests/benchmark/test_loader.py tests/benchmark/test_region_fixtures.py` — passed
- Review: self slice reviewed; valid span findings fixed; rereview found no remaining blocker or important issues

## Notes

- Data/test-only change.
- Does not change retrieval code, ranking, packing, telemetry, or defaults.
