### PR TITLE
feat(ruby): add full-tier adapter core

### DIFF
--- a/src/archex/parse/adapters/ruby.py
+++ b/src/archex/parse/adapters/ruby.py
@@ -1,0 +1,493 @@
+"""Ruby parse adapter: extract symbols and imports from .rb files using tree-sitter."""
+
+from __future__ import annotations
+
+import os
+from pathlib import PurePosixPath
+from typing import Any
+
+from archex.models import DiscoveredFile, ImportStatement, Symbol, SymbolKind, Visibility
+from archex.parse.adapters.ts_node import (
+    ts_end_line as _end_line,
+)
+from archex.parse.adapters.ts_node import (
+    ts_field as _field,
+)
+from archex.parse.adapters.ts_node import (
+    ts_named_children as _named_children,
+)
+from archex.parse.adapters.ts_node import (
+    ts_start_line as _start_line,
+)
+from archex.parse.adapters.ts_node import (
+    ts_text as _text,
+)
+from archex.parse.adapters.ts_node import (
+    ts_type as _type,
+)
+
+# ---------------------------------------------------------------------------
+# Constant / qualification helpers
+# ---------------------------------------------------------------------------
+
+
+def _constant_path(node: object, source: bytes) -> str:
+    """Return a Ruby constant or scope-resolution path with '.' separators."""
+    parts: list[str] = []
+
+    def collect(current: object) -> None:
+        current_type = _type(current)
+        if current_type == "constant":
+            parts.append(_text(current, source))
+            return
+        if current_type == "scope_resolution":
+            for child in _named_children(current):
+                if _type(child) in {"constant", "scope_resolution"}:
+                    collect(child)
+
+    collect(node)
+    if parts:
+        return ".".join(parts)
+    return _text(node, source).replace("::", ".")
+
+
+def _qualify(parent_name: str | None, name: str) -> str:
+    if not parent_name:
+        return name
+    if name.startswith(f"{parent_name}."):
+        return name
+    return f"{parent_name}.{name}"
+
+
+def _short_name(qualified_name: str) -> str:
+    return qualified_name.rsplit(".", 1)[-1]
+
+
+# ---------------------------------------------------------------------------
+# Signature / visibility helpers
+# ---------------------------------------------------------------------------
+
+
+_VISIBILITY_MARKERS: dict[str, Visibility] = {
+    "public": Visibility.PUBLIC,
+    "protected": Visibility.INTERNAL,
+    "private": Visibility.PRIVATE,
+}
+
+
+def _method_signature(node: object, source: bytes, name: str, singleton: bool) -> str:
+    params = _field(node, "parameters")
+    params_text = _text(params, source) if params is not None else "()"
+    receiver = "self." if singleton else ""
+    return f"def {receiver}{name}{params_text}"
+
+
+def _call_method_name(node: object, source: bytes) -> str | None:
+    method_node = _field(node, "method")
+    if method_node is None:
+        return None
+    return _text(method_node, source)
+
+
+def _visibility_marker(node: object, source: bytes) -> Visibility | None:
+    if _type(node) == "identifier":
+        return _VISIBILITY_MARKERS.get(_text(node, source))
+    if _type(node) == "call":
+        method_name = _call_method_name(node, source)
+        if method_name is not None:
+            return _VISIBILITY_MARKERS.get(method_name)
+    return None
+
+
+def _symbol_argument_names(node: object | None, source: bytes) -> list[str]:
+    if node is None:
+        return []
+    names: list[str] = []
+    node_type = _type(node)
+    if node_type == "simple_symbol":
+        names.append(_text(node, source).lstrip(":"))
+    elif node_type == "string_content":
+        names.append(_text(node, source))
+    for child in _named_children(node):
+        names.extend(_symbol_argument_names(child, source))
+    return names
+
+
+def _method_argument_nodes(node: object | None) -> list[object]:
+    if node is None:
+        return []
+    methods: list[object] = []
+    if _type(node) in {"method", "singleton_method"}:
+        methods.append(node)
+        return methods
+    for child in _named_children(node):
+        methods.extend(_method_argument_nodes(child))
+    return methods
+
+
+# ---------------------------------------------------------------------------
+# Symbol extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_method(
+    node: object,
+    source: bytes,
+    file_path: str,
+    parent_name: str | None,
+    visibility: Visibility,
+    force_singleton: bool = False,
+) -> Symbol | None:
+    name_node = _field(node, "name")
+    if name_node is None:
+        return None
+    name = _text(name_node, source)
+    singleton = force_singleton or _type(node) == "singleton_method"
+    qualified_parent = parent_name
+    if singleton:
+        object_node = _field(node, "object")
+        if object_node is not None and _type(object_node) != "self":
+            qualified_parent = _constant_path(object_node, source)
+    qualified_name = _qualify(qualified_parent, name)
+    return Symbol(
+        name=name,
+        qualified_name=qualified_name,
+        kind=SymbolKind.METHOD,
+        file_path=file_path,
+        start_line=_start_line(node),
+        end_line=_end_line(node),
+        visibility=visibility,
+        signature=_method_signature(node, source, name, singleton),
+        parent=qualified_parent,
+    )
+
+
+def _extract_constant(
+    node: object, source: bytes, file_path: str, parent_name: str
+) -> Symbol | None:
+    left = _field(node, "left")
+    if left is None or _type(left) != "constant":
+        return None
+    name = _text(left, source)
+    return Symbol(
+        name=name,
+        qualified_name=_qualify(parent_name, name),
+        kind=SymbolKind.CONSTANT,
+        file_path=file_path,
+        start_line=_start_line(node),
+        end_line=_end_line(node),
+        visibility=Visibility.PUBLIC,
+        parent=parent_name,
+    )
+
+
+def _extract_module_or_class(
+    node: object,
+    source: bytes,
+    file_path: str,
+    parent_name: str | None,
+) -> list[Symbol]:
+    name_node = _field(node, "name")
+    if name_node is None:
+        return []
+
+    declared_name = _constant_path(name_node, source)
+    qualified_name = _qualify(parent_name, declared_name)
+    kind = SymbolKind.MODULE if _type(node) == "module" else SymbolKind.CLASS
+    symbols = [
+        Symbol(
+            name=_short_name(declared_name),
+            qualified_name=qualified_name,
+            kind=kind,
+            file_path=file_path,
+            start_line=_start_line(node),
+            end_line=_end_line(node),
+            visibility=Visibility.PUBLIC,
+            parent=parent_name,
+        )
+    ]
+
+    body = _field(node, "body")
+    if body is not None:
+        symbols.extend(_extract_body_symbols(body, source, file_path, qualified_name))
+    return symbols
+
+
+def _apply_retroactive_visibility(
+    symbols: list[Symbol], parent_name: str | None, method_names: list[str], visibility: Visibility
+) -> None:
+    if not method_names:
+        return
+    names = set(method_names)
+    for index, symbol in enumerate(symbols):
+        if (
+            symbol.kind == SymbolKind.METHOD
+            and symbol.parent == parent_name
+            and symbol.name in names
+        ):
+            symbols[index] = symbol.model_copy(update={"visibility": visibility})
+
+
+def _extract_visibility_call_symbols(
+    node: object,
+    source: bytes,
+    file_path: str,
+    parent_name: str | None,
+    visibility: Visibility,
+) -> list[Symbol]:
+    symbols: list[Symbol] = []
+    arguments = _field(node, "arguments")
+    for method_node in _method_argument_nodes(arguments):
+        method = _extract_method(method_node, source, file_path, parent_name, visibility)
+        if method is not None:
+            symbols.append(method)
+    return symbols
+
+
+def _extract_body_symbols(
+    body: object,
+    source: bytes,
+    file_path: str,
+    parent_name: str | None,
+    force_singleton_methods: bool = False,
+) -> list[Symbol]:
+    symbols: list[Symbol] = []
+    method_visibility = Visibility.PUBLIC
+
+    for child in _named_children(body):
+        child_type = _type(child)
+        marker = _visibility_marker(child, source)
+        if marker is not None:
+            if child_type == "call":
+                call_symbols = _extract_visibility_call_symbols(
+                    child, source, file_path, parent_name, marker
+                )
+                method_names = _symbol_argument_names(_field(child, "arguments"), source)
+                if call_symbols:
+                    symbols.extend(call_symbols)
+                if method_names:
+                    _apply_retroactive_visibility(symbols, parent_name, method_names, marker)
+                    continue
+                if call_symbols:
+                    continue
+                method_visibility = marker
+                continue
+            method_visibility = marker
+            continue
+
+        if child_type in {"module", "class"}:
+            symbols.extend(_extract_module_or_class(child, source, file_path, parent_name))
+        elif child_type in {"method", "singleton_method"}:
+            method = _extract_method(
+                child,
+                source,
+                file_path,
+                parent_name,
+                method_visibility,
+                force_singleton=force_singleton_methods,
+            )
+            if method is not None:
+                symbols.append(method)
+        elif child_type == "singleton_class":
+            singleton_body = _field(child, "body")
+            singleton_parent = parent_name
+            receiver = _field(child, "value")
+            if receiver is not None and _type(receiver) != "self":
+                singleton_parent = _constant_path(receiver, source)
+            if singleton_body is not None:
+                symbols.extend(
+                    _extract_body_symbols(
+                        singleton_body,
+                        source,
+                        file_path,
+                        singleton_parent,
+                        force_singleton_methods=True,
+                    )
+                )
+        elif child_type == "assignment" and parent_name is not None:
+            constant = _extract_constant(child, source, file_path, parent_name)
+            if constant is not None:
+                symbols.append(constant)
+
+    return symbols
+
+
+# ---------------------------------------------------------------------------
+# Import parsing
+# ---------------------------------------------------------------------------
+
+
+_REQUIRE_METHODS: frozenset[str] = frozenset({"require", "require_relative"})
+
+
+def _first_string_content(node: object, source: bytes) -> str | None:
+    if _type(node) == "string_content":
+        return _text(node, source)
+    for child in _named_children(node):
+        value = _first_string_content(child, source)
+        if value is not None:
+            return value
+    return None
+
+
+def _parse_require_call(node: object, source: bytes, file_path: str) -> ImportStatement | None:
+    method_node = _field(node, "method")
+    arguments_node = _field(node, "arguments")
+    if method_node is None or arguments_node is None:
+        return None
+
+    method_name = _text(method_node, source)
+    if method_name not in _REQUIRE_METHODS:
+        return None
+
+    module = _first_string_content(arguments_node, source)
+    if module is None or not module:
+        return None
+
+    return ImportStatement(
+        module=module,
+        symbols=[],
+        file_path=file_path,
+        line=_start_line(node),
+        is_relative=method_name == "require_relative",
+    )
+
+
+def _walk_require_calls(root: object, source: bytes, file_path: str) -> list[ImportStatement]:
+    imports: list[ImportStatement] = []
+    stack = [root]
+    while stack:
+        node = stack.pop()
+        if _type(node) == "call":
+            imp = _parse_require_call(node, source, file_path)
+            if imp is not None:
+                imports.append(imp)
+        stack.extend(reversed(_named_children(node)))
+    return imports
+
+
+# ---------------------------------------------------------------------------
+# Import resolution
+# ---------------------------------------------------------------------------
+
+
+def _with_rb_suffix(module: str) -> str:
+    return module if module.endswith(".rb") else f"{module}.rb"
+
+
+def _normalize_path(path: str) -> str:
+    return os.path.normpath(path).replace(os.sep, "/")
+
+
+def _file_map_path(file_map_key: str, file_map_value: str) -> tuple[str, str]:
+    return file_map_key.replace(os.sep, "/"), _normalize_path(file_map_value)
+
+
+def _lookup_file_map_path(candidate: str, file_map: dict[str, str]) -> str | None:
+    normalized = _normalize_path(candidate)
+    for key, value in file_map.items():
+        normalized_key, normalized_value = _file_map_path(key, value)
+        if normalized in {normalized_key, normalized_value}:
+            return value
+    return None
+
+
+def _resolve_relative_require(imp: ImportStatement, file_map: dict[str, str]) -> str | None:
+    source_dir = PurePosixPath(imp.file_path).parent
+    candidate = str((source_dir / _with_rb_suffix(imp.module)).as_posix())
+    return _lookup_file_map_path(candidate, file_map)
+
+
+def _resolve_load_path_require(module: str, file_map: dict[str, str]) -> str | None:
+    candidates = {module, _with_rb_suffix(module)}
+    for rel_path, abs_path in file_map.items():
+        normalized_key, normalized_value = _file_map_path(rel_path, abs_path)
+        suffix_match = any(
+            normalized_key.endswith(f"/{c}") or normalized_value.endswith(f"/{c}")
+            for c in candidates
+        )
+        if normalized_key in candidates or normalized_value in candidates or suffix_match:
+            return abs_path
+    return None
+
+
+def _resolve_ruby_import(imp: ImportStatement, file_map: dict[str, str]) -> str | None:
+    if imp.is_relative:
+        return _resolve_relative_require(imp, file_map)
+    return _resolve_load_path_require(imp.module, file_map)
+
+
+# ---------------------------------------------------------------------------
+# Entry point detection
+# ---------------------------------------------------------------------------
+
+
+_ENTRY_BASENAMES: frozenset[str] = frozenset(
+    {"app.rb", "main.rb", "server.rb", "config.ru", "Rakefile"}
+)
+_ENTRY_MARKERS: tuple[str, ...] = ("#!/usr/bin/env ruby", "#!/usr/bin/ruby")
+
+
+# ---------------------------------------------------------------------------
+# RubyAdapter
+# ---------------------------------------------------------------------------
+
+
+class RubyAdapter:
+    """Language adapter for Ruby source files.
+
+    `qualified_name` uses Archex's uniform '.' separator rather than Ruby's
+    native '::'. Import resolution is conservative: `require_relative` resolves
+    against the importing file's directory, while load-path `require` only
+    resolves when the requested path directly matches a local file suffix.
+    External gems such as `json` and `set` therefore stay unresolved instead of
+    being guessed from unrelated same-basename files.
+    """
+
+    @property
+    def language_id(self) -> str:
+        return "ruby"
+
+    @property
+    def file_extensions(self) -> list[str]:
+        return [".rb"]
+
+    @property
+    def tree_sitter_name(self) -> str:
+        return "ruby"
+
+    def extract_symbols(self, tree: object, source: bytes, file_path: str) -> list[Symbol]:
+        """Extract module, class, method, singleton-method, and constant symbols."""
+        t: Any = tree
+        root: object = t.root_node
+        return _extract_body_symbols(root, source, file_path, None)
+
+    def parse_imports(self, tree: object, source: bytes, file_path: str) -> list[ImportStatement]:
+        """Extract `require` and `require_relative` import calls."""
+        t: Any = tree
+        root: object = t.root_node
+        return _walk_require_calls(root, source, file_path)
+
+    def resolve_import(self, imp: ImportStatement, file_map: dict[str, str]) -> str | None:
+        """Resolve a Ruby require to a local file, or None if it is external."""
+        return _resolve_ruby_import(imp, file_map)
+
+    def detect_entry_points(self, files: list[DiscoveredFile]) -> list[str]:
+        """Detect conventional Ruby application entry points and shebang scripts."""
+        entry_points: list[str] = []
+        for f in files:
+            if os.path.basename(f.path) in _ENTRY_BASENAMES:
+                entry_points.append(f.path)
+                continue
+            try:
+                with open(f.absolute_path, encoding="utf-8", errors="replace") as fh:
+                    content = fh.read(128)
+            except OSError:
+                continue
+            if any(content.startswith(marker) for marker in _ENTRY_MARKERS):
+                entry_points.append(f.path)
+        return entry_points
+
+    def classify_visibility(self, symbol: Symbol) -> Visibility:
+        """Return the symbol's stored visibility (set during extraction)."""
+        return symbol.visibility

--- a/tests/parse/adapters/test_ruby.py
+++ b/tests/parse/adapters/test_ruby.py
@@ -1,0 +1,520 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from archex.models import SymbolKind, Visibility
+from archex.parse.adapters.base import LanguageAdapter
+from archex.parse.adapters.ruby import RubyAdapter
+from archex.parse.engine import TreeSitterEngine
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures" / "ruby_simple"
+
+
+@pytest.fixture()
+def engine() -> TreeSitterEngine:
+    return TreeSitterEngine()
+
+
+@pytest.fixture()
+def adapter() -> RubyAdapter:
+    return RubyAdapter()
+
+
+def parse(engine: TreeSitterEngine, source: bytes) -> object:
+    return engine.parse_bytes(source, "ruby")
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_satisfies_language_adapter_protocol(adapter: RubyAdapter) -> None:
+    assert isinstance(adapter, LanguageAdapter)
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+def test_language_id(adapter: RubyAdapter) -> None:
+    assert adapter.language_id == "ruby"
+
+
+def test_file_extensions(adapter: RubyAdapter) -> None:
+    assert adapter.file_extensions == [".rb"]
+
+
+def test_tree_sitter_name(adapter: RubyAdapter) -> None:
+    assert adapter.tree_sitter_name == "ruby"
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: module/class qualification with '.' separators
+# ---------------------------------------------------------------------------
+
+
+def test_nested_module_qualifies_class(engine: TreeSitterEngine, adapter: RubyAdapter) -> None:
+    source = (FIXTURES_DIR / "models" / "user.rb").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "models/user.rb")
+
+    user = next(s for s in symbols if s.name == "User")
+    assert user.kind == SymbolKind.CLASS
+    assert user.qualified_name == "StoreFront.Models.User"
+    assert user.parent == "StoreFront.Models"
+
+
+def test_deeply_nested_modules_use_dot_separators(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    source = (FIXTURES_DIR / "mixins" / "trackable.rb").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "mixins/trackable.rb")
+
+    class_methods = next(s for s in symbols if s.name == "ClassMethods")
+    assert class_methods.qualified_name == "StoreFront.Mixins.Trackable.ClassMethods"
+
+    tracked_events = next(s for s in symbols if s.name == "tracked_events")
+    assert (
+        tracked_events.qualified_name == "StoreFront.Mixins.Trackable.ClassMethods.tracked_events"
+    )
+    assert "::" not in tracked_events.qualified_name
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: modules
+# ---------------------------------------------------------------------------
+
+
+def test_module_extracted_as_module_kind(engine: TreeSitterEngine, adapter: RubyAdapter) -> None:
+    source = (FIXTURES_DIR / "support" / "slugger.rb").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "support/slugger.rb")
+
+    slugger = next(s for s in symbols if s.name == "Slugger")
+    assert slugger.kind == SymbolKind.MODULE
+    assert slugger.visibility == Visibility.PUBLIC
+
+
+def test_top_level_module_has_no_parent(engine: TreeSitterEngine, adapter: RubyAdapter) -> None:
+    source = (FIXTURES_DIR / "support" / "slugger.rb").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "support/slugger.rb")
+
+    top = next(s for s in symbols if s.name == "StoreFront")
+    assert top.parent is None
+
+
+def test_sibling_classes_share_module_parent(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    source = (FIXTURES_DIR / "legacy" / "admin.rb").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "legacy/admin.rb")
+
+    classes = {s.name: s for s in symbols if s.kind == SymbolKind.CLASS}
+    assert classes["Admin"].parent == "StoreFront.Legacy"
+    assert classes["Guest"].parent == "StoreFront.Legacy"
+    assert classes["Admin"].qualified_name == "StoreFront.Legacy.Admin"
+    assert classes["Guest"].qualified_name == "StoreFront.Legacy.Guest"
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: instance, module, and singleton methods
+# ---------------------------------------------------------------------------
+
+
+def test_instance_methods_default_to_public(engine: TreeSitterEngine, adapter: RubyAdapter) -> None:
+    source = (FIXTURES_DIR / "services" / "user_service.rb").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "services/user_service.rb")
+
+    methods = {s.name: s for s in symbols if s.kind == SymbolKind.METHOD}
+    assert methods["initialize"].visibility == Visibility.PUBLIC
+    assert methods["register"].visibility == Visibility.PUBLIC
+    assert methods["serialize"].visibility == Visibility.PUBLIC
+    for m in methods.values():
+        assert m.parent == "StoreFront.Services.UserService"
+
+
+def test_protected_marker_maps_to_internal(engine: TreeSitterEngine, adapter: RubyAdapter) -> None:
+    source = (FIXTURES_DIR / "models" / "user.rb").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "models/user.rb")
+
+    methods = {s.name: s for s in symbols if s.kind == SymbolKind.METHOD}
+    assert methods["normalized_role"].visibility == Visibility.INTERNAL  # protected -> INTERNAL
+
+
+def test_private_marker_applies_only_to_subsequent_methods(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    source = (FIXTURES_DIR / "models" / "user.rb").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "models/user.rb")
+
+    methods = {s.name: s for s in symbols if s.kind == SymbolKind.METHOD}
+    assert methods["normalize_email"].visibility == Visibility.PRIVATE
+    # Declared before the `private` marker -- must stay public.
+    assert methods["display_name"].visibility == Visibility.PUBLIC
+
+
+def test_explicit_public_marker_resets_visibility_after_private(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    # Ruby lets a bare `public` call re-open public visibility after a
+    # `private` marker; the adapter's per-body visibility state must track
+    # that toggle rather than sticking once it flips to private.
+    source = b"public\ndef a; end\nprivate\ndef b; end\npublic\ndef c; end\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "vis.rb")
+
+    methods = {s.name: s for s in symbols}
+    assert methods["a"].visibility == Visibility.PUBLIC
+    assert methods["b"].visibility == Visibility.PRIVATE
+    assert methods["c"].visibility == Visibility.PUBLIC
+
+
+def test_visibility_call_with_symbol_arguments_updates_existing_methods(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    source = (
+        b"class Foo\n"
+        b"  def hidden; end\n"
+        b"  def semi_hidden; end\n"
+        b"  private :hidden\n"
+        b"  protected :semi_hidden\n"
+        b"end\n"
+    )
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "foo.rb")
+
+    methods = {s.name: s for s in symbols if s.kind == SymbolKind.METHOD}
+    assert methods["hidden"].visibility == Visibility.PRIVATE
+    assert methods["semi_hidden"].visibility == Visibility.INTERNAL
+
+
+def test_visibility_call_wrapping_method_extracts_method(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    source = b"class Foo\n  private def secret(x)\n    x\n  end\nend\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "foo.rb")
+
+    secret = next(s for s in symbols if s.name == "secret")
+    assert secret.qualified_name == "Foo.secret"
+    assert secret.visibility == Visibility.PRIVATE
+    assert secret.parent == "Foo"
+
+
+def test_visibility_call_mixes_symbol_arguments_and_wrapped_method(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    source = b"class Foo\n  def hidden; end\n  private :hidden, def secret(x)\n    x\n  end\nend\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "foo.rb")
+
+    methods = {s.name: s for s in symbols if s.kind == SymbolKind.METHOD}
+    assert methods["hidden"].visibility == Visibility.PRIVATE
+    assert methods["secret"].visibility == Visibility.PRIVATE
+
+
+def test_empty_visibility_call_resets_subsequent_method_visibility(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    source = b"class Foo\nprivate()\ndef hidden; end\npublic()\ndef shown; end\nend\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "foo.rb")
+
+    methods = {s.name: s for s in symbols if s.kind == SymbolKind.METHOD}
+    assert methods["hidden"].visibility == Visibility.PRIVATE
+    assert methods["shown"].visibility == Visibility.PUBLIC
+
+
+def test_singleton_method_with_self_receiver_stays_nested(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    source = (FIXTURES_DIR / "models" / "user.rb").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "models/user.rb")
+
+    finder = next(s for s in symbols if s.name == "find_by_email")
+    assert finder.qualified_name == "StoreFront.Models.User.find_by_email"
+    assert finder.parent == "StoreFront.Models.User"
+    assert finder.signature is not None
+    assert "self" in finder.signature
+
+
+def test_singleton_method_with_explicit_constant_receiver_reparents(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    # `def Helper.bar` inside module M rebinds the method's parent to the
+    # named receiver instead of the lexically enclosing module -- this is
+    # what lets a mixin attach "class methods" to whatever module/class
+    # extends it, decoupled from where the def itself is written.
+    source = b"module M\n  def Helper.bar(x)\n  end\nend\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "reparent.rb")
+
+    bar = next(s for s in symbols if s.name == "bar")
+    assert bar.qualified_name == "Helper.bar"
+    assert bar.parent == "Helper"
+
+
+def test_module_function_via_self_receiver(engine: TreeSitterEngine, adapter: RubyAdapter) -> None:
+    source = (FIXTURES_DIR / "support" / "slugger.rb").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "support/slugger.rb")
+
+    slugify = next(s for s in symbols if s.name == "slugify")
+    assert slugify.kind == SymbolKind.METHOD
+    assert slugify.qualified_name == "StoreFront.Slugger.slugify"
+    assert slugify.parent == "StoreFront.Slugger"
+
+
+def test_singleton_class_methods_stay_nested(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    source = (
+        b"class Widget\n"
+        b"  class << self\n"
+        b"    def build(name)\n"
+        b"      new(name)\n"
+        b"    end\n"
+        b"  end\n"
+        b"end\n"
+    )
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "widget.rb")
+
+    build = next(s for s in symbols if s.name == "build")
+    assert build.qualified_name == "Widget.build"
+    assert build.parent == "Widget"
+    assert build.signature == "def self.build(name)"
+
+
+def test_singleton_class_with_constant_receiver_reparents_methods(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    source = (
+        b"class Widget\n"
+        b"end\n"
+        b"class Gadget\n"
+        b"  class << Widget\n"
+        b"    def build(name)\n"
+        b"      name\n"
+        b"    end\n"
+        b"  end\n"
+        b"end\n"
+    )
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "widget.rb")
+
+    build = next(s for s in symbols if s.name == "build")
+    assert build.qualified_name == "Widget.build"
+    assert build.parent == "Widget"
+    assert build.signature == "def self.build(name)"
+
+
+def test_bang_method_name_preserved(engine: TreeSitterEngine, adapter: RubyAdapter) -> None:
+    source = (FIXTURES_DIR / "store_front" / "auditable.rb").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "store_front/auditable.rb")
+
+    audit = next(s for s in symbols if s.name == "audit!")
+    assert audit.qualified_name == "StoreFront.Auditable.audit!"
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: constants
+# ---------------------------------------------------------------------------
+
+
+def test_class_constant(engine: TreeSitterEngine, adapter: RubyAdapter) -> None:
+    source = (FIXTURES_DIR / "models" / "user.rb").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "models/user.rb")
+
+    default_role = next(s for s in symbols if s.name == "DEFAULT_ROLE")
+    assert default_role.kind == SymbolKind.CONSTANT
+    assert default_role.qualified_name == "StoreFront.Models.User.DEFAULT_ROLE"
+    assert default_role.parent == "StoreFront.Models.User"
+    assert default_role.visibility == Visibility.PUBLIC
+
+
+def test_module_level_constant(engine: TreeSitterEngine, adapter: RubyAdapter) -> None:
+    source = (FIXTURES_DIR / "support" / "slugger.rb").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "support/slugger.rb")
+
+    separator = next(s for s in symbols if s.name == "SEPARATOR")
+    assert separator.kind == SymbolKind.CONSTANT
+    assert separator.parent == "StoreFront.Slugger"
+
+
+def test_attr_reader_produces_no_symbols(engine: TreeSitterEngine, adapter: RubyAdapter) -> None:
+    # `attr_reader :email, :role` is a method call, not an assignment or a
+    # `def` -- it must not be mistaken for a field/constant declaration.
+    source = (FIXTURES_DIR / "models" / "user.rb").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "models/user.rb")
+
+    names = {s.name for s in symbols}
+    assert "email" not in names
+    assert "role" not in names
+    assert "attr_reader" not in names
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: top-level scripts without declarations
+# ---------------------------------------------------------------------------
+
+
+def test_top_level_script_without_declarations_has_no_symbols(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    # app.rb only contains `require`/`require_relative` calls and a local
+    # variable assignment at the top level -- none of those are declarations
+    # and must not be misreported as symbols.
+    source = (FIXTURES_DIR / "app.rb").read_bytes()
+    tree = parse(engine, source)
+    assert adapter.extract_symbols(tree, source, "app.rb") == []
+
+
+# ---------------------------------------------------------------------------
+# parse_imports: require / require_relative
+# ---------------------------------------------------------------------------
+
+
+def test_parse_require_is_not_relative(engine: TreeSitterEngine, adapter: RubyAdapter) -> None:
+    source = (FIXTURES_DIR / "app.rb").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "app.rb")
+
+    json_import = next(i for i in imports if i.module == "json")
+    assert json_import.is_relative is False
+    assert json_import.line == 3
+
+
+def test_parse_require_relative_is_relative(engine: TreeSitterEngine, adapter: RubyAdapter) -> None:
+    source = (FIXTURES_DIR / "app.rb").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "app.rb")
+
+    modules = {i.module: i for i in imports}
+    assert modules["store_front/auditable"].is_relative is True
+    assert modules["services/user_service"].is_relative is True
+
+
+def test_parse_imports_excludes_non_require_calls(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    # app.rb also calls `StoreFront::Services::UserService.new`,
+    # `JSON.generate`, and `puts` -- none of those are require calls and
+    # must not leak into the import list.
+    source = (FIXTURES_DIR / "app.rb").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "app.rb")
+
+    assert len(imports) == 5
+    assert {i.module for i in imports} == {
+        "json",
+        "store_front/auditable",
+        "support/slugger",
+        "models/user",
+        "services/user_service",
+    }
+
+
+def test_parse_require_relative_preserves_parent_dir_prefix(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    source = (FIXTURES_DIR / "models" / "user.rb").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "models/user.rb")
+
+    modules = {i.module for i in imports}
+    assert "../store_front/auditable" in modules
+    assert "../support/slugger" in modules
+    for i in imports:
+        assert i.is_relative is True
+
+
+def test_parse_require_without_relative_flag(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    source = (FIXTURES_DIR / "services" / "user_service.rb").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "services/user_service.rb")
+
+    set_import = next(i for i in imports if i.module == "set")
+    assert set_import.is_relative is False
+
+
+def test_file_with_no_requires_has_no_imports(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    source = (FIXTURES_DIR / "legacy" / "admin.rb").read_bytes()
+    tree = parse(engine, source)
+    assert adapter.parse_imports(tree, source, "legacy/admin.rb") == []
+
+
+def test_interpolated_require_string_falls_back_to_literal_suffix(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    # A dynamically interpolated require target has no single literal module
+    # name. The adapter walks the string for the first plain string_content
+    # segment rather than crashing or silently dropping the call -- pin the
+    # documented (if imperfect) result so a regression is caught either way.
+    source = b'require_relative "#{dir}/foo"\n'
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "dyn.rb")
+
+    assert len(imports) == 1
+    assert imports[0].module == "/foo"
+    assert imports[0].is_relative is True
+
+
+def test_require_call_without_arguments_produces_no_import(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    source = b"require()\n"
+    tree = parse(engine, source)
+    assert adapter.parse_imports(tree, source, "bare.rb") == []
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_file(engine: TreeSitterEngine, adapter: RubyAdapter) -> None:
+    source = b""
+    tree = parse(engine, source)
+    assert adapter.extract_symbols(tree, source, "empty.rb") == []
+    assert adapter.parse_imports(tree, source, "empty.rb") == []
+
+
+def test_all_symbols_have_qualified_names(engine: TreeSitterEngine, adapter: RubyAdapter) -> None:
+    for f in FIXTURES_DIR.rglob("*.rb"):
+        source = f.read_bytes()
+        tree = parse(engine, source)
+        symbols = adapter.extract_symbols(tree, source, str(f))
+        for s in symbols:
+            assert s.qualified_name, f"Missing qualified_name for {s.name} in {f}"
+
+
+def test_all_methods_and_constants_have_parent(
+    engine: TreeSitterEngine, adapter: RubyAdapter
+) -> None:
+    for f in FIXTURES_DIR.rglob("*.rb"):
+        source = f.read_bytes()
+        tree = parse(engine, source)
+        symbols = adapter.extract_symbols(tree, source, str(f))
+        for s in symbols:
+            if s.kind in (SymbolKind.METHOD, SymbolKind.CONSTANT):
+                assert s.parent is not None, f"Missing parent for {s.qualified_name} in {f}"


### PR DESCRIPTION
## Summary

- Add `src/archex/parse/adapters/ruby.py` with `RubyAdapter` implementing symbol extraction and import parsing.
- Add focused Ruby adapter tests for protocol conformance, properties, modules/classes, instance and singleton methods, constants, visibility-marker extraction, and `require`/`require_relative` parsing.

## Stack

Stack-Id: `m7-ruby-full-tier-20260704`
Base: `main`
Position: 2/4

1. `feat/m7-ruby-fixtures` -> #393
2. `feat/m7-ruby-adapter-core` -> this PR
3. `feat/m7-ruby-contracts` -> #396
4. `feat/m7-ruby-full-tier` -> #395

Depends on: #393
Upstack: #396

## Validation

- `uv run pytest tests/parse/adapters/test_ruby.py -v --no-cov` -> 44 passed on leaf
- `uv run pytest` -> 3050 passed, 4 deselected on leaf
- `uv run ruff check src/archex/parse/adapters/ruby.py` -> OK on leaf
- `uv run pyright` -> no diagnostics on leaf

## Notes

This PR intentionally does not flip Ruby to `LanguageTier.FULL`; registry wiring happens in the leaf PR.
