### PR TITLE
feat(languages)!: promote Ruby to full tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,8 +370,8 @@ For the full trust contract, including exact MCP JSON, Docker commands, cache lo
 
 | Tier | Languages | Extraction |
 | --- | --- | --- |
-| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift, PHP | Symbols, imports, graph edges |
-| `chunk-only` | C, C++, Ruby, Scala, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity | AST chunking + retrieval; no symbol/import graph claim |
+| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift, PHP, Ruby | Symbols, imports, graph edges |
+| `chunk-only` | C, C++, Scala, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity | AST chunking + retrieval; no symbol/import graph claim |
 | `unknown` | any other text file | line-window chunks for BM25 visibility |
 
 Need another language? Register an adapter via Python entry points. See [System Design](docs/SYSTEM_DESIGN.md) for the extension contract.

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -213,8 +213,8 @@ Language support is declared, not implied. `full` means symbol extraction, impor
 
 | Tier | Languages |
 | --- | --- |
-| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift, PHP |
-| `chunk-only` | C, C++, Ruby, Scala, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity |
+| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift, PHP, Ruby |
+| `chunk-only` | C, C++, Scala, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity |
 
 Unknown files fall back to line-window chunking so they can still be found by BM25 without pretending to have structural edges.
 

--- a/src/archex/languages.py
+++ b/src/archex/languages.py
@@ -60,14 +60,7 @@ LANGUAGE_SUPPORT: dict[str, LanguageSupport] = {
         ),
     ),
     "php": LanguageSupport("php", "PHP", (".php",), _FULL, "php"),
-    "ruby": LanguageSupport(
-        "ruby",
-        "Ruby",
-        (".rb",),
-        _CHUNK,
-        "ruby",
-        frozenset({"module", "class", "method", "singleton_method", "call"}),
-    ),
+    "ruby": LanguageSupport("ruby", "Ruby", (".rb",), _FULL, "ruby"),
     "scala": LanguageSupport(
         "scala",
         "Scala",

--- a/src/archex/parse/adapters/__init__.py
+++ b/src/archex/parse/adapters/__init__.py
@@ -15,6 +15,7 @@ from archex.parse.adapters.java import JavaAdapter
 from archex.parse.adapters.kotlin import KotlinAdapter
 from archex.parse.adapters.php import PHPAdapter
 from archex.parse.adapters.python import PythonAdapter
+from archex.parse.adapters.ruby import RubyAdapter
 from archex.parse.adapters.rust import RustAdapter
 from archex.parse.adapters.swift import SwiftAdapter
 from archex.parse.adapters.typescript import TypeScriptAdapter
@@ -92,6 +93,7 @@ default_adapter_registry.register("csharp", CSharpAdapter)  # type: ignore[type-
 default_adapter_registry.register("kotlin", KotlinAdapter)  # type: ignore[type-abstract]
 default_adapter_registry.register("swift", SwiftAdapter)  # type: ignore[type-abstract]
 default_adapter_registry.register("php", PHPAdapter)  # type: ignore[type-abstract]
+default_adapter_registry.register("ruby", RubyAdapter)  # type: ignore[type-abstract]
 for _language_id in sorted(CHUNK_ONLY_LANGUAGE_IDS):
     default_adapter_registry.register(_language_id, make_chunk_only_adapter(_language_id))
 

--- a/tests/parse/test_language_coverage.py
+++ b/tests/parse/test_language_coverage.py
@@ -24,11 +24,6 @@ CHUNK_ONLY_SAMPLES: dict[str, tuple[str, str, list[tuple[int, int]]]] = {
         "#include <vector>\nnamespace n { class C { public: void m(){} }; int f(){return 1;} }\n",
         [(1, 1), (2, 2)],
     ),
-    "ruby": (
-        "app.rb",
-        'require "json"\nmodule M\n  class C\n    def m\n    end\n  end\nend\n',
-        [(1, 1), (2, 7)],
-    ),
     "scala": (
         "App.scala",
         "import scala.collection.mutable\nclass C { def m(): Int = 1 }\nobject O { def f = 2 }\n",
@@ -97,6 +92,7 @@ FULL_LANGUAGE_FIXTURES: dict[str, Path] = {
     "csharp": FIXTURES_DIR / "csharp_simple",
     "swift": FIXTURES_DIR / "swift_simple",
     "php": FIXTURES_DIR / "php_simple",
+    "ruby": FIXTURES_DIR / "ruby_simple",
 }
 
 


### PR DESCRIPTION
## Summary

- Promote Ruby from `LanguageTier.CHUNK_ONLY` to `LanguageTier.FULL`.
- Register `RubyAdapter` in the built-in adapter registry.
- Move Ruby from chunk-only sample coverage to full-tier fixture coverage.
- Update README and system design language-support tables.

## Stack

Stack-Id: `m7-ruby-full-tier-20260704`
Base: `main`
Position: 4/4

1. `feat/m7-ruby-fixtures` -> #393
2. `feat/m7-ruby-adapter-core` -> #394
3. `feat/m7-ruby-contracts` -> #396
4. `feat/m7-ruby-full-tier` -> this PR

Depends on: #396
Upstack: none

## Validation

- `uv run pytest tests/parse/adapters/test_ruby.py -v --no-cov` -> 44 passed
- `uv run archex doctor` -> full grammars 12/12 available; chunk-only grammars 14/14 available
- `uv run archex dogfood --all --baseline .archex/baselines/pre-promotion.json` -> Regressions: 0; Ranking violations: 0
- `uv run pytest` -> 3050 passed, 4 deselected
- `uv run ruff check src/archex/parse/adapters/ruby.py` -> OK
- `uv run pyright` -> no diagnostics
- `uv run archex outline . tests/fixtures/ruby_simple/models/user.rb --json` -> returned named `StoreFront`, `StoreFront.Models`, `StoreFront.Models.User`, and method symbols including `initialize`, `find_by_email`, `display_name`, `normalized_role`, `normalize_email`

## Breaking change

Ruby files now use full-tier symbol and import extraction instead of chunk-only AST slicing.
