### PR TITLE
fix(parse): isolate per-file parse errors in sequential path

### DIFF
--- a/src/archex/parse/symbols.py
+++ b/src/archex/parse/symbols.py
@@ -107,8 +107,10 @@ def _extract_symbols_sequential(
     files: list[DiscoveredFile],
     engine: TreeSitterEngine,
     adapters: Mapping[str, LanguageAdapter],
+    strict: bool = False,
 ) -> list[ParsedFile]:
     results: list[ParsedFile] = []
+    errors: list[tuple[str, ParseError]] = []
     for discovered_file in files:
         adapter = adapters.get(discovered_file.language)
         if adapter is None:
@@ -116,15 +118,22 @@ def _extract_symbols_sequential(
                 continue
             results.append(_parse_unknown_file(discovered_file.absolute_path, discovered_file.path))
             continue
-        results.append(
-            _parse_with_adapter(
-                absolute_path=str(discovered_file.absolute_path),
-                relative_path=discovered_file.path,
-                language=discovered_file.language,
-                engine=engine,
-                adapter=adapter,
+        try:
+            results.append(
+                _parse_with_adapter(
+                    absolute_path=str(discovered_file.absolute_path),
+                    relative_path=discovered_file.path,
+                    language=discovered_file.language,
+                    engine=engine,
+                    adapter=adapter,
+                )
             )
-        )
+        except ParseError as e:
+            errors.append((discovered_file.path, e))
+            logger.warning("Skipping %s due to parse error: %s", discovered_file.path, e)
+    if errors and strict:
+        paths = ", ".join(p for p, _ in errors)
+        raise ParseError(f"Sequential parsing failed for {len(errors)} file(s): {paths}")
     return results
 
 
@@ -153,9 +162,11 @@ def _extract_symbols_and_imports_sequential(
     files: list[DiscoveredFile],
     engine: TreeSitterEngine,
     adapters: Mapping[str, LanguageAdapter],
+    strict: bool = False,
 ) -> ParsedExtraction:
     parsed_files: list[ParsedFile] = []
     imports_by_path: dict[str, list[ImportStatement]] = {}
+    errors: list[tuple[str, ParseError]] = []
     for discovered_file in files:
         adapter = adapters.get(discovered_file.language)
         if adapter is None:
@@ -165,15 +176,23 @@ def _extract_symbols_and_imports_sequential(
             parsed_files.append(parsed)
             imports_by_path[discovered_file.path] = []
             continue
-        parsed, imports = _parse_with_adapter_and_imports(
-            absolute_path=str(discovered_file.absolute_path),
-            relative_path=discovered_file.path,
-            language=discovered_file.language,
-            engine=engine,
-            adapter=adapter,
-        )
+        try:
+            parsed, imports = _parse_with_adapter_and_imports(
+                absolute_path=str(discovered_file.absolute_path),
+                relative_path=discovered_file.path,
+                language=discovered_file.language,
+                engine=engine,
+                adapter=adapter,
+            )
+        except ParseError as e:
+            errors.append((discovered_file.path, e))
+            logger.warning("Skipping %s due to parse error: %s", discovered_file.path, e)
+            continue
         parsed_files.append(parsed)
         imports_by_path[discovered_file.path] = imports
+    if errors and strict:
+        paths = ", ".join(p for p, _ in errors)
+        raise ParseError(f"Sequential parsing failed for {len(errors)} file(s): {paths}")
     return ParsedExtraction(parsed_files=parsed_files, imports_by_path=imports_by_path)
 
 
@@ -251,7 +270,7 @@ def extract_symbols(
                 raise ParseError(f"Parallel parsing failed: {e}") from e
             logger.error("Parallel executor failed, falling back to sequential: %s", e)
 
-    return _extract_symbols_sequential(eligible, engine, adapters)
+    return _extract_symbols_sequential(eligible, engine, adapters, strict=strict)
 
 
 def extract_symbols_and_imports(
@@ -303,4 +322,4 @@ def extract_symbols_and_imports(
                 raise ParseError(f"Parallel parsing failed: {e}") from e
             logger.error("Parallel executor failed, falling back to sequential: %s", e)
 
-    return _extract_symbols_and_imports_sequential(eligible, engine, adapters)
+    return _extract_symbols_and_imports_sequential(eligible, engine, adapters, strict=strict)

--- a/tests/parse/test_symbols.py
+++ b/tests/parse/test_symbols.py
@@ -279,6 +279,73 @@ def test_strict_parallel_raises_on_bad_file(
         extract_symbols(files, engine, adapters, parallel=True, strict=True)
 
 
+def test_sequential_fault_isolation_skips_oversized_file(
+    tmp_path: Path,
+    engine: TreeSitterEngine,
+    adapters: dict[str, LanguageAdapter],
+) -> None:
+    """A single oversized file raises ParseError from the engine but does not abort the batch."""
+    good = tmp_path / "good.py"
+    good.write_text("def hello():\n    pass\n")
+    oversized = tmp_path / "oversized.py"
+    oversized.write_bytes(b"x" * 10_000_001)  # exceeds TreeSitterEngine's default max_file_size
+
+    files = [
+        DiscoveredFile(path="good.py", absolute_path=str(good), language="python"),
+        DiscoveredFile(path="oversized.py", absolute_path=str(oversized), language="python"),
+    ]
+
+    result = extract_symbols(files, engine, adapters, parallel=False)
+    assert [pf.path for pf in result] == ["good.py"]
+
+
+def test_sequential_fault_isolation_and_imports_skips_bad_file(
+    tmp_path: Path,
+    engine: TreeSitterEngine,
+    adapters: dict[str, LanguageAdapter],
+) -> None:
+    """extract_symbols_and_imports isolates a per-file ParseError in the sequential path."""
+    good = tmp_path / "good.py"
+    good.write_text("def hello():\n    pass\n")
+
+    files = [
+        DiscoveredFile(path="good.py", absolute_path=str(good), language="python"),
+        DiscoveredFile(
+            path="missing.py",
+            absolute_path=str(tmp_path / "missing.py"),
+            language="python",
+        ),
+    ]
+
+    result = extract_symbols_and_imports(files, engine, adapters, parallel=False)
+    assert [pf.path for pf in result.parsed_files] == ["good.py"]
+    assert set(result.imports_by_path) == {"good.py"}
+
+
+def test_sequential_fault_isolation_strict_raises(
+    tmp_path: Path,
+    engine: TreeSitterEngine,
+    adapters: dict[str, LanguageAdapter],
+) -> None:
+    """extract_symbols raises ParseError when strict=True and a file fails sequentially."""
+    from archex.exceptions import ParseError
+
+    good = tmp_path / "good.py"
+    good.write_text("def hello():\n    pass\n")
+
+    files = [
+        DiscoveredFile(path="good.py", absolute_path=str(good), language="python"),
+        DiscoveredFile(
+            path="missing.py",
+            absolute_path=str(tmp_path / "missing.py"),
+            language="python",
+        ),
+    ]
+
+    with pytest.raises(ParseError, match="Sequential parsing failed"):
+        extract_symbols(files, engine, adapters, parallel=False, strict=True)
+
+
 def test_nonstrict_parallel_skips_bad_file(
     tmp_path: Path,
     engine: TreeSitterEngine,


### PR DESCRIPTION
## Summary

- The sequential (non-parallel) parse path in `src/archex/parse/symbols.py` propagated `ParseError` from a single oversized or malformed file, aborting the entire extraction batch. The `ProcessPoolExecutor` path already isolated per-file failures; this brings the default sequential path to parity.
- `_extract_symbols_sequential` and `_extract_symbols_and_imports_sequential` now wrap the per-file adapter call in `try/except ParseError`, collect failures, log a warning per skipped file, and only raise (`ParseError: "Sequential parsing failed for N file(s): ..."`) when `strict=True` — same shape as the existing parallel error-collection.
- `strict` is now threaded through from `extract_symbols()` / `extract_symbols_and_imports()` into their sequential fallbacks (previously dropped).

## Stack

Position: 1/2 (root)

1. `feat/parse-fault-isolation` -> this PR
2. `feat/parse-parallel-default` -> stacked on this branch

## Scope

Only `src/archex/parse/symbols.py` and its tests. No change to `Config.parallel` or parse output — that's PR 2.

## Test plan

- [x] `uv run pytest tests/parse/ -k "fault_isolation or parallel" -v` — 11 passed
- [x] `uv run ruff check src/archex/parse/ src/archex/models.py` — clean
- [x] `uv run pyright` — 0 errors
- [x] New regression tests: oversized file (>10MB) skipped without raising; missing file skipped in both `extract_symbols` and `extract_symbols_and_imports`; `strict=True` still raises `ParseError`