### PR TITLE
bench(loc): add multi-language localization tasks (2/3)

### DIFF
--- a/benchmarks/tasks/loc_express_error_middleware.yaml
+++ b/benchmarks/tasks/loc_express_error_middleware.yaml
@@ -1,0 +1,34 @@
+task_id: loc_express_error_middleware
+repo: expressjs/express
+commit: "4.21.2"
+category: external-framework
+family: localization
+languages: [javascript]
+include_paths:
+  - lib
+question: "Bug report: an error-handling middleware (a function taking four arguments err, req, res, next) is not invoked when a route handler throws, while a non-error handler with too many arguments is also mis-dispatched. Where does a router layer decide, from a handler's arity, whether to invoke it as an error handler or as a normal request handler?"
+expected_files:
+  - lib/router/layer.js
+expected_symbols:
+  - handle_error
+  - handle_request
+expected_regions:
+  - path: lib/router/layer.js
+    granularity: symbol
+    symbol: handle_error
+    start_line: 62
+    end_line: 75
+    notes: "Invokes the layer handler as an error handler only when its arity is exactly 4, otherwise forwards the error to next(); pinned to Express 4.21.2."
+  - path: lib/router/layer.js
+    granularity: line_range
+    start_line: 86
+    end_line: 99
+    notes: "Layer.prototype.handle_request: invokes the handler as a normal request handler only when its arity is <= 3; pinned to Express 4.21.2."
+    weight: 0.8
+token_budget: 8192
+keywords:
+  - middleware
+  - error handler
+  - arity
+  - layer
+  - next

--- a/benchmarks/tasks/loc_gin_context_next.yaml
+++ b/benchmarks/tasks/loc_gin_context_next.yaml
@@ -1,0 +1,38 @@
+task_id: loc_gin_context_next
+repo: gin-gonic/gin
+commit: "v1.10.0"
+category: external-framework
+family: localization
+languages: [go]
+include_paths:
+  - gin.go
+  - context.go
+  - routergroup.go
+  - logger.go
+question: "Issue: calling c.Abort() inside a middleware does not prevent the remaining handlers in the chain from running, and c.Next() advances through the handler chain incorrectly. Where does the request context advance through the middleware/handler chain, and where does Abort stop further handlers from being called?"
+expected_files:
+  - context.go
+expected_symbols:
+  - Next
+  - Abort
+expected_regions:
+  - path: context.go
+    granularity: symbol
+    symbol: Context.Next
+    start_line: 182
+    end_line: 188
+    notes: "Advances the handler index and runs the pending handlers in the chain; pinned to Gin v1.10.0."
+  - path: context.go
+    granularity: symbol
+    symbol: Context.Abort
+    start_line: 199
+    end_line: 201
+    notes: "Sets the index past the chain (abortIndex) so pending handlers are skipped; pinned to Gin v1.10.0."
+    weight: 0.8
+token_budget: 8192
+keywords:
+  - middleware
+  - context
+  - Next
+  - Abort
+  - handlers

--- a/benchmarks/tasks/loc_gin_tree_route.yaml
+++ b/benchmarks/tasks/loc_gin_tree_route.yaml
@@ -1,0 +1,38 @@
+task_id: loc_gin_tree_route
+repo: gin-gonic/gin
+commit: "v1.10.0"
+category: external-framework
+family: localization
+languages: [go]
+include_paths:
+  - tree.go
+  - routergroup.go
+  - gin.go
+  - context.go
+question: "Bug report: registering a route containing a named parameter or wildcard (for example /user/:id/*action) builds the radix tree incorrectly, so later lookups miss the route. Where does the router insert a path and its handlers into the radix tree, splitting nodes on the common prefix and creating the wildcard child nodes?"
+expected_files:
+  - tree.go
+expected_symbols:
+  - addRoute
+  - insertChild
+expected_regions:
+  - path: tree.go
+    granularity: symbol
+    symbol: addRoute
+    start_line: 152
+    end_line: 266
+    notes: "Inserts a path and its handlers into the radix tree, splitting on the longest common prefix; pinned to Gin v1.10.0."
+  - path: tree.go
+    granularity: symbol
+    symbol: insertChild
+    start_line: 293
+    end_line: 402
+    notes: "Creates the child nodes for the named-parameter/wildcard segments of the path; pinned to Gin v1.10.0."
+    weight: 0.8
+token_budget: 8192
+keywords:
+  - router
+  - radix tree
+  - wildcard
+  - addRoute
+  - param

--- a/benchmarks/tasks/loc_mini_redis_command_from_frame.yaml
+++ b/benchmarks/tasks/loc_mini_redis_command_from_frame.yaml
@@ -1,0 +1,34 @@
+task_id: loc_mini_redis_command_from_frame
+repo: tokio-rs/mini-redis
+commit: "e186482ca00f8d884ddcbe20417f3654d03315a4"
+category: external-framework
+family: localization
+languages: [rust]
+include_paths:
+  - src
+question: "Issue: an unrecognized command name is rejected with an error instead of being parsed into an Unknown command, and after parsing a known command the leftover frame fields are not checked. Where is a received frame parsed into a Command by reading the command name and dispatching to the per-command parser?"
+expected_files:
+  - src/cmd/mod.rs
+expected_symbols:
+  - from_frame
+  - apply
+expected_regions:
+  - path: src/cmd/mod.rs
+    granularity: symbol
+    symbol: from_frame
+    start_line: 44
+    end_line: 84
+    notes: "Reads the command name, dispatches to the per-command parser, returns an Unknown command for unrecognized names, and verifies no leftover frame fields; pinned to mini-redis commit e186482."
+  - path: src/cmd/mod.rs
+    granularity: line_range
+    start_line: 90
+    end_line: 109
+    notes: "Command::apply: dispatches the parsed command to its per-command apply implementation; pinned to mini-redis commit e186482."
+    weight: 0.8
+token_budget: 8192
+keywords:
+  - command
+  - from_frame
+  - parse
+  - unknown
+  - dispatch

--- a/benchmarks/tasks/loc_react_dispatch_set_state.yaml
+++ b/benchmarks/tasks/loc_react_dispatch_set_state.yaml
@@ -1,0 +1,37 @@
+task_id: loc_react_dispatch_set_state
+repo: facebook/react
+commit: "v19.0.0"
+category: external-large
+family: localization
+languages: [javascript]
+include_paths:
+  - packages/react-reconciler/src/ReactFiberHooks.js
+  - packages/react-reconciler/src/ReactFiberWorkLoop.js
+  - packages/react-reconciler/src/ReactFiberLane.js
+question: "Issue: a useState setter called with a value equal to the current state still schedules a re-render instead of taking the eager-state bail-out fast path. Which function enqueues a useState update, and where is the eager-state bail-out (comparing the eagerly computed next state to the current state) implemented?"
+expected_files:
+  - packages/react-reconciler/src/ReactFiberHooks.js
+expected_symbols:
+  - dispatchSetState
+  - dispatchSetStateInternal
+expected_regions:
+  - path: packages/react-reconciler/src/ReactFiberHooks.js
+    granularity: symbol
+    symbol: dispatchSetState
+    start_line: 3506
+    end_line: 3532
+    notes: "useState dispatch entry: requests an update lane and delegates to dispatchSetStateInternal; pinned to React v19.0.0."
+    weight: 0.8
+  - path: packages/react-reconciler/src/ReactFiberHooks.js
+    granularity: symbol
+    symbol: dispatchSetStateInternal
+    start_line: 3534
+    end_line: 3603
+    notes: "Builds the update, computes the eager state, and bails out without scheduling a render when the eager state equals the current state; pinned to React v19.0.0."
+token_budget: 8192
+keywords:
+  - useState
+  - dispatch
+  - eager state
+  - bailout
+  - reducer

--- a/benchmarks/tasks/loc_tokio_current_thread_block_on.yaml
+++ b/benchmarks/tasks/loc_tokio_current_thread_block_on.yaml
@@ -1,0 +1,34 @@
+task_id: loc_tokio_current_thread_block_on
+repo: tokio-rs/tokio
+commit: "tokio-1.42.0"
+category: external-large
+family: localization
+languages: [rust]
+include_paths:
+  - tokio/src/runtime/scheduler/current_thread
+question: "Bug report: on the current-thread runtime, block_on does not correctly take ownership of the scheduler core (or wait for it to become available) before driving the future, so the future can stall. Where does the current-thread scheduler block on a future by stealing the core, and where is the core actually taken from its shared cell?"
+expected_files:
+  - tokio/src/runtime/scheduler/current_thread/mod.rs
+expected_symbols:
+  - block_on
+  - take_core
+expected_regions:
+  - path: tokio/src/runtime/scheduler/current_thread/mod.rs
+    granularity: line_range
+    start_line: 181
+    end_line: 220
+    notes: "CurrentThread::block_on: enters the runtime, steals the scheduler core to block on the future, otherwise parks on a notification until the core is free or the future completes; pinned to tokio-1.42.0."
+  - path: tokio/src/runtime/scheduler/current_thread/mod.rs
+    granularity: symbol
+    symbol: take_core
+    start_line: 222
+    end_line: 233
+    notes: "Takes the scheduler core out of its shared cell and wraps it in a CoreGuard; pinned to tokio-1.42.0."
+    weight: 0.8
+token_budget: 8192
+keywords:
+  - runtime
+  - current_thread
+  - block_on
+  - scheduler
+  - core

--- a/tests/benchmark/test_loader.py
+++ b/tests/benchmark/test_loader.py
@@ -38,6 +38,14 @@ LABELED_EXTERNAL_TASKS = (
     "requests_sessions",
 )
 ALLOWED_REGION_GRANULARITIES = {"file", "symbol", "block", "line_range"}
+MULTILANG_LOCALIZATION_TASK_IDS = (
+    "loc_express_error_middleware",
+    "loc_react_dispatch_set_state",
+    "loc_gin_tree_route",
+    "loc_gin_context_next",
+    "loc_tokio_current_thread_block_on",
+    "loc_mini_redis_command_from_frame",
+)
 LOCALIZATION_TASK_IDS = (
     "loc_requests_redirect_auth",
     "loc_django_username_validator",
@@ -54,6 +62,7 @@ LOCALIZATION_TASK_IDS = (
     "loc_pytest_fixture_resolution",
     "loc_requests_adapter_send",
     "loc_sqlalchemy_session_merge",
+    *MULTILANG_LOCALIZATION_TASK_IDS,
 )
 
 
@@ -522,6 +531,49 @@ expected_regions:
         )
 
         with pytest.raises(ValueError, match=r"loc_django_queryset_filter\.yaml.*start_line"):
+            load_task(malformed)
+
+
+class TestLoadMultiLanguageLocalizationTasks:
+    def test_multilang_tasks_load_and_validate(self) -> None:
+        for task_id in MULTILANG_LOCALIZATION_TASK_IDS:
+            task = load_task(TASKS_DIR / f"{task_id}.yaml")
+
+            assert task.family is TaskFamily.LOCALIZATION, task_id
+            assert task.languages, f"{task_id} declares no languages"
+            # The multi-language family covers the non-Python repos in the corpus.
+            assert task.languages != ["python"], task_id
+            assert task.expected_regions, f"{task_id} declares no expected_regions"
+            region_paths = {region.path for region in task.expected_regions}
+            assert region_paths <= set(task.expected_files), task_id
+
+    def test_multilang_region_granularities_are_in_allowed_set(self) -> None:
+        for task_id in MULTILANG_LOCALIZATION_TASK_IDS:
+            task = load_task(TASKS_DIR / f"{task_id}.yaml")
+
+            granularities = {region.granularity.value for region in task.expected_regions}
+            assert granularities <= ALLOWED_REGION_GRANULARITIES, (task_id, granularities)
+
+    def test_multilang_languages_cover_js_go_and_rust(self) -> None:
+        languages: set[str] = set()
+        for task_id in MULTILANG_LOCALIZATION_TASK_IDS:
+            languages.update(load_task(TASKS_DIR / f"{task_id}.yaml").languages or [])
+
+        assert {"javascript", "go", "rust"} <= languages
+
+    def test_real_multilang_loc_task_rejects_invalid_granularity(self, tmp_path: Path) -> None:
+        source = TASKS_DIR / "loc_gin_tree_route.yaml"
+        malformed = tmp_path / source.name
+        malformed.write_text(
+            source.read_text(encoding="utf-8").replace(
+                "    granularity: symbol",
+                "    granularity: paragraph",
+                1,
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match=r"loc_gin_tree_route\.yaml.*granularity"):
             load_task(malformed)
 
 


### PR DESCRIPTION
## Summary

Extends the issue-to-edit localization family to the non-Python repositories already in the benchmark corpus, taking the family from 15 to 21 tasks. Stacked on top of #352 (Python tasks); the labeled `archex_query` baseline lands in the upstack PR.

Same schema as the Python tasks (`family: localization`, `expected_files`, `expected_symbols`, `expected_regions`), pinned to public tags. Uniquely named functions use symbol-granularity regions; collision-prone or duplicate-named methods use line-range regions, so region/line scoring stays exact. Data and tests only — no retrieval code path changes.

## Tasks added

| Task | Repo @ tag | Lang | Edit target |
|------|-----------|------|-------------|
| `loc_express_error_middleware` | expressjs/express @ 4.21.2 | JS | `Layer.handle_error` / `handle_request` |
| `loc_react_dispatch_set_state` | facebook/react @ v19.0.0 | JS | `dispatchSetState` / `dispatchSetStateInternal` |
| `loc_gin_tree_route` | gin-gonic/gin @ v1.10.0 | Go | `node.addRoute` / `insertChild` |
| `loc_gin_context_next` | gin-gonic/gin @ v1.10.0 | Go | `Context.Next` / `Context.Abort` |
| `loc_tokio_current_thread_block_on` | tokio-rs/tokio @ tokio-1.42.0 | Rust | `CurrentThread::block_on` / `take_core` |
| `loc_mini_redis_command_from_frame` | tokio-rs/mini-redis @ e186482 | Rust | `Command::from_frame` / `apply` |

## Tests

`tests/benchmark/test_loader.py`: new `MULTILANG_LOCALIZATION_TASK_IDS` roster and `TestLoadMultiLanguageLocalizationTasks` — multi-language tasks load with the localization family and non-Python languages, region paths ⊆ expected_files, every region granularity is within the allowed set, the family spans javascript/go/rust, and an invalid granularity in a real multi-language task fails loudly at load. The multi-language ids extend `LOCALIZATION_TASK_IDS`, so the coverage guard now tracks all 21 `loc_*.yaml` tasks.

## Validation

- `ruff check` + `ruff format --check` (changed files): pass
- `pyright` (changed files, strict): 0 errors
- `pytest tests/benchmark/test_loader.py tests/benchmark/test_region_fixtures.py`: 72 passed
- Every task validated against a clone at its pinned tag (expected files present; region line ranges within file bounds)

## Stack

Stack-Id: `loc-family-expansion-511e66`
Base: `loc-family/python-tasks`
Position: 2/3

1. `loc-family/python-tasks` -> #352
2. `loc-family/multilang-tasks` -> this PR
3. `loc-family/labeled-baseline` -> upstack

Depends on: #352

## Review

Reviewed against the PR delta; one finding fixed: `loc_gin_tree_route` `addRoute` region `end_line` corrected 291 -> 266 (it had overshot into the unrelated `findWildcard` helper at 270-291). All other multi-language region labels verified correct at their pinned refs.
