### PR TITLE
feat(language): handle structured tier call sites

### DIFF
--- a/src/archex/doctor.py
+++ b/src/archex/doctor.py
@@ -130,15 +130,26 @@ def render_doctor_text(report: DoctorReport) -> str:
             lines.append(f"  network: {check.details.get('network_implications', '')}")
         if check.name == "grammars":
             full_value = check.details.get("full", {})
+            structured_value = check.details.get("structured", {})
             chunk_value = check.details.get("chunk_only", {})
-            if isinstance(full_value, dict) and isinstance(chunk_value, dict):
+            if (
+                isinstance(full_value, dict)
+                and isinstance(structured_value, dict)
+                and isinstance(chunk_value, dict)
+            ):
                 full = cast("dict[str, object]", full_value)
+                structured = cast("dict[str, object]", structured_value)
                 chunk = cast("dict[str, object]", chunk_value)
                 full_available = _int_value(full.get("available", 0))
                 full_total = _int_value(full.get("total", 0))
+                structured_available = _int_value(structured.get("available", 0))
+                structured_total = _int_value(structured.get("total", 0))
                 chunk_available = _int_value(chunk.get("available", 0))
                 chunk_total = _int_value(chunk.get("total", 0))
                 lines.append(f"  full grammars: {full_available}/{full_total} available")
+                lines.append(
+                    f"  structured grammars: {structured_available}/{structured_total} available"
+                )
                 lines.append(f"  chunk-only grammars: {chunk_available}/{chunk_total} available")
     return "\n".join(lines).rstrip() + "\n"
 
@@ -410,16 +421,8 @@ def _network_implications(downloads: list[object]) -> str:
 def _grammar_check() -> DoctorCheck:
     engine = TreeSitterEngine()
     missing: dict[str, str] = {}
-    available_by_tier: dict[LanguageTier, int] = {
-        LanguageTier.FULL: 0,
-        LanguageTier.CHUNK_ONLY: 0,
-        LanguageTier.UNKNOWN: 0,
-    }
-    total_by_tier: dict[LanguageTier, int] = {
-        LanguageTier.FULL: 0,
-        LanguageTier.CHUNK_ONLY: 0,
-        LanguageTier.UNKNOWN: 0,
-    }
+    available_by_tier: dict[LanguageTier, int] = {tier: 0 for tier in LanguageTier}
+    total_by_tier: dict[LanguageTier, int] = {tier: 0 for tier in LanguageTier}
     for language_id, support in sorted(LANGUAGE_SUPPORT.items()):
         total_by_tier[support.tier] += 1
         try:
@@ -433,6 +436,10 @@ def _grammar_check() -> DoctorCheck:
         "full": {
             "available": available_by_tier[LanguageTier.FULL],
             "total": total_by_tier[LanguageTier.FULL],
+        },
+        "structured": {
+            "available": available_by_tier[LanguageTier.STRUCTURED],
+            "total": total_by_tier[LanguageTier.STRUCTURED],
         },
         "chunk_only": {
             "available": available_by_tier[LanguageTier.CHUNK_ONLY],

--- a/src/archex/languages.py
+++ b/src/archex/languages.py
@@ -18,8 +18,13 @@ class LanguageSupport:
     pack_name: str
     chunk_node_types: frozenset[str] = frozenset()
 
+    def __post_init__(self) -> None:
+        if self.tier is LanguageTier.STRUCTURED and not self.chunk_node_types:
+            raise ValueError("STRUCTURED languages must declare outline chunk_node_types")
+
 
 _FULL = LanguageTier.FULL
+_STRUCTURED = LanguageTier.STRUCTURED
 _CHUNK = LanguageTier.CHUNK_ONLY
 UNKNOWN_LANGUAGE_ID = "unknown"
 UNKNOWN_LINE_WINDOW = 80
@@ -166,6 +171,11 @@ CHUNK_ONLY_LANGUAGE_IDS: frozenset[str] = frozenset(
     language_id
     for language_id, support in LANGUAGE_SUPPORT.items()
     if support.tier == LanguageTier.CHUNK_ONLY
+)
+STRUCTURED_LANGUAGE_IDS: frozenset[str] = frozenset(
+    language_id
+    for language_id, support in LANGUAGE_SUPPORT.items()
+    if support.tier == LanguageTier.STRUCTURED
 )
 
 

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -6,9 +6,13 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from archex import doctor
 from archex.cli.main import cli
+from archex.doctor import DoctorCheck, DoctorReport, render_doctor_text
+from archex.languages import LanguageSupport
 from archex.metrics.health import record_metrics_failure
 from archex.metrics.storage import metrics_db_path
+from archex.models import LanguageTier
 from archex.project import init_project
 
 
@@ -200,3 +204,113 @@ vector = true
     assert details["embedding"]["model"] is None
     assert details["embedding"]["vector_requested"] is True
     assert details["network_downloads_required"] == []
+
+
+def test_grammar_check_reports_structured_bucket_distinct_from_full_and_chunk_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    full_support = LanguageSupport(
+        language_id="python",
+        display_name="Python",
+        extensions=(".py",),
+        tier=LanguageTier.FULL,
+        pack_name="python",
+    )
+    chunk_support = LanguageSupport(
+        language_id="sql",
+        display_name="SQL",
+        extensions=(".sql",),
+        tier=LanguageTier.CHUNK_ONLY,
+        pack_name="sql",
+    )
+    structured_support = LanguageSupport(
+        language_id="structured_stub",
+        display_name="Structured Stub",
+        extensions=(".structstub",),
+        tier=LanguageTier.STRUCTURED,
+        pack_name="structured_stub",
+        chunk_node_types=frozenset({"section"}),
+    )
+    monkeypatch.setattr(
+        doctor,
+        "LANGUAGE_SUPPORT",
+        {"python": full_support, "sql": chunk_support, "structured_stub": structured_support},
+    )
+
+    class _AlwaysLoadsEngine:
+        def get_language(self, language_id: str) -> object:
+            return object()
+
+    monkeypatch.setattr(doctor, "TreeSitterEngine", _AlwaysLoadsEngine)
+
+    check = doctor._grammar_check()  # pyright: ignore[reportPrivateUsage]
+
+    assert check.status == "ok"
+    assert check.details["full"] == {"available": 1, "total": 1}
+    assert check.details["chunk_only"] == {"available": 1, "total": 1}
+    assert check.details["structured"] == {"available": 1, "total": 1}
+
+
+def test_grammar_check_missing_structured_grammar_is_non_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    full_support = LanguageSupport(
+        language_id="python",
+        display_name="Python",
+        extensions=(".py",),
+        tier=LanguageTier.FULL,
+        pack_name="python",
+    )
+    structured_support = LanguageSupport(
+        language_id="structured_stub",
+        display_name="Structured Stub",
+        extensions=(".structstub",),
+        tier=LanguageTier.STRUCTURED,
+        pack_name="structured_stub",
+        chunk_node_types=frozenset({"section"}),
+    )
+    monkeypatch.setattr(
+        doctor, "LANGUAGE_SUPPORT", {"python": full_support, "structured_stub": structured_support}
+    )
+
+    class _SelectiveEngine:
+        def get_language(self, language_id: str) -> object:
+            if language_id == "structured_stub":
+                raise RuntimeError("no grammar available")
+            return object()
+
+    monkeypatch.setattr(doctor, "TreeSitterEngine", _SelectiveEngine)
+
+    check = doctor._grammar_check()  # pyright: ignore[reportPrivateUsage]
+
+    assert check.status == "warning"
+    assert check.details["structured"] == {"available": 0, "total": 1}
+    missing = check.details["missing"]
+    assert isinstance(missing, dict)
+    assert "structured_stub" in missing
+
+
+def test_render_doctor_text_includes_structured_grammar_line() -> None:
+    report = DoctorReport(
+        repo_root=Path("/tmp/repo"),
+        status="ok",
+        checks=[
+            DoctorCheck(
+                name="grammars",
+                status="ok",
+                message="all declared tree-sitter grammars load",
+                details={
+                    "full": {"available": 3, "total": 3},
+                    "chunk_only": {"available": 2, "total": 2},
+                    "structured": {"available": 1, "total": 1},
+                    "missing": {},
+                },
+            )
+        ],
+    )
+
+    text = render_doctor_text(report)
+
+    assert "full grammars: 3/3 available" in text
+    assert "chunk-only grammars: 2/2 available" in text
+    assert "structured grammars: 1/1 available" in text

--- a/tests/index/test_graph.py
+++ b/tests/index/test_graph.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from archex import languages
 from archex.index.graph import DependencyGraph
+from archex.languages import LanguageSupport, get_language_tier
 from archex.models import (
     Edge,
     EdgeConfidence,
     EdgeKind,
     ImportStatement,
+    LanguageTier,
     ParsedFile,
     Symbol,
     SymbolKind,
@@ -16,6 +19,8 @@ from archex.models import (
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    import pytest
 
 
 def _make_parsed_files() -> list[ParsedFile]:
@@ -117,6 +122,47 @@ def test_resolved_import_edges_are_extracted_with_evidence() -> None:
     assert edge.confidence == EdgeConfidence.EXTRACTED
     assert edge.confidence_score == 1.0
     assert edge.evidence == ["resolved import 'models' at main.py:1"]
+
+
+def test_structured_tier_parsed_file_emits_import_edge_without_symbols(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = LanguageSupport(
+        language_id="structured_stub",
+        display_name="Structured Stub",
+        extensions=(".structstub",),
+        tier=LanguageTier.STRUCTURED,
+        pack_name="structured_stub",
+        chunk_node_types=frozenset({"section"}),
+    )
+    monkeypatch.setitem(languages.LANGUAGE_SUPPORT, "structured_stub", stub)
+    assert get_language_tier("structured_stub") == LanguageTier.STRUCTURED
+
+    parsed_files = [
+        ParsedFile(path="pkg/main.structstub", language="structured_stub", symbols=[], lines=6),
+        ParsedFile(path="pkg/shared.structstub", language="structured_stub", symbols=[], lines=3),
+    ]
+    import_map = {
+        "pkg/main.structstub": [
+            ImportStatement(
+                module="./shared.structstub",
+                file_path="pkg/main.structstub",
+                line=1,
+                is_relative=True,
+                resolved_path="pkg/shared.structstub",
+            ),
+        ],
+        "pkg/shared.structstub": [],
+    }
+
+    graph = DependencyGraph.from_parsed_files(parsed_files, import_map)
+
+    assert graph.symbol_count == 0
+    [edge] = graph.file_edges()
+    assert edge.source == "pkg/main.structstub"
+    assert edge.target == "pkg/shared.structstub"
+    assert edge.kind == EdgeKind.IMPORTS
+    assert edge.confidence == EdgeConfidence.EXTRACTED
 
 
 def test_neighborhood_bfs() -> None:

--- a/tests/serve/test_profile.py
+++ b/tests/serve/test_profile.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
+
+from archex import languages
 from archex.analyze.interfaces import extract_interfaces
 from archex.index.graph import DependencyGraph
+from archex.languages import LanguageSupport
 from archex.models import (
     ArchProfile,
     ImportStatement,
+    LanguageTier,
     ParsedFile,
     RepoMetadata,
     Symbol,
@@ -132,3 +140,33 @@ def test_dependency_graph_summary() -> None:
 
     assert profile.dependency_graph.file_count == 2
     assert profile.dependency_graph.edges == 1
+
+
+def test_build_profile_reports_structured_tier_for_registered_language(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = LanguageSupport(
+        language_id="structured_stub",
+        display_name="Structured Stub",
+        extensions=(".structstub",),
+        tier=LanguageTier.STRUCTURED,
+        pack_name="structured_stub",
+        chunk_node_types=frozenset({"section"}),
+    )
+    monkeypatch.setitem(languages.LANGUAGE_SUPPORT, "structured_stub", stub)
+
+    parsed = [
+        ParsedFile(path="widget.structstub", language="structured_stub", symbols=[], lines=5),
+    ]
+    metadata = RepoMetadata(
+        local_path="/tmp/test_repo",
+        languages={"structured_stub": 1},
+        total_files=1,
+        total_lines=5,
+    )
+    import_map: dict[str, list[ImportStatement]] = {"widget.structstub": []}
+    graph = DependencyGraph.from_parsed_files(parsed, import_map)
+
+    profile = build_profile(metadata, parsed, graph)
+
+    assert profile.stats.languages["structured_stub"].tier == LanguageTier.STRUCTURED

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import pytest
 
 from archex.languages import (
     LANGUAGE_SUPPORT,
@@ -8,9 +8,6 @@ from archex.languages import (
     get_language_tier,
 )
 from archex.models import LanguageTier
-
-if TYPE_CHECKING:
-    import pytest
 
 
 def test_stub_registered_structured_language_reports_structured(
@@ -37,3 +34,14 @@ def test_stub_registered_structured_language_reports_structured(
 
 def test_unknown_language_still_reports_unknown() -> None:
     assert get_language_tier("missing-language") == LanguageTier.UNKNOWN
+
+
+def test_structured_language_requires_outline_chunk_nodes() -> None:
+    with pytest.raises(ValueError, match="STRUCTURED languages must declare"):
+        LanguageSupport(
+            language_id="structured_stub",
+            display_name="Structured Stub",
+            extensions=(".stub",),
+            tier=LanguageTier.STRUCTURED,
+            pack_name="json",
+        )


### PR DESCRIPTION
## Summary

- Adds `STRUCTURED_LANGUAGE_IDS` while keeping `CHUNK_ONLY_LANGUAGE_IDS` strictly chunk-only.
- Enforces that STRUCTURED registry entries declare outline `chunk_node_types`.
- Reports structured grammar counts separately in doctor JSON/text output.
- Adds regression coverage for doctor, profile, and graph handling of a stub structured language.

## Stack

Stack-Id: `structured-tier-m11-0704`
Base: `feat/structured-tier-enum-audit`
Position: 2/3

1. `feat/structured-tier-enum-audit` -> #409
2. `feat/structured-tier-call-sites` -> this PR (#410)
3. `feat/structured-tier-adapter` -> #411

Depends on: #409
Upstack: #411

## Validation

- `uv run pytest tests/cli/test_doctor.py tests/index/test_graph.py tests/serve/test_profile.py -v --no-cov`: passed
- `uv run ruff check src/archex/doctor.py src/archex/languages.py tests/cli/test_doctor.py tests/index/test_graph.py tests/serve/test_profile.py`: passed
- `uv run pyright src/archex/doctor.py src/archex/languages.py tests/cli/test_doctor.py tests/index/test_graph.py tests/serve/test_profile.py`: passed
- Cumulative leaf validation is recorded on #411.

## Files

- `src/archex/doctor.py`
- `src/archex/languages.py`
- `tests/cli/test_doctor.py`
- `tests/index/test_graph.py`
- `tests/serve/test_profile.py`
- `tests/test_languages.py`
