### PR TITLE
feat(scala): add full-tier adapter core

### DIFF
--- a/src/archex/parse/adapters/scala.py
+++ b/src/archex/parse/adapters/scala.py
@@ -1,0 +1,457 @@
+"""Scala parse adapter: extract symbols and imports from .scala/.sc files using tree-sitter."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from archex.models import DiscoveredFile, ImportStatement, Symbol, SymbolKind, Visibility
+from archex.parse.adapters._jvm_helpers import map_jvm_visibility, resolve_jvm_import
+from archex.parse.adapters.ts_node import ts_children as _children
+from archex.parse.adapters.ts_node import ts_end_line as _end_line
+from archex.parse.adapters.ts_node import ts_field as _field
+from archex.parse.adapters.ts_node import ts_named_children as _named_children
+from archex.parse.adapters.ts_node import ts_start_line as _start_line
+from archex.parse.adapters.ts_node import ts_text as _text
+from archex.parse.adapters.ts_node import ts_type as _type
+
+# ---------------------------------------------------------------------------
+# Qualification helpers
+# ---------------------------------------------------------------------------
+
+
+def _qualify(parent: str | None, name: str) -> str:
+    return f"{parent}.{name}" if parent else name
+
+
+# ---------------------------------------------------------------------------
+# Modifier helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_visibility(node: object, default: Visibility = Visibility.PUBLIC) -> Visibility:
+    """Extract visibility from a node's `modifiers` -> `access_modifier` child.
+
+    Scala declarations default to PUBLIC when no modifier is present. Only
+    `private`/`protected` affect visibility (bare or qualified, e.g.
+    `private[this]`, `protected[com.example]` -- the bracketed qualifier
+    doesn't change the PRIVATE/INTERNAL mapping). Other modifier keywords
+    (`override`, `implicit`, `lazy`, `abstract`, `final`, `sealed`, `case`)
+    are unnamed tokens directly under `modifiers` with no wrapping node and
+    never affect visibility.
+    """
+    for child in _children(node):
+        if _type(child) != "modifiers":
+            continue
+        for mod in _children(child):
+            if _type(mod) != "access_modifier":
+                continue
+            for tok in _children(mod):
+                tok_type = _type(tok)
+                if tok_type in ("private", "protected"):
+                    return map_jvm_visibility(tok_type, default=default)
+    return default
+
+
+# ---------------------------------------------------------------------------
+# Signature helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_function_signature(node: object, source: bytes, name: str) -> str:
+    """Build a `def name(params)(params...): ReturnType` signature string.
+
+    Curried functions declare multiple sibling `parameters` nodes (one per
+    parameter list); `child_by_field_name` only returns the first, so all
+    parameter-list children are collected positionally instead.
+    """
+    param_groups = [c for c in _named_children(node) if _type(c) == "parameters"]
+    params_text = "".join(_text(p, source) for p in param_groups) if param_groups else "()"
+
+    return_type = _field(node, "return_type")
+    if return_type is not None:
+        return f"def {name}{params_text}: {_text(return_type, source)}"
+    return f"def {name}{params_text}"
+
+
+# ---------------------------------------------------------------------------
+# Member extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_method(node: object, source: bytes, file_path: str, parent_name: str) -> Symbol | None:
+    """Extract a member `function_definition`/`function_declaration` as METHOD."""
+    name_node = _field(node, "name")
+    if name_node is None:
+        return None
+    name = _text(name_node, source)
+    vis = _extract_visibility(node)
+    sig = _build_function_signature(node, source, name)
+
+    return Symbol(
+        name=name,
+        qualified_name=_qualify(parent_name, name),
+        kind=SymbolKind.METHOD,
+        file_path=file_path,
+        start_line=_start_line(node),
+        end_line=_end_line(node),
+        visibility=vis,
+        signature=sig,
+        parent=parent_name,
+    )
+
+
+def _extract_field(
+    node: object, source: bytes, file_path: str, parent_name: str, kind: SymbolKind
+) -> list[Symbol]:
+    """Extract a member `val_definition`/`var_definition` as CONSTANT/VARIABLE.
+
+    Only the simple-binding form (`pattern` field is a plain `identifier`)
+    is extracted; destructuring patterns (`val (a, b) = ...`,
+    `val Some(x) = ...`) have no single name to report and are skipped.
+    """
+    pattern_node = _field(node, "pattern")
+    if pattern_node is None or _type(pattern_node) != "identifier":
+        return []
+    name = _text(pattern_node, source)
+    vis = _extract_visibility(node)
+
+    return [
+        Symbol(
+            name=name,
+            qualified_name=_qualify(parent_name, name),
+            kind=kind,
+            file_path=file_path,
+            start_line=_start_line(node),
+            end_line=_end_line(node),
+            visibility=vis,
+            parent=parent_name,
+        )
+    ]
+
+
+def _extract_body_members(
+    body: object, source: bytes, file_path: str, parent_name: str
+) -> list[Symbol]:
+    """Extract all member symbols from a class/object/trait `template_body`."""
+    symbols: list[Symbol] = []
+
+    for child in _named_children(body):
+        ct = _type(child)
+
+        if ct in ("function_definition", "function_declaration"):
+            sym = _extract_method(child, source, file_path, parent_name)
+            if sym is not None:
+                symbols.append(sym)
+        elif ct == "val_definition":
+            symbols.extend(
+                _extract_field(child, source, file_path, parent_name, SymbolKind.CONSTANT)
+            )
+        elif ct == "var_definition":
+            symbols.extend(
+                _extract_field(child, source, file_path, parent_name, SymbolKind.VARIABLE)
+            )
+        elif ct in ("class_definition", "object_definition"):
+            symbols.extend(
+                _extract_type_symbols(child, source, file_path, SymbolKind.CLASS, parent_name)
+            )
+        elif ct == "trait_definition":
+            symbols.extend(
+                _extract_type_symbols(child, source, file_path, SymbolKind.INTERFACE, parent_name)
+            )
+
+    return symbols
+
+
+def _extract_type_symbols(
+    node: object,
+    source: bytes,
+    file_path: str,
+    kind: SymbolKind,
+    parent_name: str | None = None,
+) -> list[Symbol]:
+    """Extract a class/object/trait declaration and its members.
+
+    `class_definition` and `object_definition` both report `SymbolKind.CLASS`
+    (matching the existing Kotlin `object_declaration -> CLASS` precedent —
+    the model has no dedicated singleton kind); `trait_definition` reports
+    `SymbolKind.INTERFACE` (the model has no dedicated trait kind, and a
+    Scala trait is structurally closest to an interface with default
+    methods). A `class Foo` / `object Foo` companion pair therefore shares
+    both `qualified_name` and `kind`; the resulting `symbol_id` collision is
+    already resolved by `pipeline/chunker.py::_disambiguate_symbol_ids`,
+    the same mechanism used for same-name/kind overloads in other languages.
+    """
+    name_node = _field(node, "name")
+    if name_node is None:
+        return []
+    name = _text(name_node, source)
+    qualified = _qualify(parent_name, name)
+    vis = _extract_visibility(node)
+
+    symbols: list[Symbol] = [
+        Symbol(
+            name=name,
+            qualified_name=qualified,
+            kind=kind,
+            file_path=file_path,
+            start_line=_start_line(node),
+            end_line=_end_line(node),
+            visibility=vis,
+            parent=parent_name,
+        )
+    ]
+
+    body = _field(node, "body")
+    if body is not None:
+        symbols.extend(_extract_body_members(body, source, file_path, qualified))
+
+    return symbols
+
+
+def _extract_top_level_function(
+    node: object, source: bytes, file_path: str, namespace: str | None
+) -> Symbol | None:
+    """Extract a package-level (non-member) `function_definition` as FUNCTION."""
+    name_node = _field(node, "name")
+    if name_node is None:
+        return None
+    name = _text(name_node, source)
+    vis = _extract_visibility(node)
+    sig = _build_function_signature(node, source, name)
+
+    return Symbol(
+        name=name,
+        qualified_name=_qualify(namespace, name),
+        kind=SymbolKind.FUNCTION,
+        file_path=file_path,
+        start_line=_start_line(node),
+        end_line=_end_line(node),
+        visibility=vis,
+        signature=sig,
+        parent=None,
+    )
+
+
+def _extract_top_level(
+    nodes: list[object],
+    source: bytes,
+    file_path: str,
+    namespace: str | None,
+    symbols: list[Symbol],
+) -> None:
+    """Walk top-level (or package-body) declarations, tracking the active package.
+
+    Scala allows both a single `package a.b` (semicolon-style, no body:
+    extends the *ambient* namespace for every following sibling, including
+    chained consecutive `package` statements) and `package a.b { ... }`
+    (brace-style, with a `body` field: nests its declarations, which are
+    NOT top-level `compilation_unit` children and must be recursed into
+    explicitly, the same shape as PHP's brace-style namespace handling).
+    """
+    active_namespace = namespace
+
+    for node in nodes:
+        ct = _type(node)
+
+        if ct == "package_clause":
+            name_node = _field(node, "name")
+            pkg_name = _text(name_node, source) if name_node is not None else None
+            body = _field(node, "body")
+            if body is not None:
+                extended = _qualify(active_namespace, pkg_name) if pkg_name else active_namespace
+                _extract_top_level(_named_children(body), source, file_path, extended, symbols)
+            elif pkg_name:
+                active_namespace = _qualify(active_namespace, pkg_name)
+        elif ct in ("class_definition", "object_definition"):
+            symbols.extend(
+                _extract_type_symbols(node, source, file_path, SymbolKind.CLASS, active_namespace)
+            )
+        elif ct == "trait_definition":
+            symbols.extend(
+                _extract_type_symbols(
+                    node, source, file_path, SymbolKind.INTERFACE, active_namespace
+                )
+            )
+        elif ct in ("function_definition", "function_declaration"):
+            fn = _extract_top_level_function(node, source, file_path, active_namespace)
+            if fn is not None:
+                symbols.append(fn)
+
+
+# ---------------------------------------------------------------------------
+# Import parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_scala_import(node: object, source: bytes, file_path: str) -> list[ImportStatement]:
+    """Parse a single `import_declaration` into one or more ImportStatements.
+
+    A dotted import path is a flat sequence of sibling `identifier` children
+    (no wrapping path node), followed optionally by a `namespace_wildcard`
+    (`import a.b._`) or a `namespace_selectors` group
+    (`import a.b.{C, D => E, _}`). Each name in a selector group becomes its
+    own ImportStatement (mirroring PHP's grouped `use` handling) since each
+    is an independently resolvable class/object/trait, unlike a Python
+    `from` import.
+    """
+    line = _start_line(node)
+    parts: list[str] = []
+    is_wildcard = False
+    selectors: object | None = None
+
+    for child in _named_children(node):
+        ct = _type(child)
+        if ct == "identifier":
+            parts.append(_text(child, source))
+        elif ct == "namespace_wildcard":
+            is_wildcard = True
+        elif ct == "namespace_selectors":
+            selectors = child
+
+    if not parts:
+        return []
+    base = ".".join(parts)
+
+    if selectors is not None:
+        imports: list[ImportStatement] = []
+        for sel in _named_children(selectors):
+            st = _type(sel)
+            if st == "identifier":
+                name = _text(sel, source)
+                imports.append(
+                    ImportStatement(
+                        module=f"{base}.{name}", file_path=file_path, line=line, is_relative=False
+                    )
+                )
+            elif st == "arrow_renamed_identifier":
+                sel_name_node = _field(sel, "name")
+                if sel_name_node is None:
+                    continue
+                sel_alias_node = _field(sel, "alias")
+                name = _text(sel_name_node, source)
+                alias = _text(sel_alias_node, source) if sel_alias_node is not None else None
+                imports.append(
+                    ImportStatement(
+                        module=f"{base}.{name}",
+                        alias=alias,
+                        file_path=file_path,
+                        line=line,
+                        is_relative=False,
+                    )
+                )
+            elif st == "namespace_wildcard":
+                imports.append(
+                    ImportStatement(
+                        module=f"{base}._", file_path=file_path, line=line, is_relative=False
+                    )
+                )
+        return imports
+
+    if is_wildcard:
+        return [
+            ImportStatement(module=f"{base}._", file_path=file_path, line=line, is_relative=False)
+        ]
+
+    return [ImportStatement(module=base, file_path=file_path, line=line, is_relative=False)]
+
+
+def _collect_imports(
+    nodes: list[object], source: bytes, file_path: str, imports: list[ImportStatement]
+) -> None:
+    """Walk top-level (or package-body) declarations, collecting imports.
+
+    Recurses into brace-style `package` bodies the same way `_extract_top_level`
+    does, so an `import` nested inside `package a.b { ... }` is not missed.
+    """
+    for node in nodes:
+        ct = _type(node)
+        if ct == "import_declaration":
+            imports.extend(_parse_scala_import(node, source, file_path))
+        elif ct == "package_clause":
+            body = _field(node, "body")
+            if body is not None:
+                _collect_imports(_named_children(body), source, file_path, imports)
+
+
+# ---------------------------------------------------------------------------
+# Entry point detection
+# ---------------------------------------------------------------------------
+
+_ENTRY_BASENAMES: frozenset[str] = frozenset({"Main.scala", "App.scala", "Boot.scala"})
+_ENTRY_MARKERS: tuple[str, ...] = ("extends App", "def main(args: Array[String]")
+
+
+# ---------------------------------------------------------------------------
+# ScalaAdapter
+# ---------------------------------------------------------------------------
+
+
+class ScalaAdapter:
+    """Language adapter for Scala source files.
+
+    Import resolution reuses the JVM package-to-directory-segment-scoring
+    heuristic (`resolve_jvm_import`, extensions=(".scala",)) shared with
+    Java/Kotlin, since Scala's package/import semantics are structurally
+    identical. Unlike Java, Scala doesn't enforce one top-level declaration
+    per file, so an import naming a non-primary declaration inside a
+    multi-declaration file will not resolve -- conservative by design,
+    consistent with the Ruby adapter's "stay unresolved instead of being
+    guessed" philosophy.
+    """
+
+    @property
+    def language_id(self) -> str:
+        return "scala"
+
+    @property
+    def file_extensions(self) -> list[str]:
+        return [".scala", ".sc"]
+
+    @property
+    def tree_sitter_name(self) -> str:
+        return "scala"
+
+    def extract_symbols(self, tree: object, source: bytes, file_path: str) -> list[Symbol]:
+        """Extract class, object, trait, and top-level function symbols from a Scala parse tree."""
+        t: Any = tree
+        root: object = t.root_node
+        symbols: list[Symbol] = []
+        _extract_top_level(_named_children(root), source, file_path, None, symbols)
+        return symbols
+
+    def parse_imports(self, tree: object, source: bytes, file_path: str) -> list[ImportStatement]:
+        """Extract all import declarations from a Scala parse tree."""
+        t: Any = tree
+        root: object = t.root_node
+        imports: list[ImportStatement] = []
+        _collect_imports(_named_children(root), source, file_path, imports)
+        return imports
+
+    def resolve_import(self, imp: ImportStatement, file_map: dict[str, str]) -> str | None:
+        """Resolve a Scala import to a local .scala file, or None if external or a wildcard."""
+        if imp.module.endswith("._"):
+            return None
+        return resolve_jvm_import(imp.module, file_map, extensions=(".scala",))
+
+    def detect_entry_points(self, files: list[DiscoveredFile]) -> list[str]:
+        """Detect Scala entry points: `extends App`, explicit `main`, and conventional filenames."""
+        entry_points: list[str] = []
+
+        for f in files:
+            if os.path.basename(f.path) in _ENTRY_BASENAMES:
+                entry_points.append(f.path)
+                continue
+            try:
+                with open(f.absolute_path, encoding="utf-8", errors="replace") as fh:
+                    content = fh.read()
+            except OSError:
+                continue
+            if any(marker in content for marker in _ENTRY_MARKERS):
+                entry_points.append(f.path)
+
+        return entry_points
+
+    def classify_visibility(self, symbol: Symbol) -> Visibility:
+        """Return the symbol's stored visibility (set during extraction)."""
+        return symbol.visibility

--- a/tests/parse/adapters/test_scala.py
+++ b/tests/parse/adapters/test_scala.py
@@ -1,0 +1,468 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from archex.models import SymbolKind, Visibility
+from archex.parse.adapters.base import LanguageAdapter
+from archex.parse.adapters.scala import ScalaAdapter
+from archex.parse.engine import TreeSitterEngine
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures" / "scala_simple"
+
+
+@pytest.fixture()
+def engine() -> TreeSitterEngine:
+    return TreeSitterEngine()
+
+
+@pytest.fixture()
+def adapter() -> ScalaAdapter:
+    return ScalaAdapter()
+
+
+def parse(engine: TreeSitterEngine, source: bytes) -> object:
+    return engine.parse_bytes(source, "scala")
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_satisfies_language_adapter_protocol(adapter: ScalaAdapter) -> None:
+    assert isinstance(adapter, LanguageAdapter)
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+def test_language_id(adapter: ScalaAdapter) -> None:
+    assert adapter.language_id == "scala"
+
+
+def test_file_extensions(adapter: ScalaAdapter) -> None:
+    assert adapter.file_extensions == [".scala", ".sc"]
+
+
+def test_tree_sitter_name(adapter: ScalaAdapter) -> None:
+    assert adapter.tree_sitter_name == "scala"
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: package qualification
+# ---------------------------------------------------------------------------
+
+
+def test_semicolon_style_package_qualifies_top_level_object(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    source = (FIXTURES_DIR / "App.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "App.scala")
+    main = next(s for s in symbols if s.name == "Main")
+    assert main.qualified_name == "com.example.app.Main"
+    assert main.parent == "com.example.app"
+
+
+def test_chained_bodyless_package_accumulates_namespace(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    # Two consecutive bodyless `package` clauses accumulate into a single
+    # ambient namespace ("com.example" then "models" -> "com.example.models")
+    # rather than only honoring the first or the last one seen.
+    source = b"package com.example\npackage models\n\nclass Widget\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "widget.scala")
+    widget = next(s for s in symbols if s.name == "Widget")
+    assert widget.qualified_name == "com.example.models.Widget"
+    assert widget.parent == "com.example.models"
+
+
+def test_brace_style_package_recurses_into_body(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    source = (FIXTURES_DIR / "legacy" / "Adjacent.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "legacy/Adjacent.scala")
+    classes = {s.name: s for s in symbols if s.kind == SymbolKind.CLASS}
+    assert classes["LegacyWidget"].qualified_name == "com.example.app.legacy.LegacyWidget"
+    assert classes["LegacyGadget"].qualified_name == "com.example.app.legacy.LegacyGadget"
+    assert classes["LegacyRegistry"].parent == "com.example.app.legacy"
+
+
+def test_adjacent_classes_in_brace_package_have_independent_boundaries(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    # Regression guard for the cascading-corruption failure mode probed in
+    # GRAMMAR_EVALUATION.md: adjacent same-kind declarations inside a brace
+    # package body must keep independently correct start/end lines.
+    source = (FIXTURES_DIR / "legacy" / "Adjacent.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "legacy/Adjacent.scala")
+    classes = {s.name: s for s in symbols if s.kind == SymbolKind.CLASS}
+    assert (classes["LegacyWidget"].start_line, classes["LegacyWidget"].end_line) == (3, 5)
+    assert (classes["LegacyGadget"].start_line, classes["LegacyGadget"].end_line) == (7, 9)
+    assert (classes["LegacyRegistry"].start_line, classes["LegacyRegistry"].end_line) == (11, 13)
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: classes and objects
+# ---------------------------------------------------------------------------
+
+
+def test_extract_class(engine: TreeSitterEngine, adapter: ScalaAdapter) -> None:
+    source = (FIXTURES_DIR / "models" / "Address.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "models/Address.scala")
+    address = next(s for s in symbols if s.name == "Address")
+    assert address.kind == SymbolKind.CLASS
+    assert address.qualified_name == "com.example.app.models.Address"
+    assert address.visibility == Visibility.PUBLIC
+
+
+def test_object_definition_reported_as_class_kind(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    # object_definition has no dedicated Symbol kind; the adapter reports it
+    # as CLASS, matching the existing Kotlin object_declaration -> CLASS
+    # precedent (no dedicated singleton kind exists on the model).
+    source = (FIXTURES_DIR / "util" / "StringUtils.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "util/StringUtils.scala")
+    utils = next(s for s in symbols if s.name == "StringUtils")
+    assert utils.kind == SymbolKind.CLASS
+    assert utils.qualified_name == "com.example.app.util.StringUtils"
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: traits
+# ---------------------------------------------------------------------------
+
+
+def test_trait_reported_as_interface(engine: TreeSitterEngine, adapter: ScalaAdapter) -> None:
+    # The Symbol model has no dedicated trait kind; a Scala trait is
+    # structurally closest to an interface, so it reports as INTERFACE.
+    source = (FIXTURES_DIR / "contracts" / "Greeter.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "contracts/Greeter.scala")
+    greeter = next(s for s in symbols if s.name == "Greeter")
+    assert greeter.kind == SymbolKind.INTERFACE
+    assert greeter.qualified_name == "com.example.app.contracts.Greeter"
+    assert greeter.visibility == Visibility.PUBLIC
+
+
+def test_trait_abstract_method_member(engine: TreeSitterEngine, adapter: ScalaAdapter) -> None:
+    source = (FIXTURES_DIR / "contracts" / "Greeter.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "contracts/Greeter.scala")
+    greet = next(s for s in symbols if s.name == "greet")
+    assert greet.kind == SymbolKind.METHOD
+    assert greet.parent == "com.example.app.contracts.Greeter"
+    assert greet.signature == "def greet(name: String): String"
+
+
+def test_trait_extending_trait_has_default_method(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    source = (FIXTURES_DIR / "contracts" / "FriendlyGreeter.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "contracts/FriendlyGreeter.scala")
+    traits = {s.name: s for s in symbols if s.kind == SymbolKind.INTERFACE}
+    methods = {s.name: s for s in symbols if s.kind == SymbolKind.METHOD}
+    assert traits["FriendlyGreeter"].qualified_name == "com.example.app.contracts.FriendlyGreeter"
+    assert traits["LoudGreeter"].qualified_name == "com.example.app.contracts.LoudGreeter"
+    assert methods["greet"].parent == "com.example.app.contracts.FriendlyGreeter"
+    assert methods["shout"].parent == "com.example.app.contracts.LoudGreeter"
+    assert methods["shout"].signature == "def shout(name: String): String"
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: companion object name/kind collision
+# ---------------------------------------------------------------------------
+
+
+def test_companion_class_and_object_share_qualified_name_and_kind(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    # `case class User` (line 4) and `object User` (line 6) are independent
+    # top-level siblings that intentionally collide on both qualified_name
+    # and kind -- documented in GRAMMAR_EVALUATION.md as expected, resolved
+    # downstream by pipeline/chunker.py's disambiguation. A dict keyed by
+    # name would silently collapse this to one entry, so assert on the raw
+    # list instead to prove both survive extraction.
+    source = (FIXTURES_DIR / "models" / "User.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "models/User.scala")
+    users = [s for s in symbols if s.name == "User"]
+    assert len(users) == 2
+    assert {s.qualified_name for s in users} == {"com.example.app.models.User"}
+    assert {s.kind for s in users} == {SymbolKind.CLASS}
+    assert sorted(s.start_line for s in users) == [4, 6]
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: methods
+# ---------------------------------------------------------------------------
+
+
+def test_method_visibility_default_public(engine: TreeSitterEngine, adapter: ScalaAdapter) -> None:
+    source = (FIXTURES_DIR / "models" / "User.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "models/User.scala")
+    validate = next(s for s in symbols if s.name == "validate")
+    assert validate.visibility == Visibility.PUBLIC
+    assert validate.signature == "def validate(user: User): Boolean"
+
+
+def test_method_visibility_private(engine: TreeSitterEngine, adapter: ScalaAdapter) -> None:
+    source = (FIXTURES_DIR / "models" / "User.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "models/User.scala")
+    normalize_email = next(s for s in symbols if s.name == "normalizeEmail")
+    assert normalize_email.visibility == Visibility.PRIVATE
+    assert normalize_email.parent == "com.example.app.models.User"
+
+
+def test_qualified_protected_maps_to_internal(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    source = (FIXTURES_DIR / "services" / "UserService.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "services/UserService.scala")
+    audit_log = next(s for s in symbols if s.name == "auditLog")
+    assert audit_log.visibility == Visibility.INTERNAL  # protected[this] -> INTERNAL
+    assert audit_log.signature == "def auditLog(message: String): Unit"
+
+
+def test_qualified_private_bracket_maps_to_private(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    # No fixture exercises the bracketed `private[X]` form (only
+    # `protected[this]` in UserService.scala) -- confirm the bracket
+    # qualifier is ignored for the PRIVATE mapping too, on both a method
+    # and a val, and regardless of the qualifier's own contents.
+    source = (
+        b"package demo\n\n"
+        b"class Widget {\n"
+        b"  private[this] def secret(): Int = 42\n"
+        b"  private[demo] val guarded: Int = 1\n"
+        b"}\n"
+    )
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "widget.scala")
+    members = {s.name: s for s in symbols if s.parent == "demo.Widget"}
+    assert members["secret"].visibility == Visibility.PRIVATE
+    assert members["guarded"].visibility == Visibility.PRIVATE
+
+
+def test_method_without_parameter_list_gets_synthesized_empty_parens(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    # `def count: Int` has no `parameters` node at all in the grammar; the
+    # adapter must not crash or omit the parens, it synthesizes "()".
+    source = (FIXTURES_DIR / "services" / "UserService.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "services/UserService.scala")
+    count = next(s for s in symbols if s.name == "count")
+    assert count.signature == "def count(): Int"
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: top-level functions
+# ---------------------------------------------------------------------------
+
+
+def test_curried_top_level_function_signature_and_no_parent(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    # Curried functions declare multiple sibling `parameters` nodes; both
+    # parameter lists must appear in the signature. Top-level functions are
+    # always parent=None even though the qualified_name carries the
+    # namespace prefix.
+    source = b"package demo\n\ndef add(a: Int)(b: Int): Int = a + b\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "add.scala")
+    add = next(s for s in symbols if s.name == "add")
+    assert add.kind == SymbolKind.FUNCTION
+    assert add.parent is None
+    assert add.qualified_name == "demo.add"
+    assert add.signature == "def add(a: Int)(b: Int): Int"
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: constants and variables
+# ---------------------------------------------------------------------------
+
+
+def test_val_definition_is_constant(engine: TreeSitterEngine, adapter: ScalaAdapter) -> None:
+    source = (FIXTURES_DIR / "models" / "User.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "models/User.scala")
+    default_role = next(s for s in symbols if s.name == "DEFAULT_ROLE")
+    assert default_role.kind == SymbolKind.CONSTANT
+    assert default_role.visibility == Visibility.PUBLIC
+    assert default_role.parent == "com.example.app.models.User"
+
+
+def test_var_definition_is_variable(engine: TreeSitterEngine, adapter: ScalaAdapter) -> None:
+    source = (FIXTURES_DIR / "services" / "UserService.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "services/UserService.scala")
+    registered = next(s for s in symbols if s.name == "registered")
+    assert registered.kind == SymbolKind.VARIABLE
+    assert registered.visibility == Visibility.PRIVATE
+    assert registered.parent == "com.example.app.services.UserService"
+
+
+def test_destructuring_val_pattern_is_silently_skipped(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    # Only the plain-identifier `pattern` form is extracted; a destructuring
+    # binding has no single name to report and must be skipped without
+    # crashing, while the plain val alongside it still gets extracted.
+    source = b"package demo\n\nobject Foo {\n  val (a, b) = (1, 2)\n  val plain = 5\n}\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "foo.scala")
+    assert {s.name for s in symbols} == {"Foo", "plain"}
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: nested types
+# ---------------------------------------------------------------------------
+
+
+def test_nested_class_inside_object_recurses_with_qualified_parent(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    source = (FIXTURES_DIR / "util" / "StringUtils.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "util/StringUtils.scala")
+    builder = next(s for s in symbols if s.name == "Builder")
+    assert builder.kind == SymbolKind.CLASS
+    assert builder.qualified_name == "com.example.app.util.StringUtils.Builder"
+    assert builder.parent == "com.example.app.util.StringUtils"
+    members = {s.name: s for s in symbols if s.parent == "com.example.app.util.StringUtils.Builder"}
+    assert members["append"].signature == "def append(part: String): Builder"
+    assert members["build"].signature == "def build(): String"
+    assert members["parts"].kind == SymbolKind.VARIABLE
+    assert members["parts"].visibility == Visibility.PRIVATE
+
+
+def test_nested_private_object_inside_class(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    source = (FIXTURES_DIR / "services" / "UserService.scala").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "services/UserService.scala")
+    metrics = next(s for s in symbols if s.name == "Metrics")
+    assert metrics.kind == SymbolKind.CLASS
+    assert metrics.visibility == Visibility.PRIVATE
+    assert metrics.qualified_name == "com.example.app.services.UserService.Metrics"
+    record_lookup = next(s for s in symbols if s.name == "recordLookup")
+    assert record_lookup.parent == "com.example.app.services.UserService.Metrics"
+    assert record_lookup.signature == "def recordLookup(): Unit"
+
+
+# ---------------------------------------------------------------------------
+# parse_imports
+# ---------------------------------------------------------------------------
+
+
+def test_parse_simple_import(engine: TreeSitterEngine, adapter: ScalaAdapter) -> None:
+    source = (FIXTURES_DIR / "App.scala").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "App.scala")
+    service_import = next(i for i in imports if i.module == "com.example.app.services.UserService")
+    assert service_import.alias is None
+    assert service_import.line == 6
+    assert service_import.is_relative is False
+
+
+def test_parse_wildcard_import(engine: TreeSitterEngine, adapter: ScalaAdapter) -> None:
+    source = (FIXTURES_DIR / "services" / "UserService.scala").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "services/UserService.scala")
+    wildcard = next(i for i in imports if i.module.endswith("._"))
+    assert wildcard.module == "com.example.app.models._"
+    assert wildcard.line == 5
+
+
+def test_parse_two_name_group_produces_one_statement_per_name(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    source = (FIXTURES_DIR / "App.scala").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "App.scala")
+    util_group = [i for i in imports if i.line == 3]
+    assert {i.module for i in util_group} == {"scala.util.Failure", "scala.util.Success"}
+    assert all(i.alias is None for i in util_group)
+
+
+def test_parse_four_name_group_produces_one_statement_per_name(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    source = (FIXTURES_DIR / "App.scala").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "App.scala")
+    shapes_group = [i for i in imports if i.line == 7]
+    assert {i.module for i in shapes_group} == {
+        "com.example.app.shapes.Circle",
+        "com.example.app.shapes.Empty",
+        "com.example.app.shapes.Shape",
+        "com.example.app.shapes.Square",
+    }
+    assert all(i.alias is None for i in shapes_group)
+
+
+def test_parse_arrow_renamed_selector_sets_alias_but_keeps_original_module(
+    engine: TreeSitterEngine, adapter: ScalaAdapter
+) -> None:
+    source = (FIXTURES_DIR / "App.scala").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "App.scala")
+    renamed = next(i for i in imports if i.alias == "Greetable")
+    assert renamed.module == "com.example.app.contracts.Greeter"
+    assert renamed.line == 4
+
+
+def test_imports_not_relative(engine: TreeSitterEngine, adapter: ScalaAdapter) -> None:
+    source = (FIXTURES_DIR / "App.scala").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "App.scala")
+    assert imports
+    for imp in imports:
+        assert imp.is_relative is False
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_file(engine: TreeSitterEngine, adapter: ScalaAdapter) -> None:
+    source = b""
+    tree = parse(engine, source)
+    assert adapter.extract_symbols(tree, source, "empty.scala") == []
+    assert adapter.parse_imports(tree, source, "empty.scala") == []
+
+
+def test_all_symbols_have_qualified_names(engine: TreeSitterEngine, adapter: ScalaAdapter) -> None:
+    for f in FIXTURES_DIR.rglob("*.scala"):
+        source = f.read_bytes()
+        tree = parse(engine, source)
+        for s in adapter.extract_symbols(tree, source, str(f.relative_to(FIXTURES_DIR))):
+            assert s.qualified_name, f"Missing qualified_name for {s.name} in {f}"
+
+
+def test_all_members_have_parent(engine: TreeSitterEngine, adapter: ScalaAdapter) -> None:
+    member_kinds = {SymbolKind.METHOD, SymbolKind.CONSTANT, SymbolKind.VARIABLE}
+    for f in FIXTURES_DIR.rglob("*.scala"):
+        source = f.read_bytes()
+        tree = parse(engine, source)
+        for s in adapter.extract_symbols(tree, source, str(f.relative_to(FIXTURES_DIR))):
+            if s.kind in member_kinds:
+                assert s.parent is not None, f"Missing parent for {s.qualified_name} in {f}"


### PR DESCRIPTION
## Summary

- Add `src/archex/parse/adapters/scala.py` implementing the full `LanguageAdapter` contract (all 5 methods land here so the class is instantiable; PR-3 adds the remaining tests only, no new adapter code).
- `extract_symbols`: packages (chained-bodyless + brace-style recursion), class/object -> CLASS, trait -> INTERFACE, top-level function -> FUNCTION, member val/var -> CONSTANT/VARIABLE, nested types, visibility (default PUBLIC; private/protected incl. qualified forms).
- `parse_imports`: simple/wildcard/grouped/arrow-renamed forms, one `ImportStatement` per imported name.
- Add `tests/parse/adapters/test_scala.py` covering `extract_symbols`/`parse_imports` (34 tests) against the `scala_simple` fixtures.

## Stack

Stack-Id: `m8-scala-full-tier-20260704`
Base: `feat/m8-scala-fixtures` (#397)
Position: 2/4

1. `feat/m8-scala-fixtures` -> #397
2. `feat/m8-scala-adapter-core` -> this PR
3. `feat/m8-scala-contracts` -> #399
4. `feat/m8-scala-full-tier` -> #400

Depends on: #397
Upstack: #399

## Validation

- `uv run pytest tests/parse/adapters/test_scala.py -v` -> 34 passed
- `uv run ruff check src/archex/parse/adapters/scala.py tests/parse/adapters/test_scala.py` -> OK
- `uv run ruff format --check src/archex/parse/adapters/scala.py tests/parse/adapters/test_scala.py` -> OK
- `uv run pyright src/archex/parse/adapters/scala.py tests/parse/adapters/test_scala.py` -> 0 errors, 0 warnings

## Notes

resolve_import/detect_entry_points/classify_visibility are implemented here (required for the class to satisfy the LanguageAdapter protocol) but their tests land in PR-3, matching the M6/M7 precedent.