### PR TITLE
feat(mcp): add explain_target tool

### DIFF
--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -27,7 +27,17 @@ from archex.api import (
     search_symbols,
 )
 from archex.config import load_config, load_index_config
-from archex.graph_artifact import GraphArtifactError
+from archex.explain import (
+    ExplainError,
+    explain_file,
+    explain_graph_file,
+    explain_graph_module,
+    explain_graph_symbol,
+    explain_module,
+    explain_symbol,
+    render_explain_context,
+)
+from archex.graph_artifact import GraphArtifactError, load_arch_graph
 from archex.graph_query import (
     GraphDirection,
     GraphEdgeSummary,
@@ -554,6 +564,92 @@ def handle_get_impact(
     return json.dumps({"content": content, "_meta": meta.model_dump()}, indent=2)
 
 
+def handle_explain_target(
+    repo_url: str | None = None,
+    target: str | None = None,
+    module_name: str | None = None,
+    graph_path: str | None = None,
+    output_format: str = "json",
+) -> str:
+    """Explain a file, symbol, or module from indexed structural data.
+
+    Args:
+        repo_url: Local path or HTTP(S) URL of the repository. Required unless
+            graph_path is given.
+        target: File path or `path::name#kind` symbol identifier to explain.
+            Mutually exclusive with module_name.
+        module_name: Module path to explain. Mutually exclusive with target.
+        graph_path: Read an exported graph artifact instead of indexing
+            repo_url.
+        output_format: Output format — 'json' or 'markdown'. Defaults to 'json'.
+
+    Returns:
+        JSON envelope with ExplainContext content and _meta efficiency block.
+    """
+    _validate_output_format(output_format)
+    if module_name is not None and target is not None:
+        raise ExplainError("use either target or module_name, not both")
+    if module_name is None and target is None:
+        raise ExplainError("explain_target requires target or module_name")
+    if graph_path is None and repo_url is None:
+        raise ExplainError("explain_target requires repo_url when graph_path is not provided")
+
+    started = time.perf_counter()
+    source: RepoSource | None = None
+    pt: PipelineTiming | None = None
+    if graph_path is not None:
+        graph = load_arch_graph(Path(graph_path))
+        if module_name is not None:
+            context = explain_graph_module(graph, module_name)
+        elif target is not None and ("::" in target or "#" in target):
+            context = explain_graph_symbol(graph, target)
+        elif target is not None:
+            context = explain_graph_file(graph, target)
+        else:
+            raise ExplainError("explain_target requires target or module_name")
+        raw_tokens = max(count_tokens(graph.to_json()), 1)
+    else:
+        assert repo_url is not None
+        source = resolve_source(repo_url)
+        config = load_config(source)
+        index_config = load_index_config(source)
+        pt = PipelineTiming()
+        store = index_repository(source, config=config, timing=pt, index_config=index_config)
+        try:
+            if module_name is not None:
+                context = explain_module(store, module_name)
+            elif target is not None and ("::" in target or "#" in target):
+                context = explain_symbol(store, target)
+            elif target is not None:
+                context = explain_file(store, target)
+            else:
+                raise ExplainError("explain_target requires target or module_name")
+        finally:
+            store.close()
+        raw_tokens = get_files_token_count(source, context.files) if context.files else 0
+    query_time_ms = (time.perf_counter() - started) * 1000
+
+    content = render_explain_context(context, output_format)
+    meta = compute_meta(
+        tool_name="explain_target",
+        response_text=content,
+        raw_file_tokens=raw_tokens or 0,
+        strategy="explain_context",
+        cached=pt.cached if pt is not None else False,
+        index_time_ms=pt.index_ms if pt is not None else 0.0,
+        query_time_ms=query_time_ms,
+    )
+    if source is not None:
+        _record_structural_metrics(
+            source,
+            "explain_target",
+            content,
+            raw_tokens,
+            file_count=len(context.files),
+        )
+    return json.dumps({"content": content, "_meta": meta.model_dump()}, indent=2)
+
+
 def handle_graph_lookup(
     graph_path: str,
     node: str,
@@ -955,6 +1051,21 @@ async def _run_mcp_tool(
         return await loop.run_in_executor(
             None, handle_get_impact, repo_url, base, impact_changed_files, fmt
         )
+    if name == "explain_target":
+        explain_repo_url: str | None = arguments.get("repo_url")
+        explain_target_arg: str | None = arguments.get("target")
+        module_name: str | None = arguments.get("module_name")
+        explain_graph_path: str | None = arguments.get("graph_path")
+        fmt = arguments.get("format", "json")
+        return await loop.run_in_executor(
+            None,
+            handle_explain_target,
+            explain_repo_url,
+            explain_target_arg,
+            module_name,
+            explain_graph_path,
+            fmt,
+        )
     if name == "graph_lookup":
         graph_path = arguments["graph_path"]
         node: str = arguments["node"]
@@ -1354,6 +1465,52 @@ def build_server() -> Any:
                         },
                     },
                     "required": ["repo_url"],
+                },
+            ),
+            mcp_types.Tool(
+                name="explain_target",
+                description=(
+                    "Explain a file, symbol, or module from indexed structural data: public "
+                    "interfaces, internal symbols, imports/imported-by, module context, and "
+                    "complexity signals."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "repo_url": {
+                            "type": "string",
+                            "description": (
+                                "Local path or HTTP(S) URL of the repository. Required "
+                                "unless graph_path is given."
+                            ),
+                        },
+                        "target": {
+                            "type": "string",
+                            "description": (
+                                "File path or `path::name#kind` symbol identifier to "
+                                "explain. Mutually exclusive with module_name."
+                            ),
+                        },
+                        "module_name": {
+                            "type": "string",
+                            "description": (
+                                "Module path to explain. Mutually exclusive with target."
+                            ),
+                        },
+                        "graph_path": {
+                            "type": "string",
+                            "description": (
+                                "Read an exported graph artifact instead of indexing repo_url."
+                            ),
+                        },
+                        "format": {
+                            "type": "string",
+                            "enum": ["json", "markdown"],
+                            "default": "json",
+                            "description": "Output format for the explain context.",
+                        },
+                    },
+                    "required": [],
                 },
             ),
             mcp_types.Tool(

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -12,6 +12,7 @@ import pytest
 
 pytest.importorskip("mcp", reason="mcp not installed")
 
+from archex.explain import ExplainError
 from archex.graph_artifact import (
     ArchGraph,
     GraphEdge,
@@ -28,6 +29,7 @@ from archex.integrations.mcp import (
     clear_graph_query_cache,
     handle_analyze_repo,
     handle_compare_repos,
+    handle_explain_target,
     handle_get_impact,
     handle_graph_hubs,
     handle_graph_neighbors,
@@ -674,7 +676,7 @@ class TestBuildServer:
         server_result = await handler(req)
         result = server_result.root
         assert isinstance(result, mcp_types.ListToolsResult)
-        assert len(result.tools) == 15
+        assert len(result.tools) == 16
         tool_names = {t.name for t in result.tools}
         assert "scout_repo" in tool_names
         assert "get_file_tree" in tool_names
@@ -684,6 +686,7 @@ class TestBuildServer:
         assert "graph_path" in tool_names
         assert "graph_stats" in tool_names
         assert "get_impact" in tool_names
+        assert "explain_target" in tool_names
 
 
 # ---------------------------------------------------------------------------
@@ -1019,3 +1022,147 @@ class TestHandleGetImpact:
 
         with pytest.raises(ImpactError, match="requires changed_files"):
             handle_get_impact("https://example.com/repo.git")
+
+
+# ---------------------------------------------------------------------------
+# explain_target handler tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandleExplainTarget:
+    def test_matches_cli_output_for_file_target(self, python_simple_repo: Path) -> None:
+        from click.testing import CliRunner
+
+        from archex.cli.main import cli
+
+        runner = CliRunner()
+        cli_result = runner.invoke(
+            cli, ["explain", str(python_simple_repo), "main.py", "--format", "json"]
+        )
+        assert cli_result.exit_code == 0, cli_result.output
+        cli_data = json.loads(cli_result.output)
+
+        mcp_result = handle_explain_target(
+            str(python_simple_repo), target="main.py", output_format="json"
+        )
+        envelope = json.loads(mcp_result)
+        mcp_data = json.loads(envelope["content"])
+
+        assert mcp_data == cli_data
+        assert envelope["_meta"]["tool_name"] == "explain_target"
+        assert envelope["_meta"]["strategy"] == "explain_context"
+
+    def test_matches_cli_output_for_symbol_target(self, python_simple_repo: Path) -> None:
+        from click.testing import CliRunner
+
+        from archex.cli.main import cli
+
+        runner = CliRunner()
+        cli_result = runner.invoke(
+            cli,
+            [
+                "explain",
+                str(python_simple_repo),
+                "main.py::run#function",
+                "--format",
+                "json",
+            ],
+        )
+        assert cli_result.exit_code == 0, cli_result.output
+        cli_data = json.loads(cli_result.output)
+
+        mcp_result = handle_explain_target(
+            str(python_simple_repo), target="main.py::run#function", output_format="json"
+        )
+        mcp_data = json.loads(json.loads(mcp_result)["content"])
+
+        assert mcp_data == cli_data
+
+    def test_matches_cli_output_for_module_target(self, python_simple_repo: Path) -> None:
+        from click.testing import CliRunner
+
+        from archex.cli.main import cli
+
+        runner = CliRunner()
+        cli_result = runner.invoke(
+            cli,
+            ["explain", str(python_simple_repo), "--module", "services", "--format", "json"],
+        )
+        assert cli_result.exit_code == 0, cli_result.output
+        cli_data = json.loads(cli_result.output)
+
+        mcp_result = handle_explain_target(
+            str(python_simple_repo), module_name="services", output_format="json"
+        )
+        mcp_data = json.loads(json.loads(mcp_result)["content"])
+
+        assert mcp_data == cli_data
+
+    def test_matches_cli_output_for_markdown_format(self, python_simple_repo: Path) -> None:
+        from click.testing import CliRunner
+
+        from archex.cli.main import cli
+
+        runner = CliRunner()
+        cli_result = runner.invoke(cli, ["explain", str(python_simple_repo), "main.py"])
+        assert cli_result.exit_code == 0, cli_result.output
+
+        mcp_result = handle_explain_target(
+            str(python_simple_repo), target="main.py", output_format="markdown"
+        )
+        envelope = json.loads(mcp_result)
+
+        assert envelope["content"] == cli_result.output
+
+    def test_matches_cli_output_for_graph_artifact_mode(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        from click.testing import CliRunner
+
+        from archex.cli.main import cli
+
+        runner = CliRunner()
+        graph_path = tmp_path / "graph.json"
+        export_result = runner.invoke(
+            cli, ["graph", "export", str(python_simple_repo), "--output", str(graph_path)]
+        )
+        assert export_result.exit_code == 0, export_result.output
+
+        cli_result = runner.invoke(
+            cli,
+            [
+                "explain",
+                "ignored",
+                "main.py",
+                "--graph",
+                str(graph_path),
+                "--format",
+                "json",
+            ],
+        )
+        assert cli_result.exit_code == 0, cli_result.output
+        cli_data = json.loads(cli_result.output)
+
+        mcp_result = handle_explain_target(
+            target="main.py", graph_path=str(graph_path), output_format="json"
+        )
+        envelope = json.loads(mcp_result)
+        mcp_data = json.loads(envelope["content"])
+
+        assert mcp_data == cli_data
+
+    def test_rejects_both_target_and_module(self) -> None:
+        with pytest.raises(ExplainError, match="not both"):
+            handle_explain_target("/fake/repo", target="a.py", module_name="a")
+
+    def test_rejects_neither_target_nor_module(self) -> None:
+        with pytest.raises(ExplainError, match="requires target or module_name"):
+            handle_explain_target("/fake/repo")
+
+    def test_requires_repo_url_without_graph_path(self) -> None:
+        with pytest.raises(ExplainError, match="requires repo_url"):
+            handle_explain_target(target="a.py")
+
+    def test_rejects_invalid_format(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported format"):
+            handle_explain_target("/fake/repo", target="a.py", output_format="xml")


### PR DESCRIPTION
## Stack

Stack-Id: `mcp-m4-parity`
Base: `feat/mcp-impact-tool`
Position: 2/3

1. `feat/mcp-impact-tool` -> #382
2. `feat/mcp-explain-tool` -> this PR
3. `feat/mcp-onboard-tool` -> #TBD

Depends on: #382
Upstack: feat/mcp-onboard-tool

## Summary

Registers `explain_target` as a 16th MCP tool in `src/archex/integrations/mcp.py`, wrapping the existing `explain.py` backend (already exposed via `archex explain`). Follows the established `_meta`-envelope handler pattern exactly.

Part of DEVELOPMENT_PLAN.md M4 (MCP parity: impact, explain, onboard). Stacked on #382 (`get_impact`).

- `handle_explain_target(repo_url=None, target=None, module_name=None, graph_path=None, output_format="json")` — file/symbol/module explain, indexing `repo_url` or reading an exported `graph_path` artifact (mirrors `archex explain`'s `--graph` mode).
- Registered in `list_tools()` and dispatched in `_run_mcp_tool`.
- No changes to `explain.py`'s underlying logic; pure MCP surface exposure.

## Validation

- `uv run pytest tests/integrations/test_mcp.py -v` — 64 passed
- `uv run pytest` — 2942 passed, coverage 90.83%
- `uv run ruff check src/archex/integrations/mcp.py` — OK
- `uv run ruff format --check` — OK
- `uv run pyright` — 0 errors

New test `TestHandleExplainTarget` asserts byte-for-byte parity between `handle_explain_target` and `archex explain` CLI output for file, symbol, module, markdown, and exported graph-artifact modes on the `python_simple_repo` fixture, plus mutual-exclusivity and required-field error paths.
