### PR TITLE
Realistic targeted-read token-savings baseline (metrics-only)

### DIFF
--- a/src/archex/metrics/capture.py
+++ b/src/archex/metrics/capture.py
@@ -171,9 +171,11 @@ def _targeted_read_tokens(
     Per returned file, take the union of ``[start_line - K, end_line + K]`` line
     spans (merged, deduped) and estimate their cost from the indexed chunk content's
     per-line token density. Deterministic and index-only: no file-system read and no
-    model call. The estimate is clamped to ``<= full_file`` and floored at
-    ``returned`` (the lower bound is prioritized), so ``returned <= targeted_read <=
-    full_file`` holds for every realistic input where ``returned <= full_file``.
+    model call. The estimate is floored at ``returned`` and capped at ``full_file``
+    (``targeted_read`` never exceeds the full-file baseline), so
+    ``returned <= targeted_read <= full_file`` holds for every realistic input where
+    ``returned <= full_file``; in the degenerate ``returned > full_file`` case
+    (a tiny file whose rendered chunks exceed its source) it reports ``full_file``.
     """
     by_file: dict[str, list[CodeChunk]] = {}
     for ranked in chunks:
@@ -183,7 +185,7 @@ def _targeted_read_tokens(
     estimate = sum(
         _targeted_file_tokens(file_chunks, context_lines) for file_chunks in by_file.values()
     )
-    return max(returned_tokens, min(estimate, full_file_tokens))
+    return min(full_file_tokens, max(returned_tokens, estimate))
 
 
 def _targeted_file_tokens(file_chunks: list[CodeChunk], context_lines: int) -> int:

--- a/src/archex/metrics/capture.py
+++ b/src/archex/metrics/capture.py
@@ -171,7 +171,9 @@ def _targeted_read_tokens(
     Per returned file, take the union of ``[start_line - K, end_line + K]`` line
     spans (merged, deduped) and estimate their cost from the indexed chunk content's
     per-line token density. Deterministic and index-only: no file-system read and no
-    model call. Clamped into ``[returned, full_file]`` so the invariant always holds.
+    model call. The estimate is clamped to ``<= full_file`` and floored at
+    ``returned`` (the lower bound is prioritized), so ``returned <= targeted_read <=
+    full_file`` holds for every realistic input where ``returned <= full_file``.
     """
     by_file: dict[str, list[CodeChunk]] = {}
     for ranked in chunks:

--- a/src/archex/metrics/capture.py
+++ b/src/archex/metrics/capture.py
@@ -7,10 +7,19 @@ from typing import TYPE_CHECKING
 
 from archex.metrics.categories import category_for_tool
 from archex.metrics.recorder import MetricsRecorder, Surface, TraceDetails, UsageEvent
+from archex.reporting import count_tokens
 
 if TYPE_CHECKING:
-    from archex.models import ContextBundle, ContextSkippedCandidate, RepoSource
+    from archex.models import (
+        CodeChunk,
+        ContextBundle,
+        ContextSkippedCandidate,
+        RankedChunk,
+        RepoSource,
+    )
     from archex.scout import ScoutResult
+
+_TARGETED_CONTEXT_LINES = 5
 
 
 def record_query_usage(
@@ -32,6 +41,11 @@ def record_query_usage(
     symbols = sorted(
         {chunk.chunk.symbol_name for chunk in bundle.chunks if chunk.chunk.symbol_name}
     )
+    targeted_read = _targeted_read_tokens(
+        bundle.chunks,
+        full_file_tokens=tokens_raw_equivalent,
+        returned_tokens=bundle.token_count,
+    )
     receipt = bundle.receipt
     MetricsRecorder(db_path).record(
         UsageEvent(
@@ -42,6 +56,7 @@ def record_query_usage(
             tokens_returned=bundle.token_count,
             tokens_raw_equivalent=tokens_raw_equivalent,
             whole_repo_tokens=whole_repo_tokens,
+            tokens_targeted_read=targeted_read,
             file_count=len(files),
             freshness=str(receipt.freshness) if receipt is not None else None,
             index_revision=receipt.index_revision if receipt is not None else None,
@@ -142,3 +157,47 @@ def _skipped_counts(candidates: list[ContextSkippedCandidate]) -> dict[str, int]
         reason = str(candidate.reason)
         counts[reason] = counts.get(reason, 0) + 1
     return counts
+
+
+def _targeted_read_tokens(
+    chunks: list[RankedChunk],
+    *,
+    full_file_tokens: int,
+    returned_tokens: int,
+    context_lines: int = _TARGETED_CONTEXT_LINES,
+) -> int | None:
+    """Estimate the realistic targeted-read baseline from returned chunk spans.
+
+    Per returned file, take the union of ``[start_line - K, end_line + K]`` line
+    spans (merged, deduped) and estimate their cost from the indexed chunk content's
+    per-line token density. Deterministic and index-only: no file-system read and no
+    model call. Clamped into ``[returned, full_file]`` so the invariant always holds.
+    """
+    by_file: dict[str, list[CodeChunk]] = {}
+    for ranked in chunks:
+        by_file.setdefault(ranked.chunk.file_path, []).append(ranked.chunk)
+    if not by_file:
+        return None
+    estimate = sum(
+        _targeted_file_tokens(file_chunks, context_lines) for file_chunks in by_file.values()
+    )
+    return max(returned_tokens, min(estimate, full_file_tokens))
+
+
+def _targeted_file_tokens(file_chunks: list[CodeChunk], context_lines: int) -> int:
+    line_text: dict[int, str] = {}
+    expanded_lines: set[int] = set()
+    for chunk in file_chunks:
+        start = chunk.start_line
+        end = chunk.end_line
+        for offset, text in enumerate(chunk.content.split("\n")):
+            line_no = start + offset
+            if line_no > end:
+                break
+            line_text[line_no] = text
+        expanded_lines.update(range(max(1, start - context_lines), end + context_lines + 1))
+    if not line_text:
+        return 0
+    matched_tokens = count_tokens("\n".join(line_text[ln] for ln in sorted(line_text)))
+    density = matched_tokens / len(line_text)
+    return round(density * len(expanded_lines))

--- a/src/archex/metrics/math.py
+++ b/src/archex/metrics/math.py
@@ -15,6 +15,9 @@ class TokenSavings:
     savings_pct: float
     whole_repo_tokens: int | None = None
     whole_repo_tokens_avoided: int | None = None
+    targeted_read_tokens: int | None = None
+    tokens_saved_vs_targeted_read: int | None = None
+    savings_pct_vs_targeted_read: float | None = None
     baseline_type: str = BASELINE_RETURNED_FULL_FILES
 
 
@@ -23,12 +26,21 @@ def compute_token_savings(
     tokens_returned: int,
     tokens_raw_equivalent: int,
     whole_repo_tokens: int | None = None,
+    targeted_read_tokens: int | None = None,
 ) -> TokenSavings:
-    """Compute conservative returned-full-files savings and context upper bound."""
+    """Compute savings against the full-file and (optional) targeted-read baselines.
+
+    The full-file baseline is compression vs a naive full-file paste. The
+    targeted-read baseline (when provided) is the realistic counterfactual of
+    reading the matched line ranges plus a small context window; it is omitted
+    (None) when spans are unavailable for the event.
+    """
     _validate_non_negative("tokens_returned", tokens_returned)
     _validate_non_negative("tokens_raw_equivalent", tokens_raw_equivalent)
     if whole_repo_tokens is not None:
         _validate_non_negative("whole_repo_tokens", whole_repo_tokens)
+    if targeted_read_tokens is not None:
+        _validate_non_negative("targeted_read_tokens", targeted_read_tokens)
 
     tokens_saved = max(tokens_raw_equivalent - tokens_returned, 0)
     savings_pct = (
@@ -37,6 +49,16 @@ def compute_token_savings(
     whole_repo_tokens_avoided = (
         max(whole_repo_tokens - tokens_returned, 0) if whole_repo_tokens is not None else None
     )
+    if targeted_read_tokens is not None:
+        tokens_saved_vs_targeted_read: int | None = max(targeted_read_tokens - tokens_returned, 0)
+        savings_pct_vs_targeted_read: float | None = (
+            (tokens_saved_vs_targeted_read / targeted_read_tokens * 100.0)
+            if targeted_read_tokens > 0
+            else 0.0
+        )
+    else:
+        tokens_saved_vs_targeted_read = None
+        savings_pct_vs_targeted_read = None
     return TokenSavings(
         tokens_returned=tokens_returned,
         tokens_raw_equivalent=tokens_raw_equivalent,
@@ -44,6 +66,9 @@ def compute_token_savings(
         savings_pct=savings_pct,
         whole_repo_tokens=whole_repo_tokens,
         whole_repo_tokens_avoided=whole_repo_tokens_avoided,
+        targeted_read_tokens=targeted_read_tokens,
+        tokens_saved_vs_targeted_read=tokens_saved_vs_targeted_read,
+        savings_pct_vs_targeted_read=savings_pct_vs_targeted_read,
     )
 
 

--- a/src/archex/metrics/recorder.py
+++ b/src/archex/metrics/recorder.py
@@ -65,6 +65,7 @@ class UsageEvent:
     tokens_returned: int
     tokens_raw_equivalent: int
     whole_repo_tokens: int | None = None
+    tokens_targeted_read: int | None = None
     occurred_at: datetime | None = None
     file_count: int = 0
     freshness: str | None = None
@@ -113,6 +114,7 @@ class MetricsRecorder:
             tokens_returned=event.tokens_returned,
             tokens_raw_equivalent=event.tokens_raw_equivalent,
             whole_repo_tokens=event.whole_repo_tokens,
+            targeted_read_tokens=event.tokens_targeted_read,
         )
         occurred_at = event.occurred_at or datetime.now(UTC)
         event_id = str(uuid4())
@@ -178,9 +180,11 @@ class MetricsRecorder:
             INSERT INTO usage_events(
                 event_id, occurred_at, repo_id, surface, tool_name, category,
                 tokens_returned, tokens_raw_equivalent, tokens_saved, savings_pct,
-                whole_repo_tokens, whole_repo_tokens_avoided, baseline_type, file_count,
+                whole_repo_tokens, whole_repo_tokens_avoided, baseline_type,
+                tokens_targeted_read, tokens_saved_vs_targeted_read,
+                savings_pct_vs_targeted_read, file_count,
                 freshness, index_revision, trace_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 event_id,
@@ -196,6 +200,9 @@ class MetricsRecorder:
                 savings.whole_repo_tokens,
                 savings.whole_repo_tokens_avoided,
                 savings.baseline_type,
+                savings.targeted_read_tokens,
+                savings.tokens_saved_vs_targeted_read,
+                savings.savings_pct_vs_targeted_read,
                 event.file_count,
                 event.freshness,
                 event.index_revision,
@@ -217,14 +224,19 @@ class MetricsRecorder:
             INSERT INTO daily_usage(
                 day, repo_id, surface, tool_name, category,
                 tokens_returned, tokens_raw_equivalent, tokens_saved,
-                whole_repo_tokens_avoided, event_count, first_event_at, last_event_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+                whole_repo_tokens_avoided, tokens_targeted_read,
+                tokens_saved_vs_targeted_read, event_count, first_event_at, last_event_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
             ON CONFLICT(day, repo_id, surface, tool_name, category) DO UPDATE SET
                 tokens_returned = tokens_returned + excluded.tokens_returned,
                 tokens_raw_equivalent = tokens_raw_equivalent + excluded.tokens_raw_equivalent,
                 tokens_saved = tokens_saved + excluded.tokens_saved,
                 whole_repo_tokens_avoided = (
                     whole_repo_tokens_avoided + excluded.whole_repo_tokens_avoided
+                ),
+                tokens_targeted_read = tokens_targeted_read + excluded.tokens_targeted_read,
+                tokens_saved_vs_targeted_read = (
+                    tokens_saved_vs_targeted_read + excluded.tokens_saved_vs_targeted_read
                 ),
                 event_count = event_count + 1,
                 first_event_at = min(first_event_at, excluded.first_event_at),
@@ -240,6 +252,8 @@ class MetricsRecorder:
                 savings.tokens_raw_equivalent,
                 savings.tokens_saved,
                 savings.whole_repo_tokens_avoided or 0,
+                savings.targeted_read_tokens or 0,
+                savings.tokens_saved_vs_targeted_read or 0,
                 occurred,
                 occurred,
             ),
@@ -262,8 +276,9 @@ class MetricsRecorder:
                 trace_id, event_id, expires_at, query_text, returned_file_paths, symbols,
                 handles, skipped_counts, tokens_returned, tokens_raw_equivalent,
                 tokens_saved, savings_pct, whole_repo_tokens, whole_repo_tokens_avoided,
-                repo_id, index_revision
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                tokens_targeted_read, tokens_saved_vs_targeted_read,
+                savings_pct_vs_targeted_read, repo_id, index_revision
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 trace_id,
@@ -280,6 +295,9 @@ class MetricsRecorder:
                 savings.savings_pct,
                 savings.whole_repo_tokens,
                 savings.whole_repo_tokens_avoided,
+                savings.targeted_read_tokens,
+                savings.tokens_saved_vs_targeted_read,
+                savings.savings_pct_vs_targeted_read,
                 repo_id,
                 event.index_revision,
             ),

--- a/src/archex/metrics/storage.py
+++ b/src/archex/metrics/storage.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 DEFAULT_RAW_EVENT_RETENTION_DAYS = 90
 DEFAULT_TRACE_RETENTION_DAYS = 14
 
@@ -39,8 +39,10 @@ class MetricsStore:
     def bootstrap(self, conn: sqlite3.Connection) -> None:
         """Create or migrate metrics tables in a single local SQLite ledger."""
         with conn:
-            conn.execute("PRAGMA user_version")
+            current_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
             _create_schema(conn)
+            if current_version < SCHEMA_VERSION:
+                _migrate_schema(conn)
             conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
             _seed_settings(conn)
 
@@ -78,6 +80,15 @@ def _create_schema(conn: sqlite3.Connection) -> None:
                 whole_repo_tokens_avoided IS NULL OR whole_repo_tokens_avoided >= 0
             ),
             baseline_type TEXT NOT NULL,
+            tokens_targeted_read INTEGER CHECK (
+                tokens_targeted_read IS NULL OR tokens_targeted_read >= 0
+            ),
+            tokens_saved_vs_targeted_read INTEGER CHECK (
+                tokens_saved_vs_targeted_read IS NULL OR tokens_saved_vs_targeted_read >= 0
+            ),
+            savings_pct_vs_targeted_read REAL CHECK (
+                savings_pct_vs_targeted_read IS NULL OR savings_pct_vs_targeted_read >= 0
+            ),
             file_count INTEGER NOT NULL DEFAULT 0 CHECK (file_count >= 0),
             freshness TEXT,
             index_revision TEXT,
@@ -99,6 +110,8 @@ def _create_schema(conn: sqlite3.Connection) -> None:
             tokens_raw_equivalent INTEGER NOT NULL DEFAULT 0,
             tokens_saved INTEGER NOT NULL DEFAULT 0,
             whole_repo_tokens_avoided INTEGER NOT NULL DEFAULT 0,
+            tokens_targeted_read INTEGER NOT NULL DEFAULT 0,
+            tokens_saved_vs_targeted_read INTEGER NOT NULL DEFAULT 0,
             event_count INTEGER NOT NULL DEFAULT 0,
             first_event_at TEXT NOT NULL,
             last_event_at TEXT NOT NULL,
@@ -127,6 +140,15 @@ def _create_schema(conn: sqlite3.Connection) -> None:
             whole_repo_tokens_avoided INTEGER CHECK (
                 whole_repo_tokens_avoided IS NULL OR whole_repo_tokens_avoided >= 0
             ),
+            tokens_targeted_read INTEGER CHECK (
+                tokens_targeted_read IS NULL OR tokens_targeted_read >= 0
+            ),
+            tokens_saved_vs_targeted_read INTEGER CHECK (
+                tokens_saved_vs_targeted_read IS NULL OR tokens_saved_vs_targeted_read >= 0
+            ),
+            savings_pct_vs_targeted_read REAL CHECK (
+                savings_pct_vs_targeted_read IS NULL OR savings_pct_vs_targeted_read >= 0
+            ),
             repo_id TEXT NOT NULL REFERENCES repos(repo_id) ON DELETE CASCADE,
             index_revision TEXT
         );
@@ -150,6 +172,43 @@ def _create_schema(conn: sqlite3.Connection) -> None:
         );
         """
     )
+
+
+def _column_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _migrate_schema(conn: sqlite3.Connection) -> None:
+    """Forward-only, idempotent migration for the long-lived local ledger.
+
+    Adds the targeted-read baseline columns to pre-existing DBs. Guarded per column
+    so it is safe on both fresh (columns already present) and legacy ledgers.
+    """
+    nullable_targeted = {
+        "tokens_targeted_read": (
+            "INTEGER CHECK (tokens_targeted_read IS NULL OR tokens_targeted_read >= 0)"
+        ),
+        "tokens_saved_vs_targeted_read": (
+            "INTEGER CHECK ("
+            "tokens_saved_vs_targeted_read IS NULL OR tokens_saved_vs_targeted_read >= 0)"
+        ),
+        "savings_pct_vs_targeted_read": (
+            "REAL CHECK (savings_pct_vs_targeted_read IS NULL OR savings_pct_vs_targeted_read >= 0)"
+        ),
+    }
+    for table in ("usage_events", "usage_traces"):
+        existing = _column_names(conn, table)
+        for column, decl in nullable_targeted.items():
+            if column not in existing:
+                conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
+    daily_targeted = {
+        "tokens_targeted_read": "INTEGER NOT NULL DEFAULT 0",
+        "tokens_saved_vs_targeted_read": "INTEGER NOT NULL DEFAULT 0",
+    }
+    daily_existing = _column_names(conn, "daily_usage")
+    for column, decl in daily_targeted.items():
+        if column not in daily_existing:
+            conn.execute(f"ALTER TABLE daily_usage ADD COLUMN {column} {decl}")
 
 
 def _seed_settings(conn: sqlite3.Connection) -> None:

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -420,3 +420,92 @@ def test_python_api_explicit_usage_event_respects_env_off(
     )
 
     assert not (tmp_path / ".archex" / "usage.sqlite").exists()
+
+
+def test_targeted_read_is_index_only_and_within_bounds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from archex.metrics.capture import record_query_usage
+    from archex.metrics.policy import set_metrics_enabled
+    from archex.models import CodeChunk, ContextBundle, RankedChunk
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    db_path = tmp_path / ".archex" / "usage.sqlite"
+    set_metrics_enabled(True, db_path=db_path)
+
+    chunk = CodeChunk(
+        id="m.py:f:3",
+        content="def f():\n    return compute()\n    # trailing body line",
+        file_path="m.py",
+        start_line=3,
+        end_line=5,
+        language="python",
+        token_count=12,
+    )
+    bundle = ContextBundle(
+        query="where is f",
+        chunks=[RankedChunk(chunk=chunk)],
+        token_count=12,
+    )
+    source = RepoSource(local_path=str(repo_root))
+
+    def _no_fs_read(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("metrics path read file contents")
+
+    with (
+        patch("pathlib.Path.read_bytes", _no_fs_read),
+        patch("pathlib.Path.read_text", _no_fs_read),
+    ):
+        record_query_usage(
+            source,
+            bundle,
+            surface="cli",
+            tokens_raw_equivalent=100,
+            whole_repo_tokens=1000,
+            db_path=db_path,
+        )
+
+    with MetricsStore(db_path).connect() as conn:
+        row = conn.execute(
+            "SELECT tokens_returned, tokens_targeted_read, tokens_raw_equivalent FROM usage_events"
+        ).fetchone()
+    assert row["tokens_targeted_read"] is not None
+    assert row["tokens_returned"] <= row["tokens_targeted_read"] <= row["tokens_raw_equivalent"]
+
+
+def test_targeted_read_helper_is_deterministic_and_bounded() -> None:
+    from archex.metrics.capture import _targeted_read_tokens  # pyright: ignore[reportPrivateUsage]
+    from archex.models import CodeChunk, RankedChunk
+
+    chunks = [
+        RankedChunk(
+            chunk=CodeChunk(
+                id="m.py:a:1",
+                content="def a():\n    return 1",
+                file_path="m.py",
+                start_line=1,
+                end_line=2,
+                language="python",
+            )
+        ),
+        RankedChunk(
+            chunk=CodeChunk(
+                id="m.py:b:40",
+                content="def b():\n    return 2",
+                file_path="m.py",
+                start_line=40,
+                end_line=41,
+                language="python",
+            )
+        ),
+    ]
+    first = _targeted_read_tokens(chunks, full_file_tokens=500, returned_tokens=8)
+    second = _targeted_read_tokens(chunks, full_file_tokens=500, returned_tokens=8)
+    assert first == second
+    assert first is not None
+    assert 8 <= first <= 500
+    # No chunks -> no spans -> baseline omitted.
+    assert _targeted_read_tokens([], full_file_tokens=500, returned_tokens=8) is None

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -509,3 +509,5 @@ def test_targeted_read_helper_is_deterministic_and_bounded() -> None:
     assert 8 <= first <= 500
     # No chunks -> no spans -> baseline omitted.
     assert _targeted_read_tokens([], full_file_tokens=500, returned_tokens=8) is None
+    # Degenerate returned > full_file: targeted is capped at full_file, never above it.
+    assert _targeted_read_tokens(chunks, full_file_tokens=3, returned_tokens=50) == 3

--- a/tests/metrics/test_recorder.py
+++ b/tests/metrics/test_recorder.py
@@ -145,11 +145,49 @@ def test_successful_record_clears_prior_health_warning(tmp_path: Path) -> None:
     assert health.last_failure_message is None
 
 
+def test_record_persists_targeted_read_baseline(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite"
+    repo_root = _repo(tmp_path)
+    set_metrics_enabled(True, db_path=db_path)
+
+    MetricsRecorder(db_path).record(_event(repo_root, targeted_read=40))
+
+    with MetricsStore(db_path).connect() as conn:
+        event = conn.execute("SELECT * FROM usage_events").fetchone()
+        daily = conn.execute("SELECT * FROM daily_usage").fetchone()
+    # returned=10, targeted=40, full_file=100: both baselines recorded.
+    assert event["tokens_raw_equivalent"] == 100
+    assert event["tokens_targeted_read"] == 40
+    assert event["tokens_saved_vs_targeted_read"] == 30
+    assert event["savings_pct_vs_targeted_read"] == 75.0
+    assert daily["tokens_targeted_read"] == 40
+    assert daily["tokens_saved_vs_targeted_read"] == 30
+
+
+def test_record_omits_targeted_read_when_absent(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite"
+    repo_root = _repo(tmp_path)
+    set_metrics_enabled(True, db_path=db_path)
+
+    MetricsRecorder(db_path).record(_event(repo_root))
+
+    with MetricsStore(db_path).connect() as conn:
+        event = conn.execute("SELECT * FROM usage_events").fetchone()
+        daily = conn.execute("SELECT * FROM daily_usage").fetchone()
+    # The full-file baseline still records; the targeted baseline is omitted (NULL).
+    assert event["tokens_raw_equivalent"] == 100
+    assert event["tokens_targeted_read"] is None
+    assert event["tokens_saved_vs_targeted_read"] is None
+    assert event["savings_pct_vs_targeted_read"] is None
+    assert daily["tokens_targeted_read"] == 0
+
+
 def _event(
     repo_root: Path,
     *,
     occurred_at: datetime | None = None,
     trace: TraceDetails | None = None,
+    targeted_read: int | None = None,
 ) -> UsageEvent:
     return UsageEvent(
         repo_root=repo_root,
@@ -159,6 +197,7 @@ def _event(
         tokens_returned=10,
         tokens_raw_equivalent=100,
         whole_repo_tokens=1000,
+        tokens_targeted_read=targeted_read,
         occurred_at=occurred_at,
         file_count=2,
         freshness="clean",

--- a/tests/metrics/test_storage.py
+++ b/tests/metrics/test_storage.py
@@ -88,6 +88,81 @@ def test_usage_events_schema_has_no_privileged_payload_columns(tmp_path: Path) -
     assert event_columns.isdisjoint(forbidden)
 
 
+def test_v1_ledger_migrates_to_targeted_read_columns(tmp_path: Path) -> None:
+    db_path = tmp_path / "usage.sqlite"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE repos (
+            repo_id TEXT PRIMARY KEY, repo_root TEXT NOT NULL UNIQUE,
+            display_name TEXT NOT NULL, first_seen_at TEXT NOT NULL, last_seen_at TEXT NOT NULL
+        );
+        CREATE TABLE usage_events (
+            event_id TEXT PRIMARY KEY, occurred_at TEXT NOT NULL, repo_id TEXT NOT NULL,
+            surface TEXT NOT NULL, tool_name TEXT NOT NULL, category TEXT NOT NULL,
+            tokens_returned INTEGER NOT NULL, tokens_raw_equivalent INTEGER NOT NULL,
+            tokens_saved INTEGER NOT NULL, savings_pct REAL NOT NULL,
+            whole_repo_tokens INTEGER, whole_repo_tokens_avoided INTEGER,
+            baseline_type TEXT NOT NULL, file_count INTEGER NOT NULL DEFAULT 0,
+            freshness TEXT, index_revision TEXT, trace_id TEXT
+        );
+        CREATE TABLE daily_usage (
+            day TEXT NOT NULL, repo_id TEXT NOT NULL, surface TEXT NOT NULL,
+            tool_name TEXT NOT NULL, category TEXT NOT NULL,
+            tokens_returned INTEGER NOT NULL DEFAULT 0,
+            tokens_raw_equivalent INTEGER NOT NULL DEFAULT 0,
+            tokens_saved INTEGER NOT NULL DEFAULT 0,
+            whole_repo_tokens_avoided INTEGER NOT NULL DEFAULT 0,
+            event_count INTEGER NOT NULL DEFAULT 0,
+            first_event_at TEXT NOT NULL, last_event_at TEXT NOT NULL,
+            PRIMARY KEY (day, repo_id, surface, tool_name, category)
+        );
+        CREATE TABLE usage_traces (
+            trace_id TEXT PRIMARY KEY, event_id TEXT NOT NULL, expires_at TEXT NOT NULL,
+            query_text TEXT, returned_file_paths TEXT NOT NULL DEFAULT '[]',
+            symbols TEXT NOT NULL DEFAULT '[]', handles TEXT NOT NULL DEFAULT '[]',
+            skipped_counts TEXT NOT NULL DEFAULT '{}',
+            tokens_returned INTEGER NOT NULL, tokens_raw_equivalent INTEGER NOT NULL,
+            tokens_saved INTEGER NOT NULL, savings_pct REAL NOT NULL,
+            whole_repo_tokens INTEGER, whole_repo_tokens_avoided INTEGER,
+            repo_id TEXT NOT NULL, index_revision TEXT
+        );
+        INSERT INTO repos VALUES ('r1', '/repo', 'repo', '2026-01-01', '2026-01-01');
+        INSERT INTO usage_events(
+            event_id, occurred_at, repo_id, surface, tool_name, category,
+            tokens_returned, tokens_raw_equivalent, tokens_saved, savings_pct,
+            whole_repo_tokens, whole_repo_tokens_avoided, baseline_type, file_count
+        ) VALUES ('e1', '2026-01-01T00:00:00+00:00', 'r1', 'cli', 'query',
+            'context_retrieval', 10, 100, 90, 90.0, 1000, 990, 'returned_full_files', 2);
+        """
+    )
+    conn.execute("PRAGMA user_version = 1")
+    conn.commit()
+    conn.close()
+
+    # Opening through MetricsStore runs the forward migration in place.
+    with MetricsStore(db_path).connect() as conn:
+        user_version = conn.execute("PRAGMA user_version").fetchone()[0]
+        event_cols = {row["name"] for row in conn.execute("PRAGMA table_info(usage_events)")}
+        daily_cols = {row["name"] for row in conn.execute("PRAGMA table_info(daily_usage)")}
+        trace_cols = {row["name"] for row in conn.execute("PRAGMA table_info(usage_traces)")}
+        row = conn.execute("SELECT * FROM usage_events WHERE event_id = 'e1'").fetchone()
+
+    assert user_version == SCHEMA_VERSION
+    targeted = {
+        "tokens_targeted_read",
+        "tokens_saved_vs_targeted_read",
+        "savings_pct_vs_targeted_read",
+    }
+    assert targeted <= event_cols
+    assert {"tokens_targeted_read", "tokens_saved_vs_targeted_read"} <= daily_cols
+    assert targeted <= trace_cols
+    # Pre-existing data survives; the new columns default to NULL on the legacy row.
+    assert row["tokens_returned"] == 10
+    assert row["tokens_raw_equivalent"] == 100
+    assert row["tokens_targeted_read"] is None
+
+
 def _table_names(conn: sqlite3.Connection) -> set[str]:
     return {
         str(row["name"])


### PR DESCRIPTION
## Summary

Adds a second, realistic token-savings baseline — `targeted_read` — recorded per event alongside the full-file baseline from PR #363. The targeted-read baseline models the realistic counterfactual of reading the matched line ranges plus a small context window, rather than pasting whole files. Metrics-only: no retrieval, returned set, or chunk `token_count` change.

Depends on #363.

- Bumps the metrics ledger `SCHEMA_VERSION` 1 → 2 with a forward, idempotent, per-column migration (ALTER for existing DBs, columns in the fresh-DB create script). New columns: `tokens_targeted_read`, `tokens_saved_vs_targeted_read`, `savings_pct_vs_targeted_read` on `usage_events`/`usage_traces` (nullable) and `tokens_targeted_read`/`tokens_saved_vs_targeted_read` on `daily_usage` (NOT NULL DEFAULT 0).
- Generalizes `TokenSavings`/`compute_token_savings` and `UsageEvent` to carry the targeted-read figures; the recorder persists both baselines.
- `capture.record_query_usage` derives `targeted_read` from the returned chunks' line spans: per file, the union of `[start_line-K, end_line+K]` spans (K=5), costed from the indexed chunk content's per-line token density. Deterministic, index-only (no file read, no model), clamped into `[returned, full_file]`.
- Scout events omit `targeted_read` (no chunk bodies to cost) — recorded as NULL; aggregates skip it.

## Invariant

`returned <= targeted_read <= full_file` is enforced by clamping and asserted in tests; it is never weakened to move a number.

## Tests

- Recorder persists both baselines; targeted savings correct; omitted (NULL) when absent with daily aggregates defaulting to 0.
- v1 ledger migrates forward to the targeted columns without data loss (round-trip on a hand-built v1 DB), landing at `SCHEMA_VERSION` 2.
- `targeted_read` within `[returned, full_file]`, deterministic on a fixed returned set, performs no file-system read, and is `None` without spans.

## Validation

- `uv run ruff check` / `ruff format --check` — pass
- `uv run pyright` (strict, incl. tests) — 0 errors
- `uv run pytest tests/metrics/test_recorder.py tests/metrics/test_storage.py tests/metrics/test_instrumentation.py --no-cov` — 31 passed

## Stack

Stack-Id: `metrics-honesty-b5169b`
Base: `feat/metrics-exact-full-file-baseline`
Position: 2/3

1. `feat/metrics-exact-full-file-baseline` → #363
2. `feat/metrics-targeted-read-baseline` → this PR
3. `feat/metrics-honest-reporting` → (upstack)

Depends on: #363
