### PR TITLE
fix(index): make apply_delta's BM25 update targeted, not a full rebuild

### DIFF
--- a/src/archex/index/bm25.py
+++ b/src/archex/index/bm25.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from archex.index.store import IndexStore
     from archex.models import CodeChunk
 
@@ -139,16 +141,34 @@ class BM25Index:
         row = self._store.conn.execute("SELECT COUNT(*) FROM chunks_fts").fetchone()
         return bool(row and row[0] > 0)
 
-    def build(self, chunks: list[CodeChunk]) -> None:
-        from archex.pipeline.chunker import expand_identifiers
-
+    def build(self, chunks: Iterable[CodeChunk]) -> None:
+        """Full rebuild: drop all FTS rows and reinsert from ``chunks``."""
         conn = self._store.conn
         conn.execute(_DROP_FTS_ROWS)
-        conn.executemany(
+        self._insert_rows(chunks)
+        conn.commit()
+
+    def update(self, chunks: Iterable[CodeChunk]) -> None:
+        """Insert FTS rows for newly-parsed chunks only — no drop.
+
+        For delta re-indexing: callers must have already removed stale FTS
+        rows for any changed or deleted files (``IndexStore.delete_chunks_for_files``
+        and ``delete_and_insert_for_files`` do this, scoped to the affected
+        file paths) before calling this. Inserting without a prior drop keeps
+        the FTS update proportional to the delta's changed chunks instead of
+        the store's total chunk count.
+        """
+        self._insert_rows(chunks)
+        self._store.conn.commit()
+
+    def _insert_rows(self, chunks: Iterable[CodeChunk]) -> None:
+        from archex.pipeline.chunker import expand_identifiers
+
+        self._store.conn.executemany(
             "INSERT INTO chunks_fts "
             "(chunk_id, content, symbol_name, file_path, docstring, breadcrumbs, summary) "
             "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            [
+            (
                 (
                     c.id,
                     expand_identifiers(c.content),
@@ -159,9 +179,8 @@ class BM25Index:
                     c.summary or "",
                 )
                 for c in chunks
-            ],
+            ),
         )
-        conn.commit()
 
     def _execute_fts(
         self,

--- a/src/archex/index/delta.py
+++ b/src/archex/index/delta.py
@@ -373,9 +373,12 @@ def apply_delta(
 
     t_start = time.perf_counter()
 
-    # Ensure chunks_fts table exists before any delete operations.
-    # BM25Index.__init__ creates the table if absent (idempotent via CREATE IF NOT EXISTS).
-    BM25Index(store)
+    # Ensure chunks_fts has the current schema before any delete operations
+    # below. A stale-schema migration here drops and recreates the table,
+    # emptying it — capture that so step 5 knows a full rebuild (not a
+    # targeted update) is required.
+    bm25 = BM25Index(store)
+    needs_full_bm25_rebuild = not bm25.has_data
 
     # 1. Handle renames
     for old_path, new_path in manifest.renamed_files:
@@ -453,16 +456,19 @@ def apply_delta(
         removed_graph_paths.add(old_path)
     graph.update_files(removed_graph_paths, new_edges)
 
-    # 5. Rebuild BM25 from updated store
-    all_chunks = store.get_chunks()
-    bm25 = BM25Index(store)
-    bm25.build(all_chunks)
+    # 5. Targeted BM25 update: insert only the newly-parsed chunks. Store
+    # deletions in steps 1-3 already scoped stale FTS rows to the delta's
+    # changed files, so no full DROP+rebuild is needed for the common case.
+    if needs_full_bm25_rebuild:
+        bm25.build(store.iter_chunks())
+    elif new_chunks:
+        bm25.update(new_chunks)
 
     # 6. Update metadata
     store.set_metadata("chunker", effective_index_config.chunker)
     store.set_metadata("chunker_revision", chunker_revision(effective_index_config.chunker))
-    store.set_metadata("repo_total_tokens", str(sum(chunk.token_count for chunk in all_chunks)))
-    store.set_metadata("chunk_count", str(len(all_chunks)))
+    store.set_metadata("repo_total_tokens", str(store.get_chunk_token_total()))
+    store.set_metadata("chunk_count", str(store.get_chunk_count()))
     store.set_metadata("commit_hash", manifest.current_commit)
     store.set_metadata("delta_applied", "true")
     file_meta = store.get_file_metadata()

--- a/tests/index/test_delta.py
+++ b/tests/index/test_delta.py
@@ -23,6 +23,8 @@ from archex.index.store import IndexStore
 from archex.models import ChangeStatus, CodeChunk, Config, IndexConfig
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from archex.index.graph import DependencyGraph
 
 from archex.pipeline.service import build_chunk_surrogates
@@ -453,6 +455,67 @@ class TestApplyDelta:
             meta = apply_delta(store, graph, manifest, delta_test_repo, Config(cache=False))
             assert meta.full_reindex_avoided is True
             assert meta.delta_time_ms >= 0
+        finally:
+            store.close()
+
+    def test_apply_delta_bm25_update_proportional_to_changed_chunks(
+        self,
+        delta_test_repo: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A single-file change triggers BM25 mutations scoped to that file's
+        chunks, not a full rebuild proportional to the repo's total chunk count.
+        """
+        from archex.index.bm25 import BM25Index
+        from archex.index.graph import DependencyGraph
+
+        store, graph = self.build_initial_index(delta_test_repo, tmp_path)
+        assert isinstance(graph, DependencyGraph)
+        try:
+            total_chunks_before = store.get_chunk_count()
+            old_utils_chunks = len(store.get_chunks_for_file("utils.py"))
+            assert old_utils_chunks > 0
+            assert total_chunks_before > old_utils_chunks + 1  # other files contribute too
+
+            build_calls: list[None] = []
+            update_calls: list[int] = []
+            original_build = BM25Index.build
+            original_update = BM25Index.update
+
+            def spy_build(self_idx: BM25Index, chunks: Iterable[CodeChunk]) -> None:
+                build_calls.append(None)
+                original_build(self_idx, chunks)
+
+            def spy_update(self_idx: BM25Index, chunks: Iterable[CodeChunk]) -> None:
+                chunks_list = list(chunks)
+                update_calls.append(len(chunks_list))
+                original_update(self_idx, chunks_list)
+
+            monkeypatch.setattr(BM25Index, "build", spy_build)
+            monkeypatch.setattr(BM25Index, "update", spy_update)
+
+            base = _git_head(delta_test_repo)
+            (delta_test_repo / "utils.py").write_text("def totally_new(): return 123\n")
+            _git(delta_test_repo, "add", ".")
+            _git(delta_test_repo, "commit", "-m", "modify utils only")
+            current = _git_head(delta_test_repo)
+
+            manifest = compute_delta(delta_test_repo, base, current)
+            apply_delta(store, graph, manifest, delta_test_repo, Config(cache=False))
+
+            # No full rebuild happened.
+            assert build_calls == []
+            # Exactly one targeted update, scoped to the changed file's new
+            # chunks — far fewer rows than the repo's total chunk count.
+            assert len(update_calls) == 1
+            new_utils_chunks = len(store.get_chunks_for_file("utils.py"))
+            assert update_calls[0] == new_utils_chunks
+            assert update_calls[0] < total_chunks_before
+
+            # FTS row count reflects exactly the scoped swap, not a full rebuild.
+            fts_count = store.conn.execute("SELECT COUNT(*) FROM chunks_fts").fetchone()[0]
+            assert fts_count == total_chunks_before - old_utils_chunks + new_utils_chunks
         finally:
             store.close()
 


### PR DESCRIPTION
## Stack

Stack-Id: `delta-bm25-a02084e`
Base: `feat/index-streaming-chunks` (#376)
Position: 2/3

1. `feat/index-streaming-chunks` -> #376
2. `feat/index-delta-bm25-targeted` -> this PR
3. `test/index-delta-bm25-parity` -> #378

Depends on: #376
Upstack: #378

## Summary

Part of milestone M2 (Index efficiency: delta-aware BM25 and streaming reads).

`apply_delta()` ended by reading every chunk in the store (`store.get_chunks()`) and calling `BM25Index.build()` on the full set — an O(total repo chunks) FTS DROP+rebuild on every delta apply, regardless of how small the change. `IndexStore`'s own `delete_chunks_for_files()`/`delete_and_insert_for_files()` already scope stale `chunks_fts` row removal to the delta's changed files, so the only real gap was inserting FTS rows for the freshly reprocessed chunks.

Changes:
- `BM25Index`: extract insert logic into `_insert_rows()`; add `update()`, an insert-only variant (no drop) for delta callers that have already removed stale rows elsewhere. `build()`/`update()` now accept `Iterable[CodeChunk]`.
- `delta.py`: replace the full rebuild with `BM25Index.update(new_chunks)`, proportional to the delta's changed chunks. A stale FTS-schema migration (which empties the table) is detected via `has_data` and still falls back to a genuine full `build(store.iter_chunks())` — the one place in this path that benefits from PR-1's streaming read.
- Metadata aggregates (`repo_total_tokens`, `chunk_count`) now use `IndexStore`'s existing SQL aggregate methods (`get_chunk_token_total()`, `get_chunk_count()`) instead of summing/counting a materialized full chunk list, removing the last full-store read from the common delta path.

Measured in isolation on a synthetic 4500-chunk / 300-file store, a single-file targeted update is ~250x faster than the previous full rebuild (137.6ms -> 0.55ms) for that step.

## Validation

- `uv run pytest tests/index/ -q` — 581 passed
- `uv run ruff check` / `uv run ruff format --check` — clean
- `uv run pyright` — 0 errors
- New test asserts `BM25Index.build()` is never called during a normal delta apply, and that the targeted update touches exactly the changed file's chunk count (not the repo total).
