### PR TITLE
feat(languages)!: promote php to full tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,8 +363,8 @@ For the full trust contract, including exact MCP JSON, Docker commands, cache lo
 
 | Tier | Languages | Extraction |
 | --- | --- | --- |
-| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift | Symbols, imports, graph edges |
-| `chunk-only` | C, C++, PHP, Ruby, Scala, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity | AST chunking + retrieval; no symbol/import graph claim |
+| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift, PHP | Symbols, imports, graph edges |
+| `chunk-only` | C, C++, Ruby, Scala, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity | AST chunking + retrieval; no symbol/import graph claim |
 | `unknown` | any other text file | line-window chunks for BM25 visibility |
 
 Need another language? Register an adapter via Python entry points. See [System Design](docs/SYSTEM_DESIGN.md) for the extension contract.

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -213,8 +213,8 @@ Language support is declared, not implied. `full` means symbol extraction, impor
 
 | Tier | Languages |
 | --- | --- |
-| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift |
-| `chunk-only` | C, C++, PHP, Ruby, Scala, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity |
+| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift, PHP |
+| `chunk-only` | C, C++, Ruby, Scala, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity |
 
 Unknown files fall back to line-window chunking so they can still be found by BM25 without pretending to have structural edges.
 

--- a/src/archex/languages.py
+++ b/src/archex/languages.py
@@ -59,23 +59,7 @@ LANGUAGE_SUPPORT: dict[str, LanguageSupport] = {
             }
         ),
     ),
-    "php": LanguageSupport(
-        "php",
-        "PHP",
-        (".php",),
-        _CHUNK,
-        "php",
-        frozenset(
-            {
-                "function_definition",
-                "class_declaration",
-                "interface_declaration",
-                "trait_declaration",
-                "namespace_definition",
-                "namespace_use_declaration",
-            }
-        ),
-    ),
+    "php": LanguageSupport("php", "PHP", (".php",), _FULL, "php"),
     "ruby": LanguageSupport(
         "ruby",
         "Ruby",

--- a/src/archex/parse/adapters/__init__.py
+++ b/src/archex/parse/adapters/__init__.py
@@ -13,6 +13,7 @@ from archex.parse.adapters.csharp import CSharpAdapter
 from archex.parse.adapters.go import GoAdapter
 from archex.parse.adapters.java import JavaAdapter
 from archex.parse.adapters.kotlin import KotlinAdapter
+from archex.parse.adapters.php import PHPAdapter
 from archex.parse.adapters.python import PythonAdapter
 from archex.parse.adapters.rust import RustAdapter
 from archex.parse.adapters.swift import SwiftAdapter
@@ -90,6 +91,7 @@ default_adapter_registry.register("java", JavaAdapter)  # type: ignore[type-abst
 default_adapter_registry.register("csharp", CSharpAdapter)  # type: ignore[type-abstract]
 default_adapter_registry.register("kotlin", KotlinAdapter)  # type: ignore[type-abstract]
 default_adapter_registry.register("swift", SwiftAdapter)  # type: ignore[type-abstract]
+default_adapter_registry.register("php", PHPAdapter)  # type: ignore[type-abstract]
 for _language_id in sorted(CHUNK_ONLY_LANGUAGE_IDS):
     default_adapter_registry.register(_language_id, make_chunk_only_adapter(_language_id))
 

--- a/tests/parse/test_language_coverage.py
+++ b/tests/parse/test_language_coverage.py
@@ -24,12 +24,6 @@ CHUNK_ONLY_SAMPLES: dict[str, tuple[str, str, list[tuple[int, int]]]] = {
         "#include <vector>\nnamespace n { class C { public: void m(){} }; int f(){return 1;} }\n",
         [(1, 1), (2, 2)],
     ),
-    "php": (
-        "index.php",
-        "<?php\nnamespace App;\nuse Foo\\Bar;\nfunction f() { return 1; }\n"
-        "class C { public function m() {} }\n",
-        [(2, 2), (3, 3), (4, 4), (5, 5)],
-    ),
     "ruby": (
         "app.rb",
         'require "json"\nmodule M\n  class C\n    def m\n    end\n  end\nend\n',
@@ -102,6 +96,7 @@ FULL_LANGUAGE_FIXTURES: dict[str, Path] = {
     "kotlin": FIXTURES_DIR / "kotlin_simple",
     "csharp": FIXTURES_DIR / "csharp_simple",
     "swift": FIXTURES_DIR / "swift_simple",
+    "php": FIXTURES_DIR / "php_simple",
 }
 
 


### PR DESCRIPTION
## Stack

Stack-Id: `m6-php-full-tier`
Base: `feat/m6-php-adapter-contract`
Position: 4/4 (leaf)

1. `feat/m6-php-fixtures` -> #387
2. `feat/m6-php-adapter-core` -> #388
3. `feat/m6-php-adapter-contract` -> #389
4. `feat/m6-php-tier-flip` -> this PR

Depends on: #389
Upstack: (none — leaf)

## Summary

Milestone M6 (DEVELOPMENT_PLAN.md §4 Section D), PR 4/4: tier flip and regression-gate evidence. Completes M6.

- Flips `php` from `LanguageTier.CHUNK_ONLY` to `LanguageTier.FULL` in `LANGUAGE_SUPPORT` (`src/archex/languages.py`).
- Registers `PHPAdapter` in the default adapter registry (`src/archex/parse/adapters/__init__.py`) — required wiring for the tier flip to actually take effect (`CHUNK_ONLY_LANGUAGE_IDS` is derived from tier, so php silently drops out of the chunk-only auto-registration loop; without this registration php would have no adapter at all).
- Moves the `php_simple` fixture coverage in `tests/parse/test_language_coverage.py` from `CHUNK_ONLY_SAMPLES` (now superseded — asserted `parsed.symbols == []`, no longer true) to `FULL_LANGUAGE_FIXTURES`.
- Updates the language-support tier tables in `README.md` and `docs/SYSTEM_DESIGN.md`.
- No new adapter logic — `PHPAdapter` (all 5 contract methods) already landed fully implemented and tested in #388/#389.

`!` + `BREAKING CHANGE` footer: per the plan's own "Backward compatibility" note (§5), every `CHUNK_ONLY` → `FULL` tier change is a behavior change for existing consumers of that language's chunk/symbol data.

## Verification (all from a clean run on this branch's final state)

| Command | Result |
|---|---|
| `uv run pytest tests/parse/adapters/test_php.py -v` | 49 passed |
| `uv run pytest tests/parse/test_language_coverage.py -v` | passed (php now under `test_full_tier_languages_extract_symbols_and_imports`) |
| `uv run pytest` (full suite) | 3007 passed, 90.91% coverage |
| `uv run ruff check .` | clean |
| `uv run ruff format --check .` | 319 files already formatted |
| `uv run pyright` | 0 errors, 0 warnings |
| `uv run archex doctor .` | `full grammars: 11/11 available` (was 10/10), `chunk-only grammars: 15/15` (was 16/16) — php reports as a working full-tier grammar |
| `uv run archex dogfood --all --baseline .archex/baselines/pre-promotion.json` | 24 tasks, **0 regressions**, **0 ranking violations** — M5's gate passes clean |

### archex outline end-to-end smoke test

Built a throwaway repo from `tests/fixtures/php_simple/`, ran `archex init` + `archex index`, then `archex outline` on several fixtures — real named symbols, not whole-file/line-window chunks (matches the existing Java/C# FULL-tier outline shape exactly, including the same pre-existing leading-header artifact those languages also show):

```text
file: Models/User.php
class User [L8-39]
  constant MAX_NAME_LEN [L12-12]
  variable id [L14-14]
  variable email [L15-15]
  method __construct [L17-20] function __construct(private readonly string $name, int $id = 0): mixed
  variable name [L17-20]
  method create [L22-25] function create(string $name): self
  method toArray [L27-33] function toArray(): array
  method validate [L35-38] function validate(): bool
```

```text
file: Contracts/Arrayable.php
interface Arrayable [L5-8]
  method toArray [L7-7] function toArray(): array
```

```text
file: Models/Status.php
enum Status [L5-17]
  constant Active [L7-7]
  constant Inactive [L8-8]
  method label [L10-16] function label(): string
```

## M6 acceptance criteria — all met

- [x] `.php` files parsed at `LanguageTier.FULL` with real symbol_name/symbol_kind extraction (functions, classes, interfaces, traits, namespaces) and import resolution
- [x] `archex outline` on a PHP fixture returns named function/class/trait/interface symbols, not whole-file/line-window chunks
- [x] `archex doctor` reports PHP as a working full-tier grammar
- [x] M5's regression gate passes against the pre-promotion baseline

Refs: #371