### PR TITLE
Add issue-to-edit localization benchmark task family

### DIFF
--- a/benchmarks/tasks/loc_django_username_validator.yaml
+++ b/benchmarks/tasks/loc_django_username_validator.yaml
@@ -1,0 +1,38 @@
+task_id: loc_django_username_validator
+repo: django/django
+commit: "5.1.4"
+category: external-large
+family: localization
+languages: [python]
+include_paths:
+  - django/contrib/auth
+question: "Issue: the set of characters accepted in account usernames during authentication needs to change (the allowed-character pattern is too permissive and accepts inputs it should reject). Which classes define the username validation pattern that must be edited?"
+expected_files:
+  - django/contrib/auth/validators.py
+expected_symbols:
+  - ASCIIUsernameValidator
+  - UnicodeUsernameValidator
+expected_regions:
+  - path: django/contrib/auth/validators.py
+    granularity: file
+    notes: "The whole module defines username character validation; pinned to Django 5.1.4."
+    weight: 0.5
+  - path: django/contrib/auth/validators.py
+    granularity: symbol
+    symbol: ASCIIUsernameValidator
+    start_line: 8
+    end_line: 15
+    notes: "ASCII username regex/message/flags; the regex pattern is the edit target. Pinned to Django 5.1.4."
+  - path: django/contrib/auth/validators.py
+    granularity: symbol
+    symbol: UnicodeUsernameValidator
+    start_line: 18
+    end_line: 25
+    notes: "Unicode username regex/message/flags; the regex pattern is the edit target. Pinned to Django 5.1.4."
+token_budget: 8192
+keywords:
+  - username
+  - validator
+  - regex
+  - auth
+  - pattern

--- a/benchmarks/tasks/loc_fastapi_jsonable_encoder.yaml
+++ b/benchmarks/tasks/loc_fastapi_jsonable_encoder.yaml
@@ -1,0 +1,27 @@
+task_id: loc_fastapi_jsonable_encoder
+repo: tiangolo/fastapi
+commit: "0.115.6"
+category: external-framework
+family: localization
+languages: [python]
+include_paths:
+  - fastapi
+question: "Issue: serializing a response object fails because jsonable_encoder does not honor a registered custom encoder for a particular type and mishandles the recursive conversion. Which function implements the recursive JSON-able conversion of arbitrary objects that must be edited?"
+expected_files:
+  - fastapi/encoders.py
+expected_symbols:
+  - jsonable_encoder
+expected_regions:
+  - path: fastapi/encoders.py
+    granularity: symbol
+    symbol: jsonable_encoder
+    start_line: 102
+    end_line: 343
+    notes: "Recursive JSON-able conversion: include/exclude handling, custom_encoder dispatch, Pydantic model and dataclass handling, and the dict/vars fallback; pinned to FastAPI 0.115.6."
+token_budget: 8192
+keywords:
+  - encoder
+  - jsonable
+  - serialize
+  - custom_encoder
+  - recursive

--- a/benchmarks/tasks/loc_flask_blueprint_register.yaml
+++ b/benchmarks/tasks/loc_flask_blueprint_register.yaml
@@ -1,0 +1,35 @@
+task_id: loc_flask_blueprint_register
+repo: pallets/flask
+commit: "3.1.0"
+category: external-framework
+family: localization
+languages: [python]
+include_paths:
+  - src/flask
+question: "Issue: registering nested blueprints does not combine the child blueprint's url_prefix and dotted name with the parent correctly. To fix nested blueprint registration, where is the blueprint registration logic that creates the setup state and recurses into nested blueprints applying their url_prefix and name prefix?"
+expected_files:
+  - src/flask/sansio/blueprints.py
+expected_symbols:
+  - Blueprint.register
+  - Blueprint.register_blueprint
+expected_regions:
+  - path: src/flask/sansio/blueprints.py
+    granularity: symbol
+    symbol: Blueprint.register
+    start_line: 273
+    end_line: 377
+    notes: "Registers the blueprint and recurses into nested blueprints, merging url_prefix/subdomain/name_prefix; pinned to Flask 3.1.0."
+  - path: src/flask/sansio/blueprints.py
+    granularity: symbol
+    symbol: Blueprint.register_blueprint
+    start_line: 256
+    end_line: 271
+    notes: "Records a child blueprint to be registered later by register(); pinned to Flask 3.1.0."
+    weight: 0.8
+token_budget: 8192
+keywords:
+  - blueprint
+  - register
+  - nested
+  - url_prefix
+  - name_prefix

--- a/benchmarks/tasks/loc_httpx_redirect_headers.yaml
+++ b/benchmarks/tasks/loc_httpx_redirect_headers.yaml
@@ -1,0 +1,35 @@
+task_id: loc_httpx_redirect_headers
+repo: encode/httpx
+commit: "0.28.1"
+category: external-framework
+family: localization
+languages: [python]
+include_paths:
+  - httpx
+question: "Bug report: on a cross-origin redirect the Authorization header is forwarded to the new origin instead of being removed (it should only survive a direct HTTP to HTTPS upgrade), and the redirect target URL must be resolved correctly. Where does httpx build the redirect request headers and compute the redirect URL?"
+expected_files:
+  - httpx/_client.py
+expected_symbols:
+  - _redirect_headers
+  - _redirect_url
+expected_regions:
+  - path: httpx/_client.py
+    granularity: symbol
+    symbol: BaseClient._redirect_headers
+    start_line: 546
+    end_line: 571
+    notes: "Strips Authorization on cross-origin redirect except direct http->https, updates Host, drops body headers on GET; pinned to httpx 0.28.1."
+  - path: httpx/_client.py
+    granularity: symbol
+    symbol: BaseClient._redirect_url
+    start_line: 517
+    end_line: 545
+    notes: "Resolves the absolute redirect target URL from the Location header; pinned to httpx 0.28.1."
+    weight: 0.8
+token_budget: 8192
+keywords:
+  - redirect
+  - authorization
+  - headers
+  - cross-origin
+  - location

--- a/benchmarks/tasks/loc_requests_redirect_auth.yaml
+++ b/benchmarks/tasks/loc_requests_redirect_auth.yaml
@@ -1,0 +1,34 @@
+task_id: loc_requests_redirect_auth
+repo: psf/requests
+commit: "v2.32.3"
+category: external-framework
+family: localization
+languages: [python]
+include_paths:
+  - src/requests
+question: "Bug report: when a request is redirected to a different host or scheme, the Authorization header can be forwarded to the new origin and leak credentials. To fix the redirect auth-stripping behavior, where does requests decide whether the Authorization header should be removed on a redirect, and where is that decision applied to the prepared request?"
+expected_files:
+  - src/requests/sessions.py
+expected_symbols:
+  - should_strip_auth
+  - rebuild_auth
+expected_regions:
+  - path: src/requests/sessions.py
+    granularity: symbol
+    symbol: SessionRedirectMixin.should_strip_auth
+    start_line: 127
+    end_line: 157
+    notes: "Decides whether the Authorization header is stripped on redirect across host/scheme/port; pinned to requests v2.32.3."
+  - path: src/requests/sessions.py
+    granularity: symbol
+    symbol: SessionRedirectMixin.rebuild_auth
+    start_line: 282
+    end_line: 300
+    notes: "Applies the should_strip_auth decision and reapplies .netrc auth on the new host; pinned to requests v2.32.3."
+token_budget: 8192
+keywords:
+  - redirect
+  - authorization
+  - strip
+  - credentials
+  - rebuild_auth

--- a/src/archex/benchmark/__init__.py
+++ b/src/archex/benchmark/__init__.py
@@ -19,6 +19,7 @@ from archex.benchmark.models import (
     RegionGranularity,
     Strategy,
     TaskCategory,
+    TaskFamily,
 )
 
 __all__ = [
@@ -38,4 +39,5 @@ __all__ = [
     "RegionGranularity",
     "Strategy",
     "TaskCategory",
+    "TaskFamily",
 ]

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -48,6 +48,20 @@ class TaskCategory(StrEnum):
     FRAMEWORK_SEMANTIC = "framework-semantic"
 
 
+class TaskFamily(StrEnum):
+    """Task shape, orthogonal to ``TaskCategory`` (which is repo type).
+
+    ``comprehension`` tasks ask "how does X work?" and are graded on whole-bundle
+    retrieval quality. ``localization`` tasks are issue-to-edit fault-localization
+    tasks graded on file- and symbol-level localization of the regions to edit.
+    The reporting layer can group the two families separately so a localization
+    result is never folded into a comprehension-mixed aggregate.
+    """
+
+    COMPREHENSION = "comprehension"
+    LOCALIZATION = "localization"
+
+
 class BenchmarkSpecModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -162,6 +176,7 @@ class BenchmarkTask(BenchmarkSpecModel):
     languages: list[str] | None = None
     include_paths: list[str] = []
     category: TaskCategory | None = None
+    family: TaskFamily = TaskFamily.COMPREHENSION
     bundle_only_eval: BundleOnlyEvaluation | None = None
     expected_regions: list[ExpectedRegion] = []
 

--- a/tests/benchmark/test_loader.py
+++ b/tests/benchmark/test_loader.py
@@ -20,6 +20,8 @@ from archex.benchmark.models import (
     BenchmarkTask,
     DeltaBenchmarkTask,
     ExpectedRegion,
+    RegionGranularity,
+    TaskFamily,
 )
 
 TASKS_DIR = Path(__file__).resolve().parents[2] / "benchmarks" / "tasks"
@@ -36,6 +38,13 @@ LABELED_EXTERNAL_TASKS = (
     "requests_sessions",
 )
 ALLOWED_REGION_GRANULARITIES = {"file", "symbol", "block", "line_range"}
+LOCALIZATION_TASK_IDS = (
+    "loc_requests_redirect_auth",
+    "loc_django_username_validator",
+    "loc_flask_blueprint_register",
+    "loc_httpx_redirect_headers",
+    "loc_fastapi_jsonable_encoder",
+)
 
 
 @pytest.fixture
@@ -414,6 +423,72 @@ expected_regions:
 
         with pytest.raises(ValueError, match=r"fastapi_routing\.yaml.*granularity"):
             load_task(malformed)
+
+
+class TestLoadLocalizationTasks:
+    def test_localization_tasks_load_with_localization_family(self) -> None:
+        for task_id in LOCALIZATION_TASK_IDS:
+            task = load_task(TASKS_DIR / f"{task_id}.yaml")
+
+            assert task.family is TaskFamily.LOCALIZATION, task_id
+            assert task.expected_regions, f"{task_id} declares no expected_regions"
+            region_paths = {region.path for region in task.expected_regions}
+            assert region_paths <= set(task.expected_files), task_id
+
+    def test_localization_tasks_accept_symbol_granularity_regions(self) -> None:
+        for task_id in LOCALIZATION_TASK_IDS:
+            task = load_task(TASKS_DIR / f"{task_id}.yaml")
+
+            symbol_regions = [
+                region
+                for region in task.expected_regions
+                if region.granularity is RegionGranularity.SYMBOL
+            ]
+            assert symbol_regions, f"{task_id} declares no symbol-granularity region"
+            for region in symbol_regions:
+                # Symbol regions may also pin an explicit line range; when they do,
+                # the bounds must round-trip as a valid inclusive range.
+                if region.start_line is not None:
+                    assert region.end_line is not None, (task_id, region.symbol)
+                    assert region.start_line <= region.end_line, (task_id, region.symbol)
+
+    def test_localization_family_includes_file_granularity_region(self) -> None:
+        task = load_task(TASKS_DIR / "loc_django_username_validator.yaml")
+
+        file_regions = [
+            region for region in task.expected_regions if region.granularity.value == "file"
+        ]
+        assert file_regions, "expected at least one file-granularity localization region"
+        assert all(region.start_line is None and region.symbol is None for region in file_regions)
+
+    def test_comprehension_is_the_default_family(self) -> None:
+        task = load_task(TASKS_DIR / "fastapi_routing.yaml")
+
+        assert task.family is TaskFamily.COMPREHENSION
+
+    def test_symbol_region_without_line_range_accepted(self, tmp_path: Path) -> None:
+        p = tmp_path / "loc_symbol_only.yaml"
+        p.write_text("""\
+task_id: loc_symbol_only
+repo: owner/repo
+commit: "v1.2.3"
+family: localization
+question: "Issue: where is the handler defined?"
+expected_files:
+  - src/app.py
+expected_regions:
+  - path: src/app.py
+    granularity: symbol
+    symbol: App.handle
+""")
+
+        task = load_task(p)
+
+        assert task.family is TaskFamily.LOCALIZATION
+        region = task.expected_regions[0]
+        assert region.symbol == "App.handle"
+        assert region.start_line is None
+        assert region.end_line is None
 
 
 class TestLoadArchTask:


### PR DESCRIPTION
## Summary

Add an issue-to-edit localization task family to the benchmark corpus (Workstream R3 of the retrieval ranking-signal enhancement design). This is corpus + schema work only: no retrieval code path changes, no product-default changes, no hosted/LLM/network behavior.

- New `TaskFamily` enum (`comprehension` / `localization`) and a `family` field on `BenchmarkTask`, defaulting to `comprehension` so every existing task is unchanged. Family is the task-shape axis, orthogonal to `TaskCategory` (repo type).
- Five hand-curated, SWE-bench-style issue-to-edit localization tasks (`benchmarks/tasks/loc_*.yaml`), each an issue-style question plus expected edit locations at file and symbol granularity, pinned to a release tag of a public repo:
  - `loc_requests_redirect_auth` — psf/requests v2.32.3
  - `loc_django_username_validator` — django/django 5.1.4
  - `loc_flask_blueprint_register` — pallets/flask 3.1.0
  - `loc_httpx_redirect_headers` — encode/httpx 0.28.1
  - `loc_fastapi_jsonable_encoder` — tiangolo/fastapi 0.115.6

Every label was verified against the pinned source: files exist, line ranges are in bounds, and region paths are a subset of `expected_files`. The set is small and maintained; no external dataset is bulk-imported.

## Stack

Stack-Id: `loc-bench-r3-20260621`
Base: `main`
Position: 1/3

1. `r3-loc-task-family` -> this PR (localization task family)
2. `r3-loc-reporting` -> localization reporting separation
3. `r3-loc-docs` -> docs

Depends on: (none - root)

## Validation

- `uv run pytest tests/benchmark/test_loader.py` — pass (59).
- `uv run pytest tests/benchmark/test_loader.py tests/benchmark/test_models.py tests/benchmark/test_region_fixtures.py tests/benchmark/test_generalization.py tests/benchmark/test_reporter.py tests/benchmark/test_triage.py tests/benchmark/test_readiness.py` — pass (166).
- Each `loc_*` task validated against a shallow clone of its pinned ref (files present, line ranges in bounds, region paths within `expected_files`).
