### PR TITLE
Add per-file recency/churn prior provider (R2 1/3)

### DIFF
--- a/src/archex/index/churn.py
+++ b/src/archex/index/churn.py
@@ -1,0 +1,296 @@
+"""Per-file recency/churn priors for benchmark-only ranking candidates.
+
+Provides a deterministic, optional, artifact-backed churn/recency prior. The
+prior is a small per-file multiplier (>= ``1.0``) that benchmark candidate lanes
+may apply to the final ranking score; the product default path never builds it.
+
+Two sources are supported, resolved in order:
+
+1. A checked-in precomputed per-file churn fixture (``archex.churn.v1`` JSON),
+   for benchmark lanes whose clones are shallow.
+2. Real git history from a full local clone.
+
+When neither is available (a shallow benchmark clone with no fixture) every
+prior is neutral (multiplier ``1.0``) so the candidate's ranking is bit-identical
+to ``archex_query``. The prior is therefore never a source of nondeterminism:
+given a fixed commit and a fixed fixture it is reproducible, and given no usable
+history it is the identity.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+CHURN_SOURCE_HISTORY = "history"
+CHURN_SOURCE_FIXTURE = "fixture"
+CHURN_SOURCE_NEUTRAL = "neutral_fallback"
+
+# Schema tag every precomputed churn fixture must carry.
+CHURN_FIXTURE_SCHEMA = "archex.churn.v1"
+
+# Maximum multiplicative boost a maximally-churned file can receive. Small by
+# design: the prior may break ties and nudge ordering but must never dominate the
+# relevance signal. Applied as ``final *= 1.0 + max_boost * churn_score`` with
+# ``churn_score`` in ``[0, 1]``.
+DEFAULT_CHURN_MAX_BOOST = 0.05
+
+# Bound the history scan so a deep repository cannot make a benchmark lane
+# unbounded. A fixed HEAD plus a fixed cap stays deterministic.
+_MAX_HISTORY_COMMITS = 5000
+_GIT_TIMEOUT_SECONDS = 60
+
+# Blend weights for the churn score: commit frequency vs last-touched recency.
+_FREQUENCY_WEIGHT = 0.5
+_RECENCY_WEIGHT = 0.5
+
+# Marks a commit-timestamp line in the parsed ``git log`` stream; no file path
+# begins with this control byte, so it cannot collide with a name-only entry.
+_COMMIT_MARKER = "\x01"
+
+
+class ChurnError(Exception):
+    """Raised when a churn fixture is malformed."""
+
+
+@dataclass(frozen=True)
+class FileChurnMetrics:
+    """Raw per-file churn inputs.
+
+    ``commits`` is the number of commits that touched the file; ``recency`` is in
+    ``[0, 1]`` where ``1.0`` is the most recently touched file in the set.
+    """
+
+    commits: int
+    recency: float
+
+
+def _empty_priors() -> dict[str, float]:
+    """Typed default factory for :attr:`ChurnPriors.priors`."""
+    return {}
+
+
+@dataclass(frozen=True)
+class ChurnPriors:
+    """Per-file ranking priors plus the source they were derived from.
+
+    ``priors`` maps a repo-relative file path to a multiplier in
+    ``[1.0, 1.0 + max_boost]``. Files absent from the map are neutral (``1.0``);
+    a neutral-fallback result carries an empty map so every lookup returns
+    ``1.0``.
+    """
+
+    source: str
+    commit: str
+    max_boost: float
+    priors: dict[str, float] = field(default_factory=_empty_priors)
+
+    def prior_for(self, file_path: str) -> float:
+        """Return the bounded multiplier for ``file_path`` (``1.0`` when unknown)."""
+        return self.priors.get(file_path, 1.0)
+
+
+def load_churn_priors(
+    repo_path: Path,
+    *,
+    fixture_path: Path | None = None,
+    max_boost: float = DEFAULT_CHURN_MAX_BOOST,
+) -> ChurnPriors:
+    """Resolve per-file churn priors for ``repo_path``.
+
+    Resolution order:
+
+    1. ``fixture_path`` when it exists — a checked-in precomputed per-file churn
+       fixture (deterministic for benchmark lanes).
+    2. Real git history from a full local clone.
+    3. Neutral fallback (every prior ``1.0``) when neither is available — e.g. a
+       shallow benchmark clone with no fixture. This guarantees the candidate's
+       ranking is identical to ``archex_query``.
+    """
+    if fixture_path is not None and fixture_path.exists():
+        metrics, commit = _load_fixture(fixture_path)
+        return ChurnPriors(
+            source=CHURN_SOURCE_FIXTURE,
+            commit=commit,
+            max_boost=max_boost,
+            priors=_priors_from_metrics(metrics, max_boost),
+        )
+    metrics, commit = _read_history(repo_path)
+    if not metrics:
+        return ChurnPriors(source=CHURN_SOURCE_NEUTRAL, commit="", max_boost=max_boost, priors={})
+    return ChurnPriors(
+        source=CHURN_SOURCE_HISTORY,
+        commit=commit,
+        max_boost=max_boost,
+        priors=_priors_from_metrics(metrics, max_boost),
+    )
+
+
+def _priors_from_metrics(
+    metrics: dict[str, FileChurnMetrics], max_boost: float
+) -> dict[str, float]:
+    """Normalize raw per-file metrics into bounded multipliers (``> 1.0``).
+
+    Frequency is normalized by the maximum commit count in the set; recency is
+    already in ``[0, 1]``. Files whose blended score is ``0`` are omitted so they
+    stay neutral via :meth:`ChurnPriors.prior_for`.
+    """
+    if not metrics or max_boost <= 0.0:
+        return {}
+    max_commits = max(metric.commits for metric in metrics.values())
+    priors: dict[str, float] = {}
+    for path, metric in metrics.items():
+        frequency = (metric.commits / max_commits) if max_commits > 0 else 0.0
+        recency = min(max(metric.recency, 0.0), 1.0)
+        score = _FREQUENCY_WEIGHT * frequency + _RECENCY_WEIGHT * recency
+        multiplier = 1.0 + max_boost * score
+        if multiplier > 1.0:
+            priors[path] = multiplier
+    return priors
+
+
+def _load_fixture(fixture_path: Path) -> tuple[dict[str, FileChurnMetrics], str]:
+    """Parse a precomputed ``archex.churn.v1`` fixture into raw metrics."""
+    try:
+        decoded: object = json.loads(fixture_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ChurnError(f"failed to read churn fixture {fixture_path}: {exc}") from exc
+    if not isinstance(decoded, dict):
+        raise ChurnError(f"churn fixture {fixture_path} must be a JSON object")
+    raw = cast("dict[str, object]", decoded)
+    schema = raw.get("schema")
+    if schema != CHURN_FIXTURE_SCHEMA:
+        raise ChurnError(
+            f"churn fixture {fixture_path} has schema {schema!r}, expected {CHURN_FIXTURE_SCHEMA!r}"
+        )
+    files_obj = raw.get("files")
+    if not isinstance(files_obj, dict):
+        raise ChurnError(f"churn fixture {fixture_path} must carry a 'files' object")
+    files = cast("dict[str, object]", files_obj)
+    commit = str(raw.get("commit", ""))
+    metrics: dict[str, FileChurnMetrics] = {}
+    for path, entry in files.items():
+        metrics[path] = _fixture_entry_metrics(path, entry)
+    return metrics, commit
+
+
+def _fixture_entry_metrics(path: str, entry: object) -> FileChurnMetrics:
+    """Validate and convert a single fixture file entry into metrics."""
+    if not isinstance(entry, dict):
+        raise ChurnError(f"churn fixture entry for {path!r} must be an object")
+    fields = cast("dict[str, object]", entry)
+    commits = fields.get("commits", 0)
+    recency = fields.get("recency", 0.0)
+    if isinstance(commits, bool) or not isinstance(commits, int) or commits < 0:
+        raise ChurnError(f"churn fixture entry {path!r} has invalid 'commits': {commits!r}")
+    if (
+        isinstance(recency, bool)
+        or not isinstance(recency, (int, float))
+        or not math.isfinite(recency)
+    ):
+        raise ChurnError(f"churn fixture entry {path!r} has invalid 'recency': {recency!r}")
+    return FileChurnMetrics(commits=commits, recency=float(recency))
+
+
+def _read_history(repo_path: Path) -> tuple[dict[str, FileChurnMetrics], str]:
+    """Read per-file churn from a full local clone.
+
+    Returns ``({}, "")`` when history is unavailable: no ``.git``, a shallow
+    clone, a single-commit repository, or any git failure. Each of those yields
+    the neutral fallback in :func:`load_churn_priors`.
+    """
+    if not (repo_path / ".git").exists():
+        return {}, ""
+    if _is_shallow(repo_path):
+        return {}, ""
+    if _commit_count(repo_path) <= 1:
+        return {}, ""
+    commit = _git_output(repo_path, ["rev-parse", "HEAD"]) or ""
+    if not commit:
+        return {}, ""
+    log = _git_output(
+        repo_path,
+        [
+            "log",
+            f"--max-count={_MAX_HISTORY_COMMITS}",
+            "--no-merges",
+            "--no-renames",
+            "--name-only",
+            f"--format=format:{_COMMIT_MARKER}%ct",
+        ],
+    )
+    if log is None:
+        return {}, ""
+    metrics = _parse_git_log(log)
+    if not metrics:
+        return {}, ""
+    return metrics, commit
+
+
+def _parse_git_log(log: str) -> dict[str, FileChurnMetrics]:
+    """Parse a marked ``git log --name-only`` stream into per-file metrics."""
+    commit_counts: dict[str, int] = {}
+    last_touched: dict[str, int] = {}
+    current_ts = 0
+    for raw in log.splitlines():
+        if not raw:
+            continue
+        if raw[0] == _COMMIT_MARKER:
+            try:
+                current_ts = int(raw[1:])
+            except ValueError:
+                current_ts = 0
+            continue
+        commit_counts[raw] = commit_counts.get(raw, 0) + 1
+        if current_ts > last_touched.get(raw, 0):
+            last_touched[raw] = current_ts
+    if not commit_counts or not last_touched:
+        return {}
+    min_ts = min(last_touched.values())
+    max_ts = max(last_touched.values())
+    span = max_ts - min_ts
+    metrics: dict[str, FileChurnMetrics] = {}
+    for path, count in commit_counts.items():
+        touched = last_touched.get(path, min_ts)
+        recency = ((touched - min_ts) / span) if span > 0 else 1.0
+        metrics[path] = FileChurnMetrics(commits=count, recency=recency)
+    return metrics
+
+
+def _is_shallow(repo_path: Path) -> bool:
+    """Whether ``repo_path`` is a shallow clone (missing representative history)."""
+    return _git_output(repo_path, ["rev-parse", "--is-shallow-repository"]) == "true"
+
+
+def _commit_count(repo_path: Path) -> int:
+    """Number of commits reachable from HEAD, or ``0`` when git fails."""
+    out = _git_output(repo_path, ["rev-list", "--count", "HEAD"])
+    if out is None:
+        return 0
+    try:
+        return int(out)
+    except ValueError:
+        return 0
+
+
+def _git_output(repo_path: Path, args: list[str]) -> str | None:
+    """Run a read-only git command, returning stripped stdout or ``None``."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()

--- a/tests/fixtures/churn/sample_churn.json
+++ b/tests/fixtures/churn/sample_churn.json
@@ -1,0 +1,10 @@
+{
+  "schema": "archex.churn.v1",
+  "commit": "0fbd93c0000000000000000000000000000000aa",
+  "files": {
+    "src/app/hot.py": {"commits": 40, "recency": 1.0},
+    "src/app/warm.py": {"commits": 12, "recency": 0.6},
+    "src/app/cold.py": {"commits": 1, "recency": 0.0},
+    "src/app/stable_core.py": {"commits": 3, "recency": 0.1}
+  }
+}

--- a/tests/index/test_churn.py
+++ b/tests/index/test_churn.py
@@ -1,0 +1,208 @@
+"""Tests for the recency/churn ranking prior provider."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from archex.index.churn import (
+    CHURN_FIXTURE_SCHEMA,
+    CHURN_SOURCE_FIXTURE,
+    CHURN_SOURCE_HISTORY,
+    CHURN_SOURCE_NEUTRAL,
+    DEFAULT_CHURN_MAX_BOOST,
+    ChurnError,
+    load_churn_priors,
+)
+
+_FIXTURE = Path(__file__).parent.parent / "fixtures" / "churn" / "sample_churn.json"
+
+
+def _git(repo: Path, *args: str, date: str | None = None) -> None:
+    import os
+
+    env = os.environ.copy()
+    if date is not None:
+        env.update(
+            {
+                "GIT_AUTHOR_DATE": date,
+                "GIT_COMMITTER_DATE": date,
+                "GIT_AUTHOR_NAME": "Test",
+                "GIT_AUTHOR_EMAIL": "test@example.com",
+                "GIT_COMMITTER_NAME": "Test",
+                "GIT_COMMITTER_EMAIL": "test@example.com",
+            }
+        )
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {result.stderr}")
+
+
+def _commit(repo: Path, path: str, content: str, *, date: str) -> None:
+    (repo / path).write_text(content, encoding="utf-8")
+    _git(repo, "add", path)
+    _git(repo, "commit", "-q", "-m", f"touch {path} @ {date}", date=date)
+
+
+def _init_history_repo(repo: Path) -> None:
+    """A small repo where ``hot.py`` is frequently and recently changed and
+    ``cold.py`` is touched once long ago."""
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _commit(repo, "cold.py", "v1\n", date="2020-01-01T00:00:00")
+    _commit(repo, "warm.py", "v1\n", date="2020-02-01T00:00:00")
+    _commit(repo, "hot.py", "v1\n", date="2020-03-01T00:00:00")
+    _commit(repo, "warm.py", "v2\n", date="2021-01-01T00:00:00")
+    _commit(repo, "hot.py", "v2\n", date="2022-01-01T00:00:00")
+    _commit(repo, "hot.py", "v3\n", date="2023-01-01T00:00:00")
+    _commit(repo, "hot.py", "v4\n", date="2024-01-01T00:00:00")
+
+
+class TestFixtureSource:
+    def test_fixture_parses_and_is_stable(self) -> None:
+        first = load_churn_priors(_FIXTURE.parent, fixture_path=_FIXTURE)
+        second = load_churn_priors(_FIXTURE.parent, fixture_path=_FIXTURE)
+
+        assert first.source == CHURN_SOURCE_FIXTURE
+        assert first.commit == "0fbd93c0000000000000000000000000000000aa"
+        # Reproducible: the same fixture yields the same priors every load.
+        assert first.priors == second.priors
+
+    def test_fixture_priors_are_ordered_and_bounded(self) -> None:
+        priors = load_churn_priors(_FIXTURE.parent, fixture_path=_FIXTURE)
+        ceiling = 1.0 + DEFAULT_CHURN_MAX_BOOST
+
+        hot = priors.prior_for("src/app/hot.py")
+        warm = priors.prior_for("src/app/warm.py")
+        cold = priors.prior_for("src/app/cold.py")
+        stable = priors.prior_for("src/app/stable_core.py")
+
+        # More churn + more recency => larger (but still bounded) multiplier.
+        assert hot > warm > stable > cold > 1.0
+        for multiplier in (hot, warm, stable, cold):
+            assert 1.0 < multiplier <= ceiling
+        # The most-churned file saturates exactly at the boost ceiling.
+        assert abs(hot - ceiling) < 1e-9
+
+    def test_unknown_file_is_neutral(self) -> None:
+        priors = load_churn_priors(_FIXTURE.parent, fixture_path=_FIXTURE)
+        assert priors.prior_for("src/app/never_seen.py") == 1.0
+
+    def test_zero_max_boost_yields_no_priors(self) -> None:
+        priors = load_churn_priors(_FIXTURE.parent, fixture_path=_FIXTURE, max_boost=0.0)
+        assert priors.source == CHURN_SOURCE_FIXTURE
+        assert priors.priors == {}
+        assert priors.prior_for("src/app/hot.py") == 1.0
+
+
+class TestFixtureValidation:
+    def test_bad_schema_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "churn.json"
+        bad.write_text('{"schema": "nope", "files": {}}', encoding="utf-8")
+        with pytest.raises(ChurnError, match="schema"):
+            load_churn_priors(tmp_path, fixture_path=bad)
+
+    def test_missing_files_object_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "churn.json"
+        bad.write_text(f'{{"schema": "{CHURN_FIXTURE_SCHEMA}"}}', encoding="utf-8")
+        with pytest.raises(ChurnError, match="files"):
+            load_churn_priors(tmp_path, fixture_path=bad)
+
+    def test_invalid_commit_count_raises(self, tmp_path: Path) -> None:
+        bad = tmp_path / "churn.json"
+        bad.write_text(
+            f'{{"schema": "{CHURN_FIXTURE_SCHEMA}", '
+            '"files": {"a.py": {"commits": -1, "recency": 0.5}}}',
+            encoding="utf-8",
+        )
+        with pytest.raises(ChurnError, match="commits"):
+            load_churn_priors(tmp_path, fixture_path=bad)
+
+    def test_non_finite_recency_raises(self, tmp_path: Path) -> None:
+        # json.loads accepts the non-standard NaN token; it must be rejected so a
+        # malformed fixture cannot smuggle a NaN multiplier into scoring.
+        bad = tmp_path / "churn.json"
+        bad.write_text(
+            f'{{"schema": "{CHURN_FIXTURE_SCHEMA}", '
+            '"files": {"a.py": {"commits": 3, "recency": NaN}}}',
+            encoding="utf-8",
+        )
+        with pytest.raises(ChurnError, match="recency"):
+            load_churn_priors(tmp_path, fixture_path=bad)
+
+
+class TestNeutralFallback:
+    def test_missing_history_returns_neutral(self, tmp_path: Path) -> None:
+        # No .git and no fixture => neutral prior for every file.
+        priors = load_churn_priors(tmp_path)
+        assert priors.source == CHURN_SOURCE_NEUTRAL
+        assert priors.priors == {}
+        assert priors.prior_for("anything.py") == 1.0
+
+    def test_single_commit_repo_returns_neutral(self, tmp_path: Path) -> None:
+        _git(tmp_path, "init", "-q")
+        _git(tmp_path, "config", "user.email", "test@example.com")
+        _git(tmp_path, "config", "user.name", "Test")
+        _commit(tmp_path, "only.py", "v1\n", date="2020-01-01T00:00:00")
+        priors = load_churn_priors(tmp_path)
+        # A single commit carries no churn signal => neutral.
+        assert priors.source == CHURN_SOURCE_NEUTRAL
+        assert priors.priors == {}
+
+
+class TestHistorySource:
+    def test_history_backed_churn_is_deterministic(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_history_repo(repo)
+
+        first = load_churn_priors(repo)
+        second = load_churn_priors(repo)
+
+        assert first.source == CHURN_SOURCE_HISTORY
+        assert first.commit != ""
+        # Reproducible given the fixed commit graph.
+        assert first.priors == second.priors
+
+    def test_history_orders_by_churn_and_recency(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _init_history_repo(repo)
+        priors = load_churn_priors(repo)
+        ceiling = 1.0 + DEFAULT_CHURN_MAX_BOOST
+
+        hot = priors.prior_for("hot.py")
+        warm = priors.prior_for("warm.py")
+        cold = priors.prior_for("cold.py")
+
+        assert hot > warm > cold
+        for multiplier in (hot, warm, cold):
+            assert 1.0 <= multiplier <= ceiling
+
+    def test_shallow_clone_yields_neutral(self, tmp_path: Path) -> None:
+        source = tmp_path / "source"
+        source.mkdir()
+        _init_history_repo(source)
+        dest = tmp_path / "shallow"
+        # A real --depth 1 clone over file:// reproduces a benchmark shallow clone.
+        subprocess.run(
+            ["git", "clone", "--quiet", "--depth", "1", source.as_uri(), str(dest)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=True,
+        )
+        priors = load_churn_priors(dest)
+        assert priors.source == CHURN_SOURCE_NEUTRAL
+        assert priors.priors == {}
+        assert priors.prior_for("hot.py") == 1.0


### PR DESCRIPTION
## Stack

Stack-Id: `recency-churn-r2-20260621`
Base: `main`
Position: 1/3

1. `r2-churn-provider` -> this PR
2. `r2-churn-prior-application` -> #343
3. `r2-churn-strategy-reports` -> #344

Depends on: (none - root)
Upstack: #343

Implements Workstream R2 (PR 1/3) of `.docs/2026-06-20-retrieval-ranking-signal-enhancement-design.md`.

## Summary

Adds a deterministic, optional, artifact-backed per-file recency/churn prior provider (`src/archex/index/churn.py`) for benchmark-only ranking candidates. No product default, retrieval code path, or benchmark number changes in this PR — nothing consumes the provider yet.

- Per-file priors are small multipliers (`>= 1.0`) blended from commit frequency and last-touched recency, bounded by `DEFAULT_CHURN_MAX_BOOST` (`0.05`).
- Two sources, resolved in order: a checked-in `archex.churn.v1` JSON fixture, then real git history from a full local clone.
- **Neutral fallback contract:** a shallow clone with no fixture, a single-commit repo, or any git failure returns a neutral prior (`1.0`) for every file, so a candidate stays bit-identical to `archex_query`. Determinism is guaranteed: fixed commit + fixed fixture is reproducible; missing history is the identity.
- History scan is bounded (`--max-count`) and read-only; no network calls beyond the existing benchmark clone path; no hosted/LLM/telemetry behavior.

## Validation

- `uv run pytest tests/index/test_churn.py --no-cov` — 13 passed (fixture parse/stability/bounds, non-finite rejection, missing-history neutral, single-commit neutral, history determinism + ordering, real `--depth 1` shallow-clone neutral, fixture validation errors).
- `uv run ruff check`, `uv run ruff format --check`, `uv run pyright` (strict) on changed files — clean.
