### PR TITLE
test(parse): cross-adapter negative-case verification for M13

### DIFF
--- a/tests/parse/adapters/test_css.py
+++ b/tests/parse/adapters/test_css.py
@@ -123,6 +123,41 @@ def test_extract_symbols_is_always_empty(engine: TreeSitterEngine, adapter: CssA
     assert adapter.extract_symbols(parse(engine, source), source, "main.css") == []
 
 
+def test_extract_symbols_ignores_selectors_and_custom_properties_named_like_programming_constructs(
+    engine: TreeSitterEngine, adapter: CssAdapter
+) -> None:
+    """A class selector, custom property, and id selector named
+    `function-name`/`class-name`/`interface-id` are still just CSS
+    selectors and properties -- `extract_symbols` is `@final` on the
+    `StructuredAdapter` base and can never be overridden to claim them
+    as programming symbols, regardless of how symbol-shaped the names
+    look."""
+    source = (
+        b".function-name {\n"
+        b"  --class-name: Cart;\n"
+        b"  color: red;\n"
+        b"}\n"
+        b"#interface-id {\n"
+        b"  width: 10px;\n"
+        b"}\n"
+    )
+
+    assert adapter.extract_symbols(parse(engine, source), source, "adversarial.css") == []
+
+
+def test_extract_references_ignores_plain_string_values_outside_url_or_import(
+    engine: TreeSitterEngine, adapter: CssAdapter
+) -> None:
+    """A quoted string value that merely *looks* like a file path (e.g. a
+    `content: "styles/other.css";` declaration) is not CSS's native
+    cross-reference mechanism unless it is wrapped in `url(...)` or is an
+    `@import` target -- treating any path-shaped string as a reference
+    would invent semantics CSS's grammar does not assign to it."""
+    source = b'.a::before { content: "styles/other.css"; }\n'
+
+    assert adapter.extract_references(parse(engine, source), source, "adversarial.css") == []
+
+
 # ---------------------------------------------------------------------------
 # extract_references: @import and url() native reference extraction
 # ---------------------------------------------------------------------------
@@ -246,3 +281,19 @@ def test_file_outline_returns_css_outline_and_resolved_references_end_to_end(
         SymbolKind.INTERFACE,
     }
     assert not programming_kinds & set(_iter_kinds(result.symbols))
+
+
+# ---------------------------------------------------------------------------
+# Cross-stack verification: JSON and TOML are unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_json_and_toml_remain_chunk_only() -> None:
+    """JSON and TOML have no generic cross-file reference syntax and stay
+    `CHUNK_ONLY` permanently. This pins that neither was swept up by the
+    XML/YAML/Markdown/CSS STRUCTURED promotion in this stack."""
+    from archex.languages import CHUNK_ONLY_LANGUAGE_IDS
+
+    assert get_language_tier("json") == LanguageTier.CHUNK_ONLY
+    assert get_language_tier("toml") == LanguageTier.CHUNK_ONLY
+    assert {"json", "toml"} <= CHUNK_ONLY_LANGUAGE_IDS

--- a/tests/parse/adapters/test_markdown.py
+++ b/tests/parse/adapters/test_markdown.py
@@ -123,6 +123,38 @@ def test_extract_symbols_is_always_empty(
     assert adapter.extract_symbols(parse(engine, source), source, "index.md") == []
 
 
+def test_extract_symbols_ignores_fenced_code_blocks_with_real_function_and_class_definitions(
+    engine: TreeSitterEngine, adapter: MarkdownAdapter
+) -> None:
+    """A fenced code block containing a genuine `def`/`class` definition
+    is still just prose content to Markdown -- `extract_symbols` is
+    `@final` on the `StructuredAdapter` base and can never be overridden
+    to reach into a fenced block's language and claim its symbols."""
+    source = (
+        b"# Cart\n\n"
+        b"```python\n"
+        b"def compute_total(items):\n"
+        b"    return sum(items)\n\n"
+        b"class Cart:\n"
+        b"    pass\n"
+        b"```\n"
+    )
+
+    assert adapter.extract_symbols(parse(engine, source), source, "adversarial.md") == []
+
+
+def test_extract_references_ignores_fenced_code_block_content(
+    engine: TreeSitterEngine, adapter: MarkdownAdapter
+) -> None:
+    """The same fenced code block must not leak an import-shaped reference
+    either -- only Markdown's own link/image/reference-definition syntax
+    counts as a native cross-reference, never a fenced block's language
+    content."""
+    source = b"# Cart\n\n```python\nfrom ./sibling import helper\n```\n"
+
+    assert adapter.extract_references(parse(engine, source), source, "adversarial.md") == []
+
+
 # ---------------------------------------------------------------------------
 # extract_references: link / image / reference-style / section-anchor extraction
 # ---------------------------------------------------------------------------
@@ -258,3 +290,19 @@ def test_file_outline_returns_markdown_outline_and_resolved_references_end_to_en
         SymbolKind.INTERFACE,
     }
     assert not programming_kinds & set(_iter_kinds(result.symbols))
+
+
+# ---------------------------------------------------------------------------
+# Cross-stack verification: JSON and TOML are unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_json_and_toml_remain_chunk_only() -> None:
+    """JSON and TOML have no generic cross-file reference syntax and stay
+    `CHUNK_ONLY` permanently. This pins that neither was swept up by the
+    XML/YAML/Markdown/CSS STRUCTURED promotion in this stack."""
+    from archex.languages import CHUNK_ONLY_LANGUAGE_IDS
+
+    assert get_language_tier("json") == LanguageTier.CHUNK_ONLY
+    assert get_language_tier("toml") == LanguageTier.CHUNK_ONLY
+    assert {"json", "toml"} <= CHUNK_ONLY_LANGUAGE_IDS

--- a/tests/parse/adapters/test_xml.py
+++ b/tests/parse/adapters/test_xml.py
@@ -121,6 +121,40 @@ def test_extract_symbols_is_always_empty(engine: TreeSitterEngine, adapter: XmlA
     assert adapter.extract_symbols(parse(engine, source), source, "catalog.xml") == []
 
 
+def test_extract_symbols_ignores_elements_named_like_programming_constructs(
+    engine: TreeSitterEngine, adapter: XmlAdapter
+) -> None:
+    """Elements literally named `<function>`/`<class>`/`<interface>` are
+    still just XML elements -- `extract_symbols` is `@final` on the
+    `StructuredAdapter` base and can never be overridden to claim them as
+    programming symbols, regardless of how symbol-shaped the tag names
+    look."""
+    source = (
+        b'<function name="computeTotal">\n'
+        b'  <class name="Cart"/>\n'
+        b'  <interface implements="Payable"/>\n'
+        b"</function>\n"
+    )
+
+    assert adapter.extract_symbols(parse(engine, source), source, "adversarial.xml") == []
+
+
+def test_extract_references_ignores_elements_named_like_programming_constructs(
+    engine: TreeSitterEngine, adapter: XmlAdapter
+) -> None:
+    """The same symbol-shaped tag names must not leak into references
+    either -- generic XML's `extract_references` stays on the empty-list
+    default no matter what the elements are named."""
+    source = (
+        b'<function name="computeTotal">\n'
+        b'  <class name="Cart"/>\n'
+        b'  <interface implements="Payable"/>\n'
+        b"</function>\n"
+    )
+
+    assert adapter.extract_references(parse(engine, source), source, "adversarial.xml") == []
+
+
 # ---------------------------------------------------------------------------
 # extract_references: generic XML has no native cross-reference mechanism
 # ---------------------------------------------------------------------------
@@ -201,3 +235,54 @@ def test_file_outline_returns_xml_element_outline_with_no_references_end_to_end(
         SymbolKind.INTERFACE,
     }
     assert not programming_kinds & set(_iter_kinds(result.symbols))
+
+
+# ---------------------------------------------------------------------------
+# Cross-stack verification: JSON and TOML are unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_json_remains_chunk_only_and_gained_no_dedicated_adapter() -> None:
+    """JSON has no generic cross-file reference syntax and stays
+    `CHUNK_ONLY` permanently. This pins that JSON was not swept up by the
+    XML/YAML/Markdown/CSS STRUCTURED promotion in this stack, and that no
+    dedicated `archex/parse/adapters/json.py` module was added -- `json`
+    is still served by the generic chunk-only factory, the same as every
+    other untouched `CHUNK_ONLY` language."""
+    import importlib
+
+    from archex.languages import CHUNK_ONLY_LANGUAGE_IDS
+
+    assert get_language_tier("json") == LanguageTier.CHUNK_ONLY
+    assert "json" in CHUNK_ONLY_LANGUAGE_IDS
+
+    from archex.parse.adapters import default_adapter_registry
+
+    json_adapter_cls = default_adapter_registry.get("json")
+    assert json_adapter_cls is not None
+    assert json_adapter_cls.__name__ == "JsonChunkOnlyAdapter"
+    assert json_adapter_cls.__module__ == "archex.parse.adapters.chunk_only"
+
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("archex.parse.adapters.json")
+
+
+def test_toml_remains_chunk_only_and_gained_no_dedicated_adapter() -> None:
+    """Same guarantee as JSON above, for TOML -- both are explicitly out
+    of scope for this stack per the report's exclusion."""
+    import importlib
+
+    from archex.languages import CHUNK_ONLY_LANGUAGE_IDS
+
+    assert get_language_tier("toml") == LanguageTier.CHUNK_ONLY
+    assert "toml" in CHUNK_ONLY_LANGUAGE_IDS
+
+    from archex.parse.adapters import default_adapter_registry
+
+    toml_adapter_cls = default_adapter_registry.get("toml")
+    assert toml_adapter_cls is not None
+    assert toml_adapter_cls.__name__ == "TomlChunkOnlyAdapter"
+    assert toml_adapter_cls.__module__ == "archex.parse.adapters.chunk_only"
+
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("archex.parse.adapters.toml")

--- a/tests/parse/adapters/test_yaml.py
+++ b/tests/parse/adapters/test_yaml.py
@@ -113,6 +113,32 @@ def test_extract_symbols_is_always_empty(engine: TreeSitterEngine, adapter: Yaml
     assert adapter.extract_symbols(parse(engine, source), source, "config.yaml") == []
 
 
+def test_extract_symbols_ignores_keys_named_like_programming_constructs(
+    engine: TreeSitterEngine, adapter: YamlAdapter
+) -> None:
+    """Mapping keys literally named `function`/`class`/`interface` are
+    still just YAML scalar keys -- `extract_symbols` is `@final` on the
+    `StructuredAdapter` base and can never be overridden to claim them
+    as programming symbols, regardless of how symbol-shaped the key
+    names look."""
+    source = b"function: computeTotal\nclass: Cart\ninterface: Payable\n"
+
+    assert adapter.extract_symbols(parse(engine, source), source, "adversarial.yaml") == []
+
+
+def test_extract_references_ignores_plain_scalars_that_look_like_file_paths(
+    engine: TreeSitterEngine, adapter: YamlAdapter
+) -> None:
+    """A plain scalar value that merely *looks* like a relative file path
+    (`path: ./other.yaml`) is not YAML's native cross-reference mechanism
+    -- only a genuine `&anchor`/`*alias` pair is. Treating arbitrary
+    path-shaped strings as references would invent a cross-file import
+    syntax YAML does not have."""
+    source = b"path: ./other.yaml\nfunction: computeTotal\n"
+
+    assert adapter.extract_references(parse(engine, source), source, "adversarial.yaml") == []
+
+
 # ---------------------------------------------------------------------------
 # extract_references: anchor/alias native cross-reference extraction
 # ---------------------------------------------------------------------------
@@ -227,3 +253,33 @@ def test_file_outline_returns_yaml_outline_and_anchor_alias_references_end_to_en
         SymbolKind.INTERFACE,
     }
     assert not programming_kinds & set(_iter_kinds(result.symbols))
+
+
+# ---------------------------------------------------------------------------
+# Cross-stack verification: TOML is unaffected
+# ---------------------------------------------------------------------------
+
+
+def test_toml_remains_chunk_only_and_gained_no_dedicated_adapter() -> None:
+    """TOML has no generic cross-file reference syntax and stays
+    `CHUNK_ONLY` permanently. This pins that TOML was not swept up by the
+    XML/YAML/Markdown/CSS STRUCTURED promotion in this stack, and that no
+    dedicated `archex/parse/adapters/toml.py` module was added -- `toml`
+    is still served by the generic chunk-only factory, the same as every
+    other untouched `CHUNK_ONLY` language."""
+    import importlib
+
+    from archex.languages import CHUNK_ONLY_LANGUAGE_IDS
+
+    assert get_language_tier("toml") == LanguageTier.CHUNK_ONLY
+    assert "toml" in CHUNK_ONLY_LANGUAGE_IDS
+
+    from archex.parse.adapters import default_adapter_registry
+
+    toml_adapter_cls = default_adapter_registry.get("toml")
+    assert toml_adapter_cls is not None
+    assert toml_adapter_cls.__name__ == "TomlChunkOnlyAdapter"
+    assert toml_adapter_cls.__module__ == "archex.parse.adapters.chunk_only"
+
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("archex.parse.adapters.toml")


### PR DESCRIPTION
## Summary

- Confirm JSON and TOML are unaffected by the XML/YAML/Markdown/CSS STRUCTURED promotion: still `CHUNK_ONLY`, still served by the generic chunk-only adapter factory, no dedicated adapter module added for either.
- Add adversarial no-invented-symbol tests to all four new adapter test files: symbol-shaped names (`<function>`/`<class>`/`<interface>` elements, `function`/`class`/`interface` YAML keys, fenced-code-block `def`/`class` definitions, `.function-name`/`--class-name` CSS selectors/properties) never leak into `extract_symbols` or `extract_references`.

## Scope

Final PR of the stack, based on PR-4 (CSS). Touches only the four adapter test files added earlier in this stack — no production code changes.

## Verification

- `uv run pytest tests/parse/adapters/test_xml.py tests/parse/adapters/test_yaml.py tests/parse/adapters/test_markdown.py tests/parse/adapters/test_css.py -v --no-cov` — 107 passed (combined with `tests/parse/test_language_coverage.py`).
- `uv run pytest` — 3328 passed, 4 deselected.
- `uv run ruff check src/archex/parse/adapters/` — OK.
- `uv run ruff format --check tests/parse/adapters/test_xml.py tests/parse/adapters/test_yaml.py tests/parse/adapters/test_markdown.py tests/parse/adapters/test_css.py` — 4 files already formatted.
- `uv run pyright` — 0 errors, 0 warnings.

## Stack

- PR-1: `feat/m13-xml-structured-adapter` → `main` (#414)
- PR-2: `feat/m13-yaml-structured-adapter` → PR-1 (#415)
- PR-3: `feat/m13-markdown-structured-adapter` → PR-2 (#416)
- PR-4: `feat/m13-css-structured-adapter` → PR-3 (#417)
- PR-5: `feat/m13-negative-case-verification` → PR-4 (this PR)