### PR TITLE
feat(config): default Config.parallel to True

### DIFF
--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -310,7 +310,7 @@ class Config:
     cache: bool = True                          # Enable index caching
     cache_dir: str = "~/.archex/cache"          # User cache unless repo-local overrides it
     max_file_size: int = 10_000_000
-    parallel: bool = False
+    parallel: bool = True                       # ProcessPoolExecutor auto-enables above 10 files
     strict: bool = False
     delta_threshold: float = 0.5                # Full rebuild threshold for changed files
 

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -206,7 +206,7 @@ class Config(BaseModel):
     cache: bool = True
     cache_dir: str = "~/.archex/cache"
     max_file_size: int = 10_000_000
-    parallel: bool = False
+    parallel: bool = True
     strict: bool = False
     delta_threshold: float = 0.5
 

--- a/tests/parse/test_symbols.py
+++ b/tests/parse/test_symbols.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import os
+from concurrent.futures import ProcessPoolExecutor
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
-from archex.models import DiscoveredFile, SymbolKind
+from archex.models import Config, DiscoveredFile, SymbolKind
 from archex.parse.adapters import default_adapter_registry
 from archex.parse.engine import TreeSitterEngine
 from archex.parse.imports import parse_imports
@@ -197,6 +198,39 @@ def test_parse_file_worker_raises_on_missing_file() -> None:
 
     with pytest.raises(ParseError):
         _parse_file_worker("/nonexistent/ghost.py", "ghost.py", "python")
+
+
+# --- parallel-by-default config tests ---
+
+
+def test_config_parallel_defaults_to_true() -> None:
+    """Config.parallel defaults to True so parsing uses all available cores by default."""
+    assert Config().parallel is True
+
+
+def test_parallel_default_config_uses_process_pool(
+    tmp_path: Path,
+    engine: TreeSitterEngine,
+    adapters: dict[str, LanguageAdapter],
+) -> None:
+    """A fresh Config's default parallel=True drives ProcessPoolExecutor for a >10-file batch."""
+    files: list[DiscoveredFile] = []
+    for i in range(12):
+        f = tmp_path / f"mod_{i}.py"
+        f.write_text(f"def func_{i}():\n    pass\n")
+        files.append(
+            DiscoveredFile(path=f"mod_{i}.py", absolute_path=str(f), language="python")
+        )
+
+    config = Config()
+
+    with patch(
+        "archex.parse.symbols.ProcessPoolExecutor", wraps=ProcessPoolExecutor
+    ) as pool_spy:
+        result = extract_symbols_and_imports(files, engine, adapters, parallel=config.parallel)
+
+    pool_spy.assert_called_once()
+    assert len(result.parsed_files) == 12
 
 
 # --- parallel path tests ---

--- a/tests/parse/test_symbols.py
+++ b/tests/parse/test_symbols.py
@@ -218,15 +218,11 @@ def test_parallel_default_config_uses_process_pool(
     for i in range(12):
         f = tmp_path / f"mod_{i}.py"
         f.write_text(f"def func_{i}():\n    pass\n")
-        files.append(
-            DiscoveredFile(path=f"mod_{i}.py", absolute_path=str(f), language="python")
-        )
+        files.append(DiscoveredFile(path=f"mod_{i}.py", absolute_path=str(f), language="python"))
 
     config = Config()
 
-    with patch(
-        "archex.parse.symbols.ProcessPoolExecutor", wraps=ProcessPoolExecutor
-    ) as pool_spy:
+    with patch("archex.parse.symbols.ProcessPoolExecutor", wraps=ProcessPoolExecutor) as pool_spy:
         result = extract_symbols_and_imports(files, engine, adapters, parallel=config.parallel)
 
     pool_spy.assert_called_once()


### PR DESCRIPTION
## Summary

- `Config.parallel` defaulted to `False`, so every default `index`/`analyze` run parsed single-threaded even though a tested `ProcessPoolExecutor` path already exists and auto-engages above 10 files (`extract_symbols`/`extract_symbols_and_imports`, `len(files) > 10`). Flips the default to `True` so multi-core parsing is the out-of-the-box behavior with zero new config surface.
- Updates the `Config` code sample in `docs/SYSTEM_DESIGN.md` to match.
- Adds a test asserting that a fresh `Config()` drives `ProcessPoolExecutor` (not just correct results) for a >10-file batch, plus a default-value assertion.

## Stack

Position: 2/2 (leaf)

1. `feat/parse-fault-isolation` -> #374
2. `feat/parse-parallel-default` -> this PR

Depends on: #374

## Scope

Only `src/archex/models.py` (default flip), `docs/SYSTEM_DESIGN.md` (doc sync), and tests. Does not touch the sequential fault-isolation logic from #374 — that's already merged into this branch's history, not re-touched here. No new auto-enable threshold logic was needed in `symbols.py` since the existing `len(files) > 10` gate already satisfies the acceptance criterion once the raw default flips.

## Test plan

- [x] `uv run pytest tests/parse/ -k "fault_isolation or parallel" -v` — 13 passed
- [x] `uv run pytest` (full suite) — 2912 passed, 90.70% coverage, ~8min
- [x] `uv run ruff check src/archex/parse/ src/archex/models.py` — clean
- [x] `uv run pyright` — 0 errors
- [x] Confirmed no test-suite timing regression from the default flip (`tests/test_integration.py`: 38.96s on this branch vs. 37.23s on `main`, within noise)