### PR TITLE
test(index): verify BM25 delta parity and wire delta benchmark into CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -91,3 +91,38 @@ jobs:
           name: benchmark-results-fusion
           path: ${{ runner.temp }}/archex-benchmark-results/fusion/
 
+  benchmark-delta:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Delta tasks under benchmarks/delta_tasks checkout specific past
+          # commits of this repo (repo: ".") to benchmark against — a shallow
+          # clone would not contain them.
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run delta benchmark + quality gate
+        run: uv run archex benchmark delta
+
+      - name: Upload delta results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-delta
+          path: .archex/delta-results/
+

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -1167,9 +1167,19 @@ def headtohead_competitive_cmd(input_dir: str, output_format: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-@benchmark_cmd.group("delta")
-def delta_cmd() -> None:
-    """Delta indexing benchmarks: measure speedup and correctness."""
+@benchmark_cmd.group("delta", invoke_without_command=True)
+@click.pass_context
+def delta_cmd(ctx: click.Context) -> None:
+    """Delta indexing benchmarks: measure speedup and correctness.
+
+    Bare invocation (no subcommand) runs the full CI-runnable pipeline: every
+    task under ``benchmarks/delta_tasks`` followed by the quality gate,
+    exiting non-zero on any correctness or speedup violation.
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+    ctx.invoke(delta_run_cmd)
+    ctx.invoke(delta_gate_cmd)
 
 
 @delta_cmd.command("run")

--- a/tests/index/test_bm25.py
+++ b/tests/index/test_bm25.py
@@ -149,6 +149,104 @@ def test_build_is_idempotent(store_and_index: tuple[IndexStore, BM25Index]) -> N
 
 
 # ---------------------------------------------------------------------------
+# update() — targeted insert-only path (delta re-indexing)
+# ---------------------------------------------------------------------------
+
+
+def test_update_inserts_without_dropping_existing_rows(
+    store_and_index: tuple[IndexStore, BM25Index],
+) -> None:
+    """update() adds rows for new chunks without touching existing ones."""
+    store, idx = store_and_index
+    new_chunk = CodeChunk(
+        id="new.py:widget:1",
+        content="def widget(): return 'a shiny new widget'",
+        file_path="new.py",
+        start_line=1,
+        end_line=1,
+        symbol_name="widget",
+        symbol_kind=SymbolKind.FUNCTION,
+        language="python",
+        token_count=10,
+    )
+    store.insert_chunks([new_chunk])
+    idx.update([new_chunk])
+
+    # Pre-existing rows survive.
+    auth_results = idx.search("authenticate")
+    assert any(c.id == "auth.py:authenticate:10" for c, _ in auth_results)
+    # The newly-inserted row is searchable.
+    widget_results = idx.search("widget")
+    assert any(c.id == "new.py:widget:1" for c, _ in widget_results)
+
+
+def test_update_matches_full_rebuild_search_results(tmp_path: Path) -> None:
+    """A build() + update() (targeted) sequence returns identical search
+    results to a single build() call over the same final corpus."""
+    baseline_chunks = [
+        CodeChunk(
+            id="a.py:foo:1",
+            content="def foo(): return authenticate_user()",
+            file_path="a.py",
+            start_line=1,
+            end_line=1,
+            symbol_name="foo",
+            symbol_kind=SymbolKind.FUNCTION,
+            language="python",
+            token_count=10,
+        ),
+        CodeChunk(
+            id="b.py:bar:1",
+            content="def bar(): return validate_token()",
+            file_path="b.py",
+            start_line=1,
+            end_line=1,
+            symbol_name="bar",
+            symbol_kind=SymbolKind.FUNCTION,
+            language="python",
+            token_count=10,
+        ),
+    ]
+    new_chunks = [
+        CodeChunk(
+            id="c.py:baz:1",
+            content="def baz(): return authenticate_user() and validate_token()",
+            file_path="c.py",
+            start_line=1,
+            end_line=1,
+            symbol_name="baz",
+            symbol_kind=SymbolKind.FUNCTION,
+            language="python",
+            token_count=15,
+        ),
+    ]
+    full_corpus = baseline_chunks + new_chunks
+
+    # Targeted path: full build over the baseline, then a scoped insert-only
+    # update for the newly-added chunk — no drop of the baseline rows.
+    targeted_store = IndexStore(tmp_path / "targeted.db")
+    targeted_store.insert_chunks(full_corpus)
+    targeted_bm25 = BM25Index(targeted_store)
+    targeted_bm25.build(baseline_chunks)
+    targeted_bm25.update(new_chunks)
+
+    # Full-rebuild baseline: a single build() over the complete final set.
+    full_store = IndexStore(tmp_path / "full.db")
+    full_store.insert_chunks(full_corpus)
+    full_bm25 = BM25Index(full_store)
+    full_bm25.build(full_corpus)
+
+    try:
+        for query in ["authenticate", "validate token", "baz"]:
+            targeted_results = [(c.id, score) for c, score in targeted_bm25.search(query)]
+            full_results = [(c.id, score) for c, score in full_bm25.search(query)]
+            assert targeted_results == full_results, f"parity mismatch for query {query!r}"
+    finally:
+        targeted_store.close()
+        full_store.close()
+
+
+# ---------------------------------------------------------------------------
 # escape_fts_query — unit tests
 # ---------------------------------------------------------------------------
 

--- a/tests/index/test_delta.py
+++ b/tests/index/test_delta.py
@@ -519,6 +519,58 @@ class TestApplyDelta:
         finally:
             store.close()
 
+    def test_apply_delta_bm25_search_parity_with_full_rebuild(
+        self, delta_test_repo: Path, tmp_path: Path
+    ) -> None:
+        """BM25 search results after a targeted delta update must match a
+        genuine full reindex of the same final repo state exactly — the
+        parity requirement for replacing DROP+rebuild with a scoped insert.
+
+        The baseline is built via a fresh, independent full parse+index of
+        the repo at its final commit (not a round-trip through IndexStore's
+        `chunks` table, which does not persist `breadcrumbs`/`summary` and
+        would understate a real full rebuild's FTS content).
+        """
+        from archex.index.bm25 import BM25Index
+        from archex.index.graph import DependencyGraph
+
+        store, graph = self.build_initial_index(delta_test_repo, tmp_path)
+        assert isinstance(graph, DependencyGraph)
+        try:
+            base = _git_head(delta_test_repo)
+            (delta_test_repo / "utils.py").write_text(
+                "def brand_new_util():\n    return 'freshly parsed content'\n"
+            )
+            (delta_test_repo / "extra_feature.py").write_text(
+                "def process_widgets(widget_list):\n    return [w for w in widget_list if w]\n"
+            )
+            _git(delta_test_repo, "add", ".")
+            _git(delta_test_repo, "commit", "-m", "modify + add for parity check")
+            current = _git_head(delta_test_repo)
+
+            manifest = compute_delta(delta_test_repo, base, current)
+            apply_delta(store, graph, manifest, delta_test_repo, Config(cache=False))
+            targeted_bm25 = BM25Index(store)
+
+            # Full-rebuild baseline: an independent full parse+index of the
+            # repo at its current (final) commit — a genuine full reindex,
+            # not a round-trip through the store's lossy `chunks` table.
+            full_reindex_dir = tmp_path / "full_reindex"
+            full_reindex_dir.mkdir()
+            full_store, full_graph = self.build_initial_index(delta_test_repo, full_reindex_dir)
+            assert isinstance(full_graph, DependencyGraph)
+            full_bm25 = BM25Index(full_store)
+
+            try:
+                for query in ["util", "widget", "brand new", "process", "authenticate"]:
+                    targeted_results = [(c.id, score) for c, score in targeted_bm25.search(query)]
+                    full_results = [(c.id, score) for c, score in full_bm25.search(query)]
+                    assert targeted_results == full_results, f"parity mismatch: {query!r}"
+            finally:
+                full_store.close()
+        finally:
+            store.close()
+
     def test_delta_import_resolution_uses_full_file_map(self, tmp_path: Path) -> None:
         """Verify that delta re-parse resolves imports targeting unchanged files.
 


### PR DESCRIPTION
## Stack

Stack-Id: `delta-bm25-a02084e`
Base: `feat/index-delta-bm25-targeted` (#377)
Position: 3/3

1. `feat/index-streaming-chunks` -> #376
2. `feat/index-delta-bm25-targeted` -> #377
3. `test/index-delta-bm25-parity` -> this PR

Depends on: #377
Upstack: (none - leaf)

## Summary

Part of milestone M2 (Index efficiency: delta-aware BM25 and streaming reads). Verifies the search-result parity requirement for PR-2's targeted BM25 update and wires the delta benchmark into CI.

- `tests/index/test_bm25.py`: unit-level parity for `BM25Index.update()` itself — build a baseline, `update()`-insert additional chunks, and compare against a single `build()` over the union. Exact score parity.
- `tests/index/test_delta.py`: end-to-end parity for `apply_delta()`'s targeted path against a genuine independent full reindex of the same final repo state at its final commit (not a round-trip through `IndexStore`'s `chunks` table, which does not persist `breadcrumbs`/`summary` and would understate what a real full rebuild produces). Exact score parity confirmed.
- `archex benchmark delta` was a bare click group with no default action (exit 2, never wired into CI). Made the group `invoke_without_command` so a bare invocation runs every task under `benchmarks/delta_tasks` followed by the quality gate in one pass — the same run-then-gate pattern already used for the bm25/fusion query benchmarks.
- Added a `benchmark-delta` job to `.github/workflows/benchmark.yml` (same workflow_dispatch/weekly-cron schedule as the existing bm25/fusion jobs) running `uv run archex benchmark delta`. Uses `fetch-depth: 0` since the delta tasks check out specific past commits of this repo.

## Milestone M2 acceptance (cumulative across the stack)

- A single-file change on a fixture triggers BM25 mutations proportional to that file's chunk count, not the repo total — verified by `test_apply_delta_bm25_update_proportional_to_changed_chunks` (row-count assertion + `BM25Index.build` never called).
- Existing delta correctness tests pass unchanged.
- Search-result parity with the old full-rebuild approach is preserved — verified by `test_apply_delta_bm25_search_parity_with_full_rebuild` and `test_update_matches_full_rebuild_search_results` (exact BM25 score parity, not just chunk-set equality).

## Validation

- `uv run pytest tests/index/test_delta.py tests/index/test_bm25.py -v` — 95 passed
- `uv run archex benchmark delta` — 2/2 tasks, correct=True, gate passed
- `uv run pytest` — 2920 passed
- `uv run pyright` — 0 errors
- `uv run ruff check` / `uv run ruff format --check` — clean
