### PR TITLE
Apply intent-gated recency/churn prior in scoring (R2 2/3)

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -118,6 +118,7 @@ if TYPE_CHECKING:
 
     import numpy as np
 
+    from archex.index.churn import ChurnPriors
     from archex.index.embeddings.base import Embedder
     from archex.index.rerank import CrossEncoderReranker
     from archex.models import ComparisonResult
@@ -1700,6 +1701,7 @@ def query(
     refresh: bool = True,
     handles: list[str] | None = None,
     centrality_mode: str = "global",
+    churn_priors: ChurnPriors | None = None,
 ) -> ContextBundle:
     """Retrieve a ranked ContextBundle for a natural-language query.
 
@@ -1956,6 +1958,7 @@ def query(
                     rerank_candidate_limit=index_config.rerank_candidate_limit,
                     apply_intent_budget=False,
                     centrality_mode=centrality_mode,
+                    churn_priors=churn_priors,
                 )
                 return _finalize_context_bundle(
                     bundle,
@@ -2327,6 +2330,7 @@ def query(
                 rerank_candidate_limit=index_config.rerank_candidate_limit,
                 apply_intent_budget=False,
                 centrality_mode=centrality_mode,
+                churn_priors=churn_priors,
             )
             logger.info("Search + assemble in %.0fms", _elapsed_ms(t6))
         finally:

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -685,6 +685,11 @@ class RetrievalMetadata(BaseModel):
     centrality_latency_ms: float = 0.0
     centrality_subgraph_nodes: int = 0
     centrality_subgraph_edges: int = 0
+    # Recency/churn ranking prior (benchmark-only candidate; default leaves these
+    # at their neutral values).
+    churn_source: str = ""
+    churn_intent_gated: bool = False
+    churn_priors_applied: dict[str, float] = {}
     # Expansion diagnostics
     seed_files_found: int = 0
     seed_file_paths: list[str] = []

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -27,6 +27,7 @@ from archex.receipt import (
 )
 
 if TYPE_CHECKING:
+    from archex.index.churn import ChurnPriors
     from archex.index.graph import DependencyGraph
 
 
@@ -919,6 +920,7 @@ def assemble_context(
     rerank_candidate_limit: int = 4,
     apply_intent_budget: bool = True,
     centrality_mode: str = "global",
+    churn_priors: ChurnPriors | None = None,
 ) -> ContextBundle:
     """Assemble a token-budgeted ContextBundle from search results and a dependency graph.
 
@@ -929,6 +931,10 @@ def assemble_context(
     and assembly phases.
     When expansion_min_override is provided, uses it instead of SEED_EXPANSION_MIN
     for expansion gating (useful for architecture-broad queries with flat BM25 scores).
+    When churn_priors is provided (benchmark-only candidate), applies a small,
+    bounded per-file recency/churn multiplier to the final score — gated to the
+    DEBUGGING and USAGE_SEARCH intents only. A neutral or non-gated prior leaves
+    the ranking identical to the default path.
     """
     assembly_start = time.perf_counter()
     # Intent-based weight routing: when no explicit weights are provided,
@@ -1400,6 +1406,16 @@ def assemble_context(
     centrality_subgraph_nodes = 0
     centrality_subgraph_edges = 0
 
+    # Recency/churn ranking prior (benchmark-only candidate). Gated to the
+    # DEBUGGING and USAGE_SEARCH intents; neutral or absent everywhere else so
+    # the default ranking is unchanged.
+    churn_source = churn_priors.source if churn_priors is not None else ""
+    churn_intent_gated = churn_priors is not None and intent in (
+        QueryIntent.DEBUGGING,
+        QueryIntent.USAGE_SEARCH,
+    )
+    churn_priors_applied: dict[str, float] = {}
+
     # Get structural centrality scores. The default product path deliberately
     # keeps using cached global PageRank; benchmark-only PPR opts in explicitly.
     if centrality_mode == CENTRALITY_MODE_PERSONALIZED_WEIGHTED:
@@ -1463,6 +1479,14 @@ def assemble_context(
         # Directory-path alignment: files under directories matching query terms
         path_boost = _path_alignment_boost(chunk.file_path, alignment_terms)
 
+        # Bounded recency/churn multiplier (>= 1.0), neutral unless the intent
+        # gate is open. It may break ties and nudge ordering but cannot dominate.
+        churn_multiplier = 1.0
+        if churn_intent_gated and churn_priors is not None:
+            churn_multiplier = churn_priors.prior_for(chunk.file_path)
+            if churn_multiplier != 1.0:
+                churn_priors_applied[chunk.file_path] = churn_multiplier
+
         final = (
             (
                 weights.relevance * relevance
@@ -1473,6 +1497,7 @@ def assemble_context(
             * support_penalty
             * entry_boost
             * path_boost
+            * churn_multiplier
         )
         ranked.append(
             RankedChunk(
@@ -1563,6 +1588,9 @@ def assemble_context(
                     "centrality_subgraph_nodes": centrality_subgraph_nodes,
                     "centrality_subgraph_edges": centrality_subgraph_edges,
                     "centrality_latency_ms": f"{centrality_latency_ms:.3f}",
+                    "churn_source": churn_source,
+                    "churn_intent_gated": churn_intent_gated,
+                    "churn_files_boosted": len(churn_priors_applied),
                 },
             )
         )
@@ -1633,6 +1661,9 @@ def assemble_context(
         centrality_latency_ms=centrality_latency_ms,
         centrality_subgraph_nodes=centrality_subgraph_nodes,
         centrality_subgraph_edges=centrality_subgraph_edges,
+        churn_source=churn_source,
+        churn_intent_gated=churn_intent_gated,
+        churn_priors_applied=churn_priors_applied,
     )
 
     bundle = ContextBundle(

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -7,6 +7,11 @@ from typing import TYPE_CHECKING
 import xml.etree.ElementTree as ET
 
 
+from archex.index.churn import (
+    CHURN_SOURCE_FIXTURE,
+    CHURN_SOURCE_NEUTRAL,
+    ChurnPriors,
+)
 from archex.index.graph import DependencyGraph
 from archex.index.rerank import DEFAULT_TOP_K, RERANK_CANDIDATE_LIMIT, CrossEncoderReranker
 from archex.models import (
@@ -14,6 +19,7 @@ from archex.models import (
     ContextCompletenessReason,
     ContextBundle,
     Module,
+    ScoringWeights,
     SymbolKind,
 )
 from archex.serve.context import assemble_context
@@ -1094,6 +1100,173 @@ def test_personalized_context_records_centrality_provenance() -> None:
     assert meta.centrality_subgraph_nodes > 0
     assert meta.centrality_subgraph_edges >= 0
     assert meta.centrality_latency_ms >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# Recency/churn prior tests (benchmark-only candidate; default unchanged)
+# ---------------------------------------------------------------------------
+
+_RELEVANCE_ONLY = ScoringWeights(relevance=1.0, structural=0.0, type_coverage=0.0, cohesion=0.0)
+
+
+def _churn_scene() -> tuple[DependencyGraph, list[CodeChunk], list[tuple[CodeChunk, float]]]:
+    """Two near-tied files: ``alpha.py`` leads ``beta.py`` by a hair on relevance."""
+    graph = DependencyGraph()
+    graph.add_file_node("alpha.py")
+    graph.add_file_node("beta.py")
+    alpha = make_chunk("alpha", "alpha.py", token_count=10)
+    beta = make_chunk("beta", "beta.py", token_count=10)
+    results = [(alpha, 1.0), (beta, 0.99)]
+    return graph, [alpha, beta], results
+
+
+def _final_scores(bundle: ContextBundle) -> dict[str, float]:
+    return {rc.chunk.file_path: rc.final_score for rc in bundle.chunks}
+
+
+# A gated intent (DEBUGGING via "fail") and a non-gated intent (GENERAL).
+_GATED_QUESTION = "why does it fail"
+_NON_GATED_QUESTION = "list the helpers here"
+
+
+def test_churn_neutral_fallback_equals_archex_query_under_gated_intent() -> None:
+    """A neutral prior under a gated intent must not perturb the default ranking."""
+    graph, all_chunks, results = _churn_scene()
+    base = assemble_context(
+        results,
+        graph,
+        all_chunks,
+        _GATED_QUESTION,
+        token_budget=1000,
+        scoring_weights=_RELEVANCE_ONLY,
+    )
+    neutral = ChurnPriors(source=CHURN_SOURCE_NEUTRAL, commit="", max_boost=0.05, priors={})
+    candidate = assemble_context(
+        results,
+        graph,
+        all_chunks,
+        _GATED_QUESTION,
+        token_budget=1000,
+        scoring_weights=_RELEVANCE_ONLY,
+        churn_priors=neutral,
+    )
+    assert _final_scores(candidate) == _final_scores(base)
+    assert candidate.retrieval_metadata.churn_intent_gated is True
+    assert candidate.retrieval_metadata.churn_priors_applied == {}
+
+
+def test_churn_non_gated_intent_equals_archex_query() -> None:
+    """Even with a non-neutral prior, a non-gated intent leaves ranking unchanged."""
+    graph, all_chunks, results = _churn_scene()
+    base = assemble_context(
+        results,
+        graph,
+        all_chunks,
+        _NON_GATED_QUESTION,
+        token_budget=1000,
+        scoring_weights=_RELEVANCE_ONLY,
+    )
+    fixture = ChurnPriors(
+        source=CHURN_SOURCE_FIXTURE, commit="c0ffee", max_boost=0.05, priors={"beta.py": 1.05}
+    )
+    candidate = assemble_context(
+        results,
+        graph,
+        all_chunks,
+        _NON_GATED_QUESTION,
+        token_budget=1000,
+        scoring_weights=_RELEVANCE_ONLY,
+        churn_priors=fixture,
+    )
+    assert _final_scores(candidate) == _final_scores(base)
+    # Source is recorded for provenance, but the gate stayed closed.
+    assert candidate.retrieval_metadata.churn_source == CHURN_SOURCE_FIXTURE
+    assert candidate.retrieval_metadata.churn_intent_gated is False
+    assert candidate.retrieval_metadata.churn_priors_applied == {}
+
+
+def test_churn_gated_fixture_shifts_order_within_bound() -> None:
+    """A gated fixture prior can break a near-tie, but only within its bound."""
+    graph, all_chunks, results = _churn_scene()
+    base = assemble_context(
+        results,
+        graph,
+        all_chunks,
+        _GATED_QUESTION,
+        token_budget=1000,
+        scoring_weights=_RELEVANCE_ONLY,
+    )
+    base_scores = _final_scores(base)
+    # alpha leads beta before the prior.
+    assert base_scores["alpha.py"] > base_scores["beta.py"]
+
+    max_boost = 0.05
+    fixture = ChurnPriors(
+        source=CHURN_SOURCE_FIXTURE,
+        commit="c0ffee",
+        max_boost=max_boost,
+        priors={"beta.py": 1.0 + max_boost},
+    )
+    candidate = assemble_context(
+        results,
+        graph,
+        all_chunks,
+        _GATED_QUESTION,
+        token_budget=1000,
+        scoring_weights=_RELEVANCE_ONLY,
+        churn_priors=fixture,
+    )
+    cand_scores = _final_scores(candidate)
+    # The bounded boost flips the near-tie in beta's favor.
+    assert cand_scores["beta.py"] > cand_scores["alpha.py"]
+    # alpha (no prior) is untouched; beta moved by exactly the bounded factor.
+    assert cand_scores["alpha.py"] == base_scores["alpha.py"]
+    assert cand_scores["beta.py"] <= base_scores["beta.py"] * (1.0 + max_boost) + 1e-12
+    assert candidate.retrieval_metadata.churn_priors_applied == {"beta.py": 1.0 + max_boost}
+
+
+def test_churn_usage_search_intent_opens_gate() -> None:
+    """The USAGE_SEARCH half of the gate also applies the bounded prior."""
+    graph, all_chunks, results = _churn_scene()
+    usage_question = "who calls this helper"  # matches the usage-search patterns
+    max_boost = 0.05
+    fixture = ChurnPriors(
+        source=CHURN_SOURCE_FIXTURE,
+        commit="c0ffee",
+        max_boost=max_boost,
+        priors={"beta.py": 1.0 + max_boost},
+    )
+    candidate = assemble_context(
+        results,
+        graph,
+        all_chunks,
+        usage_question,
+        token_budget=1000,
+        scoring_weights=_RELEVANCE_ONLY,
+        churn_priors=fixture,
+    )
+    meta = candidate.retrieval_metadata
+    assert meta.churn_intent_gated is True
+    assert meta.churn_priors_applied == {"beta.py": 1.0 + max_boost}
+    cand_scores = _final_scores(candidate)
+    assert cand_scores["beta.py"] > cand_scores["alpha.py"]
+
+
+def test_churn_absent_leaves_neutral_provenance() -> None:
+    """The default path records no churn source and an empty applied map."""
+    graph, all_chunks, results = _churn_scene()
+    bundle = assemble_context(
+        results,
+        graph,
+        all_chunks,
+        _GATED_QUESTION,
+        token_budget=1000,
+        scoring_weights=_RELEVANCE_ONLY,
+    )
+    meta = bundle.retrieval_metadata
+    assert meta.churn_source == ""
+    assert meta.churn_intent_gated is False
+    assert meta.churn_priors_applied == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stack

Stack-Id: `recency-churn-r2-20260621`
Base: `r2-churn-provider` (#342)
Position: 2/3

1. `r2-churn-provider` -> #342
2. `r2-churn-prior-application` -> this PR
3. `r2-churn-strategy-reports` -> #344

Depends on: #342
Upstack: #344

Implements Workstream R2 (PR 2/3) of `.docs/2026-06-20-retrieval-ranking-signal-enhancement-design.md`.

## Summary

Applies the recency/churn prior from #342 inside scoring, behind an intent gate. Threads an optional `ChurnPriors` from `query` into `assemble_context`; the product default never supplies one, so its ranking is unchanged.

- Gated to `DEBUGGING` and `USAGE_SEARCH` intents only (off for definition/architecture/CLI/general).
- Enters as a bounded multiplier in `[1.0, 1.0 + max_boost]` on the final score — alongside the existing `support_penalty` / `entry_boost` / `path_boost` multipliers — so it can break ties and nudge ordering but never dominate relevance.
- `RetrievalMetadata` records provenance: `churn_source`, `churn_intent_gated`, and `churn_priors_applied` (per-file multipliers actually applied).
- Neutral or non-gated → bit-identical to `archex_query`.

No benchmark strategy is wired yet (PR 3/3, #344); no default behavior changes.

## Validation

- `uv run pytest tests/serve/test_context.py tests/serve/test_intent.py --no-cov` — 133 passed.
- New tests prove: neutral prior under a gated intent equals the default; a non-gated intent with a non-neutral prior equals the default; both gate intents (DEBUGGING and USAGE_SEARCH) apply the bounded prior; a gated fixture prior flips a near-tie within the bound and leaves un-prior'd files untouched; default path records neutral provenance.
- `uv run ruff check`, `uv run ruff format --check`, `uv run pyright` (strict) on changed files — clean.
