### PR TITLE
Add benchmark-only query-adaptive diversity packing lane (R5)

### DIFF
--- a/src/archex/serve/packing.py
+++ b/src/archex/serve/packing.py
@@ -523,17 +523,19 @@ class DiversityPackingPlan(PackingPlan):
     deselected_for_diversity: int
     protected_regions: int
 
+    def diversity_provenance(self) -> dict[str, str]:
+        """The diversity-specific provenance keys (single source for all consumers)."""
+        return {
+            "diversity_applied": str(self.diversity_applied).lower(),
+            "query_aspects": str(self.query_aspects),
+            "diversity_lambda": f"{self.diversity_lambda:.2f}",
+            "deselected_for_diversity": str(self.deselected_for_diversity),
+            "protected_regions": str(self.protected_regions),
+        }
+
     def to_provenance(self) -> dict[str, str]:
         provenance = super().to_provenance()
-        provenance.update(
-            {
-                "diversity_applied": str(self.diversity_applied).lower(),
-                "query_aspects": str(self.query_aspects),
-                "diversity_lambda": f"{self.diversity_lambda:.2f}",
-                "deselected_for_diversity": str(self.deselected_for_diversity),
-                "protected_regions": str(self.protected_regions),
-            }
-        )
+        provenance.update(self.diversity_provenance())
         return provenance
 
 

--- a/src/archex/serve/packing.py
+++ b/src/archex/serve/packing.py
@@ -455,3 +455,184 @@ def pack_efficiently(
         budget_tier=budget_tier,
         token_budget=token_budget,
     )
+
+
+# --------------------------------------------------------------------------- #
+# Query-adaptive diversity packing (benchmark-only experimental lane)
+# --------------------------------------------------------------------------- #
+#
+# Pointwise packing can still spend budget on cross-file/cross-chunk redundancy
+# (re-imported symbols, near-duplicate code). Maximal-marginal-relevance (MMR)
+# de-selection trims that redundant tail to lift relevance-per-token, but MMR is
+# a diversity control, not a guaranteed precision win, so the lane is
+# benchmark-only and conservative:
+#
+# - lambda is query-adaptive: narrow single-aspect lookups keep lambda at 1.0
+#   (diversity off; identical to pack_efficiently); multi-aspect queries lower it.
+# - required/direct/high-confidence regions are never de-selected.
+# - a redundant optional region is dropped only when its file is already
+#   represented by another kept region, so the kept-file set is a superset of
+#   pack_efficiently's and file recall never regresses.
+#
+# Similarity is a deterministic, local token-signature Jaccard — no model, no
+# network — consistent with the local-first no-inference posture.
+
+# Query-adaptive MMR lambda schedule (DF-RAG style). A single-aspect query keeps
+# lambda at 1.0 so diversity is off and the pack is pure relevance; multi-aspect
+# queries lower lambda to apply diversity pressure on the redundant tail.
+_DIVERSITY_LAMBDA_NARROW = 1.0
+_DIVERSITY_LAMBDA_BROAD = 0.7
+
+# Two optional regions are "redundant" when their token signatures overlap at or
+# above this Jaccard similarity. Only a redundant region whose file is already
+# represented may be de-selected, so file recall is preserved.
+_REDUNDANCY_SIMILARITY_THRESHOLD = 0.8
+
+
+def jaccard(a: frozenset[str], b: frozenset[str]) -> float:
+    """Jaccard similarity of two token signatures (0 when either is empty)."""
+    if not a or not b:
+        return 0.0
+    union = len(a | b)
+    return len(a & b) / union if union else 0.0
+
+
+def query_adaptive_lambda(query_aspects: int) -> float:
+    """Resolve the MMR lambda from the query's aspect count.
+
+    A single-aspect (narrow) query keeps lambda at 1.0 so diversity is off and the
+    pack is pure relevance; a multi-aspect query lowers lambda to apply diversity.
+    """
+    return _DIVERSITY_LAMBDA_NARROW if query_aspects <= 1 else _DIVERSITY_LAMBDA_BROAD
+
+
+@dataclass(frozen=True)
+class DiversityPackingPlan(PackingPlan):
+    """A :class:`PackingPlan` produced with query-adaptive diversity de-selection.
+
+    Adds the diversity provenance: whether diversity ran, the query aspect count
+    and resolved lambda, how many optional regions were de-selected for
+    redundancy, and how many protected (direct/high-confidence) regions were
+    retained. ``deselected_for_diversity`` counts only redundant-tail de-selection;
+    a protected region is never counted because it is never de-selected.
+    """
+
+    diversity_applied: bool
+    query_aspects: int
+    diversity_lambda: float
+    deselected_for_diversity: int
+    protected_regions: int
+
+    def to_provenance(self) -> dict[str, str]:
+        provenance = super().to_provenance()
+        provenance.update(
+            {
+                "diversity_applied": str(self.diversity_applied).lower(),
+                "query_aspects": str(self.query_aspects),
+                "diversity_lambda": f"{self.diversity_lambda:.2f}",
+                "deselected_for_diversity": str(self.deselected_for_diversity),
+                "protected_regions": str(self.protected_regions),
+            }
+        )
+        return provenance
+
+
+def pack_with_diversity(
+    candidates: list[PackingCandidate],
+    signatures: dict[str, frozenset[str]],
+    *,
+    token_budget: int,
+    budget_tier: BudgetTier,
+    query_aspects: int,
+) -> DiversityPackingPlan:
+    """Pack with query-adaptive MMR diversity over the low-confidence tail.
+
+    Behaves exactly like :func:`pack_efficiently` for narrow single-aspect queries
+    (diversity off). For multi-aspect queries it applies MMR de-selection: a
+    non-protected optional region is dropped only when it is a near-duplicate
+    (token-signature Jaccard at or above the redundancy threshold) of an
+    already-kept content region AND its file is already represented by another kept
+    region. A required/direct/high-confidence region is therefore never
+    de-selected, and because candidates are processed in the same order as
+    :func:`pack_efficiently` while diversity only converts optional regions to
+    SKIP (never charging more budget), the diversity kept-file set is a superset of
+    pack_efficiently's — file recall never regresses.
+
+    ``signatures`` maps candidate id to a deterministic token signature used for
+    redundancy scoring; a missing or empty signature is treated as non-redundant.
+    """
+    lam = query_adaptive_lambda(query_aspects)
+    diversity_applied = lam < _DIVERSITY_LAMBDA_NARROW
+
+    by_id = {candidate.signals.candidate_id: candidate for candidate in candidates}
+    scores = [
+        score_candidate(candidate.signals, budget_tier=budget_tier) for candidate in candidates
+    ]
+    ordered = order_candidates(scores)
+
+    used = 0
+    regions: list[PackedRegion] = []
+    kept_signatures: list[frozenset[str]] = []
+    file_kept_counts: dict[str, int] = {}
+    deselected = 0
+    protected = 0
+    for score in ordered:
+        candidate = by_id[score.candidate_id]
+        is_protected = score.direct_match
+        if is_protected:
+            protected += 1
+        signature = signatures.get(score.candidate_id, frozenset())
+        if diversity_applied and not is_protected and signature:
+            max_similarity = max(
+                (jaccard(signature, kept) for kept in kept_signatures), default=0.0
+            )
+            file_represented = file_kept_counts.get(candidate.signals.file_path, 0) > 0
+            # MMR de-selection: drop a redundant optional region only when its file
+            # stays represented, so file recall never regresses.
+            if max_similarity >= _REDUNDANCY_SIMILARITY_THRESHOLD and file_represented:
+                deselected += 1
+                regions.append(
+                    PackedRegion(
+                        candidate_id=score.candidate_id,
+                        decision=PackDecision.SKIP,
+                        score=score,
+                        tokens_charged=0,
+                        retrieval_score=candidate.signals.retrieval_score,
+                    )
+                )
+                continue
+        allow_skip = not is_protected
+        decision = _fit_decision(
+            candidate, score.decision, token_budget - used, allow_skip=allow_skip
+        )
+        cost = _decision_cost(decision, candidate)
+        charged = 0 if decision is PackDecision.SKIP else cost
+        used += charged
+        if decision is not PackDecision.SKIP:
+            file_kept_counts[candidate.signals.file_path] = (
+                file_kept_counts.get(candidate.signals.file_path, 0) + 1
+            )
+            # Only content-bearing regions anchor redundancy comparisons; an ELIDE
+            # keeps an anchor, not the body, so it does not represent content here.
+            if decision in (PackDecision.INCLUDE, PackDecision.COMPRESS):
+                kept_signatures.append(signature)
+        regions.append(
+            PackedRegion(
+                candidate_id=score.candidate_id,
+                decision=decision,
+                score=score,
+                tokens_charged=charged,
+                retrieval_score=candidate.signals.retrieval_score,
+            )
+        )
+    return DiversityPackingPlan(
+        regions=regions,
+        included_tokens=used,
+        budget_tier=budget_tier,
+        token_budget=token_budget,
+        diversity_applied=diversity_applied,
+        query_aspects=query_aspects,
+        diversity_lambda=lam,
+        deselected_for_diversity=deselected,
+        protected_regions=protected,
+    )

--- a/src/archex/serve/packing.py
+++ b/src/archex/serve/packing.py
@@ -547,16 +547,19 @@ def pack_with_diversity(
 ) -> DiversityPackingPlan:
     """Pack with query-adaptive MMR diversity over the low-confidence tail.
 
-    Behaves exactly like :func:`pack_efficiently` for narrow single-aspect queries
-    (diversity off). For multi-aspect queries it applies MMR de-selection: a
-    non-protected optional region is dropped only when it is a near-duplicate
-    (token-signature Jaccard at or above the redundancy threshold) of an
-    already-kept content region AND its file is already represented by another kept
-    region. A required/direct/high-confidence region is therefore never
-    de-selected, and because candidates are processed in the same order as
-    :func:`pack_efficiently` while diversity only converts optional regions to
-    SKIP (never charging more budget), the diversity kept-file set is a superset of
-    pack_efficiently's — file recall never regresses.
+    Derived from :func:`pack_efficiently`: the baseline plan is computed first,
+    then for a multi-aspect query a redundant non-protected optional region is
+    flipped to SKIP. Every other region keeps its baseline decision verbatim — the
+    diversity plan never upgrades a region to a richer (costlier) representation, so
+    it can never re-spend freed budget and starve a later region. A region is
+    de-selected only when it is a near-duplicate (token-signature Jaccard at or
+    above the redundancy threshold) of an already-kept content region AND its file
+    is already represented by another kept region. Because every region's decision
+    is the baseline's or SKIP, the per-region charged cost never exceeds the
+    baseline's and the first kept region of each file is never de-selected, so the
+    diversity kept-file set is a superset of pack_efficiently's — file recall never
+    regresses. A required/direct/high-confidence region is never de-selected, and a
+    narrow single-aspect query (lambda 1.0) returns the baseline plan unchanged.
 
     ``signatures`` maps candidate id to a deterministic token signature used for
     redundancy scoring; a missing or empty signature is treated as non-redundant.
@@ -564,11 +567,10 @@ def pack_with_diversity(
     lam = query_adaptive_lambda(query_aspects)
     diversity_applied = lam < _DIVERSITY_LAMBDA_NARROW
 
-    by_id = {candidate.signals.candidate_id: candidate for candidate in candidates}
-    scores = [
-        score_candidate(candidate.signals, budget_tier=budget_tier) for candidate in candidates
-    ]
-    ordered = order_candidates(scores)
+    baseline = pack_efficiently(candidates, token_budget=token_budget, budget_tier=budget_tier)
+    file_by_id = {
+        candidate.signals.candidate_id: candidate.signals.file_path for candidate in candidates
+    }
 
     used = 0
     regions: list[PackedRegion] = []
@@ -576,55 +578,44 @@ def pack_with_diversity(
     file_kept_counts: dict[str, int] = {}
     deselected = 0
     protected = 0
-    for score in ordered:
-        candidate = by_id[score.candidate_id]
-        is_protected = score.direct_match
+    for region in baseline.regions:
+        # Baseline already dropped this region; carry the SKIP through untouched.
+        if region.decision is PackDecision.SKIP:
+            regions.append(region)
+            continue
+        is_protected = region.score.direct_match
         if is_protected:
             protected += 1
-        signature = signatures.get(score.candidate_id, frozenset())
+        signature = signatures.get(region.candidate_id, frozenset())
+        file_path = file_by_id[region.candidate_id]
         if diversity_applied and not is_protected and signature:
             max_similarity = max(
                 (jaccard(signature, kept) for kept in kept_signatures), default=0.0
             )
-            file_represented = file_kept_counts.get(candidate.signals.file_path, 0) > 0
+            file_represented = file_kept_counts.get(file_path, 0) > 0
             # MMR de-selection: drop a redundant optional region only when its file
             # stays represented, so file recall never regresses.
             if max_similarity >= _REDUNDANCY_SIMILARITY_THRESHOLD and file_represented:
                 deselected += 1
                 regions.append(
                     PackedRegion(
-                        candidate_id=score.candidate_id,
+                        candidate_id=region.candidate_id,
                         decision=PackDecision.SKIP,
-                        score=score,
+                        score=region.score,
                         tokens_charged=0,
-                        retrieval_score=candidate.signals.retrieval_score,
+                        retrieval_score=region.retrieval_score,
                     )
                 )
                 continue
-        allow_skip = not is_protected
-        decision = _fit_decision(
-            candidate, score.decision, token_budget - used, allow_skip=allow_skip
-        )
-        cost = _decision_cost(decision, candidate)
-        charged = 0 if decision is PackDecision.SKIP else cost
-        used += charged
-        if decision is not PackDecision.SKIP:
-            file_kept_counts[candidate.signals.file_path] = (
-                file_kept_counts.get(candidate.signals.file_path, 0) + 1
-            )
-            # Only content-bearing regions anchor redundancy comparisons; an ELIDE
-            # keeps an anchor, not the body, so it does not represent content here.
-            if decision in (PackDecision.INCLUDE, PackDecision.COMPRESS):
-                kept_signatures.append(signature)
-        regions.append(
-            PackedRegion(
-                candidate_id=score.candidate_id,
-                decision=decision,
-                score=score,
-                tokens_charged=charged,
-                retrieval_score=candidate.signals.retrieval_score,
-            )
-        )
+        # Keep the baseline decision verbatim — never richer, so budget is never
+        # re-spent and a downstream baseline-kept region is never starved.
+        regions.append(region)
+        used += region.tokens_charged
+        file_kept_counts[file_path] = file_kept_counts.get(file_path, 0) + 1
+        # Only content-bearing regions anchor redundancy comparisons; an ELIDE
+        # keeps an anchor, not the body, so it does not represent content here.
+        if region.decision in (PackDecision.INCLUDE, PackDecision.COMPRESS):
+            kept_signatures.append(signature)
     return DiversityPackingPlan(
         regions=regions,
         included_tokens=used,

--- a/tests/serve/test_packing.py
+++ b/tests/serve/test_packing.py
@@ -10,11 +10,15 @@ import archex.serve.packing as packing
 from archex.models import CompressionLossRisk
 from archex.serve.modality import BudgetTier
 from archex.serve.packing import (
+    DiversityPackingPlan,
     PackDecision,
     PackingCandidate,
     PackingSignals,
+    jaccard,
     order_candidates,
     pack_efficiently,
+    pack_with_diversity,
+    query_adaptive_lambda,
     relevance_per_1k_tokens,
     score_candidate,
 )
@@ -521,3 +525,237 @@ class TestPackerEdgeCases:
         plan = pack_efficiently([wf], token_budget=2000, budget_tier=BudgetTier.STANDARD)
         assert plan.decision_for("wf") is PackDecision.ELIDE
         assert plan.included_tokens == 30
+
+
+def _div_candidate(
+    candidate_id: str,
+    *,
+    file_path: str,
+    retrieval_score: float,
+    direct_match: bool = False,
+    token_count: int = 100,
+) -> PackingCandidate:
+    return _candidate(
+        _signals(
+            candidate_id,
+            file_path=file_path,
+            retrieval_score=retrieval_score,
+            direct_match=direct_match,
+            token_count=token_count,
+        )
+    )
+
+
+_BIG_BUDGET = 100_000
+
+
+class TestJaccard:
+    def test_identical_signatures(self) -> None:
+        sig = frozenset({"auth", "login", "token"})
+        assert jaccard(sig, sig) == 1.0
+
+    def test_disjoint_signatures(self) -> None:
+        assert jaccard(frozenset({"a", "b"}), frozenset({"c", "d"})) == 0.0
+
+    def test_empty_signature_is_zero(self) -> None:
+        assert jaccard(frozenset(), frozenset({"a"})) == 0.0
+
+    def test_partial_overlap(self) -> None:
+        # |{a,b} & {b,c}| / |{a,b,c}| = 1/3
+        assert jaccard(frozenset({"a", "b"}), frozenset({"b", "c"})) == 1 / 3
+
+
+class TestQueryAdaptiveLambda:
+    def test_narrow_query_disables_diversity(self) -> None:
+        assert query_adaptive_lambda(1) == 1.0
+        assert query_adaptive_lambda(0) == 1.0
+
+    def test_multi_aspect_query_lowers_lambda(self) -> None:
+        assert query_adaptive_lambda(2) < 1.0
+        assert query_adaptive_lambda(5) < 1.0
+
+
+class TestDiversityNarrowBypass:
+    def test_narrow_query_matches_pack_efficiently(self) -> None:
+        # Two near-duplicate optional regions in the same file plus a direct hit:
+        # diversity WOULD de-select the redundant tail, but a narrow query must not.
+        sig = frozenset({"auth", "login", "token", "user"})
+        candidates = [
+            _div_candidate(
+                "direct", file_path="src/auth.py", retrieval_score=0.9, direct_match=True
+            ),
+            _div_candidate("opt_a", file_path="src/util.py", retrieval_score=0.5),
+            _div_candidate("opt_b", file_path="src/util.py", retrieval_score=0.5),
+        ]
+        signatures = {"direct": frozenset({"auth"}), "opt_a": sig, "opt_b": sig}
+        plan = pack_with_diversity(
+            candidates,
+            signatures,
+            token_budget=_BIG_BUDGET,
+            budget_tier=BudgetTier.STANDARD,
+            query_aspects=1,
+        )
+        baseline = pack_efficiently(
+            candidates, token_budget=_BIG_BUDGET, budget_tier=BudgetTier.STANDARD
+        )
+        assert plan.diversity_applied is False
+        assert plan.deselected_for_diversity == 0
+        assert plan.kept_ids() == baseline.kept_ids()
+        assert plan.included_tokens == baseline.included_tokens
+
+
+class TestDiversityRequiredRegionsRetained:
+    def test_direct_region_never_deselected_even_when_redundant(self) -> None:
+        # A direct hit that is a near-duplicate of a kept optional region must
+        # still be retained: diversity only ever touches the optional tail.
+        sig = frozenset({"auth", "login", "token", "user"})
+        candidates = [
+            _div_candidate("opt_a", file_path="src/util.py", retrieval_score=0.6),
+            _div_candidate(
+                "direct_dup", file_path="src/auth.py", retrieval_score=0.55, direct_match=True
+            ),
+        ]
+        signatures = {"opt_a": sig, "direct_dup": sig}
+        plan = pack_with_diversity(
+            candidates,
+            signatures,
+            token_budget=_BIG_BUDGET,
+            budget_tier=BudgetTier.STANDARD,
+            query_aspects=3,
+        )
+        assert plan.diversity_applied is True
+        assert "direct_dup" in plan.kept_ids()
+        assert plan.decision_for("direct_dup") is PackDecision.INCLUDE
+        assert plan.protected_regions == 1
+        # The direct region is never counted as a diversity de-selection.
+        deselected = [r.candidate_id for r in plan.regions if r.decision is PackDecision.SKIP]
+        assert "direct_dup" not in deselected
+
+
+class TestDiversityDeselectsRedundantTail:
+    def test_redundant_same_file_region_deselected(self) -> None:
+        sig = frozenset({"auth", "login", "token", "user"})
+        unique = frozenset({"parse", "ast", "node", "walk"})
+        candidates = [
+            _div_candidate(
+                "direct", file_path="src/auth.py", retrieval_score=0.9, direct_match=True
+            ),
+            _div_candidate("opt_a", file_path="src/util.py", retrieval_score=0.6),
+            _div_candidate("opt_b", file_path="src/util.py", retrieval_score=0.5),
+            _div_candidate("opt_unique", file_path="src/parse.py", retrieval_score=0.55),
+        ]
+        signatures = {
+            "direct": frozenset({"auth"}),
+            "opt_a": sig,
+            "opt_b": sig,
+            "opt_unique": unique,
+        }
+        plan = pack_with_diversity(
+            candidates,
+            signatures,
+            token_budget=_BIG_BUDGET,
+            budget_tier=BudgetTier.STANDARD,
+            query_aspects=2,
+        )
+        assert plan.diversity_applied is True
+        # Redundant same-file tail region dropped; representative + unique + direct kept.
+        assert plan.decision_for("opt_b") is PackDecision.SKIP
+        assert plan.deselected_for_diversity == 1
+        assert {"direct", "opt_a", "opt_unique"} <= set(plan.kept_ids())
+        assert "opt_b" not in plan.kept_ids()
+        # The de-selected region's file stays represented (opt_a kept).
+        kept_files = {
+            c.signals.file_path
+            for c in candidates
+            if c.signals.candidate_id in set(plan.kept_ids())
+        }
+        assert "src/util.py" in kept_files
+
+    def test_deselection_only_touches_unprotected_regions(self) -> None:
+        sig = frozenset({"auth", "login", "token", "user"})
+        candidates = [
+            _div_candidate("opt_a", file_path="src/util.py", retrieval_score=0.6),
+            _div_candidate("opt_b", file_path="src/util.py", retrieval_score=0.5),
+        ]
+        signatures = {"opt_a": sig, "opt_b": sig}
+        plan = pack_with_diversity(
+            candidates,
+            signatures,
+            token_budget=_BIG_BUDGET,
+            budget_tier=BudgetTier.STANDARD,
+            query_aspects=2,
+        )
+        deselected = [r for r in plan.regions if r.decision is PackDecision.SKIP]
+        assert all(not r.score.direct_match for r in deselected)
+
+
+class TestDiversityNeverRegressesRecall:
+    def test_cross_file_duplicate_keeps_file_representative(self) -> None:
+        # opt_b duplicates opt_a but is the only region of its file: it must be
+        # kept so file recall does not regress, even though it is redundant.
+        sig = frozenset({"auth", "login", "token", "user"})
+        candidates = [
+            _div_candidate("opt_a", file_path="src/x.py", retrieval_score=0.6),
+            _div_candidate("opt_b", file_path="src/y.py", retrieval_score=0.5),
+        ]
+        signatures = {"opt_a": sig, "opt_b": sig}
+        plan = pack_with_diversity(
+            candidates,
+            signatures,
+            token_budget=_BIG_BUDGET,
+            budget_tier=BudgetTier.STANDARD,
+            query_aspects=2,
+        )
+        assert plan.deselected_for_diversity == 0
+        assert set(plan.kept_ids()) == {"opt_a", "opt_b"}
+
+    def test_diversity_kept_file_set_is_superset_of_baseline(self) -> None:
+        sig = frozenset({"auth", "login", "token", "user"})
+        unique = frozenset({"parse", "ast", "node", "walk"})
+        candidates = [
+            _div_candidate(
+                "direct", file_path="src/auth.py", retrieval_score=0.9, direct_match=True
+            ),
+            _div_candidate("opt_a", file_path="src/util.py", retrieval_score=0.6),
+            _div_candidate("opt_b", file_path="src/util.py", retrieval_score=0.5),
+            _div_candidate("opt_unique", file_path="src/parse.py", retrieval_score=0.55),
+        ]
+        signatures = {
+            "direct": frozenset({"auth"}),
+            "opt_a": sig,
+            "opt_b": sig,
+            "opt_unique": unique,
+        }
+        baseline = pack_efficiently(
+            candidates, token_budget=_BIG_BUDGET, budget_tier=BudgetTier.STANDARD
+        )
+        plan = pack_with_diversity(
+            candidates,
+            signatures,
+            token_budget=_BIG_BUDGET,
+            budget_tier=BudgetTier.STANDARD,
+            query_aspects=2,
+        )
+        by_id = {c.signals.candidate_id: c for c in candidates}
+        baseline_files = {by_id[cid].signals.file_path for cid in baseline.kept_ids()}
+        diversity_files = {by_id[cid].signals.file_path for cid in plan.kept_ids()}
+        assert baseline_files <= diversity_files
+
+
+class TestDiversityPlanProvenance:
+    def test_to_provenance_includes_diversity_fields(self) -> None:
+        candidates = [_div_candidate("opt_a", file_path="src/util.py", retrieval_score=0.6)]
+        plan = pack_with_diversity(
+            candidates,
+            {"opt_a": frozenset({"a", "b"})},
+            token_budget=_BIG_BUDGET,
+            budget_tier=BudgetTier.STANDARD,
+            query_aspects=2,
+        )
+        assert isinstance(plan, DiversityPackingPlan)
+        prov = plan.to_provenance()
+        assert prov["diversity_applied"] == "true"
+        assert prov["query_aspects"] == "2"
+        assert prov["diversity_lambda"] == "0.70"
+        assert "deselected_for_diversity" in prov
+        assert prov["protected_regions"] == "0"

--- a/tests/serve/test_packing.py
+++ b/tests/serve/test_packing.py
@@ -759,3 +759,100 @@ class TestDiversityPlanProvenance:
         assert prov["diversity_lambda"] == "0.70"
         assert "deselected_for_diversity" in prov
         assert prov["protected_regions"] == "0"
+
+
+class TestDiversityTightBudget:
+    def test_recall_superset_holds_when_deselection_frees_budget(self) -> None:
+        # Regression guard: de-selecting a redundant region must not let a later
+        # region upgrade and starve a downstream single-region file. Baseline keeps
+        # fileP (x2), fileU (elided), fileK; diversity must keep all three files.
+        sig = frozenset({"a", "b", "c", "d", "e"})
+        candidates = [
+            _candidate(
+                _signals(
+                    "P",
+                    file_path="src/fileP.py",
+                    retrieval_score=0.50,
+                    token_count=100,
+                    handle_priority=1.0,
+                ),
+                elided_token_count=5,
+            ),
+            _candidate(
+                _signals(
+                    "R",
+                    file_path="src/fileP.py",
+                    retrieval_score=0.50,
+                    token_count=100,
+                    handle_priority=0.8,
+                ),
+                elided_token_count=5,
+            ),
+            _candidate(
+                _signals(
+                    "U",
+                    file_path="src/fileU.py",
+                    retrieval_score=0.41,
+                    token_count=205,
+                    handle_priority=0.6,
+                ),
+                elided_token_count=5,
+            ),
+            _candidate(
+                _signals(
+                    "K",
+                    file_path="src/fileK.py",
+                    retrieval_score=0.30,
+                    token_count=100,
+                    handle_priority=0.0,
+                ),
+                elided_token_count=5,
+            ),
+        ]
+        signatures = {"P": sig, "R": sig}
+        baseline = pack_efficiently(candidates, token_budget=305, budget_tier=BudgetTier.STANDARD)
+        plan = pack_with_diversity(
+            candidates,
+            signatures,
+            token_budget=305,
+            budget_tier=BudgetTier.STANDARD,
+            query_aspects=2,
+        )
+        by_id = {c.signals.candidate_id: c for c in candidates}
+        baseline_files = {by_id[cid].signals.file_path for cid in baseline.kept_ids()}
+        diversity_files = {by_id[cid].signals.file_path for cid in plan.kept_ids()}
+        assert plan.deselected_for_diversity == 1
+        assert plan.decision_for("R") is PackDecision.SKIP
+        # The redundant de-selection must not drop fileK that the baseline kept.
+        assert "src/fileK.py" in diversity_files
+        assert baseline_files <= diversity_files
+        # Diversity never re-spends freed budget on a richer representation.
+        assert plan.included_tokens <= baseline.included_tokens
+
+    def test_direct_region_never_skipped_under_tight_budget(self) -> None:
+        candidates = [
+            _candidate(
+                _signals(
+                    "direct",
+                    file_path="src/auth.py",
+                    retrieval_score=0.9,
+                    direct_match=True,
+                    token_count=1000,
+                ),
+                elided_token_count=5,
+            ),
+            _candidate(
+                _signals("opt", file_path="src/util.py", retrieval_score=0.5, token_count=200),
+                elided_token_count=5,
+            ),
+        ]
+        plan = pack_with_diversity(
+            candidates,
+            {"opt": frozenset({"a", "b"})},
+            token_budget=10,
+            budget_tier=BudgetTier.STANDARD,
+            query_aspects=2,
+        )
+        # A direct/required region is kept (at least as an anchor), never skipped.
+        assert plan.decision_for("direct") is not PackDecision.SKIP
+        assert "direct" in plan.kept_ids()


### PR DESCRIPTION
## Stack

Stack-Id: `r4r5-rerank-diversity-d8c7ab`
Base: `r4-conditional-rerank`
Position: 2/3

1. `r4-conditional-rerank` -> #348
2. `r5-diversity-packing` -> this PR
3. `r4-r5-strategies-docs` -> (next)

Depends on: #348
Upstack: (next)

## Summary

Adds a **benchmark-only** query-adaptive diversity (MMR) packer to `src/archex/serve/packing.py` (Workstream R5 of `.docs/2026-06-20-retrieval-ranking-signal-enhancement-design.md`). Pointwise packing can still spend budget on cross-file/cross-chunk redundancy; this lane trims the redundant tail to lift relevance-per-token.

- **Query-adaptive λ.** Narrow single-aspect lookups keep λ at `1.0` — diversity off, output identical to `pack_efficiently`. Multi-aspect queries lower λ to apply diversity pressure.
- **Required-region invariant.** Required/direct/high-confidence regions are never de-selected (the diversity gate only runs for non-protected candidates).
- **Recall never regresses.** A redundant optional region is dropped only when its file is already represented by another kept region. Because candidates are processed in the same order as `pack_efficiently` and diversity only converts optional regions to SKIP (never charging more budget), the diversity kept-file set is a *superset* of `pack_efficiently`'s — proven by a test asserting `baseline_files <= diversity_files`.
- **Deterministic, local.** Similarity is a token-signature Jaccard; no model, no network. The plan carries diversity provenance.

No product default changes. The benchmark lane that consumes this packer is wired in PR 3.

## Validation

- `uv run pytest tests/serve/test_packing.py tests/serve/test_context.py` — pass (145).
- `uv run ruff check` / `ruff format --check` / `uv run pyright` on changed files — clean.
