### PR TITLE
feat(cache): evict opportunistically on put() instead of manual-only

### DIFF
--- a/src/archex/cache.py
+++ b/src/archex/cache.py
@@ -18,6 +18,12 @@ if TYPE_CHECKING:
 
 _KEY_RE = re.compile(r"^[0-9a-f]{64}$")
 
+# Global (non-project-layout) caches accumulate one entry per distinct
+# (source, resolved-ref) pair — unbounded over a CI/benchmark loop that
+# indexes many repos or many past commits of one repo. put() opportunistically
+# bounds this without requiring a manual `archex cache clean` invocation.
+_DEFAULT_MAX_CACHE_ENTRIES = 500
+
 
 class CacheManager:
     """Manage cached SQLite analysis artifacts on disk."""
@@ -27,10 +33,12 @@ class CacheManager:
         cache_dir: str = "~/.archex/cache",
         *,
         project_layout: bool = False,
+        max_entries: int = _DEFAULT_MAX_CACHE_ENTRIES,
     ) -> None:
         self._cache_dir = Path(cache_dir).expanduser()
         self._cache_dir.mkdir(parents=True, exist_ok=True)
         self._project_layout = project_layout
+        self._max_entries = max_entries
 
     # ------------------------------------------------------------------
     # Key helpers
@@ -193,6 +201,7 @@ class CacheManager:
             "stable_identity": stable_identity or "",
         }
         meta.write_text(json.dumps(meta_data))
+        self._evict_if_needed()
         return dest
 
     def get_meta(self, key: str) -> dict[str, str]:
@@ -288,6 +297,38 @@ class CacheManager:
                     meta.unlink()
                 removed += 1
         return removed
+
+    def _evict_if_needed(self) -> None:
+        """Opportunistically bound cache growth after each put().
+
+        Runs the existing age-based clean() first (default max_age_hours),
+        then, if the entry count still exceeds max_entries, evicts the
+        oldest entries by created_at until back under the cap. This is what
+        makes eviction automatic — no manual `archex cache clean` call is
+        required to keep a long-running CI/benchmark loop's cache bounded.
+
+        A project-layout cache holds a single fixed-path entry, is always
+        overwritten in place by put(), and never accumulates — exempt.
+        """
+        if self._project_layout:
+            return
+        self.clean()
+        if self._max_entries <= 0:
+            return
+        entries = self.list_entries()
+        overflow = len(entries) - self._max_entries
+        if overflow <= 0:
+            return
+
+        def _created_at(entry: dict[str, str]) -> float:
+            try:
+                return float(entry.get("created_at", "0"))
+            except ValueError:
+                return 0.0
+
+        entries.sort(key=_created_at)
+        for entry in entries[:overflow]:
+            self.invalidate(entry["key"])
 
     def find_store_for_source(self, source: RepoSource) -> tuple[Path, str] | None:
         """Find a cached store for the same source identity, regardless of commit.

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import itertools
 import json
 import time
 from typing import TYPE_CHECKING
@@ -655,3 +656,70 @@ class TestStableIdentity:
         cache.put(key, sample_db)
         meta = cache.get_meta(key)
         assert meta["stable_identity"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Automatic (opportunistic) eviction
+# ---------------------------------------------------------------------------
+
+
+class TestAutomaticEviction:
+    def test_put_stays_bounded_across_n_runs(self, tmp_path: Path, sample_db: Path) -> None:
+        """Repeated put() calls never grow the cache past max_entries."""
+        cache = CacheManager(cache_dir=str(tmp_path / "cache"), max_entries=5)
+
+        for i in range(20):
+            key = hashlib.sha256(f"run-{i}".encode()).hexdigest()
+            cache.put(key, sample_db)
+
+        assert len(cache.list_entries()) <= 5
+
+    def test_eviction_removes_oldest_entries_first(self, tmp_path: Path, sample_db: Path) -> None:
+        cache = CacheManager(cache_dir=str(tmp_path / "cache"), max_entries=2)
+        keys = [hashlib.sha256(f"ordered-{i}".encode()).hexdigest() for i in range(4)]
+
+        base = 1_700_000_000.0
+        with patch("archex.cache.time.time", side_effect=itertools.count(base, 1.0)):
+            for key in keys:
+                cache.put(key, sample_db)
+
+        remaining = {e["key"] for e in cache.list_entries()}
+        assert remaining == {keys[2], keys[3]}
+
+    def test_max_entries_zero_disables_count_based_eviction(
+        self, tmp_path: Path, sample_db: Path
+    ) -> None:
+        cache = CacheManager(cache_dir=str(tmp_path / "cache"), max_entries=0)
+
+        for i in range(5):
+            key = hashlib.sha256(f"unbounded-{i}".encode()).hexdigest()
+            cache.put(key, sample_db)
+
+        assert len(cache.list_entries()) == 5
+
+    def test_project_layout_cache_is_exempt_from_eviction(
+        self, tmp_path: Path, sample_db: Path
+    ) -> None:
+        cache = CacheManager(
+            cache_dir=str(tmp_path / ".archex"), project_layout=True, max_entries=1
+        )
+
+        # A project-layout cache always writes to the same fixed index.db path,
+        # so repeated put()s under different keys just overwrite it in place.
+        cache.put(KEY_A, sample_db)
+        cache.put(KEY_B, sample_db)
+
+        assert len(cache.list_entries()) == 1
+
+    def test_eviction_runs_age_based_clean_even_under_the_count_cap(
+        self, tmp_path: Path, sample_db: Path
+    ) -> None:
+        """put() opportunistically evicts stale entries even when count is under the cap."""
+        cache = CacheManager(cache_dir=str(tmp_path / "cache"), max_entries=50)
+        cache.put(KEY_OLD, sample_db)
+        cache.meta_path(KEY_OLD).write_text(str(time.time() - 48 * 3600))
+
+        cache.put(KEY_NEW, sample_db)
+
+        assert cache.get(KEY_OLD) is None
+        assert cache.get(KEY_NEW) is not None


### PR DESCRIPTION
## Stack

Stack-Id: `m3-graph-ops-safety-7e78b62`
Base: `feat/benchmark-gate-hard-fail-latency` (#380)
Position: 3/3

1. `feat/graph-bounded-co-directory-edges` -> #379
2. `feat/benchmark-gate-hard-fail-latency` -> #380
3. `feat/cache-automatic-eviction` -> this PR

Depends on: #380
Upstack: (none - leaf)

## Summary

Part of milestone M3 (Graph and ops safety net). Closes out the milestone.

`CacheManager.clean()` only ever ran through the manual `archex cache clean` CLI command — a global (non-project-layout) cache accumulates one entry per distinct (source, resolved-ref) pair indefinitely (report measured 17,502 files / ~56 MB, never auto-evicted). `put()` now opportunistically calls `clean()` on every write (age-based, unchanged default), and additionally caps total entry count at `max_entries` (default 500, oldest-by-`created_at` evicted first) as a backstop for bursts too fast for the 24h age window to catch. A project-layout cache (single fixed-path `index.db`, always overwritten in place) never accumulates and is exempt from both checks.

## Validation

- `uv run pytest tests/test_cache.py -v` — 75 passed
- `uv run ruff check src/archex/cache.py tests/test_cache.py` — clean
- `uv run ruff format --check src/archex/cache.py tests/test_cache.py` — clean
- `uv run pyright` (full repo) — 0 errors
- `uv run pytest` (full repo) — 2929 passed, 90.75% coverage
