### PR TITLE
feat(cpp): resolve header/impl-split out-of-class member definitions

### DIFF
--- a/src/archex/parse/adapters/cpp.py
+++ b/src/archex/parse/adapters/cpp.py
@@ -130,16 +130,17 @@ def _map_access_specifier(text: str, current: Visibility) -> Visibility:
 # A function-shaped declarator's *inner* declarator tells us what kind of
 # callable this is, independent of whether it has a body:
 #
+# - `qualified_identifier` (e.g. `Point::getX`, `geo::Point::move`) -- an
+#   out-of-class member definition, the .cpp half of a header/impl split.
+#   The qualified_identifier's own scope prefix supplies the parent, so
+#   this works whether the .cpp file re-opens the same namespace as the
+#   header (relative scope) or spells the namespace out in full.
 # - `field_identifier` / `destructor_name` / `operator_name` -- these only
 #   ever occur inside a class/struct body: a plain method, destructor, or
 #   operator overload declared (or inline-defined) as a member.
 # - `identifier` -- a free function at namespace/file scope, OR (inside a
 #   class body) an inline constructor, whose declarator is indistinguishable
 #   from a free function's except for the `in_class` context it was found in.
-#
-# Out-of-class member definitions (`Point::getX() { ... }`, the .cpp half of
-# a header/impl split) use a third declarator shape, `qualified_identifier`
-# -- handled separately once header/impl pairing is in scope.
 
 _STATIC_KEYWORD = "static"
 
@@ -174,6 +175,18 @@ def _function_signature(node: object, declarator: object, source: bytes) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
+def _split_qualified_scope(text: str) -> tuple[str, str]:
+    """Split a qualified_identifier's raw '::'-joined text (e.g.
+    'geo::Point::getX') into (scope_prefix, tail_name), converting the
+    scope portion's '::' separators to '.'. `qualified_identifier`'s own
+    `scope`/`name` fields are right-recursively nested (`geo::Point::getX`
+    = scope: geo, name: (Point::getX), ...), so splitting the node's full
+    raw text once from the right is simpler and correct regardless of
+    nesting depth."""
+    scope, _, tail = text.rpartition("::")
+    return scope.replace("::", "."), tail
+
+
 def _extract_function_like(
     node: object,
     source: bytes,
@@ -196,7 +209,11 @@ def _extract_function_like(
         return None
     inner_type = _type(inner)
 
-    if inner_type in ("field_identifier", "destructor_name", "operator_name"):
+    if inner_type == "qualified_identifier":
+        scope_prefix, name = _split_qualified_scope(_text(inner, source))
+        parent = _qualify(scope_path, scope_prefix)
+        kind = SymbolKind.METHOD
+    elif inner_type in ("field_identifier", "destructor_name", "operator_name"):
         if not in_class:
             return None
         name = _text(inner, source)
@@ -545,8 +562,8 @@ class CppAdapter:
     def extract_symbols(self, tree: object, source: bytes, file_path: str) -> list[Symbol]:
         """Extract all symbols from a C++ parse tree: namespaces, classes,
         structs (including nested types and template specializations),
-        functions, and data members. Out-of-class (header/impl-split)
-        member definitions are handled separately."""
+        functions, methods (including out-of-class header/impl-split
+        definitions), and data members."""
         t: Any = tree
         root: object = t.root_node
         flat = _flatten_declarations(root)

--- a/tests/parse/adapters/test_cpp.py
+++ b/tests/parse/adapters/test_cpp.py
@@ -639,3 +639,132 @@ def test_classify_visibility_private(adapter: CppAdapter) -> None:
         visibility=Visibility.PRIVATE,
     )
     assert adapter.classify_visibility(s) == Visibility.PRIVATE
+
+
+# ---------------------------------------------------------------------------
+# Header/impl pairing: out-of-class member definitions
+# ---------------------------------------------------------------------------
+
+
+def test_out_of_class_method_matches_header_declaration(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    header_symbols = extract(engine, adapter, "point.hpp")
+    impl_symbols = extract(engine, adapter, "point.cpp")
+    header_get_x = by_qname(header_symbols, "geo.Point.getX")[0]
+    impl_get_x = by_qname(impl_symbols, "geo.Point.getX")[0]
+    assert header_get_x.qualified_name == impl_get_x.qualified_name
+    assert header_get_x.parent == impl_get_x.parent == "geo.Point"
+    assert header_get_x.file_path != impl_get_x.file_path
+    assert header_get_x.kind == impl_get_x.kind == SymbolKind.METHOD
+
+
+def test_out_of_class_overloads_still_distinct(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    impl_symbols = extract(engine, adapter, "point.cpp")
+    moves = by_qname(impl_symbols, "geo.Point.move")
+    assert len(moves) == 2
+    assert {m.signature for m in moves} == {
+        "void Point::move(int dx, int dy)",
+        "void Point::move(double dx, double dy)",
+    }
+
+
+def test_out_of_class_constructor_destructor_operator(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    impl_symbols = extract(engine, adapter, "point.cpp")
+    ctors = by_qname(impl_symbols, "geo.Point.Point")
+    dtor = by_qname(impl_symbols, "geo.Point.~Point")
+    op = by_qname(impl_symbols, "geo.Point.operator+")
+    assert len(ctors) == 2
+    assert len(dtor) == 1
+    assert len(op) == 1
+    assert all(s.kind == SymbolKind.METHOD for s in [*ctors, *dtor, *op])
+
+
+def test_free_function_out_of_class_definition_matches_header(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    header_symbols = extract(engine, adapter, "shapes.hpp")
+    impl_symbols = extract(engine, adapter, "shapes.cpp")
+    header_areas = by_qname(header_symbols, "geo.shapes.area")
+    impl_areas = by_qname(impl_symbols, "geo.shapes.area")
+    assert len(header_areas) == len(impl_areas) == 2
+    assert {a.parent for a in impl_areas} == {"geo.shapes"}
+
+
+def test_fully_qualified_out_of_class_definition(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    """A .cpp file may spell the namespace out in full (`int
+    geo::Point::getX() const`) instead of re-opening it -- both styles must
+    resolve to the same qualified name."""
+    source = b"int geo::Point::getX() const { return 0; }\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "point.cpp")
+    get_x = by_qname(symbols, "geo.Point.getX")
+    assert len(get_x) == 1
+    assert get_x[0].parent == "geo.Point"
+
+
+def test_deeply_nested_qualified_definition(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    source = b"void geo::inner::Foo::bar() {}\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "foo.cpp")
+    bar = by_qname(symbols, "geo.inner.Foo.bar")
+    assert len(bar) == 1
+    assert bar[0].parent == "geo.inner.Foo"
+
+
+def test_no_duplicate_symbols_within_impl_file(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    """Every definition in point.cpp is a distinct declaration site (no
+    accidental double-extraction of the same node)."""
+    symbols = extract(engine, adapter, "point.cpp")
+    locations = [(s.qualified_name, s.start_line) for s in symbols if s.kind != SymbolKind.MODULE]
+    assert len(locations) == len(set(locations))
+
+
+def test_no_orphaned_out_of_class_symbols(engine: TreeSitterEngine, adapter: CppAdapter) -> None:
+    """Every out-of-class method definition resolves a real parent -- none
+    fall back to a None/empty parent, which would misfile them as free
+    functions at file scope."""
+    symbols = extract(engine, adapter, "point.cpp")
+    methods = [s for s in symbols if s.kind == SymbolKind.METHOD]
+    assert len(methods) == 8
+    assert all(s.parent == "geo.Point" for s in methods)
+
+
+def test_out_of_class_overload_symbol_ids_disambiguate(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    source = (FIXTURES_DIR / "point.cpp").read_bytes()
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "point.cpp")
+    parsed = ParsedFile(
+        path="point.cpp", language="cpp", symbols=symbols, lines=source.count(b"\n")
+    )
+    chunks = ASTChunker().chunk_file(parsed, source)
+    all_ids = [c.symbol_id for c in chunks]
+    assert len(all_ids) == len(set(all_ids))
+
+
+def test_member_template_out_of_class_definition_does_not_crash(
+    engine: TreeSitterEngine, adapter: CppAdapter
+) -> None:
+    """Documented, accepted limitation (see GRAMMAR_EVALUATION.md): an
+    out-of-class template-member definition's scope text carries the
+    template placeholder (`Box<T>`), so it will not nest under the
+    header-declared primary template's plain `Box` in the outline tree --
+    but it must still extract as a valid, non-crashing, non-colliding
+    symbol rather than being dropped or raising."""
+    source = b"template <typename T>\nT Box<T>::get() const { return T(); }\n"
+    tree = parse(engine, source)
+    symbols = adapter.extract_symbols(tree, source, "box.cpp")
+    assert len(symbols) == 1
+    assert symbols[0].name == "get"
+    assert symbols[0].kind == SymbolKind.METHOD
+    assert symbols[0].parent == "Box<T>"


### PR DESCRIPTION
## Stack

Stack-Id: `m10-cpp-full-tier-20260704`
Base: `feat/m10-cpp-import-contract`
Position: 4/5

1. `feat/m10-cpp-fixtures` -> #404
2. `feat/m10-cpp-adapter-core` -> #405
3. `feat/m10-cpp-import-contract` -> #406
4. `feat/m10-cpp-header-impl` -> this PR
5. `feat/m10-cpp-full-tier` -> (next)

Depends on: #406
Upstack: feat/m10-cpp-full-tier

## Summary

DEVELOPMENT_PLAN.md M10, PR-4: adds the `qualified_identifier` declarator
branch to `_extract_function_like` (previously deferred in PR-2), enabling
out-of-class member definitions -- the `.cpp` half of a header/impl split
(`Point::getX() { ... }`).

- Not mixed with PR-2's qualified-name-uniqueness scope: this PR only adds
  one new `elif` branch plus a `_split_qualified_scope` helper. Overload
  handling itself is untouched.
- Handles both the namespace-reopened (`Point::getX`) and fully-qualified
  (`geo::Point::getX`) spelling styles identically, including multi-level
  nesting (`geo::inner::Foo::bar`).
- Header declaration and impl definition resolve to the same
  `qualified_name` in different files: no `symbol_id` collision (file_path
  differs) and no orphan (parent always resolves to the enclosing class).
- Documents and tests one accepted, non-blocking limitation: an out-of-class
  *template*-member definition's scope text carries the template
  placeholder (`Box<T>`), so it extracts as a valid, correctly named,
  non-crashing symbol but does not nest under the primary template's plain
  `Box` in the outline tree -- real template code is overwhelmingly
  header-only for exactly this reason.

## Validation

- `uv run pytest tests/parse/adapters/test_cpp.py -v`: 71 passed
- `uv run ruff check src/archex/parse/adapters/cpp.py`: clean
- `uv run ruff format --check src/archex/parse/adapters/cpp.py`: clean
- `uv run pyright src/archex/parse/adapters/cpp.py tests/parse/adapters/test_cpp.py`: 0 errors