### PR TITLE
feat(parse): add structured adapter base

### DIFF
--- a/src/archex/parse/adapters/__init__.py
+++ b/src/archex/parse/adapters/__init__.py
@@ -6,7 +6,7 @@ import importlib.metadata
 import logging
 
 from archex.exceptions import ConfigError
-from archex.languages import CHUNK_ONLY_LANGUAGE_IDS
+from archex.languages import CHUNK_ONLY_LANGUAGE_IDS, STRUCTURED_LANGUAGE_IDS
 from archex.parse.adapters.base import LanguageAdapter
 from archex.parse.adapters.c import CAdapter
 from archex.parse.adapters.chunk_only import make_chunk_only_adapter
@@ -20,6 +20,7 @@ from archex.parse.adapters.python import PythonAdapter
 from archex.parse.adapters.ruby import RubyAdapter
 from archex.parse.adapters.rust import RustAdapter
 from archex.parse.adapters.scala import ScalaAdapter
+from archex.parse.adapters.structured import make_structured_adapter
 from archex.parse.adapters.swift import SwiftAdapter
 from archex.parse.adapters.typescript import TypeScriptAdapter
 
@@ -102,6 +103,8 @@ default_adapter_registry.register("c", CAdapter)  # type: ignore[type-abstract]
 default_adapter_registry.register("cpp", CppAdapter)  # type: ignore[type-abstract]
 for _language_id in sorted(CHUNK_ONLY_LANGUAGE_IDS):
     default_adapter_registry.register(_language_id, make_chunk_only_adapter(_language_id))
+for _language_id in sorted(STRUCTURED_LANGUAGE_IDS):
+    default_adapter_registry.register(_language_id, make_structured_adapter(_language_id))
 
 # Legacy compat
 ADAPTERS: dict[str, type[LanguageAdapter]] = default_adapter_registry.adapter_classes

--- a/src/archex/parse/adapters/structured.py
+++ b/src/archex/parse/adapters/structured.py
@@ -1,0 +1,155 @@
+"""Shared STRUCTURED-tier adapter base.
+
+STRUCTURED languages expose outline chunks and native file references without
+claiming programming symbols. Concrete adapters override ``extract_references``
+for language-native reference syntax and inherit the chunk-node-driven outline
+logic used by chunk-only languages.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, final
+
+from archex.languages import LanguageSupport, get_language_support
+from archex.models import (
+    ChunkRange,
+    DiscoveredFile,
+    ImportStatement,
+    LanguageTier,
+    Symbol,
+    Visibility,
+)
+
+
+class StructuredAdapter:
+    """Base adapter for outline-plus-reference languages with no code symbols."""
+
+    _language_id: str = ""
+
+    def __init__(self) -> None:
+        self._support()
+
+    def _support(self) -> LanguageSupport:
+        support = get_language_support(self._language_id)
+        if support is None:
+            raise ValueError(f"STRUCTURED adapter language {self._language_id!r} is not registered")
+        if support.tier is not LanguageTier.STRUCTURED:
+            raise ValueError(
+                f"STRUCTURED adapter language {self._language_id!r} is registered as {support.tier}"
+            )
+        return support
+
+    @property
+    def language_id(self) -> str:
+        return self._language_id
+
+    @property
+    def file_extensions(self) -> list[str]:
+        return list(self._support().extensions)
+
+    @property
+    def tree_sitter_name(self) -> str:
+        return self._support().pack_name
+
+    @final
+    def extract_symbols(self, tree: object, source: bytes, file_path: str) -> list[Symbol]:
+        return []
+
+    def extract_references(
+        self, tree: object, source: bytes, file_path: str
+    ) -> list[ImportStatement]:
+        return []
+
+    def parse_imports(self, tree: object, source: bytes, file_path: str) -> list[ImportStatement]:
+        return self.extract_references(tree, source, file_path)
+
+    def resolve_import(self, imp: ImportStatement, file_map: dict[str, str]) -> str | None:
+        if imp.is_relative or _is_relative_reference(imp.module):
+            return _resolve_relative_reference(imp.module, imp.file_path, file_map)
+        return _resolve_direct_reference(imp.module, file_map)
+
+    def detect_entry_points(self, files: list[DiscoveredFile]) -> list[str]:
+        return []
+
+    def classify_visibility(self, symbol: Symbol) -> Visibility:
+        return Visibility.PUBLIC
+
+    def extract_chunk_ranges(self, tree: object, source: bytes, file_path: str) -> list[ChunkRange]:
+        support = self._support()
+
+        root = _root_node(tree)
+        ranges: list[ChunkRange] = []
+        for node in _walk_named(root):
+            if node.type not in support.chunk_node_types:
+                continue
+            start_line = int(node.start_point[0]) + 1
+            end_row = int(node.end_point[0])
+            end_column = int(node.end_point[1])
+            end_line = end_row + 1 if end_column > 0 else end_row
+            if end_line < start_line:
+                continue
+            ranges.append(ChunkRange(start_line=start_line, end_line=end_line))
+        return _deduplicate_ranges(ranges)
+
+
+def make_structured_adapter(language_id: str) -> type[StructuredAdapter]:
+    class _Adapter(StructuredAdapter):
+        _language_id = language_id
+
+    _Adapter.__name__ = f"{language_id.title().replace('_', '')}StructuredAdapter"
+    return _Adapter
+
+
+def _resolve_direct_reference(module: str, file_map: dict[str, str]) -> str | None:
+    normalized = os.path.normpath(module).replace(os.sep, "/")
+    values = {os.path.normpath(path).replace(os.sep, "/"): path for path in file_map.values()}
+    if normalized in values:
+        return values[normalized]
+    if _is_path_reference(normalized) and normalized in file_map:
+        return file_map[normalized]
+    return None
+
+
+def _is_relative_reference(reference: str) -> bool:
+    return reference.startswith("./") or reference.startswith("../")
+
+
+def _is_path_reference(reference: str) -> bool:
+    return "/" in reference or bool(os.path.splitext(reference)[1])
+
+
+def _resolve_relative_reference(
+    module: str,
+    file_path: str,
+    file_map: dict[str, str],
+) -> str | None:
+    base_dir = os.path.dirname(file_path)
+    candidate = os.path.normpath(os.path.join(base_dir, module)).replace(os.sep, "/")
+    return _resolve_direct_reference(candidate, file_map)
+
+
+def _root_node(tree: object) -> Any:
+    parsed_tree: Any = tree
+    return parsed_tree.root_node
+
+
+def _walk_named(node: Any) -> list[Any]:
+    children = [child for child in node.children if child.is_named]
+    result: list[Any] = []
+    for child in children:
+        result.append(child)
+        result.extend(_walk_named(child))
+    return result
+
+
+def _deduplicate_ranges(ranges: list[ChunkRange]) -> list[ChunkRange]:
+    ranges.sort(key=lambda item: (item.start_line, item.end_line))
+    result: list[ChunkRange] = []
+    last_end = 0
+    for item in ranges:
+        if item.start_line <= last_end:
+            continue
+        result.append(item)
+        last_end = item.end_line
+    return result

--- a/tests/parse/adapters/test_structured.py
+++ b/tests/parse/adapters/test_structured.py
@@ -1,0 +1,264 @@
+"""Tests for the shared STRUCTURED-tier base adapter.
+
+`StructuredAdapter` (src/archex/parse/adapters/structured.py) is the M11 base
+for outline-plus-native-cross-reference languages: it must never claim
+programming symbols, must produce chunk-node-driven outline ranges the same
+way `ChunkOnlyAdapter` does, and must route `parse_imports` through an
+overridable `extract_references` hook so concrete languages (HTML, XML, ...)
+can extract native cross-file references without re-implementing the
+outline/symbol invariants.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from archex import languages
+from archex.languages import LanguageSupport
+from archex.models import ChunkRange, ImportStatement, LanguageTier
+from archex.parse.adapters.structured import StructuredAdapter, make_structured_adapter
+
+_REF_PATTERN = re.compile(r'ref="([^"]+)"')
+
+# A tiny two-"section" fixture with a filler node of a different named type
+# (must be excluded from the outline) and a native reference embedded in the
+# second section (must be extracted by the hook).
+FIXTURE_SOURCE = (
+    b"<section>Intro</section>\n"
+    b"<note>see also</note>\n"
+    b'<section ref="./shared.struct">Details</section>\n'
+)
+
+
+class _FakeNode:
+    """Minimal duck-typed stand-in for a tree-sitter node.
+
+    Only the attributes `extract_chunk_ranges`'s named-node walk relies on:
+    `.children`, `.is_named`, `.type`, `.start_point`, `.end_point`.
+    """
+
+    def __init__(
+        self,
+        node_type: str,
+        start_line: int,
+        end_line: int,
+        *,
+        is_named: bool = True,
+        children: list[_FakeNode] | None = None,
+    ) -> None:
+        self.type = node_type
+        self.is_named = is_named
+        self.start_point = (start_line - 1, 0)
+        self.end_point = (end_line - 1, 10)
+        self.children: list[_FakeNode] = children or []
+
+
+class _FakeTree:
+    def __init__(self, root: _FakeNode) -> None:
+        self.root_node = root
+
+
+def _fixture_tree() -> _FakeTree:
+    root = _FakeNode(
+        "document",
+        1,
+        3,
+        children=[
+            _FakeNode("section", 1, 1),
+            _FakeNode("note", 2, 2),
+            _FakeNode("section", 3, 3),
+        ],
+    )
+    return _FakeTree(root)
+
+
+class _StubStructuredAdapter(StructuredAdapter):
+    """Stands in for a future concrete adapter (e.g. M12's html.py)."""
+
+    _language_id = "structured_stub"
+
+    def extract_references(
+        self, tree: object, source: bytes, file_path: str
+    ) -> list[ImportStatement]:
+        references: list[ImportStatement] = []
+        for line_no, line in enumerate(source.decode("utf-8").splitlines(), start=1):
+            match = _REF_PATTERN.search(line)
+            if match is None:
+                continue
+            target = match.group(1)
+            references.append(
+                ImportStatement(
+                    module=target,
+                    file_path=file_path,
+                    line=line_no,
+                    is_relative=target.startswith("./") or target.startswith("../"),
+                )
+            )
+        return references
+
+
+@pytest.fixture
+def _structured_stub_registered(  # pyright: ignore[reportUnusedFunction]
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = LanguageSupport(
+        language_id="structured_stub",
+        display_name="Structured Stub",
+        extensions=(".structstub",),
+        tier=LanguageTier.STRUCTURED,
+        pack_name="structured_stub",
+        chunk_node_types=frozenset({"section"}),
+    )
+    monkeypatch.setitem(languages.LANGUAGE_SUPPORT, "structured_stub", stub)
+
+
+def test_extract_chunk_ranges_produces_outline_only_for_declared_node_types(
+    _structured_stub_registered: None,
+) -> None:
+    adapter = _StubStructuredAdapter()
+
+    ranges = adapter.extract_chunk_ranges(_fixture_tree(), FIXTURE_SOURCE, "pkg/main.struct")
+
+    assert ranges == [
+        ChunkRange(start_line=1, end_line=1),
+        ChunkRange(start_line=3, end_line=3),
+    ]
+
+
+def test_extract_symbols_never_claims_programming_symbols(
+    _structured_stub_registered: None,
+) -> None:
+    adapter = _StubStructuredAdapter()
+
+    assert adapter.extract_symbols(_fixture_tree(), FIXTURE_SOURCE, "pkg/main.struct") == []
+
+
+def test_parse_imports_delegates_to_extract_references_hook(
+    _structured_stub_registered: None,
+) -> None:
+    adapter = _StubStructuredAdapter()
+    tree = _fixture_tree()
+
+    imports = adapter.parse_imports(tree, FIXTURE_SOURCE, "pkg/main.struct")
+
+    assert imports == adapter.extract_references(tree, FIXTURE_SOURCE, "pkg/main.struct")
+    assert len(imports) == 1
+    assert imports[0].module == "./shared.struct"
+    assert imports[0].line == 3
+    assert imports[0].is_relative is True
+
+
+def test_resolve_import_resolves_relative_local_reference(
+    _structured_stub_registered: None,
+) -> None:
+    adapter = _StubStructuredAdapter()
+    imp = ImportStatement(
+        module="./shared.struct",
+        file_path="pkg/main.struct",
+        line=3,
+        is_relative=True,
+    )
+
+    resolved = adapter.resolve_import(imp, {"pkg/shared.struct": "pkg/shared.struct"})
+
+    assert resolved == "pkg/shared.struct"
+
+
+def test_resolve_import_matches_production_file_map_values(
+    _structured_stub_registered: None,
+) -> None:
+    adapter = _StubStructuredAdapter()
+    imp = ImportStatement(
+        module="./shared.struct",
+        file_path="pkg/main.struct",
+        line=3,
+        is_relative=True,
+    )
+
+    resolved = adapter.resolve_import(imp, {"pkg.shared": "pkg/shared.struct"})
+
+    assert resolved == "pkg/shared.struct"
+
+
+def test_resolve_import_infers_relative_reference_syntax(
+    _structured_stub_registered: None,
+) -> None:
+    adapter = _StubStructuredAdapter()
+    imp = ImportStatement(
+        module="./shared.struct",
+        file_path="pkg/main.struct",
+        line=3,
+        is_relative=False,
+    )
+
+    resolved = adapter.resolve_import(imp, {"pkg.shared": "pkg/shared.struct"})
+
+    assert resolved == "pkg/shared.struct"
+
+
+def test_resolve_import_accepts_direct_file_map_match(
+    _structured_stub_registered: None,
+) -> None:
+    adapter = _StubStructuredAdapter()
+    imp = ImportStatement(
+        module="pkg/shared.struct",
+        file_path="pkg/main.struct",
+        line=4,
+        is_relative=False,
+    )
+
+    resolved = adapter.resolve_import(imp, {"pkg/shared.struct": "pkg/shared.struct"})
+
+    assert resolved == "pkg/shared.struct"
+
+
+def test_make_structured_adapter_sets_language_id_and_name(
+    _structured_stub_registered: None,
+) -> None:
+    adapter_cls = make_structured_adapter("structured_stub")
+
+    assert adapter_cls.__name__ == "StructuredStubStructuredAdapter"
+    assert adapter_cls().language_id == "structured_stub"
+    assert adapter_cls().tree_sitter_name == "structured_stub"
+    assert adapter_cls().file_extensions == [".structstub"]
+
+
+def test_structured_adapter_rejects_wrong_tier_language(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chunk_support = LanguageSupport(
+        language_id="chunk_stub",
+        display_name="Chunk Stub",
+        extensions=(".chunkstub",),
+        tier=LanguageTier.CHUNK_ONLY,
+        pack_name="chunk_stub",
+        chunk_node_types=frozenset({"section"}),
+    )
+    monkeypatch.setitem(languages.LANGUAGE_SUPPORT, "chunk_stub", chunk_support)
+
+    adapter_cls = make_structured_adapter("chunk_stub")
+    with pytest.raises(ValueError, match="registered as"):
+        adapter_cls()
+
+
+def test_structured_adapter_rejects_unregistered_language() -> None:
+    adapter_cls = make_structured_adapter("missing_structured_stub")
+
+    with pytest.raises(ValueError, match="not registered"):
+        adapter_cls()
+
+
+def test_resolve_import_returns_none_for_unresolvable_reference(
+    _structured_stub_registered: None,
+) -> None:
+    adapter = _StubStructuredAdapter()
+    imp = ImportStatement(
+        module="https://example.com/shared.struct",
+        file_path="pkg/main.struct",
+        line=5,
+        is_relative=False,
+    )
+
+    assert adapter.resolve_import(imp, {"pkg/shared.struct": "pkg/shared.struct"}) is None


### PR DESCRIPTION
## Summary

- Adds `src/archex/parse/adapters/structured.py` as the shared STRUCTURED-tier base adapter.
- Registers `STRUCTURED_LANGUAGE_IDS` in the default adapter registry through `make_structured_adapter()` so future concrete STRUCTURED languages are first-class parser adapters.
- Preserves the no-programming-symbol invariant via `extract_symbols() -> []`.
- Fails fast at adapter construction when a STRUCTURED adapter is unregistered or bound to a non-STRUCTURED language id.
- Reuses declared `chunk_node_types` for outline chunk ranges and routes native references through `parse_imports()` -> `extract_references()` -> `resolve_import()`.
- Adds stub structured adapter tests for outline extraction, reference extraction, local relative reference resolution through production-style file maps, adapter registry wiring, wrong-tier/unregistered rejection, and unresolved external references.

## Stack

Stack-Id: `structured-tier-m11-0704`
Base: `feat/structured-tier-call-sites`
Position: 3/3

1. `feat/structured-tier-enum-audit` -> #409
2. `feat/structured-tier-call-sites` -> #410
3. `feat/structured-tier-adapter` -> this PR (#411)

Depends on: #410
Upstack: none (leaf)

## Validation

- `uv run pytest tests/parse/adapters/test_structured.py tests/parse/test_adapter_registry.py -v --no-cov`: passed, 16 passed
- `uv run ruff check src/archex/parse/adapters/structured.py src/archex/parse/adapters/__init__.py tests/parse/adapters/test_structured.py`: passed
- `uv run pyright src/archex/parse/adapters/structured.py src/archex/parse/adapters/__init__.py tests/parse/adapters/test_structured.py`: passed
- Cumulative leaf validation on this stack after final amendments:
  - `uv run pytest tests/test_languages.py tests/index/ tests/serve/ -v --no-cov`: passed, 923 passed, 2 deselected
  - `uv run pytest`: passed, 3229 passed, 4 deselected, coverage 91.10%
  - `uv run ruff check src/archex/models.py src/archex/languages.py`: passed
  - `uv run pyright`: passed
  - `uv run ruff check src/archex/doctor.py src/archex/languages.py src/archex/models.py src/archex/parse/adapters/__init__.py src/archex/parse/adapters/structured.py tests/cli/test_doctor.py tests/index/test_graph.py tests/parse/adapters/test_structured.py tests/serve/test_profile.py tests/test_languages.py`: passed
  - `uv run ruff format --check src/archex/doctor.py src/archex/languages.py src/archex/models.py src/archex/parse/adapters/__init__.py src/archex/parse/adapters/structured.py tests/cli/test_doctor.py tests/index/test_graph.py tests/parse/adapters/test_structured.py tests/serve/test_profile.py tests/test_languages.py`: passed
  - `uv run pyright src/archex/doctor.py src/archex/languages.py src/archex/models.py src/archex/parse/adapters/__init__.py src/archex/parse/adapters/structured.py tests/cli/test_doctor.py tests/index/test_graph.py tests/parse/adapters/test_structured.py tests/serve/test_profile.py tests/test_languages.py`: passed

## Files

- `src/archex/parse/adapters/__init__.py`
- `src/archex/parse/adapters/structured.py`
- `tests/parse/adapters/test_structured.py`
