### PR TITLE
Cross-tool efficiency: per-corpus reference artifact + docs

### DIFF
--- a/benchmarks/cross-tool-efficiency/cross-tool-comparison.json
+++ b/benchmarks/cross-tool-efficiency/cross-tool-comparison.json
@@ -1,0 +1,2381 @@
+{
+  "generated_at": "2026-06-23T01:18:07.008263+00:00",
+  "strategy": "archex_query",
+  "target_recall": 1.0,
+  "context_window": 5,
+  "archex_version": "0.14.0",
+  "comparisons": [
+    {
+      "task_id": "archex_adapter_registry",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 2214,
+        "recall_reached": 0.6666666666666666,
+        "target_reached": false,
+        "units_consumed": 22
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 638791,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 173
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 240491,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 173
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_benchmark_gate_lifecycle",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 5,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 1129,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 5
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 445627,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 79
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 295745,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 79
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_delta_index_lifecycle",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 6410,
+        "recall_reached": 0.6666666666666666,
+        "target_reached": false,
+        "units_consumed": 24
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 312020,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 49
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 175828,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 49
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_delta_indexing",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 2,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 1241,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 3
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 210265,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 28
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 107194,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 28
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_graph_expansion",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 2,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 613,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 2
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 187238,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 18
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 112906,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 18
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_mcp_query_lifecycle",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 5,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 1199,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 5
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 629079,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 164
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 306576,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 164
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_pattern_detection",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 2,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 455,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 2
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 343848,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 68
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 128481,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 68
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_project_config_resolution",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 4,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 1728,
+        "recall_reached": 0.75,
+        "target_reached": false,
+        "units_consumed": 8
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 524256,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 127
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 210512,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 127
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_project_index",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 5,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 926,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 5
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 351790,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 59
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 242743,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 59
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_project_init",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 4,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 748,
+        "recall_reached": 0.75,
+        "target_reached": false,
+        "units_consumed": 6
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 611460,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 158
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 313797,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 158
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_project_reset",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 631,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 4
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 622137,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 162
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 305442,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 162
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_project_status",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 4,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 2471,
+        "recall_reached": 0.5,
+        "target_reached": false,
+        "units_consumed": 8
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 468486,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 96
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 296010,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 96
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_query_cache_lifecycle",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 5,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 7330,
+        "recall_reached": 0.8,
+        "target_reached": false,
+        "units_consumed": 33
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 513532,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 111
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 220921,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 111
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_query_pipeline",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 365,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 3
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 336554,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 51
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 209383,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 51
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_scoring",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 793,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 3
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 289620,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 37
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 181705,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 37
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "archex_vector_cache_lifecycle",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 5,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 4298,
+        "recall_reached": 0.6,
+        "target_reached": false,
+        "units_consumed": 15
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 744753,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 236
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 333274,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 236
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "celery_task_dispatch",
+      "repo": "celery/celery",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "external-large",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 2101,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 5
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 63870,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 13
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 47273,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 13
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "click_decorators",
+      "repo": "pallets/click",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "external-framework",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 7044,
+        "recall_reached": 0.6666666666666666,
+        "target_reached": false,
+        "units_consumed": 25
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 41512,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 4
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 31554,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 4
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "django_middleware",
+      "repo": "django/django",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "architecture-broad",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 4737,
+        "recall_reached": 0.6666666666666666,
+        "target_reached": false,
+        "units_consumed": 16
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 31909,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 11
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 21552,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 11
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "django_orm_queries",
+      "repo": "django/django",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "external-large",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 1941,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 6
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 97324,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 6
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 52082,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 6
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "express_error_handling",
+      "repo": "expressjs/express",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "architecture-broad",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 2063,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 5
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 16999,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 5
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 8101,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 5
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "express_middleware",
+      "repo": "expressjs/express",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "framework-semantic",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 1561,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 4
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 21822,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 7
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 14560,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 7
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "fastapi_dependency_injection",
+      "repo": "tiangolo/fastapi",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "framework-semantic",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 4968,
+        "recall_reached": 0.6666666666666666,
+        "target_reached": false,
+        "units_consumed": 17
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 58619,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 10
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 31267,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 10
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "fastapi_routing",
+      "repo": "tiangolo/fastapi",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "external-framework",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 1521,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 5
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 78780,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 4
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 56258,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 4
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "flask_blueprints",
+      "repo": "pallets/flask",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "external-framework",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 2560,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 5
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 54962,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 10
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 28640,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 10
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "gin_routing",
+      "repo": "gin-gonic/gin",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "external-framework",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 522,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 5
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 14812,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 3
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 11909,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 3
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "go_gin_middleware",
+      "repo": "gin-gonic/gin",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "architecture-broad",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 310,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 4
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 19798,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 4
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 9934,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 4
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "httpx_pooling",
+      "repo": "encode/httpx",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "external-framework",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 1575,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 4
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 29143,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 6
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 15789,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 6
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_celery_task_retry",
+      "repo": "celery/celery",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-large",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 505,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 9359,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 9154,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_click_param_process",
+      "repo": "pallets/click",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 814,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 3
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 24337,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 21189,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_django_queryset_filter",
+      "repo": "django/django",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-large",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 102,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 21178,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 16898,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_django_username_validator",
+      "repo": "django/django",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-large",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 3495,
+        "recall_reached": 0.0,
+        "target_reached": false,
+        "units_consumed": 17
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 34551,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 20
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 24540,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 20
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_express_error_middleware",
+      "repo": "expressjs/express",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 621,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 2
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 21822,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 7
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 19579,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 7
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_fastapi_jsonable_encoder",
+      "repo": "tiangolo/fastapi",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 1174,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 3
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 97917,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 7
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 71487,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 7
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_fastapi_solve_dependencies",
+      "repo": "tiangolo/fastapi",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 896,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 5
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 7579,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 5483,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_flask_blueprint_register",
+      "repo": "pallets/flask",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 509,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 5228,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 5030,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_flask_full_dispatch",
+      "repo": "pallets/flask",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 122,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 12978,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 11200,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_gin_context_next",
+      "repo": "gin-gonic/gin",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 68,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 9927,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 8946,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_gin_tree_route",
+      "repo": "gin-gonic/gin",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 177,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 6456,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 6191,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_httpx_pool_transport",
+      "repo": "encode/httpx",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 2033,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 5
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 16576,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 2
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 15093,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 2
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_httpx_redirect_headers",
+      "repo": "encode/httpx",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 436,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 13659,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 12545,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_mini_redis_command_from_frame",
+      "repo": "tokio-rs/mini-redis",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 529,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 3
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 16163,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 7
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 13859,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 7
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_pydantic_validate_call",
+      "repo": "pydantic/pydantic",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 498,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 82933,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 16
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 76370,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 16
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_pytest_fixture_resolution",
+      "repo": "pytest-dev/pytest",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 205,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 16012,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 15243,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_react_dispatch_set_state",
+      "repo": "facebook/react",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-large",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 498,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 43101,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 42057,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_requests_adapter_send",
+      "repo": "psf/requests",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 2199,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 7
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 12072,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 2
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 11389,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 2
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_requests_redirect_auth",
+      "repo": "psf/requests",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-framework",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 473,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 3
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 6353,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 6065,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_sqlalchemy_session_merge",
+      "repo": "sqlalchemy/sqlalchemy",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-large",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 1159,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 3
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 40677,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 35274,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "loc_tokio_current_thread_block_on",
+      "repo": "tokio-rs/tokio",
+      "corpus": "external-localization",
+      "family": "localization",
+      "category": "external-large",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 229,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 5509,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 5358,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 1
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "mini_redis_async",
+      "repo": "tokio-rs/mini-redis",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "external-framework",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 572,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 5
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 16178,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 7
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 11948,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 7
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "pydantic_validators",
+      "repo": "pydantic/pydantic",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "external-framework",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 628,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 3
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 86008,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 18
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 62108,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 18
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "pytest_fixtures",
+      "repo": "pytest-dev/pytest",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "external-framework",
+      "required_file_count": 2,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 1220,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 4
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 29970,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 2
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 23836,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 2
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "react_hooks",
+      "repo": "facebook/react",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "external-large",
+      "required_file_count": 2,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 2676,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 8
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 86538,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 4
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 63916,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 4
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "requests_sessions",
+      "repo": "psf/requests",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "external-framework",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 1536,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 3
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 19529,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 3
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 11862,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 3
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "routing_mixed_cache",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 2,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 122,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 2
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 401747,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 58
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 351887,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 58
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "routing_mixed_chunker",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 683,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 2
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 169004,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 14
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 108235,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 14
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "routing_pl_intent",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 519,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 12366,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 3
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 4417,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 3
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "routing_pl_large",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 107,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 79398,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 6
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 35338,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 6
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "routing_pl_path_symbol",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 189,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 43098,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 2
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 25360,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 2
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "routing_pl_scoring",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 2,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 7380,
+        "recall_reached": 0.5,
+        "target_reached": false,
+        "units_consumed": 20
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 229113,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 30
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 121772,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 30
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "routing_pl_tight",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 1,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 179,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 1
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 213646,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 22
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 135717,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 22
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "routing_trace_api",
+      "repo": ".",
+      "corpus": "self",
+      "family": "comprehension",
+      "category": "self",
+      "required_file_count": 2,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 333,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 3
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 81264,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 4
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 75716,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 4
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "rust_tokio_runtime",
+      "repo": "tokio-rs/tokio",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "external-large",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 192,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 4
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 21662,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 6
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 16712,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 6
+          }
+        }
+      ]
+    },
+    {
+      "task_id": "sqlalchemy_sessions",
+      "repo": "sqlalchemy/sqlalchemy",
+      "corpus": "external-comprehension",
+      "family": "comprehension",
+      "category": "external-large",
+      "required_file_count": 3,
+      "target_recall": 1.0,
+      "context_window": 5,
+      "archex": {
+        "tokens": 1703,
+        "recall_reached": 1.0,
+        "target_reached": true,
+        "units_consumed": 5
+      },
+      "naive": [
+        {
+          "model": "full_file",
+          "at_recall": {
+            "tokens": 126330,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 6
+          }
+        },
+        {
+          "model": "grep_window",
+          "at_recall": {
+            "tokens": 57191,
+            "recall_reached": 1.0,
+            "target_reached": true,
+            "units_consumed": 6
+          }
+        }
+      ]
+    }
+  ],
+  "aggregates": [
+    {
+      "corpus": "self",
+      "model": "full_file",
+      "task_count": 24,
+      "comparable_count": 16,
+      "archex_tokens": 9484,
+      "naive_tokens": 4416681,
+      "mean_token_ratio": 673.4403932105373,
+      "median_token_ratio": 387.3061425945092,
+      "token_reduction_pct": 99.7852686213924
+    },
+    {
+      "corpus": "self",
+      "model": "grep_window",
+      "task_count": 24,
+      "comparable_count": 16,
+      "archex_tokens": 9484,
+      "naive_tokens": 2626845,
+      "mean_token_ratio": 445.0554823593159,
+      "median_token_ratio": 258.82306668311577,
+      "token_reduction_pct": 99.63895852248609
+    },
+    {
+      "corpus": "external-comprehension",
+      "model": "full_file",
+      "task_count": 19,
+      "comparable_count": 16,
+      "archex_tokens": 22681,
+      "naive_tokens": 783725,
+      "mean_token_ratio": 44.2893151596519,
+      "median_token_ratio": 29.387644270836184,
+      "token_reduction_pct": 97.10600019139366
+    },
+    {
+      "corpus": "external-comprehension",
+      "model": "grep_window",
+      "task_count": 19,
+      "comparable_count": 16,
+      "archex_tokens": 22681,
+      "naive_tokens": 492119,
+      "mean_token_ratio": 29.20010620388154,
+      "median_token_ratio": 22.657207113562052,
+      "token_reduction_pct": 95.39115539127732
+    },
+    {
+      "corpus": "external-localization",
+      "model": "full_file",
+      "task_count": 21,
+      "comparable_count": 20,
+      "archex_tokens": 13247,
+      "naive_tokens": 469836,
+      "mean_token_ratio": 58.07335120131277,
+      "median_token_ratio": 33.212308340787295,
+      "token_reduction_pct": 97.18050553810265
+    },
+    {
+      "corpus": "external-localization",
+      "model": "grep_window",
+      "task_count": 21,
+      "comparable_count": 20,
+      "archex_tokens": 13247,
+      "naive_tokens": 408410,
+      "mean_token_ratio": 51.148786288536755,
+      "median_token_ratio": 29.603896707854762,
+      "token_reduction_pct": 96.75644572855708
+    }
+  ]
+}

--- a/docs/LOCAL_METRICS.md
+++ b/docs/LOCAL_METRICS.md
@@ -151,8 +151,8 @@ pure, deterministic function of the gitignore-aware corpus, the task keywords, a
 The checked-in reference artifact
 [`benchmarks/cross-tool-efficiency/cross-tool-comparison.json`](../benchmarks/cross-tool-efficiency/cross-tool-comparison.json)
 grades the benchmark task set per corpus (localization graded separately, never merged with
-comprehension). At 100% required-file recall the token reduction archex delivers versus the
-naive agent is:
+comprehension). At 100% required-file recall, on the tasks where archex itself fully
+localizes the required files, the token reduction versus the naive agent is:
 
 | Corpus | Naive model | Comparable tasks | archex tokens | naive tokens | Token reduction |
 | --- | --- | ---: | ---: | ---: | ---: |
@@ -163,10 +163,15 @@ naive agent is:
 | external-localization | full_file | 20 / 21 | 13,247 | 469,836 | 97.2% |
 | external-localization | grep_window | 20 / 21 | 13,247 | 408,410 | 96.8% |
 
-"Comparable tasks" counts only tasks where both paths reach 100% required-file recall; the
-remainder are cases the naive grep path never localizes at all (no keyword hit in a required
-file), excluded from the token delta rather than scored at unequal recall. Regenerate the
-artifact from a clean run (do not hand-edit metric values):
+"Comparable tasks" counts only tasks where both paths reach 100% required-file recall; every
+token figure sums over exactly that set, so no figure compares unequal recall. The reduction
+is therefore conditioned on archex fully localizing the task — it measures how much cheaper
+archex localizes when it succeeds, not that archex always succeeds. In this artifact the
+naive grep/read path reaches full recall on every comparable task, and all 12 excluded tasks
+(of 64: 8 self, 3 external-comprehension, 1 external-localization) are archex recall misses —
+cases where archex did not return all required files within its token budget (archex recall
+0.0–0.8 there), excluded rather than scored at unequal recall. Regenerate the artifact from a
+clean run (do not hand-edit metric values):
 
 ```bash
 uv run archex benchmark cross-tool --tasks-dir benchmarks/tasks \

--- a/docs/LOCAL_METRICS.md
+++ b/docs/LOCAL_METRICS.md
@@ -125,11 +125,56 @@ Interpretation:
 - `savings_pct` (vs full-file paste) is compression versus a naive full-file paste.
 - `savings_pct_vs_targeted_read` is the realistic, conservative number.
 - `whole_repo_tokens_avoided` is an upper-bound/context metric, never the headline.
-- A defensible cross-tool number (vs grep / read / LSP) is not produced in-process; it
-  is available only via the offline benchmark harness.
+- A defensible cross-tool number (vs grep / read) is not produced in-process; it is
+  available only via the offline benchmark harness — see "Cross-tool efficiency" below.
 
 Both baselines are derived from the index (per-file token totals and chunk line spans).
 Neither re-reads files on the query path, and no metrics path calls a model.
+
+## Cross-tool efficiency (offline benchmark)
+
+The two in-process savings numbers above compare archex's returned context against a
+counterfactual reconstruction of the *same* returned set. They do not answer "how many
+tokens would a non-archex agent spend to localize the same code?" That cross-tool number
+cannot be computed on the query path — it requires running both retrieval paths at a fixed
+recall on labeled tasks — so it lives only in the benchmark harness and never enters the
+`archex metrics summary` ledger or any product path.
+
+`archex benchmark cross-tool` measures **tokens-at-fixed-recall**: the tokens archex spends
+to localize a task's required files (its targeted returned regions, in rank order) versus a
+naive grep/read agent (whole grep-hit files, or `+/-K` context windows around grep hits, in
+grep-relevance order), tokenized with the same `cl100k_base` encoder. Recall is held equal:
+a token delta is reported only for tasks where both paths reach the target required-file
+recall (default 100%), so the number never compares unequal recall. The naive model is a
+pure, deterministic function of the gitignore-aware corpus, the task keywords, and `K`.
+
+The checked-in reference artifact
+[`benchmarks/cross-tool-efficiency/cross-tool-comparison.json`](../benchmarks/cross-tool-efficiency/cross-tool-comparison.json)
+grades the benchmark task set per corpus (localization graded separately, never merged with
+comprehension). At 100% required-file recall the token reduction archex delivers versus the
+naive agent is:
+
+| Corpus | Naive model | Comparable tasks | archex tokens | naive tokens | Token reduction |
+| --- | --- | ---: | ---: | ---: | ---: |
+| self | full_file | 16 / 24 | 9,484 | 4,416,681 | 99.8% |
+| self | grep_window | 16 / 24 | 9,484 | 2,626,845 | 99.6% |
+| external-comprehension | full_file | 16 / 19 | 22,681 | 783,725 | 97.1% |
+| external-comprehension | grep_window | 16 / 19 | 22,681 | 492,119 | 95.4% |
+| external-localization | full_file | 20 / 21 | 13,247 | 469,836 | 97.2% |
+| external-localization | grep_window | 20 / 21 | 13,247 | 408,410 | 96.8% |
+
+"Comparable tasks" counts only tasks where both paths reach 100% required-file recall; the
+remainder are cases the naive grep path never localizes at all (no keyword hit in a required
+file), excluded from the token delta rather than scored at unequal recall. Regenerate the
+artifact from a clean run (do not hand-edit metric values):
+
+```bash
+uv run archex benchmark cross-tool --tasks-dir benchmarks/tasks \
+  --output benchmarks/cross-tool-efficiency
+```
+
+This is an offline benchmark number, not a per-event ledger metric: it is never recorded in
+`~/.archex/usage.sqlite` and never shown by `archex metrics summary`.
 
 ## Surface defaults
 

--- a/tests/benchmark/test_cross_tool.py
+++ b/tests/benchmark/test_cross_tool.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import subprocess
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 
 from archex.benchmark.cross_tool import (
+    CrossToolReport,
     CrossToolTaskComparison,
     NaiveBaselineModel,
     NaiveBaselineResult,
@@ -23,9 +24,7 @@ from archex.benchmark.cross_tool import (
 )
 from archex.benchmark.models import BenchmarkTask, TaskFamily
 from archex.benchmark.region_metrics import ReturnedRegion
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from archex.benchmark.reporter import format_cross_tool_comparison
 
 _QUESTION = "Where is zorptoken handled?"
 
@@ -333,3 +332,65 @@ class TestArchexUnits:
         ]
         units = archex_units(regions)
         assert [(u.path, u.tokens) for u in units] == [("a.py", 12), ("b.py", 34)]
+
+
+class TestCheckedInArtifact:
+    """Validate the committed per-corpus reference artifact and its rendering."""
+
+    ARTIFACT = (
+        Path(__file__).resolve().parents[2]
+        / "benchmarks"
+        / "cross-tool-efficiency"
+        / "cross-tool-comparison.json"
+    )
+
+    def _load(self) -> CrossToolReport:
+        return CrossToolReport.model_validate_json(self.ARTIFACT.read_text(encoding="utf-8"))
+
+    def test_artifact_exists_and_parses(self) -> None:
+        report = self._load()
+        assert report.strategy == "archex_query"
+        assert report.comparisons
+        assert report.aggregates
+
+    def test_localization_graded_as_its_own_corpus(self) -> None:
+        report = self._load()
+        corpora = {aggregate.corpus for aggregate in report.aggregates}
+        # The localization family is graded separately, never merged with comprehension.
+        assert "external-localization" in corpora
+        assert "external-comprehension" in corpora
+        loc_tasks = {
+            comparison.task_id
+            for comparison in report.comparisons
+            if comparison.corpus == "external-localization"
+        }
+        comp_tasks = {
+            comparison.task_id
+            for comparison in report.comparisons
+            if comparison.corpus == "external-comprehension"
+        }
+        assert loc_tasks and comp_tasks
+        # Disjoint task sets: no task is counted under both corpora.
+        assert loc_tasks.isdisjoint(comp_tasks)
+        # Every localization-corpus task actually carries the localization family.
+        for comparison in report.comparisons:
+            if comparison.corpus == "external-localization":
+                assert comparison.family is TaskFamily.LOCALIZATION
+
+    def test_recall_held_equal_in_every_scored_comparison(self) -> None:
+        report = self._load()
+        for comparison in report.comparisons:
+            for naive in comparison.naive:
+                # A delta is only meaningful when both paths reached the target; when
+                # they do, the artifact measured them at the same achieved recall.
+                if comparison.archex.target_reached and naive.at_recall.target_reached:
+                    assert comparison.archex.recall_reached == naive.at_recall.recall_reached
+        # Aggregates never count more comparable tasks than exist in the corpus.
+        for aggregate in report.aggregates:
+            assert aggregate.comparable_count <= aggregate.task_count
+
+    def test_artifact_renders(self) -> None:
+        md = format_cross_tool_comparison(self._load())
+        assert "# Cross-Tool Token Efficiency (offline benchmark)" in md
+        assert "Recall is held equal" in md
+        assert "External localization" in md


### PR DESCRIPTION
## Summary

Generates and checks in the per-corpus cross-tool efficiency reference artifact and documents the number. Builds on #366 (the tokens-at-fixed-recall metric).

## What this adds

- `benchmarks/cross-tool-efficiency/cross-tool-comparison.json`: the reference artifact, produced from a clean run of `archex benchmark cross-tool` over the benchmark task set. Metric values are not hand-edited.
- `docs/LOCAL_METRICS.md`: a "Cross-tool efficiency (offline benchmark)" section citing the artifact and its per-corpus figures, stating the number is offline benchmark-only and never enters the in-process ledger or `archex metrics summary`.
- A test asserting the checked-in artifact parses, grades the localization family as its own corpus, holds recall equal in every scored comparison, and renders.

## Per-corpus reference values (tokens at 100% required-file recall)

| Corpus | Naive model | Comparable | archex | naive | Reduction |
| --- | --- | ---: | ---: | ---: | ---: |
| self | full_file | 16/24 | 9,484 | 4,416,681 | 99.8% |
| self | grep_window | 16/24 | 9,484 | 2,626,845 | 99.6% |
| external-comprehension | full_file | 16/19 | 22,681 | 783,725 | 97.1% |
| external-comprehension | grep_window | 16/19 | 22,681 | 492,119 | 95.4% |
| external-localization | full_file | 20/21 | 13,247 | 469,836 | 97.2% |
| external-localization | grep_window | 20/21 | 13,247 | 408,410 | 96.8% |

"Comparable" counts only tasks where both paths reach 100% required-file recall, so no figure compares unequal recall. Localization is graded as its own corpus, never merged with comprehension.

## Artifact location

`.archex/` is gitignored repo-wide (and by a user-global ignore), so the committed reference artifact lives under the tracked `benchmarks/` tree rather than punching negation holes in the ignored workspace dir. The `archex benchmark cross-tool` default output stays `.archex/cross-tool-efficiency` for ephemeral ad-hoc runs.

## Out of scope (unchanged)

- No in-process metrics ledger, metrics reporter, retrieval ranking, or default change.

## Stack

Stack-Id: `cross-tool-efficiency-cfdfb5`
Base: `feat/cross-tool-token-model`
Position: 2/2

1. `feat/cross-tool-token-model` -> #366
2. `feat/cross-tool-artifact-docs` -> this PR

Depends on: #366

## Validation

- `uv run ruff check` / `ruff format --check` / `uv run pyright` on changed Python — pass
- `uv run pytest tests/benchmark/test_cross_tool.py tests/benchmark/test_reporter.py --no-cov` — 80 passed
- Doc figures verified byte-for-byte against the checked-in artifact aggregates
