### PR TITLE
bench(symbolic-rerank): per-corpus validation artifact + reporter grading

### DIFF
--- a/docs/symbolic-rerank-validation.md
+++ b/docs/symbolic-rerank-validation.md
@@ -1,0 +1,66 @@
+# Symbolic-blend reranker — per-corpus validation
+
+Validated evidence for the benchmark-only `archex_query_symbolic_rerank` lane (Workstream L2 of `.docs/2026-06-21-localization-rerank-enhancement-plan.md`). This is the checked-in aggregated result that backs the disposition in `docs/RETRIEVAL_DEFAULT_DECISIONS.md`. The raw per-task benchmark JSONs are local-only (the run directory is gitignored); this aggregated table is the committed evidence.
+
+## Run
+
+- Corpus: `benchmarks/tasks` — 64 tasks (self=24, external-comprehension=19, external-localization=21).
+- Cross-encoder pinned to `cross-encoder/ms-marco-MiniLM-L-6-v2`, warmed once in-process; BM25-only clean driver (no vector fusion lanes).
+- Lanes: `archex_query` (base), `archex_query_conditional_rerank` (pure cross-encoder A/B baseline), `archex_query_symbolic_rerank` (blend mode, the lane default, alpha=0.5).
+- The ambiguity gate fired and the model applied on every task (`cross_encoder_status=applied`). Reranking only reorders the returned set, so recall, required-file recall, and F1 are identical to `archex_query` in every corpus.
+
+Reproduce: warm `CrossEncoderReranker(model_name="cross-encoder/ms-marco-MiniLM-L-6-v2", allow_remote_code=True).warm()`, assert `loaded_reranker_model_names() == [model]`, then `run_all(Path("benchmarks/tasks"), <local-out-dir>, strategies=[ARCHEX_QUERY, ARCHEX_QUERY_CONDITIONAL_RERANK, ARCHEX_QUERY_SYMBOLIC_RERANK], retrieval_options=BenchmarkRetrievalOptions(rerank_model=model))`.
+
+## Order-metric comparison (base = `archex_query`)
+
+### Self-repo (24 tasks)
+
+| metric | base | conditional (pure CE) | symbolic-blend |
+|---|---:|---:|---:|
+| recall | 0.8708 | 0.8708 | 0.8708 |
+| required_file_recall | 0.8708 | 0.8708 | 0.8708 |
+| f1_score | 0.6033 | 0.6033 | 0.6033 |
+| mrr | 0.9792 | 0.9062 | 0.9375 |
+| ndcg | 0.8792 | 0.8218 | 0.8507 |
+| map_score | 0.8217 | 0.7390 | 0.7789 |
+| ranked_region_mrr | 0.4745 | 0.3740 (−0.1005) | 0.5229 (+0.0484) |
+| ranked_region_ndcg | 0.3567 | 0.2906 | 0.3562 |
+| p95_wall_ms | 2446 | 3063 | 2685 |
+| guard_fired (total) | — | 0 | 53 |
+
+### External-comprehension (19 tasks)
+
+| metric | base | conditional (pure CE) | symbolic-blend |
+|---|---:|---:|---:|
+| recall | 0.9474 | 0.9474 | 0.9474 |
+| required_file_recall | 0.9474 | 0.9474 | 0.9474 |
+| f1_score | 0.6610 | 0.6610 | 0.6610 |
+| mrr | 0.8246 | 0.9474 | 0.9386 |
+| ndcg | 0.7965 | 0.8717 | 0.8636 |
+| map_score | 0.6791 | 0.7746 | 0.7617 |
+| ranked_region_mrr | 0.4585 | 0.5037 (+0.0452) | 0.6889 (+0.2304) |
+| ranked_region_ndcg | 0.5144 | 0.5776 | 0.6440 |
+| p95_wall_ms | 610 | 889 | 786 |
+| guard_fired (total) | — | 0 | 16 |
+
+### External-localization (21 tasks)
+
+| metric | base | conditional (pure CE) | symbolic-blend |
+|---|---:|---:|---:|
+| recall | 0.9524 | 0.9524 | 0.9524 |
+| required_file_recall | 0.9524 | 0.9524 | 0.9524 |
+| f1_score | 0.3567 | 0.3567 | 0.3567 |
+| mrr | 0.6671 | 0.8492 | 0.8333 |
+| ndcg | 0.7372 | 0.8758 | 0.8634 |
+| map_score | 0.6671 | 0.8492 | 0.8333 |
+| ranked_region_mrr | 0.4838 | 0.6782 (+0.1945) | 0.7391 (+0.2554) |
+| ranked_region_ndcg | 0.5220 | 0.6703 | 0.6994 |
+| p95_wall_ms | 1130 | 1353 | 1373 |
+| guard_fired (total) | — | 0 | 68 |
+
+## Reading
+
+- The symbolic-blend lane preserves and exceeds the pure-cross-encoder localization win: external-localization ranked-region MRR `0.7391` ≥ pure-CE `0.6782` (and far above base `0.4838`).
+- It reverses the self-repo regression the pure cross-encoder suffers: self ranked-region MRR `0.5229` ≥ base `0.4745`, where pure CE drops to `0.3740` (−0.1005).
+- p95 stays at or below `3000 ms` warm in every corpus where the lane fires (self `2685`, external-comprehension `786`, external-localization `1373`).
+- The lane never changes the returned set (recall/required-file recall/F1 identical to `archex_query`), so the win lives entirely in ranking quality.

--- a/tests/benchmark/test_reporter.py
+++ b/tests/benchmark/test_reporter.py
@@ -842,3 +842,56 @@ class TestR4R5LaneReporting:
         summary = format_summary([self._report(results)])
         assert "diversity packing" in summary
         assert "archex_query_diversity_packed" in summary
+
+
+class TestSymbolicRerankLocalizationGrading:
+    """format_localization_summary grades the symbolic-rerank lane on the
+    localization family separately and renders its order metrics."""
+
+    SYMBOLIC = Strategy.ARCHEX_QUERY_SYMBOLIC_RERANK
+
+    def _loc_report_with_symbolic(self, task_id: str) -> BenchmarkReport:
+        base = _loc_result(task_id, strategy=Strategy.ARCHEX_QUERY)
+        symbolic = _loc_result(
+            task_id,
+            strategy=self.SYMBOLIC,
+            mrr=0.83,
+            ndcg=0.86,
+            ranked_region_mrr=0.74,
+            ranked_region_ndcg=0.70,
+        )
+        return BenchmarkReport(
+            task_id=task_id,
+            repo="owner/repo",
+            question="Issue: where is the bug?",
+            results=[base, symbolic],
+            baseline_tokens=2000,
+        )
+
+    def test_localization_family_graded_separately_with_symbolic_lane(self) -> None:
+        reports = [self._loc_report_with_symbolic("loc_a"), _comprehension_report("comp_a")]
+        md = format_localization_summary(reports)
+        assert "## Localization (issue-to-edit) (1 tasks)" in md
+        assert "## Comprehension (1 tasks)" in md
+        # Localization is graded before, and never folded into, comprehension.
+        assert md.index("## Localization (issue-to-edit)") < md.index("## Comprehension")
+        loc_section, comp_section = md.split("## Comprehension")
+        # The new lane is graded under localization, not comprehension.
+        assert self.SYMBOLIC.value in loc_section
+        assert self.SYMBOLIC.value not in comp_section
+
+    def test_symbolic_lane_order_metrics_render(self) -> None:
+        md = format_localization_summary([self._loc_report_with_symbolic("loc_a")])
+        loc_section = md.split("## Comprehension")[0]
+        assert "File MRR" in loc_section and "File nDCG" in loc_section
+        assert "Region MRR" in loc_section and "Region nDCG" in loc_section
+        sym_rows = [
+            line
+            for line in loc_section.splitlines()
+            if line.startswith(f"| {self.SYMBOLIC.value} ")
+        ]
+        assert len(sym_rows) == 1
+        # Order metrics render as real numbers, not "unknown".
+        assert "unknown" not in sym_rows[0]
+        assert "0.830" in sym_rows[0]  # file MRR
+        assert "0.740" in sym_rows[0]  # ranked-region MRR


### PR DESCRIPTION
## Stack

Stack-Id: `symbolic-rerank-955e6c`
Base: `loc-rerank/symbolic-blend-variant`
Position: 2/3

1. `loc-rerank/symbolic-blend-variant` -> #355
2. `loc-rerank/symbolic-validation-artifact` -> this PR
3. `loc-rerank/symbolic-disposition` -> (pending)

Depends on: #355

## What

Record the clean, model-pinned, per-corpus validation evidence for the symbolic-blend reranker, and add a reporter test that grades the new lane on the localization family.

- `docs/symbolic-rerank-validation.md` — the aggregated per-corpus order-metric comparison (`mrr`, `ndcg`, `map_score`, `ranked_region_mrr`, `ranked_region_ndcg`) plus recall/F1, p95, and guard-fired counts for `archex_query`, `archex_query_conditional_rerank` (pure cross-encoder A/B baseline), and `archex_query_symbolic_rerank` (blend mode, the lane default, alpha=0.5). Cross-encoder pinned to `cross-encoder/ms-marco-MiniLM-L-6-v2`, BM25-only clean driver (no vector fusion lanes), 64 tasks (self=24, external-comprehension=19, external-localization=21). The gate fired and the model applied on every task.
- `tests/benchmark/test_reporter.py::TestSymbolicRerankLocalizationGrading` — asserts the localization family is graded separately from comprehension and the new lane's order metrics render. Uses synthetic in-memory reports, so it carries no checked-in benchmark artifact.

The raw per-task benchmark JSONs are local-only (the run directory is gitignored); `docs/symbolic-rerank-validation.md` is the committed evidence.

## Per-corpus result (ranked-region MRR)

| corpus | base `archex_query` | `archex_query_symbolic_rerank` | pure CE `archex_query_conditional_rerank` |
|---|---:|---:|---:|
| self (24) | 0.4745 | 0.5229 (+0.0484) | 0.3740 (−0.1005) |
| external-comprehension (19) | 0.4585 | 0.6889 (+0.2304) | 0.5037 (+0.0452) |
| external-localization (21) | 0.4838 | 0.7391 (+0.2554) | 0.6782 (+0.1945) |

p95 warm where the lane fires: self 2685 ms, ext-comp 786 ms, ext-loc 1373 ms (all ≤ 3000). Recall, required-file recall, and F1 are identical to `archex_query` in every corpus (the lane only reorders).

The symbolic-blend lane preserves and exceeds the pure-cross-encoder localization win (loc ranked-region MRR 0.7391 ≥ 0.6782) and reverses the self-repo regression (0.5229 ≥ baseline 0.4745) that the pure cross-encoder lane suffers (−0.1005). The disposition is recorded in PR 3 citing `docs/symbolic-rerank-validation.md`.

## Validation

- `uv run pytest tests/benchmark/test_strategy_registry.py tests/benchmark/test_strategies.py tests/benchmark/test_reporter.py` — pass (162).
- `uv run ruff check . && uv run ruff format --check .` — pass.
- `uv run pyright` on the changed test — 0 errors.
