### PR TITLE
bench(loc): expand Python issue-to-edit localization family (1/3)

### DIFF
--- a/benchmarks/tasks/loc_celery_task_retry.yaml
+++ b/benchmarks/tasks/loc_celery_task_retry.yaml
@@ -1,0 +1,27 @@
+task_id: loc_celery_task_retry
+repo: celery/celery
+commit: "v5.4.0"
+category: external-large
+family: localization
+languages: [python]
+include_paths:
+  - celery/app
+question: "Issue: when a task calls self.retry() the countdown/eta and max_retries handling is wrong — the retry is re-queued even after the maximum number of retries is exceeded, and the default retry delay is not applied. Which method re-sends the task for retry and enforces the max-retries limit?"
+expected_files:
+  - celery/app/task.py
+expected_symbols:
+  - retry
+expected_regions:
+  - path: celery/app/task.py
+    granularity: symbol
+    symbol: Task.retry
+    start_line: 647
+    end_line: 758
+    notes: "Computes retries/countdown, enforces max_retries (raising MaxRetriesExceededError), builds the retry signature, and re-sends it; pinned to Celery v5.4.0."
+token_budget: 8192
+keywords:
+  - retry
+  - countdown
+  - max_retries
+  - eta
+  - task

--- a/benchmarks/tasks/loc_click_param_process.yaml
+++ b/benchmarks/tasks/loc_click_param_process.yaml
@@ -1,0 +1,35 @@
+task_id: loc_click_param_process
+repo: pallets/click
+commit: "8.1.8"
+category: external-framework
+family: localization
+languages: [python]
+include_paths:
+  - src/click
+question: "Bug report: a required option backed by a callback is accepted even when its value is missing, because the missing-value check and the callback are not applied during parameter processing. Where does Click type-cast a parameter value, enforce the required/missing check, run the callback, and store the processed value during parse?"
+expected_files:
+  - src/click/core.py
+expected_symbols:
+  - process_value
+  - handle_parse_result
+expected_regions:
+  - path: src/click/core.py
+    granularity: symbol
+    symbol: Parameter.process_value
+    start_line: 2358
+    end_line: 2367
+    notes: "Type-casts the value, enforces the required/missing check, and runs the callback; pinned to Click 8.1.8."
+  - path: src/click/core.py
+    granularity: symbol
+    symbol: Parameter.handle_parse_result
+    start_line: 2395
+    end_line: 2413
+    notes: "Consumes the raw value, calls process_value, and stores the processed value into ctx.params; pinned to Click 8.1.8."
+    weight: 0.8
+token_budget: 8192
+keywords:
+  - option
+  - parameter
+  - process_value
+  - callback
+  - required

--- a/benchmarks/tasks/loc_django_queryset_filter.yaml
+++ b/benchmarks/tasks/loc_django_queryset_filter.yaml
@@ -1,0 +1,42 @@
+task_id: loc_django_queryset_filter
+repo: django/django
+commit: "5.1.4"
+category: external-large
+family: localization
+languages: [python]
+include_paths:
+  - django/db/models
+question: "Issue: calling QuerySet.filter()/exclude() after a slice has been taken should raise, and the negated exclude() must wrap the lookup in NOT, but the conditions are added to the wrong query. Where does the QuerySet add the filter/exclude conditions to the underlying query (chaining a clone and ANDing or negating the Q)?"
+expected_files:
+  - django/db/models/query.py
+expected_symbols:
+  - filter
+  - _filter_or_exclude
+  - _filter_or_exclude_inplace
+expected_regions:
+  - path: django/db/models/query.py
+    granularity: symbol
+    symbol: QuerySet.filter
+    start_line: 1470
+    end_line: 1476
+    notes: "Public filter entry: rejects combined queries and delegates to _filter_or_exclude; pinned to Django 5.1.4."
+    weight: 0.8
+  - path: django/db/models/query.py
+    granularity: symbol
+    symbol: QuerySet._filter_or_exclude
+    start_line: 1486
+    end_line: 1495
+    notes: "Guards against filtering a sliced query and chains a clone before applying the conditions; pinned to Django 5.1.4."
+  - path: django/db/models/query.py
+    granularity: symbol
+    symbol: QuerySet._filter_or_exclude_inplace
+    start_line: 1497
+    end_line: 1501
+    notes: "Adds the Q to the query, negating it for exclude(); pinned to Django 5.1.4."
+token_budget: 8192
+keywords:
+  - queryset
+  - filter
+  - exclude
+  - add_q
+  - negate

--- a/benchmarks/tasks/loc_fastapi_solve_dependencies.yaml
+++ b/benchmarks/tasks/loc_fastapi_solve_dependencies.yaml
@@ -1,0 +1,27 @@
+task_id: loc_fastapi_solve_dependencies
+repo: tiangolo/fastapi
+commit: "0.115.6"
+category: external-framework
+family: localization
+languages: [python]
+include_paths:
+  - fastapi/dependencies
+question: "Bug report: a dependency override registered via app.dependency_overrides is ignored, and sub-dependency results are not cached/reused within a single request. Which function recursively resolves a dependant's sub-dependencies, applies dependency overrides, and populates the dependency cache?"
+expected_files:
+  - fastapi/dependencies/utils.py
+expected_symbols:
+  - solve_dependencies
+expected_regions:
+  - path: fastapi/dependencies/utils.py
+    granularity: symbol
+    symbol: solve_dependencies
+    start_line: 572
+    end_line: 695
+    notes: "Recursively resolves sub-dependencies, applies dependency_overrides, caches results, and assembles request param values; pinned to FastAPI 0.115.6."
+token_budget: 8192
+keywords:
+  - dependency
+  - solve_dependencies
+  - override
+  - cache
+  - dependant

--- a/benchmarks/tasks/loc_flask_full_dispatch.yaml
+++ b/benchmarks/tasks/loc_flask_full_dispatch.yaml
@@ -1,0 +1,42 @@
+task_id: loc_flask_full_dispatch
+repo: pallets/flask
+commit: "3.1.0"
+category: external-framework
+family: localization
+languages: [python]
+include_paths:
+  - src/flask
+question: "Issue: an exception raised inside a view is not routed through the registered error handlers, so the user sees a raw 500 instead of the handler's response. Where does Flask run the full request cycle (preprocess, dispatch, error handling) and where is a raised exception handed to the user error handlers?"
+expected_files:
+  - src/flask/app.py
+expected_symbols:
+  - full_dispatch_request
+  - dispatch_request
+  - handle_user_exception
+expected_regions:
+  - path: src/flask/app.py
+    granularity: symbol
+    symbol: Flask.full_dispatch_request
+    start_line: 904
+    end_line: 920
+    notes: "Runs preprocessing and dispatch, routing any exception to handle_user_exception before finalizing; pinned to Flask 3.1.0."
+  - path: src/flask/app.py
+    granularity: symbol
+    symbol: Flask.dispatch_request
+    start_line: 879
+    end_line: 902
+    notes: "Matches the URL rule and invokes the view function; pinned to Flask 3.1.0."
+    weight: 0.8
+  - path: src/flask/app.py
+    granularity: symbol
+    symbol: Flask.handle_user_exception
+    start_line: 779
+    end_line: 809
+    notes: "Selects and invokes the registered handler for a raised exception; pinned to Flask 3.1.0."
+token_budget: 8192
+keywords:
+  - dispatch
+  - request
+  - error handler
+  - exception
+  - view

--- a/benchmarks/tasks/loc_httpx_pool_transport.yaml
+++ b/benchmarks/tasks/loc_httpx_pool_transport.yaml
@@ -1,0 +1,27 @@
+task_id: loc_httpx_pool_transport
+repo: encode/httpx
+commit: "0.28.1"
+category: external-framework
+family: localization
+languages: [python]
+include_paths:
+  - httpx
+question: "Issue: the synchronous transport does not translate httpcore connection-pool errors into httpx exceptions and the request extensions are not forwarded to the connection pool. Which method on the sync transport converts an httpx Request into an httpcore request, dispatches it through the connection pool, and maps the errors back?"
+expected_files:
+  - httpx/_transports/default.py
+expected_symbols:
+  - handle_request
+expected_regions:
+  - path: httpx/_transports/default.py
+    granularity: symbol
+    symbol: HTTPTransport.handle_request
+    start_line: 230
+    end_line: 259
+    notes: "Builds the httpcore request, dispatches via the connection pool under map_httpcore_exceptions, and wraps the response; pinned to httpx 0.28.1."
+token_budget: 8192
+keywords:
+  - transport
+  - handle_request
+  - connection pool
+  - httpcore
+  - exceptions

--- a/benchmarks/tasks/loc_pydantic_validate_call.yaml
+++ b/benchmarks/tasks/loc_pydantic_validate_call.yaml
@@ -1,0 +1,38 @@
+task_id: loc_pydantic_validate_call
+repo: pydantic/pydantic
+commit: "v2.10.5"
+category: external-framework
+family: localization
+languages: [python]
+include_paths:
+  - pydantic/_internal
+question: "Issue: a function decorated with @validate_call no longer validates its arguments against the generated schema, and when validate_return is enabled the return value is not validated either. Which wrapper builds the argument validator (and the optional return validator) and applies them when the decorated callable is invoked?"
+expected_files:
+  - pydantic/_internal/_validate_call.py
+expected_symbols:
+  - ValidateCallWrapper
+expected_regions:
+  - path: pydantic/_internal/_validate_call.py
+    granularity: file
+    notes: "The whole module wraps a callable with argument and return validation; pinned to pydantic v2.10.5."
+    weight: 0.5
+  - path: pydantic/_internal/_validate_call.py
+    granularity: symbol
+    symbol: ValidateCallWrapper.__init__
+    start_line: 53
+    end_line: 108
+    notes: "Builds the pydantic-core argument validator and the optional return validator; pinned to pydantic v2.10.5."
+  - path: pydantic/_internal/_validate_call.py
+    granularity: symbol
+    symbol: ValidateCallWrapper.__call__
+    start_line: 110
+    end_line: 115
+    notes: "Validates call arguments and applies the return validator on the result; pinned to pydantic v2.10.5."
+    weight: 0.8
+token_budget: 8192
+keywords:
+  - validate_call
+  - validator
+  - arguments
+  - return
+  - schema

--- a/benchmarks/tasks/loc_pytest_fixture_resolution.yaml
+++ b/benchmarks/tasks/loc_pytest_fixture_resolution.yaml
@@ -1,0 +1,36 @@
+task_id: loc_pytest_fixture_resolution
+repo: pytest-dev/pytest
+commit: "8.3.4"
+category: external-framework
+family: localization
+languages: [python]
+include_paths:
+  - src/_pytest/fixtures.py
+  - src/_pytest/python.py
+question: "Issue: a fixture defined on a plugin class is not bound to the requesting test instance, so the wrong callable is invoked during fixture setup. Which function resolves the actual fixture callable (binding it to request.instance when appropriate), and where is it invoked during fixture setup?"
+expected_files:
+  - src/_pytest/fixtures.py
+expected_symbols:
+  - resolve_fixture_function
+  - pytest_fixture_setup
+expected_regions:
+  - path: src/_pytest/fixtures.py
+    granularity: symbol
+    symbol: resolve_fixture_function
+    start_line: 1105
+    end_line: 1126
+    notes: "Resolves the fixture callable and binds it to request.instance when the fixture lives on a class; pinned to pytest 8.3.4."
+  - path: src/_pytest/fixtures.py
+    granularity: symbol
+    symbol: pytest_fixture_setup
+    start_line: 1129
+    end_line: 1150
+    notes: "Computes fixture argument values and calls the resolved fixture function; pinned to pytest 8.3.4."
+    weight: 0.8
+token_budget: 8192
+keywords:
+  - fixture
+  - resolve
+  - setup
+  - instance
+  - fixturedef

--- a/benchmarks/tasks/loc_requests_adapter_send.yaml
+++ b/benchmarks/tasks/loc_requests_adapter_send.yaml
@@ -1,0 +1,35 @@
+task_id: loc_requests_adapter_send
+repo: psf/requests
+commit: "v2.32.3"
+category: external-framework
+family: localization
+languages: [python]
+include_paths:
+  - src/requests
+question: "Bug report: a (connect, read) timeout tuple passed to a request is not honored and urllib3 errors are not translated into the requests exception hierarchy. Where does the HTTP adapter open the connection, build the urllib3 timeout, send the request, and map low-level errors before constructing the Response?"
+expected_files:
+  - src/requests/adapters.py
+expected_symbols:
+  - send
+  - build_response
+expected_regions:
+  - path: src/requests/adapters.py
+    granularity: symbol
+    symbol: HTTPAdapter.send
+    start_line: 613
+    end_line: 719
+    notes: "Opens the connection, normalizes the timeout tuple, calls urlopen, and maps urllib3 errors to requests exceptions; pinned to requests v2.32.3."
+  - path: src/requests/adapters.py
+    granularity: symbol
+    symbol: HTTPAdapter.build_response
+    start_line: 359
+    end_line: 394
+    notes: "Builds the requests.Response from the urllib3 response; pinned to requests v2.32.3."
+    weight: 0.8
+token_budget: 8192
+keywords:
+  - adapter
+  - send
+  - timeout
+  - urlopen
+  - response

--- a/benchmarks/tasks/loc_sqlalchemy_session_merge.yaml
+++ b/benchmarks/tasks/loc_sqlalchemy_session_merge.yaml
@@ -1,0 +1,34 @@
+task_id: loc_sqlalchemy_session_merge
+repo: sqlalchemy/sqlalchemy
+commit: "rel_2_0_36"
+category: external-large
+family: localization
+languages: [python]
+include_paths:
+  - lib/sqlalchemy/orm
+question: "Bug report: Session.merge() does not reconcile an incoming detached instance with an existing row by primary key, and the merge cascade into associated objects misbehaves. Where does the Session run the merge (handling autoflush) and recurse the merge into related instances?"
+expected_files:
+  - lib/sqlalchemy/orm/session.py
+expected_symbols:
+  - merge
+  - _merge
+expected_regions:
+  - path: lib/sqlalchemy/orm/session.py
+    granularity: symbol
+    symbol: Session.merge
+    start_line: 3883
+    end_line: 3968
+    notes: "Public entry point: verifies the mapping, manages autoflush, and delegates to _merge; pinned to SQLAlchemy rel_2_0_36."
+  - path: lib/sqlalchemy/orm/session.py
+    granularity: symbol
+    symbol: Session._merge
+    start_line: 3970
+    end_line: 4134
+    notes: "Reconciles primary-key identity, loads the existing row, copies attribute state, and cascades the merge; pinned to SQLAlchemy rel_2_0_36."
+token_budget: 8192
+keywords:
+  - session
+  - merge
+  - cascade
+  - identity
+  - primary key

--- a/tests/benchmark/test_loader.py
+++ b/tests/benchmark/test_loader.py
@@ -44,6 +44,16 @@ LOCALIZATION_TASK_IDS = (
     "loc_flask_blueprint_register",
     "loc_httpx_redirect_headers",
     "loc_fastapi_jsonable_encoder",
+    "loc_celery_task_retry",
+    "loc_click_param_process",
+    "loc_django_queryset_filter",
+    "loc_fastapi_solve_dependencies",
+    "loc_flask_full_dispatch",
+    "loc_httpx_pool_transport",
+    "loc_pydantic_validate_call",
+    "loc_pytest_fixture_resolution",
+    "loc_requests_adapter_send",
+    "loc_sqlalchemy_session_merge",
 )
 
 
@@ -489,6 +499,30 @@ expected_regions:
         assert region.symbol == "App.handle"
         assert region.start_line is None
         assert region.end_line is None
+
+    def test_localization_task_ids_cover_every_loc_file(self) -> None:
+        on_disk = {path.stem for path in TASKS_DIR.glob("loc_*.yaml")}
+        # No duplicate ids in the roster, and the roster matches the files on disk.
+        assert len(LOCALIZATION_TASK_IDS) == len(set(LOCALIZATION_TASK_IDS))
+        assert set(LOCALIZATION_TASK_IDS) == on_disk
+        assert 15 <= len(on_disk) <= 25
+
+    def test_real_python_loc_task_rejects_malformed_region(self, tmp_path: Path) -> None:
+        # Inverting a real symbol region's line range must fail loudly at load
+        # time rather than silently scoring against a malformed label.
+        source = TASKS_DIR / "loc_django_queryset_filter.yaml"
+        malformed = tmp_path / source.name
+        malformed.write_text(
+            source.read_text(encoding="utf-8").replace(
+                "    end_line: 1495",
+                "    end_line: 1485",
+                1,
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match=r"loc_django_queryset_filter\.yaml.*start_line"):
+            load_task(malformed)
 
 
 class TestLoadArchTask:

--- a/tests/benchmark/test_region_fixtures.py
+++ b/tests/benchmark/test_region_fixtures.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from archex.benchmark.loader import load_tasks, validate_task
+import pytest
+
+from archex.benchmark.loader import load_task, load_tasks, validate_task
+from archex.benchmark.models import RegionGranularity, TaskFamily
 from archex.benchmark.strategies import run_archex_query
 
 REGION_TASKS_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "region_tasks"
@@ -76,3 +79,39 @@ def test_region_fixture_task_computes_region_metrics(python_simple_repo: Path) -
     assert result.useful_tokens is not None
     assert result.wasted_tokens is not None
     assert result.relevance_per_1k_tokens is not None
+
+
+def test_external_localization_tasks_declare_valid_region_labels() -> None:
+    loc_files = sorted(REAL_TASKS_DIR.glob("loc_*.yaml"))
+    assert loc_files, "expected hand-curated loc_*.yaml localization tasks"
+    for path in loc_files:
+        task = load_task(path)
+        assert task.family is TaskFamily.LOCALIZATION, task.task_id
+        assert task.expected_regions, f"{task.task_id} declares no expected_regions"
+        assert {region.path for region in task.expected_regions} <= set(task.expected_files), (
+            task.task_id
+        )
+        for region in task.expected_regions:
+            if region.granularity in (RegionGranularity.SYMBOL, RegionGranularity.BLOCK):
+                assert region.symbol and region.symbol.strip(), task.task_id
+            if region.start_line is not None:
+                assert region.end_line is not None, (task.task_id, region.symbol)
+                assert region.start_line <= region.end_line, (task.task_id, region.symbol)
+
+
+def test_external_localization_task_rejects_malformed_region(tmp_path: Path) -> None:
+    # A malformed line range in a real, checked-in localization task must fail
+    # loudly at load time so a bad label can never be scored silently.
+    source = REAL_TASKS_DIR / "loc_pydantic_validate_call.yaml"
+    malformed = tmp_path / source.name
+    malformed.write_text(
+        source.read_text(encoding="utf-8").replace(
+            "    end_line: 108",
+            "    end_line: 52",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=r"loc_pydantic_validate_call\.yaml.*start_line"):
+        load_task(malformed)


### PR DESCRIPTION
## Summary

Grows the issue-to-edit localization task family with 10 hand-curated, region-labeled, SWE-bench-style tasks for Python repositories already in the benchmark corpus. The family goes from 5 to 15 tasks; the multi-language tasks and the labeled `archex_query` baseline land in the upstack PRs.

Each task pairs an issue-style question with `expected_files`, `expected_symbols`, and `expected_regions` at file and symbol granularity, pinned to a public release tag. Symbol-granularity regions carry verified inclusive line ranges, so a label matches on symbol name and still survives minor line drift.

Data and tests only — reuses the existing region-label schema (`family: localization`, `expected_regions`) and the existing localization reporting (`reporter.format_localization_summary`). No retrieval code path changes.

## Tasks added

| Task | Repo @ tag | Edit target |
|------|-----------|-------------|
| `loc_pydantic_validate_call` | pydantic/pydantic @ v2.10.5 | `ValidateCallWrapper` |
| `loc_sqlalchemy_session_merge` | sqlalchemy/sqlalchemy @ rel_2_0_36 | `Session.merge` / `Session._merge` |
| `loc_celery_task_retry` | celery/celery @ v5.4.0 | `Task.retry` |
| `loc_click_param_process` | pallets/click @ 8.1.8 | `Parameter.process_value` / `handle_parse_result` |
| `loc_pytest_fixture_resolution` | pytest-dev/pytest @ 8.3.4 | `resolve_fixture_function` / `pytest_fixture_setup` |
| `loc_django_queryset_filter` | django/django @ 5.1.4 | `QuerySet.filter` / `_filter_or_exclude` |
| `loc_fastapi_solve_dependencies` | tiangolo/fastapi @ 0.115.6 | `solve_dependencies` |
| `loc_flask_full_dispatch` | pallets/flask @ 3.1.0 | `Flask.full_dispatch_request` / `dispatch_request` |
| `loc_requests_adapter_send` | psf/requests @ v2.32.3 | `HTTPAdapter.send` / `build_response` |
| `loc_httpx_pool_transport` | encode/httpx @ 0.28.1 | `HTTPTransport.handle_request` |

## Tests

- `tests/benchmark/test_loader.py`: new tasks load with the localization family; symbol-granularity regions accepted; `LOCALIZATION_TASK_IDS` covers every `loc_*.yaml`; a malformed (inverted) line range in a real task fails loudly at load time.
- `tests/benchmark/test_region_fixtures.py`: every checked-in `loc_*.yaml` declares valid region labels (paths ⊆ files, symbol handles present, valid inclusive ranges); a malformed region in a real task fails loudly.

## Validation

- `ruff check` + `ruff format --check` (changed files): pass
- `pyright` (changed files, strict): 0 errors
- `pytest tests/benchmark/test_loader.py tests/benchmark/test_region_fixtures.py`: 68 passed
- Every task validated against a clone at its pinned tag (expected files present; region line ranges within file bounds)

## Stack

Stack-Id: `loc-family-expansion-511e66`
Base: `main`
Position: 1/3

1. `loc-family/python-tasks` -> this PR
2. `loc-family/multilang-tasks` -> upstack
3. `loc-family/labeled-baseline` -> upstack

Depends on: (none - root)

## Review

Reviewed against the PR diff; one finding fixed: `loc_flask_full_dispatch` `Flask.handle_user_exception` region `end_line` corrected 878 -> 809 (it had overshot into the sibling `handle_exception`/`log_exception` methods). All other region labels verified correct at their pinned tags.
