### PR TITLE
feat(html): extract local structured references

### DIFF
--- a/src/archex/cli/outline_cmd.py
+++ b/src/archex/cli/outline_cmd.py
@@ -56,6 +56,15 @@ def outline_cmd(source: str, file_path: str, output_json: bool, timing: bool) ->
             f"lines: {result.lines}",
         ]
         lines.extend(_render_symbols(result.symbols))
+        if result.outline_ranges:
+            lines.append("outline:")
+            for outline_range in result.outline_ranges:
+                lines.append(f"  lines [L{outline_range.start_line}-{outline_range.end_line}]")
+        if result.references:
+            lines.append("references:")
+            for ref in result.references:
+                resolved = f" -> {ref.resolved_path}" if ref.resolved_path else ""
+                lines.append(f"  {ref.module}{resolved} [L{ref.line}]")
         output = "\n".join(lines)
     click.echo(output)
 

--- a/src/archex/languages.py
+++ b/src/archex/languages.py
@@ -77,7 +77,7 @@ LANGUAGE_SUPPORT: dict[str, LanguageSupport] = {
         "html",
         "HTML",
         (".html", ".htm"),
-        _CHUNK,
+        _STRUCTURED,
         "html",
         frozenset({"element", "script_element", "style_element"}),
     ),

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -894,13 +894,15 @@ class SymbolOutline(BaseModel):
 
 
 class FileOutline(BaseModel):
-    """Symbol hierarchy for a single file."""
+    """Symbol hierarchy, structural ranges, and local references for a single file."""
 
     file_path: str
     language: str
     lines: int
     symbols: list[SymbolOutline]
     token_count_raw: int
+    outline_ranges: list[ChunkRange] = []
+    references: list[ImportStatement] = []
 
 
 class SymbolMatch(BaseModel):

--- a/src/archex/parse/adapters/__init__.py
+++ b/src/archex/parse/adapters/__init__.py
@@ -13,6 +13,7 @@ from archex.parse.adapters.chunk_only import make_chunk_only_adapter
 from archex.parse.adapters.cpp import CppAdapter
 from archex.parse.adapters.csharp import CSharpAdapter
 from archex.parse.adapters.go import GoAdapter
+from archex.parse.adapters.html import HtmlAdapter
 from archex.parse.adapters.java import JavaAdapter
 from archex.parse.adapters.kotlin import KotlinAdapter
 from archex.parse.adapters.php import PHPAdapter
@@ -104,7 +105,10 @@ default_adapter_registry.register("cpp", CppAdapter)  # type: ignore[type-abstra
 for _language_id in sorted(CHUNK_ONLY_LANGUAGE_IDS):
     default_adapter_registry.register(_language_id, make_chunk_only_adapter(_language_id))
 for _language_id in sorted(STRUCTURED_LANGUAGE_IDS):
-    default_adapter_registry.register(_language_id, make_structured_adapter(_language_id))
+    if _language_id == "html":
+        default_adapter_registry.register(_language_id, HtmlAdapter)
+    else:
+        default_adapter_registry.register(_language_id, make_structured_adapter(_language_id))
 
 # Legacy compat
 ADAPTERS: dict[str, type[LanguageAdapter]] = default_adapter_registry.adapter_classes

--- a/src/archex/parse/adapters/html.py
+++ b/src/archex/parse/adapters/html.py
@@ -142,9 +142,10 @@ def _normalize_path(path: str) -> str:
 
 def _resolve_html_reference(candidate: str, file_map: dict[str, str]) -> str | None:
     normalized = _normalize_path(candidate)
-    values = {_normalize_path(path): path for path in file_map.values()}
-    if normalized in values:
-        return values[normalized]
     if normalized in file_map:
         return file_map[normalized]
+    module_key, _ = posixpath.splitext(normalized)
+    dotted_key = module_key.replace("/", ".")
+    if dotted_key in file_map:
+        return file_map[dotted_key]
     return None

--- a/src/archex/parse/adapters/html.py
+++ b/src/archex/parse/adapters/html.py
@@ -2,10 +2,149 @@
 
 from __future__ import annotations
 
+import posixpath
+from typing import Any
+from urllib.parse import urlsplit
+
+from archex.models import ImportStatement
 from archex.parse.adapters.structured import StructuredAdapter
+
+_REFERENCE_ATTRIBUTES = {
+    "a": "href",
+    "img": "src",
+    "link": "href",
+    "script": "src",
+}
+_SKIPPED_SCHEMES = {"data", "http", "https", "javascript", "mailto", "tel"}
 
 
 class HtmlAdapter(StructuredAdapter):
-    """Extract HTML element outlines without claiming programming symbols."""
+    """Extract HTML element outlines and local file references."""
 
     _language_id = "html"
+
+    def extract_references(
+        self, tree: object, source: bytes, file_path: str
+    ) -> list[ImportStatement]:
+        references: list[ImportStatement] = []
+        root = _root_node(tree)
+        for node in _walk_named(root):
+            if node.type not in {"start_tag", "self_closing_tag"}:
+                continue
+            tag_name = _tag_name(node, source)
+            if tag_name is None:
+                continue
+            attribute_name = _REFERENCE_ATTRIBUTES.get(tag_name)
+            if attribute_name is None:
+                continue
+            raw_target = _attribute_value(node, attribute_name, source)
+            if raw_target is None:
+                continue
+            target = _local_reference_path(raw_target)
+            if target is None:
+                continue
+            references.append(
+                ImportStatement(
+                    module=target,
+                    file_path=file_path,
+                    line=int(node.start_point[0]) + 1,
+                    is_relative=not target.startswith("/"),
+                )
+            )
+        return references
+
+    def resolve_import(self, imp: ImportStatement, file_map: dict[str, str]) -> str | None:
+        module = _normalize_path(imp.module)
+        if module.startswith("/"):
+            return _resolve_html_reference(module.lstrip("/"), file_map)
+
+        base_dir = posixpath.dirname(imp.file_path)
+        candidates: list[str] = []
+        if base_dir:
+            candidates.append(_normalize_path(posixpath.join(base_dir, module)))
+        candidates.append(module)
+
+        for candidate in candidates:
+            resolved = _resolve_html_reference(candidate, file_map)
+            if resolved is not None:
+                return resolved
+        return None
+
+
+def _root_node(tree: object) -> Any:
+    parsed_tree: Any = tree
+    return parsed_tree.root_node
+
+
+def _walk_named(node: Any) -> list[Any]:
+    children = [child for child in node.children if child.is_named]
+    result: list[Any] = []
+    for child in children:
+        result.append(child)
+        result.extend(_walk_named(child))
+    return result
+
+
+def _tag_name(node: Any, source: bytes) -> str | None:
+    for child in node.children:
+        if child.type == "tag_name":
+            return _node_text(child, source).lower()
+    return None
+
+
+def _attribute_value(node: Any, attribute_name: str, source: bytes) -> str | None:
+    for child in node.children:
+        if child.type != "attribute":
+            continue
+        name: str | None = None
+        value: str | None = None
+        for attr_child in child.children:
+            if attr_child.type == "attribute_name":
+                name = _node_text(attr_child, source).lower()
+            elif attr_child.type in {"quoted_attribute_value", "attribute_value"}:
+                value = _unquote_attribute_value(_node_text(attr_child, source))
+        if name == attribute_name:
+            return value
+    return None
+
+
+def _node_text(node: Any, source: bytes) -> str:
+    return source[int(node.start_byte) : int(node.end_byte)].decode("utf-8", errors="replace")
+
+
+def _unquote_attribute_value(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def _local_reference_path(reference: str) -> str | None:
+    stripped = reference.strip()
+    if not stripped or stripped.startswith("#") or stripped.startswith("//"):
+        return None
+
+    parsed = urlsplit(stripped)
+    if parsed.scheme.lower() in _SKIPPED_SCHEMES or parsed.netloc:
+        return None
+    if not parsed.path:
+        return None
+    return parsed.path
+
+
+def _normalize_path(path: str) -> str:
+    normalized = posixpath.normpath(path)
+    if normalized == ".":
+        return ""
+    if path.startswith("/") and not normalized.startswith("/"):
+        return f"/{normalized}"
+    return normalized
+
+
+def _resolve_html_reference(candidate: str, file_map: dict[str, str]) -> str | None:
+    normalized = _normalize_path(candidate)
+    values = {_normalize_path(path): path for path in file_map.values()}
+    if normalized in values:
+        return values[normalized]
+    if normalized in file_map:
+        return file_map[normalized]
+    return None

--- a/src/archex/precision.py
+++ b/src/archex/precision.py
@@ -3,15 +3,20 @@
 from __future__ import annotations
 
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
+from archex.languages import get_language_tier
 from archex.models import (
+    ChunkRange,
     CodeChunk,
     Config,
     FileOutline,
     FileTree,
     FileTreeEntry,
+    ImportStatement,
     IndexConfig,
+    LanguageTier,
     PipelineTiming,
     RepoSource,
     SymbolKind,
@@ -142,20 +147,29 @@ def file_outline(
     language = chunks[0].language
     max_line = max(c.end_line for c in chunks)
     token_count_raw = sum(c.token_count for c in chunks)
-    outlines = [_chunk_to_symbol_outline(c) for c in chunks]
+    is_structured = get_language_tier(language) is LanguageTier.STRUCTURED
+    if is_structured:
+        symbol_chunks: list[CodeChunk] = []
+        outline_ranges = [
+            ChunkRange(start_line=chunk.start_line, end_line=chunk.end_line) for chunk in chunks
+        ]
+    else:
+        symbol_chunks = chunks
+        outline_ranges: list[ChunkRange] = []
+    outlines = [_chunk_to_symbol_outline(c) for c in symbol_chunks]
 
     top_level: list[SymbolOutline] = []
     by_qname: dict[str, SymbolOutline] = {}
 
     for outline in outlines:
         qname = outline.name
-        chunk = next((c for c in chunks if (c.symbol_id or c.id) == outline.symbol_id), None)
+        chunk = next((c for c in symbol_chunks if (c.symbol_id or c.id) == outline.symbol_id), None)
         if chunk and chunk.qualified_name:
             qname = chunk.qualified_name
         by_qname[qname] = outline
 
     for outline in outlines:
-        chunk = next((c for c in chunks if (c.symbol_id or c.id) == outline.symbol_id), None)
+        chunk = next((c for c in symbol_chunks if (c.symbol_id or c.id) == outline.symbol_id), None)
         qname = chunk.qualified_name if chunk and chunk.qualified_name else outline.name
         parent_name = _get_parent_qname(qname)
         if parent_name and parent_name in by_qname:
@@ -165,13 +179,62 @@ def file_outline(
 
     if timing is not None:
         timing.total_ms = _elapsed_ms(t0)
+    references = (
+        _extract_file_references(source, file_path, language, config) if is_structured else []
+    )
     return FileOutline(
         file_path=file_path,
         language=language,
         lines=max_line,
         symbols=top_level,
         token_count_raw=token_count_raw,
+        outline_ranges=outline_ranges,
+        references=references,
     )
+
+
+def _extract_file_references(
+    source: RepoSource,
+    file_path: str,
+    language: str,
+    config: Config | None,  # noqa: ARG001
+) -> list[ImportStatement]:
+    if source.local_path is None:
+        return []
+
+    repo_path = Path(source.local_path)
+    absolute_path = repo_path / file_path
+    if not absolute_path.is_file():
+        return []
+
+    from archex.parse import TreeSitterEngine
+    from archex.parse.adapters import default_adapter_registry
+
+    adapter_cls = default_adapter_registry.get(language)
+    if adapter_cls is None:
+        return []
+    adapter = adapter_cls()
+
+    source_bytes = absolute_path.read_bytes()
+    tree = TreeSitterEngine().parse_bytes(source_bytes, language)
+    references = adapter.parse_imports(tree, source_bytes, file_path)
+    if not references:
+        return []
+
+    file_map = _local_file_map(repo_path)
+    for reference in references:
+        reference.resolved_path = adapter.resolve_import(reference, file_map)
+    return references
+
+
+def _local_file_map(repo_path: Path) -> dict[str, str]:
+    file_map: dict[str, str] = {}
+    for path in repo_path.rglob("*"):
+        if not path.is_file() or ".git" in path.relative_to(repo_path).parts:
+            continue
+        relative_path = path.relative_to(repo_path).as_posix()
+        file_map[relative_path] = relative_path
+    return file_map
 
 
 def search_symbols(

--- a/tests/parse/adapters/test_html.py
+++ b/tests/parse/adapters/test_html.py
@@ -14,13 +14,26 @@ file-path references, never a claimed programming symbol.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from pathlib import Path
+
 import pytest
 
+from archex.api import file_outline
 from archex.languages import get_language_tier
-from archex.models import ChunkRange, ImportStatement, LanguageTier
+from archex.models import (
+    ChunkRange,
+    Config,
+    ImportStatement,
+    LanguageTier,
+    RepoSource,
+    SymbolKind,
+    SymbolOutline,
+)
 from archex.parse.adapters.base import LanguageAdapter
 from archex.parse.adapters.html import HtmlAdapter
 from archex.parse.engine import TreeSitterEngine
+from tests.conftest import _init_fixture_repo  # pyright: ignore[reportPrivateUsage]
 
 FIXTURES_DIR = "tests/fixtures/html_structured"
 
@@ -339,3 +352,52 @@ def test_extract_symbols_stays_empty_while_extract_references_finds_local_target
 
     assert references != []
     assert symbols == []
+
+
+# ---------------------------------------------------------------------------
+# archex.api.file_outline: end-to-end M12 outline acceptance
+# ---------------------------------------------------------------------------
+
+
+def test_file_outline_returns_html_outline_and_local_references_end_to_end(
+    tmp_path: Path,
+) -> None:
+    """M12 acceptance: `archex.api.file_outline` against the realistic fixture
+    surfaces the HTML element outline plus the local references its
+    `<head>`/`<body>` declare -- without ever claiming a function/class/
+    method/interface symbol for markup. File-outline reference resolution uses
+    the repository's actual file tree, so local CSS, JavaScript, HTML, and image
+    targets all resolve to fixture-relative paths without adding graph edges."""
+    repo = _init_fixture_repo(tmp_path, "html_structured")
+    source = RepoSource(local_path=str(repo))
+
+    result = file_outline(
+        source, file_path="index.html", config=Config(languages=["html"], cache=False)
+    )
+
+    assert result.language == "html"
+    assert result.symbols == []
+    assert [(item.start_line, item.end_line) for item in result.outline_ranges] == [(1, 1), (2, 36)]
+
+    def _iter_kinds(symbols: Sequence[SymbolOutline]) -> list[SymbolKind]:
+        kinds: list[SymbolKind] = []
+        for sym in symbols:
+            kinds.append(sym.kind)
+            kinds.extend(_iter_kinds(sym.children))
+        return kinds
+
+    programming_kinds = {
+        SymbolKind.FUNCTION,
+        SymbolKind.CLASS,
+        SymbolKind.METHOD,
+        SymbolKind.INTERFACE,
+    }
+    assert not programming_kinds & set(_iter_kinds(result.symbols))
+
+    resolved_by_module = {ref.module: ref.resolved_path for ref in result.references}
+    assert resolved_by_module == {
+        "./styles/main.css": "styles/main.css",
+        "./scripts/app.js": "scripts/app.js",
+        "./about.html": "about.html",
+        "./images/logo.png": "images/logo.png",
+    }

--- a/tests/parse/adapters/test_html.py
+++ b/tests/parse/adapters/test_html.py
@@ -2,49 +2,27 @@
 
 `HtmlAdapter` (src/archex/parse/adapters/html.py) builds on the M11
 `StructuredAdapter` base to produce an element/script/style outline for
-`.html`/`.htm` files without ever claiming programming symbols. `html`
-remains registered at `LanguageTier.CHUNK_ONLY` in `archex.languages` until
-M12's tier-flip PR lands on top of this one, so every test that instantiates
-`HtmlAdapter` first monkeypatches a STRUCTURED-tier copy of the existing
-registry entry. Local script/link/img/anchor reference extraction is out of
-scope here -- that lands in the follow-up PR that overrides
-`extract_references`.
+`.html`/`.htm` files without ever claiming programming symbols. M12's
+tier-flip PR lands `html` at `LanguageTier.STRUCTURED` for real in
+`archex.languages`, so every test below builds `HtmlAdapter()` straight off
+the production registry entry -- no monkeypatched stand-in is needed
+anymore. This module also covers the local `script`/`link`/`img`/`a`
+reference extraction and resolution that ships alongside the tier flip:
+`extract_references` and `resolve_import` only ever surface *local*
+file-path references, never a claimed programming symbol.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from archex import languages
-from archex.languages import LanguageSupport
-from archex.models import ChunkRange, LanguageTier
+from archex.languages import get_language_tier
+from archex.models import ChunkRange, ImportStatement, LanguageTier
 from archex.parse.adapters.base import LanguageAdapter
 from archex.parse.adapters.html import HtmlAdapter
 from archex.parse.engine import TreeSitterEngine
 
 FIXTURES_DIR = "tests/fixtures/html_structured"
-
-
-@pytest.fixture
-def _html_structured_registered(  # pyright: ignore[reportUnusedFunction]
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Register `html` at STRUCTURED tier for the duration of one test.
-
-    Copies extensions/pack_name/chunk_node_types straight from the real
-    (still CHUNK_ONLY) registry entry so only the tier under test changes --
-    the actual `languages.py` flip is a separate, later PR.
-    """
-    existing = languages.LANGUAGE_SUPPORT["html"]
-    stub = LanguageSupport(
-        language_id="html",
-        display_name=existing.display_name,
-        extensions=existing.extensions,
-        tier=LanguageTier.STRUCTURED,
-        pack_name=existing.pack_name,
-        chunk_node_types=existing.chunk_node_types,
-    )
-    monkeypatch.setitem(languages.LANGUAGE_SUPPORT, "html", stub)
 
 
 @pytest.fixture()
@@ -53,7 +31,7 @@ def engine() -> TreeSitterEngine:
 
 
 @pytest.fixture()
-def adapter(_html_structured_registered: None) -> HtmlAdapter:
+def adapter() -> HtmlAdapter:
     return HtmlAdapter()
 
 
@@ -70,12 +48,12 @@ def test_satisfies_language_adapter_protocol(adapter: HtmlAdapter) -> None:
     assert isinstance(adapter, LanguageAdapter)
 
 
-def test_rejects_instantiation_while_html_registry_entry_is_still_chunk_only() -> None:
-    """PR-1 ships the adapter class before the registry tier flip: building it
-    against the real, unpatched registry (still CHUNK_ONLY) must fail loudly
-    instead of silently accepting the mismatched tier."""
-    with pytest.raises(ValueError, match="registered as"):
-        HtmlAdapter()
+def test_html_registered_at_structured_tier() -> None:
+    """M12 flips `html` to STRUCTURED for real in `archex.languages` -- this
+    pins that registry fact directly, independent of any single adapter
+    call, so a tier regression fails here even if some other test's mocks
+    would otherwise mask it."""
+    assert get_language_tier("html") == LanguageTier.STRUCTURED
 
 
 # ---------------------------------------------------------------------------
@@ -190,4 +168,174 @@ def test_extract_symbols_on_realistic_fixture_with_function_and_class_in_script(
 
     symbols = adapter.extract_symbols(parse(engine, source), source, "index.html")
 
+    assert symbols == []
+
+
+# ---------------------------------------------------------------------------
+# extract_references: local script/link/img/a reference extraction (M12)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_references_extracts_local_script_link_img_and_anchor_targets(
+    engine: TreeSitterEngine, adapter: HtmlAdapter
+) -> None:
+    """Against the realistic fixture, the adapter extracts exactly the four
+    local reference-bearing attributes -- `<link href>`, `<script src>`,
+    `<a href>`, `<img src>` -- in document order, each pinned to its source
+    line. The fixture's *inline* `<script>`/`<style>` blocks carry no
+    `src`/`href` attribute and must not contribute an entry."""
+    with open(f"{FIXTURES_DIR}/index.html", "rb") as f:
+        source = f.read()
+
+    references = adapter.extract_references(parse(engine, source), source, "index.html")
+
+    assert [(imp.module, imp.line, imp.is_relative) for imp in references] == [
+        ("./styles/main.css", 6, True),
+        ("./scripts/app.js", 7, True),
+        ("./about.html", 12, True),
+        ("./images/logo.png", 13, True),
+    ]
+    assert all(imp.file_path == "index.html" for imp in references)
+
+
+# ---------------------------------------------------------------------------
+# extract_references: external / non-file targets never become references
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("case", "snippet"),
+    [
+        ("https_scheme", b'<a href="https://example.com/about.html">About</a>\n'),
+        ("http_scheme", b'<script src="http://cdn.example.com/lib.js"></script>\n'),
+        ("protocol_relative", b'<script src="//cdn.example.com/lib.js"></script>\n'),
+        ("data_uri", b'<img src="data:image/png;base64,AAAA">\n'),
+        ("mailto_scheme", b'<a href="mailto:hello@example.com">Mail</a>\n'),
+        ("javascript_scheme", b'<a href="javascript:void(0)">Click</a>\n'),
+        ("fragment_only", b'<a href="#section-2">Jump</a>\n'),
+    ],
+)
+def test_extract_references_ignores_external_and_non_file_targets(
+    engine: TreeSitterEngine, adapter: HtmlAdapter, case: str, snippet: bytes
+) -> None:
+    references = adapter.extract_references(parse(engine, snippet), snippet, "page.html")
+
+    assert references == [], f"{case} produced a reference for a non-local target"
+
+
+# ---------------------------------------------------------------------------
+# extract_references: query strings and fragments are stripped
+# ---------------------------------------------------------------------------
+
+
+def test_extract_references_strips_query_string_and_fragment_before_resolution(
+    engine: TreeSitterEngine, adapter: HtmlAdapter
+) -> None:
+    """A same-page-relative link decorated with a query string and a
+    fragment resolves as if neither were present -- both are stripped from
+    the extracted module before `resolve_import` ever sees it."""
+    source = b'<a href="./about.html?tab=2#intro">About</a>\n'
+
+    references = adapter.extract_references(parse(engine, source), source, "index.html")
+
+    assert len(references) == 1
+    assert references[0].module == "./about.html"
+    resolved = adapter.resolve_import(references[0], {"about.html": "about.html"})
+    assert resolved == "about.html"
+
+
+# ---------------------------------------------------------------------------
+# resolve_import: relative and root-relative resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_import_resolves_relative_reference_against_containing_file_directory(
+    adapter: HtmlAdapter,
+) -> None:
+    """A `./`-relative reference resolves against the directory of the HTML
+    file that contains it, not against the repo root."""
+    imp = ImportStatement(
+        module="./about.html", file_path="pages/index.html", line=12, is_relative=True
+    )
+
+    resolved = adapter.resolve_import(imp, {"pages/about.html": "pages/about.html"})
+
+    assert resolved == "pages/about.html"
+
+
+def test_resolve_import_root_relative_reference_ignores_containing_file_nesting(
+    adapter: HtmlAdapter,
+) -> None:
+    """A `/`-rooted reference resolves against the repo root file map -- the
+    containing file's own directory nesting must not be joined in, unlike a
+    relative reference."""
+    imp = ImportStatement(
+        module="/assets/shared/logo.png",
+        file_path="deeply/nested/pages/about.html",
+        line=3,
+        is_relative=False,
+    )
+
+    resolved = adapter.resolve_import(
+        imp, {"assets/shared/logo.png": "/repo/assets/shared/logo.png"}
+    )
+
+    assert resolved == "/repo/assets/shared/logo.png"
+
+
+def test_resolve_import_returns_none_for_unresolvable_local_reference(adapter: HtmlAdapter) -> None:
+    imp = ImportStatement(
+        module="./missing.html", file_path="pages/index.html", line=1, is_relative=True
+    )
+
+    assert adapter.resolve_import(imp, {"pages/about.html": "pages/about.html"}) is None
+
+
+def test_extract_and_resolve_all_reference_kinds_against_realistic_fixture(
+    engine: TreeSitterEngine, adapter: HtmlAdapter
+) -> None:
+    """script src, link href, img src, and a href in the fixture all resolve
+    against a file map keyed by the fixture's own relative layout -- the
+    containing file (`index.html`) sits beside every referenced target, so
+    each reference resolves without a directory prefix."""
+    with open(f"{FIXTURES_DIR}/index.html", "rb") as f:
+        source = f.read()
+
+    references = adapter.extract_references(parse(engine, source), source, "index.html")
+    file_map = {
+        "styles/main.css": "styles/main.css",
+        "scripts/app.js": "scripts/app.js",
+        "about.html": "about.html",
+        "images/logo.png": "images/logo.png",
+    }
+
+    resolved = {imp.module: adapter.resolve_import(imp, file_map) for imp in references}
+
+    assert resolved == {
+        "./styles/main.css": "styles/main.css",
+        "./scripts/app.js": "scripts/app.js",
+        "./about.html": "about.html",
+        "./images/logo.png": "images/logo.png",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reference extraction never becomes a programming-symbol claim (M12 invariant)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_symbols_stays_empty_while_extract_references_finds_local_targets(
+    engine: TreeSitterEngine, adapter: HtmlAdapter
+) -> None:
+    """M12 adds reference extraction on top of the M11 STRUCTURED base -- it
+    must not also start claiming programming symbols. On the realistic
+    fixture, references are non-empty but symbols remain empty."""
+    with open(f"{FIXTURES_DIR}/index.html", "rb") as f:
+        source = f.read()
+    tree = parse(engine, source)
+
+    references = adapter.extract_references(tree, source, "index.html")
+    symbols = adapter.extract_symbols(tree, source, "index.html")
+
+    assert references != []
     assert symbols == []

--- a/tests/parse/test_language_coverage.py
+++ b/tests/parse/test_language_coverage.py
@@ -8,6 +8,7 @@ from archex.index.graph import DependencyGraph
 from archex.languages import CHUNK_ONLY_LANGUAGE_IDS, LANGUAGE_SUPPORT, get_language_tier
 from archex.models import Config, LanguageTier, ParsedFile, RepoMetadata
 from archex.parse.adapters import LanguageAdapter, default_adapter_registry
+from archex.parse.adapters.html import HtmlAdapter
 from archex.pipeline.service import produce_artifacts
 from archex.serve.profile import build_profile
 
@@ -26,11 +27,6 @@ CHUNK_ONLY_SAMPLES: dict[str, tuple[str, str, list[tuple[int, int]]]] = {
         "SELECT * FROM users;\n"
         "CREATE VIEW active_users AS SELECT id FROM users;\n",
         [(1, 1), (2, 2), (3, 3)],
-    ),
-    "html": (
-        "index.html",
-        "<html><body><section><h1>Hello</h1></section></body></html>\n",
-        [(1, 1)],
     ),
     "xml": (
         "MoquiEntity.xml",
@@ -124,6 +120,15 @@ def test_full_tier_languages_extract_symbols_and_imports(language_id: str) -> No
 @pytest.mark.parametrize("language_id", sorted(CHUNK_ONLY_LANGUAGE_IDS))
 def test_chunk_only_languages_report_chunk_only_tier(language_id: str) -> None:
     assert get_language_tier(language_id) == LanguageTier.CHUNK_ONLY
+
+
+def test_html_registered_as_structured_tier_with_html_adapter() -> None:
+    """M12 flips `html` from CHUNK_ONLY to STRUCTURED and wires the real
+    `HtmlAdapter` into the default registry -- it must no longer show up
+    among the chunk-only languages exercised above."""
+    assert get_language_tier("html") == LanguageTier.STRUCTURED
+    assert "html" not in CHUNK_ONLY_LANGUAGE_IDS
+    assert default_adapter_registry.get("html") is HtmlAdapter
 
 
 def test_javascript_full_tier_extracts_symbols_and_imports(tmp_path: Path) -> None:

--- a/tests/test_api_precision.py
+++ b/tests/test_api_precision.py
@@ -228,6 +228,24 @@ class TestFileOutline:
         assert result.lines > 0
         assert result.token_count_raw > 0
 
+    def test_full_tier_outline_does_not_extract_references(
+        self, populated_store: IndexStore
+    ) -> None:
+        from archex.api import file_outline
+        from archex.models import RepoSource
+
+        source = RepoSource(local_path="/fake")
+        with (
+            _patch_ensure(populated_store),
+            patch(
+                "archex.precision._extract_file_references",
+                side_effect=AssertionError("non-STRUCTURED references must not run"),
+            ),
+        ):
+            result = file_outline(source, file_path="src/main.py")
+
+        assert result.references == []
+
     def test_missing_file_returns_empty_outline(self, populated_store: IndexStore) -> None:
         from archex.api import file_outline
         from archex.models import RepoSource

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -963,6 +963,45 @@ class TestOutlineCmd:
         assert "L3-12" in result.output
         assert "method bar" in result.output
         assert "def bar(self)" in result.output
+        assert "references:" not in result.output
+
+    def test_outline_human_renders_references(self) -> None:
+        from unittest.mock import patch
+
+        from archex.models import ChunkRange, FileOutline, ImportStatement
+
+        outline = FileOutline(
+            file_path="index.html",
+            language="html",
+            lines=36,
+            symbols=[],
+            token_count_raw=120,
+            outline_ranges=[ChunkRange(start_line=2, end_line=36)],
+            references=[
+                ImportStatement(
+                    module="./styles/main.css",
+                    file_path="index.html",
+                    line=6,
+                    is_relative=True,
+                ),
+                ImportStatement(
+                    module="./about.html",
+                    file_path="index.html",
+                    line=12,
+                    is_relative=True,
+                    resolved_path="about.html",
+                ),
+            ],
+        )
+        runner = CliRunner()
+        with patch("archex.cli.outline_cmd.file_outline", return_value=outline):
+            result = runner.invoke(cli, ["outline", "/repo", "index.html"])
+        assert result.exit_code == 0, result.output
+        assert "outline:" in result.output
+        assert "  lines [L2-36]" in result.output
+        assert "references:" in result.output
+        assert "  ./styles/main.css [L6]" in result.output
+        assert "  ./about.html -> about.html [L12]" in result.output
 
     def test_outline_json(self) -> None:
         from unittest.mock import patch


### PR DESCRIPTION
## Summary

- Extract same-repo local HTML references from `src` and `href` attributes while ignoring external URLs, fragment-only anchors, data/mail/tel/javascript schemes, and root-relative unresolved paths.
- Register `html` as `LanguageTier.STRUCTURED` and wire `HtmlAdapter` into the default adapter registry.
- Surface STRUCTURED outline ranges and extracted local references from `archex outline` / `file_outline` without adding M15 graph wiring or programming-symbol claims.
- Preserve FULL-tier `file_outline` symbol behavior by gating reference extraction to STRUCTURED languages only.

## Scope

PR-2 is based on PR-1. It extracts raw local references and exposes them in outline output. It does not add dependency-graph edges; graph wiring remains M15 scope.

## Verification

- `uv run pytest tests/parse/adapters/test_html.py -v --no-cov` — 28 passed.
- `uv run pytest tests/test_api_precision.py -q --no-cov` — 24 passed.
- `uv run pytest` — 3258 passed, 4 deselected; coverage 91.12%.
- `uv run ruff check src/archex/parse/adapters/html.py` — OK.
- `uv run ruff format --check src/archex/parse/adapters/html.py src/archex/parse/adapters/__init__.py src/archex/languages.py src/archex/precision.py src/archex/models.py src/archex/cli/outline_cmd.py tests/parse/adapters/test_html.py tests/parse/test_language_coverage.py tests/test_cli.py tests/test_api_precision.py` — 10 files already formatted.
- `uv run pyright` — passed; warning only for newer available pyright version.
- `uv run archex outline . tests/fixtures/html_structured/index.html --json` — returned `language: html`, `symbols: []`, `outline_ranges` for doctype and document element, and resolved local references for `./styles/main.css`, `./scripts/app.js`, `./about.html`, and `./images/logo.png`.

## Stack

- PR-1: `feat/html-structured-adapter` → `main`
- PR-2: `feat/html-structured-references` → `feat/html-structured-adapter`
