### PR TITLE
Wire archex query PPR benchmark lane

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1699,6 +1699,7 @@ def query(
     explicit_token_budget: bool = False,
     refresh: bool = True,
     handles: list[str] | None = None,
+    centrality_mode: str = "global",
 ) -> ContextBundle:
     """Retrieve a ranked ContextBundle for a natural-language query.
 
@@ -1954,6 +1955,7 @@ def query(
                     reranker=_reranker,
                     rerank_candidate_limit=index_config.rerank_candidate_limit,
                     apply_intent_budget=False,
+                    centrality_mode=centrality_mode,
                 )
                 return _finalize_context_bundle(
                     bundle,
@@ -2324,6 +2326,7 @@ def query(
                 reranker=_reranker_miss,
                 rerank_candidate_limit=index_config.rerank_candidate_limit,
                 apply_intent_budget=False,
+                centrality_mode=centrality_mode,
             )
             logger.info("Search + assemble in %.0fms", _elapsed_ms(t6))
         finally:

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -20,6 +20,7 @@ class Strategy(StrEnum):
     RAW_GREPPED = "raw_grepped"
     RAW_RIPGREP = "raw_ripgrep"
     ARCHEX_QUERY = "archex_query"
+    ARCHEX_QUERY_PPR = "archex_query_ppr"
     ARCHEX_SCOUT_FETCH = "archex_scout_fetch"
     ARCHEX_QUERY_VECTOR = "archex_query_vector"
     SURROGATE_VECTOR = "surrogate_vector"

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -54,6 +54,7 @@ AVAILABLE_STRATEGIES: list[Strategy] = [
     Strategy.ARCHEX_QUERY_BOUNDED_RERANK,
     Strategy.ARCHEX_QUERY_SUMMARY_SIDECAR,
     Strategy.ARCHEX_QUERY_GRAPH_MULTIHOP,
+    Strategy.ARCHEX_QUERY_PPR,
 ]
 
 _VECTOR_STRATEGIES: frozenset[Strategy] = frozenset(

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -67,6 +67,7 @@ from archex.models import (
     RepoSource,
 )
 from archex.reporting import count_tokens
+from archex.serve.context import CENTRALITY_MODE_PERSONALIZED_WEIGHTED
 from archex.serve.modality import budget_tier, classify_query
 from archex.serve.packing import (
     PackDecision,
@@ -1091,6 +1092,7 @@ def _query_bundle(
     strategy: Strategy,
     index_config: IndexConfig,
     cache: bool,
+    centrality_mode: str = "global",
 ) -> tuple[ContextBundle, IndexConfig, PipelineTiming]:
     """Run the query pipeline once; return the bundle and effective index config."""
     from archex.api import query
@@ -1108,6 +1110,7 @@ def _query_bundle(
         config=config,
         index_config=effective_config,
         timing=timing,
+        centrality_mode=centrality_mode,
     )
     return bundle, effective_config, timing
 
@@ -1199,6 +1202,16 @@ def _assemble_query_result(
         "surrogate_version": index_config.surrogate_version,
         "cache_state": _cache_state(timing),
     }
+    if strategy == Strategy.ARCHEX_QUERY_PPR:
+        meta = bundle.retrieval_metadata
+        result_fields["provenance"] = {
+            "centrality_variant": meta.centrality_variant,
+            "centrality_personalized": str(meta.centrality_personalized).lower(),
+            "centrality_fallback_reason": meta.centrality_fallback_reason,
+            "centrality_latency_ms": f"{meta.centrality_latency_ms:.3f}",
+            "centrality_subgraph_nodes": str(meta.centrality_subgraph_nodes),
+            "centrality_subgraph_edges": str(meta.centrality_subgraph_edges),
+        }
     if include_completion:
         completion_tokens, completion_files = compute_bundle_completion_penalty(
             repo_path, result_files, task.expected_files
@@ -1241,10 +1254,16 @@ def _run_query_strategy(
     cache: bool,
     include_completion: bool = True,
     measure_freshness: bool = False,
+    centrality_mode: str = "global",
 ) -> BenchmarkResult:
     t0 = time.perf_counter()
     bundle, effective_config, timing = _query_bundle(
-        task, repo_path, strategy=strategy, index_config=index_config, cache=cache
+        task,
+        repo_path,
+        strategy=strategy,
+        index_config=index_config,
+        cache=cache,
+        centrality_mode=centrality_mode,
     )
     wall_ms = (time.perf_counter() - t0) * 1000
     logger.info(
@@ -1277,6 +1296,20 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
         cache=benchmark_cache_enabled(default=False),
         include_completion=True,
         measure_freshness=True,
+    )
+
+
+def run_archex_query_ppr(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
+    """Benchmark-only lane: BM25 retrieval with personalized structural centrality."""
+    return _run_query_strategy(
+        task,
+        repo_path,
+        strategy=Strategy.ARCHEX_QUERY_PPR,
+        index_config=IndexConfig(vector=False),
+        cache=benchmark_cache_enabled(default=False),
+        include_completion=True,
+        measure_freshness=True,
+        centrality_mode=CENTRALITY_MODE_PERSONALIZED_WEIGHTED,
     )
 
 
@@ -3144,6 +3177,7 @@ default_strategy_registry.register(Strategy.RAW_FILES.value, run_raw_files)
 default_strategy_registry.register(Strategy.RAW_GREPPED.value, run_raw_grepped)
 default_strategy_registry.register(Strategy.RAW_RIPGREP.value, run_raw_ripgrep)
 default_strategy_registry.register(Strategy.ARCHEX_QUERY.value, run_archex_query)
+default_strategy_registry.register(Strategy.ARCHEX_QUERY_PPR.value, run_archex_query_ppr)
 default_strategy_registry.register(Strategy.ARCHEX_SCOUT_FETCH.value, run_archex_scout_fetch)
 default_strategy_registry.register(Strategy.ARCHEX_QUERY_VECTOR.value, run_archex_query_vector)
 default_strategy_registry.register(Strategy.SURROGATE_VECTOR.value, run_surrogate_vector)

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -679,6 +679,12 @@ class RetrievalMetadata(BaseModel):
     signal_agreement: float | None = None
     fusion_bm25_weight: float | None = None
     fusion_vector_weight: float | None = None
+    centrality_variant: str = "global"
+    centrality_personalized: bool = False
+    centrality_fallback_reason: str = ""
+    centrality_latency_ms: float = 0.0
+    centrality_subgraph_nodes: int = 0
+    centrality_subgraph_edges: int = 0
     # Expansion diagnostics
     seed_files_found: int = 0
     seed_file_paths: list[str] = []

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -90,6 +90,7 @@ SEED_EXPANSION_MIN = 0.05
 # Files below this fraction of the top file's aggregate score are excluded.
 FILE_SCORE_CUTOFF = 0.10
 FUSION_FILE_SCORE_CUTOFF = 0.05
+CENTRALITY_MODE_PERSONALIZED_WEIGHTED = "personalized_weighted_directional"
 
 
 def estimate_tokens(chunk: CodeChunk) -> int:
@@ -917,6 +918,7 @@ def assemble_context(
     reranker: object | None = None,
     rerank_candidate_limit: int = 4,
     apply_intent_budget: bool = True,
+    centrality_mode: str = "global",
 ) -> ContextBundle:
     """Assemble a token-budgeted ContextBundle from search results and a dependency graph.
 
@@ -1391,8 +1393,29 @@ def assemble_context(
     # --- Scoring phase ---
     _scoring_start = time.perf_counter_ns()
 
-    # Get structural centrality scores
-    centrality = graph.structural_centrality()
+    centrality_variant = "global"
+    centrality_personalized = False
+    centrality_fallback_reason = ""
+    centrality_latency_ms = 0.0
+    centrality_subgraph_nodes = 0
+    centrality_subgraph_edges = 0
+
+    # Get structural centrality scores. The default product path deliberately
+    # keeps using cached global PageRank; benchmark-only PPR opts in explicitly.
+    if centrality_mode == CENTRALITY_MODE_PERSONALIZED_WEIGHTED:
+        centrality_seed_scores = {
+            fp: score for fp, score in norm_seed_scores.items() if score >= effective_expansion_min
+        }
+        centrality_result = graph.personalized_centrality(centrality_seed_scores)
+        centrality = centrality_result.scores
+        centrality_variant = centrality_result.variant
+        centrality_personalized = centrality_result.personalized
+        centrality_fallback_reason = centrality_result.fallback_reason
+        centrality_latency_ms = centrality_result.latency_ms
+        centrality_subgraph_nodes = centrality_result.subgraph_nodes
+        centrality_subgraph_edges = centrality_result.subgraph_edges
+    else:
+        centrality = graph.structural_centrality()
 
     # Signal agreement was computed pre-fusion; carry it forward for metadata
     signal_agreement: float | None = signal_agreement_pre if vector_results else None
@@ -1535,6 +1558,11 @@ def assemble_context(
                     "files_selected": len(top_files),
                     "chunks_included": len(included),
                     "chunks_dropped": chunks_dropped,
+                    "centrality_variant": centrality_variant,
+                    "centrality_personalized": centrality_personalized,
+                    "centrality_subgraph_nodes": centrality_subgraph_nodes,
+                    "centrality_subgraph_edges": centrality_subgraph_edges,
+                    "centrality_latency_ms": f"{centrality_latency_ms:.3f}",
                 },
             )
         )
@@ -1599,6 +1627,12 @@ def assemble_context(
         splade_used=bool(effective_splade),
         splade_fusion_skipped=splade_fusion_skipped,
         splade_fusion_skip_reason=splade_fusion_skip_reason,
+        centrality_variant=centrality_variant,
+        centrality_personalized=centrality_personalized,
+        centrality_fallback_reason=centrality_fallback_reason,
+        centrality_latency_ms=centrality_latency_ms,
+        centrality_subgraph_nodes=centrality_subgraph_nodes,
+        centrality_subgraph_edges=centrality_subgraph_edges,
     )
 
     bundle = ContextBundle(

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -46,6 +46,8 @@ class TestAvailableStrategies:
         assert Strategy.CROSS_LAYER_FUSION in AVAILABLE_STRATEGIES
         assert Strategy.ARCHEX_QUERY_HYBRID in AVAILABLE_STRATEGIES
         assert Strategy.ARCHEX_QUERY_HYBRID_QUANTIZED_4BIT in AVAILABLE_STRATEGIES
+        assert Strategy.ARCHEX_QUERY_PPR in AVAILABLE_STRATEGIES
+        assert Strategy.ARCHEX_QUERY_PPR not in DEFAULT_STRATEGIES
 
 
 class TestBenchmarkPreflight:
@@ -276,9 +278,11 @@ class TestRunBenchmark:
             explicit_token_budget: bool,
             config: object,
             index_config: IndexConfig,
+            centrality_mode: str = "global",
         ) -> ContextBundle:
             del config
             del explicit_token_budget
+            del centrality_mode
             captured.append(
                 (
                     index_config.embedder,

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -41,6 +41,7 @@ from archex.benchmark.strategies import (
     run_archex_query_fusion_rerank,
     run_archex_query_hybrid,
     run_archex_query_hybrid_quantized_4bit,
+    run_archex_query_ppr,
     run_archex_query_vector,
     run_archex_scout_fetch,
     run_cross_layer_fusion,
@@ -727,6 +728,30 @@ class TestRunArchexQuery:
         assert result.all_required_files_present is True
         assert result.task_completion_result.value == "pass"
 
+    def test_archex_query_ppr_strategy_records_centrality_provenance(
+        self,
+        python_simple_repo: Path,
+    ) -> None:
+        task = BenchmarkTask(
+            task_id="test",
+            repo="test/repo",
+            commit="abc",
+            question="How does the main module work?",
+            expected_files=["main.py"],
+            token_budget=128,
+        )
+        result = run_archex_query_ppr(task, python_simple_repo)
+
+        assert result.strategy == Strategy.ARCHEX_QUERY_PPR
+        assert result.tool_calls == 1
+        assert result.provenance["centrality_variant"] in {
+            "personalized_weighted_directional",
+            "global",
+        }
+        assert "centrality_personalized" in result.provenance
+        assert int(result.provenance["centrality_subgraph_nodes"]) >= 0
+        assert float(result.provenance["centrality_latency_ms"]) >= 0.0
+
     def test_archex_query_without_regions_leaves_region_fields_none(
         self,
         python_simple_repo: Path,
@@ -1217,8 +1242,9 @@ def test_vector_strategies_read_configured_embedder(
         config: object,
         index_config: IndexConfig,
         timing: object | None = None,
+        centrality_mode: str = "global",
     ) -> ContextBundle:
-        del config, explicit_token_budget, timing
+        del config, explicit_token_budget, timing, centrality_mode
         captured.append(index_config.embedder)
         return ContextBundle(
             query=question,

--- a/tests/benchmark/test_strategy_registry.py
+++ b/tests/benchmark/test_strategy_registry.py
@@ -54,6 +54,9 @@ class TestStrategyRegistry:
         assert Strategy.CROSS_LAYER_FUSION.value in names
         assert Strategy.ARCHEX_QUERY_FUSION_RERANK.value in names
 
+        assert Strategy.ARCHEX_QUERY_PPR.value in names
+        assert default_strategy_registry.get(Strategy.ARCHEX_QUERY_PPR) is not None
+
     def test_load_entry_points_registers_runner(self) -> None:
         reg = StrategyRegistry()
         mock_ep = MagicMock()

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 import xml.etree.ElementTree as ET
+
 
 from archex.index.graph import DependencyGraph
 from archex.index.rerank import DEFAULT_TOP_K, RERANK_CANDIDATE_LIMIT, CrossEncoderReranker
@@ -19,6 +21,9 @@ from archex.serve.intent import INTENT_TOKEN_BUDGETS, QueryIntent
 from archex.serve.renderers.json import render_json
 from archex.serve.renderers.markdown import render_markdown
 from archex.serve.renderers.xml import render_xml
+
+if TYPE_CHECKING:
+    import pytest
 
 # ruff: noqa: I001
 
@@ -1051,6 +1056,44 @@ def test_high_relevance_low_centrality_beats_low_relevance_high_centrality() -> 
     bundle = assemble_context(results, graph, all_chunks, "q", token_budget=1000)
     scores = {rc.chunk.file_path: rc.final_score for rc in bundle.chunks}
     assert scores.get("leaf.py", 0) > scores.get("hub.py", 0)
+
+
+def test_default_context_uses_global_centrality(monkeypatch: pytest.MonkeyPatch) -> None:
+    graph = DependencyGraph()
+    graph.add_file_node("seed.py")
+    chunk = make_chunk("seed", "seed.py", token_count=10)
+
+    def fail_personalized(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("default query path must not run personalized centrality")
+
+    monkeypatch.setattr(graph, "personalized_centrality", fail_personalized)
+    bundle = assemble_context([(chunk, 1.0)], graph, [chunk], "q", token_budget=1000)
+
+    assert bundle.retrieval_metadata.centrality_variant == "global"
+    assert bundle.retrieval_metadata.centrality_personalized is False
+
+
+def test_personalized_context_records_centrality_provenance() -> None:
+    graph = DependencyGraph()
+    graph.add_file_edge("seed.py", "dep.py", kind="imports")
+    seed = make_chunk("seed", "seed.py", token_count=10)
+    dep = make_chunk("dep", "dep.py", token_count=10)
+
+    bundle = assemble_context(
+        [(seed, 1.0)],
+        graph,
+        [seed, dep],
+        "q",
+        token_budget=1000,
+        centrality_mode="personalized_weighted_directional",
+    )
+    meta = bundle.retrieval_metadata
+
+    assert meta.centrality_variant == "personalized_weighted_directional"
+    assert meta.centrality_personalized is True
+    assert meta.centrality_subgraph_nodes > 0
+    assert meta.centrality_subgraph_edges >= 0
+    assert meta.centrality_latency_ms >= 0.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stack

Stack-Id: `structural-centrality-r1-20260620`
Base: `main`
Position: 3/4

1. `r1-ppr-weighted-directional` -> #338
2. `r1-ppr-personalized-centrality` -> #339
3. `r1-ppr-strategy-wiring` -> this PR (#340)
4. `r1-ppr-reports-docs` -> #341

Depends on: #339
Upstack: #341

## Scope

Registers `archex_query_ppr` as an available benchmark-only strategy, not a default strategy, and threads the personalized structural centrality mode through benchmark query assembly. `archex_query` keeps using `graph.structural_centrality()` unchanged.

## Validation

- Passed: `uv run pytest tests/benchmark/test_strategy_registry.py tests/benchmark/test_strategies.py tests/benchmark/test_runner.py tests/serve/test_context.py --no-cov`
- Passed: `uv run pytest tests/index/test_graph.py tests/serve/test_context.py tests/serve/test_intent.py tests/benchmark/test_strategy_registry.py tests/benchmark/test_strategies.py tests/benchmark/test_runner.py tests/benchmark/test_reporter.py --no-cov`
- Passed: `uv run ruff check ...`, `uv run ruff format --check ...`, `uv run pyright ...` for changed Python files
- Passed: per-PR review; no blocking findings remain
