### PR TITLE
feat(languages): promote YAML to STRUCTURED tier

### DIFF
--- a/src/archex/languages.py
+++ b/src/archex/languages.py
@@ -91,7 +91,7 @@ LANGUAGE_SUPPORT: dict[str, LanguageSupport] = {
     ),
     "xml": LanguageSupport("xml", "XML", (".xml",), _STRUCTURED, "xml", frozenset({"element"})),
     "yaml": LanguageSupport(
-        "yaml", "YAML", (".yaml", ".yml"), _CHUNK, "yaml", frozenset({"document"})
+        "yaml", "YAML", (".yaml", ".yml"), _STRUCTURED, "yaml", frozenset({"document"})
     ),
     "toml": LanguageSupport(
         "toml", "TOML", (".toml",), _CHUNK, "toml", frozenset({"table", "table_array_element"})

--- a/src/archex/parse/adapters/__init__.py
+++ b/src/archex/parse/adapters/__init__.py
@@ -25,6 +25,7 @@ from archex.parse.adapters.structured import make_structured_adapter
 from archex.parse.adapters.swift import SwiftAdapter
 from archex.parse.adapters.typescript import TypeScriptAdapter
 from archex.parse.adapters.xml import XmlAdapter
+from archex.parse.adapters.yaml import YamlAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +111,8 @@ for _language_id in sorted(STRUCTURED_LANGUAGE_IDS):
         default_adapter_registry.register(_language_id, HtmlAdapter)
     elif _language_id == "xml":
         default_adapter_registry.register(_language_id, XmlAdapter)
+    elif _language_id == "yaml":
+        default_adapter_registry.register(_language_id, YamlAdapter)
     else:
         default_adapter_registry.register(_language_id, make_structured_adapter(_language_id))
 

--- a/src/archex/parse/adapters/yaml.py
+++ b/src/archex/parse/adapters/yaml.py
@@ -1,0 +1,83 @@
+"""YAML STRUCTURED-tier adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from archex.models import ImportStatement
+from archex.parse.adapters.structured import StructuredAdapter
+
+
+class YamlAdapter(StructuredAdapter):
+    """Extract YAML document outlines and anchor/alias cross-references.
+
+    YAML's only native cross-reference mechanism is the anchor (`&name`) /
+    alias (`*name`) pair, and it is intra-document by construction -- YAML
+    has no native cross-file import syntax. An alias only counts as a
+    correctly extracted reference when a matching anchor is actually
+    defined somewhere in the same document; an alias with no matching
+    anchor is dropped rather than reported as an unverifiable reference.
+    Because every surfaced reference is confirmed intra-document,
+    `resolve_import` always resolves back to the alias's own containing
+    file.
+    """
+
+    _language_id = "yaml"
+
+    def extract_references(
+        self, tree: object, source: bytes, file_path: str
+    ) -> list[ImportStatement]:
+        root = _root_node(tree)
+        named_nodes = _walk_named(root)
+        anchor_names = {
+            name
+            for node in named_nodes
+            if node.type == "anchor"
+            for name in (_named_child_text(node, "anchor_name", source),)
+            if name is not None
+        }
+
+        references: list[ImportStatement] = []
+        for node in named_nodes:
+            if node.type != "alias":
+                continue
+            alias_name = _named_child_text(node, "alias_name", source)
+            if alias_name is None or alias_name not in anchor_names:
+                continue
+            references.append(
+                ImportStatement(
+                    module=alias_name,
+                    file_path=file_path,
+                    line=int(node.start_point[0]) + 1,
+                    is_relative=False,
+                )
+            )
+        return references
+
+    def resolve_import(self, imp: ImportStatement, file_map: dict[str, str]) -> str | None:
+        return file_map.get(imp.file_path)
+
+
+def _root_node(tree: object) -> Any:
+    parsed_tree: Any = tree
+    return parsed_tree.root_node
+
+
+def _walk_named(node: Any) -> list[Any]:
+    children = [child for child in node.children if child.is_named]
+    result: list[Any] = []
+    for child in children:
+        result.append(child)
+        result.extend(_walk_named(child))
+    return result
+
+
+def _named_child_text(node: Any, child_type: str, source: bytes) -> str | None:
+    for child in node.children:
+        if child.type == child_type:
+            return _node_text(child, source)
+    return None
+
+
+def _node_text(node: Any, source: bytes) -> str:
+    return source[int(node.start_byte) : int(node.end_byte)].decode("utf-8", errors="replace")

--- a/tests/fixtures/yaml_structured/config.yaml
+++ b/tests/fixtures/yaml_structured/config.yaml
@@ -1,0 +1,13 @@
+defaults: &defaults
+  timeout: 30
+  retries: 3
+
+production:
+  <<: *defaults
+  host: prod.example.com
+
+staging:
+  <<: *defaults
+  host: staging.example.com
+
+fallback_host: *undefined_anchor

--- a/tests/parse/adapters/test_yaml.py
+++ b/tests/parse/adapters/test_yaml.py
@@ -1,0 +1,229 @@
+"""Tests for the YAML STRUCTURED-tier adapter.
+
+`YamlAdapter` (src/archex/parse/adapters/yaml.py) builds on the shared
+`StructuredAdapter` base to produce a document outline for `.yaml`/`.yml`
+files plus YAML's native anchor (`&name`) / alias (`*name`) cross-reference
+mechanism, without claiming programming symbols. `yaml` is registered
+at `LanguageTier.STRUCTURED` for real in `archex.languages`, so every
+test below builds `YamlAdapter()` straight off the production registry
+entry -- no monkeypatched stand-in is needed. Anchors/aliases are always
+intra-document (YAML has no native cross-file import syntax), so a
+resolved reference always points back at the alias's own containing file.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from archex.api import file_outline
+from archex.languages import get_language_tier
+from archex.models import (
+    ChunkRange,
+    Config,
+    ImportStatement,
+    LanguageTier,
+    RepoSource,
+    SymbolKind,
+    SymbolOutline,
+)
+from archex.parse.adapters.base import LanguageAdapter
+from archex.parse.adapters.yaml import YamlAdapter
+from archex.parse.engine import TreeSitterEngine
+from tests.conftest import _init_fixture_repo  # pyright: ignore[reportPrivateUsage]
+
+FIXTURES_DIR = "tests/fixtures/yaml_structured"
+
+
+@pytest.fixture()
+def engine() -> TreeSitterEngine:
+    return TreeSitterEngine()
+
+
+@pytest.fixture()
+def adapter() -> YamlAdapter:
+    return YamlAdapter()
+
+
+def parse(engine: TreeSitterEngine, source: bytes) -> object:
+    return engine.parse_bytes(source, "yaml")
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_satisfies_language_adapter_protocol(adapter: YamlAdapter) -> None:
+    assert isinstance(adapter, LanguageAdapter)
+
+
+def test_yaml_registered_at_structured_tier() -> None:
+    """Pins that `yaml` is registered at STRUCTURED tier directly in the
+    registry, independent of any single adapter call, so a tier
+    regression fails here even if some other test's mocks would
+    otherwise mask it."""
+    assert get_language_tier("yaml") == LanguageTier.STRUCTURED
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+def test_language_id(adapter: YamlAdapter) -> None:
+    assert adapter.language_id == "yaml"
+
+
+def test_file_extensions(adapter: YamlAdapter) -> None:
+    assert adapter.file_extensions == [".yaml", ".yml"]
+
+
+def test_tree_sitter_name(adapter: YamlAdapter) -> None:
+    assert adapter.tree_sitter_name == "yaml"
+
+
+# ---------------------------------------------------------------------------
+# extract_chunk_ranges: document outline
+# ---------------------------------------------------------------------------
+
+
+def test_extract_chunk_ranges_covers_whole_document(
+    engine: TreeSitterEngine, adapter: YamlAdapter
+) -> None:
+    with open(f"{FIXTURES_DIR}/config.yaml", "rb") as f:
+        source = f.read()
+
+    ranges = adapter.extract_chunk_ranges(parse(engine, source), source, "config.yaml")
+
+    assert ranges == [ChunkRange(start_line=1, end_line=13)]
+
+
+# ---------------------------------------------------------------------------
+# extract_symbols: never claims programming symbols
+# ---------------------------------------------------------------------------
+
+
+def test_extract_symbols_is_always_empty(engine: TreeSitterEngine, adapter: YamlAdapter) -> None:
+    with open(f"{FIXTURES_DIR}/config.yaml", "rb") as f:
+        source = f.read()
+
+    assert adapter.extract_symbols(parse(engine, source), source, "config.yaml") == []
+
+
+# ---------------------------------------------------------------------------
+# extract_references: anchor/alias native cross-reference extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_references_finds_every_alias_with_a_matching_anchor(
+    engine: TreeSitterEngine, adapter: YamlAdapter
+) -> None:
+    """The fixture merge-keys `<<: *defaults` into both `production` and
+    `staging`, each aliasing the `&defaults` anchor -- both usages must be
+    extracted, each pinned to its own alias line, in document order."""
+    with open(f"{FIXTURES_DIR}/config.yaml", "rb") as f:
+        source = f.read()
+
+    references = adapter.extract_references(parse(engine, source), source, "config.yaml")
+
+    assert [(imp.module, imp.line, imp.is_relative) for imp in references] == [
+        ("defaults", 6, False),
+        ("defaults", 10, False),
+    ]
+    assert all(imp.file_path == "config.yaml" for imp in references)
+
+
+def test_extract_references_drops_an_alias_with_no_matching_anchor(
+    engine: TreeSitterEngine, adapter: YamlAdapter
+) -> None:
+    """`fallback_host: *undefined_anchor` is a syntactically valid alias
+    node, but no `&undefined_anchor` anchor exists anywhere in the
+    document. Reporting it as a 'correctly extracted' reference would be
+    unverifiable, so it must not appear in the extracted list."""
+    with open(f"{FIXTURES_DIR}/config.yaml", "rb") as f:
+        source = f.read()
+    text = source.decode("utf-8")
+    assert "*undefined_anchor" in text
+
+    references = adapter.extract_references(parse(engine, source), source, "config.yaml")
+
+    assert "undefined_anchor" not in [imp.module for imp in references]
+
+
+def test_parse_imports_delegates_to_extract_references(
+    engine: TreeSitterEngine, adapter: YamlAdapter
+) -> None:
+    with open(f"{FIXTURES_DIR}/config.yaml", "rb") as f:
+        source = f.read()
+    tree = parse(engine, source)
+
+    assert adapter.parse_imports(tree, source, "config.yaml") == adapter.extract_references(
+        tree, source, "config.yaml"
+    )
+
+
+# ---------------------------------------------------------------------------
+# resolve_import: anchors/aliases always resolve to their own file
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_import_resolves_to_the_containing_file(adapter: YamlAdapter) -> None:
+    imp = ImportStatement(module="defaults", file_path="config.yaml", line=6, is_relative=False)
+
+    resolved = adapter.resolve_import(imp, {"config.yaml": "config.yaml"})
+
+    assert resolved == "config.yaml"
+
+
+def test_resolve_import_returns_none_when_containing_file_is_absent_from_the_file_map(
+    adapter: YamlAdapter,
+) -> None:
+    imp = ImportStatement(module="defaults", file_path="config.yaml", line=6, is_relative=False)
+
+    assert adapter.resolve_import(imp, {"other.yaml": "other.yaml"}) is None
+
+
+# ---------------------------------------------------------------------------
+# archex.api.file_outline: end-to-end outline acceptance
+# ---------------------------------------------------------------------------
+
+
+def test_file_outline_returns_yaml_outline_and_anchor_alias_references_end_to_end(
+    tmp_path: Path,
+) -> None:
+    """Acceptance for YAML: `archex.api.file_outline` surfaces the
+    document outline plus the two valid `&defaults`/`*defaults`
+    references, resolved to the fixture's own file, without ever claiming
+    a function/class/method/interface symbol for configuration data."""
+    repo = _init_fixture_repo(tmp_path, "yaml_structured")
+    source = RepoSource(local_path=str(repo))
+
+    result = file_outline(
+        source, file_path="config.yaml", config=Config(languages=["yaml"], cache=False)
+    )
+
+    assert result.language == "yaml"
+    assert result.symbols == []
+    assert [(item.start_line, item.end_line) for item in result.outline_ranges] == [(1, 13)]
+
+    resolved_by_line = {ref.line: ref.resolved_path for ref in result.references}
+    assert resolved_by_line == {6: "config.yaml", 10: "config.yaml"}
+    assert all(ref.module == "defaults" for ref in result.references)
+
+    def _iter_kinds(symbols: Sequence[SymbolOutline]) -> list[SymbolKind]:
+        kinds: list[SymbolKind] = []
+        for sym in symbols:
+            kinds.append(sym.kind)
+            kinds.extend(_iter_kinds(sym.children))
+        return kinds
+
+    programming_kinds = {
+        SymbolKind.FUNCTION,
+        SymbolKind.CLASS,
+        SymbolKind.METHOD,
+        SymbolKind.INTERFACE,
+    }
+    assert not programming_kinds & set(_iter_kinds(result.symbols))

--- a/tests/parse/test_language_coverage.py
+++ b/tests/parse/test_language_coverage.py
@@ -33,7 +33,6 @@ CHUNK_ONLY_SAMPLES: dict[str, tuple[str, str, list[tuple[int, int]]]] = {
         '@import url("x.css");\n.foo { color: red; }\n@media screen { .bar { display: none; } }\n',
         [(1, 1), (2, 2), (3, 3)],
     ),
-    "yaml": ("config.yaml", "name: test\nitems:\n  - one\n", [(1, 3)]),
     "toml": ("config.toml", '[a]\nname = "a"\n\n[b]\nname = "b"\n', [(1, 3), (4, 5)]),
     "json": ("data.json", '{"name": "x", "items": [1, 2]}\n', [(1, 1)]),
     "markdown": ("README.md", "# Title\n\nBody\n\n## Section\n\nMore\n", [(1, 7)]),
@@ -121,6 +120,17 @@ def test_xml_registered_as_structured_tier_with_xml_adapter() -> None:
     assert get_language_tier("xml") == LanguageTier.STRUCTURED
     assert "xml" not in CHUNK_ONLY_LANGUAGE_IDS
     assert default_adapter_registry.get("xml") is XmlAdapter
+
+
+def test_yaml_registered_as_structured_tier_with_yaml_adapter() -> None:
+    """`yaml` is flipped from CHUNK_ONLY to STRUCTURED and the real
+    `YamlAdapter` is wired into the default registry -- it must no longer
+    show up among the chunk-only languages exercised above."""
+    from archex.parse.adapters.yaml import YamlAdapter
+
+    assert get_language_tier("yaml") == LanguageTier.STRUCTURED
+    assert "yaml" not in CHUNK_ONLY_LANGUAGE_IDS
+    assert default_adapter_registry.get("yaml") is YamlAdapter
 
 
 def test_javascript_full_tier_extracts_symbols_and_imports(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Add a `YamlAdapter` built on the M11 `StructuredAdapter` base: document outline plus YAML's native anchor (`&name`) / alias (`*name`) cross-reference mechanism.
- Register `yaml` as `LanguageTier.STRUCTURED` and wire `YamlAdapter` into the default adapter registry.
- Add `tests/fixtures/yaml_structured/` fixtures, including an alias with no matching anchor proving unverifiable references are dropped rather than invented.

## Scope

PR-2 of the M13 stack, based on PR-1 (XML). Anchors/aliases are intra-document by construction (YAML has no native cross-file import syntax), so every extracted reference resolves back to its own containing file. An alias is only surfaced when a matching `&anchor` genuinely exists in the same document.

## Verification

- `uv run pytest tests/parse/adapters/test_yaml.py -v --no-cov` — 14 passed.
- `uv run pytest tests/parse/adapters/test_yaml.py tests/parse/adapters/test_xml.py tests/parse/test_language_coverage.py tests/parse/adapters/test_structured.py tests/test_languages.py -v --no-cov` — 74 passed.
- `uv run pytest` — 3281 passed, 4 deselected.
- `uv run ruff check src/archex/parse/adapters/` — OK.
- `uv run ruff format --check src/archex/parse/adapters/yaml.py src/archex/parse/adapters/__init__.py src/archex/languages.py tests/parse/adapters/test_yaml.py tests/parse/test_language_coverage.py` — 5 files already formatted.
- `uv run pyright` — 0 errors, 0 warnings.

## Stack

- PR-1: `feat/m13-xml-structured-adapter` → `main` (#414)
- PR-2: `feat/m13-yaml-structured-adapter` → PR-1 (this PR)
- PR-3: Markdown STRUCTURED adapter → PR-2
- PR-4: CSS STRUCTURED adapter → PR-3
- PR-5: Cross-adapter negative-case verification → PR-4