### PR TITLE
feat(benchmark): add ranking-quality check to the promotion gate

### DIFF
--- a/.archex/baselines/pre-promotion.json
+++ b/.archex/baselines/pre-promotion.json
@@ -529,6 +529,2833 @@
       "token_efficiency": 0.86070712535404
     }
   ],
+  "ranking": [
+    {
+      "file_path": ".archex/baselines/pre-promotion.json",
+      "centrality": 0.0,
+      "symbol_count": 11
+    },
+    {
+      "file_path": ".dockerignore",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": ".github/workflows/benchmark.yml",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": ".github/workflows/ci.yml",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": ".github/workflows/docker.yml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": ".github/workflows/dogfood.yml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": ".gitignore",
+      "centrality": 0.0,
+      "symbol_count": 4
+    },
+    {
+      "file_path": ".pre-commit-config.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "CHANGELOG.md",
+      "centrality": 0.0,
+      "symbol_count": 22
+    },
+    {
+      "file_path": "CONTRIBUTING.md",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "LICENSE",
+      "centrality": 0.0,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "README.md",
+      "centrality": 0.0,
+      "symbol_count": 13
+    },
+    {
+      "file_path": "SECURITY.md",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "assets/archex-banner.html",
+      "centrality": 0.0,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "assets/archex-banner.svg",
+      "centrality": 0.0,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "assets/archex-infographic-landscape.html",
+      "centrality": 0.0,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "assets/archex-infographic-landscape.svg",
+      "centrality": 0.0,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "assets/archex-infographic.html",
+      "centrality": 0.0,
+      "symbol_count": 12
+    },
+    {
+      "file_path": "assets/archex-infographic.svg",
+      "centrality": 0.0,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "assets/archex-logo.html",
+      "centrality": 0.0,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "assets/archex-logo.svg",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "assets/archex_explainer.py",
+      "centrality": 0.0,
+      "symbol_count": 21
+    },
+    {
+      "file_path": "benchmarks/arch_tasks/go_middleware_interfaces.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/arch_tasks/mixed_language_false_positives.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/arch_tasks/python_false_positives.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/arch_tasks/python_patterns.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/arch_tasks/python_strategy_sorting.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/arch_tasks/rust_traits_async.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/arch_tasks/typescript_react_hooks.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/baseline.json",
+      "centrality": 0.0,
+      "symbol_count": 23
+    },
+    {
+      "file_path": "benchmarks/cross-tool-efficiency/cross-tool-comparison.json",
+      "centrality": 0.0,
+      "symbol_count": 33
+    },
+    {
+      "file_path": "benchmarks/delta_tasks/archex_delta_large.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/delta_tasks/archex_delta_small.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/dogfood_baseline.json",
+      "centrality": 0.0,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "benchmarks/headtohead/README.md",
+      "centrality": 0.0,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "benchmarks/headtohead/manifest.yaml",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/celery_task_dispatch.json",
+      "centrality": 0.0,
+      "symbol_count": 24
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/click_decorators.json",
+      "centrality": 0.0,
+      "symbol_count": 18
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/django_middleware.json",
+      "centrality": 0.0,
+      "symbol_count": 66
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/django_orm_queries.json",
+      "centrality": 0.0,
+      "symbol_count": 67
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/express_error_handling.json",
+      "centrality": 0.0,
+      "symbol_count": 17
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/express_middleware.json",
+      "centrality": 0.0,
+      "symbol_count": 17
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/fastapi_dependency_injection.json",
+      "centrality": 0.0,
+      "symbol_count": 46
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/fastapi_routing.json",
+      "centrality": 0.0,
+      "symbol_count": 45
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/flask_blueprints.json",
+      "centrality": 0.0,
+      "symbol_count": 19
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/gin_routing.json",
+      "centrality": 0.0,
+      "symbol_count": 16
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/go_gin_middleware.json",
+      "centrality": 0.0,
+      "symbol_count": 16
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/celery_task_dispatch.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/click_decorators.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/django_middleware.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/django_orm_queries.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/express_error_handling.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/express_middleware.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/fastapi_dependency_injection.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/fastapi_routing.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/flask_blueprints.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/gin_routing.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/go_gin_middleware.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/httpx_pooling.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/mini_redis_async.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/pydantic_validators.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/pytest_fixtures.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/react_hooks.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/requests_sessions.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/rust_tokio_runtime.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_build_plus_query/sqlalchemy_sessions.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/celery_task_dispatch.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/click_decorators.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/django_middleware.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/django_orm_queries.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/express_error_handling.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/express_middleware.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/fastapi_dependency_injection.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/fastapi_routing.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/flask_blueprints.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/gin_routing.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/go_gin_middleware.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/httpx_pooling.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/mini_redis_async.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/pydantic_validators.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/pytest_fixtures.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/react_hooks.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/requests_sessions.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/rust_tokio_runtime.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/graphify_query_warm/sqlalchemy_sessions.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/httpx_pooling.json",
+      "centrality": 0.0,
+      "symbol_count": 17
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/manifest.yaml",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/mini_redis_async.json",
+      "centrality": 0.0,
+      "symbol_count": 16
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/pydantic_validators.json",
+      "centrality": 0.0,
+      "symbol_count": 23
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/pytest_fixtures.json",
+      "centrality": 0.0,
+      "symbol_count": 20
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/react_hooks.json",
+      "centrality": 0.0,
+      "symbol_count": 112
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/requests_sessions.json",
+      "centrality": 0.0,
+      "symbol_count": 17
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/rust_tokio_runtime.json",
+      "centrality": 0.0,
+      "symbol_count": 31
+    },
+    {
+      "file_path": "benchmarks/headtohead/results/sqlalchemy_sessions.json",
+      "centrality": 0.0,
+      "symbol_count": 31
+    },
+    {
+      "file_path": "benchmarks/held_out.txt",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_adapter_registry.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_benchmark_gate_lifecycle.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_delta_index_lifecycle.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_delta_indexing.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_graph_expansion.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_mcp_query_lifecycle.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_pattern_detection.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_project_config_resolution.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_project_index.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_project_init.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_project_reset.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_project_status.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_query_cache_lifecycle.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_query_pipeline.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_scoring.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/archex_vector_cache_lifecycle.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/celery_task_dispatch.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/click_decorators.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/django_middleware.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/django_orm_queries.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/express_error_handling.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/express_middleware.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/fastapi_dependency_injection.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/fastapi_routing.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/flask_blueprints.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/gin_routing.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/go_gin_middleware.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/httpx_pooling.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_celery_task_retry.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_click_param_process.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_django_queryset_filter.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_django_username_validator.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_express_error_middleware.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_fastapi_jsonable_encoder.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_fastapi_solve_dependencies.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_flask_blueprint_register.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_flask_full_dispatch.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_gin_context_next.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_gin_tree_route.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_httpx_pool_transport.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_httpx_redirect_headers.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_mini_redis_command_from_frame.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_pydantic_validate_call.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_pytest_fixture_resolution.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_react_dispatch_set_state.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_requests_adapter_send.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_requests_redirect_auth.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_sqlalchemy_session_merge.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/loc_tokio_current_thread_block_on.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/mini_redis_async.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/pydantic_validators.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/pytest_fixtures.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/react_hooks.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/requests_sessions.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/routing_mixed_cache.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/routing_mixed_chunker.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/routing_pl_intent.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/routing_pl_large.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/routing_pl_path_symbol.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/routing_pl_scoring.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/routing_pl_tight.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/routing_trace_api.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/rust_tokio_runtime.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "benchmarks/tasks/sqlalchemy_sessions.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "docker/Dockerfile.full",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "docker/Dockerfile.slim",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "docs/ARCHEX_VS_COCOINDEX.md",
+      "centrality": 0.0,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "docs/CLIENT_COMPATIBILITY_MATRIX.md",
+      "centrality": 0.0,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "docs/CONTEXT_RECEIPTS.md",
+      "centrality": 0.0,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "docs/INSTALLATION_TRUST_CONTRACT.md",
+      "centrality": 0.0,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "docs/LANGUAGE_PROMOTION_GATE.md",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "docs/LOCAL_METRICS.md",
+      "centrality": 0.0,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "docs/OVERVIEW.md",
+      "centrality": 0.0,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "docs/RETRIEVAL_DEFAULT_DECISIONS.md",
+      "centrality": 0.0,
+      "symbol_count": 24
+    },
+    {
+      "file_path": "docs/ROADMAP.md",
+      "centrality": 0.0,
+      "symbol_count": 24
+    },
+    {
+      "file_path": "docs/SYSTEM_DESIGN.md",
+      "centrality": 0.0,
+      "symbol_count": 32
+    },
+    {
+      "file_path": "docs/WHY_ARCHEX.md",
+      "centrality": 0.0,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "docs/symbolic-rerank-validation.md",
+      "centrality": 0.0,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "pyproject.toml",
+      "centrality": 0.0,
+      "symbol_count": 16
+    },
+    {
+      "file_path": "scripts/benchmark_pipeline.sh",
+      "centrality": 0.0,
+      "symbol_count": 21
+    },
+    {
+      "file_path": "scripts/benchmark_replay_smoke.sh",
+      "centrality": 0.0,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "scripts/run_graphify_headtohead_lane.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "scripts/showcase.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 32
+    },
+    {
+      "file_path": "scripts/showcase_batch.sh",
+      "centrality": 0.0,
+      "symbol_count": 19
+    },
+    {
+      "file_path": "skills/archex/SKILL.md",
+      "centrality": 0.0,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "skills/archex/commands/archex.md",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "src/archex/__init__.py",
+      "centrality": 0.0317468356116144,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "src/archex/acquire/__init__.py",
+      "centrality": 0.0025746026330788993,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "src/archex/acquire/discovery.py",
+      "centrality": 0.004089339036341464,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "src/archex/acquire/git.py",
+      "centrality": 0.0031642927532452925,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "src/archex/acquire/local.py",
+      "centrality": 0.0031642927532452925,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/analyze/__init__.py",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "src/archex/analyze/decisions.py",
+      "centrality": 0.0033749454538074927,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "src/archex/analyze/interfaces.py",
+      "centrality": 0.0031328765563055833,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "src/archex/analyze/modules.py",
+      "centrality": 0.002406669863799857,
+      "symbol_count": 9
+    },
+    {
+      "file_path": "src/archex/analyze/patterns.py",
+      "centrality": 0.002648738761301766,
+      "symbol_count": 20
+    },
+    {
+      "file_path": "src/archex/api.py",
+      "centrality": 0.005286664115917326,
+      "symbol_count": 84
+    },
+    {
+      "file_path": "src/archex/benchmark/__init__.py",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "src/archex/benchmark/arch_quality.py",
+      "centrality": 0.0032541324385077933,
+      "symbol_count": 16
+    },
+    {
+      "file_path": "src/archex/benchmark/baseline.py",
+      "centrality": 0.007087797326440832,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "src/archex/benchmark/bounded_rerank.py",
+      "centrality": 0.0018122634694193386,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "src/archex/benchmark/bundle_eval.py",
+      "centrality": 0.0032541324385077933,
+      "symbol_count": 21
+    },
+    {
+      "file_path": "src/archex/benchmark/competitive.py",
+      "centrality": 0.0032541324385077933,
+      "symbol_count": 23
+    },
+    {
+      "file_path": "src/archex/benchmark/cross_tool.py",
+      "centrality": 0.003774910120515723,
+      "symbol_count": 23
+    },
+    {
+      "file_path": "src/archex/benchmark/delta_runner.py",
+      "centrality": 0.00180171905349634,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "src/archex/benchmark/delta_strategies.py",
+      "centrality": 0.004692577411287455,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "src/archex/benchmark/external_mcp.py",
+      "centrality": 0.005298166449640572,
+      "symbol_count": 19
+    },
+    {
+      "file_path": "src/archex/benchmark/gate.py",
+      "centrality": 0.00180171905349634,
+      "symbol_count": 21
+    },
+    {
+      "file_path": "src/archex/benchmark/graph_multihop.py",
+      "centrality": 0.0032646768544307924,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "src/archex/benchmark/graphify.py",
+      "centrality": 0.005875503641936495,
+      "symbol_count": 15
+    },
+    {
+      "file_path": "src/archex/benchmark/headroom.py",
+      "centrality": 0.004637316464789651,
+      "symbol_count": 14
+    },
+    {
+      "file_path": "src/archex/benchmark/headtohead.py",
+      "centrality": 0.007542143234812559,
+      "symbol_count": 30
+    },
+    {
+      "file_path": "src/archex/benchmark/loader.py",
+      "centrality": 0.012499168452791361,
+      "symbol_count": 18
+    },
+    {
+      "file_path": "src/archex/benchmark/models.py",
+      "centrality": 0.00888902431241136,
+      "symbol_count": 45
+    },
+    {
+      "file_path": "src/archex/benchmark/preflight.py",
+      "centrality": 0.00180171905349634,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/benchmark/progress.py",
+      "centrality": 0.004275521786341047,
+      "symbol_count": 24
+    },
+    {
+      "file_path": "src/archex/benchmark/query_transform.py",
+      "centrality": 0.0032646768544307924,
+      "symbol_count": 13
+    },
+    {
+      "file_path": "src/archex/benchmark/readiness.py",
+      "centrality": 0.0032541324385077933,
+      "symbol_count": 26
+    },
+    {
+      "file_path": "src/archex/benchmark/region_metrics.py",
+      "centrality": 0.0036644278864400802,
+      "symbol_count": 14
+    },
+    {
+      "file_path": "src/archex/benchmark/reporter.py",
+      "centrality": 0.0026489601947530216,
+      "symbol_count": 46
+    },
+    {
+      "file_path": "src/archex/benchmark/runner.py",
+      "centrality": 0.002527925746002067,
+      "symbol_count": 15
+    },
+    {
+      "file_path": "src/archex/benchmark/strategies.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 143
+    },
+    {
+      "file_path": "src/archex/benchmark/summary_sidecar.py",
+      "centrality": 0.0032646768544307924,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "src/archex/benchmark/task_aware.py",
+      "centrality": 0.003022607956928883,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "src/archex/benchmark/triage.py",
+      "centrality": 0.00602050049107151,
+      "symbol_count": 24
+    },
+    {
+      "file_path": "src/archex/cache.py",
+      "centrality": 0.0021926574512080525,
+      "symbol_count": 25
+    },
+    {
+      "file_path": "src/archex/cli/__init__.py",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "src/archex/cli/analyze_cmd.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "src/archex/cli/benchmark_cmd.py",
+      "centrality": 0.0021926574512080525,
+      "symbol_count": 49
+    },
+    {
+      "file_path": "src/archex/cli/cache_cmd.py",
+      "centrality": 0.0026708321060816475,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "src/archex/cli/compare_cmd.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "src/archex/cli/doctor_cmd.py",
+      "centrality": 0.0026708321060816475,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/cli/dogfood_cmd.py",
+      "centrality": 0.0026708321060816475,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/cli/explain_cmd.py",
+      "centrality": 0.0026708321060816475,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/cli/graph_cmd.py",
+      "centrality": 0.0026708321060816475,
+      "symbol_count": 24
+    },
+    {
+      "file_path": "src/archex/cli/impact_cmd.py",
+      "centrality": 0.0026708321060816475,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/cli/index_cmd.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "src/archex/cli/init_cmd.py",
+      "centrality": 0.0026708321060816475,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/cli/install_client_cmd.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/cli/main.py",
+      "centrality": 0.013583728142226453,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "src/archex/cli/mcp_cmd.py",
+      "centrality": 0.0026708321060816475,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/cli/metrics_cmd.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 19
+    },
+    {
+      "file_path": "src/archex/cli/onboard_cmd.py",
+      "centrality": 0.0026708321060816475,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/cli/outline_cmd.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "src/archex/cli/query_cmd.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "src/archex/cli/reset_cmd.py",
+      "centrality": 0.0026708321060816475,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/cli/scout_cmd.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "src/archex/cli/status_cmd.py",
+      "centrality": 0.0026708321060816475,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "src/archex/cli/symbol_cmd.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "src/archex/cli/symbols_cmd.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "src/archex/cli/tree_cmd.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "src/archex/client_setup.py",
+      "centrality": 0.0031609330412156883,
+      "symbol_count": 16
+    },
+    {
+      "file_path": "src/archex/config.py",
+      "centrality": 0.0026995935717013266,
+      "symbol_count": 13
+    },
+    {
+      "file_path": "src/archex/doctor.py",
+      "centrality": 0.003979030805390631,
+      "symbol_count": 37
+    },
+    {
+      "file_path": "src/archex/dogfood.py",
+      "centrality": 0.0044631686003944486,
+      "symbol_count": 23
+    },
+    {
+      "file_path": "src/archex/exceptions.py",
+      "centrality": 0.07578996711975358,
+      "symbol_count": 12
+    },
+    {
+      "file_path": "src/archex/explain.py",
+      "centrality": 0.002792861684906204,
+      "symbol_count": 34
+    },
+    {
+      "file_path": "src/archex/graph_artifact.py",
+      "centrality": 0.014420781712063194,
+      "symbol_count": 49
+    },
+    {
+      "file_path": "src/archex/graph_query.py",
+      "centrality": 0.00399113482361332,
+      "symbol_count": 44
+    },
+    {
+      "file_path": "src/archex/impact.py",
+      "centrality": 0.0017939557376754967,
+      "symbol_count": 21
+    },
+    {
+      "file_path": "src/archex/index/__init__.py",
+      "centrality": 0.0026767952462118704,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "src/archex/index/bm25.py",
+      "centrality": 0.0021926574512080525,
+      "symbol_count": 22
+    },
+    {
+      "file_path": "src/archex/index/delta.py",
+      "centrality": 0.0019990023332065255,
+      "symbol_count": 16
+    },
+    {
+      "file_path": "src/archex/index/embeddings/__init__.py",
+      "centrality": 0.002555760797460916,
+      "symbol_count": 15
+    },
+    {
+      "file_path": "src/archex/index/embeddings/base.py",
+      "centrality": 0.004615620347351531,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "src/archex/index/embeddings/coderank.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 9
+    },
+    {
+      "file_path": "src/archex/index/embeddings/fast.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "src/archex/index/embeddings/nomic.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "src/archex/index/embeddings/sentence_tf.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "src/archex/index/fusion.py",
+      "centrality": 0.0045387289611660145,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "src/archex/index/graph.py",
+      "centrality": 0.002434726348709962,
+      "symbol_count": 30
+    },
+    {
+      "file_path": "src/archex/index/huggingface.py",
+      "centrality": 0.004260378446577522,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/index/model_policy.py",
+      "centrality": 0.006632571765824582,
+      "symbol_count": 9
+    },
+    {
+      "file_path": "src/archex/index/quantize.py",
+      "centrality": 0.008643798774221438,
+      "symbol_count": 16
+    },
+    {
+      "file_path": "src/archex/index/rerank.py",
+      "centrality": 0.004204895959528323,
+      "symbol_count": 26
+    },
+    {
+      "file_path": "src/archex/index/splade.py",
+      "centrality": 0.0021926574512080525,
+      "symbol_count": 25
+    },
+    {
+      "file_path": "src/archex/index/store.py",
+      "centrality": 0.0044245671472220955,
+      "symbol_count": 71
+    },
+    {
+      "file_path": "src/archex/index/vector.py",
+      "centrality": 0.0026767952462118704,
+      "symbol_count": 24
+    },
+    {
+      "file_path": "src/archex/integrations/__init__.py",
+      "centrality": 0.0019505885537061437,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "src/archex/integrations/langchain.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "src/archex/integrations/llamaindex.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "src/archex/integrations/lsap.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "src/archex/integrations/lsap_models.py",
+      "centrality": 0.008853553528671489,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "src/archex/integrations/mcp.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 56
+    },
+    {
+      "file_path": "src/archex/languages.py",
+      "centrality": 0.0024032631355424537,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "src/archex/metrics/__init__.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "src/archex/metrics/capture.py",
+      "centrality": 0.0017939557376754967,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "src/archex/metrics/categories.py",
+      "centrality": 0.002424355345922416,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/metrics/health.py",
+      "centrality": 0.006936654094774706,
+      "symbol_count": 9
+    },
+    {
+      "file_path": "src/archex/metrics/math.py",
+      "centrality": 0.0023176133758034062,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "src/archex/metrics/policy.py",
+      "centrality": 0.008790411738948727,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "src/archex/metrics/recorder.py",
+      "centrality": 0.0035824364587716652,
+      "symbol_count": 22
+    },
+    {
+      "file_path": "src/archex/metrics/registry.py",
+      "centrality": 0.00406050943781715,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "src/archex/metrics/reporter.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 30
+    },
+    {
+      "file_path": "src/archex/metrics/storage.py",
+      "centrality": 0.0054057208825063294,
+      "symbol_count": 13
+    },
+    {
+      "file_path": "src/archex/models.py",
+      "centrality": 0.013392475497239025,
+      "symbol_count": 90
+    },
+    {
+      "file_path": "src/archex/observe.py",
+      "centrality": 0.004295015307664499,
+      "symbol_count": 19
+    },
+    {
+      "file_path": "src/archex/onboarding.py",
+      "centrality": 0.0025507927874042955,
+      "symbol_count": 12
+    },
+    {
+      "file_path": "src/archex/parse/__init__.py",
+      "centrality": 0.003542878223086535,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "src/archex/parse/adapters/__init__.py",
+      "centrality": 0.006617153221360778,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "src/archex/parse/adapters/_jvm_helpers.py",
+      "centrality": 0.0052479383250086335,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "src/archex/parse/adapters/base.py",
+      "centrality": 0.011747926155026282,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "src/archex/parse/adapters/chunk_only.py",
+      "centrality": 0.002219914819526227,
+      "symbol_count": 15
+    },
+    {
+      "file_path": "src/archex/parse/adapters/csharp.py",
+      "centrality": 0.002946121512031954,
+      "symbol_count": 31
+    },
+    {
+      "file_path": "src/archex/parse/adapters/go.py",
+      "centrality": 0.002946121512031954,
+      "symbol_count": 24
+    },
+    {
+      "file_path": "src/archex/parse/adapters/java.py",
+      "centrality": 0.003672328204537681,
+      "symbol_count": 24
+    },
+    {
+      "file_path": "src/archex/parse/adapters/kotlin.py",
+      "centrality": 0.002946121512031954,
+      "symbol_count": 25
+    },
+    {
+      "file_path": "src/archex/parse/adapters/python.py",
+      "centrality": 0.005366810487051043,
+      "symbol_count": 22
+    },
+    {
+      "file_path": "src/archex/parse/adapters/rust.py",
+      "centrality": 0.003672328204537681,
+      "symbol_count": 28
+    },
+    {
+      "file_path": "src/archex/parse/adapters/swift.py",
+      "centrality": 0.002946121512031954,
+      "symbol_count": 37
+    },
+    {
+      "file_path": "src/archex/parse/adapters/ts_node.py",
+      "centrality": 0.022224152611956236,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "src/archex/parse/adapters/typescript.py",
+      "centrality": 0.002946121512031954,
+      "symbol_count": 26
+    },
+    {
+      "file_path": "src/archex/parse/engine.py",
+      "centrality": 0.0030084353792972263,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "src/archex/parse/imports.py",
+      "centrality": 0.004424788311347426,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "src/archex/parse/symbols.py",
+      "centrality": 0.0019505885537061437,
+      "symbol_count": 14
+    },
+    {
+      "file_path": "src/archex/pipeline/__init__.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "src/archex/pipeline/chunker.py",
+      "centrality": 0.006980256567613642,
+      "symbol_count": 47
+    },
+    {
+      "file_path": "src/archex/pipeline/models.py",
+      "centrality": 0.003377279589995112,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/pipeline/service.py",
+      "centrality": 0.004602240507649911,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "src/archex/precision.py",
+      "centrality": 0.0,
+      "symbol_count": 19
+    },
+    {
+      "file_path": "src/archex/project.py",
+      "centrality": 0.017350750559779457,
+      "symbol_count": 19
+    },
+    {
+      "file_path": "src/archex/receipt.py",
+      "centrality": 0.007199842077687406,
+      "symbol_count": 21
+    },
+    {
+      "file_path": "src/archex/reporting.py",
+      "centrality": 0.02214675080039896,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "src/archex/scout.py",
+      "centrality": 0.002520162430181224,
+      "symbol_count": 45
+    },
+    {
+      "file_path": "src/archex/serve/__init__.py",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "src/archex/serve/compare/__init__.py",
+      "centrality": 0.02370956975044141,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "src/archex/serve/compare/_base.py",
+      "centrality": 0.010422999966272956,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "src/archex/serve/compare/api_surface.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "src/archex/serve/compare/concurrency.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "src/archex/serve/compare/configuration.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "src/archex/serve/compare/error_handling.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "src/archex/serve/compare/state_management.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "src/archex/serve/compare/testing.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "src/archex/serve/compression.py",
+      "centrality": 0.0025384701619250655,
+      "symbol_count": 18
+    },
+    {
+      "file_path": "src/archex/serve/context.py",
+      "centrality": 0.002164600966297948,
+      "symbol_count": 53
+    },
+    {
+      "file_path": "src/archex/serve/intent.py",
+      "centrality": 0.014999817570821018,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "src/archex/serve/modality.py",
+      "centrality": 0.00920253545278469,
+      "symbol_count": 16
+    },
+    {
+      "file_path": "src/archex/serve/packing.py",
+      "centrality": 0.0025384701619250655,
+      "symbol_count": 35
+    },
+    {
+      "file_path": "src/archex/serve/profile.py",
+      "centrality": 0.003011842107554629,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "src/archex/serve/renderers/__init__.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "src/archex/serve/renderers/json.py",
+      "centrality": 0.0038871397337214147,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "src/archex/serve/renderers/markdown.py",
+      "centrality": 0.002434726348709962,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "src/archex/serve/renderers/xml.py",
+      "centrality": 0.004214644712694586,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "src/archex/status.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "src/archex/utils.py",
+      "centrality": 0.0037235906634764276,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "tests/__init__.py",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "tests/acquire/test_discovery.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 28
+    },
+    {
+      "file_path": "tests/acquire/test_git.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 19
+    },
+    {
+      "file_path": "tests/acquire/test_local.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/analyze/test_decisions.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "tests/analyze/test_interfaces.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 20
+    },
+    {
+      "file_path": "tests/analyze/test_modules.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 26
+    },
+    {
+      "file_path": "tests/analyze/test_patterns.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 38
+    },
+    {
+      "file_path": "tests/benchmark/test_arch_quality.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 17
+    },
+    {
+      "file_path": "tests/benchmark/test_baseline.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "tests/benchmark/test_bounded_rerank_strategy.py",
+      "centrality": 0.0,
+      "symbol_count": 33
+    },
+    {
+      "file_path": "tests/benchmark/test_bundle_eval.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 19
+    },
+    {
+      "file_path": "tests/benchmark/test_cli.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 59
+    },
+    {
+      "file_path": "tests/benchmark/test_competitive_artifacts.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "tests/benchmark/test_competitive_report.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 15
+    },
+    {
+      "file_path": "tests/benchmark/test_compression_strategy.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 22
+    },
+    {
+      "file_path": "tests/benchmark/test_conditional_rerank_strategy.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 52
+    },
+    {
+      "file_path": "tests/benchmark/test_cross_tool.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 37
+    },
+    {
+      "file_path": "tests/benchmark/test_delta_strategies.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 26
+    },
+    {
+      "file_path": "tests/benchmark/test_diversity_packed_strategy.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 23
+    },
+    {
+      "file_path": "tests/benchmark/test_dogfood.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 18
+    },
+    {
+      "file_path": "tests/benchmark/test_dual_transform_strategy.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 28
+    },
+    {
+      "file_path": "tests/benchmark/test_efficiency_packed_strategy.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 19
+    },
+    {
+      "file_path": "tests/benchmark/test_external_mcp.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/benchmark/test_gate.py",
+      "centrality": 0.0,
+      "symbol_count": 26
+    },
+    {
+      "file_path": "tests/benchmark/test_generalization.py",
+      "centrality": 0.0,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/benchmark/test_graph_multihop_strategy.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 26
+    },
+    {
+      "file_path": "tests/benchmark/test_graphify.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 13
+    },
+    {
+      "file_path": "tests/benchmark/test_headroom.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "tests/benchmark/test_headtohead.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 22
+    },
+    {
+      "file_path": "tests/benchmark/test_headtohead_report.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/benchmark/test_integration.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 14
+    },
+    {
+      "file_path": "tests/benchmark/test_loader.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 86
+    },
+    {
+      "file_path": "tests/benchmark/test_metrics.py",
+      "centrality": 0.0,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "tests/benchmark/test_models.py",
+      "centrality": 0.0,
+      "symbol_count": 44
+    },
+    {
+      "file_path": "tests/benchmark/test_progress.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "tests/benchmark/test_readiness.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "tests/benchmark/test_region_fixtures.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "tests/benchmark/test_regression.py",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "tests/benchmark/test_reporter.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 94
+    },
+    {
+      "file_path": "tests/benchmark/test_runner.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 53
+    },
+    {
+      "file_path": "tests/benchmark/test_strategies.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 134
+    },
+    {
+      "file_path": "tests/benchmark/test_strategy_registry.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 13
+    },
+    {
+      "file_path": "tests/benchmark/test_summary_sidecar_strategy.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 28
+    },
+    {
+      "file_path": "tests/benchmark/test_task_aware.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 17
+    },
+    {
+      "file_path": "tests/benchmark/test_task_aware_strategy.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 34
+    },
+    {
+      "file_path": "tests/benchmark/test_triage.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 16
+    },
+    {
+      "file_path": "tests/cli/test_doctor.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 9
+    },
+    {
+      "file_path": "tests/cli/test_index_cmd.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 9
+    },
+    {
+      "file_path": "tests/cli/test_install_client.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 23
+    },
+    {
+      "file_path": "tests/conftest.py",
+      "centrality": 0.0031609330412156883,
+      "symbol_count": 19
+    },
+    {
+      "file_path": "tests/fixtures/bundle_eval_command.py",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "tests/fixtures/csharp_simple/Events/EventHandler.cs",
+      "centrality": 0.0,
+      "symbol_count": 9
+    },
+    {
+      "file_path": "tests/fixtures/csharp_simple/Models/User.cs",
+      "centrality": 0.0,
+      "symbol_count": 18
+    },
+    {
+      "file_path": "tests/fixtures/csharp_simple/Program.cs",
+      "centrality": 0.0,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "tests/fixtures/csharp_simple/Services/UserService.cs",
+      "centrality": 0.0,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "tests/fixtures/csharp_simple/Utils/StringExtensions.cs",
+      "centrality": 0.0,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "tests/fixtures/go_handler.go",
+      "centrality": 0.0,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "tests/fixtures/go_simple/handlers.go",
+      "centrality": 0.0,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "tests/fixtures/go_simple/main.go",
+      "centrality": 0.0,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "tests/fixtures/go_simple/models.go",
+      "centrality": 0.0,
+      "symbol_count": 12
+    },
+    {
+      "file_path": "tests/fixtures/go_simple/utils.go",
+      "centrality": 0.0,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/fixtures/headroom_artifacts/httpx_pooling.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "tests/fixtures/java_repository.java",
+      "centrality": 0.0,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/fixtures/java_simple/Main.java",
+      "centrality": 0.0,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "tests/fixtures/java_simple/enums/Status.java",
+      "centrality": 0.0,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "tests/fixtures/java_simple/models/Record.java",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "tests/fixtures/java_simple/models/User.java",
+      "centrality": 0.0,
+      "symbol_count": 16
+    },
+    {
+      "file_path": "tests/fixtures/java_simple/services/UserService.java",
+      "centrality": 0.0,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/fixtures/java_simple/utils/StringUtils.java",
+      "centrality": 0.0,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "tests/fixtures/kotlin_simple/Main.kt",
+      "centrality": 0.0,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "tests/fixtures/kotlin_simple/config/AppConfig.kt",
+      "centrality": 0.0,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "tests/fixtures/kotlin_simple/models/User.kt",
+      "centrality": 0.0,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "tests/fixtures/kotlin_simple/services/UserService.kt",
+      "centrality": 0.0,
+      "symbol_count": 12
+    },
+    {
+      "file_path": "tests/fixtures/kotlin_simple/utils/Extensions.kt",
+      "centrality": 0.0,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "tests/fixtures/monorepo_simple/packages/cli/pyproject.toml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "tests/fixtures/monorepo_simple/packages/cli/src/__init__.py",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "tests/fixtures/monorepo_simple/packages/cli/src/main.py",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "tests/fixtures/monorepo_simple/packages/core/pyproject.toml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "tests/fixtures/monorepo_simple/packages/core/src/__init__.py",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "tests/fixtures/monorepo_simple/packages/core/src/index.py",
+      "centrality": 0.0,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "tests/fixtures/monorepo_simple/pyproject.toml",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "tests/fixtures/python_patterns/events.py",
+      "centrality": 0.0,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "tests/fixtures/python_patterns/middleware.py",
+      "centrality": 0.0,
+      "symbol_count": 9
+    },
+    {
+      "file_path": "tests/fixtures/python_patterns/plugins.py",
+      "centrality": 0.0,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "tests/fixtures/python_patterns/repository.py",
+      "centrality": 0.0,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "tests/fixtures/python_patterns/strategies.py",
+      "centrality": 0.0,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "tests/fixtures/python_simple/main.py",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "tests/fixtures/python_simple/models.py",
+      "centrality": 0.0,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/fixtures/python_simple/pyproject.toml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "tests/fixtures/python_simple/services/__init__.py",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "tests/fixtures/python_simple/services/auth.py",
+      "centrality": 0.0,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "tests/fixtures/python_simple/utils.py",
+      "centrality": 0.0,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "tests/fixtures/region_tasks/region_python_simple_auth.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "tests/fixtures/region_tasks/region_python_simple_utils.yaml",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "tests/fixtures/repos/csharp_middleware/Middleware/AuthMiddleware.cs",
+      "centrality": 0.0,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/fixtures/repos/csharp_middleware/Middleware/LoggingMiddleware.cs",
+      "centrality": 0.0,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "tests/fixtures/repos/csharp_middleware/Startup.cs",
+      "centrality": 0.0,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "tests/fixtures/repos/false_positives/utils.py",
+      "centrality": 0.0,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "tests/fixtures/repos/go_middleware_chi/middleware/auth.go",
+      "centrality": 0.0,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/fixtures/repos/go_middleware_chi/middleware/logging.go",
+      "centrality": 0.0,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "tests/fixtures/repos/go_middleware_chi/routes/router.go",
+      "centrality": 0.0,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "tests/fixtures/repos/java_observer/src/EventBus.java",
+      "centrality": 0.0,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "tests/fixtures/repos/java_observer/src/EventListener.java",
+      "centrality": 0.0,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "tests/fixtures/repos/java_observer/src/OrderService.java",
+      "centrality": 0.0,
+      "symbol_count": 9
+    },
+    {
+      "file_path": "tests/fixtures/repos/kotlin_coroutine_flow/src/DataRepository.kt",
+      "centrality": 0.0,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/fixtures/repos/kotlin_coroutine_flow/src/DataStream.kt",
+      "centrality": 0.0,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/fixtures/repos/kotlin_coroutine_flow/src/FlowCollector.kt",
+      "centrality": 0.0,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "tests/fixtures/repos/mixed_false_positives/web/toolbar.ts",
+      "centrality": 0.0,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "tests/fixtures/repos/mixed_false_positives/worker/collector.go",
+      "centrality": 0.0,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/fixtures/repos/python_strategy_sorting/sorters/base.py",
+      "centrality": 0.004504501574967389,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/fixtures/repos/python_strategy_sorting/sorters/context.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "tests/fixtures/repos/python_strategy_sorting/sorters/implementations.py",
+      "centrality": 0.002434726348709962,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "tests/fixtures/repos/react_hooks_state/src/components/Login.tsx",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "tests/fixtures/repos/react_hooks_state/src/hooks/useAuth.ts",
+      "centrality": 0.0031609330412156883,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "tests/fixtures/repos/react_hooks_state/src/hooks/useLocalStorage.ts",
+      "centrality": 0.004395656723707637,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "tests/fixtures/repos/rust_actix_handler/src/handlers/auth.rs",
+      "centrality": 0.0031609330412156883,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "tests/fixtures/repos/rust_actix_handler/src/handlers/mod.rs",
+      "centrality": 0.0,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "tests/fixtures/repos/rust_actix_handler/src/middleware.rs",
+      "centrality": 0.0,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "tests/fixtures/repos/rust_async_boundaries/src/auth.rs",
+      "centrality": 0.0,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "tests/fixtures/repos/rust_async_boundaries/src/lib.rs",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "tests/fixtures/repos/rust_async_boundaries/src/server.rs",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "tests/fixtures/repos/spring_repository/src/User.java",
+      "centrality": 0.0,
+      "symbol_count": 13
+    },
+    {
+      "file_path": "tests/fixtures/repos/spring_repository/src/UserRepository.java",
+      "centrality": 0.0,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "tests/fixtures/repos/spring_repository/src/UserService.java",
+      "centrality": 0.0,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "tests/fixtures/repos/swift_combine/Sources/AuthPublisher.swift",
+      "centrality": 0.0,
+      "symbol_count": 12
+    },
+    {
+      "file_path": "tests/fixtures/repos/swift_combine/Sources/DataPublisher.swift",
+      "centrality": 0.0,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "tests/fixtures/repos/swift_combine/Sources/SubscriptionManager.swift",
+      "centrality": 0.0,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "tests/fixtures/repos/typescript_express_auth/middleware/auth.ts",
+      "centrality": 0.004395656723707637,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/fixtures/repos/typescript_express_auth/middleware/index.ts",
+      "centrality": 0.0031609330412156883,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "tests/fixtures/repos/typescript_express_auth/routes/user.ts",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "tests/fixtures/repos/typescript_nestjs_modules/src/app.module.ts",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "tests/fixtures/repos/typescript_nestjs_modules/src/user/user.module.ts",
+      "centrality": 0.0031609330412156883,
+      "symbol_count": 2
+    },
+    {
+      "file_path": "tests/fixtures/repos/typescript_nestjs_modules/src/user/user.service.ts",
+      "centrality": 0.004395656723707637,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "tests/fixtures/rust_simple/src/lib.rs",
+      "centrality": 0.0,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "tests/fixtures/rust_simple/src/main.rs",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "tests/fixtures/rust_simple/src/models.rs",
+      "centrality": 0.002434726348709962,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "tests/fixtures/rust_simple/src/utils.rs",
+      "centrality": 0.002434726348709962,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "tests/fixtures/swift_simple/Models/User.swift",
+      "centrality": 0.0,
+      "symbol_count": 18
+    },
+    {
+      "file_path": "tests/fixtures/swift_simple/Services/UserService.swift",
+      "centrality": 0.0,
+      "symbol_count": 14
+    },
+    {
+      "file_path": "tests/fixtures/swift_simple/Utils/Extensions.swift",
+      "centrality": 0.0,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "tests/fixtures/swift_simple/Views/ContentView.swift",
+      "centrality": 0.0,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "tests/fixtures/swift_simple/main.swift",
+      "centrality": 0.0,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "tests/fixtures/typescript_middleware.ts",
+      "centrality": 0.0,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "tests/fixtures/typescript_simple/package.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "tests/fixtures/typescript_simple/src/handlers/auth.ts",
+      "centrality": 0.0021926574512080525,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "tests/fixtures/typescript_simple/src/index.ts",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "tests/fixtures/typescript_simple/src/types.ts",
+      "centrality": 0.003124651424129104,
+      "symbol_count": 3
+    },
+    {
+      "file_path": "tests/fixtures/typescript_simple/src/utils.ts",
+      "centrality": 0.003124651424129104,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "tests/fixtures/typescript_simple/tsconfig.json",
+      "centrality": 0.0,
+      "symbol_count": 1
+    },
+    {
+      "file_path": "tests/index/embeddings/test_embeddings.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 49
+    },
+    {
+      "file_path": "tests/index/test_bm25.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 61
+    },
+    {
+      "file_path": "tests/index/test_bm25_graduated.py",
+      "centrality": 0.0,
+      "symbol_count": 21
+    },
+    {
+      "file_path": "tests/index/test_breadcrumbs.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 39
+    },
+    {
+      "file_path": "tests/index/test_chunker.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 46
+    },
+    {
+      "file_path": "tests/index/test_delta.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 67
+    },
+    {
+      "file_path": "tests/index/test_embedder_registry.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 14
+    },
+    {
+      "file_path": "tests/index/test_fusion.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 58
+    },
+    {
+      "file_path": "tests/index/test_graph.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 36
+    },
+    {
+      "file_path": "tests/index/test_huggingface.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/index/test_quantize.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 76
+    },
+    {
+      "file_path": "tests/index/test_rerank.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 78
+    },
+    {
+      "file_path": "tests/index/test_splade.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 35
+    },
+    {
+      "file_path": "tests/index/test_store.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 98
+    },
+    {
+      "file_path": "tests/index/test_symbol_ids.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 30
+    },
+    {
+      "file_path": "tests/index/test_vector.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 100
+    },
+    {
+      "file_path": "tests/integrations/test_langchain.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 14
+    },
+    {
+      "file_path": "tests/integrations/test_llamaindex.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 14
+    },
+    {
+      "file_path": "tests/integrations/test_lsap.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 27
+    },
+    {
+      "file_path": "tests/integrations/test_mcp.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 100
+    },
+    {
+      "file_path": "tests/metrics/test_health.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "tests/metrics/test_instrumentation.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 24
+    },
+    {
+      "file_path": "tests/metrics/test_metrics_cli.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "tests/metrics/test_policy.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 9
+    },
+    {
+      "file_path": "tests/metrics/test_recorder.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 12
+    },
+    {
+      "file_path": "tests/metrics/test_storage.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "tests/parse/adapters/test_csharp.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 59
+    },
+    {
+      "file_path": "tests/parse/adapters/test_go.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 36
+    },
+    {
+      "file_path": "tests/parse/adapters/test_java.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 47
+    },
+    {
+      "file_path": "tests/parse/adapters/test_jvm_cross.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 6
+    },
+    {
+      "file_path": "tests/parse/adapters/test_kotlin.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 56
+    },
+    {
+      "file_path": "tests/parse/adapters/test_python.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 48
+    },
+    {
+      "file_path": "tests/parse/adapters/test_rust.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 51
+    },
+    {
+      "file_path": "tests/parse/adapters/test_swift.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 56
+    },
+    {
+      "file_path": "tests/parse/adapters/test_typescript.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 57
+    },
+    {
+      "file_path": "tests/parse/test_adapter_registry.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 11
+    },
+    {
+      "file_path": "tests/parse/test_engine.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 15
+    },
+    {
+      "file_path": "tests/parse/test_imports.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 26
+    },
+    {
+      "file_path": "tests/parse/test_language_coverage.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "tests/parse/test_symbols.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 25
+    },
+    {
+      "file_path": "tests/pipeline/test_service.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 30
+    },
+    {
+      "file_path": "tests/serve/test_compare.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 75
+    },
+    {
+      "file_path": "tests/serve/test_compression.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 20
+    },
+    {
+      "file_path": "tests/serve/test_context.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 103
+    },
+    {
+      "file_path": "tests/serve/test_context_recall.py",
+      "centrality": 0.0,
+      "symbol_count": 14
+    },
+    {
+      "file_path": "tests/serve/test_intent.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 31
+    },
+    {
+      "file_path": "tests/serve/test_modality.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 27
+    },
+    {
+      "file_path": "tests/serve/test_packing.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 86
+    },
+    {
+      "file_path": "tests/serve/test_profile.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "tests/serve/test_query_normalization.py",
+      "centrality": 0.0,
+      "symbol_count": 37
+    },
+    {
+      "file_path": "tests/serve/test_renderers.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 22
+    },
+    {
+      "file_path": "tests/test_api_precision.py",
+      "centrality": 0.0,
+      "symbol_count": 38
+    },
+    {
+      "file_path": "tests/test_api_robustness.py",
+      "centrality": 0.0,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "tests/test_cache.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 80
+    },
+    {
+      "file_path": "tests/test_cli.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 89
+    },
+    {
+      "file_path": "tests/test_config.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 20
+    },
+    {
+      "file_path": "tests/test_conftest.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "tests/test_explain_cli.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/test_graph_artifact.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 9
+    },
+    {
+      "file_path": "tests/test_graph_export_cli.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 8
+    },
+    {
+      "file_path": "tests/test_graph_load_cli.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "tests/test_graph_query.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "tests/test_impact_cli.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 5
+    },
+    {
+      "file_path": "tests/test_integration.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 119
+    },
+    {
+      "file_path": "tests/test_models.py",
+      "centrality": 0.0,
+      "symbol_count": 93
+    },
+    {
+      "file_path": "tests/test_observe.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 29
+    },
+    {
+      "file_path": "tests/test_onboard_cli.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 4
+    },
+    {
+      "file_path": "tests/test_performance.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 51
+    },
+    {
+      "file_path": "tests/test_pipeline_service.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 10
+    },
+    {
+      "file_path": "tests/test_project.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 13
+    },
+    {
+      "file_path": "tests/test_query_pipeline.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 21
+    },
+    {
+      "file_path": "tests/test_receipt.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 7
+    },
+    {
+      "file_path": "tests/test_reporting.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 14
+    },
+    {
+      "file_path": "tests/test_scout.py",
+      "centrality": 0.0017085196562042348,
+      "symbol_count": 16
+    },
+    {
+      "file_path": "uv.lock",
+      "centrality": 0.0,
+      "symbol_count": 860
+    }
+  ],
   "created_at": "2026-07-04T09:25:12.925262+00:00",
   "archex_version": ""
 }

--- a/docs/LANGUAGE_PROMOTION_GATE.md
+++ b/docs/LANGUAGE_PROMOTION_GATE.md
@@ -4,7 +4,11 @@ Every language-tier promotion milestone (Section D/E of the enhancement plan: PH
 
 ## What the gate checks
 
-The gate reuses the existing `compute_recall`/`compute_required_file_metrics`/F1 machinery in `src/archex/benchmark/strategies.py` through the standard `archex dogfood` baseline-comparison path: recall, precision, F1, MRR, nDCG, MAP, and token efficiency per self-repo task/strategy, compared against the stored baseline with the existing tolerance in `archex.benchmark.baseline.compare_baseline`. A violation is hard-fail: the gate exits non-zero.
+The gate reuses the existing `compute_recall`/`compute_required_file_metrics`/F1 machinery in `src/archex/benchmark/strategies.py` through the standard `archex dogfood` baseline-comparison path: recall, precision, F1, MRR, nDCG, MAP, and token efficiency per self-repo task/strategy, compared against the stored baseline with the existing tolerance in `archex.benchmark.baseline.compare_baseline`.
+
+It also checks ranking stability. `structural_centrality()` PageRank and `symbol_count` are load-bearing ranking signals feeding `graph_hubs`, `graph_neighbors`, and query ranking. A promotion that floods the graph with many low-value symbols — an overzealous chunk-only to full conversion, for example — can reorder these rankings for files that were never touched, without moving recall/precision/F1 at all. `archex.benchmark.gate.check_ranking_stability` compares a live PageRank/symbol_count snapshot of every indexed file against the baseline's snapshot with a Spearman rank-correlation check, restricted to files present in both. This check only runs when the baseline JSON carries a non-empty `ranking` field — a recall-only baseline (no `ranking`) skips it at zero extra indexing cost.
+
+Both checks are hard-fail: a violation exits the gate non-zero.
 
 ## Baseline artifact
 
@@ -30,3 +34,14 @@ uv run archex benchmark baseline save \
   --input .archex/baseline-bootstrap \
   --output .archex/baselines/pre-promotion.json
 ```
+
+To also attach a ranking-stability snapshot to the regenerated baseline, add `--ranking-source`:
+
+```bash
+uv run archex benchmark baseline save \
+  --input .archex/baseline-bootstrap \
+  --output .archex/baselines/pre-promotion.json \
+  --ranking-source .
+```
+
+`--ranking-source` indexes the given repo path (here, the repo itself) and attaches a PageRank/symbol_count snapshot to the saved baseline. Omit it to save a recall-only baseline; `archex dogfood` then skips the ranking-stability check entirely rather than failing on a missing snapshot.

--- a/src/archex/benchmark/baseline.py
+++ b/src/archex/benchmark/baseline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Collection
 from datetime import UTC, datetime
+from pathlib import Path
 
 from pydantic import BaseModel
 
@@ -22,8 +23,17 @@ class BaselineEntry(BaseModel):
     token_efficiency: float = 0.0
 
 
+class RankingSnapshotEntry(BaseModel):
+    """Per-file PageRank centrality and symbol count for ranking-stability gating."""
+
+    file_path: str
+    centrality: float
+    symbol_count: int
+
+
 class Baseline(BaseModel):
     entries: list[BaselineEntry] = []
+    ranking: list[RankingSnapshotEntry] = []
     created_at: str = ""
     archex_version: str = ""
 
@@ -69,6 +79,39 @@ def save_baseline(
 def load_baseline(data: dict[str, object]) -> Baseline:
     """Validate and load a baseline from parsed JSON data."""
     return Baseline.model_validate(data)
+
+
+def build_ranking_snapshot(repo_root: Path) -> list[RankingSnapshotEntry]:
+    """Index *repo_root* and snapshot per-file PageRank centrality and symbol count.
+
+    Used to populate ``Baseline.ranking`` and, later, to compare a promotion
+    candidate's index against that baseline for ranking-stability regressions
+    (see ``archex.benchmark.gate.check_ranking_stability``). Files with no import
+    edges get centrality ``0.0``; every indexed file gets its chunk-derived
+    symbol count regardless of edges.
+    """
+    from archex.api import index_repository
+    from archex.config import load_config
+    from archex.index.graph import DependencyGraph
+    from archex.models import RepoSource
+
+    source = RepoSource(local_path=str(repo_root))
+    config = load_config(source)
+    store = index_repository(source, config=config)
+    try:
+        centrality = DependencyGraph.from_edges(store.get_edges()).structural_centrality()
+        file_metadata = store.get_file_metadata()
+    finally:
+        store.close()
+
+    return [
+        RankingSnapshotEntry(
+            file_path=str(item["file_path"]),
+            centrality=centrality.get(str(item["file_path"]), 0.0),
+            symbol_count=int(item["symbol_count"]),
+        )
+        for item in file_metadata
+    ]
 
 
 _METRICS = ("recall", "precision", "f1_score", "mrr", "ndcg", "map_score", "token_efficiency")

--- a/src/archex/benchmark/gate.py
+++ b/src/archex/benchmark/gate.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import math
+
+import numpy as np
 from pydantic import BaseModel
 
+from archex.benchmark.baseline import (
+    RankingSnapshotEntry,  # noqa: TCH001 — Pydantic needs at runtime
+)
 from archex.benchmark.models import (  # noqa: TCH001 — Pydantic needs at runtime
     BenchmarkReport,
     DeltaBenchmarkResult,
@@ -383,6 +389,104 @@ def check_delta_gate(
                     metric="speedup_factor",
                     threshold=thresholds.min_speedup,
                     actual=r.speedup_factor,
+                )
+            )
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Ranking-stability gate
+#
+# structural_centrality() PageRank and symbol_count are load-bearing ranking
+# signals feeding graph_hubs/graph_neighbors and query ranking. A promotion
+# that floods the graph with many low-value symbols (an overzealous chunk-only
+# -> full conversion, for example) can reorder these rankings for files that
+# were never touched, without moving recall/precision/F1 at all. This check
+# catches that class of regression on the existing FULL-language corpus.
+# ---------------------------------------------------------------------------
+
+
+class RankingQualityThresholds(BaseModel):
+    min_centrality_rank_correlation: float = 0.8
+    min_symbol_count_rank_correlation: float = 0.8
+
+
+class RankingGateViolation(BaseModel):
+    metric: str
+    correlation: float
+    threshold: float
+    sample_size: int
+
+
+_RANKING_METRIC_FIELDS = {
+    "structural_centrality": "centrality",
+    "symbol_count": "symbol_count",
+}
+
+
+def _rank(values: list[float]) -> list[float]:
+    """Average (1-indexed) ranks, tie-safe, for Spearman rank correlation."""
+    order = sorted(range(len(values)), key=lambda i: values[i])
+    ranks = [0.0] * len(values)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
+            j += 1
+        average_rank = (i + j) / 2 + 1
+        for k in range(i, j + 1):
+            ranks[order[k]] = average_rank
+        i = j + 1
+    return ranks
+
+
+def _spearman_correlation(current: list[float], baseline: list[float]) -> float | None:
+    """Spearman rank correlation, or None when either series has zero variance."""
+    current_ranks = np.array(_rank(current))
+    baseline_ranks = np.array(_rank(baseline))
+    if current_ranks.std() == 0.0 or baseline_ranks.std() == 0.0:
+        return None
+    correlation = float(np.corrcoef(current_ranks, baseline_ranks)[0, 1])
+    return None if math.isnan(correlation) else correlation
+
+
+def check_ranking_stability(
+    current: list[RankingSnapshotEntry],
+    baseline: list[RankingSnapshotEntry],
+    thresholds: RankingQualityThresholds | None = None,
+) -> list[RankingGateViolation]:
+    """Flag PageRank/symbol_count ranking-stability regressions against a baseline.
+
+    Compares Spearman rank correlation over files present in both snapshots, for
+    each of structural centrality and symbol count independently. Fewer than two
+    common files makes correlation undefined, so no violation can be raised.
+    """
+    if thresholds is None:
+        thresholds = RankingQualityThresholds()
+    current_by_path = {entry.file_path: entry for entry in current}
+    baseline_by_path = {entry.file_path: entry for entry in baseline}
+    common_paths = sorted(set(current_by_path) & set(baseline_by_path))
+
+    violations: list[RankingGateViolation] = []
+    if len(common_paths) < 2:
+        return violations
+
+    metric_floors = (
+        ("structural_centrality", thresholds.min_centrality_rank_correlation),
+        ("symbol_count", thresholds.min_symbol_count_rank_correlation),
+    )
+    for metric, floor in metric_floors:
+        field = _RANKING_METRIC_FIELDS[metric]
+        current_values = [getattr(current_by_path[path], field) for path in common_paths]
+        baseline_values = [getattr(baseline_by_path[path], field) for path in common_paths]
+        correlation = _spearman_correlation(current_values, baseline_values)
+        if correlation is not None and correlation < floor:
+            violations.append(
+                RankingGateViolation(
+                    metric=metric,
+                    correlation=correlation,
+                    threshold=floor,
+                    sample_size=len(common_paths),
                 )
             )
     return violations

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -15,7 +15,12 @@ from archex.benchmark.arch_quality import (
     load_architecture_results,
     run_architecture_all,
 )
-from archex.benchmark.baseline import compare_baseline, load_baseline, save_baseline
+from archex.benchmark.baseline import (
+    build_ranking_snapshot,
+    compare_baseline,
+    load_baseline,
+    save_baseline,
+)
 from archex.benchmark.bundle_eval import BundleOnlyEvaluatorError, run_bundle_only_eval_all
 from archex.benchmark.competitive import format_competitive_markdown, load_compression_results
 from archex.benchmark.cross_tool import NaiveBaselineModel, run_cross_tool
@@ -703,7 +708,17 @@ def baseline_cmd() -> None:
     type=click.Path(),
     help="Output path for baseline JSON.",
 )
-def baseline_save_cmd(input_dir: str, output_path: str) -> None:
+@click.option(
+    "--ranking-source",
+    "ranking_source",
+    default=None,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True),
+    help=(
+        "Optional repo path to index for a PageRank/symbol_count ranking snapshot, "
+        "attached to the saved baseline for ranking-stability gating."
+    ),
+)
+def baseline_save_cmd(input_dir: str, output_path: str, ranking_source: str | None) -> None:
     """Save current benchmark results as a golden baseline."""
     input_path = Path(input_dir)
     reports: list[BenchmarkReport] = []
@@ -715,10 +730,15 @@ def baseline_save_cmd(input_dir: str, output_path: str) -> None:
         raise click.ClickException(f"No result files found in {input_dir}")
 
     baseline = save_baseline(reports)
+    if ranking_source is not None:
+        ranking = build_ranking_snapshot(Path(ranking_source))
+        baseline = baseline.model_copy(update={"ranking": ranking})
     out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(baseline.model_dump_json(indent=2), encoding="utf-8")
     click.echo(f"Saved baseline with {len(baseline.entries)} entries to {output_path}")
+    if ranking_source is not None:
+        click.echo(f"Ranking snapshot:   {len(baseline.ranking)} files")
 
 
 @baseline_cmd.command("compare")

--- a/src/archex/cli/dogfood_cmd.py
+++ b/src/archex/cli/dogfood_cmd.py
@@ -88,6 +88,15 @@ def dogfood_cmd(
                 )
         else:
             click.echo("Regressions:        0")
+        if result.ranking_violations:
+            click.echo(f"Ranking violations: {len(result.ranking_violations)}")
+            for violation in result.ranking_violations:
+                click.echo(
+                    f"  {violation.metric}: correlation {violation.correlation:.3f} "
+                    f"< threshold {violation.threshold:.3f} (n={violation.sample_size})"
+                )
+        else:
+            click.echo("Ranking violations: 0")
 
-    if result.regressions:
+    if result.regressions or result.ranking_violations:
         raise click.exceptions.Exit(1)

--- a/src/archex/dogfood.py
+++ b/src/archex/dogfood.py
@@ -9,7 +9,14 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
-from archex.benchmark.baseline import BaselineComparison, compare_baseline, load_baseline
+from archex.benchmark.baseline import (
+    Baseline,
+    BaselineComparison,
+    build_ranking_snapshot,
+    compare_baseline,
+    load_baseline,
+)
+from archex.benchmark.gate import RankingGateViolation, check_ranking_stability
 from archex.benchmark.loader import load_tasks
 from archex.benchmark.models import (
     BenchmarkReport,
@@ -40,6 +47,7 @@ class DogfoodRunResult:
     tasks: list[BenchmarkTask]
     reports: list[BenchmarkReport]
     comparisons: list[BaselineComparison]
+    ranking_violations: list[RankingGateViolation]
     baseline_path: Path | None
     output_dir: Path
     latest_json_path: Path
@@ -84,12 +92,15 @@ def run_dogfood(
         explicit_baseline=baseline_path,
         output_dir=output_dir,
     )
-    comparisons = _compare_to_baseline(reports, baseline_file)
+    baseline = _load_baseline_file(baseline_file)
+    comparisons = _compare_to_baseline(reports, baseline)
+    ranking_violations = _check_ranking_stability(state.repo_root, baseline)
     latest_json_path, latest_markdown_path, history_json_path = _write_reports(
         output_dir,
         selected_tasks,
         reports,
         comparisons,
+        ranking_violations,
         baseline_file,
     )
 
@@ -98,6 +109,7 @@ def run_dogfood(
         tasks=selected_tasks,
         reports=reports,
         comparisons=comparisons,
+        ranking_violations=ranking_violations,
         baseline_path=baseline_file,
         output_dir=output_dir,
         latest_json_path=latest_json_path,
@@ -221,14 +233,19 @@ def _resolve_baseline_path(
     raise ValueError("Dogfood requires an explicit --baseline path")
 
 
+def _load_baseline_file(baseline_path: Path | None) -> Baseline | None:
+    if baseline_path is None:
+        return None
+    baseline_data = json.loads(baseline_path.read_text(encoding="utf-8"))
+    return load_baseline(baseline_data)
+
+
 def _compare_to_baseline(
     reports: list[BenchmarkReport],
-    baseline_path: Path | None,
+    baseline: Baseline | None,
 ) -> list[BaselineComparison]:
-    if baseline_path is None:
+    if baseline is None:
         return []
-    baseline_data = json.loads(baseline_path.read_text(encoding="utf-8"))
-    baseline = load_baseline(baseline_data)
     return compare_baseline(
         reports,
         baseline,
@@ -236,11 +253,27 @@ def _compare_to_baseline(
     )
 
 
+def _check_ranking_stability(
+    repo_root: Path,
+    baseline: Baseline | None,
+) -> list[RankingGateViolation]:
+    """Compare a live ranking snapshot against the baseline's, when one is embedded.
+
+    Skipped (no indexing cost) when the baseline carries no ranking snapshot, so
+    recall-only baselines are unaffected.
+    """
+    if baseline is None or not baseline.ranking:
+        return []
+    current = build_ranking_snapshot(repo_root)
+    return check_ranking_stability(current, baseline.ranking)
+
+
 def _write_reports(
     output_dir: Path,
     tasks: list[BenchmarkTask],
     reports: list[BenchmarkReport],
     comparisons: list[BaselineComparison],
+    ranking_violations: list[RankingGateViolation],
     baseline_path: Path | None,
 ) -> tuple[Path, Path, Path]:
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -248,7 +281,9 @@ def _write_reports(
     history_dir.mkdir(parents=True, exist_ok=True)
 
     timestamp = datetime.now(tz=UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-    payload = _json_payload(timestamp, tasks, reports, comparisons, baseline_path)
+    payload = _json_payload(
+        timestamp, tasks, reports, comparisons, ranking_violations, baseline_path
+    )
 
     latest_json_path = output_dir / "latest.json"
     latest_markdown_path = output_dir / "latest.md"
@@ -258,7 +293,7 @@ def _write_reports(
     latest_json_path.write_text(serialized, encoding="utf-8")
     history_json_path.write_text(serialized, encoding="utf-8")
     latest_markdown_path.write_text(
-        _markdown_report(tasks, reports, comparisons, baseline_path),
+        _markdown_report(tasks, reports, comparisons, ranking_violations, baseline_path),
         encoding="utf-8",
     )
     return latest_json_path, latest_markdown_path, history_json_path
@@ -269,6 +304,7 @@ def _json_payload(
     tasks: list[BenchmarkTask],
     reports: list[BenchmarkReport],
     comparisons: list[BaselineComparison],
+    ranking_violations: list[RankingGateViolation],
     baseline_path: Path | None,
 ) -> dict[str, object]:
     return {
@@ -281,6 +317,9 @@ def _json_payload(
             comparison.model_dump(mode="json")
             for comparison in comparisons
             if comparison.regression
+        ],
+        "ranking_violations": [
+            violation.model_dump(mode="json") for violation in ranking_violations
         ],
         "retrieval_diagnostics": _retrieval_diagnostics(tasks, reports),
     }
@@ -376,6 +415,7 @@ def _markdown_report(
     tasks: list[BenchmarkTask],
     reports: list[BenchmarkReport],
     comparisons: list[BaselineComparison],
+    ranking_violations: list[RankingGateViolation],
     baseline_path: Path | None,
 ) -> str:
     lines: list[str] = ["# Dogfood Report", ""]
@@ -401,6 +441,19 @@ def _markdown_report(
                 f"| {regression.task_id} | {regression.strategy} | {regression.metric} "
                 f"| {regression.baseline_value:.3f} | {regression.current_value:.3f} "
                 f"| {regression.delta:+.3f} |"
+            )
+    lines.append("")
+    lines.append("## Ranking Stability")
+    lines.append("")
+    if not ranking_violations:
+        lines.append("No ranking-stability regressions detected.")
+    else:
+        lines.append("| Metric | Correlation | Threshold | Sample size |")
+        lines.append("|--------|-------------|-----------|-------------|")
+        for violation in ranking_violations:
+            lines.append(
+                f"| {violation.metric} | {violation.correlation:.3f} "
+                f"| {violation.threshold:.3f} | {violation.sample_size} |"
             )
     lines.append("")
     lines.extend(_markdown_retrieval_diagnostics(tasks, reports))

--- a/tests/benchmark/test_baseline.py
+++ b/tests/benchmark/test_baseline.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+
 from archex.benchmark.baseline import (
     Baseline,
     BaselineEntry,
+    RankingSnapshotEntry,
+    build_ranking_snapshot,
     compare_baseline,
     load_baseline,
     save_baseline,
@@ -167,3 +172,70 @@ def test_compare_baseline_excludes_diagnostic_strategies() -> None:
 
     assert {comparison.strategy for comparison in comparisons} == {Strategy.ARCHEX_QUERY.value}
     assert [comparison for comparison in comparisons if comparison.regression] == []
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
+
+
+def test_baseline_ranking_field_defaults_empty() -> None:
+    assert Baseline().ranking == []
+    baseline_with_entries = Baseline(
+        entries=[
+            BaselineEntry(
+                task_id="test_task",
+                strategy="archex_query",
+                recall=1.0,
+                precision=1.0,
+                f1_score=1.0,
+                mrr=1.0,
+            )
+        ]
+    )
+    assert baseline_with_entries.ranking == []
+
+
+def test_baseline_ranking_roundtrips_through_json() -> None:
+    baseline = Baseline(
+        ranking=[
+            RankingSnapshotEntry(file_path="src/a.py", centrality=0.4, symbol_count=12),
+            RankingSnapshotEntry(file_path="src/b.py", centrality=0.1, symbol_count=3),
+        ]
+    )
+    loaded = load_baseline(baseline.model_dump())
+    assert [(e.file_path, e.centrality, e.symbol_count) for e in loaded.ranking] == [
+        ("src/a.py", 0.4, 12),
+        ("src/b.py", 0.1, 3),
+    ]
+
+
+def test_build_ranking_snapshot_reflects_indexed_files(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    (tmp_path / "target_pkg").mkdir()
+    (tmp_path / "target_pkg" / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "target_pkg" / "helper.py").write_text(
+        "def one():\n    return 1\n\n\ndef two():\n    return 2\n\n\ndef three():\n    return 3\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "importer.py").write_text(
+        "import target_pkg.helper\n\n\ndef use_helper():\n    return target_pkg.helper.one()\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "lonely.py").write_text(
+        "def solo_a():\n    return 1\n\n\ndef solo_b():\n    return 2\n",
+        encoding="utf-8",
+    )
+
+    snapshot = build_ranking_snapshot(tmp_path)
+    by_path = {entry.file_path: entry for entry in snapshot}
+
+    assert set(by_path) == {"target_pkg/helper.py", "importer.py", "lonely.py"}
+    # helper.py has 3 top-level defs and no import statements, so its symbol
+    # count matches the def count exactly (imports add their own chunk).
+    assert by_path["target_pkg/helper.py"].symbol_count == 3
+    assert by_path["lonely.py"].symbol_count == 2
+    # helper.py is imported by importer.py, so PageRank credits it with
+    # non-zero centrality; a file with no incoming or outgoing edges (lonely.py)
+    # gets centrality 0.0.
+    assert by_path["target_pkg/helper.py"].centrality > 0.0
+    assert by_path["lonely.py"].centrality == 0.0

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, cast
 import pytest
 from click.testing import CliRunner
 
+from archex.benchmark.baseline import RankingSnapshotEntry
 from archex.benchmark.models import (
     BenchmarkReport,
     BenchmarkResult,
@@ -171,6 +172,74 @@ class TestReportCommand:
         result = runner.invoke(benchmark_cmd, ["report", "--input", str(empty_dir)])
         assert result.exit_code != 0
         assert "No result files" in result.output
+
+
+class TestBaselineSaveCommand:
+    def test_without_ranking_source_omits_ranking(
+        self,
+        runner: CliRunner,
+        results_dir: Path,
+        tmp_path: Path,
+    ) -> None:
+        output_path = tmp_path / "baseline.json"
+
+        result = runner.invoke(
+            benchmark_cmd,
+            ["baseline", "save", "--input", str(results_dir), "--output", str(output_path)],
+        )
+
+        assert result.exit_code == 0
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+        assert payload["ranking"] == []
+
+    def test_with_ranking_source_attaches_snapshot(
+        self,
+        runner: CliRunner,
+        results_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        ranking_source = tmp_path / "ranking_source"
+        ranking_source.mkdir()
+        output_path = tmp_path / "baseline.json"
+
+        stub_ranking = [
+            RankingSnapshotEntry(file_path="src/a.py", centrality=0.4, symbol_count=12),
+            RankingSnapshotEntry(file_path="src/b.py", centrality=0.1, symbol_count=3),
+        ]
+        captured: list[Path] = []
+
+        def fake_build_ranking_snapshot(repo_root: Path) -> list[RankingSnapshotEntry]:
+            captured.append(repo_root)
+            return stub_ranking
+
+        monkeypatch.setattr(
+            "archex.cli.benchmark_cmd.build_ranking_snapshot",
+            fake_build_ranking_snapshot,
+        )
+
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "baseline",
+                "save",
+                "--input",
+                str(results_dir),
+                "--output",
+                str(output_path),
+                "--ranking-source",
+                str(ranking_source),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured == [ranking_source]
+        assert f"Ranking snapshot:   {len(stub_ranking)} files" in result.output
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+        assert payload["ranking"] == [
+            {"file_path": "src/a.py", "centrality": 0.4, "symbol_count": 12},
+            {"file_path": "src/b.py", "centrality": 0.1, "symbol_count": 3},
+        ]
 
 
 class TestTriageCommand:

--- a/tests/benchmark/test_dogfood.py
+++ b/tests/benchmark/test_dogfood.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from click.testing import CliRunner
 
-from archex.benchmark.baseline import Baseline, BaselineEntry
+from archex.benchmark.baseline import Baseline, BaselineEntry, RankingSnapshotEntry
 from archex.benchmark.models import BenchmarkReport, BenchmarkResult, BenchmarkTask, Strategy
 from archex.cli.main import cli
 from archex.dogfood import format_product_default_delta, run_dogfood
@@ -59,6 +59,7 @@ def _write_baseline(
     *,
     recall: float = 1.0,
     include_diagnostics: bool = False,
+    ranking: list[RankingSnapshotEntry] | None = None,
 ) -> Path:
     baseline_path = path / "baseline.json"
     entries = [
@@ -95,7 +96,7 @@ def _write_baseline(
                 ),
             ]
         )
-    baseline = Baseline(entries=entries)
+    baseline = Baseline(entries=entries, ranking=ranking or [])
     baseline_path.write_text(baseline.model_dump_json(indent=2), encoding="utf-8")
     return baseline_path
 
@@ -440,3 +441,116 @@ def test_dogfood_requires_explicit_baseline(
 
     assert result.exit_code == 1
     assert "Dogfood requires an explicit --baseline path" in result.output
+
+
+def test_dogfood_skips_ranking_check_when_baseline_has_no_ranking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_tasks(tmp_path)
+    baseline_path = _write_baseline(tmp_path)  # no ranking -> Baseline.ranking defaults to []
+    monkeypatch.setattr("archex.dogfood.run_benchmark", _passing_report)
+
+    def _fail_if_called(repo_root: Path) -> list[RankingSnapshotEntry]:
+        del repo_root
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr("archex.dogfood.build_ranking_snapshot", _fail_if_called)
+
+    result = run_dogfood(tmp_path, task_id="archex_query_pipeline", baseline_path=baseline_path)
+
+    assert result.ranking_violations == []
+    payload = json.loads(result.latest_json_path.read_text(encoding="utf-8"))
+    assert payload["ranking_violations"] == []
+
+
+def test_dogfood_reports_ranking_violation_when_baseline_has_ranking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_tasks(tmp_path)
+    baseline_ranking = [
+        RankingSnapshotEntry(file_path="src/a.py", centrality=0.1, symbol_count=10),
+        RankingSnapshotEntry(file_path="src/b.py", centrality=0.2, symbol_count=20),
+        RankingSnapshotEntry(file_path="src/c.py", centrality=0.3, symbol_count=30),
+        RankingSnapshotEntry(file_path="src/d.py", centrality=0.4, symbol_count=40),
+    ]
+    baseline_path = _write_baseline(tmp_path, ranking=baseline_ranking)
+    monkeypatch.setattr("archex.dogfood.run_benchmark", _passing_report)
+
+    # Same centrality as baseline (no drift) but symbol_count fully reversed —
+    # a deterministic stand-in for a symbol-flooding conversion, avoiding a
+    # second real indexing pass on top of the fixture repo.
+    current_ranking = [
+        RankingSnapshotEntry(file_path="src/a.py", centrality=0.1, symbol_count=40),
+        RankingSnapshotEntry(file_path="src/b.py", centrality=0.2, symbol_count=30),
+        RankingSnapshotEntry(file_path="src/c.py", centrality=0.3, symbol_count=20),
+        RankingSnapshotEntry(file_path="src/d.py", centrality=0.4, symbol_count=10),
+    ]
+
+    def _fake_current_ranking(repo_root: Path) -> list[RankingSnapshotEntry]:
+        del repo_root
+        return current_ranking
+
+    monkeypatch.setattr("archex.dogfood.build_ranking_snapshot", _fake_current_ranking)
+
+    result = run_dogfood(tmp_path, task_id="archex_query_pipeline", baseline_path=baseline_path)
+
+    assert len(result.ranking_violations) == 1
+    assert result.ranking_violations[0].metric == "symbol_count"
+
+    payload = json.loads(result.latest_json_path.read_text(encoding="utf-8"))
+    assert len(payload["ranking_violations"]) == 1
+    assert payload["ranking_violations"][0]["metric"] == "symbol_count"
+
+    markdown = result.latest_markdown_path.read_text(encoding="utf-8")
+    assert "## Ranking Stability" in markdown
+    assert "symbol_count" in markdown
+
+
+def test_dogfood_command_exits_nonzero_on_ranking_violation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _init_git_repo(tmp_path)
+    _write_tasks(tmp_path)
+    baseline_ranking = [
+        RankingSnapshotEntry(file_path="src/a.py", centrality=0.1, symbol_count=10),
+        RankingSnapshotEntry(file_path="src/b.py", centrality=0.2, symbol_count=20),
+        RankingSnapshotEntry(file_path="src/c.py", centrality=0.3, symbol_count=30),
+        RankingSnapshotEntry(file_path="src/d.py", centrality=0.4, symbol_count=40),
+    ]
+    baseline_path = _write_baseline(tmp_path, ranking=baseline_ranking)
+    monkeypatch.setattr("archex.dogfood.run_benchmark", _passing_report)
+
+    current_ranking = [
+        RankingSnapshotEntry(file_path="src/a.py", centrality=0.1, symbol_count=40),
+        RankingSnapshotEntry(file_path="src/b.py", centrality=0.2, symbol_count=30),
+        RankingSnapshotEntry(file_path="src/c.py", centrality=0.3, symbol_count=20),
+        RankingSnapshotEntry(file_path="src/d.py", centrality=0.4, symbol_count=10),
+    ]
+
+    def _fake_current_ranking(repo_root: Path) -> list[RankingSnapshotEntry]:
+        del repo_root
+        return current_ranking
+
+    monkeypatch.setattr("archex.dogfood.build_ranking_snapshot", _fake_current_ranking)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "dogfood",
+            str(tmp_path),
+            "--task",
+            "archex_query_pipeline",
+            "--baseline",
+            str(baseline_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Ranking violations:" in result.output
+    assert "symbol_count" in result.output

--- a/tests/benchmark/test_gate.py
+++ b/tests/benchmark/test_gate.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from archex.benchmark.baseline import RankingSnapshotEntry
 from archex.benchmark.gate import (
     PRODUCT_DEFAULT_TOKEN_EFFICIENCY_FLOOR,
     QualityThresholds,
+    RankingQualityThresholds,
     check_gate,
+    check_ranking_stability,
     check_recall_regressions,
     non_token_quality_warnings,
     token_efficiency_violations,
@@ -394,3 +397,122 @@ def test_gate_region_violations_are_advisory_warnings() -> None:
     # Region failures are non-token quality warnings, not hard token failures.
     assert any(v.metric == "region_recall" for v in non_token_quality_warnings(violations))
     assert token_efficiency_violations(violations) == []
+
+
+def test_check_ranking_stability_passes_when_unchanged() -> None:
+    entries = [
+        RankingSnapshotEntry(file_path="src/a.py", centrality=0.1, symbol_count=5),
+        RankingSnapshotEntry(file_path="src/b.py", centrality=0.4, symbol_count=12),
+        RankingSnapshotEntry(file_path="src/c.py", centrality=0.9, symbol_count=3),
+        RankingSnapshotEntry(file_path="src/d.py", centrality=0.2, symbol_count=40),
+        RankingSnapshotEntry(file_path="src/e.py", centrality=0.6, symbol_count=8),
+    ]
+    assert check_ranking_stability(entries, entries) == []
+
+
+def test_check_ranking_stability_detects_symbol_flooding_regression() -> None:
+    """A symbol-flooding conversion reorders symbol_count ranks while leaving
+    structural_centrality untouched — proving the two metrics are checked
+    independently and that the gate has teeth.
+
+    This class of regression is invisible to recall/precision/F1/MRR: it never
+    touches a `BenchmarkReport`/`BenchmarkResult` at all, and `RankingSnapshotEntry`
+    (the only type flowing through `check_ranking_stability`) carries no
+    retrieval-quality fields whatsoever. A baseline comparison over the same
+    underlying retrieval results (`compare_baseline`) would report zero drift
+    for this exact scenario, so `violations != []` below is the only signal
+    that could ever catch it — a no-op stand-in for `check_ranking_stability`
+    (always returning `[]`) would silently pass this regression through.
+    """
+    baseline = [
+        RankingSnapshotEntry(file_path="src/a.py", centrality=0.05, symbol_count=10),
+        RankingSnapshotEntry(file_path="src/b.py", centrality=0.30, symbol_count=20),
+        RankingSnapshotEntry(file_path="src/c.py", centrality=0.10, symbol_count=30),
+        RankingSnapshotEntry(file_path="src/d.py", centrality=0.50, symbol_count=40),
+        RankingSnapshotEntry(file_path="src/e.py", centrality=0.20, symbol_count=50),
+        RankingSnapshotEntry(file_path="src/f.py", centrality=0.40, symbol_count=60),
+    ]
+    # Simulate an overzealous chunk-only -> full conversion that floods the two
+    # lowest-symbol_count files with many new low-value symbols. Every file's
+    # structural centrality (PageRank over import edges) is left unchanged, so
+    # only the symbol_count ranking should regress.
+    current = [
+        RankingSnapshotEntry(file_path="src/a.py", centrality=0.05, symbol_count=10_000),
+        RankingSnapshotEntry(file_path="src/b.py", centrality=0.30, symbol_count=8_000),
+        RankingSnapshotEntry(file_path="src/c.py", centrality=0.10, symbol_count=30),
+        RankingSnapshotEntry(file_path="src/d.py", centrality=0.50, symbol_count=40),
+        RankingSnapshotEntry(file_path="src/e.py", centrality=0.20, symbol_count=50),
+        RankingSnapshotEntry(file_path="src/f.py", centrality=0.40, symbol_count=60),
+    ]
+
+    violations = check_ranking_stability(current, baseline)
+
+    symbol_violations = [v for v in violations if v.metric == "symbol_count"]
+    assert symbol_violations, "symbol-flooding must reorder the symbol_count ranking"
+    assert (
+        symbol_violations[0].correlation
+        < RankingQualityThresholds().min_symbol_count_rank_correlation
+    )
+    assert not any(v.metric == "structural_centrality" for v in violations)
+
+
+def test_check_ranking_stability_ignores_files_absent_from_one_snapshot() -> None:
+    baseline = [RankingSnapshotEntry(file_path="src/shared.py", centrality=0.1, symbol_count=5)]
+    current = [RankingSnapshotEntry(file_path="src/shared.py", centrality=0.9, symbol_count=500)]
+    # Only one file is common to both snapshots: correlation is undefined below
+    # two points, so no violation can be raised even though the shared file's
+    # values differ wildly.
+    assert check_ranking_stability(current, baseline) == []
+
+
+def test_check_ranking_stability_respects_custom_thresholds() -> None:
+    baseline = [
+        RankingSnapshotEntry(file_path="src/a.py", centrality=0.1, symbol_count=10),
+        RankingSnapshotEntry(file_path="src/b.py", centrality=0.2, symbol_count=20),
+        RankingSnapshotEntry(file_path="src/c.py", centrality=0.3, symbol_count=30),
+        RankingSnapshotEntry(file_path="src/d.py", centrality=0.4, symbol_count=40),
+        RankingSnapshotEntry(file_path="src/e.py", centrality=0.5, symbol_count=50),
+    ]
+    current = [
+        RankingSnapshotEntry(file_path="src/a.py", centrality=0.1, symbol_count=10),
+        RankingSnapshotEntry(file_path="src/b.py", centrality=0.2, symbol_count=20),
+        RankingSnapshotEntry(file_path="src/c.py", centrality=0.3, symbol_count=50),
+        RankingSnapshotEntry(file_path="src/d.py", centrality=0.4, symbol_count=40),
+        RankingSnapshotEntry(file_path="src/e.py", centrality=0.5, symbol_count=30),
+    ]
+    # A mild symbol_count reorder (Spearman rho == 0.6) fails the default 0.8
+    # floor...
+    default_violations = check_ranking_stability(current, baseline)
+    assert any(v.metric == "symbol_count" for v in default_violations)
+
+    # ...but clears a lowered custom floor.
+    lenient = RankingQualityThresholds(
+        min_centrality_rank_correlation=0.0,
+        min_symbol_count_rank_correlation=0.0,
+    )
+    assert check_ranking_stability(current, baseline, lenient) == []
+
+
+def test_check_ranking_stability_zero_variance_metric_skipped() -> None:
+    baseline = [
+        RankingSnapshotEntry(file_path="src/a.py", centrality=0.1, symbol_count=10),
+        RankingSnapshotEntry(file_path="src/b.py", centrality=0.2, symbol_count=10),
+        RankingSnapshotEntry(file_path="src/c.py", centrality=0.3, symbol_count=10),
+        RankingSnapshotEntry(file_path="src/d.py", centrality=0.4, symbol_count=10),
+        RankingSnapshotEntry(file_path="src/e.py", centrality=0.5, symbol_count=10),
+    ]
+    # symbol_count is constant (10) in both snapshots, so its correlation is
+    # undefined and must never fire — even though centrality is fully inverted
+    # (a genuine regression) and must fire. Proves a zero-variance metric can't
+    # crash the gate or mask a real regression on the other metric.
+    current = [
+        RankingSnapshotEntry(file_path="src/a.py", centrality=0.5, symbol_count=10),
+        RankingSnapshotEntry(file_path="src/b.py", centrality=0.4, symbol_count=10),
+        RankingSnapshotEntry(file_path="src/c.py", centrality=0.3, symbol_count=10),
+        RankingSnapshotEntry(file_path="src/d.py", centrality=0.2, symbol_count=10),
+        RankingSnapshotEntry(file_path="src/e.py", centrality=0.1, symbol_count=10),
+    ]
+
+    violations = check_ranking_stability(current, baseline)
+
+    assert [v.metric for v in violations] == ["structural_centrality"]


### PR DESCRIPTION
## Summary

PR 2/2 of the M5 stack (Recall regression gate for language promotion). Adds the ranking-quality check (report §8 objection 3) to the gate PR 1 established a baseline for.

## Stack

Stack: M5 - Recall regression gate for language promotion
Base: `feat/m5-pre-promotion-baseline`
Position: 2/2

1. `feat/m5-pre-promotion-baseline` -> #385
2. `feat/m5-ranking-quality-gate` -> this PR

Depends on: #385
Upstack: none (leaf)

## What

- `structural_centrality()` PageRank and `symbol_count` are load-bearing ranking signals feeding `graph_hubs`/`graph_neighbors`/query ranking. A language-tier promotion that floods the graph with many low-value symbols (an overzealous chunk-only -> full conversion) can silently reorder these rankings for files that were never touched, without moving recall/precision/F1 at all. This PR adds the check.
- `Baseline` (`src/archex/benchmark/baseline.py`) gains an optional `ranking: list[RankingSnapshotEntry]` field (backward compatible, defaults to `[]`) and `build_ranking_snapshot(repo_root)`, which indexes a repo and pairs each file's PageRank centrality with its chunk-derived symbol count.
- `gate.py` gains `check_ranking_stability(current, baseline, thresholds)`: a tie-safe Spearman rank correlation (numpy-based — no new dependency) over `structural_centrality` and `symbol_count` independently, restricted to files present in both snapshots, flagging a `RankingGateViolation` when a metric's correlation drops below its threshold.
- `run_dogfood` now runs this check whenever the loaded baseline carries a non-empty `ranking` field, and skips it entirely (zero extra indexing cost) otherwise. `DogfoodRunResult.ranking_violations`, the JSON payload's `ranking_violations` array, the markdown report's "Ranking Stability" section, and the CLI's exit code (now non-zero on either a recall regression or a ranking violation) all thread this through.
- `archex benchmark baseline save` gains `--ranking-source <path>` to attach a ranking snapshot when (re)generating a baseline.
- `.archex/baselines/pre-promotion.json` (from PR 1) is regenerated with a real ranking snapshot (565 indexed files) so the check is active by default going forward.
- `docs/LANGUAGE_PROMOTION_GATE.md` documents the check and the `--ranking-source` regeneration flow.

## Proving the gate has teeth

`tests/benchmark/test_gate.py::test_check_ranking_stability_detects_symbol_flooding_regression` injects an order-of-magnitude `symbol_count` inflation on two files (a stand-in for an overzealous chunk-only-to-full conversion) while holding `centrality` constant, and asserts the gate flags a `symbol_count` violation while leaving `structural_centrality` untouched (proving the two metrics are checked independently).

Verified explicitly, not just "tests are green": temporarily neutered `check_ranking_stability` to a no-op (`return []`) and re-ran the test —

```
FAILED tests/benchmark/test_gate.py::test_check_ranking_stability_detects_symbol_flooding_regression
AssertionError: symbol-flooding must reorder the symbol_count ranking
assert []
```

— then restored the real implementation and re-ran —

```
tests/benchmark/test_gate.py::test_check_ranking_stability_detects_symbol_flooding_regression PASSED
```

## Verification

```
uv run ruff check .                 # OK
uv run ruff format --check .        # 317 files already formatted
uv run pyright                      # 0 errors (project include/exclude config)
uv run pytest tests/benchmark/test_gate.py tests/benchmark/test_baseline.py \
  tests/benchmark/test_dogfood.py tests/benchmark/test_cli.py -v --no-cov
# 84 passed
uv run pytest -q
# 2959 passed, 4 deselected, 90.86% coverage
```

Gate invocation against the regenerated baseline (all 16 self-repo tasks, verified per-task — see note below):

```
16/16 self tasks: 112 metric comparisons, 0 regressions, 0 ranking_violations
```

**Note on `archex dogfood --all` in this environment:** a single combined `archex dogfood --all --baseline ... --format json` process run exceeds 900s+ in this sandbox for reasons unrelated to this stack (reproduced identically before any M5 code existed, on stock `main`) — each of the same 16 tasks completes in 45-80s when run individually (in-process or as separate invocations), so the underlying gate mechanics are exhaustively verified per-task above; only running all 16 within one combined process is slow here. Not a correctness regression from this PR; flagged as a separate follow-up if it reproduces outside this sandbox.
