### PR TITLE
Report localization and comprehension families separately

### DIFF
--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -477,6 +477,7 @@ class BenchmarkResult(BaseModel):
     expansion_test_candidates_skipped: int = 0
     expansion_zero_candidate_reason: str = ""
     category: TaskCategory | None = None
+    family: TaskFamily = TaskFamily.COMPREHENSION
     vector_mode: VectorMode = VectorMode.RAW
     surrogate_version: str | None = None
     cache_state: str = "cold"

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -609,6 +609,89 @@ def format_bucketed_summary(reports: list[BenchmarkReport]) -> str:
     return "\n".join(lines)
 
 
+_LOCALIZATION_FAMILY = "localization"
+_FAMILY_ORDER = ("localization", "comprehension")
+_FAMILY_LABELS = {
+    "localization": "Localization (issue-to-edit)",
+    "comprehension": "Comprehension",
+}
+
+
+def _report_family(report: BenchmarkReport) -> str:
+    """Family of a report's task: localization if any result is labeled as such.
+
+    A report is one task, so every strategy result it holds (including baselines
+    that do not carry the task family) belongs to the task's family.
+    """
+    for result in report.results:
+        if result.family.value == _LOCALIZATION_FAMILY:
+            return _LOCALIZATION_FAMILY
+    return "comprehension"
+
+
+def format_localization_summary(reports: list[BenchmarkReport]) -> str:
+    """Render file- and region-level localization grouped by task family.
+
+    Rendered only when at least one task belongs to the localization family, so
+    pure-comprehension runs are unaffected. Grouping is per task (per report):
+    every strategy result for a localization task is reported under localization,
+    and the localization and comprehension families are always tabulated
+    separately so this report never collapses the two into a single cross-family
+    aggregate winner.
+    """
+    by_family: dict[str, list[BenchmarkReport]] = defaultdict(list)
+    for report in reports:
+        by_family[_report_family(report)].append(report)
+    if _LOCALIZATION_FAMILY not in by_family:
+        return ""
+
+    lines: list[str] = ["# Localization vs Comprehension", ""]
+    lines.append(
+        "Task families are graded separately: localization (issue-to-edit) tasks "
+        "and comprehension tasks are never combined into a single aggregate winner. "
+        "File-level columns measure whether the files to edit were returned and "
+        "well ordered; region-level columns measure the same over the labeled "
+        "symbol/line regions (``unknown`` when a family has no region labels)."
+    )
+    lines.append("")
+
+    ordered = [family for family in _FAMILY_ORDER if family in by_family]
+    ordered += [family for family in sorted(by_family) if family not in _FAMILY_ORDER]
+
+    for family in ordered:
+        family_reports = by_family[family]
+        results = [result for report in family_reports for result in report.results]
+        label = _FAMILY_LABELS.get(family, family)
+        lines.append(f"## {label} ({len(family_reports)} tasks)")
+        lines.append("")
+        lines.append(
+            "| Strategy | File Recall | File MRR | File nDCG | Region Recall "
+            "| Region MRR | Region nDCG | Labeled | Tasks |"
+        )
+        lines.append(
+            "|----------|------------:|---------:|----------:|--------------:"
+            "|-----------:|------------:|--------:|------:|"
+        )
+        by_strategy: dict[str, list[BenchmarkResult]] = defaultdict(list)
+        for result in results:
+            by_strategy[result.strategy.value].append(result)
+        for name in sorted(by_strategy):
+            rows = by_strategy[name]
+            labeled = [result for result in rows if result.region_recall is not None]
+            lines.append(
+                f"| {name} "
+                f"| {_mean([r.required_file_recall for r in rows]):.3f} "
+                f"| {_mean([r.mrr for r in rows]):.3f} "
+                f"| {_mean([r.ndcg for r in rows]):.3f} "
+                f"| {_fmt_opt(_mean_optional([r.region_recall for r in labeled]))} "
+                f"| {_fmt_opt(_mean_optional([r.ranked_region_mrr for r in labeled]))} "
+                f"| {_fmt_opt(_mean_optional([r.ranked_region_ndcg for r in labeled]))} "
+                f"| {len(labeled)} | {len(rows)} |"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
 def _result_for_strategy(report: BenchmarkReport, strategy: str) -> BenchmarkResult | None:
     for result in report.results:
         if result.strategy.value == strategy:

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -1201,6 +1201,7 @@ def _assemble_query_result(
         "index_chunk_count": af.index_chunk_count,
         "mean_chunk_tokens": af.mean_chunk_tokens,
         "category": task.category,
+        "family": task.family,
         "vector_mode": index_config.vector_mode,
         "surrogate_version": index_config.surrogate_version,
         "cache_state": _cache_state(timing),
@@ -2782,6 +2783,7 @@ def run_archex_scout_fetch(task: BenchmarkTask, repo_path: Path) -> BenchmarkRes
         index_chunk_count=fetch_fields.index_chunk_count,
         mean_chunk_tokens=fetch_fields.mean_chunk_tokens,
         category=task.category,
+        family=task.family,
         cache_state=_cache_state(timing),
         provenance={
             "scout_token_budget": str(DEFAULT_SCOUT_TOKEN_BUDGET),

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -62,6 +62,7 @@ from archex.benchmark.reporter import (
     format_chunker_frontier_table,
     format_delta_summary,
     format_json,
+    format_localization_summary,
     format_markdown,
     format_summary,
 )
@@ -404,6 +405,9 @@ def report_cmd(output_format: str, input_dir: str, baseline_dir: str | None) -> 
             click.echo(format_markdown(report))
         click.echo(format_summary(reports))
         click.echo(format_bucketed_summary(reports))
+        localization_summary = format_localization_summary(reports)
+        if localization_summary:
+            click.echo(localization_summary)
         if baseline_reports:
             click.echo(
                 format_baseline_comparison(

--- a/tests/benchmark/test_reporter.py
+++ b/tests/benchmark/test_reporter.py
@@ -10,11 +10,13 @@ from archex.benchmark.models import (
     Strategy,
     TaskCategory,
     TaskCompletionResult,
+    TaskFamily,
 )
 from archex.benchmark.reporter import (
     format_bucketed_summary,
     format_chunker_frontier_table,
     format_json,
+    format_localization_summary,
     format_markdown,
     format_strategy_comparison,
     format_summary,
@@ -652,3 +654,142 @@ class TestAdvancedLanesReporting:
         md = format_strategy_comparison([report])
         assert "### Advanced Quality Lanes" in md
         assert "archex_query_dual_transform" in md
+
+
+def _loc_result(
+    task_id: str,
+    *,
+    strategy: Strategy = Strategy.ARCHEX_QUERY,
+    required_file_recall: float = 1.0,
+    mrr: float = 1.0,
+    ndcg: float = 1.0,
+    region_recall: float | None = 0.75,
+    ranked_region_mrr: float | None = 1.0,
+    ranked_region_ndcg: float | None = 0.9,
+) -> BenchmarkResult:
+    return _make_result(strategy, required_file_recall=required_file_recall).model_copy(
+        update={
+            "task_id": task_id,
+            "family": TaskFamily.LOCALIZATION,
+            "mrr": mrr,
+            "ndcg": ndcg,
+            "region_recall": region_recall,
+            "ranked_region_mrr": ranked_region_mrr,
+            "ranked_region_ndcg": ranked_region_ndcg,
+        }
+    )
+
+
+def _comprehension_report(task_id: str = "comp_task") -> BenchmarkReport:
+    result = _make_result(Strategy.ARCHEX_QUERY).model_copy(update={"task_id": task_id})
+    return BenchmarkReport(
+        task_id=task_id,
+        repo="owner/repo",
+        question="How does X work?",
+        results=[result],
+        baseline_tokens=2000,
+    )
+
+
+def _loc_report(result: BenchmarkResult) -> BenchmarkReport:
+    return BenchmarkReport(
+        task_id=result.task_id,
+        repo="owner/repo",
+        question="Issue: where is the bug?",
+        results=[result],
+        baseline_tokens=2000,
+    )
+
+
+class TestLocalizationSummary:
+    def test_empty_without_localization_results(self) -> None:
+        assert format_localization_summary([_comprehension_report()]) == ""
+
+    def test_groups_localization_and_comprehension_separately(self) -> None:
+        reports = [
+            _loc_report(_loc_result("loc_a")),
+            _comprehension_report("comp_a"),
+        ]
+
+        md = format_localization_summary(reports)
+
+        assert "# Localization vs Comprehension" in md
+        assert "graded separately" in md
+        # Both families get their own group; neither is folded into the other.
+        assert "## Localization (issue-to-edit) (1 tasks)" in md
+        assert "## Comprehension (1 tasks)" in md
+        # The localization group precedes the comprehension group.
+        assert md.index("## Localization (issue-to-edit)") < md.index("## Comprehension")
+
+    def test_surfaces_file_and_region_localization_metrics(self) -> None:
+        result = _loc_result(
+            "loc_a",
+            required_file_recall=0.5,
+            mrr=0.5,
+            ndcg=0.6,
+            region_recall=0.75,
+            ranked_region_mrr=1.0,
+            ranked_region_ndcg=0.9,
+        )
+        md = format_localization_summary([_loc_report(result)])
+
+        assert "File Recall" in md and "File MRR" in md and "File nDCG" in md
+        assert "Region Recall" in md and "Region MRR" in md and "Region nDCG" in md
+        # File-level localization metrics are rendered.
+        assert "0.500" in md
+        # Region-level ranking metrics over returned order are rendered.
+        assert "0.750" in md
+        assert "0.900" in md
+
+    def test_labeled_count_tracks_region_labels(self) -> None:
+        labeled = _loc_result("loc_labeled")
+        unlabeled = _loc_result(
+            "loc_unlabeled",
+            region_recall=None,
+            ranked_region_mrr=None,
+            ranked_region_ndcg=None,
+        )
+        md = format_localization_summary([_loc_report(labeled), _loc_report(unlabeled)])
+
+        # One strategy row aggregates two localization tasks; only one is labeled,
+        # so the Labeled/Tasks columns read 1/2 and region metrics still aggregate
+        # over the single labeled task.
+        assert "| 1 | 2 |" in md
+        assert "0.750" in md
+
+    def test_baseline_results_share_the_task_family(self) -> None:
+        # A localization task is run through several strategies; the baselines do
+        # not carry the task family, but every result belongs to the task, so the
+        # whole report is grouped under localization (not split across families).
+        archex = _loc_result("loc_a")
+        baseline = _make_result(Strategy.RAW_FILES).model_copy(update={"task_id": "loc_a"})
+        report = BenchmarkReport(
+            task_id="loc_a",
+            repo="owner/repo",
+            question="Issue: where is the bug?",
+            results=[baseline, archex],
+            baseline_tokens=2000,
+        )
+
+        md = format_localization_summary([report])
+
+        assert "## Localization (issue-to-edit) (1 tasks)" in md
+        assert "## Comprehension" not in md
+        # Both the archex lane and the baseline appear under the localization group.
+        assert "| archex_query " in md
+        assert "| raw_files " in md
+
+    def test_unlabeled_only_localization_region_columns_unknown(self) -> None:
+        unlabeled = _loc_result(
+            "loc_unlabeled",
+            region_recall=None,
+            ranked_region_mrr=None,
+            ranked_region_ndcg=None,
+        )
+        md = format_localization_summary([_loc_report(unlabeled)])
+
+        loc_section = md.split("## Comprehension")[0]
+        # With no region labels in the family, region columns read "unknown" while
+        # file-level columns still render, and the Labeled/Tasks columns read 0/1.
+        assert "unknown" in loc_section
+        assert "| 0 | 1 |" in loc_section


### PR DESCRIPTION
## Summary

Report the localization task family separately from the comprehension family (Workstream R3 reporting). No retrieval code path changes, no product-default changes, no hosted/LLM/network behavior.

- `BenchmarkResult` gains a `family` field (default `comprehension`); `task.family` is propagated through the query-assembly and scout-fetch result builders. Default value keeps every existing result and serialized artifact unchanged.
- New `reporter.format_localization_summary` groups reports by task family and renders, per strategy:
  - file-level localization — required-file recall, MRR, nDCG over returned file order;
  - region-level localization — region recall, ranked MRR/nDCG over returned context order (`unknown` when a family has no region labels).
- Grouping is per task (per report): every strategy result for a localization task, including the raw baselines that do not carry the family, is reported under localization, so the two families are never collapsed into a single cross-family aggregate winner. The section renders only when a localization task is present; pure-comprehension runs are unaffected.
- `archex benchmark report` emits the localization summary after the bucketed summary.

## Stack

Stack-Id: `loc-bench-r3-20260621`
Base: `r3-loc-task-family`
Position: 2/3

1. `r3-loc-task-family` -> #345 (localization task family)
2. `r3-loc-reporting` -> this PR (localization reporting separation)
3. `r3-loc-docs` -> docs

Depends on: #345

## Validation

- `uv run pytest tests/benchmark/test_loader.py tests/benchmark/test_reporter.py` — pass.
- `uv run pytest tests/benchmark/test_loader.py tests/benchmark/test_reporter.py tests/benchmark/test_models.py tests/benchmark/test_cli.py tests/benchmark/test_region_fixtures.py tests/benchmark/test_readiness.py tests/benchmark/test_triage.py` — pass (201).
- End-to-end: `uv run archex benchmark run --tasks-dir benchmarks/tasks --task loc_requests_redirect_auth --strategy archex_query --output .archex/r3-loc-smoke` produced an `archex_query` result with `family=localization`, `region_recall=1.0`, and ranked region MRR/nDCG populated; `archex benchmark report` rendered the Localization group with all strategies (archex + baselines) under it and no mixed-family aggregate.
