### PR TITLE
Honest two-baseline metrics reporting + docs (metrics-only)

### DIFF
--- a/docs/INSTALLATION_TRUST_CONTRACT.md
+++ b/docs/INSTALLATION_TRUST_CONTRACT.md
@@ -260,7 +260,7 @@ ARCHEX_USAGE_TRACE=off
 
 Detailed traces are local-only and opt-in. They may store query text, returned file paths, symbols, handles, skipped counts, token math, repo ID, and index revision. They never store source code, rendered output bodies, or prompt bodies.
 
-Headline savings always mean saved tokens versus returned full files. Whole-repo avoided tokens are stored separately and must be treated as an upper-bound/context metric, not the headline savings number.
+archex records two labeled savings numbers per event: savings versus a full-file paste (compression vs naive full-file access) and savings versus a realistic targeted read (matched line ranges plus a small context window — the conservative number). The full-file baseline equals the true per-file token cost, so it is not inflated by synthetic per-chunk import breadcrumbs. Whole-repo avoided tokens are stored separately and must be treated as an upper-bound/context metric, demoted below the savings lines and never reported as the headline savings number. A defensible cross-tool number (versus grep / read / LSP) is not produced in-process; it is available only via the offline benchmark harness.
 Run `archex doctor --security --format json` to inspect selected providers, remote-code policy, revision pins, cache state, offline environment flags, and model-download implications.
 
 ## Remote-code policy

--- a/docs/LOCAL_METRICS.md
+++ b/docs/LOCAL_METRICS.md
@@ -41,9 +41,9 @@ When metrics are enabled, default event rows store anonymous counters only:
 - tool name
 - category
 - returned tokens
-- raw-equivalent tokens
-- saved tokens
-- savings percent
+- full-file (raw-equivalent) tokens
+- saved tokens and savings percent vs full-file
+- optional targeted-read tokens and savings vs targeted read
 - optional whole-repo avoided tokens
 - file count
 - freshness
@@ -66,44 +66,70 @@ The local `repos` table does map the machine-local repo UUID back to a local pat
 
 ## Savings calculation
 
-The metrics ledger tracks three token views:
+The metrics ledger tracks these token views per event:
 
 1. Returned tokens
    - The size of the actual archex response delivered to the caller.
 
-2. Raw-equivalent tokens
-   - The cost of returning the same result as full-file access for the files archex actually returned.
-   - This is the baseline used for the headline savings number.
-   - `baseline_type` is currently `returned_full_files`.
+2. Full-file tokens (raw-equivalent)
+   - The true token cost of reading the returned files in full (`count_tokens` of each
+     file's source, summed), derived from the index — not a chunk sum, which would
+     over-count synthetic per-chunk import breadcrumbs.
+   - This is the naive "paste the whole file" baseline. `baseline_type` is
+     `returned_full_files`.
 
-3. Whole-repo tokens
-   - The token count for the indexed repository when archex already has that number cheaply.
-   - This is not the headline baseline. It is context only.
+3. Targeted-read tokens
+   - The realistic counterfactual: reading only the matched line ranges plus a small
+     context window (K = 5 lines each side), costed from the index.
+   - Recorded when line spans are available (`query`); omitted (null) otherwise
+     (for example, scout file-only results).
+
+4. Whole-repo tokens
+   - The token count for the indexed repository when archex already has that number
+     cheaply. Context only, never a savings number.
+
+The two savings numbers each name their baseline:
+
+- Savings vs full-file paste — compression versus dumping every returned file in full.
+- Savings vs realistic targeted read — the conservative number, versus how code is
+  actually pulled (matched ranges plus a little context).
 
 The formulas are:
 
 ```text
-tokens_saved = max(tokens_raw_equivalent - tokens_returned, 0)
-savings_pct = 0 if tokens_raw_equivalent <= 0 else (tokens_saved / tokens_raw_equivalent) * 100
-whole_repo_tokens_avoided = null if whole_repo_tokens is unavailable
-whole_repo_tokens_avoided = max(whole_repo_tokens - tokens_returned, 0) otherwise
+tokens_saved              = max(full_file - returned, 0)
+savings_pct               = 0 if full_file <= 0 else (tokens_saved / full_file) * 100
+
+tokens_saved_vs_targeted  = max(targeted_read - returned, 0)   # null if targeted unavailable
+savings_pct_vs_targeted   = 0 if targeted_read <= 0 else (tokens_saved_vs_targeted / targeted_read) * 100
+
+whole_repo_tokens_avoided = max(whole_repo - returned, 0)      # null if whole_repo unavailable
 ```
+
+Invariant: `returned <= targeted_read <= full_file`.
 
 Example:
 
 ```text
-returned tokens = 6,132
-raw-equivalent tokens = 13,120
-whole-repo tokens = 1,302,860
+returned tokens      = 6,132
+full-file tokens     = 13,120
+targeted-read tokens = 8,400
+whole-repo tokens    = 1,302,860
 
-tokens_saved = 13,120 - 6,132 = 6,988
-savings_pct = 6,988 / 13,120 = 53.3%
-whole_repo_tokens_avoided = 1,302,860 - 6,132 = 1,296,728
+savings_pct             = (13,120 - 6,132) / 13,120 = 53.3%   (vs full-file paste)
+savings_pct_vs_targeted = (8,400 - 6,132)  / 8,400  = 27.0%   (vs realistic targeted read)
+whole_repo_tokens_avoided = 1,302,860 - 6,132 = 1,296,728     (context only, not savings)
 ```
 
 Interpretation:
-- `tokens_saved` is the headline savings number.
-- `whole_repo_tokens_avoided` is an upper-bound/context metric, not the headline number.
+- `savings_pct` (vs full-file paste) is compression versus a naive full-file paste.
+- `savings_pct_vs_targeted_read` is the realistic, conservative number.
+- `whole_repo_tokens_avoided` is an upper-bound/context metric, never the headline.
+- A defensible cross-tool number (vs grep / read / LSP) is not produced in-process; it
+  is available only via the offline benchmark harness.
+
+Both baselines are derived from the index (per-file token totals and chunk line spans).
+Neither re-reads files on the query path, and no metrics path calls a model.
 
 ## Surface defaults
 
@@ -213,19 +239,22 @@ If recording fails:
 The health flag lives in the single machine-local ledger (`~/.archex/usage.sqlite`), so
 it is shared across every repo on the machine.
 
-Expected, non-actionable conditions are **not** treated as failures. The optional
-whole-repo and raw-equivalent token baselines are computed by walking the source tree;
-when a source is not a usable local repo (path gone, not a directory, no `.git`), that
-baseline is simply omitted (`whole_repo_tokens` becomes null) without latching a warning.
+Expected, non-actionable conditions are **not** treated as failures. The full-file and
+targeted-read baselines are derived from the index (per-file token totals and chunk line
+spans); when those are unavailable — a legacy index built before per-file totals existed,
+or a source that is not a usable local repo — the baseline is simply omitted (the event is
+not recorded, or `targeted_read`/`whole_repo_tokens` become null) without latching a
+warning. A reindex repopulates the per-file totals.
 
 ## Reading the output
 
 `archex metrics summary` reports:
-- headline saved tokens versus returned full files
 - returned token total
-- raw-equivalent token total
-- percentage savings
-- whole-repo avoided tokens as context only
+- full-file (raw-equivalent) token total
+- targeted-read token total
+- savings vs full-file paste (compression) and savings vs realistic targeted read
+- whole-repo avoided tokens, demoted below the savings lines and labeled an
+  upper-bound/context number, not savings
 - a per-surface event split (`cli` / `mcp` / `python_api`)
 
 The surface split shows how many events each surface contributed. A near-zero `mcp`

--- a/docs/LOCAL_METRICS.md
+++ b/docs/LOCAL_METRICS.md
@@ -106,7 +106,7 @@ savings_pct_vs_targeted   = 0 if targeted_read <= 0 else (tokens_saved_vs_target
 whole_repo_tokens_avoided = max(whole_repo - returned, 0)      # null if whole_repo unavailable
 ```
 
-Invariant: `returned <= targeted_read <= full_file`.
+Invariant: `returned <= targeted_read <= full_file` for any input where `returned <= full_file` (the realistic case). On a tiny file whose rendered chunks exceed its source (`returned > full_file`), `targeted_read` is capped at `full_file`, so savings versus targeted reports 0.
 
 Example:
 

--- a/src/archex/metrics/reporter.py
+++ b/src/archex/metrics/reporter.py
@@ -184,11 +184,13 @@ def render_summary_text(payload: dict[str, Any]) -> str:
         f"Trace:                  {_on_off(payload['trace_enabled'])}",
         f"Events:                 {payload['event_count']}",
         f"Surface mix:            {surface_mix}",
-        f"Saved tokens:           {totals['tokens_saved']} vs returned full files",
         f"Returned tokens:        {totals['tokens_returned']}",
-        f"Raw-equivalent tokens:  {totals['tokens_raw_equivalent']}",
-        f"Savings:                {totals['savings_pct']:.1f}%",
-        f"Whole-repo avoided:     {totals['whole_repo_tokens_avoided']} upper-bound/context only",
+        f"Full-file tokens:       {totals['tokens_raw_equivalent']}",
+        f"Targeted-read tokens:   {totals['tokens_targeted_read']}",
+        f"Savings vs full-file:   {totals['savings_pct']:.1f}% (vs full-file paste)",
+        f"Savings vs targeted:    "
+        f"{totals['savings_pct_vs_targeted_read']:.1f}% (vs realistic targeted read)",
+        f"Whole-repo avoided:     {totals['whole_repo_tokens_avoided']} (upper bound, not savings)",
     ]
     if payload["health_warning"]:
         lines.append(f"Metrics warning:        {payload['health_warning']}")
@@ -284,7 +286,9 @@ def _totals(conn: Any, window: TimeWindow, repo_ids: list[str] | None) -> dict[s
             COALESCE(SUM(tokens_returned), 0) AS tokens_returned,
             COALESCE(SUM(tokens_raw_equivalent), 0) AS tokens_raw_equivalent,
             COALESCE(SUM(tokens_saved), 0) AS tokens_saved,
-            COALESCE(SUM(whole_repo_tokens_avoided), 0) AS whole_repo_tokens_avoided
+            COALESCE(SUM(whole_repo_tokens_avoided), 0) AS whole_repo_tokens_avoided,
+            COALESCE(SUM(tokens_targeted_read), 0) AS tokens_targeted_read,
+            COALESCE(SUM(tokens_saved_vs_targeted_read), 0) AS tokens_saved_vs_targeted_read
         FROM usage_events
         WHERE {" AND ".join(clauses)}
         """,
@@ -296,8 +300,12 @@ def _totals(conn: Any, window: TimeWindow, repo_ids: list[str] | None) -> dict[s
         "tokens_raw_equivalent": int(row["tokens_raw_equivalent"]),
         "tokens_saved": int(row["tokens_saved"]),
         "whole_repo_tokens_avoided": int(row["whole_repo_tokens_avoided"]),
+        "tokens_targeted_read": int(row["tokens_targeted_read"]),
     }
     totals["savings_pct"] = _savings_pct(totals["tokens_saved"], totals["tokens_raw_equivalent"])
+    totals["savings_pct_vs_targeted_read"] = _savings_pct(
+        int(row["tokens_saved_vs_targeted_read"]), totals["tokens_targeted_read"]
+    )
     totals["by_surface"] = _surface_mix(conn, clauses, params)
     return totals
 
@@ -309,7 +317,9 @@ def _empty_totals() -> dict[str, Any]:
         "tokens_raw_equivalent": 0,
         "tokens_saved": 0,
         "whole_repo_tokens_avoided": 0,
+        "tokens_targeted_read": 0,
         "savings_pct": 0.0,
+        "savings_pct_vs_targeted_read": 0.0,
         "by_surface": _empty_surface_mix(),
     }
 

--- a/src/archex/status.py
+++ b/src/archex/status.py
@@ -10,7 +10,7 @@ from archex.cache import CacheManager
 from archex.config import load_config
 from archex.index.delta import compute_working_tree_signature
 from archex.index.store import IndexStore
-from archex.metrics.storage import metrics_db_path
+from archex.metrics.storage import MetricsStore, metrics_db_path
 from archex.project import ProjectState
 
 
@@ -150,9 +150,10 @@ def _metrics_savings(repo_root: Path) -> dict[str, int | float] | None:
     if not db_path.exists():
         return None
     try:
-        conn = sqlite3.connect(db_path)
-        conn.row_factory = sqlite3.Row
-        try:
+        # Open through MetricsStore so the ledger is migrated before querying the
+        # targeted-read columns; a raw connection on a pre-migration ledger would
+        # raise and silently drop the savings line until another command migrates it.
+        with MetricsStore(db_path).connect() as conn:
             repo = conn.execute(
                 "SELECT repo_id FROM repos WHERE repo_root = ?",
                 (str(repo_root.resolve()),),
@@ -172,8 +173,6 @@ def _metrics_savings(repo_root: Path) -> dict[str, int | float] | None:
                 """,
                 (str(repo["repo_id"]),),
             ).fetchone()
-        finally:
-            conn.close()
     except sqlite3.Error:
         return None
     raw = int(row["tokens_raw_equivalent"])

--- a/src/archex/status.py
+++ b/src/archex/status.py
@@ -164,7 +164,9 @@ def _metrics_savings(repo_root: Path) -> dict[str, int | float] | None:
                 SELECT COUNT(*) AS event_count,
                     COALESCE(SUM(tokens_saved), 0) AS tokens_saved,
                     COALESCE(SUM(tokens_returned), 0) AS tokens_returned,
-                    COALESCE(SUM(tokens_raw_equivalent), 0) AS tokens_raw_equivalent
+                    COALESCE(SUM(tokens_raw_equivalent), 0) AS tokens_raw_equivalent,
+                    COALESCE(SUM(tokens_targeted_read), 0) AS tokens_targeted_read,
+                    COALESCE(SUM(tokens_saved_vs_targeted_read), 0) AS tokens_saved_vs_targeted_read
                 FROM usage_events
                 WHERE repo_id = ?
                 """,
@@ -176,12 +178,18 @@ def _metrics_savings(repo_root: Path) -> dict[str, int | float] | None:
         return None
     raw = int(row["tokens_raw_equivalent"])
     saved = int(row["tokens_saved"])
+    targeted = int(row["tokens_targeted_read"])
+    saved_vs_targeted = int(row["tokens_saved_vs_targeted_read"])
     return {
         "event_count": int(row["event_count"]),
         "tokens_saved": saved,
         "tokens_returned": int(row["tokens_returned"]),
         "tokens_raw_equivalent": raw,
+        "tokens_targeted_read": targeted,
         "savings_pct": (saved / raw * 100.0) if raw > 0 else 0.0,
+        "savings_pct_vs_targeted_read": (
+            (saved_vs_targeted / targeted * 100.0) if targeted > 0 else 0.0
+        ),
     }
 
 

--- a/tests/metrics/test_metrics_cli.py
+++ b/tests/metrics/test_metrics_cli.py
@@ -30,10 +30,55 @@ def test_bare_metrics_prints_current_repo_summary(
         result = runner.invoke(cli, ["metrics"])
 
     assert result.exit_code == 0, result.output
-    assert "Saved tokens:           90 vs returned full files" in result.output
-    assert "Whole-repo avoided:     990 upper-bound/context only" in result.output
+    assert "Savings vs full-file:   90.0% (vs full-file paste)" in result.output
+    assert "Savings vs targeted:    0.0% (vs realistic targeted read)" in result.output
+    assert "Whole-repo avoided:     990 (upper bound, not savings)" in result.output
     assert "Recording:              on" in result.output
     assert "Trace:                  off" in result.output
+
+
+def test_metrics_summary_shows_both_baselines_and_demotes_whole_repo(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo_root = tmp_path / "repo-b"
+    repo_root.mkdir()
+    db_path = metrics_db_path(home=tmp_path)
+    set_metrics_enabled(True, db_path=db_path)
+    # returned=10, targeted=40, full_file=100 -> 90% vs full-file, 75% vs targeted.
+    MetricsRecorder(db_path).record(
+        UsageEvent(
+            repo_root=repo_root,
+            surface="cli",
+            tool_name="query",
+            category="context_retrieval",
+            tokens_returned=10,
+            tokens_raw_equivalent=100,
+            whole_repo_tokens=1000,
+            tokens_targeted_read=40,
+            occurred_at=datetime.now(UTC),
+            file_count=1,
+        )
+    )
+    runner = CliRunner()
+    text = runner.invoke(cli, ["metrics", "summary", str(repo_root)])
+    payload = runner.invoke(cli, ["metrics", "summary", str(repo_root), "--format", "json"])
+
+    assert text.exit_code == 0, text.output
+    assert "Savings vs full-file:   90.0% (vs full-file paste)" in text.output
+    assert "Savings vs targeted:    75.0% (vs realistic targeted read)" in text.output
+    assert "Whole-repo avoided:     990 (upper bound, not savings)" in text.output
+    # The whole-repo line is demoted below the savings lines.
+    lines = text.output.splitlines()
+    savings_idx = next(i for i, ln in enumerate(lines) if ln.startswith("Savings vs targeted:"))
+    whole_idx = next(i for i, ln in enumerate(lines) if ln.startswith("Whole-repo avoided:"))
+    assert whole_idx > savings_idx
+
+    totals = json.loads(payload.output)["totals"]
+    assert totals["savings_pct"] == 90.0
+    assert totals["savings_pct_vs_targeted_read"] == 75.0
+    assert totals["tokens_targeted_read"] == 40
 
 
 def test_metrics_summary_repos_inspect_json(
@@ -66,6 +111,8 @@ def test_metrics_summary_repos_inspect_json(
     inspect_payload = json.loads(inspect.output)
     workspace_payload = json.loads(workspace.output)
     assert summary_payload["totals"]["tokens_saved"] == 90
+    assert "savings_pct_vs_targeted_read" in summary_payload["totals"]
+    assert "tokens_targeted_read" in summary_payload["totals"]
     assert workspace_payload["totals"]["tokens_saved"] == 90
     assert repos_payload["repos"][0]["display_name"] == "repo-a"
     assert inspect_payload["events"][0]["tool_name"] == "query"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -269,6 +269,72 @@ def test_status_command_reports_metrics_savings(
     assert metrics["savings_pct"] == 90.0
 
 
+def test_status_reports_metrics_savings_on_legacy_ledger(
+    python_simple_repo: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sqlite3
+
+    from archex.metrics.storage import metrics_db_path
+    from archex.project import init_project
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    init_project(python_simple_repo)
+    runner = CliRunner()
+    indexed = runner.invoke(cli, ["index", str(python_simple_repo), "--format", "json"])
+    assert indexed.exit_code == 0, indexed.output
+
+    # Build a pre-targeted (v1) ledger by hand: usage_events lacks the targeted-read
+    # columns, so status must migrate it before the savings query references them.
+    db_path = metrics_db_path(home=tmp_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE repos (
+            repo_id TEXT PRIMARY KEY, repo_root TEXT NOT NULL UNIQUE,
+            display_name TEXT NOT NULL, first_seen_at TEXT NOT NULL, last_seen_at TEXT NOT NULL
+        );
+        CREATE TABLE usage_events (
+            event_id TEXT PRIMARY KEY, occurred_at TEXT NOT NULL, repo_id TEXT NOT NULL,
+            surface TEXT NOT NULL, tool_name TEXT NOT NULL, category TEXT NOT NULL,
+            tokens_returned INTEGER NOT NULL, tokens_raw_equivalent INTEGER NOT NULL,
+            tokens_saved INTEGER NOT NULL, savings_pct REAL NOT NULL,
+            whole_repo_tokens INTEGER, whole_repo_tokens_avoided INTEGER,
+            baseline_type TEXT NOT NULL, file_count INTEGER NOT NULL DEFAULT 0,
+            freshness TEXT, index_revision TEXT, trace_id TEXT
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO repos VALUES (?, ?, ?, ?, ?)",
+        ("r1", str(python_simple_repo.resolve()), "repo", "2026-01-01", "2026-01-01"),
+    )
+    conn.execute(
+        """
+        INSERT INTO usage_events(
+            event_id, occurred_at, repo_id, surface, tool_name, category,
+            tokens_returned, tokens_raw_equivalent, tokens_saved, savings_pct,
+            whole_repo_tokens, whole_repo_tokens_avoided, baseline_type, file_count
+        ) VALUES ('e1', '2026-01-01T00:00:00+00:00', 'r1', 'cli', 'query',
+            'context_retrieval', 10, 100, 90, 90.0, 1000, 990, 'returned_full_files', 1)
+        """
+    )
+    conn.execute("PRAGMA user_version = 1")
+    conn.commit()
+    conn.close()
+
+    result = runner.invoke(cli, ["status", str(python_simple_repo), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    metrics = json.loads(result.output)["metrics_savings"]
+    assert metrics is not None
+    assert metrics["event_count"] == 1
+    assert metrics["tokens_saved"] == 90
+    assert metrics["savings_pct_vs_targeted_read"] == 0.0
+
+
 def test_status_command_strict_fails_on_dirty_index(python_simple_repo: Path) -> None:
     from archex.project import init_project
 


### PR DESCRIPTION
## Summary

Makes `archex metrics summary` report both savings baselines honestly and demotes the whole-repo upper bound, and brings the docs in line with the shipped output. Metrics/reporting-only.

Depends on #364 (and #363).

- Text summary shows two labeled numbers — `Savings vs full-file: …% (vs full-file paste)` (compression vs naive paste) and `Savings vs targeted: …% (vs realistic targeted read)` — and moves the whole-repo line below them, tagged `(upper bound, not savings)`.
- JSON `totals` keeps `savings_pct` meaning the full-file value (unchanged for existing consumers) and adds `savings_pct_vs_targeted_read` and `tokens_targeted_read`.
- `status.py` repo savings figure carries the targeted figures consistently.
- `docs/LOCAL_METRICS.md` (Savings calculation, stored fields, failure behavior, Reading the output) and the headline-savings sentence in `docs/INSTALLATION_TRUST_CONTRACT.md` document both baselines, the formulas, and the honest interpretation: full-file = compression vs naive paste; targeted-read = realistic counterfactual; whole-repo = context-only upper bound; cross-tool = benchmark-only. No doc claims a number the ledger does not produce.

## Smoke (isolated HOME, full index of a fixture copy)

```text
Returned tokens:        707
Full-file tokens:       512
Targeted-read tokens:   512
Savings vs full-file:   0.0% (vs full-file paste)
Savings vs targeted:    0.0% (vs realistic targeted read)
Whole-repo avoided:     0 (upper bound, not savings)
```

On a tiny fixture, archex's rendered output exceeds the files' true token count, so the honest result is 0% — the inflated headline is gone. JSON exposes `savings_pct_vs_targeted_read` and `tokens_targeted_read`.

## Tests

- `test_metrics_cli.py`: both percentages render with their baseline labels, the whole-repo line is demoted below them and labeled non-savings, and the JSON totals expose the new keys.

## Validation

- `uv run ruff check` / `ruff format --check` — pass
- `uv run pyright` (strict, incl. tests) — 0 errors
- `uv run pytest tests/metrics/test_metrics_cli.py --no-cov` — 8 passed

## Stack

Stack-Id: `metrics-honesty-b5169b`
Base: `feat/metrics-targeted-read-baseline`
Position: 3/3

1. `feat/metrics-exact-full-file-baseline` → #363
2. `feat/metrics-targeted-read-baseline` → #364
3. `feat/metrics-honest-reporting` → this PR

Depends on: #364
