### PR TITLE
feat(cpp): implement import resolution and remaining adapter contract

### DIFF
--- a/src/archex/parse/adapters/cpp.py
+++ b/src/archex/parse/adapters/cpp.py
@@ -3,10 +3,11 @@ files using tree-sitter."""
 
 from __future__ import annotations
 
+import os
 import re
 from typing import Any
 
-from archex.models import Symbol, SymbolKind, Visibility
+from archex.models import DiscoveredFile, ImportStatement, Symbol, SymbolKind, Visibility
 from archex.parse.adapters.ts_node import (
     ts_children as _children,
 )
@@ -442,6 +443,86 @@ def _extract_scope_members(
 
 
 # ---------------------------------------------------------------------------
+# #include parsing -- identical shape to C's, extension-agnostic
+# ---------------------------------------------------------------------------
+
+
+def _parse_include(node: object, source: bytes, file_path: str) -> ImportStatement | None:
+    path_node = _field(node, "path")
+    if path_node is None:
+        return None
+    path_type = _type(path_node)
+    if path_type == "string_literal":
+        module = _text(path_node, source).strip('"')
+        is_relative = True
+    elif path_type == "system_lib_string":
+        module = _text(path_node, source).strip("<>")
+        is_relative = False
+    else:
+        return None
+    return ImportStatement(
+        module=module,
+        file_path=file_path,
+        line=_start_line(node),
+        is_relative=is_relative,
+    )
+
+
+def _parse_includes(root: object, source: bytes, file_path: str) -> list[ImportStatement]:
+    """#include directives are always written at file scope in idiomatic
+    C++ (never inside a namespace), so only the top-level flatten is
+    walked -- same scope C's adapter parses includes at."""
+    imports: list[ImportStatement] = []
+    for node in _flatten_declarations(root):
+        if _type(node) != "preproc_include":
+            continue
+        imp = _parse_include(node, source, file_path)
+        if imp is not None:
+            imports.append(imp)
+    return imports
+
+
+# ---------------------------------------------------------------------------
+# Import resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_cpp_include(imp: ImportStatement, file_map: dict[str, str]) -> str | None:
+    """Resolve a quoted #include to a local file, or None for angle-bracket
+    (system/library) includes, which are never local by convention. Not
+    extension-specific: a .cpp file including a C-tier .h header resolves
+    exactly the same way, since `file_map` spans the whole repo."""
+    if not imp.is_relative:
+        return None
+
+    file_dir = os.path.dirname(imp.file_path)
+    candidate = os.path.normpath(os.path.join(file_dir, imp.module))
+    values = set(file_map.values())
+    if candidate in values:
+        return candidate
+
+    # Fallback: match by basename anywhere in the project -- real C++
+    # projects commonly reference headers via a compiler -I search path
+    # rather than strictly alongside the including file.
+    target_basename = os.path.basename(imp.module)
+    for value in file_map.values():
+        if os.path.basename(value) == target_basename:
+            return value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Entry point detection
+# ---------------------------------------------------------------------------
+
+# Matches a `main` function *definition* (has a body), not a prototype or an
+# unrelated call -- same pattern C's adapter uses.
+_MAIN_DEFINITION = re.compile(r"\bmain\s*\([^;{}]*\)\s*\{")
+
+_IMPL_EXTENSIONS = (".cc", ".cpp", ".cxx")
+
+
+# ---------------------------------------------------------------------------
 # CppAdapter
 # ---------------------------------------------------------------------------
 
@@ -470,3 +551,39 @@ class CppAdapter:
         root: object = t.root_node
         flat = _flatten_declarations(root)
         return _extract_scope_members(flat, source, file_path, [], False, Visibility.PUBLIC)
+
+    def parse_imports(self, tree: object, source: bytes, file_path: str) -> list[ImportStatement]:
+        """Extract all #include directives from a C++ parse tree."""
+        t: Any = tree
+        root: object = t.root_node
+        return _parse_includes(root, source, file_path)
+
+    def resolve_import(self, imp: ImportStatement, file_map: dict[str, str]) -> str | None:
+        """Resolve a quoted #include to a local file, or None if external."""
+        return _resolve_cpp_include(imp, file_map)
+
+    def detect_entry_points(self, files: list[DiscoveredFile]) -> list[str]:
+        """Detect C++ entry points: implementation files (.cc/.cpp/.cxx)
+        containing a `main` function definition. Headers are excluded -- a
+        `main` definition in a header would produce a multiple-definition
+        link error in any real project including it from more than one
+        translation unit."""
+        entry_points: list[str] = []
+        for f in files:
+            if not f.path.endswith(_IMPL_EXTENSIONS):
+                continue
+            try:
+                with open(f.absolute_path, encoding="utf-8", errors="replace") as fh:
+                    content = fh.read()
+            except OSError:
+                continue
+            if _MAIN_DEFINITION.search(content):
+                entry_points.append(f.path)
+        return entry_points
+
+    def classify_visibility(self, symbol: Symbol) -> Visibility:
+        """Return the symbol's stored visibility -- set during extraction
+        from real C++ semantics (`static`/anonymous-namespace internal
+        linkage for free functions, access-specifier state for members),
+        not recomputable from a bare name."""
+        return symbol.visibility

--- a/tests/parse/adapters/test_cpp.py
+++ b/tests/parse/adapters/test_cpp.py
@@ -4,7 +4,15 @@ from pathlib import Path
 
 import pytest
 
-from archex.models import ParsedFile, Symbol, SymbolKind, Visibility
+from archex.models import (
+    DiscoveredFile,
+    ImportStatement,
+    ParsedFile,
+    Symbol,
+    SymbolKind,
+    Visibility,
+)
+from archex.parse.adapters.base import LanguageAdapter
 from archex.parse.adapters.cpp import CppAdapter
 from archex.parse.engine import TreeSitterEngine
 from archex.pipeline.chunker import ASTChunker
@@ -34,6 +42,15 @@ def extract(engine: TreeSitterEngine, adapter: CppAdapter, path: str) -> list[Sy
 
 def by_qname(symbols: list[Symbol], qualified_name: str) -> list[Symbol]:
     return [s for s in symbols if s.qualified_name == qualified_name]
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_satisfies_language_adapter_protocol(adapter: CppAdapter) -> None:
+    assert isinstance(adapter, LanguageAdapter)
 
 
 # ---------------------------------------------------------------------------
@@ -456,3 +473,169 @@ def test_class_only_declarations_still_walk(engine: TreeSitterEngine, adapter: C
     symbols = extract(engine, adapter, "pair.hpp")
     assert len(symbols) > 0
     assert all(isinstance(s, Symbol) for s in symbols)
+
+
+# ---------------------------------------------------------------------------
+# parse_imports
+# ---------------------------------------------------------------------------
+
+
+def test_parse_quoted_include(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    source = (FIXTURES_DIR / "point.cpp").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "point.cpp")
+    assert [imp.module for imp in imports] == ["point.hpp"]
+    assert imports[0].is_relative is True
+
+
+def test_parse_angle_bracket_include(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    source = (FIXTURES_DIR / "list.cpp").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "list.cpp")
+    modules = {imp.module: imp for imp in imports}
+    assert modules["cstdlib"].is_relative is False
+
+
+def test_parse_includes_through_extern_c_and_ifdef(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    source = (FIXTURES_DIR / "platform.hpp").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "platform.hpp")
+    assert imports == []
+
+
+def test_multiple_includes_in_order(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    source = (FIXTURES_DIR / "main.cpp").read_bytes()
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "main.cpp")
+    modules = [imp.module for imp in imports]
+    assert modules == ["cstdio", "list.hpp", "platform.hpp", "point.hpp", "shapes.hpp"]
+
+
+def test_include_not_present_inside_namespace(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    source = b'namespace geo {\n#include "inner.hpp"\n}\n'
+    tree = parse(engine, source)
+    imports = adapter.parse_imports(tree, source, "weird.cpp")
+    assert imports == []
+
+
+def test_empty_file_has_no_imports(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    source = b""
+    tree = parse(engine, source)
+    assert adapter.parse_imports(tree, source, "empty.cpp") == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_import
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_quoted_include_same_directory(adapter: CppAdapter) -> None:
+    file_map = {"list.hpp": "list.hpp", "point.hpp": "point.hpp"}
+    imp = ImportStatement(module="point.hpp", file_path="list.hpp", line=5, is_relative=True)
+    assert adapter.resolve_import(imp, file_map) == "point.hpp"
+
+
+def test_resolve_quoted_include_subdirectory(adapter: CppAdapter) -> None:
+    file_map = {"src/main.cpp": "src/main.cpp", "include/foo.hpp": "include/foo.hpp"}
+    imp = ImportStatement(
+        module="../include/foo.hpp", file_path="src/main.cpp", line=1, is_relative=True
+    )
+    assert adapter.resolve_import(imp, file_map) == "include/foo.hpp"
+
+
+def test_resolve_quoted_include_basename_fallback(adapter: CppAdapter) -> None:
+    file_map = {"main.cpp": "main.cpp", "include/deep/foo.hpp": "include/deep/foo.hpp"}
+    imp = ImportStatement(module="foo.hpp", file_path="main.cpp", line=1, is_relative=True)
+    assert adapter.resolve_import(imp, file_map) == "include/deep/foo.hpp"
+
+
+def test_resolve_quoted_include_unresolvable(adapter: CppAdapter) -> None:
+    file_map = {"main.cpp": "main.cpp"}
+    imp = ImportStatement(module="missing.hpp", file_path="main.cpp", line=1, is_relative=True)
+    assert adapter.resolve_import(imp, file_map) is None
+
+
+def test_resolve_angle_bracket_always_external(adapter: CppAdapter) -> None:
+    file_map = {"vector": "vector"}  # even a coincidental name match
+    imp = ImportStatement(module="vector", file_path="main.cpp", line=1, is_relative=False)
+    assert adapter.resolve_import(imp, file_map) is None
+
+
+def test_resolve_include_of_c_tier_header(adapter: CppAdapter) -> None:
+    """A .cpp file including a C-tier .h header resolves the same way --
+    file_map spans the whole repo, not just cpp-tier files."""
+    file_map = {"legacy.h": "legacy.h", "main.cpp": "main.cpp"}
+    imp = ImportStatement(module="legacy.h", file_path="main.cpp", line=1, is_relative=True)
+    assert adapter.resolve_import(imp, file_map) == "legacy.h"
+
+
+# ---------------------------------------------------------------------------
+# detect_entry_points
+# ---------------------------------------------------------------------------
+
+
+def test_detect_entry_point(adapter: CppAdapter) -> None:
+    files = [
+        DiscoveredFile(
+            path="main.cpp",
+            absolute_path=str(FIXTURES_DIR / "main.cpp"),
+            language="cpp",
+        )
+    ]
+    assert adapter.detect_entry_points(files) == ["main.cpp"]
+
+
+def test_header_never_an_entry_point(adapter: CppAdapter, tmp_path: Path) -> None:
+    header = tmp_path / "fake_main.hpp"
+    header.write_text("int main() { return 0; }\n")
+    files = [DiscoveredFile(path="fake_main.hpp", absolute_path=str(header), language="cpp")]
+    assert adapter.detect_entry_points(files) == []
+
+
+def test_main_prototype_is_not_an_entry_point(adapter: CppAdapter, tmp_path: Path) -> None:
+    source_file = tmp_path / "proto.cpp"
+    source_file.write_text("int main();\n")
+    files = [DiscoveredFile(path="proto.cpp", absolute_path=str(source_file), language="cpp")]
+    assert adapter.detect_entry_points(files) == []
+
+
+def test_non_main_file_not_entry_point(adapter: CppAdapter, tmp_path: Path) -> None:
+    lib_file = tmp_path / "lib.cpp"
+    lib_file.write_text("void helper() {}\n")
+    files = [DiscoveredFile(path="lib.cpp", absolute_path=str(lib_file), language="cpp")]
+    assert adapter.detect_entry_points(files) == []
+
+
+# ---------------------------------------------------------------------------
+# classify_visibility
+# ---------------------------------------------------------------------------
+
+
+def test_classify_visibility_public(adapter: CppAdapter) -> None:
+    s = Symbol(
+        name="getX",
+        qualified_name="geo.Point.getX",
+        kind=SymbolKind.METHOD,
+        file_path="point.hpp",
+        start_line=1,
+        end_line=1,
+        visibility=Visibility.PUBLIC,
+    )
+    assert adapter.classify_visibility(s) == Visibility.PUBLIC
+
+
+def test_classify_visibility_private(adapter: CppAdapter) -> None:
+    s = Symbol(
+        name="x_",
+        qualified_name="geo.Point.x_",
+        kind=SymbolKind.VARIABLE,
+        file_path="point.hpp",
+        start_line=1,
+        end_line=1,
+        visibility=Visibility.PRIVATE,
+    )
+    assert adapter.classify_visibility(s) == Visibility.PRIVATE


### PR DESCRIPTION
## Stack

Stack-Id: `m10-cpp-full-tier-20260704`
Base: `feat/m10-cpp-adapter-core`
Position: 3/5

1. `feat/m10-cpp-fixtures` -> #404
2. `feat/m10-cpp-adapter-core` -> #405
3. `feat/m10-cpp-import-contract` -> this PR
4. `feat/m10-cpp-header-impl` -> (next)
5. `feat/m10-cpp-full-tier` -> (next)

Depends on: #405
Upstack: feat/m10-cpp-header-impl

## Summary

DEVELOPMENT_PLAN.md M10, PR-3: completes the `LanguageAdapter` protocol on
`src/archex/parse/adapters/cpp.py` -- `parse_imports`, `resolve_import`,
`detect_entry_points`, `classify_visibility` -- editing the file PR-2
created. Out-of-class (header/impl-split) member definitions are still out
of scope; that lands in the next PR.

- `parse_imports`: `#include` in both quoted/angle-bracket forms, parsed at
  file scope only (idiomatic C++ never places `#include` inside a
  namespace).
- `resolve_import`: relative-to-includer then basename fallback, same policy
  as C's resolver and deliberately extension-agnostic -- a `.cpp` file
  including a C-tier `.h` header resolves correctly since `file_map` spans
  the whole repo.
- `detect_entry_points`: a `main` function *definition* in an implementation
  file (`.cc`/`.cpp`/`.cxx`); headers excluded.
- `classify_visibility`: returns the stored value (set from real C++
  semantics during extraction).

## Validation

- `uv run pytest tests/parse/adapters/test_cpp.py -v`: 61 passed
- `uv run ruff check src/archex/parse/adapters/cpp.py`: clean
- `uv run ruff format --check src/archex/parse/adapters/cpp.py`: clean
- `uv run pyright src/archex/parse/adapters/cpp.py tests/parse/adapters/test_cpp.py`: 0 errors