### PR TITLE
feat(index): bound co-directory edge growth on large flat directories

### DIFF
--- a/src/archex/index/graph.py
+++ b/src/archex/index/graph.py
@@ -18,6 +18,15 @@ _CO_DIRECTORY_EVIDENCE = [
     "same directory package scope; added only when no direct import edge exists"
 ]
 
+# Directories at or below this file count get full pairwise co-directory
+# edges (every file linked to every other, both directions). Above it,
+# each file only links to a bounded forward window of neighbors instead —
+# a flat directory of 500 files would otherwise add ~250k edges (O(n^2));
+# windowing bounds growth to O(n * window) while preserving local
+# same-directory connectivity for languages that rely on this fallback.
+_CO_DIRECTORY_DENSE_THRESHOLD = 50
+_CO_DIRECTORY_WINDOW_SIZE = 20
+
 
 def _resolved_import_evidence(file_path: str, imported_module: str, line: int) -> list[str]:
     return [f"resolved import {imported_module!r} at {file_path}:{line}"]
@@ -127,6 +136,11 @@ class DependencyGraph:
         same directory are implicitly co-dependent — they share the same package
         scope and can reference each other's symbols without import statements.
 
+        Directories with more than `_CO_DIRECTORY_DENSE_THRESHOLD` files skip
+        full pairwise edge generation in favor of a bounded per-file window
+        (`_CO_DIRECTORY_WINDOW_SIZE`), so a large flat directory cannot produce
+        a near-complete graph.
+
         Only adds edges where none exist yet.  Returns the number of edges added.
         """
         from collections import defaultdict
@@ -141,8 +155,12 @@ class DependencyGraph:
         for files in dir_groups.values():
             if len(files) < 2:
                 continue
+            dense = len(files) <= _CO_DIRECTORY_DENSE_THRESHOLD
             for i, src in enumerate(files):
-                for tgt in files[i + 1 :]:
+                targets = (
+                    files[i + 1 :] if dense else files[i + 1 : i + 1 + _CO_DIRECTORY_WINDOW_SIZE]
+                )
+                for tgt in targets:
                     if not self._file_graph.has_edge(src, tgt):  # type: ignore[misc]
                         self._file_graph.add_edge(  # type: ignore[misc]
                             src,

--- a/tests/index/test_graph.py
+++ b/tests/index/test_graph.py
@@ -439,3 +439,25 @@ class TestCoDirectoryEdges:
         assert {edge.confidence for edge in edges} == {EdgeConfidence.HEURISTIC}
         assert {edge.confidence_score for edge in edges} == {0.6}
         assert all(edge.evidence for edge in edges)
+
+    def test_bounds_edges_on_large_flat_directory(self) -> None:
+        from archex.index.graph import (
+            _CO_DIRECTORY_DENSE_THRESHOLD,  # pyright: ignore[reportPrivateUsage]
+            _CO_DIRECTORY_WINDOW_SIZE,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        graph = DependencyGraph()
+        file_count = 500
+        for i in range(file_count):
+            graph.add_file_node(f"flat/f{i:03d}.py")
+
+        added = graph.add_co_directory_edges()
+
+        full_pairwise = file_count * (file_count - 1)  # both directions, unbounded
+        assert file_count > _CO_DIRECTORY_DENSE_THRESHOLD
+        # Windowed bound: each file links to at most _CO_DIRECTORY_WINDOW_SIZE
+        # forward neighbors, both directions.
+        max_windowed = file_count * _CO_DIRECTORY_WINDOW_SIZE * 2
+        assert added > 0
+        assert added <= max_windowed
+        assert added < full_pairwise // 10


### PR DESCRIPTION
## Stack

Stack-Id: `m3-graph-ops-safety-7e78b62`
Base: `main`
Position: 1/3

1. `feat/graph-bounded-co-directory-edges` -> this PR
2. `feat/benchmark-gate-hard-fail-latency` -> #380
3. `feat/cache-automatic-eviction` -> (opening next)

Depends on: (none - root)
Upstack: #380

## Summary

Part of milestone M3 (Graph and ops safety net).

`add_co_directory_edges()` built a full pairwise (complete-graph) co-directory fallback for every directory regardless of size: O(n^2) edges, so a 500-file flat directory (config trees, docs, generated code) would add ~250k edges. Directories at or below a 50-file threshold keep the existing full-pairwise behavior unchanged; above it, each file links only to a bounded 20-file forward window (both directions), bounding growth to O(n * window) while preserving local same-directory connectivity for the Go/Rust import-resolution fallback this method exists for.

## Validation

- `uv run pytest tests/index/test_graph.py -v` — 30 passed
- `uv run ruff check src/archex/index/graph.py tests/index/test_graph.py` — clean
- `uv run ruff format --check src/archex/index/graph.py tests/index/test_graph.py` — clean
- `uv run pyright src/archex/index/graph.py` — 0 errors
- `uv run archex benchmark arch run --output /tmp/arch-before` (pre-change) then `--output /tmp/arch-after` (post-change), then `uv run archex benchmark arch gate --input /tmp/arch-after --baseline /tmp/arch-before` — advisory gate passed, no architecture-quality regression on the labeled fixture corpus.