### PR TITLE
Add opt-in low-latency conditional reranker lane (R4)

### DIFF
--- a/src/archex/index/rerank.py
+++ b/src/archex/index/rerank.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import logging
 import sys
 import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from archex.exceptions import ArchexIndexError
+from archex.exceptions import ArchexIndexError, ConfigError
 from archex.index.fusion import bm25_score_cv
 from archex.index.huggingface import resolve_hf_model_path
 from archex.index.model_policy import (
@@ -267,9 +269,10 @@ class CrossEncoderReranker:
 # optionally an ONNX/INT8 backend), but it is model-agnostic: the operator
 # supplies the model via ``rerank_model``.
 
-# Hard wall-clock ceiling (ms) for one conditional rerank stage. A model pass
-# slower than this is aborted and the original order is kept, so the rerank stage
-# can never blow the latency budget even when the model misbehaves.
+# Hard wall-clock ceiling (ms) for one conditional rerank stage. The model pass
+# runs in a worker thread and the caller is released at this cap, so the rerank
+# stage the pipeline observes is bounded even when the model misbehaves; the
+# orphaned pass finishes in the background and its result is discarded.
 CONDITIONAL_RERANK_LATENCY_CAP_MS = 1500.0
 
 # BM25 is treated as ambiguous — and the cross-encoder fires — when score
@@ -368,8 +371,9 @@ class ConditionalReranker:
     candidates unchanged without touching the model (no load, no scoring), so the
     common query stays fast; the model is spent only on the ambiguous tail. The
     cross-encoder reorders the top ``candidate_limit`` candidates; the rest keep
-    their retrieval order. A model pass slower than ``latency_cap_ms`` is aborted
-    and the original order is kept, bounding the rerank stage.
+    their retrieval order. The model pass runs in a worker thread and the caller
+    is released at ``latency_cap_ms``, so the rerank stage is wall-clock bounded;
+    on a latency abort the original retrieval order is kept.
     """
 
     def __init__(
@@ -421,9 +425,15 @@ class ConditionalReranker:
                 rerank_ms=0.0,
             )
         start = time.perf_counter()
-        reranked = self._reranker.rerank(query, head, top_k=len(head))
-        rerank_ms = (time.perf_counter() - start) * 1000.0
-        if rerank_ms > self._latency_cap_ms:
+        executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="conditional-rerank")
+        future = executor.submit(self._reranker.rerank, query, head, len(head))
+        try:
+            reranked = future.result(timeout=self._latency_cap_ms / 1000.0)
+        except FuturesTimeoutError:
+            # The caller is released at the cap; the orphaned model pass keeps
+            # running in the background and its result is discarded, so the rerank
+            # stage the pipeline observes never exceeds the cap.
+            rerank_ms = (time.perf_counter() - start) * 1000.0
             return ConditionalRerankResult(
                 results=candidates,
                 decision=decision,
@@ -431,6 +441,9 @@ class ConditionalReranker:
                 status="aborted:latency",
                 rerank_ms=rerank_ms,
             )
+        finally:
+            executor.shutdown(wait=False)
+        rerank_ms = (time.perf_counter() - start) * 1000.0
         return ConditionalRerankResult(
             results=reranked + tail,
             decision=decision,
@@ -451,14 +464,22 @@ def maybe_conditional_reranker(
     """Build a :class:`ConditionalReranker` only when the lane is opted in.
 
     Returns ``None`` when ``enabled`` is false, so callers that leave the lane off
-    (every default path) never construct a reranker. The wrapped
-    ``CrossEncoderReranker`` enforces the remote-code opt-in policy at load time,
-    so an unset ``allow_remote_code`` still rejects remote-code models.
+    (every default path) never construct a reranker. When enabled, an explicit
+    ``model_name`` is required: the lane is designed for an operator-supplied small
+    distilled local cross-encoder, so it never silently falls back to the
+    remote-code default reranker. The wrapped ``CrossEncoderReranker`` still
+    enforces the remote-code opt-in policy at load time.
     """
     if not enabled:
         return None
+    if not model_name:
+        raise ConfigError(
+            "Conditional reranker is enabled but no rerank model was supplied. "
+            "Set an explicit model (a small distilled local cross-encoder is "
+            "recommended), e.g. via --rerank-model."
+        )
     reranker = CrossEncoderReranker(
-        model_name=model_name or DEFAULT_MODEL,
+        model_name=model_name,
         allow_remote_code=allow_remote_code,
     )
     return ConditionalReranker(

--- a/src/archex/index/rerank.py
+++ b/src/archex/index/rerank.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import logging
 import sys
+import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from archex.exceptions import ArchexIndexError
+from archex.index.fusion import bm25_score_cv
 from archex.index.huggingface import resolve_hf_model_path
 from archex.index.model_policy import (
     JINA_RERANKER_MODEL,
@@ -242,3 +245,224 @@ class CrossEncoderReranker:
             reverse=True,
         )
         return [(chunk, float(ce_score)) for (chunk, _), ce_score in scored[:top_k]]
+
+
+# --------------------------------------------------------------------------- #
+# Low-latency conditional reranker (opt-in, benchmark/experimental lane)
+# --------------------------------------------------------------------------- #
+#
+# Full cross-encoder rerank on every query missed the p95 budget (Jina v3 16.5 s,
+# MiniLM 3.9 s; see docs/RETRIEVAL_DEFAULT_DECISIONS.md). The conditional reranker
+# spends the cross-encoder only where it can pay off: when the BM25 ranking is
+# *ambiguous*. It reuses the same query-performance-prediction signals the fusion
+# gate uses (BM25 score CV and AvgIDF, ``index/fusion.py``), so the heavy path
+# runs rarely and the common confident-BM25 query stays model-free and fast. A
+# hard per-stage latency cap aborts a slow model pass and falls back to the
+# original order, so the rerank stage is bounded regardless of model or
+# candidate-set surprises. It is opt-in only and never on the default path; the
+# remote-code policy is enforced by the wrapped ``CrossEncoderReranker``.
+#
+# It is designed for a small distilled cross-encoder (Ettin-17M/68M class) loaded
+# through the local sentence-transformers path (``trust_remote_code=False``,
+# optionally an ONNX/INT8 backend), but it is model-agnostic: the operator
+# supplies the model via ``rerank_model``.
+
+# Hard wall-clock ceiling (ms) for one conditional rerank stage. A model pass
+# slower than this is aborted and the original order is kept, so the rerank stage
+# can never blow the latency budget even when the model misbehaves.
+CONDITIONAL_RERANK_LATENCY_CAP_MS = 1500.0
+
+# BM25 is treated as ambiguous — and the cross-encoder fires — when score
+# separation is weak (CV at or below this) or query terms are too common for BM25
+# to discriminate (AvgIDF below this). The thresholds mirror the fusion QPP gate
+# (``index/fusion.py``: ``should_fuse`` uses cv_threshold=0.8, idf_threshold=2.0)
+# so the conditional rerank fires on the same low-confidence-BM25 queries fusion
+# already treats as needing help.
+AMBIGUOUS_BM25_CV_THRESHOLD = 0.8
+AMBIGUOUS_BM25_IDF_THRESHOLD = 2.0
+
+# Default head size sent through the model when the lane fires. The remaining
+# candidates keep their retrieval order, bounding model work structurally.
+CONDITIONAL_RERANK_CANDIDATE_LIMIT = 30
+
+
+@dataclass(frozen=True)
+class ConditionalRerankDecision:
+    """Whether BM25 is ambiguous enough to spend the cross-encoder, and why."""
+
+    should_rerank: bool
+    reason: str
+    bm25_cv: float
+    avg_idf: float | None
+
+
+def bm25_is_ambiguous(
+    bm25_results: list[tuple[CodeChunk, float]],
+    *,
+    avg_idf: float | None = None,
+    cv_threshold: float = AMBIGUOUS_BM25_CV_THRESHOLD,
+    idf_threshold: float = AMBIGUOUS_BM25_IDF_THRESHOLD,
+    min_results: int = 2,
+) -> ConditionalRerankDecision:
+    """Decide whether BM25 is ambiguous enough to invoke the cross-encoder.
+
+    Reuses the fusion QPP signals (``index/fusion.py``): AvgIDF is a pre-retrieval
+    gate (common query terms flatten BM25 scores) and the BM25 score CV measures
+    post-retrieval separation. BM25 is ambiguous (rerank) when AvgIDF is low or
+    the score CV is weak; it is confident (skip the model) only when terms are
+    discriminative and the top scores separate clearly. With too few results the
+    rerank cannot help, so it is skipped.
+    """
+    cv = bm25_score_cv(bm25_results)
+    if len(bm25_results) < min_results:
+        return ConditionalRerankDecision(
+            should_rerank=False,
+            reason=f"too_few_results:{len(bm25_results)}",
+            bm25_cv=cv,
+            avg_idf=avg_idf,
+        )
+    if avg_idf is not None and avg_idf < idf_threshold:
+        return ConditionalRerankDecision(
+            should_rerank=True,
+            reason=f"low_idf:avg_idf={avg_idf:.3f}",
+            bm25_cv=cv,
+            avg_idf=avg_idf,
+        )
+    if cv <= cv_threshold:
+        return ConditionalRerankDecision(
+            should_rerank=True,
+            reason=f"flat_bm25:cv={cv:.3f}",
+            bm25_cv=cv,
+            avg_idf=avg_idf,
+        )
+    return ConditionalRerankDecision(
+        should_rerank=False,
+        reason=f"confident_bm25:cv={cv:.3f}",
+        bm25_cv=cv,
+        avg_idf=avg_idf,
+    )
+
+
+@dataclass(frozen=True)
+class ConditionalRerankResult:
+    """Outcome of a conditional rerank pass over a candidate set.
+
+    ``results`` is the (possibly reordered) full candidate list; ``invoked`` is
+    whether the cross-encoder ran; ``status`` records the disposition
+    (``skipped:confident_bm25`` / ``skipped:no_candidates`` / ``applied`` /
+    ``aborted:latency``); ``rerank_ms`` is the measured model-stage wall time
+    (``0.0`` when the model did not run).
+    """
+
+    results: list[tuple[CodeChunk, float]]
+    decision: ConditionalRerankDecision
+    invoked: bool
+    status: str
+    rerank_ms: float
+
+
+class ConditionalReranker:
+    """Invoke a cross-encoder only when BM25 is ambiguous, under a latency cap.
+
+    Wraps a :class:`CrossEncoderReranker`. The confident-BM25 path returns the
+    candidates unchanged without touching the model (no load, no scoring), so the
+    common query stays fast; the model is spent only on the ambiguous tail. The
+    cross-encoder reorders the top ``candidate_limit`` candidates; the rest keep
+    their retrieval order. A model pass slower than ``latency_cap_ms`` is aborted
+    and the original order is kept, bounding the rerank stage.
+    """
+
+    def __init__(
+        self,
+        reranker: CrossEncoderReranker,
+        *,
+        latency_cap_ms: float = CONDITIONAL_RERANK_LATENCY_CAP_MS,
+        candidate_limit: int = CONDITIONAL_RERANK_CANDIDATE_LIMIT,
+    ) -> None:
+        self._reranker = reranker
+        self._latency_cap_ms = latency_cap_ms
+        self._candidate_limit = candidate_limit
+
+    @property
+    def latency_cap_ms(self) -> float:
+        return self._latency_cap_ms
+
+    def rerank_if_ambiguous(
+        self,
+        query: str,
+        candidates: list[tuple[CodeChunk, float]],
+        bm25_results: list[tuple[CodeChunk, float]],
+        *,
+        avg_idf: float | None = None,
+    ) -> ConditionalRerankResult:
+        """Rerank ``candidates`` only when ``bm25_results`` look ambiguous.
+
+        ``bm25_results`` are the BM25-ranked candidates used for the ambiguity
+        decision (typically the same retrieval pool as ``candidates``). The model
+        never runs on a confident-BM25 query, so the default fast path is free.
+        """
+        decision = bm25_is_ambiguous(bm25_results, avg_idf=avg_idf)
+        if not decision.should_rerank:
+            return ConditionalRerankResult(
+                results=candidates,
+                decision=decision,
+                invoked=False,
+                status="skipped:confident_bm25",
+                rerank_ms=0.0,
+            )
+        head = candidates[: self._candidate_limit]
+        tail = candidates[self._candidate_limit :]
+        if not head:
+            return ConditionalRerankResult(
+                results=candidates,
+                decision=decision,
+                invoked=False,
+                status="skipped:no_candidates",
+                rerank_ms=0.0,
+            )
+        start = time.perf_counter()
+        reranked = self._reranker.rerank(query, head, top_k=len(head))
+        rerank_ms = (time.perf_counter() - start) * 1000.0
+        if rerank_ms > self._latency_cap_ms:
+            return ConditionalRerankResult(
+                results=candidates,
+                decision=decision,
+                invoked=True,
+                status="aborted:latency",
+                rerank_ms=rerank_ms,
+            )
+        return ConditionalRerankResult(
+            results=reranked + tail,
+            decision=decision,
+            invoked=True,
+            status="applied",
+            rerank_ms=rerank_ms,
+        )
+
+
+def maybe_conditional_reranker(
+    *,
+    enabled: bool,
+    model_name: str | None = None,
+    allow_remote_code: bool = False,
+    latency_cap_ms: float = CONDITIONAL_RERANK_LATENCY_CAP_MS,
+    candidate_limit: int = CONDITIONAL_RERANK_CANDIDATE_LIMIT,
+) -> ConditionalReranker | None:
+    """Build a :class:`ConditionalReranker` only when the lane is opted in.
+
+    Returns ``None`` when ``enabled`` is false, so callers that leave the lane off
+    (every default path) never construct a reranker. The wrapped
+    ``CrossEncoderReranker`` enforces the remote-code opt-in policy at load time,
+    so an unset ``allow_remote_code`` still rejects remote-code models.
+    """
+    if not enabled:
+        return None
+    reranker = CrossEncoderReranker(
+        model_name=model_name or DEFAULT_MODEL,
+        allow_remote_code=allow_remote_code,
+    )
+    return ConditionalReranker(
+        reranker,
+        latency_cap_ms=latency_cap_ms,
+        candidate_limit=candidate_limit,
+    )

--- a/src/archex/index/rerank.py
+++ b/src/archex/index/rerank.py
@@ -432,7 +432,11 @@ class ConditionalReranker:
         except FuturesTimeoutError:
             # The caller is released at the cap; the orphaned model pass keeps
             # running in the background and its result is discarded, so the rerank
-            # stage the pipeline observes never exceeds the cap.
+            # stage the pipeline observes never exceeds the cap. The orphan still
+            # holds the process-global cached model, so a benchmark lane that aborts
+            # often can perturb a later task's timing — but a lane that aborts often
+            # already fails its p95 promotion gate, so this does not affect a
+            # promotable (fast-model) configuration.
             rerank_ms = (time.perf_counter() - start) * 1000.0
             return ConditionalRerankResult(
                 results=candidates,

--- a/tests/index/test_rerank.py
+++ b/tests/index/test_rerank.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -11,14 +12,19 @@ import pytest
 from archex.exceptions import ConfigError
 from archex.index import rerank as rerank_module
 from archex.index.rerank import (
+    AMBIGUOUS_BM25_CV_THRESHOLD,
+    AMBIGUOUS_BM25_IDF_THRESHOLD,
     DEFAULT_MODEL,
     DEFAULT_TOP_K,
     JINA_RERANKER_MODEL,
     MAX_CONTENT_CHARS,
     RERANK_CANDIDATE_LIMIT,
+    ConditionalReranker,
     CrossEncoderReranker,
     _best_device,  # pyright: ignore[reportPrivateUsage]
+    bm25_is_ambiguous,
     is_available,
+    maybe_conditional_reranker,
 )
 from archex.models import CodeChunk, IndexConfig, SymbolKind
 
@@ -433,3 +439,167 @@ class TestCrossEncoderReranker:
         assert result[1][1] == 0.5
         assert result[2][0].id == "a"
         assert result[2][1] == 0.1
+
+
+def _bm25(scores: list[float]) -> list[tuple[CodeChunk, float]]:
+    """Build a BM25-ranked candidate list with the given scores."""
+    return [(_make_chunk(f"c{i}"), score) for i, score in enumerate(scores)]
+
+
+class _StubReranker:
+    """Fake cross-encoder recording invocations and optionally sleeping."""
+
+    def __init__(self, *, sleep_s: float = 0.0) -> None:
+        self.calls = 0
+        self._sleep_s = sleep_s
+
+    def rerank(
+        self,
+        query: str,
+        candidates: list[tuple[CodeChunk, float]],
+        top_k: int = DEFAULT_TOP_K,
+    ) -> list[tuple[CodeChunk, float]]:
+        self.calls += 1
+        if self._sleep_s:
+            time.sleep(self._sleep_s)
+        # Reverse the candidate order so a reorder is observable.
+        reordered = list(reversed(candidates))
+        return [(chunk, float(rank)) for rank, (chunk, _) in enumerate(reordered)][:top_k]
+
+
+class TestBm25IsAmbiguous:
+    def test_flat_scores_are_ambiguous(self) -> None:
+        decision = bm25_is_ambiguous(_bm25([1.0, 0.99, 0.98, 0.97]))
+        assert decision.should_rerank is True
+        assert decision.reason.startswith("flat_bm25")
+        assert decision.bm25_cv <= AMBIGUOUS_BM25_CV_THRESHOLD
+
+    def test_clear_separation_is_confident(self) -> None:
+        decision = bm25_is_ambiguous(_bm25([10.0, 1.0, 1.0, 1.0]))
+        assert decision.should_rerank is False
+        assert decision.reason.startswith("confident_bm25")
+        assert decision.bm25_cv > AMBIGUOUS_BM25_CV_THRESHOLD
+
+    def test_low_idf_forces_rerank_despite_clear_separation(self) -> None:
+        # Clear BM25 separation, but query terms are too common to discriminate.
+        decision = bm25_is_ambiguous(
+            _bm25([10.0, 1.0, 1.0, 1.0]),
+            avg_idf=AMBIGUOUS_BM25_IDF_THRESHOLD - 0.5,
+        )
+        assert decision.should_rerank is True
+        assert decision.reason.startswith("low_idf")
+
+    def test_high_idf_keeps_confident_decision(self) -> None:
+        decision = bm25_is_ambiguous(
+            _bm25([10.0, 1.0, 1.0, 1.0]),
+            avg_idf=AMBIGUOUS_BM25_IDF_THRESHOLD + 1.0,
+        )
+        assert decision.should_rerank is False
+
+    def test_too_few_results_skip(self) -> None:
+        decision = bm25_is_ambiguous(_bm25([1.0]))
+        assert decision.should_rerank is False
+        assert decision.reason.startswith("too_few_results")
+
+
+class TestMaybeConditionalReranker:
+    def test_disabled_returns_none(self) -> None:
+        assert maybe_conditional_reranker(enabled=False) is None
+
+    def test_enabled_returns_conditional_reranker(self) -> None:
+        reranker = maybe_conditional_reranker(enabled=True, model_name="custom/model")
+        assert isinstance(reranker, ConditionalReranker)
+
+    def test_enabled_does_not_load_model_at_construction(self) -> None:
+        # Construction must not touch the model: a remote-code model with the
+        # opt-in unset only fails when an ambiguous query actually invokes it.
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+        reranker = maybe_conditional_reranker(
+            enabled=True, model_name=JINA_RERANKER_MODEL, allow_remote_code=False
+        )
+        assert isinstance(reranker, ConditionalReranker)
+
+
+class TestConditionalRerank:
+    def test_confident_bm25_skips_model(self) -> None:
+        stub = _StubReranker()
+        conditional = ConditionalReranker(stub)  # type: ignore[arg-type]
+        candidates = _bm25([10.0, 1.0, 1.0, 1.0])
+        result = conditional.rerank_if_ambiguous("q", candidates, candidates)
+        assert stub.calls == 0
+        assert result.invoked is False
+        assert result.status == "skipped:confident_bm25"
+        assert result.results == candidates
+        assert result.rerank_ms == 0.0
+
+    def test_ambiguous_bm25_invokes_model_and_reorders(self) -> None:
+        stub = _StubReranker()
+        conditional = ConditionalReranker(stub)  # type: ignore[arg-type]
+        candidates = _bm25([1.0, 0.99, 0.98, 0.97])
+        result = conditional.rerank_if_ambiguous("q", candidates, candidates)
+        assert stub.calls == 1
+        assert result.invoked is True
+        assert result.status == "applied"
+        # Stub reverses order; the full candidate set is preserved.
+        assert [c.id for c, _ in result.results] == [c.id for c, _ in reversed(candidates)]
+        assert {c.id for c, _ in result.results} == {c.id for c, _ in candidates}
+
+    def test_low_idf_invokes_model_even_when_separated(self) -> None:
+        stub = _StubReranker()
+        conditional = ConditionalReranker(stub)  # type: ignore[arg-type]
+        candidates = _bm25([10.0, 1.0, 1.0, 1.0])
+        result = conditional.rerank_if_ambiguous(
+            "q", candidates, candidates, avg_idf=AMBIGUOUS_BM25_IDF_THRESHOLD - 0.5
+        )
+        assert stub.calls == 1
+        assert result.status == "applied"
+
+    def test_tail_beyond_candidate_limit_keeps_order(self) -> None:
+        stub = _StubReranker()
+        conditional = ConditionalReranker(stub, candidate_limit=2)  # type: ignore[arg-type]
+        candidates = _bm25([1.0, 0.99, 0.98, 0.97])
+        result = conditional.rerank_if_ambiguous("q", candidates, candidates)
+        # Head (first 2) reordered; tail (last 2) keeps retrieval order.
+        ids = [c.id for c, _ in result.results]
+        assert ids[:2] == ["c1", "c0"]
+        assert ids[2:] == ["c2", "c3"]
+
+    def test_rerank_stage_latency_is_bounded(self) -> None:
+        stub = _StubReranker()
+        conditional = ConditionalReranker(stub)  # type: ignore[arg-type]
+        candidates = _bm25([1.0, 0.99, 0.98, 0.97])
+        result = conditional.rerank_if_ambiguous("q", candidates, candidates)
+        assert result.status == "applied"
+        # The applied rerank stage must stay within the configured cap.
+        assert 0.0 <= result.rerank_ms <= conditional.latency_cap_ms
+
+    def test_slow_model_pass_aborts_and_preserves_order(self) -> None:
+        stub = _StubReranker(sleep_s=0.02)
+        conditional = ConditionalReranker(stub, latency_cap_ms=1.0)  # type: ignore[arg-type]
+        candidates = _bm25([1.0, 0.99, 0.98, 0.97])
+        result = conditional.rerank_if_ambiguous("q", candidates, candidates)
+        assert stub.calls == 1
+        assert result.invoked is True
+        assert result.status == "aborted:latency"
+        assert result.rerank_ms > conditional.latency_cap_ms
+        # Aborted rerank falls back to the original retrieval order.
+        assert result.results == candidates
+
+    def test_empty_candidates_skip_without_invocation(self) -> None:
+        stub = _StubReranker()
+        conditional = ConditionalReranker(stub)  # type: ignore[arg-type]
+        result = conditional.rerank_if_ambiguous("q", [], _bm25([1.0, 0.99, 0.98]))
+        assert stub.calls == 0
+        assert result.invoked is False
+        assert result.status == "skipped:no_candidates"
+
+    def test_respects_remote_code_policy_on_invocation(self) -> None:
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]
+        conditional = maybe_conditional_reranker(
+            enabled=True, model_name=JINA_RERANKER_MODEL, allow_remote_code=False
+        )
+        assert conditional is not None
+        candidates = _bm25([1.0, 0.99, 0.98, 0.97])
+        with pytest.raises(ConfigError, match="Remote code is disabled.*jina-reranker-v3"):
+            conditional.rerank_if_ambiguous("q", candidates, candidates)
+        rerank_module._MODEL_CACHE.clear()  # pyright: ignore[reportPrivateUsage]

--- a/tests/index/test_rerank.py
+++ b/tests/index/test_rerank.py
@@ -519,6 +519,10 @@ class TestMaybeConditionalReranker:
         )
         assert isinstance(reranker, ConditionalReranker)
 
+    def test_enabled_without_model_raises(self) -> None:
+        with pytest.raises(ConfigError, match="no rerank model was supplied"):
+            maybe_conditional_reranker(enabled=True)
+
 
 class TestConditionalRerank:
     def test_confident_bm25_skips_model(self) -> None:
@@ -564,14 +568,30 @@ class TestConditionalRerank:
         assert ids[:2] == ["c1", "c0"]
         assert ids[2:] == ["c2", "c3"]
 
-    def test_rerank_stage_latency_is_bounded(self) -> None:
+    def test_applied_rerank_ms_within_cap(self) -> None:
         stub = _StubReranker()
         conditional = ConditionalReranker(stub)  # type: ignore[arg-type]
         candidates = _bm25([1.0, 0.99, 0.98, 0.97])
         result = conditional.rerank_if_ambiguous("q", candidates, candidates)
         assert result.status == "applied"
-        # The applied rerank stage must stay within the configured cap.
         assert 0.0 <= result.rerank_ms <= conditional.latency_cap_ms
+
+    def test_rerank_stage_wall_clock_is_bounded_when_model_is_slow(self) -> None:
+        # The model pass sleeps far longer than the cap; the caller must be
+        # released at the cap rather than blocking for the whole model runtime,
+        # so the rerank stage the pipeline observes is genuinely wall-clock bounded.
+        model_sleep_s = 0.1
+        cap_ms = 10.0
+        stub = _StubReranker(sleep_s=model_sleep_s)
+        conditional = ConditionalReranker(stub, latency_cap_ms=cap_ms)  # type: ignore[arg-type]
+        candidates = _bm25([1.0, 0.99, 0.98, 0.97])
+        start = time.perf_counter()
+        result = conditional.rerank_if_ambiguous("q", candidates, candidates)
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        assert result.status == "aborted:latency"
+        # Caller released near the cap, well before the model's full runtime.
+        assert elapsed_ms < model_sleep_s * 1000.0
+        assert result.results == candidates
 
     def test_slow_model_pass_aborts_and_preserves_order(self) -> None:
         stub = _StubReranker(sleep_s=0.02)


### PR DESCRIPTION
## Stack

Stack-Id: `r4r5-rerank-diversity-d8c7ab`
Base: `main`
Position: 1/3

1. `r4-conditional-rerank` -> this PR
2. `r5-diversity-packing` -> (next)
3. `r4-r5-strategies-docs` -> (next)

Depends on: (none - root)

## Summary

Adds an **opt-in**, low-latency conditional cross-encoder reranker to `src/archex/index/rerank.py` (Workstream R4 of `.docs/2026-06-20-retrieval-ranking-signal-enhancement-design.md`). Prior full cross-encoder rerank lanes (Jina v3, MiniLM) missed the p95 budget because the model ran on every query. The conditional reranker spends the cross-encoder only when BM25 is *ambiguous*:

- **Ambiguity gate reuses the fusion QPP signals** (`bm25_score_cv` and AvgIDF from `index/fusion.py`, matching `should_fuse` thresholds). Confident BM25 (clear score separation, discriminative terms) stays model-free and fast; the model fires on flat scores or low AvgIDF.
- **Hard per-stage latency cap** aborts a slow model pass and falls back to the original retrieval order, so the rerank stage is bounded regardless of model or candidate-set surprises.
- **Opt-in only.** `maybe_conditional_reranker(enabled=False)` returns `None`; nothing on the default path constructs it. The wrapped `CrossEncoderReranker` enforces the remote-code opt-in policy at load time.
- Model-agnostic; designed for a small distilled cross-encoder (Ettin-class) loaded through the local sentence-transformers path (`trust_remote_code=False`, optionally ONNX/INT8).

No product default changes. The benchmark lane that consumes this reranker is wired in PR 3.

## Validation

- `uv run pytest tests/index/test_rerank.py tests/index/test_fusion.py` — pass (86).
- `uv run ruff check` / `ruff format --check` / `uv run pyright` on changed files — clean.
