### PR TITLE
feat(benchmark): add hard-fail max-latency-ms threshold to gate

### DIFF
--- a/src/archex/benchmark/gate.py
+++ b/src/archex/benchmark/gate.py
@@ -40,6 +40,10 @@ class QualityThresholds(BaseModel):
     min_relevance_per_1k_tokens: float = 0.0
     # Latency: warn-only, does not fail the gate
     warn_latency_ms: float = 5000.0
+    # Latency: hard-fail. None (default) disables the check entirely — distinct
+    # from warn_latency_ms, which only ever prints a warning. Set via
+    # --max-latency-ms on `archex benchmark gate`.
+    max_latency_ms: float | None = None
     # Strategies exempt from gate checks (results are informational only)
     gate_exempt_strategies: set[str] = {
         "raw_files",
@@ -68,6 +72,13 @@ class BaselineGateViolation(BaseModel):
 
 
 class LatencyWarning(BaseModel):
+    task_id: str
+    strategy: str
+    threshold_ms: float
+    actual_ms: float
+
+
+class LatencyViolation(BaseModel):
     task_id: str
     strategy: str
     threshold_ms: float
@@ -296,6 +307,37 @@ def check_latency_warnings(
                     )
                 )
     return warnings
+
+
+def check_latency_violations(
+    reports: list[BenchmarkReport],
+    thresholds: QualityThresholds | None = None,
+) -> list[LatencyViolation]:
+    """Return hard latency violations for results exceeding max_latency_ms.
+
+    Distinct from `check_latency_warnings`: this check is skipped entirely
+    when `thresholds.max_latency_ms` is None (the default), and callers are
+    expected to fail the gate on any returned violation.
+    """
+    if thresholds is None:
+        thresholds = QualityThresholds()
+    if thresholds.max_latency_ms is None:
+        return []
+
+    max_latency_ms = thresholds.max_latency_ms
+    violations: list[LatencyViolation] = []
+    for report in reports:
+        for r in report.results:
+            if r.wall_time_ms > max_latency_ms:
+                violations.append(
+                    LatencyViolation(
+                        task_id=r.task_id,
+                        strategy=r.strategy.value,
+                        threshold_ms=max_latency_ms,
+                        actual_ms=r.wall_time_ms,
+                    )
+                )
+    return violations
 
 
 # ---------------------------------------------------------------------------

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -22,10 +22,12 @@ from archex.benchmark.cross_tool import NaiveBaselineModel, run_cross_tool
 from archex.benchmark.delta_runner import run_all_delta
 from archex.benchmark.gate import (
     DeltaQualityThresholds,
+    LatencyViolation,
     LatencyWarning,
     QualityThresholds,
     check_delta_gate,
     check_gate,
+    check_latency_violations,
     check_latency_warnings,
     check_recall_regressions,
     non_token_quality_warnings,
@@ -789,6 +791,15 @@ def baseline_compare_cmd(input_dir: str, baseline_path: str) -> None:
     type=float,
     help="Warn (non-fatal) if mean task latency exceeds this value in ms.",
 )
+@click.option(
+    "--max-latency-ms",
+    default=None,
+    type=float,
+    help=(
+        "Hard-fail (non-zero exit) if mean task latency exceeds this value in ms. "
+        "Distinct from --warn-latency-ms, which only prints a warning. Disabled by default."
+    ),
+)
 def gate_cmd(
     input_dir: str,
     min_recall: float,
@@ -797,6 +808,7 @@ def gate_cmd(
     min_mrr: float,
     baseline_dir: str | None,
     warn_latency_ms: float,
+    max_latency_ms: float | None,
 ) -> None:
     """Check benchmark results against quality thresholds."""
     input_path = Path(input_dir)
@@ -814,6 +826,7 @@ def gate_cmd(
         min_f1=min_f1,
         min_mrr=min_mrr,
         warn_latency_ms=warn_latency_ms,
+        max_latency_ms=max_latency_ms,
     )
 
     latency_warnings: list[LatencyWarning] = check_latency_warnings(reports, thresholds)
@@ -826,6 +839,19 @@ def gate_cmd(
                 f"  {w.task_id}/{w.strategy}: {w.actual_ms:.0f}ms"
                 f" (threshold: {w.threshold_ms:.0f}ms)"
             )
+
+    latency_violations: list[LatencyViolation] = check_latency_violations(reports, thresholds)
+    if latency_violations:
+        click.echo(
+            f"LATENCY GATE FAILED: {len(latency_violations)} task(s) exceeded "
+            f"{max_latency_ms:.0f}ms"
+        )
+        for v in latency_violations:
+            click.echo(
+                f"  {v.task_id}/{v.strategy}: {v.actual_ms:.0f}ms"
+                f" (threshold: {v.threshold_ms:.0f}ms)"
+            )
+        raise SystemExit(1)
 
     absolute_violations = check_gate(reports, thresholds)
     token_violations = token_efficiency_violations(absolute_violations)

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -387,6 +387,58 @@ expected_delta:
         assert "Failed to parse YAML" in result.output
 
 
+class TestGateCommand:
+    def test_passes_when_max_latency_ms_not_set(self, runner: CliRunner, results_dir: Path) -> None:
+        result = runner.invoke(benchmark_cmd, ["gate", "--input", str(results_dir)])
+        assert result.exit_code == 0
+        assert "Quality gate passed." in result.output
+
+    def test_max_latency_ms_hard_fails_on_breach(self, runner: CliRunner, tmp_path: Path) -> None:
+        results = tmp_path / "results"
+        results.mkdir()
+        result_obj = BenchmarkResult(
+            task_id="slow_task",
+            strategy=Strategy.RAW_FILES,
+            tokens_total=1000,
+            tool_calls=1,
+            files_accessed=3,
+            recall=1.0,
+            precision=1.0,
+            savings_vs_raw=0.0,
+            wall_time_ms=9000.0,
+            cached=False,
+            timestamp="2025-01-01T00:00:00Z",
+        )
+        report = BenchmarkReport(
+            task_id="slow_task",
+            repo="owner/repo",
+            question="How?",
+            results=[result_obj],
+            baseline_tokens=1000,
+        )
+        (results / "slow.json").write_text(report.model_dump_json(indent=2))
+
+        result = runner.invoke(
+            benchmark_cmd,
+            ["gate", "--input", str(results), "--max-latency-ms", "5000"],
+        )
+
+        assert result.exit_code != 0
+        assert "LATENCY GATE FAILED" in result.output
+        assert "slow_task/raw_files" in result.output
+
+    def test_max_latency_ms_passes_under_threshold(
+        self, runner: CliRunner, results_dir: Path
+    ) -> None:
+        # results_dir fixture's sample result has wall_time_ms=50.0
+        result = runner.invoke(
+            benchmark_cmd,
+            ["gate", "--input", str(results_dir), "--max-latency-ms", "5000"],
+        )
+        assert result.exit_code == 0
+        assert "LATENCY GATE FAILED" not in result.output
+
+
 class TestBundleEvalCommand:
     def test_bundle_eval_help(self, runner: CliRunner) -> None:
         result = runner.invoke(benchmark_cmd, ["bundle-eval", "--help"])


### PR DESCRIPTION
## Stack

Stack-Id: `m3-graph-ops-safety-7e78b62`
Base: `feat/graph-bounded-co-directory-edges` (#379)
Position: 2/3

1. `feat/graph-bounded-co-directory-edges` -> #379
2. `feat/benchmark-gate-hard-fail-latency` -> this PR
3. `feat/cache-automatic-eviction` -> #381

Depends on: #379
Upstack: #381

## Summary

Part of milestone M3 (Graph and ops safety net).

`archex benchmark gate` only ever warns on latency (`--warn-latency-ms`, `check_latency_warnings`) — a real latency regression never fails the gate. Add a distinct hard-fail `--max-latency-ms` flag (disabled by default, `None`), threaded through `QualityThresholds.max_latency_ms` and a new `check_latency_violations()` gate check. When breached, the CLI prints `LATENCY GATE FAILED` with the offending task/strategy/latency and exits non-zero, independent of `--baseline` or any other gate branch.

## Validation

- `uv run pytest tests/benchmark/test_gate.py tests/benchmark/test_cli.py -v` — 85 passed
- `uv run ruff check src/archex/benchmark/gate.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_gate.py tests/benchmark/test_cli.py` — clean
- `uv run ruff format --check` on the same files — clean
- `uv run pyright` (full repo) — 0 errors
- Manual CLI smoke test: a synthetic 9000ms result with `--max-latency-ms 5000` exits 1 with `LATENCY GATE FAILED`; without the flag the same result exits 0 (warning only).