### PR TITLE
feat(languages): add XML at chunk-only tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ For the full trust contract, including exact MCP JSON, Docker commands, cache lo
 | Tier | Languages | Extraction |
 | --- | --- | --- |
 | `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift | Symbols, imports, graph edges |
-| `chunk-only` | C, C++, PHP, Ruby, Scala, Lua, Bash/Shell, SQL, HTML, CSS, YAML, TOML, JSON, Markdown, Solidity | AST chunking + retrieval; no symbol/import graph claim |
+| `chunk-only` | C, C++, PHP, Ruby, Scala, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity | AST chunking + retrieval; no symbol/import graph claim |
 | `unknown` | any other text file | line-window chunks for BM25 visibility |
 
 Need another language? Register an adapter via Python entry points. See [System Design](docs/SYSTEM_DESIGN.md) for the extension contract.

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -214,7 +214,7 @@ Language support is declared, not implied. `full` means symbol extraction, impor
 | Tier | Languages |
 | --- | --- |
 | `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift |
-| `chunk-only` | C, C++, PHP, Ruby, Scala, Lua, Bash/Shell, SQL, HTML, CSS, YAML, TOML, JSON, Markdown, Solidity |
+| `chunk-only` | C, C++, PHP, Ruby, Scala, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity |
 
 Unknown files fall back to line-window chunking so they can still be found by BM25 without pretending to have structural edges.
 

--- a/src/archex/languages.py
+++ b/src/archex/languages.py
@@ -142,6 +142,7 @@ LANGUAGE_SUPPORT: dict[str, LanguageSupport] = {
         "css",
         frozenset({"rule_set", "media_statement", "import_statement"}),
     ),
+    "xml": LanguageSupport("xml", "XML", (".xml",), _CHUNK, "xml", frozenset({"element"})),
     "yaml": LanguageSupport(
         "yaml", "YAML", (".yaml", ".yml"), _CHUNK, "yaml", frozenset({"document"})
     ),
@@ -205,6 +206,7 @@ EXTENSION_LANGUAGE_MAP: dict[str, str] = {
     ".html": "html",
     ".htm": "html",
     ".css": "css",
+    ".xml": "xml",
     ".yaml": "yaml",
     ".yml": "yaml",
     ".toml": "toml",

--- a/tests/parse/test_language_coverage.py
+++ b/tests/parse/test_language_coverage.py
@@ -58,6 +58,25 @@ CHUNK_ONLY_SAMPLES: dict[str, tuple[str, str, list[tuple[int, int]]]] = {
         "<html><body><section><h1>Hello</h1></section></body></html>\n",
         [(1, 1)],
     ),
+    "xml": (
+        "MoquiEntity.xml",
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<entity name="Foo" package="example">\n'
+        '    <field name="id" type="id"/>\n'
+        '    <field name="name" type="text-medium"/>\n'
+        '    <relationship type="one" related="Bar"/>\n'
+        "</entity>\n"
+        '<service name="bar#Create" verb="create" noun="Bar">\n'
+        "    <in-parameters>\n"
+        '        <parameter name="id"/>\n'
+        '        <parameter name="name"/>\n'
+        "    </in-parameters>\n"
+        "    <actions>\n"
+        '        <service-call name="create#Bar" in-map="context"/>\n'
+        "    </actions>\n"
+        "</service>\n",
+        [(2, 6), (7, 15)],
+    ),
     "css": (
         "style.css",
         '@import url("x.css");\n.foo { color: red; }\n@media screen { .bar { display: none; } }\n',


### PR DESCRIPTION
## Summary

Adds XML at `CHUNK_ONLY` tier, resolving the XML half of #371.

- `src/archex/languages.py`: registers `"xml"` (`.xml`) in `LANGUAGE_SUPPORT`, chunk-node type `element`, pack name `xml` (resolved via the already-pinned `tree_sitter_language_pack` dependency — `tree-sitter-grammars/tree-sitter-xml`, the same mature grammar family HTML already uses). No new dependency, no new adapter code — `make_chunk_only_adapter` auto-generates the adapter and the `CHUNK_ONLY_LANGUAGE_IDS` loop in `parse/adapters/__init__.py` auto-registers it.
- `README.md` / `docs/SYSTEM_DESIGN.md`: added XML to the chunk-only row of the language-support table.
- `tests/parse/test_language_coverage.py`: added an `"xml"` entry to `CHUNK_ONLY_SAMPLES` with a Moqui-style entity/service fixture (2 top-level elements, each with nested children) and empirically-verified expected chunk ranges, proving nested elements are correctly deduped out of the top-level chunk set.

No symbol claim is made for XML — element semantics (what counts as a "class"-equivalent) are dialect-specific (Moqui entity vs. Spring bean vs. Maven POM vs. Android layout), so full tier is out of scope for this change. See the issue thread for the fuller design rationale, including why Groovy is not included in this PR.

## Verification

- `uv run pytest tests/parse/test_language_coverage.py -q` — 43 passed (0 failures; only the repo-wide 85% coverage gate reports low on this single-file run, expected on a partial run).
- `uv run ruff check` and `uv run mypy` on all touched files — no new diagnostics (confirmed against an unmodified baseline: `git stash` reproduces the identical unrelated pre-existing mypy errors in other modules).
- End-to-end CLI smoke test against a real Moqui-style entity/service XML file:
  - `archex doctor` — `chunk-only grammars: 16/16 available` (was 15/15), file classified as `xml` instead of `unknown`.
  - `archex query` — returns two separate scoped chunks (`entity.xml:_module:2` for the `<entity>` element, `entity.xml:_module:6` for the `<service>` element) instead of one whole-file/line-window chunk.

Closes the XML portion of #371.
