### PR TITLE
chore(release): v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.14.0] - 2026-06-22
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archex"
-version = "0.13.2"
+version = "0.14.0"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Cut the v0.14.0 release: bump the package version `0.13.2` → `0.14.0` and promote the curated `[Unreleased]` changelog section to `## [0.14.0] - 2026-06-22`.

This minor release surfaces the MCP-adoption and metrics-health line:

- `omp` (oh-my-pi) as a first-class `install-client` target
- Agent-file MCP guidance prompt and `--agent-file`
- CLI-vs-MCP surface split in `archex metrics`
- `install-client` default-global scope and `--dry-run` (replacing `--write`)
- MCP adoption documentation across the trust contract, compatibility matrix, README, and LOCAL_METRICS
- Sticky global metrics-health warning fix plus `archex metrics repair`

Benchmark-only retrieval experiments landed since v0.13.2 stay in `docs/RETRIEVAL_DEFAULT_DECISIONS.md` per the established convention and are intentionally not enumerated in the changelog. No product-default, retrieval-code, or dependency change.
