### PR TITLE
feat(languages)!: promote Scala to full tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,8 +370,8 @@ For the full trust contract, including exact MCP JSON, Docker commands, cache lo
 
 | Tier | Languages | Extraction |
 | --- | --- | --- |
-| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift, PHP, Ruby | Symbols, imports, graph edges |
-| `chunk-only` | C, C++, Scala, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity | AST chunking + retrieval; no symbol/import graph claim |
+| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift, PHP, Ruby, Scala | Symbols, imports, graph edges |
+| `chunk-only` | C, C++, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity | AST chunking + retrieval; no symbol/import graph claim |
 | `unknown` | any other text file | line-window chunks for BM25 visibility |
 
 Need another language? Register an adapter via Python entry points. See [System Design](docs/SYSTEM_DESIGN.md) for the extension contract.

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -213,8 +213,8 @@ Language support is declared, not implied. `full` means symbol extraction, impor
 
 | Tier | Languages |
 | --- | --- |
-| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift, PHP, Ruby |
-| `chunk-only` | C, C++, Scala, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity |
+| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift, PHP, Ruby, Scala |
+| `chunk-only` | C, C++, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity |
 
 Unknown files fall back to line-window chunking so they can still be found by BM25 without pretending to have structural edges.
 

--- a/src/archex/languages.py
+++ b/src/archex/languages.py
@@ -61,22 +61,7 @@ LANGUAGE_SUPPORT: dict[str, LanguageSupport] = {
     ),
     "php": LanguageSupport("php", "PHP", (".php",), _FULL, "php"),
     "ruby": LanguageSupport("ruby", "Ruby", (".rb",), _FULL, "ruby"),
-    "scala": LanguageSupport(
-        "scala",
-        "Scala",
-        (".scala", ".sc"),
-        _CHUNK,
-        "scala",
-        frozenset(
-            {
-                "class_definition",
-                "object_definition",
-                "trait_definition",
-                "function_definition",
-                "import_declaration",
-            }
-        ),
-    ),
+    "scala": LanguageSupport("scala", "Scala", (".scala", ".sc"), _FULL, "scala"),
     "lua": LanguageSupport(
         "lua",
         "Lua",

--- a/src/archex/parse/adapters/__init__.py
+++ b/src/archex/parse/adapters/__init__.py
@@ -17,6 +17,7 @@ from archex.parse.adapters.php import PHPAdapter
 from archex.parse.adapters.python import PythonAdapter
 from archex.parse.adapters.ruby import RubyAdapter
 from archex.parse.adapters.rust import RustAdapter
+from archex.parse.adapters.scala import ScalaAdapter
 from archex.parse.adapters.swift import SwiftAdapter
 from archex.parse.adapters.typescript import TypeScriptAdapter
 
@@ -94,6 +95,7 @@ default_adapter_registry.register("kotlin", KotlinAdapter)  # type: ignore[type-
 default_adapter_registry.register("swift", SwiftAdapter)  # type: ignore[type-abstract]
 default_adapter_registry.register("php", PHPAdapter)  # type: ignore[type-abstract]
 default_adapter_registry.register("ruby", RubyAdapter)  # type: ignore[type-abstract]
+default_adapter_registry.register("scala", ScalaAdapter)  # type: ignore[type-abstract]
 for _language_id in sorted(CHUNK_ONLY_LANGUAGE_IDS):
     default_adapter_registry.register(_language_id, make_chunk_only_adapter(_language_id))
 

--- a/tests/parse/test_language_coverage.py
+++ b/tests/parse/test_language_coverage.py
@@ -24,11 +24,6 @@ CHUNK_ONLY_SAMPLES: dict[str, tuple[str, str, list[tuple[int, int]]]] = {
         "#include <vector>\nnamespace n { class C { public: void m(){} }; int f(){return 1;} }\n",
         [(1, 1), (2, 2)],
     ),
-    "scala": (
-        "App.scala",
-        "import scala.collection.mutable\nclass C { def m(): Int = 1 }\nobject O { def f = 2 }\n",
-        [(1, 1), (2, 2), (3, 3)],
-    ),
     "lua": (
         "app.lua",
         'require("json")\nfunction f(x) return x end\nlocal t = { a = 1 }\n',
@@ -93,6 +88,7 @@ FULL_LANGUAGE_FIXTURES: dict[str, Path] = {
     "swift": FIXTURES_DIR / "swift_simple",
     "php": FIXTURES_DIR / "php_simple",
     "ruby": FIXTURES_DIR / "ruby_simple",
+    "scala": FIXTURES_DIR / "scala_simple",
 }
 
 


### PR DESCRIPTION
## Summary

- Promote Scala from `LanguageTier.CHUNK_ONLY` to `LanguageTier.FULL`.
- Register `ScalaAdapter` in the built-in adapter registry.
- Move Scala from chunk-only sample coverage to full-tier fixture coverage.
- Update README and system design language-support tables.

## Stack

Stack-Id: `m8-scala-full-tier-20260704`
Base: `feat/m8-scala-contracts` (#399)
Position: 4/4

1. `feat/m8-scala-fixtures` -> #397
2. `feat/m8-scala-adapter-core` -> #398
3. `feat/m8-scala-contracts` -> #399
4. `feat/m8-scala-full-tier` -> this PR

Depends on: #399
Upstack: none

## Validation

- `uv run pytest tests/parse/adapters/test_scala.py -v --no-cov` -> 46 passed
- `uv run pytest tests/parse/test_language_coverage.py -v --no-cov` -> passed
- `uv run pytest` -> 3102 passed, 4 deselected, 90.98% coverage
- `uv run ruff check .` / `uv run ruff format --check .` -> clean
- `uv run pyright` -> 0 errors, 0 warnings, 0 informations
- `uv run archex doctor` -> full grammars 13/13 available (was 12); chunk-only grammars 13/13 available (was 14)
- `uv run archex dogfood --all --baseline .archex/baselines/pre-promotion.json --format json` -> 24 tasks, 0 regressions, 0 ranking violations
- `uv run archex outline . tests/fixtures/scala_simple/shapes/Shape.scala` -> returned named `interface Shape`, `class Circle`, `class Square`, `class Empty`, `class Shape` with `method area`/`method totalArea`; `util/StringUtils.scala` and `App.scala` confirm `object` declarations correctly report as `class`

## Breaking change

Scala files now use full-tier symbol and import extraction instead of chunk-only AST slicing.