### PR TITLE
Add bounded personalized graph centrality

### DIFF
--- a/src/archex/index/graph.py
+++ b/src/archex/index/graph.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import networkx as nx
@@ -19,6 +22,22 @@ _CO_DIRECTORY_EVIDENCE = [
 ]
 
 _CENTRALITY_WEIGHT_ATTR = "centrality_weight"
+_PERSONALIZED_CENTRALITY_HOPS = 2
+_PERSONALIZED_CENTRALITY_MAX_NODES = 128
+_PERSONALIZED_CENTRALITY_FRONTIER_CAP = 32
+
+
+@dataclass(frozen=True)
+class PersonalizedCentralityResult:
+    """Per-query structural centrality scores plus bounded-walk provenance."""
+
+    scores: dict[str, float]
+    variant: str
+    personalized: bool
+    fallback_reason: str
+    latency_ms: float
+    subgraph_nodes: int
+    subgraph_edges: int
 
 
 def _resolved_import_evidence(file_path: str, imported_module: str, line: int) -> list[str]:
@@ -339,7 +358,59 @@ class DependencyGraph:
         self._centrality_cache = {str(k): v for k, v in raw.items()}
         return self._centrality_cache
 
-    def _weighted_directional_graph(self) -> nx.DiGraph[str]:  # type: ignore[type-arg]
+    def _bounded_personalization_nodes(
+        self,
+        seed_scores: Mapping[str, float],
+        *,
+        max_nodes: int,
+        frontier_cap: int,
+        hops: int,
+    ) -> set[str]:
+        """Return seeds plus a capped bidirectional neighborhood."""
+        selected: set[str] = set()
+        frontier_scores: dict[str, float] = {}
+        for node, score in sorted(seed_scores.items(), key=lambda item: (-item[1], item[0])):
+            if len(selected) >= max_nodes or len(frontier_scores) >= frontier_cap:
+                break
+            if self._file_graph.has_node(node):  # type: ignore[misc]
+                selected.add(node)
+                frontier_scores[node] = score
+
+        for _ in range(hops):
+            if len(selected) >= max_nodes or not frontier_scores:
+                break
+            candidates: dict[str, float] = {}
+            for node, base_score in frontier_scores.items():
+                for pred, _, data in self._file_graph.in_edges(node, data=True):  # type: ignore[misc]
+                    if not data.get("traversable", True):
+                        continue
+                    pred_str = str(pred)
+                    if pred_str in selected:
+                        continue
+                    confidence_score = float(data.get("confidence_score", 1.0))
+                    candidates[pred_str] = candidates.get(pred_str, 0.0) + (
+                        base_score * confidence_score
+                    )
+                for _, succ, data in self._file_graph.out_edges(node, data=True):  # type: ignore[misc]
+                    if not data.get("traversable", True):
+                        continue
+                    succ_str = str(succ)
+                    if succ_str in selected:
+                        continue
+                    confidence_score = float(data.get("confidence_score", 1.0))
+                    candidates[succ_str] = candidates.get(succ_str, 0.0) + (
+                        base_score * confidence_score
+                    )
+            next_frontier: dict[str, float] = {}
+            for node, score in sorted(candidates.items(), key=lambda item: (-item[1], item[0])):
+                if len(next_frontier) >= frontier_cap or len(selected) >= max_nodes:
+                    break
+                selected.add(node)
+                next_frontier[node] = score
+            frontier_scores = next_frontier
+        return selected
+
+    def _weighted_directional_graph(self, nodes: set[str] | None = None) -> nx.DiGraph[str]:  # type: ignore[type-arg]
         """Return traversable graph with confidence weights and ranking direction.
 
         Import edges are stored as importer -> imported (see ``from_parsed_files`` and
@@ -348,8 +419,14 @@ class DependencyGraph:
         files; no reversal is needed for import edges.
         """
         graph: nx.DiGraph[str] = nx.DiGraph()  # type: ignore[type-arg]
-        graph.add_nodes_from(str(node) for node in self._file_graph.nodes())  # type: ignore[misc]
-        for src, tgt, data in self._file_graph.edges(data=True):  # type: ignore[misc]
+        source_nodes = {str(node) for node in self._file_graph.nodes()}  # type: ignore[misc]
+        if nodes is not None:
+            source_nodes &= nodes
+        graph.add_nodes_from(source_nodes)  # type: ignore[misc]
+        edge_graph = (
+            self._file_graph.subgraph(source_nodes) if nodes is not None else self._file_graph
+        )
+        for src, tgt, data in edge_graph.edges(data=True):  # type: ignore[misc]
             if not data.get("traversable", True):
                 continue
             src_str = str(src)
@@ -374,6 +451,73 @@ class DependencyGraph:
         raw: dict[Any, float] = nx.pagerank(graph, weight=_CENTRALITY_WEIGHT_ATTR)  # type: ignore[misc]
         self._weighted_directional_centrality_cache = {str(k): v for k, v in raw.items()}
         return self._weighted_directional_centrality_cache
+
+    def personalized_centrality(
+        self,
+        seed_scores: Mapping[str, float],
+        *,
+        max_nodes: int = _PERSONALIZED_CENTRALITY_MAX_NODES,
+        frontier_cap: int = _PERSONALIZED_CENTRALITY_FRONTIER_CAP,
+        hops: int = _PERSONALIZED_CENTRALITY_HOPS,
+    ) -> PersonalizedCentralityResult:
+        """Return bounded query-personalized weighted PageRank.
+
+        Personalization runs only on seeds plus a capped 1-2 hop neighborhood.
+        Empty or unusable seeds fall back to the cached global centrality.
+        """
+        started_at = time.perf_counter()
+        usable_seed_scores = {
+            path: score
+            for path, score in seed_scores.items()
+            if score > 0.0 and self._file_graph.has_node(path)  # type: ignore[misc]
+        }
+        if not usable_seed_scores:
+            return PersonalizedCentralityResult(
+                scores=dict(self.structural_centrality()),
+                variant="global",
+                personalized=False,
+                fallback_reason="no_usable_seeds",
+                latency_ms=(time.perf_counter() - started_at) * 1000,
+                subgraph_nodes=0,
+                subgraph_edges=0,
+            )
+
+        nodes = self._bounded_personalization_nodes(
+            usable_seed_scores,
+            max_nodes=max_nodes,
+            frontier_cap=frontier_cap,
+            hops=hops,
+        )
+        graph = self._weighted_directional_graph(nodes)
+        personalization = {
+            str(node): usable_seed_scores.get(str(node), 0.0)
+            for node in graph.nodes()  # type: ignore[misc]
+        }
+        if sum(personalization.values()) <= 0.0:
+            return PersonalizedCentralityResult(
+                scores=dict(self.structural_centrality()),
+                variant="global",
+                personalized=False,
+                fallback_reason="no_seed_nodes_in_subgraph",
+                latency_ms=(time.perf_counter() - started_at) * 1000,
+                subgraph_nodes=graph.number_of_nodes(),  # type: ignore[misc]
+                subgraph_edges=graph.number_of_edges(),  # type: ignore[misc]
+            )
+
+        raw: dict[Any, float] = nx.pagerank(
+            graph,
+            personalization=personalization,
+            weight=_CENTRALITY_WEIGHT_ATTR,
+        )  # type: ignore[misc]
+        return PersonalizedCentralityResult(
+            scores={str(k): v for k, v in raw.items()},
+            variant="personalized_weighted_directional",
+            personalized=True,
+            fallback_reason="",
+            latency_ms=(time.perf_counter() - started_at) * 1000,
+            subgraph_nodes=graph.number_of_nodes(),  # type: ignore[misc]
+            subgraph_edges=graph.number_of_edges(),  # type: ignore[misc]
+        )
 
     # ------------------------------------------------------------------
     # Persistence

--- a/tests/index/test_graph.py
+++ b/tests/index/test_graph.py
@@ -230,6 +230,86 @@ def test_sqlite_round_trip(tmp_path: Path) -> None:
     assert restored.file_edge_count == graph.file_edge_count
 
 
+def test_personalized_centrality_differs_from_global() -> None:
+    graph = DependencyGraph.from_edges(
+        [
+            Edge(source="a.py", target="shared.py", kind=EdgeKind.IMPORTS),
+            Edge(source="b.py", target="shared.py", kind=EdgeKind.IMPORTS),
+            Edge(source="seed.py", target="local.py", kind=EdgeKind.IMPORTS),
+            Edge(source="local.py", target="leaf.py", kind=EdgeKind.IMPORTS),
+        ]
+    )
+
+    global_scores = graph.structural_centrality()
+    personalized = graph.personalized_centrality({"seed.py": 1.0})
+
+    assert personalized.personalized is True
+    assert personalized.variant == "personalized_weighted_directional"
+    assert personalized.scores != global_scores
+    assert "shared.py" not in personalized.scores
+    assert personalized.scores["local.py"] > 0.0
+    assert personalized.latency_ms >= 0.0
+    assert personalized.subgraph_nodes > 0
+
+
+def test_personalized_centrality_respects_node_cap() -> None:
+    graph = DependencyGraph()
+    graph.add_file_node("seed.py")
+    for index in range(20):
+        graph.add_file_edge("seed.py", f"dep_{index}.py", kind=EdgeKind.IMPORTS)
+        graph.add_file_edge(f"dep_{index}.py", f"leaf_{index}.py", kind=EdgeKind.IMPORTS)
+
+    personalized = graph.personalized_centrality(
+        {"seed.py": 1.0},
+        max_nodes=6,
+        frontier_cap=4,
+        hops=2,
+    )
+
+    assert personalized.personalized is True
+    assert personalized.subgraph_nodes <= 6
+    assert len(personalized.scores) <= 6
+
+
+def test_personalized_centrality_falls_back_to_global_without_seeds() -> None:
+    graph = DependencyGraph.from_edges(
+        [
+            Edge(source="a.py", target="b.py", kind=EdgeKind.IMPORTS),
+            Edge(source="c.py", target="b.py", kind=EdgeKind.IMPORTS),
+        ]
+    )
+
+    global_scores = graph.structural_centrality()
+    personalized = graph.personalized_centrality({})
+
+    assert personalized.personalized is False
+    assert personalized.variant == "global"
+    assert personalized.fallback_reason == "no_usable_seeds"
+    assert personalized.scores == global_scores
+    assert personalized.scores is not graph._centrality_cache  # pyright: ignore[reportPrivateUsage]
+    assert graph._centrality_cache == global_scores  # pyright: ignore[reportPrivateUsage]
+
+
+def test_personalized_centrality_latency_stays_bounded_on_large_graph() -> None:
+    graph = DependencyGraph()
+    graph.add_file_node("seed.py")
+    for index in range(1_000):
+        node = f"node_{index}.py"
+        graph.add_file_edge("seed.py", node, kind=EdgeKind.IMPORTS)
+        graph.add_file_edge(node, f"leaf_{index}.py", kind=EdgeKind.IMPORTS)
+
+    personalized = graph.personalized_centrality(
+        {"seed.py": 1.0},
+        max_nodes=64,
+        frontier_cap=16,
+        hops=2,
+    )
+
+    assert personalized.personalized is True
+    assert personalized.subgraph_nodes <= 64
+    assert personalized.latency_ms < 3_000.0
+
+
 def test_sqlite_round_trip_preserves_edge_confidence(tmp_path: Path) -> None:
     edge = Edge(
         source="a.py",


### PR DESCRIPTION
## Stack

Stack-Id: `structural-centrality-r1-20260620`
Base: `main`
Position: 2/4

1. `r1-ppr-weighted-directional` -> #338
2. `r1-ppr-personalized-centrality` -> this PR (#339)
3. `r1-ppr-strategy-wiring` -> #340
4. `r1-ppr-reports-docs` -> #341

Depends on: #338
Upstack: #340

## Scope

Adds bounded query-personalized PageRank over seed files and a capped graph neighborhood. Empty or unusable seeds fall back to the cached global centrality result without changing the default path.

## Validation

- Passed: `uv run pytest tests/index/test_graph.py --no-cov`
- Passed: `uv run ruff check ...`, `uv run ruff format --check ...`, `uv run pyright ...` for changed Python files
- Passed: per-PR review; valid findings fixed
