### PR TITLE
feat(index): add generator-based streaming chunk read path

### DIFF
--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -18,6 +18,7 @@ from archex.models import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from types import TracebackType
 
 
@@ -501,6 +502,22 @@ class IndexStore:
     def get_chunks(self) -> list[CodeChunk]:
         cur = self._conn.execute(_CHUNK_SELECT)
         return [_row_to_chunk(row) for row in cur.fetchall()]
+
+    def iter_chunks(self, batch_size: int = 500) -> Iterator[CodeChunk]:
+        """Stream all chunks without materializing the full result set in memory.
+
+        Equivalent to ``get_chunks()`` but yields chunks incrementally via
+        batched cursor fetches. A caller that processes (rather than retains)
+        each chunk keeps peak memory bounded to ``batch_size`` rows instead of
+        the store's total chunk count.
+        """
+        cur = self._conn.execute(_CHUNK_SELECT)
+        while True:
+            rows = cur.fetchmany(batch_size)
+            if not rows:
+                return
+            for row in rows:
+                yield _row_to_chunk(row)
 
     def get_chunk(self, chunk_id: str) -> CodeChunk | None:
         cur = self._conn.execute(f"{_CHUNK_SELECT} WHERE id = ?", (chunk_id,))

--- a/tests/index/test_store.py
+++ b/tests/index/test_store.py
@@ -103,6 +103,54 @@ def test_insert_and_get_all_chunks(store: IndexStore) -> None:
     assert ids == {c.id for c in SAMPLE_CHUNKS}
 
 
+def test_iter_chunks_matches_get_chunks(store: IndexStore) -> None:
+    """iter_chunks() yields the same chunks as get_chunks(), just incrementally."""
+    store.insert_chunks(SAMPLE_CHUNKS)
+    streamed = list(store.iter_chunks())
+    materialized = store.get_chunks()
+    assert len(streamed) == len(materialized) == 3
+    assert {c.id for c in streamed} == {c.id for c in materialized}
+    by_id = {c.id: c for c in materialized}
+    for chunk in streamed:
+        assert chunk == by_id[chunk.id]
+
+
+def test_iter_chunks_empty_store(store: IndexStore) -> None:
+    assert list(store.iter_chunks()) == []
+
+
+def test_iter_chunks_respects_small_batch_size(store: IndexStore) -> None:
+    """Batch size smaller than the row count still yields every chunk exactly once."""
+    many_chunks = [
+        CodeChunk(
+            id=f"chunk_{i}",
+            content=f"def f_{i}(): pass",
+            file_path=f"file_{i}.py",
+            start_line=1,
+            end_line=1,
+            symbol_name=f"f_{i}",
+            symbol_kind=SymbolKind.FUNCTION,
+            language="python",
+            token_count=5,
+        )
+        for i in range(7)
+    ]
+    store.insert_chunks(many_chunks)
+    streamed = list(store.iter_chunks(batch_size=2))
+    assert len(streamed) == 7
+    assert {c.id for c in streamed} == {c.id for c in many_chunks}
+
+
+def test_iter_chunks_is_lazy_generator(store: IndexStore) -> None:
+    """Calling iter_chunks() returns a generator; no rows are fetched until iterated."""
+    import inspect
+
+    store.insert_chunks(SAMPLE_CHUNKS)
+    gen = store.iter_chunks()
+    assert inspect.isgenerator(gen)
+    assert next(gen).id in {c.id for c in SAMPLE_CHUNKS}
+
+
 def test_insert_and_get_chunk_surrogates(store: IndexStore) -> None:
     store.insert_chunk_surrogates(SAMPLE_SURROGATES)
     result = store.get_chunk_surrogates()


### PR DESCRIPTION
## Stack

Stack-Id: `delta-bm25-a02084e`
Base: `main`
Position: 1/3

1. `feat/index-streaming-chunks` -> this PR
2. `feat/index-delta-bm25-targeted` -> #377
3. `test/index-delta-bm25-parity` -> #378

Depends on: (none - root)
Upstack: #377

## Summary

Part of milestone M2 (Index efficiency: delta-aware BM25 and streaming reads).

Adds `IndexStore.iter_chunks()`, a generator-based alternative to `get_chunks()` that fetches rows in batches instead of materializing the whole store's chunk set as a list of Pydantic objects at once. Purely additive — no existing call sites are migrated in this PR (that happens in PR-2, where it's genuinely beneficial).

## Validation

- `uv run pytest tests/index/test_store.py -k iter_chunks -v` — 4 passed
- `uv run ruff check` / `uv run ruff format --check` — clean
- `uv run pyright` — 0 errors
