### PR TITLE
feat(c): full-tier adapter implementation (M9 2/3)

### DIFF
--- a/src/archex/parse/adapters/c.py
+++ b/src/archex/parse/adapters/c.py
@@ -1,0 +1,366 @@
+"""C parse adapter: extract symbols and imports from .c/.h files using tree-sitter."""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+from archex.models import DiscoveredFile, ImportStatement, Symbol, SymbolKind, Visibility
+from archex.parse.adapters.ts_node import (
+    ts_end_line as _end_line,
+)
+from archex.parse.adapters.ts_node import (
+    ts_field as _field,
+)
+from archex.parse.adapters.ts_node import (
+    ts_named_children as _named_children,
+)
+from archex.parse.adapters.ts_node import (
+    ts_start_line as _start_line,
+)
+from archex.parse.adapters.ts_node import (
+    ts_text as _text,
+)
+from archex.parse.adapters.ts_node import (
+    ts_type as _type,
+)
+
+# ---------------------------------------------------------------------------
+# Top-level declaration walking
+# ---------------------------------------------------------------------------
+#
+# C headers overwhelmingly wrap their declarations in constructs that nest
+# children rather than flattening them to top-level siblings of
+# translation_unit: preprocessor conditionals (#ifdef/#if/#elif/#else, for
+# platform guards and include guards) and `extern "C" { ... }` linkage blocks
+# (for C++ interop). A naive one-level scan of root.children would silently
+# miss the majority of real-world .h file content. Symbol extraction and
+# #include parsing both walk through this same helper so a conditionally
+# compiled declaration or include is never missed by one and found by the
+# other.
+
+_CONDITIONAL_TYPES = frozenset({"preproc_ifdef", "preproc_if", "preproc_elif", "preproc_else"})
+
+
+def _toplevel_declarations(node: object) -> list[object]:
+    """Flatten declarations nested inside preprocessor conditionals and
+    `extern "C"` linkage blocks into one top-level sequence."""
+    result: list[object] = []
+    for child in _named_children(node):
+        ctype = _type(child)
+        if ctype in _CONDITIONAL_TYPES:
+            result.extend(_toplevel_declarations(child))
+        elif ctype == "linkage_specification":
+            body = _field(child, "body")
+            if body is not None:
+                result.extend(_toplevel_declarations(body))
+        else:
+            result.append(child)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Visibility: C has no naming convention, only the `static` storage class
+# ---------------------------------------------------------------------------
+
+
+def _is_static(node: object, source: bytes) -> bool:
+    """True if `node` carries a `static` storage_class_specifier child.
+
+    C's public/private distinction is a real language semantic (internal
+    vs. external linkage), not a project convention like Go's uppercase
+    letter -- so this cannot be recomputed from a symbol's name alone.
+    """
+    for child in _named_children(node):
+        if _type(child) == "storage_class_specifier" and _text(child, source) == "static":
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Function extraction: definitions and prototypes share one code path
+# ---------------------------------------------------------------------------
+
+
+def _unwrap_function_declarator(declarator: object | None) -> object | None:
+    """Unwrap leading pointer_declarator layers (pointer return types) to
+    find the underlying function_declarator, or None if `declarator` does
+    not describe a function at all (e.g. a plain variable or a
+    function-pointer variable, whose function_declarator wraps a
+    parenthesized_declarator instead of a bare identifier -- rejected by
+    the caller, not here)."""
+    node = declarator
+    while node is not None and _type(node) == "pointer_declarator":
+        node = _field(node, "declarator")
+    if node is not None and _type(node) == "function_declarator":
+        return node
+    return None
+
+
+def _function_name(func_declarator: object, source: bytes) -> str | None:
+    """Return the function's name, or None if this is a function-*pointer*
+    declarator (`int (*fp)(int)`) rather than a function declaration --
+    those wrap a parenthesized_declarator instead of a plain identifier."""
+    inner = _field(func_declarator, "declarator")
+    if inner is not None and _type(inner) == "identifier":
+        return _text(inner, source)
+    return None
+
+
+def _function_signature(node: object, declarator: object, source: bytes) -> str:
+    """Slice the source from the declaration's start through the end of its
+    outermost declarator, excluding the body/semicolon -- covers storage
+    class, return type, name, and parameters exactly as written."""
+    n: Any = node
+    d: Any = declarator
+    text = source[n.start_byte : d.end_byte].decode("utf-8", errors="replace")
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _extract_function(node: object, source: bytes, file_path: str) -> Symbol | None:
+    declarator = _field(node, "declarator")
+    if declarator is None:
+        return None
+    func_declarator = _unwrap_function_declarator(declarator)
+    if func_declarator is None:
+        return None
+    name = _function_name(func_declarator, source)
+    if not name:
+        return None
+    return Symbol(
+        name=name,
+        qualified_name=name,
+        kind=SymbolKind.FUNCTION,
+        file_path=file_path,
+        start_line=_start_line(node),
+        end_line=_end_line(node),
+        visibility=Visibility.PRIVATE if _is_static(node, source) else Visibility.PUBLIC,
+        signature=_function_signature(node, declarator, source),
+    )
+
+
+def _extract_functions(root: object, source: bytes, file_path: str) -> list[Symbol]:
+    """Extract both function definitions and function prototype
+    declarations -- a .h file's public API is almost entirely prototypes,
+    so limiting extraction to function_definition would report zero
+    functions for every header."""
+    symbols: list[Symbol] = []
+    for node in _toplevel_declarations(root):
+        ntype = _type(node)
+        if ntype not in ("function_definition", "declaration"):
+            continue
+        symbol = _extract_function(node, source, file_path)
+        if symbol is not None:
+            symbols.append(symbol)
+    return symbols
+
+
+# ---------------------------------------------------------------------------
+# Struct extraction: bare, typedef-anonymous, typedef-named, K&R combined
+# ---------------------------------------------------------------------------
+
+
+def _struct_symbol(
+    spec: object,
+    source: bytes,
+    file_path: str,
+    line_node: object,
+    name_override: str | None = None,
+) -> Symbol | None:
+    """Build a TYPE symbol from a struct_specifier, or None for a
+    forward declaration / bare type reference (no `body` field) or an
+    anonymous struct with no typedef alias to name it."""
+    body = _field(spec, "body")
+    if body is None:
+        return None
+    name = name_override
+    if name is None:
+        name_node = _field(spec, "name")
+        if name_node is not None:
+            name = _text(name_node, source)
+    if not name:
+        return None
+    return Symbol(
+        name=name,
+        qualified_name=name,
+        kind=SymbolKind.TYPE,
+        file_path=file_path,
+        start_line=_start_line(line_node),
+        end_line=_end_line(line_node),
+        visibility=Visibility.PUBLIC,
+    )
+
+
+def _extract_structs(root: object, source: bytes, file_path: str) -> list[Symbol]:
+    symbols: list[Symbol] = []
+    for node in _toplevel_declarations(root):
+        ntype = _type(node)
+        if ntype == "struct_specifier":
+            # struct Point { ... }; -- bare top-level definition.
+            symbol = _struct_symbol(node, source, file_path, line_node=node)
+            if symbol is not None:
+                symbols.append(symbol)
+        elif ntype == "declaration":
+            # struct Point { ... } origin; -- K&R combined struct + variable.
+            type_field = _field(node, "type")
+            if type_field is not None and _type(type_field) == "struct_specifier":
+                symbol = _struct_symbol(type_field, source, file_path, line_node=node)
+                if symbol is not None:
+                    symbols.append(symbol)
+        elif ntype == "type_definition":
+            # typedef struct { ... } Size;  /  typedef struct Rect { ... } Rect;
+            type_field = _field(node, "type")
+            declarator = _field(node, "declarator")
+            if (
+                type_field is not None
+                and _type(type_field) == "struct_specifier"
+                and declarator is not None
+                and _type(declarator) == "type_identifier"
+            ):
+                alias = _text(declarator, source)
+                symbol = _struct_symbol(
+                    type_field, source, file_path, line_node=node, name_override=alias
+                )
+                if symbol is not None:
+                    symbols.append(symbol)
+    return symbols
+
+
+# ---------------------------------------------------------------------------
+# #include parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_include(node: object, source: bytes, file_path: str) -> ImportStatement | None:
+    path_node = _field(node, "path")
+    if path_node is None:
+        return None
+    path_type = _type(path_node)
+    if path_type == "string_literal":
+        module = _text(path_node, source).strip('"')
+        is_relative = True
+    elif path_type == "system_lib_string":
+        module = _text(path_node, source).strip("<>")
+        is_relative = False
+    else:
+        return None
+    return ImportStatement(
+        module=module,
+        file_path=file_path,
+        line=_start_line(node),
+        is_relative=is_relative,
+    )
+
+
+def _parse_includes(root: object, source: bytes, file_path: str) -> list[ImportStatement]:
+    imports: list[ImportStatement] = []
+    for node in _toplevel_declarations(root):
+        if _type(node) != "preproc_include":
+            continue
+        imp = _parse_include(node, source, file_path)
+        if imp is not None:
+            imports.append(imp)
+    return imports
+
+
+# ---------------------------------------------------------------------------
+# Import resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_c_include(imp: ImportStatement, file_map: dict[str, str]) -> str | None:
+    """Resolve a quoted #include to a local file, or None for angle-bracket
+    (system/library) includes, which are never local by convention."""
+    if not imp.is_relative:
+        return None
+
+    file_dir = os.path.dirname(imp.file_path)
+    candidate = os.path.normpath(os.path.join(file_dir, imp.module))
+    values = set(file_map.values())
+    if candidate in values:
+        return candidate
+
+    # Fallback: match by basename anywhere in the project. Real C projects
+    # commonly reference headers via a compiler -I search path rather than
+    # strictly alongside the including file -- a build-system detail this
+    # adapter has no visibility into, so basename matching is the best
+    # available heuristic (the same class of tradeoff Go's resolver makes
+    # for package-path matching).
+    target_basename = os.path.basename(imp.module)
+    for value in file_map.values():
+        if os.path.basename(value) == target_basename:
+            return value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Entry point detection
+# ---------------------------------------------------------------------------
+
+# Matches a `main` function *definition* (has a body), not a prototype
+# (`int main(void);`, terminated by `;` rather than `{`) or an unrelated call.
+_MAIN_DEFINITION = re.compile(r"\bmain\s*\([^;{}]*\)\s*\{")
+
+
+# ---------------------------------------------------------------------------
+# CAdapter
+# ---------------------------------------------------------------------------
+
+
+class CAdapter:
+    """Language adapter for C source and header files."""
+
+    @property
+    def language_id(self) -> str:
+        return "c"
+
+    @property
+    def file_extensions(self) -> list[str]:
+        return [".c", ".h"]
+
+    @property
+    def tree_sitter_name(self) -> str:
+        return "c"
+
+    def extract_symbols(self, tree: object, source: bytes, file_path: str) -> list[Symbol]:
+        """Extract all symbols from a C parse tree: functions (definitions
+        and prototypes) and structs (bare, typedef-anonymous, typedef-named)."""
+        t: Any = tree
+        root: object = t.root_node
+        symbols: list[Symbol] = []
+        symbols.extend(_extract_structs(root, source, file_path))
+        symbols.extend(_extract_functions(root, source, file_path))
+        return symbols
+
+    def parse_imports(self, tree: object, source: bytes, file_path: str) -> list[ImportStatement]:
+        """Extract all #include directives from a C parse tree."""
+        t: Any = tree
+        root: object = t.root_node
+        return _parse_includes(root, source, file_path)
+
+    def resolve_import(self, imp: ImportStatement, file_map: dict[str, str]) -> str | None:
+        """Resolve a quoted #include to a local file, or None if external."""
+        return _resolve_c_include(imp, file_map)
+
+    def detect_entry_points(self, files: list[DiscoveredFile]) -> list[str]:
+        """Detect C entry points: .c files containing a `main` function
+        definition. Headers are excluded -- a `main` definition in a header
+        would produce a multiple-definition link error in any real project."""
+        entry_points: list[str] = []
+        for f in files:
+            if not f.path.endswith(".c"):
+                continue
+            try:
+                with open(f.absolute_path, encoding="utf-8", errors="replace") as fh:
+                    content = fh.read()
+            except OSError:
+                continue
+            if _MAIN_DEFINITION.search(content):
+                entry_points.append(f.path)
+        return entry_points
+
+    def classify_visibility(self, symbol: Symbol) -> Visibility:
+        """Return the symbol's stored visibility (set during extraction from
+        the `static` storage class -- not recomputable from the name alone)."""
+        return symbol.visibility

--- a/tests/parse/adapters/test_c.py
+++ b/tests/parse/adapters/test_c.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from archex.models import SymbolKind, Visibility
+from archex.models import DiscoveredFile, ImportStatement, Symbol, SymbolKind, Visibility
 from archex.parse.adapters.base import LanguageAdapter
 from archex.parse.adapters.c import CAdapter
 from archex.parse.engine import TreeSitterEngine
@@ -298,3 +298,109 @@ def test_include_only_file(engine: TreeSitterEngine, adapter: CAdapter) -> None:
     assert adapter.extract_symbols(tree, source, "includes.h") == []
     imports = adapter.parse_imports(tree, source, "includes.h")
     assert len(imports) == 2
+
+
+# ---------------------------------------------------------------------------
+# resolve_import
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_quoted_include_same_directory(adapter: CAdapter) -> None:
+    file_map = {"list.h": "list.h", "point.h": "point.h"}
+    imp = ImportStatement(module="point.h", file_path="list.h", line=4, is_relative=True)
+    assert adapter.resolve_import(imp, file_map) == "point.h"
+
+
+def test_resolve_quoted_include_subdirectory(adapter: CAdapter) -> None:
+    file_map = {"src/main.c": "src/main.c", "include/foo.h": "include/foo.h"}
+    imp = ImportStatement(
+        module="../include/foo.h", file_path="src/main.c", line=1, is_relative=True
+    )
+    assert adapter.resolve_import(imp, file_map) == "include/foo.h"
+
+
+def test_resolve_quoted_include_basename_fallback(adapter: CAdapter) -> None:
+    """Header lives on a compiler -I search path, not next to the includer --
+    the adapter has no build-system visibility, so basename matching is the
+    best available fallback."""
+    file_map = {"src/main.c": "src/main.c", "include/deep/foo.h": "include/deep/foo.h"}
+    imp = ImportStatement(module="foo.h", file_path="src/main.c", line=1, is_relative=True)
+    assert adapter.resolve_import(imp, file_map) == "include/deep/foo.h"
+
+
+def test_resolve_quoted_include_unresolvable(adapter: CAdapter) -> None:
+    file_map = {"main.c": "main.c"}
+    imp = ImportStatement(module="missing.h", file_path="main.c", line=1, is_relative=True)
+    assert adapter.resolve_import(imp, file_map) is None
+
+
+def test_resolve_angle_bracket_always_external(adapter: CAdapter) -> None:
+    file_map = {"stdio.h": "stdio.h"}  # even a coincidental name match
+    imp = ImportStatement(module="stdio.h", file_path="main.c", line=1, is_relative=False)
+    assert adapter.resolve_import(imp, file_map) is None
+
+
+# ---------------------------------------------------------------------------
+# detect_entry_points
+# ---------------------------------------------------------------------------
+
+
+def test_detect_entry_point(adapter: CAdapter) -> None:
+    files = [
+        DiscoveredFile(path="main.c", absolute_path=str(FIXTURES_DIR / "main.c"), language="c"),
+        DiscoveredFile(path="point.c", absolute_path=str(FIXTURES_DIR / "point.c"), language="c"),
+    ]
+    entry_points = adapter.detect_entry_points(files)
+    assert entry_points == ["main.c"]
+
+
+def test_header_never_an_entry_point(adapter: CAdapter, tmp_path: Path) -> None:
+    header = tmp_path / "fake_main.h"
+    header.write_text("int main(void) {\n    return 0;\n}\n")
+    files = [DiscoveredFile(path="fake_main.h", absolute_path=str(header), language="c")]
+    assert adapter.detect_entry_points(files) == []
+
+
+def test_main_prototype_is_not_an_entry_point(adapter: CAdapter, tmp_path: Path) -> None:
+    source_file = tmp_path / "proto.c"
+    source_file.write_text("int main(void);\n")
+    files = [DiscoveredFile(path="proto.c", absolute_path=str(source_file), language="c")]
+    assert adapter.detect_entry_points(files) == []
+
+
+def test_non_main_file_not_entry_point(adapter: CAdapter, tmp_path: Path) -> None:
+    lib_file = tmp_path / "lib.c"
+    lib_file.write_text("int add(int a, int b) {\n    return a + b;\n}\n")
+    files = [DiscoveredFile(path="lib.c", absolute_path=str(lib_file), language="c")]
+    assert adapter.detect_entry_points(files) == []
+
+
+# ---------------------------------------------------------------------------
+# classify_visibility
+# ---------------------------------------------------------------------------
+
+
+def test_classify_visibility_public(adapter: CAdapter) -> None:
+    s = Symbol(
+        name="point_make",
+        qualified_name="point_make",
+        kind=SymbolKind.FUNCTION,
+        file_path="point.c",
+        start_line=1,
+        end_line=1,
+        visibility=Visibility.PUBLIC,
+    )
+    assert adapter.classify_visibility(s) == Visibility.PUBLIC
+
+
+def test_classify_visibility_private(adapter: CAdapter) -> None:
+    s = Symbol(
+        name="square",
+        qualified_name="square",
+        kind=SymbolKind.FUNCTION,
+        file_path="point.c",
+        start_line=1,
+        end_line=1,
+        visibility=Visibility.PRIVATE,
+    )
+    assert adapter.classify_visibility(s) == Visibility.PRIVATE

--- a/tests/parse/adapters/test_c.py
+++ b/tests/parse/adapters/test_c.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from archex.models import SymbolKind, Visibility
+from archex.parse.adapters.base import LanguageAdapter
+from archex.parse.adapters.c import CAdapter
+from archex.parse.engine import TreeSitterEngine
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures" / "c_simple"
+
+
+@pytest.fixture()
+def engine() -> TreeSitterEngine:
+    return TreeSitterEngine()
+
+
+@pytest.fixture()
+def adapter() -> CAdapter:
+    return CAdapter()
+
+
+def parse(engine: TreeSitterEngine, source: bytes) -> object:
+    return engine.parse_bytes(source, "c")
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_satisfies_language_adapter_protocol(adapter: CAdapter) -> None:
+    assert isinstance(adapter, LanguageAdapter)
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+def test_language_id(adapter: CAdapter) -> None:
+    assert adapter.language_id == "c"
+
+
+def test_file_extensions(adapter: CAdapter) -> None:
+    assert adapter.file_extensions == [".c", ".h"]
+
+
+def test_tree_sitter_name(adapter: CAdapter) -> None:
+    assert adapter.tree_sitter_name == "c"
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: functions (definitions)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_function_definition(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (FIXTURES_DIR / "point.c").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "point.c")
+    funcs = {s.name: s for s in symbols if s.kind == SymbolKind.FUNCTION}
+    assert "point_make" in funcs
+    assert "point_distance_squared" in funcs
+
+
+def test_static_function_is_private(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (FIXTURES_DIR / "point.c").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "point.c")
+    square = next(s for s in symbols if s.name == "square")
+    assert square.visibility == Visibility.PRIVATE
+    assert square.kind == SymbolKind.FUNCTION
+
+
+def test_non_static_function_is_public(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (FIXTURES_DIR / "point.c").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "point.c")
+    make = next(s for s in symbols if s.name == "point_make")
+    assert make.visibility == Visibility.PUBLIC
+
+
+def test_pointer_returning_function(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (FIXTURES_DIR / "list.c").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "list.c")
+    push = next(s for s in symbols if s.name == "list_push")
+    assert push.kind == SymbolKind.FUNCTION
+    assert "struct ListNode *list_push" in (push.signature or "")
+
+
+def test_function_signature_excludes_body(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (FIXTURES_DIR / "point.c").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "point.c")
+    make = next(s for s in symbols if s.name == "point_make")
+    assert make.signature == "Point point_make(int x, int y)"
+
+
+def test_function_qualified_name_is_flat(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (FIXTURES_DIR / "point.c").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "point.c")
+    make = next(s for s in symbols if s.name == "point_make")
+    assert make.qualified_name == "point_make"
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: functions (prototypes -- headers are mostly bodyless)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_function_prototypes(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (FIXTURES_DIR / "point.h").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "point.h")
+    funcs = {s.name: s for s in symbols if s.kind == SymbolKind.FUNCTION}
+    assert "point_make" in funcs
+    assert "point_distance_squared" in funcs
+    # Prototypes have no body: start_line == end_line.
+    assert funcs["point_make"].start_line == funcs["point_make"].end_line
+
+
+def test_prototype_signature_excludes_semicolon(
+    engine: TreeSitterEngine, adapter: CAdapter
+) -> None:
+    source = (FIXTURES_DIR / "point.h").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "point.h")
+    make = next(s for s in symbols if s.name == "point_make")
+    assert make.signature == "Point point_make(int x, int y)"
+    assert ";" not in (make.signature or "")
+
+
+def test_function_pointer_variable_is_not_a_function(
+    engine: TreeSitterEngine, adapter: CAdapter
+) -> None:
+    source = b"int (*fp)(int, int);\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "fp.c")
+    assert symbols == []
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: structs
+# ---------------------------------------------------------------------------
+
+
+def test_extract_named_typedef_struct(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (FIXTURES_DIR / "point.h").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "point.h")
+    point = next(s for s in symbols if s.name == "Point")
+    assert point.kind == SymbolKind.TYPE
+    assert point.visibility == Visibility.PUBLIC
+
+
+def test_extract_anonymous_typedef_struct(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (FIXTURES_DIR / "point.h").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "point.h")
+    names = {s.name for s in symbols if s.kind == SymbolKind.TYPE}
+    assert "Size" in names
+
+
+def test_extract_bare_struct(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (FIXTURES_DIR / "list.h").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "list.h")
+    node = next(s for s in symbols if s.name == "ListNode")
+    assert node.kind == SymbolKind.TYPE
+
+
+def test_self_referential_field_does_not_duplicate_struct(
+    engine: TreeSitterEngine, adapter: CAdapter
+) -> None:
+    """struct ListNode { ...; struct ListNode *next; }; must report ListNode
+    exactly once -- the bodyless `struct ListNode *next` field reference
+    must not be mistaken for a second (invalid, bodyless) definition."""
+    source = (FIXTURES_DIR / "list.h").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "list.h")
+    names = [s.name for s in symbols if s.kind == SymbolKind.TYPE]
+    assert names.count("ListNode") == 1
+
+
+def test_forward_declaration_is_not_a_symbol(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = b"struct Fwd;\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "fwd.h")
+    assert symbols == []
+
+
+def test_kr_combined_struct_and_variable(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = b"struct Vec {\n    int x;\n    int y;\n} origin;\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "vec.c")
+    vec = next(s for s in symbols if s.name == "Vec")
+    assert vec.kind == SymbolKind.TYPE
+
+
+def test_typedef_alias_preferred_over_tag_name(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = b"typedef struct Rect {\n    int w;\n} Rect;\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "rect.h")
+    assert len(symbols) == 1
+    assert symbols[0].name == "Rect"
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: preprocessor conditionals and extern "C" blocks
+# ---------------------------------------------------------------------------
+
+
+def test_extracts_through_extern_c_and_ifdef(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (FIXTURES_DIR / "platform.h").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "platform.h")
+    names = [s.name for s in symbols]
+    assert names.count("platform_sleep_ms") == 2
+    assert "platform_name" in names
+
+
+def test_ifdef_branch_boundaries_are_independent(
+    engine: TreeSitterEngine, adapter: CAdapter
+) -> None:
+    """The two #ifdef/#else platform_sleep_ms prototypes must keep distinct,
+    correct line ranges despite the extern "C" wrapper's contained parser
+    diagnostic on this fixture (see GRAMMAR_EVALUATION.md)."""
+    source = (FIXTURES_DIR / "platform.h").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "platform.h")
+    sleep_variants = [s for s in symbols if s.name == "platform_sleep_ms"]
+    assert len(sleep_variants) == 2
+    lines = {s.start_line for s in sleep_variants}
+    assert len(lines) == 2
+
+
+# ---------------------------------------------------------------------------
+# parse_imports
+# ---------------------------------------------------------------------------
+
+
+def test_parse_quoted_include(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (FIXTURES_DIR / "point.c").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "point.c")
+    assert len(imports) == 1
+    assert imports[0].module == "point.h"
+    assert imports[0].is_relative is True
+
+
+def test_parse_angle_bracket_include(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (FIXTURES_DIR / "list.c").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "list.c")
+    modules = {imp.module: imp for imp in imports}
+    assert "stdlib.h" in modules
+    assert modules["stdlib.h"].is_relative is False
+
+
+def test_parse_includes_through_extern_c(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (
+        b'#ifdef __cplusplus\nextern "C" {\n#endif\n'
+        b'#include "inner.h"\n#ifdef __cplusplus\n}\n#endif\n'
+    )
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "wrapped.h")
+    assert [imp.module for imp in imports] == ["inner.h"]
+
+
+def test_multiple_includes_in_order(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = (FIXTURES_DIR / "main.c").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "main.c")
+    modules = [imp.module for imp in imports]
+    assert modules == ["list.h", "platform.h", "point.h", "stdio.h"]
+
+
+# ---------------------------------------------------------------------------
+# Inline source: edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_file(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = b""
+    tree = parse(engine, source)
+    assert adapter.extract_symbols(tree, source, "empty.c") == []
+    assert adapter.parse_imports(tree, source, "empty.c") == []
+
+
+def test_include_only_file(engine: TreeSitterEngine, adapter: CAdapter) -> None:
+    source = b'#include <stdio.h>\n#include "local.h"\n'
+    tree = parse(engine, source)
+    assert adapter.extract_symbols(tree, source, "includes.h") == []
+    imports = adapter.parse_imports(tree, source, "includes.h")
+    assert len(imports) == 2


### PR DESCRIPTION
## Stack

Stack-Id: `m9-c-full-tier-20260704`
Base: `main`
Position: 2/3

1. `feat/m9-c-fixtures` -> #401
2. `feat/m9-c-adapter` -> this PR
3. `feat/m9-c-full-tier` -> next

Depends on: #401
Upstack: (next PR, not yet open)

## Summary

M9 (DEVELOPMENT_PLAN.md Section D) PR 2/3: `src/archex/parse/adapters/c.py`
implementing the full `LanguageAdapter` contract, plus its test suite. No
tier-flip or registry wiring yet -- that's PR 3/3.

- `extract_symbols`: function definitions and bodyless prototype
  declarations (both -> `FUNCTION` -- a `.h` file's public API is almost
  entirely prototypes) and struct definitions -- bare, typedef-anonymous, and
  typedef-named (-> `TYPE`, preferring the typedef alias over the bare tag
  name). Both recurse through preprocessor conditionals
  (`#ifdef`/`#if`/`#elif`/`#else`) and `extern "C"` linkage blocks, since C
  nests declarations inside those wrapper nodes rather than flattening them
  to top-level `translation_unit` siblings -- a naive one-level scan would
  miss most real `.h` file content.
- `parse_imports`: both `#include` forms (quoted, angle-bracket) through the
  same recursive walk.
- `resolve_import`: angle-bracket includes are always external; quoted
  includes resolve relative to the including file first, falling back to a
  basename match anywhere in the project (no build-system `-I` search-path
  visibility).
- `detect_entry_points`: a `main` function definition (not prototype) in a
  `.c` file.
- `classify_visibility`: AST-derived from the `static` storage class
  (internal vs. external linkage) -- a real C semantic, not name-derived
  like Go's uppercase convention, so the value set during extraction is
  trusted rather than recomputed.

## Validation

- `uv run pytest tests/parse/adapters/test_c.py -v`: 39 passed
- `uv run pytest`: 3141 passed, 4 deselected, 91.03% coverage (was 3102
  pre-M9)
- `uv run ruff check .` / `uv run ruff format --check .`: clean
- `uv run pyright`: 0 errors, 0 warnings, 0 informations
- Adapter is not yet registered/wired (tier flip lands in PR 3/3), so no
  behavioral change from this PR alone -- verified by the full-suite pass
  above.
