### PR TITLE
test(ruby): add full-tier fixture corpus

### DIFF
--- a/tests/fixtures/ruby_simple/GRAMMAR_EVALUATION.md
+++ b/tests/fixtures/ruby_simple/GRAMMAR_EVALUATION.md
@@ -1,0 +1,33 @@
+# Ruby grammar evaluation (M7 prerequisite)
+
+**Grammar:** bundled Ruby grammar resolved by `tree_sitter_language_pack.get_language("ruby")` and Archex's existing `tree-sitter-language-pack==0.13.0` fallback. No new dependency is required; Ruby already resolves through this grammar at `CHUNK_ONLY` tier.
+
+**Method:** probed the grammar directly with `tree_sitter_language_pack.get_language("ruby")` + `tree_sitter.Parser`, walking every parsed fixture `root_node` for `has_error`, `ERROR`, and `is_error` nodes. The fixture set intentionally checks adjacent declarations, nested modules, singleton methods, mixin calls, visibility markers, constants, external `require`, and relative `require_relative` forms because the Groovy halt precedent was boundary corruption on idiomatic declarations, not grammar absence.
+
+## Idioms probed (all `has_error == False`, zero `ERROR` nodes)
+
+- Top-level `require` and `require_relative` calls with string arguments.
+- Nested modules (`module StoreFront`, `module StoreFront::Mixins`, `module ClassMethods`) and adjacent class declarations in one namespace body.
+- Classes under nested modules, inheritance (`class User < ApplicationRecord`), constants, initializer methods, instance methods, singleton methods (`def self.find_by_email`, `def self.slugify`, `def self.included`).
+- Ruby mixin idioms: `include`, `extend`, and an `included(base)` hook extending nested `ClassMethods`.
+- Visibility markers (`protected`, `private`) affecting subsequent methods without corrupting method boundaries.
+- Attribute helper calls (`attr_reader :email, :role`), keyword arguments, hash literals, instance variables, chained calls, regex literals, and block-free collection calls.
+- Adjacent declarations of the same kind (`Admin` and `Guest` classes) inside `StoreFront::Legacy`, verifying one declaration does not swallow the next sibling's boundary.
+
+## Result: PASS, no GAP
+
+The bundled Ruby grammar handles every construct required by this milestone without a single error node. Module, class, method, singleton method, mixin, import, and visibility constructs all parse into stable named nodes with independent `start_point`/`end_point` ranges. Full-tier promotion proceeds; the adapter test suite exercises these fixtures.
+
+## Fixture layout
+
+Mirrors the existing `java_simple`/`php_simple` convention: a small namespace-rooted Ruby tree under this directory, with each file exercising a distinct construct so symbol extraction and cross-file import resolution are covered end to end.
+
+| File | Constructs covered |
+|---|---|
+| `app.rb` | Script-style entry point, `require`, multiple `require_relative` imports, full fixture wiring |
+| `store_front/auditable.rb` | Nested modules, mixin instance method |
+| `support/slugger.rb` | Module constant, singleton method |
+| `models/user.rb` | Class, inheritance, include/extend mixins, constants, attr reader, initializer, singleton method, public/protected/private methods |
+| `services/user_service.rb` | External and relative imports, class service object, constants, methods using imported model |
+| `mixins/trackable.rb` | Nested modules, `included` hook singleton method, nested `ClassMethods` module, mixin instance method |
+| `legacy/admin.rb` | Adjacent classes in one namespace body for boundary-corruption probing |

--- a/tests/fixtures/ruby_simple/app.rb
+++ b/tests/fixtures/ruby_simple/app.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "json"
+require_relative "store_front/auditable"
+require_relative "support/slugger"
+require_relative "models/user"
+require_relative "services/user_service"
+
+service = StoreFront::Services::UserService.new
+puts JSON.generate(service.serialize(StoreFront::Models::User.find_by_email("ada@example.com")))

--- a/tests/fixtures/ruby_simple/legacy/admin.rb
+++ b/tests/fixtures/ruby_simple/legacy/admin.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module StoreFront
+  module Legacy
+    class Admin
+      def initialize(name)
+        @name = name
+      end
+    end
+
+    class Guest
+      def initialize
+        @name = "guest"
+      end
+    end
+  end
+end

--- a/tests/fixtures/ruby_simple/mixins/trackable.rb
+++ b/tests/fixtures/ruby_simple/mixins/trackable.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module StoreFront
+  module Mixins
+    module Trackable
+      def self.included(base)
+        base.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def tracked_events
+          @tracked_events ||= []
+        end
+      end
+
+      def track(event)
+        self.class.tracked_events << event
+      end
+    end
+  end
+end

--- a/tests/fixtures/ruby_simple/models/user.rb
+++ b/tests/fixtures/ruby_simple/models/user.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require_relative "../store_front/auditable"
+require_relative "../support/slugger"
+
+module StoreFront
+  module Models
+    class User < ApplicationRecord
+      include StoreFront::Auditable
+      extend StoreFront::Slugger
+
+      DEFAULT_ROLE = "customer"
+
+      attr_reader :email, :role
+
+      def initialize(email:, role: DEFAULT_ROLE)
+        @email = email
+        @role = role
+      end
+
+      def self.find_by_email(email)
+        new(email: email)
+      end
+
+      def display_name
+        email.split("@").first
+      end
+
+      protected
+
+      def normalized_role
+        role.to_s.downcase
+      end
+
+      private
+
+      def normalize_email
+        email.to_s.strip.downcase
+      end
+    end
+  end
+end

--- a/tests/fixtures/ruby_simple/services/user_service.rb
+++ b/tests/fixtures/ruby_simple/services/user_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "set"
+require_relative "../models/user"
+
+module StoreFront
+  module Services
+    class UserService
+      BATCH_SIZE = 25
+
+      def initialize(users = Set.new)
+        @users = users
+      end
+
+      def register(email)
+        user = Models::User.new(email: email)
+        @users.add(user)
+        user
+      end
+
+      def serialize(user)
+        {
+          email: user.email,
+          role: user.role,
+          name: user.display_name
+        }
+      end
+    end
+  end
+end

--- a/tests/fixtures/ruby_simple/store_front/auditable.rb
+++ b/tests/fixtures/ruby_simple/store_front/auditable.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module StoreFront
+  module Auditable
+    def audit!(event)
+      @events ||= []
+      @events << event
+    end
+  end
+end

--- a/tests/fixtures/ruby_simple/support/slugger.rb
+++ b/tests/fixtures/ruby_simple/support/slugger.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module StoreFront
+  module Slugger
+    SEPARATOR = "-"
+
+    def self.slugify(value)
+      value.to_s.downcase.gsub(/[^a-z0-9]+/, SEPARATOR).gsub(/^-|-$/, "")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `tests/fixtures/ruby_simple/` with representative Ruby modules, classes, singleton methods, mixins, visibility markers, constants, and require forms.
- Document bundled Ruby grammar evaluation results in `tests/fixtures/ruby_simple/GRAMMAR_EVALUATION.md`.

## Stack

Stack-Id: `m7-ruby-full-tier-20260704`
Base: `main`
Position: 1/4

1. `feat/m7-ruby-fixtures` -> this PR
2. `feat/m7-ruby-adapter-core` -> #394
3. `feat/m7-ruby-contracts` -> #396
4. `feat/m7-ruby-full-tier` -> #395

Depends on: none
Upstack: #394

## Validation

- `tree_sitter_language_pack.get_language("ruby")` direct probe across all `tests/fixtures/ruby_simple/**/*.rb`: zero `ERROR` nodes, `root_node.has_error == False`
- Leaf validation completed on `feat/m7-ruby-full-tier`:
  - `uv run pytest tests/parse/adapters/test_ruby.py -v --no-cov` -> 44 passed
  - `uv run archex doctor` -> full grammars 12/12, chunk-only grammars 14/14
  - `uv run archex dogfood --all --baseline .archex/baselines/pre-promotion.json` -> Regressions: 0, Ranking violations: 0
  - `uv run pytest` -> 3050 passed, 4 deselected
  - `uv run ruff check src/archex/parse/adapters/ruby.py` -> OK
  - `uv run pyright` -> no diagnostics

## Notes

No adapter code in this PR.
