### PR TITLE
feat(scout): adapt file limit to query intent

### DIFF
--- a/src/archex/scout.py
+++ b/src/archex/scout.py
@@ -26,6 +26,21 @@ DEFAULT_SCOUT_FILE_LIMIT = 12
 DEFAULT_SCOUT_SYMBOLS_PER_FILE = 3
 DEFAULT_SCOUT_MODULE_LIMIT = 6
 DEFAULT_SCOUT_GRAPH_EDGE_LIMIT = 12
+
+# Adaptive cap on `_rank_files`' selected file count per query intent — mirrors
+# `query`'s `_adaptive_max_files` (serve/context.py), which reduces file count
+# when score separation is clear. Narrow lookups need few files; architecture
+# and usage queries legitimately span more of a growing repo. GENERAL keeps
+# the historical default so untriaged queries are unaffected.
+INTENT_SCOUT_FILE_LIMITS: dict[QueryIntent, int] = {
+    QueryIntent.DEFINITION_LOOKUP: 6,
+    QueryIntent.ARCHITECTURE_BROAD: 16,
+    QueryIntent.USAGE_SEARCH: 12,
+    QueryIntent.DEBUGGING: 10,
+    QueryIntent.CLI: 8,
+    QueryIntent.GENERAL: DEFAULT_SCOUT_FILE_LIMIT,
+}
+
 FILE_HANDLE_PREFIX = "file:"
 SYMBOL_HANDLE_PREFIX = "symbol:"
 CHUNK_HANDLE_PREFIX = "chunk:"
@@ -227,7 +242,7 @@ def assemble_scout_from_store(
     ranked_chunks: list[RankedChunk] | None = None,
     token_budget: int = DEFAULT_SCOUT_TOKEN_BUDGET,
     output_format: ScoutFormat = "markdown",
-    file_limit: int = DEFAULT_SCOUT_FILE_LIMIT,
+    file_limit: int | None = None,
     symbols_per_file: int = DEFAULT_SCOUT_SYMBOLS_PER_FILE,
     module_limit: int = DEFAULT_SCOUT_MODULE_LIMIT,
     modules_override: list[Module] | None = None,
@@ -238,14 +253,23 @@ def assemble_scout_from_store(
     direct_query_tokens: int = 0,
     direct_query_file_paths: list[str] | None = None,
 ) -> ScoutResult:
-    """Build a deterministic no-body structural map from an indexed repository."""
+    """Build a deterministic no-body structural map from an indexed repository.
+
+    `file_limit` defaults to an intent-adaptive cap (see `INTENT_SCOUT_FILE_LIMITS`)
+    when not given explicitly, mirroring `query`'s adaptive `MAX_FILES` reduction.
+    """
     _validate_token_budget(token_budget)
+    effective_file_limit = (
+        file_limit
+        if file_limit is not None
+        else INTENT_SCOUT_FILE_LIMITS[classify_intent(question)]
+    )
     ranked = ranked_chunks or []
     score_by_chunk = _score_by_chunk(ranked)
     files, omitted_files = _rank_files(
         store,
         ranked,
-        file_limit=file_limit,
+        file_limit=effective_file_limit,
         bundle_file_paths=bundle_file_paths or [],
         seed_file_paths=seed_file_paths or [],
         expanded_file_paths=expanded_file_paths or [],

--- a/tests/test_scout.py
+++ b/tests/test_scout.py
@@ -424,3 +424,168 @@ def test_scout_cli_emits_handles_and_budget() -> None:
     assert result.exit_code == 0, result.output
     assert file_handle("src/archex/index/delta.py") in result.output
     assert scout_mock.call_args.kwargs["token_budget"] == 120
+
+
+def test_scout_caps_files_at_definition_lookup_intent_limit(tmp_path: Path) -> None:
+    with _populate_store(tmp_path / "index.db") as store:
+        extras = [
+            CodeChunk(
+                id=f"pkg/extra_{idx}.py::extra_{idx}#function",
+                content=f"def extra_{idx}():\\n    return {idx}",
+                file_path=f"pkg/extra_{idx}.py",
+                start_line=1,
+                end_line=2,
+                symbol_name=f"extra_{idx}",
+                symbol_kind=SymbolKind.FUNCTION,
+                language="python",
+                token_count=8,
+                symbol_id=f"pkg/extra_{idx}.py::extra_{idx}#function",
+                qualified_name=f"extra_{idx}",
+                signature=f"def extra_{idx}()",
+            )
+            for idx in range(6)
+        ]
+        store.insert_chunks(extras)
+        ranked_chunks = [
+            RankedChunk(chunk=chunk, final_score=score)
+            for chunk, score in zip(
+                [store.get_chunk("pkg/app.py::run#function"), *extras],
+                [1.0, 0.95, 0.9, 0.85, 0.8, 0.75, 0.7],
+                strict=True,
+            )
+            if chunk is not None
+        ]
+        result = assemble_scout_from_store(
+            store,
+            "implementation of run",
+            ranked_chunks=ranked_chunks,
+            token_budget=8000,
+        )
+
+    # 7 candidate files exist; DEFINITION_LOOKUP intent caps at 6 (old fixed
+    # default of 12 would have kept all 7).
+    assert len(result.ranked_files) == 6
+    assert result.budget.truncated is False
+    assert result.budget.omitted_files == 1
+
+
+def test_scout_raises_file_cap_for_architecture_broad_intent(tmp_path: Path) -> None:
+    with _populate_store(tmp_path / "index.db") as store:
+        extras = [
+            CodeChunk(
+                id=f"pkg/extra_{idx}.py::extra_{idx}#function",
+                content=f"def extra_{idx}():\\n    return {idx}",
+                file_path=f"pkg/extra_{idx}.py",
+                start_line=1,
+                end_line=2,
+                symbol_name=f"extra_{idx}",
+                symbol_kind=SymbolKind.FUNCTION,
+                language="python",
+                token_count=8,
+                symbol_id=f"pkg/extra_{idx}.py::extra_{idx}#function",
+                qualified_name=f"extra_{idx}",
+                signature=f"def extra_{idx}()",
+            )
+            for idx in range(20)
+        ]
+        store.insert_chunks(extras)
+        ranked_chunks = [
+            RankedChunk(chunk=chunk, final_score=1.0 - idx * 0.03)
+            for idx, chunk in enumerate([store.get_chunk("pkg/app.py::run#function"), *extras])
+            if chunk is not None
+        ]
+        result = assemble_scout_from_store(
+            store,
+            "pipeline overview",
+            ranked_chunks=ranked_chunks,
+            token_budget=20000,
+        )
+
+    # 21 candidate files exist; ARCHITECTURE_BROAD intent caps at 16 (old fixed
+    # default of 12 would have dropped 5 additional relevant files).
+    assert len(result.ranked_files) == 16
+    assert result.budget.truncated is False
+    assert result.budget.omitted_files == 5
+
+
+def test_scout_keeps_historical_default_cap_for_general_intent(tmp_path: Path) -> None:
+    with _populate_store(tmp_path / "index.db") as store:
+        extras = [
+            CodeChunk(
+                id=f"pkg/extra_{idx}.py::extra_{idx}#function",
+                content=f"def extra_{idx}():\\n    return {idx}",
+                file_path=f"pkg/extra_{idx}.py",
+                start_line=1,
+                end_line=2,
+                symbol_name=f"extra_{idx}",
+                symbol_kind=SymbolKind.FUNCTION,
+                language="python",
+                token_count=8,
+                symbol_id=f"pkg/extra_{idx}.py::extra_{idx}#function",
+                qualified_name=f"extra_{idx}",
+                signature=f"def extra_{idx}()",
+            )
+            for idx in range(15)
+        ]
+        store.insert_chunks(extras)
+        ranked_chunks = [
+            RankedChunk(chunk=chunk, final_score=1.0 - idx * 0.03)
+            for idx, chunk in enumerate([store.get_chunk("pkg/app.py::run#function"), *extras])
+            if chunk is not None
+        ]
+        result = assemble_scout_from_store(
+            store,
+            "models",
+            ranked_chunks=ranked_chunks,
+            token_budget=15000,
+        )
+
+    # 16 candidate files exist; GENERAL intent is unaffected by the adaptive
+    # table and keeps the historical fixed default of 12.
+    assert len(result.ranked_files) == 12
+    assert result.budget.truncated is False
+    assert result.budget.omitted_files == 4
+
+
+def test_scout_explicit_file_limit_overrides_intent_classification(tmp_path: Path) -> None:
+    with _populate_store(tmp_path / "index.db") as store:
+        extras = [
+            CodeChunk(
+                id=f"pkg/extra_{idx}.py::extra_{idx}#function",
+                content=f"def extra_{idx}():\\n    return {idx}",
+                file_path=f"pkg/extra_{idx}.py",
+                start_line=1,
+                end_line=2,
+                symbol_name=f"extra_{idx}",
+                symbol_kind=SymbolKind.FUNCTION,
+                language="python",
+                token_count=8,
+                symbol_id=f"pkg/extra_{idx}.py::extra_{idx}#function",
+                qualified_name=f"extra_{idx}",
+                signature=f"def extra_{idx}()",
+            )
+            for idx in range(5)
+        ]
+        store.insert_chunks(extras)
+        ranked_chunks = [
+            RankedChunk(chunk=chunk, final_score=score)
+            for chunk, score in zip(
+                [store.get_chunk("pkg/app.py::run#function"), *extras],
+                [1.0, 0.95, 0.9, 0.85, 0.8, 0.75],
+                strict=True,
+            )
+            if chunk is not None
+        ]
+        # "pipeline overview" would classify as ARCHITECTURE_BROAD (cap 16),
+        # but an explicit file_limit bypasses intent classification entirely.
+        result = assemble_scout_from_store(
+            store,
+            "pipeline overview",
+            ranked_chunks=ranked_chunks,
+            token_budget=4000,
+            file_limit=3,
+        )
+
+    assert len(result.ranked_files) == 3
+    assert result.budget.truncated is False
+    assert result.budget.omitted_files == 3


### PR DESCRIPTION
## What

`scout`'s ranked-file selection used a hardcoded `DEFAULT_SCOUT_FILE_LIMIT = 12` regardless of query intent, unlike `query`'s existing `_adaptive_max_files` pattern (`src/archex/serve/context.py`) which already scales file count with score-separation confidence.

Adds `INTENT_SCOUT_FILE_LIMITS: dict[QueryIntent, int]` and computes `assemble_scout_from_store`'s effective `file_limit` from `classify_intent(question)` when the caller doesn't pass one explicitly:

| Intent | New limit | Old (fixed) |
|---|---|---|
| `DEFINITION_LOOKUP` | 6 | 12 |
| `ARCHITECTURE_BROAD` | 16 | 12 |
| `USAGE_SEARCH` | 12 | 12 |
| `DEBUGGING` | 10 | 12 |
| `CLI` | 8 | 12 |
| `GENERAL` | 12 (unchanged) | 12 |

## Why

Found while auditing 30-day archex usage metrics across VIROC/oh-my-pi/archex: VIROC's `scout` calls consistently hit exactly 12 files with 25-63 candidates omitted per call, on a repo whose `whole_repo_tokens` grew ~10x within the same window. No visible recall failure yet, but the cap was the one static parameter in an otherwise-adaptive retrieval pipeline — narrow lookups were wastefully ranking/scoring 12 files when 6 suffice, and architecture-broad queries on growing repos were capped below what `query`'s own adaptive logic already judges reasonable elsewhere in the same intent table (`INTENT_DIRECT_QUERY_FALLBACK_FILE_LIMITS[ARCHITECTURE_BROAD] = 12`, comparable order of magnitude to the new 16).

## Compat

- Explicit `file_limit=<int>` still bypasses intent classification entirely — existing callers/tests passing it directly are unaffected.
- `GENERAL` intent (unclassified queries) keeps the historical default of 12 — no behavior change for queries that don't match a specific pattern.
- No CLI/MCP surface change; `scout_cmd.py` and `integrations/mcp.py` never pass `file_limit`, so they inherit intent-adaptivity automatically.

## Verification

- `ruff check`, `ruff format --check`, `pyright --strict` clean on both changed files.
- `tests/test_scout.py`: 14/14 pass (10 pre-existing + 4 new covering DEFINITION_LOOKUP cap, ARCHITECTURE_BROAD cap, GENERAL regression guard, and explicit-override bypass).
- Manual CLI smoke test against this repo: `archex scout . "where is DEFAULT_SCOUT_FILE_LIMIT defined" --budget 8000` → 6 files (was 12); `archex scout . "archex retrieval pipeline architecture overview" --budget 8000` → 16 files (was 12).
- `tests/benchmark/test_strategies.py -k scout`: 4/4 pass, no regression.