### PR TITLE
feat(cpp): implement adapter core with overload-safe qualified names

### DIFF
--- a/src/archex/parse/adapters/cpp.py
+++ b/src/archex/parse/adapters/cpp.py
@@ -1,0 +1,472 @@
+"""C++ parse adapter: extract symbols and imports from .cc/.cpp/.cxx/.hpp/.hh/.hxx
+files using tree-sitter."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from archex.models import Symbol, SymbolKind, Visibility
+from archex.parse.adapters.ts_node import (
+    ts_children as _children,
+)
+from archex.parse.adapters.ts_node import (
+    ts_end_line as _end_line,
+)
+from archex.parse.adapters.ts_node import (
+    ts_field as _field,
+)
+from archex.parse.adapters.ts_node import (
+    ts_named_children as _named_children,
+)
+from archex.parse.adapters.ts_node import (
+    ts_start_line as _start_line,
+)
+from archex.parse.adapters.ts_node import (
+    ts_text as _text,
+)
+from archex.parse.adapters.ts_node import (
+    ts_type as _type,
+)
+
+# ---------------------------------------------------------------------------
+# Top-level declaration flattening
+# ---------------------------------------------------------------------------
+#
+# Three C++ constructs wrap declarations that must be treated as their
+# enclosing scope's direct members rather than opaque containers:
+#
+# - Preprocessor conditionals (#ifdef/#if/#elif/#else) -- same idiom as C,
+#   most commonly the `#ifdef __cplusplus extern "C" { ... } #endif` guard
+#   real C++ headers use to stay includable from C.
+# - `extern "C" { ... }` linkage-specification blocks (and their unbraced,
+#   single-declaration form `extern "C" void f();`) -- C++-to-C interop.
+# - `template <...> ...` wrappers around a templated function or class --
+#   the template parameter list carries no symbol information the adapter
+#   needs, so the templated declaration underneath is unwrapped and treated
+#   like any other function/class at that scope.
+#
+# Symbol extraction and #include parsing both flatten through the same
+# helper so a conditionally compiled declaration or include is never missed
+# by one and found by the other -- same discipline as the C adapter's
+# `_toplevel_declarations`, extended for the two C++-only wrapper kinds.
+
+_CONDITIONAL_TYPES = frozenset({"preproc_ifdef", "preproc_if", "preproc_elif", "preproc_else"})
+
+
+def _unwrap_template_declaration(node: object) -> object | None:
+    """A `template_declaration` wraps exactly one templated declaration
+    (function_definition, a `;`-terminated class_specifier, etc.) after its
+    `template_parameter_list` child. Returns that inner node."""
+    for child in _named_children(node):
+        if _type(child) != "template_parameter_list":
+            return child
+    return None
+
+
+def _flatten_declarations(node: object) -> list[object]:
+    """Flatten preprocessor conditionals, extern "C" linkage blocks, and
+    template wrappers into one top-level sequence of real declarations."""
+    result: list[object] = []
+    for child in _named_children(node):
+        ctype = _type(child)
+        if ctype in _CONDITIONAL_TYPES:
+            result.extend(_flatten_declarations(child))
+        elif ctype == "linkage_specification":
+            body = _field(child, "body")
+            if body is None:
+                continue
+            if _type(body) == "declaration_list":
+                result.extend(_flatten_declarations(body))
+            else:
+                # Unbraced form: extern "C" void f(); -- `body` IS the
+                # single wrapped declaration, not a container of them.
+                result.append(body)
+        elif ctype == "template_declaration":
+            inner = _unwrap_template_declaration(child)
+            if inner is not None:
+                result.append(inner)
+        else:
+            result.append(child)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Scope-path qualification helpers
+# ---------------------------------------------------------------------------
+#
+# `scope_path` is a list of namespace/class name segments accumulated while
+# recursing (e.g. ["geo", "shapes"] or ["geo", "Point"]). Qualified names are
+# always "."-joined -- including for explicit/partial template
+# specializations, whose own "name" is the full templated-type text (e.g.
+# "Pair<int>"). This keeps every C++ qualified name compatible with
+# `archex.precision._get_parent_qname`'s generic dotted-name parent lookup,
+# which is shared across every language adapter.
+
+
+def _scope_qname(scope_path: list[str]) -> str | None:
+    return ".".join(scope_path) if scope_path else None
+
+
+def _qualify(scope_path: list[str], name: str) -> str:
+    return ".".join([*scope_path, name]) if scope_path else name
+
+
+def _map_access_specifier(text: str, current: Visibility) -> Visibility:
+    if text == "public":
+        return Visibility.PUBLIC
+    if text == "private":
+        return Visibility.PRIVATE
+    if text == "protected":
+        return Visibility.INTERNAL
+    return current
+
+
+# ---------------------------------------------------------------------------
+# Function/method extraction -- definitions and prototypes share one path
+# ---------------------------------------------------------------------------
+#
+# A function-shaped declarator's *inner* declarator tells us what kind of
+# callable this is, independent of whether it has a body:
+#
+# - `field_identifier` / `destructor_name` / `operator_name` -- these only
+#   ever occur inside a class/struct body: a plain method, destructor, or
+#   operator overload declared (or inline-defined) as a member.
+# - `identifier` -- a free function at namespace/file scope, OR (inside a
+#   class body) an inline constructor, whose declarator is indistinguishable
+#   from a free function's except for the `in_class` context it was found in.
+#
+# Out-of-class member definitions (`Point::getX() { ... }`, the .cpp half of
+# a header/impl split) use a third declarator shape, `qualified_identifier`
+# -- handled separately once header/impl pairing is in scope.
+
+_STATIC_KEYWORD = "static"
+
+
+def _is_static_free_function(node: object, source: bytes) -> bool:
+    """True if `node` carries a `static` storage_class_specifier -- internal
+    linkage, the same real C++ semantic C's adapter checks for."""
+    for child in _named_children(node):
+        if _type(child) == "storage_class_specifier" and _text(child, source) == _STATIC_KEYWORD:
+            return True
+    return False
+
+
+def _unwrap_function_declarator(declarator: object | None) -> object | None:
+    """Unwrap leading pointer_declarator layers (pointer return types) to
+    find the underlying function_declarator, or None if `declarator` does
+    not describe a function at all."""
+    node = declarator
+    while node is not None and _type(node) == "pointer_declarator":
+        node = _field(node, "declarator")
+    if node is not None and _type(node) == "function_declarator":
+        return node
+    return None
+
+
+def _function_signature(node: object, declarator: object, source: bytes) -> str:
+    """Slice the source from the declaration's start through the end of its
+    outermost declarator, excluding the body/semicolon."""
+    n: Any = node
+    d: Any = declarator
+    text = source[n.start_byte : d.end_byte].decode("utf-8", errors="replace")
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _extract_function_like(
+    node: object,
+    source: bytes,
+    file_path: str,
+    scope_path: list[str],
+    in_class: bool,
+    default_visibility: Visibility,
+) -> Symbol | None:
+    """Extract a FUNCTION or METHOD symbol from a function_definition, or a
+    bodyless `declaration`/`field_declaration` sharing the same declarator
+    shape (a prototype -- headers are mostly prototypes)."""
+    declarator = _field(node, "declarator")
+    if declarator is None:
+        return None
+    func_declarator = _unwrap_function_declarator(declarator)
+    if func_declarator is None:
+        return None
+    inner = _field(func_declarator, "declarator")
+    if inner is None:
+        return None
+    inner_type = _type(inner)
+
+    if inner_type in ("field_identifier", "destructor_name", "operator_name"):
+        if not in_class:
+            return None
+        name = _text(inner, source)
+        parent = _scope_qname(scope_path)
+        kind = SymbolKind.METHOD
+    elif inner_type == "identifier":
+        name = _text(inner, source)
+        parent = _scope_qname(scope_path)
+        kind = SymbolKind.METHOD if in_class else SymbolKind.FUNCTION
+    else:
+        return None
+
+    if not name:
+        return None
+    visibility = default_visibility
+    if kind == SymbolKind.FUNCTION and _is_static_free_function(node, source):
+        visibility = Visibility.PRIVATE
+    return Symbol(
+        name=name,
+        qualified_name=f"{parent}.{name}" if parent else name,
+        kind=kind,
+        file_path=file_path,
+        start_line=_start_line(node),
+        end_line=_end_line(node),
+        visibility=visibility,
+        signature=_function_signature(node, declarator, source),
+        parent=parent,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data member extraction
+# ---------------------------------------------------------------------------
+
+
+def _unwrap_field_identifier(node: object) -> object | None:
+    """Unwrap pointer_declarator/reference_declarator layers on a data
+    member's declarator to find its field_identifier. `reference_declarator`
+    exposes no `declarator` field (unlike `pointer_declarator`), so its
+    identifier is found positionally instead."""
+    while node is not None and _type(node) in ("pointer_declarator", "reference_declarator"):
+        if _type(node) == "pointer_declarator":
+            node = _field(node, "declarator")
+        else:
+            named = _named_children(node)
+            node = named[-1] if named else None
+    if node is not None and _type(node) == "field_identifier":
+        return node
+    return None
+
+
+def _extract_field_symbols(
+    node: object, source: bytes, file_path: str, parent: str | None, visibility: Visibility
+) -> list[Symbol]:
+    """Extract VARIABLE/CONSTANT symbols from a field_declaration whose
+    declarator(s) are plain data members (`int x_, y_;`), not functions --
+    a single field_declaration may declare more than one member. A member
+    is CONSTANT when it carries both `static` and a const-ish qualifier
+    (`const`/`constexpr`); everything else is a VARIABLE."""
+    tokens = {_text(c, source) for c in _children(node)}
+    is_constant = _STATIC_KEYWORD in tokens and ("const" in tokens or "constexpr" in tokens)
+    kind = SymbolKind.CONSTANT if is_constant else SymbolKind.VARIABLE
+
+    symbols: list[Symbol] = []
+    for child in _children(node):
+        target = child if _type(child) == "field_identifier" else _unwrap_field_identifier(child)
+        if target is None:
+            continue
+        name = _text(target, source)
+        symbols.append(
+            Symbol(
+                name=name,
+                qualified_name=f"{parent}.{name}" if parent else name,
+                kind=kind,
+                file_path=file_path,
+                start_line=_start_line(node),
+                end_line=_end_line(node),
+                visibility=visibility,
+                parent=parent,
+            )
+        )
+    return symbols
+
+
+# ---------------------------------------------------------------------------
+# Class/struct extraction -- default visibility, nested types, member walk
+# ---------------------------------------------------------------------------
+
+
+def _class_or_struct_name(node: object, source: bytes) -> str | None:
+    """Return the class/struct's own name, or the full templated-type text
+    for an explicit/partial specialization (e.g. 'Pair<int>' -- genuinely
+    distinct from the primary template's plain 'Pair', by construction, not
+    by disambiguation), or None for an anonymous class/struct."""
+    name_node = _field(node, "name")
+    if name_node is None:
+        return None
+    return _text(name_node, source).replace("::", ".")
+
+
+def _extract_type_decl(
+    node: object,
+    source: bytes,
+    file_path: str,
+    scope_path: list[str],
+    default_visibility: Visibility,
+) -> list[Symbol]:
+    """Build a CLASS (class_specifier) or TYPE (struct_specifier) symbol
+    plus its recursively extracted members, or [] for a forward declaration
+    (no `body` field) or an anonymous class/struct with no name to give it."""
+    body = _field(node, "body")
+    if body is None:
+        return []
+    name = _class_or_struct_name(node, source)
+    if not name:
+        return []
+    kind = SymbolKind.CLASS if _type(node) == "class_specifier" else SymbolKind.TYPE
+    parent = _scope_qname(scope_path)
+    own_symbol = Symbol(
+        name=name,
+        qualified_name=_qualify(scope_path, name),
+        kind=kind,
+        file_path=file_path,
+        start_line=_start_line(node),
+        end_line=_end_line(node),
+        visibility=default_visibility,
+        parent=parent,
+    )
+    # C++ default member access: private for `class`, public for `struct` --
+    # a real language semantic (like C's `static` storage class), not a
+    # naming convention, so it cannot be recomputed from a member's name.
+    member_default_visibility = Visibility.PUBLIC if kind == SymbolKind.TYPE else Visibility.PRIVATE
+    members = _extract_scope_members(
+        _flatten_declarations(body),
+        source,
+        file_path,
+        [*scope_path, name],
+        True,
+        member_default_visibility,
+    )
+    return [own_symbol, *members]
+
+
+# ---------------------------------------------------------------------------
+# Namespace extraction
+# ---------------------------------------------------------------------------
+
+
+def _namespace_name(node: object, source: bytes) -> str | None:
+    """Return the namespace's name -- a plain `namespace_identifier`, or the
+    full `::`-joined text of a C++17 nested-namespace-definition
+    (`namespace geo::shapes { ... }`), converted to '.' -- or None for an
+    anonymous namespace (`namespace { ... }`)."""
+    name_node = _field(node, "name")
+    if name_node is None:
+        return None
+    return _text(name_node, source).replace("::", ".")
+
+
+def _extract_namespace(
+    node: object, source: bytes, file_path: str, scope_path: list[str]
+) -> list[Symbol]:
+    name = _namespace_name(node, source)
+    body = _field(node, "body")
+    if body is None:
+        return []
+    inner_scope = [*scope_path, name] if name else scope_path
+    # An anonymous namespace gives its direct members internal linkage --
+    # the modern-C++-preferred equivalent of a top-level `static` -- without
+    # affecting the access-specifier-governed visibility of members nested
+    # deeper inside a class declared within it.
+    inner_default = Visibility.PUBLIC if name else Visibility.PRIVATE
+    members = _extract_scope_members(
+        _flatten_declarations(body), source, file_path, inner_scope, False, inner_default
+    )
+    if name is None:
+        return members
+    own = Symbol(
+        name=name.rsplit(".", 1)[-1],
+        qualified_name=_qualify(scope_path, name),
+        kind=SymbolKind.MODULE,
+        file_path=file_path,
+        start_line=_start_line(node),
+        end_line=_end_line(node),
+        visibility=Visibility.PUBLIC,
+        parent=_scope_qname(scope_path),
+    )
+    return [own, *members]
+
+
+# ---------------------------------------------------------------------------
+# Unified scope-member dispatcher -- shared by namespace/file scope and
+# class/struct body scope
+# ---------------------------------------------------------------------------
+
+
+def _extract_scope_members(
+    nodes_flat: list[object],
+    source: bytes,
+    file_path: str,
+    scope_path: list[str],
+    in_class: bool,
+    default_visibility: Visibility,
+) -> list[Symbol]:
+    symbols: list[Symbol] = []
+    visibility = default_visibility
+    for node in nodes_flat:
+        ntype = _type(node)
+        if ntype == "namespace_definition":
+            if in_class:
+                continue  # namespaces cannot nest inside a class
+            symbols.extend(_extract_namespace(node, source, file_path, scope_path))
+        elif ntype == "access_specifier":
+            visibility = _map_access_specifier(_text(node, source), visibility)
+        elif ntype in ("class_specifier", "struct_specifier"):
+            symbols.extend(_extract_type_decl(node, source, file_path, scope_path, visibility))
+        elif ntype == "function_definition":
+            sym = _extract_function_like(node, source, file_path, scope_path, in_class, visibility)
+            if sym is not None:
+                symbols.append(sym)
+        elif ntype in ("declaration", "field_declaration"):
+            type_field = _field(node, "type")
+            is_nested_type = type_field is not None and _type(type_field) in (
+                "class_specifier",
+                "struct_specifier",
+            )
+            if is_nested_type:
+                # A nested type declaration (no declarator) or a K&R
+                # combined struct-definition-plus-variable
+                # (`struct Foo { ... } var;`, declarator present) -- either
+                # way the type itself is the symbol; a trailing variable
+                # name is not.
+                symbols.extend(
+                    _extract_type_decl(type_field, source, file_path, scope_path, visibility)
+                )
+                continue
+            sym = _extract_function_like(node, source, file_path, scope_path, in_class, visibility)
+            if sym is not None:
+                symbols.append(sym)
+            elif ntype == "field_declaration" and in_class:
+                parent = _scope_qname(scope_path)
+                symbols.extend(_extract_field_symbols(node, source, file_path, parent, visibility))
+    return symbols
+
+
+# ---------------------------------------------------------------------------
+# CppAdapter
+# ---------------------------------------------------------------------------
+
+
+class CppAdapter:
+    """Language adapter for C++ source and header files."""
+
+    @property
+    def language_id(self) -> str:
+        return "cpp"
+
+    @property
+    def file_extensions(self) -> list[str]:
+        return [".cc", ".cpp", ".cxx", ".hpp", ".hh", ".hxx"]
+
+    @property
+    def tree_sitter_name(self) -> str:
+        return "cpp"
+
+    def extract_symbols(self, tree: object, source: bytes, file_path: str) -> list[Symbol]:
+        """Extract all symbols from a C++ parse tree: namespaces, classes,
+        structs (including nested types and template specializations),
+        functions, and data members. Out-of-class (header/impl-split)
+        member definitions are handled separately."""
+        t: Any = tree
+        root: object = t.root_node
+        flat = _flatten_declarations(root)
+        return _extract_scope_members(flat, source, file_path, [], False, Visibility.PUBLIC)

--- a/tests/parse/adapters/test_cpp.py
+++ b/tests/parse/adapters/test_cpp.py
@@ -1,0 +1,458 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from archex.models import ParsedFile, Symbol, SymbolKind, Visibility
+from archex.parse.adapters.cpp import CppAdapter
+from archex.parse.engine import TreeSitterEngine
+from archex.pipeline.chunker import ASTChunker
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures" / "cpp_simple"
+
+
+@pytest.fixture()
+def engine() -> TreeSitterEngine:
+    return TreeSitterEngine()
+
+
+@pytest.fixture()
+def adapter() -> CppAdapter:
+    return CppAdapter()
+
+
+def parse(engine: TreeSitterEngine, source: bytes) -> object:
+    return engine.parse_bytes(source, "cpp")
+
+
+def extract(engine: TreeSitterEngine, adapter: CppAdapter, path: str) -> list[Symbol]:
+    source = (FIXTURES_DIR / path).read_bytes()
+    tree = parse(engine, source)
+    return adapter.extract_symbols(tree, source, path)
+
+
+def by_qname(symbols: list[Symbol], qualified_name: str) -> list[Symbol]:
+    return [s for s in symbols if s.qualified_name == qualified_name]
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+def test_language_id(adapter: CppAdapter) -> None:
+    assert adapter.language_id == "cpp"
+
+
+def test_file_extensions(adapter: CppAdapter) -> None:
+    assert adapter.file_extensions == [".cc", ".cpp", ".cxx", ".hpp", ".hh", ".hxx"]
+
+
+def test_tree_sitter_name(adapter: CppAdapter) -> None:
+    assert adapter.tree_sitter_name == "cpp"
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: namespaces
+# ---------------------------------------------------------------------------
+
+
+def test_single_namespace_is_a_module_symbol(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "point.hpp")
+    modules = by_qname(symbols, "geo")
+    assert len(modules) == 1
+    assert modules[0].kind == SymbolKind.MODULE
+
+
+def test_cpp17_nested_namespace_syntax(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "shapes.hpp")
+    modules = by_qname(symbols, "geo.shapes")
+    assert len(modules) == 1
+    assert modules[0].kind == SymbolKind.MODULE
+
+
+def test_classic_nested_namespace_syntax(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    source = b"namespace outer { namespace inner { class Widget {}; } }\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "nested.hpp")
+    names = {s.qualified_name for s in symbols}
+    assert {"outer", "outer.inner", "outer.inner.Widget"} <= names
+
+
+def test_anonymous_namespace_has_no_module_symbol(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    source = b"namespace {\n    int helper() { return 1; }\n}\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "anon.cpp")
+    assert [s.kind for s in symbols] == [SymbolKind.FUNCTION]
+
+
+def test_anonymous_namespace_members_get_internal_linkage(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    source = b"namespace {\n    int helper() { return 1; }\n}\nint pub() { return 2; }\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "anon.cpp")
+    helper = by_qname(symbols, "helper")[0]
+    pub = by_qname(symbols, "pub")[0]
+    assert helper.visibility == Visibility.PRIVATE
+    assert pub.visibility == Visibility.PUBLIC
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: classes and structs
+# ---------------------------------------------------------------------------
+
+
+def test_class_specifier_maps_to_class_kind(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "point.hpp")
+    point = by_qname(symbols, "geo.Point")[0]
+    assert point.kind == SymbolKind.CLASS
+
+
+def test_struct_specifier_maps_to_type_kind(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "shapes.hpp")
+    size = by_qname(symbols, "geo.shapes.Size")[0]
+    assert size.kind == SymbolKind.TYPE
+
+
+def test_top_level_class_is_public(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "point.hpp")
+    point = by_qname(symbols, "geo.Point")[0]
+    assert point.visibility == Visibility.PUBLIC
+
+
+def test_nested_type_declaration(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    source = (
+        b"class Outer {\npublic:\n    struct Meta { int version; };\n"
+        b"private:\n    class Impl {};\n};\n"
+    )
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "outer.hpp")
+    meta = by_qname(symbols, "Outer.Meta")[0]
+    impl = by_qname(symbols, "Outer.Impl")[0]
+    assert meta.kind == SymbolKind.TYPE
+    assert meta.visibility == Visibility.PUBLIC
+    assert impl.kind == SymbolKind.CLASS
+    assert impl.visibility == Visibility.PRIVATE
+
+
+def test_kr_combined_struct_and_variable(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    source = b"struct Vec {\n    int x;\n    int y;\n} origin;\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "vec.hpp")
+    vec = by_qname(symbols, "Vec")[0]
+    assert vec.kind == SymbolKind.TYPE
+
+
+def test_forward_declaration_is_not_a_symbol(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    source = b"struct Fwd;\nclass Fwd2;\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "fwd.hpp")
+    assert symbols == []
+
+
+def test_self_referential_struct_does_not_duplicate(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    symbols = extract(engine, adapter, "list.hpp")
+    nodes = by_qname(symbols, "geo.ListNode")
+    assert len(nodes) == 1
+    assert nodes[0].kind == SymbolKind.TYPE
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: functions (free, static, prototype vs definition)
+# ---------------------------------------------------------------------------
+
+
+def test_free_function_definition(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "shapes.cpp")
+    funcs = by_qname(symbols, "geo.shapes.area")
+    assert len(funcs) == 2
+    assert all(s.kind == SymbolKind.FUNCTION for s in funcs)
+
+
+def test_free_function_prototype_counts_as_symbol(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    symbols = extract(engine, adapter, "shapes.hpp")
+    funcs = by_qname(symbols, "geo.shapes.area")
+    assert len(funcs) == 2
+    assert all(s.signature and ";" not in s.signature for s in funcs)
+
+
+def test_static_free_function_is_private(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    source = b"static int helper(int x) { return x; }\nint pub(int x) { return x; }\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "util.cpp")
+    helper = by_qname(symbols, "helper")[0]
+    pub = by_qname(symbols, "pub")[0]
+    assert helper.visibility == Visibility.PRIVATE
+    assert pub.visibility == Visibility.PUBLIC
+
+
+def test_function_pointer_variable_is_not_a_function(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    source = b"int (*fp)(int, int);\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "fp.hpp")
+    assert symbols == []
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: overloads -- the milestone's core regression concern
+# ---------------------------------------------------------------------------
+
+
+def test_method_overloads_produce_distinct_symbols(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    symbols = extract(engine, adapter, "point.hpp")
+    moves = by_qname(symbols, "geo.Point.move")
+    assert len(moves) == 2
+    signatures = {m.signature for m in moves}
+    assert signatures == {"void move(int dx, int dy)", "void move(double dx, double dy)"}
+    lines = {m.start_line for m in moves}
+    assert len(lines) == 2
+
+
+def test_free_function_overloads_produce_distinct_symbols(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    symbols = extract(engine, adapter, "shapes.hpp")
+    areas = by_qname(symbols, "geo.shapes.area")
+    assert len(areas) == 2
+    signatures = {a.signature for a in areas}
+    assert signatures == {
+        "int area(int width, int height)",
+        "double area(double width, double height)",
+    }
+
+
+def test_template_method_overloads_produce_distinct_symbols(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    symbols = extract(engine, adapter, "container.hpp")
+    adds = by_qname(symbols, "geo.Container.add")
+    assert len(adds) == 2
+    signatures = {a.signature for a in adds}
+    assert signatures == {"void add(T item)", "void add(const T& item, int count)"}
+
+
+def test_overloads_are_not_silently_dropped(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    """A dict/set keyed naively by name would silently collapse overloads to
+    one entry -- assert the exact expected symbol count for a Point.hpp
+    walk, not just that *some* symbols exist."""
+    symbols = extract(engine, adapter, "point.hpp")
+    method_names = [s.name for s in symbols if s.kind == SymbolKind.METHOD]
+    assert method_names.count("move") == 2
+    assert method_names.count("Point") == 2  # two overloaded constructors
+
+
+def test_overload_symbol_ids_disambiguate_with_zero_collisions(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    """Overloads intentionally share one `qualified_name` (see
+    GRAMMAR_EVALUATION.md); final `symbol_id` uniqueness across the whole
+    file is proven end-to-end through the real chunker pipeline, the same
+    `_disambiguate_symbol_ids` mechanism the Scala adapter's companion-object
+    collision already relies on -- not a bespoke per-adapter mechanism."""
+    source = (FIXTURES_DIR / "point.hpp").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "point.hpp")
+    parsed = ParsedFile(
+        path="point.hpp", language="cpp", symbols=symbols, lines=source.count(b"\n")
+    )
+    chunks = ASTChunker().chunk_file(parsed, source)
+
+    all_ids = [c.symbol_id for c in chunks]
+    assert len(all_ids) == len(set(all_ids))
+
+    move_chunks = sorted((c for c in chunks if c.symbol_name == "move"), key=lambda c: c.start_line)
+    assert len(move_chunks) == 2
+    assert move_chunks[0].symbol_id != move_chunks[1].symbol_id
+    assert move_chunks[1].symbol_id == f"{move_chunks[0].symbol_id}@2"
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: templates and specializations
+# ---------------------------------------------------------------------------
+
+
+def test_template_class_members_extracted(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "container.hpp")
+    container = by_qname(symbols, "geo.Container")[0]
+    size_method = by_qname(symbols, "geo.Container.size")[0]
+    assert container.kind == SymbolKind.CLASS
+    assert size_method.kind == SymbolKind.METHOD
+
+
+def test_template_class_with_default_parameter(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    symbols = extract(engine, adapter, "pair.hpp")
+    pair = by_qname(symbols, "geo.Pair")
+    assert len(pair) == 1
+    assert pair[0].kind == SymbolKind.CLASS
+
+
+def test_explicit_specialization_has_distinct_qualified_name(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    """The specialization's qualified name is genuinely distinct from the
+    primary template's by construction (not by disambiguation) -- see
+    GRAMMAR_EVALUATION.md."""
+    symbols = extract(engine, adapter, "pair.hpp")
+    primary = by_qname(symbols, "geo.Pair")
+    specialization = by_qname(symbols, "geo.Pair<int>")
+    assert len(primary) == 1
+    assert len(specialization) == 1
+    assert primary[0].qualified_name != specialization[0].qualified_name
+
+
+def test_specialization_members_are_independent_of_primary(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    symbols = extract(engine, adapter, "pair.hpp")
+    primary_ctor = by_qname(symbols, "geo.Pair.Pair")
+    spec_ctor = by_qname(symbols, "geo.Pair<int>.Pair")
+    assert len(primary_ctor) == 1
+    assert len(spec_ctor) == 1
+    assert primary_ctor[0].signature != spec_ctor[0].signature
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: constructors, destructors, operators
+# ---------------------------------------------------------------------------
+
+
+def test_overloaded_constructors(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "point.hpp")
+    ctors = by_qname(symbols, "geo.Point.Point")
+    assert len(ctors) == 2
+    assert all(c.kind == SymbolKind.METHOD for c in ctors)
+
+
+def test_destructor_is_a_method(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "point.hpp")
+    dtor = by_qname(symbols, "geo.Point.~Point")[0]
+    assert dtor.kind == SymbolKind.METHOD
+    assert dtor.name == "~Point"
+
+
+def test_operator_overload_is_a_method(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "point.hpp")
+    op = by_qname(symbols, "geo.Point.operator+")[0]
+    assert op.kind == SymbolKind.METHOD
+    assert op.name == "operator+"
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: data members
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_declarators_in_one_field_declaration(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    source = b"class Point {\npublic:\n    int x_, y_;\n};\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "point.hpp")
+    names = {s.name for s in symbols if s.kind == SymbolKind.VARIABLE}
+    assert names == {"x_", "y_"}
+
+
+def test_pointer_and_reference_members(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    source = b"class Foo {\npublic:\n    Foo* self_;\n    int& ref_;\n};\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "foo.hpp")
+    names = {s.name for s in symbols if s.kind == SymbolKind.VARIABLE}
+    assert names == {"self_", "ref_"}
+
+
+def test_static_const_member_is_constant(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    source = (
+        b"class Config {\npublic:\n    static const int kMaxSize;\n    int instanceField;\n};\n"
+    )
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "config.hpp")
+    max_size = by_qname(symbols, "Config.kMaxSize")[0]
+    instance = by_qname(symbols, "Config.instanceField")[0]
+    assert max_size.kind == SymbolKind.CONSTANT
+    assert instance.kind == SymbolKind.VARIABLE
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: visibility (class default private, struct default public)
+# ---------------------------------------------------------------------------
+
+
+def test_class_members_default_private(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "point.hpp")
+    x = by_qname(symbols, "geo.Point.x_")[0]
+    assert x.visibility == Visibility.PRIVATE
+
+
+def test_class_public_section_is_public(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "point.hpp")
+    get_x = by_qname(symbols, "geo.Point.getX")[0]
+    assert get_x.visibility == Visibility.PUBLIC
+
+
+def test_struct_members_default_public(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "shapes.hpp")
+    width = by_qname(symbols, "geo.shapes.Size.width")[0]
+    assert width.visibility == Visibility.PUBLIC
+
+
+def test_protected_maps_to_internal(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    source = b"class Base {\nprotected:\n    int shared_;\n};\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "base.hpp")
+    shared = by_qname(symbols, "Base.shared_")[0]
+    assert shared.visibility == Visibility.INTERNAL
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: preprocessor conditionals and extern "C" (contained gap)
+# ---------------------------------------------------------------------------
+
+
+def test_extracts_through_extern_c_and_ifdef(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "platform.hpp")
+    names = {s.name for s in symbols}
+    assert "platform_name" in names
+
+
+def test_ifdef_branch_boundaries_are_independent(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    """The two #ifdef/#else platform_sleep_ms prototypes must keep distinct,
+    independent line boundaries despite the file's one documented,
+    non-cascading is_missing diagnostic (see GRAMMAR_EVALUATION.md)."""
+    symbols = extract(engine, adapter, "platform.hpp")
+    sleeps = [s for s in symbols if s.name == "platform_sleep_ms"]
+    lines = {s.start_line for s in sleeps}
+    assert len(sleeps) == 2
+    assert len(lines) == 2
+
+
+# ---------------------------------------------------------------------------
+# Inline source: edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_file(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    source = b""
+    tree = parse(engine, source)
+    assert adapter.extract_symbols(tree, source, "empty.cpp") == []
+
+
+def test_class_only_declarations_still_walk(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    symbols = extract(engine, adapter, "pair.hpp")
+    assert len(symbols) > 0
+    assert all(isinstance(s, Symbol) for s in symbols)


### PR DESCRIPTION
## Stack

Stack-Id: `m10-cpp-full-tier-20260704`
Base: `feat/m10-cpp-fixtures`
Position: 2/5

1. `feat/m10-cpp-fixtures` -> #404
2. `feat/m10-cpp-adapter-core` -> this PR
3. `feat/m10-cpp-import-contract` -> (next)
4. `feat/m10-cpp-header-impl` -> (next)
5. `feat/m10-cpp-full-tier` -> (next)

Depends on: #404
Upstack: feat/m10-cpp-import-contract

## Summary

DEVELOPMENT_PLAN.md M10, PR-2: `src/archex/parse/adapters/cpp.py` (new),
`extract_symbols` only. `parse_imports`/`resolve_import`/
`detect_entry_points`/`classify_visibility` land in the next PR; out-of-class
(header/impl-split) member definitions land in the PR after that -- this PR
is scoped strictly to in-place symbol extraction and its overload/template
qualified-name design.

- Namespaces (classic nesting, C++17 `geo::shapes` syntax, anonymous with
  internal-linkage default), classes/structs (`class_specifier` -> CLASS,
  `struct_specifier` -> TYPE, nested types, forward-declaration exclusion),
  free functions and inline class members (constructors, destructors,
  operator overloads, methods), data members (multi-declarator,
  pointer/reference, static-const-as-CONSTANT).
- Design decision (documented in PR-1's `GRAMMAR_EVALUATION.md` and repeated
  in this PR's commit): `qualified_name` never embeds parameter-type
  signatures. Overloads share one `qualified_name`; final `symbol_id`
  uniqueness is proven end-to-end through the real chunker's existing
  `_disambiguate_symbol_ids` mechanism, not a new bespoke one. Template
  specializations (`Pair` vs `Pair<int>`) get a genuinely distinct
  `qualified_name` by construction.

## Validation

- `uv run pytest tests/parse/adapters/test_cpp.py -v`: 42 passed
- `uv run ruff check src/archex/parse/adapters/cpp.py`: clean
- `uv run ruff format --check src/archex/parse/adapters/cpp.py`: clean
- `uv run pyright src/archex/parse/adapters/cpp.py tests/parse/adapters/test_cpp.py`: 0 errors