### PR TITLE
feat(languages)!: promote C++ to full tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,8 +370,8 @@ For the full trust contract, including exact MCP JSON, Docker commands, cache lo
 
 | Tier | Languages | Extraction |
 | --- | --- | --- |
-| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift, PHP, Ruby, Scala, C | Symbols, imports, graph edges |
-| `chunk-only` | C++, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity | AST chunking + retrieval; no symbol/import graph claim |
+| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift, PHP, Ruby, Scala, C, C++ | Symbols, imports, graph edges |
+| `chunk-only` | Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity | AST chunking + retrieval; no symbol/import graph claim |
 | `unknown` | any other text file | line-window chunks for BM25 visibility |
 
 Need another language? Register an adapter via Python entry points. See [System Design](docs/SYSTEM_DESIGN.md) for the extension contract.

--- a/benchmarks/tasks/archex_adapter_registry.yaml
+++ b/benchmarks/tasks/archex_adapter_registry.yaml
@@ -16,14 +16,14 @@ expected_regions:
   - path: src/archex/parse/adapters/__init__.py
     granularity: symbol
     symbol: AdapterRegistry
-    start_line: 28
-    end_line: 83
+    start_line: 29
+    end_line: 84
     notes: "Registry construction, lookup, instantiation, and entry-point loading."
   - path: src/archex/parse/adapters/__init__.py
     granularity: block
     symbol: default_adapter_registry
-    start_line: 86
-    end_line: 102
+    start_line: 87
+    end_line: 104
     notes: "Built-in adapter registration table."
   - path: src/archex/parse/adapters/python.py
     granularity: symbol

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -213,8 +213,8 @@ Language support is declared, not implied. `full` means symbol extraction, impor
 
 | Tier | Languages |
 | --- | --- |
-| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift, PHP, Ruby, Scala, C |
-| `chunk-only` | C++, Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity |
+| `full` | Python, JavaScript, TypeScript/TSX, Go, Rust, Java, Kotlin, C#, Swift, PHP, Ruby, Scala, C, C++ |
+| `chunk-only` | Lua, Bash/Shell, SQL, HTML, CSS, XML, YAML, TOML, JSON, Markdown, Solidity |
 
 Unknown files fall back to line-window chunking so they can still be found by BM25 without pretending to have structural edges.
 

--- a/src/archex/languages.py
+++ b/src/archex/languages.py
@@ -37,20 +37,7 @@ LANGUAGE_SUPPORT: dict[str, LanguageSupport] = {
     "swift": LanguageSupport("swift", "Swift", (".swift",), _FULL, "swift"),
     "c": LanguageSupport("c", "C", (".c", ".h"), _FULL, "c"),
     "cpp": LanguageSupport(
-        "cpp",
-        "C++",
-        (".cc", ".cpp", ".cxx", ".hpp", ".hh", ".hxx"),
-        _CHUNK,
-        "cpp",
-        frozenset(
-            {
-                "function_definition",
-                "class_specifier",
-                "struct_specifier",
-                "namespace_definition",
-                "preproc_include",
-            }
-        ),
+        "cpp", "C++", (".cc", ".cpp", ".cxx", ".hpp", ".hh", ".hxx"), _FULL, "cpp"
     ),
     "php": LanguageSupport("php", "PHP", (".php",), _FULL, "php"),
     "ruby": LanguageSupport("ruby", "Ruby", (".rb",), _FULL, "ruby"),

--- a/src/archex/parse/adapters/__init__.py
+++ b/src/archex/parse/adapters/__init__.py
@@ -10,6 +10,7 @@ from archex.languages import CHUNK_ONLY_LANGUAGE_IDS
 from archex.parse.adapters.base import LanguageAdapter
 from archex.parse.adapters.c import CAdapter
 from archex.parse.adapters.chunk_only import make_chunk_only_adapter
+from archex.parse.adapters.cpp import CppAdapter
 from archex.parse.adapters.csharp import CSharpAdapter
 from archex.parse.adapters.go import GoAdapter
 from archex.parse.adapters.java import JavaAdapter
@@ -98,6 +99,7 @@ default_adapter_registry.register("php", PHPAdapter)  # type: ignore[type-abstra
 default_adapter_registry.register("ruby", RubyAdapter)  # type: ignore[type-abstract]
 default_adapter_registry.register("scala", ScalaAdapter)  # type: ignore[type-abstract]
 default_adapter_registry.register("c", CAdapter)  # type: ignore[type-abstract]
+default_adapter_registry.register("cpp", CppAdapter)  # type: ignore[type-abstract]
 for _language_id in sorted(CHUNK_ONLY_LANGUAGE_IDS):
     default_adapter_registry.register(_language_id, make_chunk_only_adapter(_language_id))
 

--- a/tests/parse/test_language_coverage.py
+++ b/tests/parse/test_language_coverage.py
@@ -14,11 +14,6 @@ from archex.serve.profile import build_profile
 FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
 
 CHUNK_ONLY_SAMPLES: dict[str, tuple[str, str, list[tuple[int, int]]]] = {
-    "cpp": (
-        "main.cpp",
-        "#include <vector>\nnamespace n { class C { public: void m(){} }; int f(){return 1;} }\n",
-        [(1, 1), (2, 2)],
-    ),
     "lua": (
         "app.lua",
         'require("json")\nfunction f(x) return x end\nlocal t = { a = 1 }\n',
@@ -85,6 +80,7 @@ FULL_LANGUAGE_FIXTURES: dict[str, Path] = {
     "ruby": FIXTURES_DIR / "ruby_simple",
     "scala": FIXTURES_DIR / "scala_simple",
     "c": FIXTURES_DIR / "c_simple",
+    "cpp": FIXTURES_DIR / "cpp_simple",
 }
 
 


### PR DESCRIPTION
## Stack

Stack-Id: `m10-cpp-full-tier-20260704`
Base: `feat/m10-cpp-header-impl`
Position: 5/5 (leaf)

1. `feat/m10-cpp-fixtures` -> #404
2. `feat/m10-cpp-adapter-core` -> #405
3. `feat/m10-cpp-import-contract` -> #406
4. `feat/m10-cpp-header-impl` -> #407
5. `feat/m10-cpp-full-tier` -> this PR

Depends on: #407
Upstack: (none - leaf)

## Summary

DEVELOPMENT_PLAN.md M10, PR-5 (final): flips `cpp` from `LanguageTier.CHUNK_ONLY`
to `LanguageTier.FULL`, registers `CppAdapter` in the default adapter
registry, moves `cpp_simple` fixtures from `test_language_coverage.py`'s
`CHUNK_ONLY_SAMPLES` to `FULL_LANGUAGE_FIXTURES`, and updates the
language-support tables in `README.md`/`docs/SYSTEM_DESIGN.md`. Second
commit fixes a stale `expected_regions` line-number drift in
`benchmarks/tasks/archex_adapter_registry.yaml` caused by this milestone's
new import/registration lines in `parse/adapters/__init__.py`.

**BREAKING CHANGE:** `.cc`/`.cpp`/`.cxx`/`.hpp`/`.hh`/`.hxx` files are now
parsed at `LanguageTier.FULL` instead of `LanguageTier.CHUNK_ONLY`.

## M10 acceptance criteria (DEVELOPMENT_PLAN.md)

- ✅ `archex outline` on a C++ fixture with overloaded functions produces
  distinct, non-colliding symbol entries for each overload.
- ✅ `archex doctor` reports C++ as a working full-tier grammar.
- ✅ M5's regression gate passes against the pre-promotion baseline.

## M5 gate result

Unlike M9 (C), which found and had to investigate a structural
token_efficiency dilution regression on `archex_adapter_registry` (resolved
via a documented baseline ratchet), this promotion produces **zero**
regressions and **zero** ranking violations against the *existing*,
unmodified `.archex/baselines/pre-promotion.json` — no baseline
regeneration was needed:

```
uv run archex dogfood --all --baseline .archex/baselines/pre-promotion.json
24 tasks, 0 regressions, 0 ranking violations (168 metric comparisons)
archex_adapter_registry / archex_query / token_efficiency: 0.5329 -> 0.5566 (+0.024, improvement)
```

## Verification

- `uv run pytest tests/parse/adapters/test_cpp.py -v`: 71 passed
- `uv run pytest tests/parse/test_language_coverage.py -v`: passed
- `uv run pytest`: 3210 passed, 4 deselected, 91.07% coverage
- `uv run ruff check .` / `uv run ruff format --check .`: clean
- `uv run pyright`: 0 errors, 0 warnings, 0 informations
- `uv run archex benchmark validate`: all 64 tasks valid
- `uv run archex doctor .`: full grammars 15/15 available (was 14), chunk-only
  11/11 (was 12) -- cpp reports as a working full-tier grammar
- `uv run archex outline . tests/fixtures/cpp_simple/point.hpp`: `move`
  overloads and constructor overloads each appear as distinct, correctly
  line-ranged, correctly signed symbol entries
- `uv run archex outline . tests/fixtures/cpp_simple/pair.hpp`: `Pair` and
  `Pair<int>` (explicit specialization) appear as distinct top-level class
  entries
- `uv run archex dogfood --all --baseline .archex/baselines/pre-promotion.json`:
  24 tasks, 0 regressions, 0 ranking violations