### PR TITLE
Add external benchmark region labels

### DIFF
--- a/benchmarks/tasks/click_decorators.yaml
+++ b/benchmarks/tasks/click_decorators.yaml
@@ -11,6 +11,19 @@ expected_files:
   - src/click/core.py
   - src/click/types.py
 expected_symbols: []
+expected_regions:
+  - path: src/click/decorators.py
+    granularity: block
+    symbol: command/group/argument/option decorators
+    start_line: 163
+    end_line: 364
+    notes: "Decorator factories attach parameters and build Command/Group objects; pinned to Click 8.1.8."
+  - path: src/click/core.py
+    granularity: block
+    symbol: Command and Parameter classes
+    start_line: 1161
+    end_line: 3037
+    notes: "Concrete Command, Parameter, Option, and Argument classes used by decorators; pinned to Click 8.1.8."
 token_budget: 8192
 keywords:
   - decorator

--- a/benchmarks/tasks/django_middleware.yaml
+++ b/benchmarks/tasks/django_middleware.yaml
@@ -20,6 +20,13 @@ expected_files:
   - django/core/handlers/wsgi.py
   - django/middleware/common.py
 expected_symbols: []
+expected_regions:
+  - path: django/core/handlers/base.py
+    granularity: symbol
+    symbol: BaseHandler
+    start_line: 25
+    end_line: 260
+    notes: "Middleware stack loading plus sync/async request-response execution; pinned to Django 5.1.4."
 token_budget: 8192
 keywords:
   - middleware

--- a/benchmarks/tasks/django_middleware.yaml
+++ b/benchmarks/tasks/django_middleware.yaml
@@ -24,8 +24,8 @@ expected_regions:
   - path: django/core/handlers/base.py
     granularity: symbol
     symbol: BaseHandler
-    start_line: 25
-    end_line: 260
+    start_line: 20
+    end_line: 367
     notes: "Middleware stack loading plus sync/async request-response execution; pinned to Django 5.1.4."
 token_budget: 8192
 keywords:

--- a/benchmarks/tasks/django_orm_queries.yaml
+++ b/benchmarks/tasks/django_orm_queries.yaml
@@ -16,6 +16,19 @@ expected_files:
   - django/db/models/sql/compiler.py
   - django/db/models/query.py
 expected_symbols: []
+expected_regions:
+  - path: django/db/models/sql/query.py
+    granularity: symbol
+    symbol: Query
+    start_line: 216
+    end_line: 1693
+    notes: "Query state, joins, filtering, cloning, and SQL compilation entrypoints; pinned to Django 5.1.4."
+  - path: django/db/models/sql/compiler.py
+    granularity: symbol
+    symbol: SQLCompiler
+    start_line: 43
+    end_line: 2085
+    notes: "Translates Query state into SQL and executes it; pinned to Django 5.1.4."
 token_budget: 8192
 keywords:
   - queryset

--- a/benchmarks/tasks/django_orm_queries.yaml
+++ b/benchmarks/tasks/django_orm_queries.yaml
@@ -20,14 +20,14 @@ expected_regions:
   - path: django/db/models/sql/query.py
     granularity: symbol
     symbol: Query
-    start_line: 216
-    end_line: 1693
+    start_line: 219
+    end_line: 2631
     notes: "Query state, joins, filtering, cloning, and SQL compilation entrypoints; pinned to Django 5.1.4."
   - path: django/db/models/sql/compiler.py
     granularity: symbol
     symbol: SQLCompiler
-    start_line: 43
-    end_line: 2085
+    start_line: 39
+    end_line: 1635
     notes: "Translates Query state into SQL and executes it; pinned to Django 5.1.4."
 token_budget: 8192
 keywords:

--- a/benchmarks/tasks/fastapi_dependency_injection.yaml
+++ b/benchmarks/tasks/fastapi_dependency_injection.yaml
@@ -23,25 +23,25 @@ expected_regions:
   - path: fastapi/dependencies/models.py
     granularity: symbol
     symbol: Dependant
-    start_line: 1
-    end_line: 31
+    start_line: 14
+    end_line: 38
     notes: "Dependency graph node with request parameter buckets and cache key; pinned to FastAPI 0.115.6."
   - path: fastapi/dependencies/utils.py
     granularity: symbol
     symbol: get_dependant
-    start_line: 259
-    end_line: 336
+    start_line: 265
+    end_line: 316
     notes: "Builds a dependency tree from an endpoint callable signature; pinned to FastAPI 0.115.6."
   - path: fastapi/dependencies/utils.py
     granularity: symbol
     symbol: solve_dependencies
-    start_line: 556
-    end_line: 724
+    start_line: 572
+    end_line: 697
     notes: "Resolves nested dependencies, parameters, and body values before handler invocation; pinned to FastAPI 0.115.6."
   - path: fastapi/routing.py
     granularity: symbol
     symbol: APIRoute.get_route_handler
-    start_line: 569
+    start_line: 571
     end_line: 590
     notes: "Connects route execution to dependency solving and request handling; pinned to FastAPI 0.115.6."
     weight: 0.9

--- a/benchmarks/tasks/fastapi_dependency_injection.yaml
+++ b/benchmarks/tasks/fastapi_dependency_injection.yaml
@@ -19,6 +19,32 @@ expected_symbols:
   - solve_dependencies
   - Dependant
   - get_dependant
+expected_regions:
+  - path: fastapi/dependencies/models.py
+    granularity: symbol
+    symbol: Dependant
+    start_line: 1
+    end_line: 31
+    notes: "Dependency graph node with request parameter buckets and cache key; pinned to FastAPI 0.115.6."
+  - path: fastapi/dependencies/utils.py
+    granularity: symbol
+    symbol: get_dependant
+    start_line: 259
+    end_line: 336
+    notes: "Builds a dependency tree from an endpoint callable signature; pinned to FastAPI 0.115.6."
+  - path: fastapi/dependencies/utils.py
+    granularity: symbol
+    symbol: solve_dependencies
+    start_line: 556
+    end_line: 724
+    notes: "Resolves nested dependencies, parameters, and body values before handler invocation; pinned to FastAPI 0.115.6."
+  - path: fastapi/routing.py
+    granularity: symbol
+    symbol: APIRoute.get_route_handler
+    start_line: 569
+    end_line: 590
+    notes: "Connects route execution to dependency solving and request handling; pinned to FastAPI 0.115.6."
+    weight: 0.9
 token_budget: 8192
 keywords:
   - dependency

--- a/benchmarks/tasks/fastapi_dependency_injection.yaml
+++ b/benchmarks/tasks/fastapi_dependency_injection.yaml
@@ -42,7 +42,7 @@ expected_regions:
     granularity: symbol
     symbol: APIRoute.get_route_handler
     start_line: 571
-    end_line: 590
+    end_line: 587
     notes: "Connects route execution to dependency solving and request handling; pinned to FastAPI 0.115.6."
     weight: 0.9
 token_budget: 8192

--- a/benchmarks/tasks/fastapi_routing.yaml
+++ b/benchmarks/tasks/fastapi_routing.yaml
@@ -24,21 +24,21 @@ expected_regions:
   - path: fastapi/routing.py
     granularity: symbol
     symbol: APIRouter.add_api_route
-    start_line: 876
-    end_line: 1116
+    start_line: 881
+    end_line: 962
     notes: "Registers APIRoute instances onto the router stack; pinned to FastAPI 0.115.6."
   - path: fastapi/applications.py
     granularity: symbol
     symbol: FastAPI.add_api_route
-    start_line: 1061
-    end_line: 1119
+    start_line: 1056
+    end_line: 1114
     notes: "App-level route-registration wrapper over APIRouter.add_api_route; pinned to FastAPI 0.115.6."
     weight: 0.9
   - path: fastapi/params.py
     granularity: symbol
     symbol: Path
-    start_line: 142
-    end_line: 225
+    start_line: 139
+    end_line: 224
     notes: "Required path-parameter metadata and validation inputs; pinned to FastAPI 0.115.6."
 token_budget: 8192
 keywords:

--- a/benchmarks/tasks/fastapi_routing.yaml
+++ b/benchmarks/tasks/fastapi_routing.yaml
@@ -18,8 +18,8 @@ expected_regions:
   - path: fastapi/routing.py
     granularity: symbol
     symbol: APIRoute
-    start_line: 426
-    end_line: 591
+    start_line: 428
+    end_line: 592
     notes: "Route object setup, path regex conversion, dependant construction, and handler wiring; pinned to FastAPI 0.115.6."
   - path: fastapi/routing.py
     granularity: symbol

--- a/benchmarks/tasks/fastapi_routing.yaml
+++ b/benchmarks/tasks/fastapi_routing.yaml
@@ -14,6 +14,32 @@ expected_files:
   - fastapi/applications.py
   - fastapi/params.py
 expected_symbols: []
+expected_regions:
+  - path: fastapi/routing.py
+    granularity: symbol
+    symbol: APIRoute
+    start_line: 426
+    end_line: 591
+    notes: "Route object setup, path regex conversion, dependant construction, and handler wiring; pinned to FastAPI 0.115.6."
+  - path: fastapi/routing.py
+    granularity: symbol
+    symbol: APIRouter.add_api_route
+    start_line: 876
+    end_line: 1116
+    notes: "Registers APIRoute instances onto the router stack; pinned to FastAPI 0.115.6."
+  - path: fastapi/applications.py
+    granularity: symbol
+    symbol: FastAPI.add_api_route
+    start_line: 1061
+    end_line: 1119
+    notes: "App-level route-registration wrapper over APIRouter.add_api_route; pinned to FastAPI 0.115.6."
+    weight: 0.9
+  - path: fastapi/params.py
+    granularity: symbol
+    symbol: Path
+    start_line: 142
+    end_line: 225
+    notes: "Required path-parameter metadata and validation inputs; pinned to FastAPI 0.115.6."
 token_budget: 8192
 keywords:
   - route

--- a/benchmarks/tasks/flask_blueprints.yaml
+++ b/benchmarks/tasks/flask_blueprints.yaml
@@ -11,6 +11,19 @@ expected_files:
   - src/flask/blueprints.py
   - src/flask/app.py
 expected_symbols: []
+expected_regions:
+  - path: src/flask/sansio/blueprints.py
+    granularity: symbol
+    symbol: BlueprintSetupState
+    start_line: 39
+    end_line: 118
+    notes: "Registration state for blueprint deferred setup; pinned to Flask 3.1.0."
+  - path: src/flask/sansio/blueprints.py
+    granularity: symbol
+    symbol: Blueprint
+    start_line: 123
+    end_line: 560
+    notes: "Deferred registration, nested blueprints, and blueprint URL rule wiring; pinned to Flask 3.1.0."
 token_budget: 8192
 keywords:
   - blueprint

--- a/benchmarks/tasks/flask_blueprints.yaml
+++ b/benchmarks/tasks/flask_blueprints.yaml
@@ -15,7 +15,7 @@ expected_regions:
   - path: src/flask/sansio/blueprints.py
     granularity: symbol
     symbol: BlueprintSetupState
-    start_line: 39
+    start_line: 34
     end_line: 118
     notes: "Registration state for blueprint deferred setup; pinned to Flask 3.1.0."
   - path: src/flask/sansio/blueprints.py

--- a/benchmarks/tasks/flask_blueprints.yaml
+++ b/benchmarks/tasks/flask_blueprints.yaml
@@ -21,8 +21,8 @@ expected_regions:
   - path: src/flask/sansio/blueprints.py
     granularity: symbol
     symbol: Blueprint
-    start_line: 123
-    end_line: 560
+    start_line: 119
+    end_line: 633
     notes: "Deferred registration, nested blueprints, and blueprint URL rule wiring; pinned to Flask 3.1.0."
 token_budget: 8192
 keywords:

--- a/benchmarks/tasks/httpx_pooling.yaml
+++ b/benchmarks/tasks/httpx_pooling.yaml
@@ -11,6 +11,19 @@ expected_files:
   - httpx/_client.py
   - httpx/_config.py
 expected_symbols: []
+expected_regions:
+  - path: httpx/_client.py
+    granularity: block
+    symbol: BaseClient/Client/AsyncClient
+    start_line: 183
+    end_line: 1470
+    notes: "Client-side pool, proxy, and transport configuration for sync and async clients; pinned to httpx 0.28.1."
+  - path: httpx/_transports/default.py
+    granularity: block
+    symbol: HTTPTransport/AsyncHTTPTransport
+    start_line: 137
+    end_line: 406
+    notes: "httpcore-backed connection pools and keep-alive handling; pinned to httpx 0.28.1."
 token_budget: 8192
 keywords:
   - pool

--- a/benchmarks/tasks/httpx_pooling.yaml
+++ b/benchmarks/tasks/httpx_pooling.yaml
@@ -21,7 +21,7 @@ expected_regions:
   - path: httpx/_transports/default.py
     granularity: block
     symbol: HTTPTransport/AsyncHTTPTransport
-    start_line: 137
+    start_line: 135
     end_line: 406
     notes: "httpcore-backed connection pools and keep-alive handling; pinned to httpx 0.28.1."
 token_budget: 8192

--- a/benchmarks/tasks/httpx_pooling.yaml
+++ b/benchmarks/tasks/httpx_pooling.yaml
@@ -15,8 +15,8 @@ expected_regions:
   - path: httpx/_client.py
     granularity: block
     symbol: BaseClient/Client/AsyncClient
-    start_line: 183
-    end_line: 1470
+    start_line: 188
+    end_line: 2020
     notes: "Client-side pool, proxy, and transport configuration for sync and async clients; pinned to httpx 0.28.1."
   - path: httpx/_transports/default.py
     granularity: block

--- a/benchmarks/tasks/pydantic_validators.yaml
+++ b/benchmarks/tasks/pydantic_validators.yaml
@@ -25,14 +25,14 @@ expected_regions:
   - path: pydantic/functional_validators.py
     granularity: symbol
     symbol: model_validator
-    start_line: 642
-    end_line: 705
+    start_line: 641
+    end_line: 723
     notes: "Model-validator decorator overloads and descriptor proxy construction; pinned to Pydantic v2.10.5."
   - path: pydantic/_internal/_validators.py
     granularity: block
     symbol: standard validators
-    start_line: 25
-    end_line: 257
+    start_line: 20
+    end_line: 388
     notes: "Low-level standard/container/value validators composed by the validation pipeline; pinned to Pydantic v2.10.5."
     weight: 0.9
 token_budget: 8192

--- a/benchmarks/tasks/pydantic_validators.yaml
+++ b/benchmarks/tasks/pydantic_validators.yaml
@@ -15,6 +15,26 @@ expected_symbols:
   - field_validator
   - model_validator
   - ValidatorDecoratorInfo
+expected_regions:
+  - path: pydantic/functional_validators.py
+    granularity: symbol
+    symbol: field_validator
+    start_line: 375
+    end_line: 515
+    notes: "Field-validator decorator overloads and descriptor proxy construction; pinned to Pydantic v2.10.5."
+  - path: pydantic/functional_validators.py
+    granularity: symbol
+    symbol: model_validator
+    start_line: 642
+    end_line: 705
+    notes: "Model-validator decorator overloads and descriptor proxy construction; pinned to Pydantic v2.10.5."
+  - path: pydantic/_internal/_validators.py
+    granularity: block
+    symbol: standard validators
+    start_line: 25
+    end_line: 257
+    notes: "Low-level standard/container/value validators composed by the validation pipeline; pinned to Pydantic v2.10.5."
+    weight: 0.9
 token_budget: 8192
 keywords:
   - validator

--- a/benchmarks/tasks/requests_sessions.yaml
+++ b/benchmarks/tasks/requests_sessions.yaml
@@ -15,8 +15,8 @@ expected_regions:
   - path: src/requests/sessions.py
     granularity: symbol
     symbol: Session
-    start_line: 358
-    end_line: 824
+    start_line: 356
+    end_line: 818
     notes: "Session persistence, adapter mounting, request preparation, redirects, and cookie handling; pinned to requests v2.32.3."
   - path: src/requests/adapters.py
     granularity: symbol

--- a/benchmarks/tasks/requests_sessions.yaml
+++ b/benchmarks/tasks/requests_sessions.yaml
@@ -11,6 +11,19 @@ expected_files:
   - src/requests/adapters.py
   - src/requests/models.py
 expected_symbols: []
+expected_regions:
+  - path: src/requests/sessions.py
+    granularity: symbol
+    symbol: Session
+    start_line: 358
+    end_line: 824
+    notes: "Session persistence, adapter mounting, request preparation, redirects, and cookie handling; pinned to requests v2.32.3."
+  - path: src/requests/adapters.py
+    granularity: symbol
+    symbol: HTTPAdapter
+    start_line: 167
+    end_line: 719
+    notes: "urllib3-backed connection-pool adapter including pool manager setup and send; pinned to requests v2.32.3."
 token_budget: 8192
 keywords:
   - session

--- a/tests/benchmark/test_loader.py
+++ b/tests/benchmark/test_loader.py
@@ -24,6 +24,18 @@ from archex.benchmark.models import (
 
 TASKS_DIR = Path(__file__).resolve().parents[2] / "benchmarks" / "tasks"
 LABELED_SELF_TASK = TASKS_DIR / "archex_delta_indexing.yaml"
+LABELED_EXTERNAL_TASKS = (
+    "click_decorators",
+    "django_middleware",
+    "django_orm_queries",
+    "fastapi_dependency_injection",
+    "fastapi_routing",
+    "flask_blueprints",
+    "httpx_pooling",
+    "pydantic_validators",
+    "requests_sessions",
+)
+ALLOWED_REGION_GRANULARITIES = {"file", "symbol", "block", "line_range"}
 
 
 @pytest.fixture
@@ -376,6 +388,31 @@ expected_regions:
         )
 
         with pytest.raises(ValueError, match=r"archex_delta_indexing\.yaml.*end_line"):
+            load_task(malformed)
+
+    def test_load_real_external_task_regions(self) -> None:
+        for task_id in LABELED_EXTERNAL_TASKS:
+            task = load_task(TASKS_DIR / f"{task_id}.yaml")
+
+            assert task.expected_regions, f"{task_id} declares no expected_regions"
+            assert {region.path for region in task.expected_regions} <= set(task.expected_files)
+            assert {region.granularity.value for region in task.expected_regions} <= (
+                ALLOWED_REGION_GRANULARITIES
+            )
+
+    def test_real_external_task_rejects_invalid_region_granularity(self, tmp_path: Path) -> None:
+        source = TASKS_DIR / "fastapi_routing.yaml"
+        malformed = tmp_path / source.name
+        malformed.write_text(
+            source.read_text(encoding="utf-8").replace(
+                "    granularity: symbol",
+                "    granularity: paragraph",
+                1,
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match=r"fastapi_routing\.yaml.*granularity"):
             load_task(malformed)
 
 


### PR DESCRIPTION
## Summary

Adds expected-region labels to selected pinned external benchmark tasks where the relevant source regions are defensible, plus loader tests for external task region loading and granularity validation.

## Stack

Stack-Id: `r0-region-labels-20260620`
Base: `main`
Position: 2/3

1. `r0-region-labels-self` -> #335
2. `r0-region-labels-external` -> this PR (#336)
3. `r0-region-labeled-baseline` -> #337

Depends on: #335
Upstack: #337

## Validation

- `uv run pytest tests/benchmark/test_loader.py tests/benchmark/test_region_fixtures.py --no-cov` — passed
- `uv run ruff check tests/benchmark/test_loader.py tests/benchmark/test_region_fixtures.py` — passed
- `uv run ruff format --check tests/benchmark/test_loader.py tests/benchmark/test_region_fixtures.py` — passed
- `uv run pyright tests/benchmark/test_loader.py tests/benchmark/test_region_fixtures.py` — passed
- Review: external slice reviewed; all valid span findings fixed; final rereview issues fixed

## Notes

- Data/test-only change.
- Labels are pinned to each task's existing ref/tag.
- Does not change retrieval code, ranking, packing, telemetry, or defaults.
