### PR TITLE
feat(mcp): add generate_onboarding tool

### DIFF
--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -37,7 +37,11 @@ from archex.explain import (
     explain_symbol,
     render_explain_context,
 )
-from archex.graph_artifact import GraphArtifactError, load_arch_graph
+from archex.graph_artifact import (
+    GraphArtifactError,
+    build_arch_graph_from_store,
+    load_arch_graph,
+)
 from archex.graph_query import (
     GraphDirection,
     GraphEdgeSummary,
@@ -61,6 +65,7 @@ from archex.metrics.capture import record_query_usage, record_scout_usage, recor
 from archex.metrics.health import note_metrics_recording_failure
 from archex.metrics.policy import resolve_metrics_policy
 from archex.models import ContextBundle, PipelineTiming, RepoSource
+from archex.onboarding import OnboardingError, render_onboarding_markdown
 from archex.reporting import compute_meta, count_tokens
 from archex.scout import DEFAULT_SCOUT_TOKEN_BUDGET, ScoutFormat, ScoutResult, render_scout
 from archex.serve.compare import validate_dimensions
@@ -650,6 +655,71 @@ def handle_explain_target(
     return json.dumps({"content": content, "_meta": meta.model_dump()}, indent=2)
 
 
+def handle_generate_onboarding(
+    repo_url: str | None = None,
+    graph_path: str | None = None,
+    max_files: int = 40,
+) -> str:
+    """Generate a deterministic onboarding guide from graph/index data.
+
+    Args:
+        repo_url: Local path or HTTP(S) URL of the repository. Required
+            unless graph_path is given.
+        graph_path: Read an exported graph artifact instead of indexing
+            repo_url.
+        max_files: Maximum paths per capped section. Defaults to 40.
+
+    Returns:
+        JSON envelope with the markdown onboarding guide and _meta
+        efficiency block. Onboarding output is markdown-only.
+    """
+    if graph_path is None and repo_url is None:
+        raise OnboardingError(
+            "generate_onboarding requires repo_url when graph_path is not provided"
+        )
+
+    started = time.perf_counter()
+    source: RepoSource | None = None
+    pt: PipelineTiming | None = None
+    if graph_path is not None:
+        graph = load_arch_graph(Path(graph_path))
+        raw_tokens = max(count_tokens(graph.to_json()), 1)
+    else:
+        assert repo_url is not None
+        source = resolve_source(repo_url)
+        repo_root = Path(source.local_path).expanduser().resolve() if source.local_path else None
+        config = load_config(source)
+        index_config = load_index_config(source)
+        pt = PipelineTiming()
+        store = index_repository(source, config=config, timing=pt, index_config=index_config)
+        try:
+            graph = build_arch_graph_from_store(store, repo_root=repo_root)
+        finally:
+            store.close()
+        raw_tokens = get_repo_total_tokens(source) or 0
+    query_time_ms = (time.perf_counter() - started) * 1000
+
+    content = render_onboarding_markdown(graph, max_files=max_files)
+    meta = compute_meta(
+        tool_name="generate_onboarding",
+        response_text=content,
+        raw_file_tokens=raw_tokens,
+        strategy="onboarding_guide",
+        cached=pt.cached if pt is not None else False,
+        index_time_ms=pt.index_ms if pt is not None else 0.0,
+        query_time_ms=query_time_ms,
+    )
+    if source is not None:
+        _record_structural_metrics(
+            source,
+            "generate_onboarding",
+            content,
+            raw_tokens,
+            whole_repo_tokens=raw_tokens,
+        )
+    return json.dumps({"content": content, "_meta": meta.model_dump()}, indent=2)
+
+
 def handle_graph_lookup(
     graph_path: str,
     node: str,
@@ -1065,6 +1135,13 @@ async def _run_mcp_tool(
             module_name,
             explain_graph_path,
             fmt,
+        )
+    if name == "generate_onboarding":
+        onboard_repo_url: str | None = arguments.get("repo_url")
+        onboard_graph_path: str | None = arguments.get("graph_path")
+        max_files = int(arguments.get("max_files", 40))
+        return await loop.run_in_executor(
+            None, handle_generate_onboarding, onboard_repo_url, onboard_graph_path, max_files
         )
     if name == "graph_lookup":
         graph_path = arguments["graph_path"]
@@ -1508,6 +1585,39 @@ def build_server() -> Any:
                             "enum": ["json", "markdown"],
                             "default": "json",
                             "description": "Output format for the explain context.",
+                        },
+                    },
+                    "required": [],
+                },
+            ),
+            mcp_types.Tool(
+                name="generate_onboarding",
+                description=(
+                    "Generate a deterministic onboarding guide from graph/index data: "
+                    "repository overview, architecture modules, entry points, public "
+                    "interfaces, recommended reading order, complexity hotspots, test "
+                    "surface, and configuration surface. Markdown-only output."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "repo_url": {
+                            "type": "string",
+                            "description": (
+                                "Local path or HTTP(S) URL of the repository. Required "
+                                "unless graph_path is given."
+                            ),
+                        },
+                        "graph_path": {
+                            "type": "string",
+                            "description": (
+                                "Read an exported graph artifact instead of indexing repo_url."
+                            ),
+                        },
+                        "max_files": {
+                            "type": "integer",
+                            "default": 40,
+                            "description": "Maximum paths per capped section.",
                         },
                     },
                     "required": [],

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -30,6 +30,7 @@ from archex.integrations.mcp import (
     handle_analyze_repo,
     handle_compare_repos,
     handle_explain_target,
+    handle_generate_onboarding,
     handle_get_impact,
     handle_graph_hubs,
     handle_graph_neighbors,
@@ -676,7 +677,7 @@ class TestBuildServer:
         server_result = await handler(req)
         result = server_result.root
         assert isinstance(result, mcp_types.ListToolsResult)
-        assert len(result.tools) == 16
+        assert len(result.tools) == 17
         tool_names = {t.name for t in result.tools}
         assert "scout_repo" in tool_names
         assert "get_file_tree" in tool_names
@@ -687,6 +688,7 @@ class TestBuildServer:
         assert "graph_stats" in tool_names
         assert "get_impact" in tool_names
         assert "explain_target" in tool_names
+        assert "generate_onboarding" in tool_names
 
 
 # ---------------------------------------------------------------------------
@@ -1166,3 +1168,62 @@ class TestHandleExplainTarget:
     def test_rejects_invalid_format(self) -> None:
         with pytest.raises(ValueError, match="Unsupported format"):
             handle_explain_target("/fake/repo", target="a.py", output_format="xml")
+
+
+# ---------------------------------------------------------------------------
+# generate_onboarding handler tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandleGenerateOnboarding:
+    def test_matches_cli_output_for_indexed_repo(self, python_simple_repo: Path) -> None:
+        from click.testing import CliRunner
+
+        from archex.cli.main import cli
+
+        runner = CliRunner()
+        cli_result = runner.invoke(cli, ["onboard", str(python_simple_repo), "--max-files", "5"])
+        assert cli_result.exit_code == 0, cli_result.output
+
+        mcp_result = handle_generate_onboarding(str(python_simple_repo), max_files=5)
+        envelope = json.loads(mcp_result)
+
+        assert envelope["content"] == cli_result.output
+        assert envelope["_meta"]["tool_name"] == "generate_onboarding"
+        assert envelope["_meta"]["strategy"] == "onboarding_guide"
+
+    def test_matches_cli_output_for_graph_artifact_mode(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        from click.testing import CliRunner
+
+        from archex.cli.main import cli
+
+        runner = CliRunner()
+        graph_path = tmp_path / "graph.json"
+        export_result = runner.invoke(
+            cli, ["graph", "export", str(python_simple_repo), "--output", str(graph_path)]
+        )
+        assert export_result.exit_code == 0, export_result.output
+
+        cli_result = runner.invoke(
+            cli, ["onboard", "ignored", "--graph", str(graph_path), "--max-files", "5"]
+        )
+        assert cli_result.exit_code == 0, cli_result.output
+
+        mcp_result = handle_generate_onboarding(graph_path=str(graph_path), max_files=5)
+        envelope = json.loads(mcp_result)
+
+        assert envelope["content"] == cli_result.output
+
+    def test_requires_repo_url_without_graph_path(self) -> None:
+        from archex.onboarding import OnboardingError
+
+        with pytest.raises(OnboardingError, match="requires repo_url"):
+            handle_generate_onboarding()
+
+    def test_rejects_non_positive_max_files(self, python_simple_repo: Path) -> None:
+        from archex.onboarding import OnboardingError
+
+        with pytest.raises(OnboardingError, match="max-files must be greater than zero"):
+            handle_generate_onboarding(str(python_simple_repo), max_files=0)


### PR DESCRIPTION
## Stack

Stack-Id: `mcp-m4-parity`
Base: `feat/mcp-explain-tool`
Position: 3/3

1. `feat/mcp-impact-tool` -> #382
2. `feat/mcp-explain-tool` -> #383
3. `feat/mcp-onboard-tool` -> this PR

Depends on: #383
Upstack: (none - leaf)

## Summary

Registers `generate_onboarding` as a 17th MCP tool in `src/archex/integrations/mcp.py`, wrapping the existing `onboarding.py` backend (already exposed via `archex onboard`). Follows the established `_meta`-envelope handler pattern; onboarding output is markdown-only, matching the CLI's `Choice(["markdown"])` constraint.

Part of DEVELOPMENT_PLAN.md M4 (MCP parity: impact, explain, onboard). Stacked on #383 (`explain_target`). Completes the M4 stack: `archex mcp` now exposes 17 tools total (14 pre-existing + 3 added: `get_impact`, `explain_target`, `generate_onboarding`).

- `handle_generate_onboarding(repo_url=None, graph_path=None, max_files=40)` — indexing `repo_url` or reading an exported `graph_path` artifact (mirrors `archex onboard`'s `--graph` mode).
- Registered in `list_tools()` and dispatched in `_run_mcp_tool`.
- No changes to `onboarding.py`'s underlying logic; pure MCP surface exposure.

**Correction to the milestone's stated tool count:** the M4 objective and the source enhancement report state the server had 13 tools before this stack. Ground truth in `src/archex/integrations/mcp.py`/`tests/integrations/test_mcp.py` (`test_list_tools_returns_graph_tools`) shows it was actually **14** (the report's own tool enumeration lists 14 names but miscounted them as 13). Each PR in this stack bumps the `list_tools()` count assertion by one against the correct baseline: 14 → 15 (#382) → 16 (#383) → 17 (this PR). No `archex` doc/README references a numeric MCP tool count in prose; the only "14 tools" references left in the repo are generated marketing infographics under `assets/` (`archex-infographic*.{html,svg}`), which are out of scope for this milestone (regenerated on a separate cadence, not part of the MCP capability surface).

## Validation

- `uv run pytest tests/integrations/test_mcp.py -v` — 68 passed
- `uv run pytest` — 2946 passed, coverage 90.82%
- `uv run ruff check src/archex/integrations/mcp.py` — OK
- `uv run ruff format --check` — OK
- `uv run pyright` — 0 errors

New test `TestHandleGenerateOnboarding` asserts byte-for-byte parity between `handle_generate_onboarding` and `archex onboard` CLI output for both indexed-repo and exported graph-artifact modes, plus required-repo_url and max-files validation error paths.

## Stack-level summary (cumulative)

- `archex mcp` (stdio) exposes 17 tools total: the 14 pre-existing tools plus `get_impact`, `explain_target`, `generate_onboarding`.
- Each new tool wraps an already-tested CLI backend (`impact.py`, `explain.py`, `onboarding.py`) with zero changes to that backend's logic and zero new dependencies.
- Each PR adds exactly one tool; no scope leakage across the stack.
- Full verification per M4's acceptance: `uv run pytest tests/integrations/test_mcp.py -v && uv run pytest && uv run ruff check src/archex/integrations/mcp.py && uv run pyright` passes on this branch (leaf of the stack).
