### PR TITLE
Cross-tool token-efficiency: naive baseline + tokens-at-fixed-recall metric

### DIFF
--- a/src/archex/benchmark/cross_tool.py
+++ b/src/archex/benchmark/cross_tool.py
@@ -1,0 +1,466 @@
+"""Offline cross-tool token-efficiency comparison: archex retrieval vs a naive baseline.
+
+This module models the token cost of *localizing* a task's required files two ways
+and compares them at a fixed required-file recall:
+
+- **archex**: the targeted regions the ``archex_query`` retrieval returns, in rank
+  order. The cost to localize is the sum of region tokens consumed until the
+  required files are covered.
+- **naive baseline**: how a non-archex agent reaches the same files — grep the
+  corpus for the task keywords, then either read the full grep-hit files
+  (``full_file``) or read ``+/-K`` context windows around the grep hits
+  (``grep_window``), in grep-relevance order. The cost to localize is the sum of
+  file/window tokens consumed until the required files are covered.
+
+The comparison is **offline and benchmark-only**: it never touches the query hot
+path, the in-process metrics ledger, retrieval ranking, or any product default.
+The naive token model is a pure, deterministic function of the corpus snapshot,
+the task keywords, and the context window ``K`` (tokenized with the same
+``cl100k_base`` encoder the rest of archex uses).
+
+Recall is held equal across the compared paths: a token delta is reported only
+for tasks where *both* paths reach the target required-file recall, so the
+aggregate efficiency number never compares unequal recall.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+from archex import __version__
+from archex.acquire.discovery import discover_files
+from archex.benchmark.models import BenchmarkTask, TaskCategory, TaskFamily
+from archex.reporting import count_tokens
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from archex.benchmark.region_metrics import ReturnedRegion
+
+logger = logging.getLogger(__name__)
+
+# Source extensions the naive grep model scans, matching the existing raw grep/rg
+# baselines so archex and naive see the same corpus.
+_SOURCE_EXTENSIONS: frozenset[str] = frozenset(
+    {".py", ".ts", ".js", ".go", ".rs", ".java", ".kt", ".cs", ".swift"}
+)
+
+# Corpus buckets the cross-tool number is aggregated per. Localization is graded
+# as its own corpus and never merged with comprehension.
+CORPUS_SELF = "self"
+CORPUS_EXTERNAL_COMPREHENSION = "external-comprehension"
+CORPUS_EXTERNAL_LOCALIZATION = "external-localization"
+_CORPUS_ORDER: tuple[str, ...] = (
+    CORPUS_SELF,
+    CORPUS_EXTERNAL_COMPREHENSION,
+    CORPUS_EXTERNAL_LOCALIZATION,
+)
+
+
+class NaiveBaselineModel(StrEnum):
+    """How the naive (non-archex) baseline spends tokens to read a grep-hit file."""
+
+    FULL_FILE = "full_file"
+    GREP_WINDOW = "grep_window"
+
+
+@dataclass(frozen=True)
+class RetrievalUnit:
+    """One context unit a path surfaces, in the order that path ranks it.
+
+    ``path`` is a repo-relative POSIX path; ``tokens`` is the cl100k_base token
+    cost of opening this unit (a region, a full file, or a context window).
+    """
+
+    path: str
+    tokens: int
+
+
+@dataclass(frozen=True)
+class _FileScan:
+    """A scanned source file with at least one keyword hit."""
+
+    path: str
+    hit_lines: tuple[int, ...]
+    content: str
+
+
+class PathTokensAtRecall(BaseModel):
+    """Tokens one path spends to reach a target required-file recall.
+
+    ``recall_reached`` is the achieved required-file recall at the measurement
+    point; ``target_reached`` is whether the target recall was reached at all.
+    When the target is reached, ``tokens`` counts every unit consumed up to and
+    including the one that crossed the target; otherwise it counts every unit.
+    """
+
+    tokens: int
+    recall_reached: float
+    target_reached: bool
+    units_consumed: int
+
+
+class NaiveBaselineResult(BaseModel):
+    """A naive baseline model and its tokens-at-recall for one task."""
+
+    model: NaiveBaselineModel
+    at_recall: PathTokensAtRecall
+
+
+class CrossToolTaskComparison(BaseModel):
+    """Per-task archex-vs-naive tokens-at-fixed-recall comparison."""
+
+    task_id: str
+    repo: str
+    corpus: str
+    family: TaskFamily
+    category: TaskCategory | None = None
+    required_file_count: int
+    target_recall: float
+    context_window: int
+    archex: PathTokensAtRecall
+    naive: list[NaiveBaselineResult]
+
+
+class CrossToolAggregate(BaseModel):
+    """Per-corpus, per-naive-model aggregate over tasks where recall is held equal.
+
+    ``comparable_count`` is the number of tasks where both archex and this naive
+    model reach the target recall; every token figure is summed/averaged over
+    exactly that comparable set, so the reduction never reflects unequal recall.
+    """
+
+    corpus: str
+    model: NaiveBaselineModel
+    task_count: int
+    comparable_count: int
+    archex_tokens: int
+    naive_tokens: int
+    mean_token_ratio: float
+    median_token_ratio: float
+    token_reduction_pct: float
+
+
+class CrossToolReport(BaseModel):
+    """Full cross-tool efficiency report: per-task comparisons plus aggregates."""
+
+    generated_at: str
+    strategy: str
+    target_recall: float
+    context_window: int
+    archex_version: str
+    comparisons: list[CrossToolTaskComparison]
+    aggregates: list[CrossToolAggregate]
+
+
+def corpus_of(task: BenchmarkTask) -> str:
+    """Bucket a task into self / external-comprehension / external-localization."""
+    if task.repo == ".":
+        return CORPUS_SELF
+    if task.family is TaskFamily.LOCALIZATION:
+        return CORPUS_EXTERNAL_LOCALIZATION
+    return CORPUS_EXTERNAL_COMPREHENSION
+
+
+def tokens_at_recall(
+    units: Sequence[RetrievalUnit],
+    required_files: Sequence[str],
+    target_recall: float,
+) -> PathTokensAtRecall:
+    """Tokens consumed walking ``units`` until required-file recall reaches the target.
+
+    Required files are covered the first time a unit in that file is consumed.
+    Tokens accrue for every unit consumed (including grep false positives ranked
+    ahead of the required file), modelling the true cost of localizing the
+    required set along that path's own ranking.
+    """
+    required = set(required_files)
+    if not required:
+        return PathTokensAtRecall(
+            tokens=0, recall_reached=1.0, target_reached=True, units_consumed=0
+        )
+
+    covered: set[str] = set()
+    cumulative = 0
+    consumed = 0
+    for unit in units:
+        cumulative += unit.tokens
+        consumed += 1
+        if unit.path in required:
+            covered.add(unit.path)
+        recall = len(covered) / len(required)
+        if recall + 1e-9 >= target_recall:
+            return PathTokensAtRecall(
+                tokens=cumulative,
+                recall_reached=recall,
+                target_reached=True,
+                units_consumed=consumed,
+            )
+    return PathTokensAtRecall(
+        tokens=cumulative,
+        recall_reached=len(covered) / len(required),
+        target_reached=False,
+        units_consumed=consumed,
+    )
+
+
+def archex_units(regions: Sequence[ReturnedRegion]) -> list[RetrievalUnit]:
+    """One retrieval unit per returned region, preserving the bundle's rank order."""
+    return [RetrievalUnit(path=region.path, tokens=region.tokens) for region in regions]
+
+
+def _iter_source_files(repo_path: Path) -> list[tuple[str, Path]]:
+    """Repo source files the naive model may open, as ``(rel_posix, absolute)``.
+
+    Reuses archex's gitignore-aware discovery so the naive grep agent scans the
+    same corpus archex indexes (no ``.venv``/build-artifact pollution), then
+    narrows to the source extensions the grep/ripgrep baselines search. Sorted
+    for determinism.
+    """
+    files = [
+        (Path(discovered.path).as_posix(), Path(discovered.absolute_path))
+        for discovered in discover_files(repo_path)
+        if Path(discovered.path).suffix in _SOURCE_EXTENSIONS
+    ]
+    return sorted(files)
+
+
+def _scan_for_hits(repo_path: Path, keywords: Sequence[str]) -> list[_FileScan]:
+    """Deterministic in-process grep: source files with >=1 case-insensitive hit.
+
+    Pure Python (no subprocess for matching), so the naive token model is
+    reproducible across machines regardless of the installed grep/ripgrep.
+    """
+    if not keywords:
+        return []
+    pattern = re.compile("|".join(re.escape(keyword) for keyword in keywords), re.IGNORECASE)
+    scans: list[_FileScan] = []
+    for rel, absolute in _iter_source_files(repo_path):
+        content = absolute.read_text(encoding="utf-8", errors="replace")
+        hit_lines = tuple(
+            number
+            for number, line in enumerate(content.splitlines(), start=1)
+            if pattern.search(line)
+        )
+        if hit_lines:
+            scans.append(_FileScan(path=rel, hit_lines=hit_lines, content=content))
+    return scans
+
+
+def _window_tokens(content: str, hit_lines: Sequence[int], context_window: int) -> int:
+    """Tokens of the merged ``+/-context_window`` line windows around grep hits."""
+    lines = content.splitlines()
+    line_count = len(lines)
+    selected: set[int] = set()
+    for hit in hit_lines:
+        low = max(1, hit - context_window)
+        high = min(line_count, hit + context_window)
+        selected.update(range(low, high + 1))
+    if not selected:
+        return 0
+    window_text = "\n".join(lines[number - 1] for number in sorted(selected))
+    return count_tokens(window_text)
+
+
+def naive_units(
+    repo_path: Path,
+    task: BenchmarkTask,
+    *,
+    model: NaiveBaselineModel,
+    context_window: int,
+) -> list[RetrievalUnit]:
+    """Ordered naive-baseline units for a task: grep-hit files in relevance order.
+
+    Files are ranked by hit count (descending) with a path tiebreak, the order a
+    naive agent would triage grep output. ``full_file`` costs the whole file;
+    ``grep_window`` costs only the merged context windows around the hits.
+    """
+    from archex.benchmark.strategies import extract_keywords
+
+    keywords = extract_keywords(task.question, task.keywords)
+    scans = _scan_for_hits(repo_path, keywords)
+    ordered = sorted(scans, key=lambda scan: (-len(scan.hit_lines), scan.path))
+    units: list[RetrievalUnit] = []
+    for scan in ordered:
+        if model is NaiveBaselineModel.FULL_FILE:
+            tokens = count_tokens(scan.content)
+        else:
+            tokens = _window_tokens(scan.content, scan.hit_lines, context_window)
+        units.append(RetrievalUnit(path=scan.path, tokens=tokens))
+    return units
+
+
+def compare_task(
+    task: BenchmarkTask,
+    repo_path: Path,
+    regions: Sequence[ReturnedRegion],
+    *,
+    target_recall: float,
+    context_window: int,
+    models: Sequence[NaiveBaselineModel],
+) -> CrossToolTaskComparison:
+    """Compare archex's targeted token cost against each naive model for one task."""
+    archex = tokens_at_recall(archex_units(regions), task.expected_files, target_recall)
+    naive: list[NaiveBaselineResult] = []
+    for model in models:
+        units = naive_units(repo_path, task, model=model, context_window=context_window)
+        naive.append(
+            NaiveBaselineResult(
+                model=model,
+                at_recall=tokens_at_recall(units, task.expected_files, target_recall),
+            )
+        )
+    return CrossToolTaskComparison(
+        task_id=task.task_id,
+        repo=task.repo,
+        corpus=corpus_of(task),
+        family=task.family,
+        category=task.category,
+        required_file_count=len(task.expected_files),
+        target_recall=target_recall,
+        context_window=context_window,
+        archex=archex,
+        naive=naive,
+    )
+
+
+def _median(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[middle]
+    return (ordered[middle - 1] + ordered[middle]) / 2
+
+
+def _naive_for_model(
+    comparison: CrossToolTaskComparison, model: NaiveBaselineModel
+) -> NaiveBaselineResult | None:
+    for result in comparison.naive:
+        if result.model is model:
+            return result
+    return None
+
+
+def aggregate_cross_tool(
+    comparisons: Sequence[CrossToolTaskComparison],
+    models: Sequence[NaiveBaselineModel],
+) -> list[CrossToolAggregate]:
+    """Aggregate per corpus and naive model over the recall-held-equal task set."""
+    by_corpus: dict[str, list[CrossToolTaskComparison]] = {}
+    for comparison in comparisons:
+        by_corpus.setdefault(comparison.corpus, []).append(comparison)
+
+    ordered_corpora = [corpus for corpus in _CORPUS_ORDER if corpus in by_corpus]
+    ordered_corpora += [corpus for corpus in sorted(by_corpus) if corpus not in _CORPUS_ORDER]
+
+    aggregates: list[CrossToolAggregate] = []
+    for corpus in ordered_corpora:
+        corpus_comparisons = by_corpus[corpus]
+        for model in models:
+            comparable = [
+                comparison
+                for comparison in corpus_comparisons
+                if comparison.archex.target_reached
+                and (naive := _naive_for_model(comparison, model)) is not None
+                and naive.at_recall.target_reached
+            ]
+            archex_tokens = sum(comparison.archex.tokens for comparison in comparable)
+            naive_tokens = 0
+            ratios: list[float] = []
+            for comparison in comparable:
+                naive = _naive_for_model(comparison, model)
+                assert naive is not None  # guaranteed by the comparable filter
+                naive_tokens += naive.at_recall.tokens
+                if comparison.archex.tokens > 0:
+                    ratios.append(naive.at_recall.tokens / comparison.archex.tokens)
+            reduction = (
+                (naive_tokens - archex_tokens) / naive_tokens * 100.0 if naive_tokens > 0 else 0.0
+            )
+            aggregates.append(
+                CrossToolAggregate(
+                    corpus=corpus,
+                    model=model,
+                    task_count=len(corpus_comparisons),
+                    comparable_count=len(comparable),
+                    archex_tokens=archex_tokens,
+                    naive_tokens=naive_tokens,
+                    mean_token_ratio=(sum(ratios) / len(ratios)) if ratios else 0.0,
+                    median_token_ratio=_median(ratios),
+                    token_reduction_pct=reduction,
+                )
+            )
+    return aggregates
+
+
+def run_cross_tool(
+    tasks: Sequence[BenchmarkTask],
+    *,
+    target_recall: float = 1.0,
+    context_window: int = 5,
+    models: Sequence[NaiveBaselineModel] = (
+        NaiveBaselineModel.FULL_FILE,
+        NaiveBaselineModel.GREP_WINDOW,
+    ),
+    strategy_label: str = "archex_query",
+    regions_provider: Callable[[BenchmarkTask, Path], list[ReturnedRegion]] | None = None,
+    on_task: Callable[[int, BenchmarkTask], None] | None = None,
+) -> CrossToolReport:
+    """Run the cross-tool comparison over ``tasks`` and aggregate per corpus.
+
+    ``regions_provider`` returns archex's ranked returned regions for a task;
+    it defaults to the real ``archex_query`` retrieval. Repos are cloned and
+    scoped exactly as the standard benchmark runner does. A per-task clone
+    failure is isolated so one bad repo does not abort the batch.
+    """
+    from archex.benchmark.runner import repo_path_for_task
+    from archex.benchmark.strategies import archex_returned_regions
+    from archex.exceptions import BenchmarkCloneError
+
+    provider = regions_provider or archex_returned_regions
+    repo_cache: dict[tuple[str, str, tuple[str, ...]], Path] = {}
+    cleanup_paths: list[Path] = []
+    comparisons: list[CrossToolTaskComparison] = []
+    try:
+        for index, task in enumerate(tasks, start=1):
+            if on_task is not None:
+                on_task(index, task)
+            try:
+                repo_path = repo_path_for_task(task, repo_cache, cleanup_paths)
+            except BenchmarkCloneError as exc:
+                logger.warning("Skipping cross-tool task %s: %s", task.task_id, exc)
+                continue
+            regions = provider(task, repo_path)
+            comparisons.append(
+                compare_task(
+                    task,
+                    repo_path,
+                    regions,
+                    target_recall=target_recall,
+                    context_window=context_window,
+                    models=models,
+                )
+            )
+    finally:
+        for path in cleanup_paths:
+            shutil.rmtree(path, ignore_errors=True)
+
+    return CrossToolReport(
+        generated_at=datetime.now(tz=UTC).isoformat(),
+        strategy=strategy_label,
+        target_recall=target_recall,
+        context_window=context_window,
+        archex_version=__version__,
+        comparisons=comparisons,
+        aggregates=aggregate_cross_tool(comparisons, models),
+    )

--- a/src/archex/benchmark/cross_tool.py
+++ b/src/archex/benchmark/cross_tool.py
@@ -163,7 +163,14 @@ class CrossToolReport(BaseModel):
 
 
 def corpus_of(task: BenchmarkTask) -> str:
-    """Bucket a task into self / external-comprehension / external-localization."""
+    """Bucket a task into self / external-comprehension / external-localization.
+
+    The cross-tool number publishes exactly these three corpora. Self-repo tasks
+    bucket to ``self`` first (the maintained self corpus is comprehension-shaped;
+    the localization family is external by construction). External tasks split
+    so external localization is graded as its own corpus, never merged with
+    external comprehension.
+    """
     if task.repo == ".":
         return CORPUS_SELF
     if task.family is TaskFamily.LOCALIZATION:
@@ -420,12 +427,12 @@ def run_cross_tool(
 
     ``regions_provider`` returns archex's ranked returned regions for a task;
     it defaults to the real ``archex_query`` retrieval. Repos are cloned and
-    scoped exactly as the standard benchmark runner does. A per-task clone
-    failure is isolated so one bad repo does not abort the batch.
+    scoped exactly as the standard benchmark runner does. A per-task clone or
+    retrieval failure is isolated so one bad repo does not abort the batch.
     """
     from archex.benchmark.runner import repo_path_for_task
     from archex.benchmark.strategies import archex_returned_regions
-    from archex.exceptions import BenchmarkCloneError
+    from archex.exceptions import ArchexIndexError, BenchmarkCloneError
 
     provider = regions_provider or archex_returned_regions
     repo_cache: dict[tuple[str, str, tuple[str, ...]], Path] = {}
@@ -440,7 +447,11 @@ def run_cross_tool(
             except BenchmarkCloneError as exc:
                 logger.warning("Skipping cross-tool task %s: %s", task.task_id, exc)
                 continue
-            regions = provider(task, repo_path)
+            try:
+                regions = provider(task, repo_path)
+            except (ArchexIndexError, NotImplementedError) as exc:
+                logger.warning("Skipping cross-tool task %s: %s", task.task_id, exc)
+                continue
             comparisons.append(
                 compare_task(
                     task,

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from archex.benchmark.cross_tool import CrossToolReport
     from archex.benchmark.models import BenchmarkReport, BenchmarkResult, DeltaBenchmarkResult
 
 
@@ -1020,5 +1021,80 @@ def format_delta_summary(results: list[DeltaBenchmarkResult]) -> str:
             f"| {r.chunks_updated} | {r.chunks_unchanged} |"
         )
 
+    lines.append("")
+    return "\n".join(lines)
+
+
+_CORPUS_LABELS = {
+    "self": "Self (archex repo)",
+    "external-comprehension": "External comprehension",
+    "external-localization": "External localization",
+}
+
+
+def _fmt_ratio(value: float) -> str:
+    return "n/a" if value <= 0 else f"{value:.1f}x"
+
+
+def format_cross_tool_comparison(report: CrossToolReport) -> str:
+    """Render the offline cross-tool tokens-at-fixed-recall comparison.
+
+    Shows, per corpus and naive model, the tokens archex spends to localize a
+    task's required files versus a naive grep/read agent, at a fixed required-file
+    recall. Recall is held equal: the aggregate counts only tasks where both
+    paths reach the target, so a token reduction never compares unequal recall.
+    Localization is graded as its own corpus and never merged with comprehension.
+    """
+    target_pct = f"{report.target_recall * 100:.0f}%"
+    lines = [
+        "# Cross-Tool Token Efficiency (offline benchmark)",
+        "",
+        f"Tokens to reach {target_pct} required-file recall: archex "
+        f"`{report.strategy}` retrieval vs a naive grep/read agent. "
+        "Offline benchmark only — no in-process metric or query-path change.",
+        "",
+        "Recall is held equal: deltas count only tasks where both paths reach the "
+        "target recall. Naive models: `full_file` reads whole grep-hit files in "
+        f"relevance order; `grep_window` reads +/-{report.context_window} line "
+        "context windows around grep hits. Both tokenized with cl100k_base.",
+        "",
+        "## Per-corpus aggregate (recall held equal)",
+        "",
+        "| Corpus | Naive model | Tasks | Comparable | archex tokens "
+        "| naive tokens | Naive/archex | Token reduction |",
+        "|--------|-------------|------:|-----------:|--------------:"
+        "|-------------:|-------------:|----------------:|",
+    ]
+    for aggregate in report.aggregates:
+        corpus_label = _CORPUS_LABELS.get(aggregate.corpus, aggregate.corpus)
+        lines.append(
+            f"| {corpus_label} | {aggregate.model.value} "
+            f"| {aggregate.task_count} | {aggregate.comparable_count} "
+            f"| {aggregate.archex_tokens:,} | {aggregate.naive_tokens:,} "
+            f"| {_fmt_ratio(aggregate.mean_token_ratio)} "
+            f"| {aggregate.token_reduction_pct:.1f}% |"
+        )
+    lines.append("")
+    lines.append("## Per-task (tokens at fixed required-file recall)")
+    lines.append("")
+    lines.append(
+        "| Task | Corpus | archex tokens | archex recall | Naive model "
+        "| naive tokens | naive recall | Both reached |"
+    )
+    lines.append(
+        "|------|--------|--------------:|--------------:|-------------"
+        "|-------------:|-------------:|:------------:|"
+    )
+    for comparison in report.comparisons:
+        for naive in comparison.naive:
+            both = comparison.archex.target_reached and naive.at_recall.target_reached
+            lines.append(
+                f"| {comparison.task_id} | {comparison.corpus} "
+                f"| {comparison.archex.tokens:,} "
+                f"| {comparison.archex.recall_reached:.3f} "
+                f"| {naive.model.value} | {naive.at_recall.tokens:,} "
+                f"| {naive.at_recall.recall_reached:.3f} "
+                f"| {'yes' if both else 'no'} |"
+            )
     lines.append("")
     return "\n".join(lines)

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -1061,9 +1061,9 @@ def format_cross_tool_comparison(report: CrossToolReport) -> str:
         "## Per-corpus aggregate (recall held equal)",
         "",
         "| Corpus | Naive model | Tasks | Comparable | archex tokens "
-        "| naive tokens | Naive/archex | Token reduction |",
+        "| naive tokens | Mean naive/archex | Token reduction |",
         "|--------|-------------|------:|-----------:|--------------:"
-        "|-------------:|-------------:|----------------:|",
+        "|-------------:|-----------------:|----------------:|",
     ]
     for aggregate in report.aggregates:
         corpus_label = _CORPUS_LABELS.get(aggregate.corpus, aggregate.corpus)

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -1291,6 +1291,25 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     )
 
 
+def archex_returned_regions(task: BenchmarkTask, repo_path: Path) -> list[ReturnedRegion]:
+    """Ranked returned regions from the default ``archex_query`` retrieval.
+
+    Benchmark-only helper that exposes the bundle's targeted regions in rank
+    order so offline analyses (e.g. the cross-tool tokens-at-recall comparison)
+    can measure archex's localization token cost without re-implementing
+    retrieval. It runs the same pipeline as ``run_archex_query`` and never
+    changes retrieval ranking, the returned set, or any product path.
+    """
+    bundle, _config, _timing = _query_bundle(
+        task,
+        repo_path,
+        strategy=Strategy.ARCHEX_QUERY,
+        index_config=IndexConfig(vector=False),
+        cache=benchmark_cache_enabled(default=False),
+    )
+    return _bundle_returned_regions(bundle)
+
+
 _PASSTHROUGH_SCORE_FRACTION = 0.6
 
 

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -18,6 +18,7 @@ from archex.benchmark.arch_quality import (
 from archex.benchmark.baseline import compare_baseline, load_baseline, save_baseline
 from archex.benchmark.bundle_eval import BundleOnlyEvaluatorError, run_bundle_only_eval_all
 from archex.benchmark.competitive import format_competitive_markdown, load_compression_results
+from archex.benchmark.cross_tool import NaiveBaselineModel, run_cross_tool
 from archex.benchmark.delta_runner import run_all_delta
 from archex.benchmark.gate import (
     DeltaQualityThresholds,
@@ -45,6 +46,7 @@ from archex.benchmark.models import (
     ArchitectureBenchmarkResult,
     BenchmarkReport,
     BenchmarkRetrievalOptions,
+    BenchmarkTask,
     BundleOnlyEvaluatorCommand,
     DeltaBenchmarkResult,
     Strategy,
@@ -60,6 +62,7 @@ from archex.benchmark.reporter import (
     format_baseline_comparison,
     format_bucketed_summary,
     format_chunker_frontier_table,
+    format_cross_tool_comparison,
     format_delta_summary,
     format_json,
     format_localization_summary,
@@ -278,6 +281,91 @@ def run_cmd(
         raise click.ClickException(str(exc)) from exc
 
     click.echo(f"\nCompleted {len(reports)} benchmark(s).", err=True)
+
+
+@benchmark_cmd.command("cross-tool")
+@click.option(
+    "--output",
+    "output_dir",
+    default=".archex/cross-tool-efficiency",
+    type=click.Path(),
+    help="Directory for the cross-tool comparison artifact.",
+)
+@click.option("--task", "task_id", default=None, help="Run a single task by task_id.")
+@click.option(
+    "--tasks-dir",
+    default="benchmarks/tasks",
+    type=click.Path(exists=True),
+    help="Directory containing task YAML files.",
+)
+@click.option(
+    "--target-recall",
+    default=1.0,
+    show_default=True,
+    type=click.FloatRange(0.0, 1.0, min_open=True),
+    help="Required-file recall both paths must reach before tokens are compared.",
+)
+@click.option(
+    "--context-window",
+    default=5,
+    show_default=True,
+    type=click.IntRange(min=0),
+    help="Context lines around each grep hit for the grep_window naive model.",
+)
+@click.option(
+    "--naive-model",
+    "naive_models",
+    multiple=True,
+    type=click.Choice([model.value for model in NaiveBaselineModel]),
+    help="Naive baseline model(s) to compare (repeatable; default: all).",
+)
+@click.option(
+    "--self-only",
+    is_flag=True,
+    default=False,
+    help='Run only benchmark tasks whose repo is ".".',
+)
+def cross_tool_cmd(
+    output_dir: str,
+    task_id: str | None,
+    tasks_dir: str,
+    target_recall: float,
+    context_window: int,
+    naive_models: tuple[str, ...],
+    self_only: bool,
+) -> None:
+    """Offline cross-tool tokens-at-fixed-recall comparison: archex vs naive grep/read.
+
+    Benchmark-only: it never touches the query hot path, the in-process metrics
+    ledger, retrieval ranking, or any product default.
+    """
+    models = (
+        tuple(NaiveBaselineModel(name) for name in naive_models)
+        if naive_models
+        else (NaiveBaselineModel.FULL_FILE, NaiveBaselineModel.GREP_WINDOW)
+    )
+    tasks = load_selected_tasks(Path(tasks_dir), task_filter=task_id, self_only=self_only)
+
+    def _log(index: int, task: BenchmarkTask) -> None:
+        click.echo(f"[{index}/{len(tasks)}] {task.task_id} ({task.repo})", err=True)
+
+    try:
+        report = run_cross_tool(
+            tasks,
+            target_recall=target_recall,
+            context_window=context_window,
+            models=models,
+            on_task=_log,
+        )
+    except ArchexError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    artifact = output_path / "cross-tool-comparison.json"
+    artifact.write_text(report.model_dump_json(indent=2), encoding="utf-8")
+    click.echo(format_cross_tool_comparison(report))
+    click.echo(f"\nWrote cross-tool artifact to {artifact}", err=True)
 
 
 @benchmark_cmd.command("bundle-eval")

--- a/tests/benchmark/test_cross_tool.py
+++ b/tests/benchmark/test_cross_tool.py
@@ -1,0 +1,315 @@
+"""Tests for the offline cross-tool tokens-at-fixed-recall comparison."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from archex.benchmark.cross_tool import (
+    CrossToolTaskComparison,
+    NaiveBaselineModel,
+    NaiveBaselineResult,
+    PathTokensAtRecall,
+    RetrievalUnit,
+    aggregate_cross_tool,
+    archex_units,
+    compare_task,
+    corpus_of,
+    naive_units,
+    run_cross_tool,
+    tokens_at_recall,
+)
+from archex.benchmark.models import BenchmarkTask, TaskFamily
+from archex.benchmark.region_metrics import ReturnedRegion
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_QUESTION = "Where is zorptoken handled?"
+
+
+def _build_repo(root: Path) -> Path:
+    """A small repo: a required file with sparse hits, a noisier false positive."""
+    pkg = root / "pkg"
+    pkg.mkdir(parents=True)
+    # 2 keyword hits in the file that must be localized.
+    (pkg / "target.py").write_text("def handle(zorptoken):\n    return zorptoken\n")
+    # 3 keyword hits: a naive agent triages this false positive first.
+    (pkg / "noise.py").write_text("zorptoken\nzorptoken\nzorptoken\n")
+    # One hit near the top, then many non-matching lines: window << full file.
+    body = "\n".join(["zorptoken = 0", *[f"padding_{i} = {i}" for i in range(40)]])
+    (pkg / "big.py").write_text(body + "\n")
+    # No keyword hits at all.
+    (pkg / "unrelated.py").write_text("answer = 41\n")
+    return root
+
+
+def _loc_task(expected: list[str], *, repo: str = "owner/repo") -> BenchmarkTask:
+    return BenchmarkTask(
+        task_id="loc_zorp",
+        repo=repo,
+        commit="HEAD",
+        question=_QUESTION,
+        expected_files=expected,
+        family=TaskFamily.LOCALIZATION,
+    )
+
+
+class TestTokensAtRecall:
+    def test_walks_until_target_reached(self) -> None:
+        units = [
+            RetrievalUnit("a.py", 10),
+            RetrievalUnit("b.py", 20),
+            RetrievalUnit("c.py", 30),
+        ]
+        at = tokens_at_recall(units, ["b.py", "c.py"], 1.0)
+        assert at.target_reached
+        assert at.tokens == 60  # pays for the false positive a.py too
+        assert at.recall_reached == 1.0
+        assert at.units_consumed == 3
+
+    def test_stops_at_partial_target(self) -> None:
+        units = [RetrievalUnit("a.py", 10), RetrievalUnit("b.py", 20), RetrievalUnit("c.py", 30)]
+        at = tokens_at_recall(units, ["b.py", "c.py"], 0.5)
+        # Half the required set is covered by b.py; stop before paying for c.py.
+        assert at.target_reached
+        assert at.tokens == 30
+        assert at.recall_reached == 0.5
+        assert at.units_consumed == 2
+
+    def test_unreached_target(self) -> None:
+        units = [RetrievalUnit("a.py", 10)]
+        at = tokens_at_recall(units, ["b.py"], 1.0)
+        assert not at.target_reached
+        assert at.tokens == 10
+        assert at.recall_reached == 0.0
+
+    def test_empty_required_set_is_trivially_reached(self) -> None:
+        at = tokens_at_recall([RetrievalUnit("a.py", 10)], [], 1.0)
+        assert at.target_reached
+        assert at.tokens == 0
+        assert at.units_consumed == 0
+
+
+class TestCorpusOf:
+    def test_self_repo(self) -> None:
+        assert corpus_of(_loc_task(["pkg/target.py"], repo=".")) == "self"
+
+    def test_external_localization(self) -> None:
+        assert corpus_of(_loc_task(["pkg/target.py"])) == "external-localization"
+
+    def test_external_comprehension(self) -> None:
+        task = BenchmarkTask(
+            task_id="comp",
+            repo="owner/repo",
+            commit="HEAD",
+            question=_QUESTION,
+            expected_files=["pkg/target.py"],
+            family=TaskFamily.COMPREHENSION,
+        )
+        assert corpus_of(task) == "external-comprehension"
+
+
+class TestNaiveTokenModel:
+    def test_full_file_model_is_deterministic(self, tmp_path: Path) -> None:
+        repo = _build_repo(tmp_path)
+        task = _loc_task(["pkg/target.py"])
+        first = naive_units(repo, task, model=NaiveBaselineModel.FULL_FILE, context_window=5)
+        second = naive_units(repo, task, model=NaiveBaselineModel.FULL_FILE, context_window=5)
+        assert first == second
+
+    def test_orders_files_by_hit_count(self, tmp_path: Path) -> None:
+        repo = _build_repo(tmp_path)
+        task = _loc_task(["pkg/target.py"])
+        units = naive_units(repo, task, model=NaiveBaselineModel.FULL_FILE, context_window=5)
+        paths = [unit.path for unit in units]
+        # noise.py (3 hits) outranks big.py and target.py (lower hit counts).
+        assert paths[0] == "pkg/noise.py"
+        # unrelated.py has no keyword hit, so a naive grep never opens it.
+        assert "pkg/unrelated.py" not in paths
+
+    def test_grep_window_never_exceeds_full_file(self, tmp_path: Path) -> None:
+        repo = _build_repo(tmp_path)
+        task = _loc_task(["pkg/target.py"])
+        full = {
+            unit.path: unit.tokens
+            for unit in naive_units(
+                repo, task, model=NaiveBaselineModel.FULL_FILE, context_window=5
+            )
+        }
+        window = {
+            unit.path: unit.tokens
+            for unit in naive_units(
+                repo, task, model=NaiveBaselineModel.GREP_WINDOW, context_window=5
+            )
+        }
+        for path, full_tokens in full.items():
+            assert window[path] <= full_tokens
+        # big.py has sparse hits, so the window is strictly cheaper than the file.
+        assert window["pkg/big.py"] < full["pkg/big.py"]
+
+
+class TestCompareTask:
+    def test_recall_held_equal_when_both_reach_target(self, tmp_path: Path) -> None:
+        repo = _build_repo(tmp_path)
+        task = _loc_task(["pkg/target.py"])
+        regions = [ReturnedRegion("pkg/target.py", 1, 2, "handle", 8)]
+        comparison = compare_task(
+            task,
+            repo,
+            regions,
+            target_recall=1.0,
+            context_window=5,
+            models=[NaiveBaselineModel.FULL_FILE],
+        )
+        naive = comparison.naive[0].at_recall
+        assert comparison.archex.target_reached and naive.target_reached
+        # Both measured at the same achieved recall.
+        assert comparison.archex.recall_reached == naive.recall_reached == 1.0
+        # archex's targeted region is cheaper than reading full grep-hit files.
+        assert comparison.archex.tokens < naive.tokens
+
+    def test_naive_miss_is_not_marked_reached(self, tmp_path: Path) -> None:
+        repo = _build_repo(tmp_path)
+        # unrelated.py has no keyword hit: the naive grep path can never reach it.
+        task = _loc_task(["pkg/unrelated.py"])
+        regions = [ReturnedRegion("pkg/unrelated.py", 1, 1, None, 5)]
+        comparison = compare_task(
+            task,
+            repo,
+            regions,
+            target_recall=1.0,
+            context_window=5,
+            models=[NaiveBaselineModel.FULL_FILE],
+        )
+        assert comparison.archex.target_reached
+        assert not comparison.naive[0].at_recall.target_reached
+
+
+def _comparison(
+    task_id: str,
+    corpus: str,
+    family: TaskFamily,
+    *,
+    archex_tokens: int,
+    naive_tokens: int,
+    naive_reached: bool = True,
+) -> CrossToolTaskComparison:
+    return CrossToolTaskComparison(
+        task_id=task_id,
+        repo="." if corpus == "self" else "owner/repo",
+        corpus=corpus,
+        family=family,
+        category=None,
+        required_file_count=1,
+        target_recall=1.0,
+        context_window=5,
+        archex=PathTokensAtRecall(
+            tokens=archex_tokens, recall_reached=1.0, target_reached=True, units_consumed=1
+        ),
+        naive=[
+            NaiveBaselineResult(
+                model=NaiveBaselineModel.FULL_FILE,
+                at_recall=PathTokensAtRecall(
+                    tokens=naive_tokens,
+                    recall_reached=1.0 if naive_reached else 0.0,
+                    target_reached=naive_reached,
+                    units_consumed=1,
+                ),
+            )
+        ],
+    )
+
+
+class TestAggregate:
+    def test_grades_localization_separately(self) -> None:
+        comparisons = [
+            _comparison(
+                "loc",
+                "external-localization",
+                TaskFamily.LOCALIZATION,
+                archex_tokens=100,
+                naive_tokens=1000,
+            ),
+            _comparison(
+                "comp",
+                "external-comprehension",
+                TaskFamily.COMPREHENSION,
+                archex_tokens=200,
+                naive_tokens=400,
+            ),
+        ]
+        aggregates = aggregate_cross_tool(comparisons, [NaiveBaselineModel.FULL_FILE])
+        by_corpus = {agg.corpus: agg for agg in aggregates}
+        assert set(by_corpus) == {"external-localization", "external-comprehension"}
+        # The localization corpus aggregates only its own task.
+        loc = by_corpus["external-localization"]
+        assert loc.archex_tokens == 100 and loc.naive_tokens == 1000
+        assert loc.token_reduction_pct == pytest.approx(90.0)  # pyright: ignore[reportUnknownMemberType]
+        assert loc.mean_token_ratio == pytest.approx(10.0)  # pyright: ignore[reportUnknownMemberType]
+
+    def test_excludes_tasks_at_unequal_recall(self) -> None:
+        comparisons = [
+            _comparison(
+                "reached", "self", TaskFamily.COMPREHENSION, archex_tokens=100, naive_tokens=500
+            ),
+            _comparison(
+                "missed",
+                "self",
+                TaskFamily.COMPREHENSION,
+                archex_tokens=100,
+                naive_tokens=999,
+                naive_reached=False,
+            ),
+        ]
+        aggregates = aggregate_cross_tool(comparisons, [NaiveBaselineModel.FULL_FILE])
+        agg = aggregates[0]
+        assert agg.task_count == 2
+        # Only the both-reached task contributes to the token delta.
+        assert agg.comparable_count == 1
+        assert agg.archex_tokens == 100 and agg.naive_tokens == 500
+
+
+class TestRunCrossTool:
+    def test_orchestrates_with_injected_regions(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = _build_repo(tmp_path)
+        task = _loc_task(["pkg/target.py"])
+
+        import archex.benchmark.runner as runner_mod
+
+        def _fixed_repo(
+            _task: BenchmarkTask,
+            _cache: dict[tuple[str, str, tuple[str, ...]], Path],
+            _cleanup: list[Path],
+        ) -> Path:
+            return repo
+
+        monkeypatch.setattr(runner_mod, "repo_path_for_task", _fixed_repo)
+        regions = [ReturnedRegion("pkg/target.py", 1, 2, "handle", 8)]
+
+        report = run_cross_tool(
+            [task],
+            models=[NaiveBaselineModel.FULL_FILE],
+            regions_provider=lambda _task, _path: regions,
+        )
+
+        assert report.target_recall == 1.0
+        assert len(report.comparisons) == 1
+        assert report.comparisons[0].archex.tokens == 8
+        agg = report.aggregates[0]
+        assert agg.corpus == "external-localization"
+        assert agg.comparable_count == 1
+        assert agg.naive_tokens > agg.archex_tokens
+
+
+class TestArchexUnits:
+    def test_preserves_region_order(self) -> None:
+        regions = [
+            ReturnedRegion("a.py", 1, 5, "f", 12),
+            ReturnedRegion("b.py", 1, 5, "g", 34),
+        ]
+        units = archex_units(regions)
+        assert [(u.path, u.tokens) for u in units] == [("a.py", 12), ("b.py", 34)]

--- a/tests/benchmark/test_cross_tool.py
+++ b/tests/benchmark/test_cross_tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from typing import TYPE_CHECKING
 
 import pytest
@@ -43,6 +44,12 @@ def _build_repo(root: Path) -> Path:
     # No keyword hits at all.
     (pkg / "unrelated.py").write_text("answer = 41\n")
     return root
+
+
+def _git_init(repo: Path) -> None:
+    """Initialise a git repo and stage files so discovery takes the git ls-files path."""
+    subprocess.run(["git", "init", "--quiet"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
 
 
 def _loc_task(expected: list[str], *, repo: str = "owner/repo") -> BenchmarkTask:
@@ -148,6 +155,19 @@ class TestNaiveTokenModel:
             assert window[path] <= full_tokens
         # big.py has sparse hits, so the window is strictly cheaper than the file.
         assert window["pkg/big.py"] < full["pkg/big.py"]
+
+    def test_full_file_model_is_deterministic_over_git_corpus(self, tmp_path: Path) -> None:
+        # A real benchmark repo has a .git dir, so discovery uses git ls-files
+        # rather than the rglob fallback; the model must be deterministic there too.
+        repo = _build_repo(tmp_path)
+        _git_init(repo)
+        task = _loc_task(["pkg/target.py"])
+        first = naive_units(repo, task, model=NaiveBaselineModel.FULL_FILE, context_window=5)
+        second = naive_units(repo, task, model=NaiveBaselineModel.FULL_FILE, context_window=5)
+        assert first == second
+        # The git ls-files path discovers the same source files as the fallback.
+        assert [unit.path for unit in first][0] == "pkg/noise.py"
+        assert "pkg/unrelated.py" not in [unit.path for unit in first]
 
 
 class TestCompareTask:

--- a/tests/benchmark/test_reporter.py
+++ b/tests/benchmark/test_reporter.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from archex.benchmark.cross_tool import (
+    CrossToolAggregate,
+    CrossToolReport,
+    CrossToolTaskComparison,
+    NaiveBaselineModel,
+    NaiveBaselineResult,
+    PathTokensAtRecall,
+)
 from archex.benchmark.models import (
     BenchmarkReport,
     BenchmarkResult,
@@ -15,6 +23,7 @@ from archex.benchmark.models import (
 from archex.benchmark.reporter import (
     format_bucketed_summary,
     format_chunker_frontier_table,
+    format_cross_tool_comparison,
     format_json,
     format_localization_summary,
     format_markdown,
@@ -864,3 +873,62 @@ class TestSymbolicRerankLocalizationGrading:
         assert "unknown" not in sym_rows[0]
         assert "0.830" in sym_rows[0]  # file MRR
         assert "0.740" in sym_rows[0]  # ranked-region MRR
+
+
+def _cross_tool_report() -> CrossToolReport:
+    archex = PathTokensAtRecall(
+        tokens=120, recall_reached=1.0, target_reached=True, units_consumed=2
+    )
+    naive = NaiveBaselineResult(
+        model=NaiveBaselineModel.FULL_FILE,
+        at_recall=PathTokensAtRecall(
+            tokens=1500, recall_reached=1.0, target_reached=True, units_consumed=4
+        ),
+    )
+    comparison = CrossToolTaskComparison(
+        task_id="loc_zorp",
+        repo="owner/repo",
+        corpus="external-localization",
+        family=TaskFamily.LOCALIZATION,
+        required_file_count=1,
+        target_recall=1.0,
+        context_window=5,
+        archex=archex,
+        naive=[naive],
+    )
+    aggregate = CrossToolAggregate(
+        corpus="external-localization",
+        model=NaiveBaselineModel.FULL_FILE,
+        task_count=1,
+        comparable_count=1,
+        archex_tokens=120,
+        naive_tokens=1500,
+        mean_token_ratio=12.5,
+        median_token_ratio=12.5,
+        token_reduction_pct=92.0,
+    )
+    return CrossToolReport(
+        generated_at="2026-06-23T00:00:00Z",
+        strategy="archex_query",
+        target_recall=1.0,
+        context_window=5,
+        archex_version="0.14.0",
+        comparisons=[comparison],
+        aggregates=[aggregate],
+    )
+
+
+class TestCrossToolReporting:
+    def test_renders_aggregate_and_per_task_columns(self) -> None:
+        md = format_cross_tool_comparison(_cross_tool_report())
+        assert "# Cross-Tool Token Efficiency (offline benchmark)" in md
+        assert "Recall is held equal" in md
+        # Per-corpus aggregate columns.
+        assert "| Corpus | Naive model | Tasks | Comparable | archex tokens" in md
+        assert "External localization" in md
+        assert "92.0%" in md  # token reduction
+        assert "12.5x" in md  # naive/archex ratio
+        # Per-task table renders the comparison with both-reached marked yes.
+        assert "## Per-task (tokens at fixed required-file recall)" in md
+        assert "loc_zorp" in md
+        assert "1,500" in md


### PR DESCRIPTION
## Summary

Adds an offline, benchmark-only cross-tool token-efficiency comparison: how many tokens archex retrieval spends to localize a task's required files versus a naive grep/read agent, measured at a fixed required-file recall.

This is Stack B / Workstream M4 of the token-savings-metric-honesty plan. It produces a defensible "vs grep / full-file read" number without any in-process metric, reporter, retrieval, or default-path change.

## What this adds

- `archex/benchmark/cross_tool.py`: the naive token model and the tokens-at-fixed-recall metric.
  - **archex path**: the targeted returned regions of `archex_query`, in rank order; cost to localize = region tokens consumed until the required files are covered.
  - **naive path**: grep the corpus for the task keywords (deterministic, in-process matching over archex's own gitignore-aware corpus), then read either whole grep-hit files (`full_file`) or `+/-K` context windows around the hits (`grep_window`), in grep-relevance order.
  - Both tokenized with the existing `cl100k_base` encoder. The naive model is a pure, deterministic function of the corpus snapshot, the keywords, and `K`.
- `archex_returned_regions` helper in `benchmark/strategies.py` exposing the bundle's ranked regions (same pipeline as `run_archex_query`).
- `format_cross_tool_comparison` reporter: per-corpus aggregate plus per-task tables.
- `archex benchmark cross-tool` subcommand to run the comparison and write the artifact.

## Recall held equal

A token delta is reported only for tasks where **both** paths reach the target required-file recall (default 100%). Tasks where the naive grep path never reaches a required file are marked unreached and excluded from the aggregate, so the efficiency number never compares unequal recall. Localization is aggregated as its own corpus and never merged with comprehension.

## Out of scope (unchanged)

- Not in `DEFAULT_STRATEGIES`; no product code path.
- No in-process metrics ledger, metrics reporter, retrieval ranking, or default change.

## Stack

Stack-Id: `cross-tool-efficiency-cfdfb5`
Base: `main`
Position: 1/2

1. `feat/cross-tool-token-model` -> this PR
2. `feat/cross-tool-artifact-docs` -> per-corpus artifact + docs

Depends on: (none - root)

## Validation

- `uv run ruff check` — pass (changed files)
- `uv run ruff format --check` — pass (changed files)
- `uv run pyright` — pass (changed files)
- `uv run pytest tests/benchmark/test_cross_tool.py tests/benchmark/test_reporter.py tests/benchmark/test_runner.py --no-cov` — 105 passed
