### PR TITLE
chore: drop milestone labels from code and doc comments

### DIFF
--- a/docs/LANGUAGE_PROMOTION_GATE.md
+++ b/docs/LANGUAGE_PROMOTION_GATE.md
@@ -22,7 +22,7 @@ This baseline is a separate artifact from `benchmarks/dogfood_baseline.json` (th
 uv run archex dogfood --all --baseline .archex/baselines/pre-promotion.json --format json
 ```
 
-A clean run against an unpromoted index passes with zero regressions. Each language milestone (M6–M10, M12, M13) re-runs this exact command as part of its own verification before merging; a non-zero exit blocks the milestone.
+A clean run against an unpromoted index passes with zero regressions. Each language-tier promotion milestone re-runs this exact command as part of its own verification before merging; a non-zero exit blocks the milestone.
 
 ## Regenerating the baseline
 

--- a/tests/fixtures/c_simple/GRAMMAR_EVALUATION.md
+++ b/tests/fixtures/c_simple/GRAMMAR_EVALUATION.md
@@ -1,4 +1,4 @@
-# C grammar evaluation (M9 prerequisite)
+# C grammar evaluation
 
 **Grammar:** `tree-sitter/tree-sitter-c`, the official `tree-sitter` GitHub org
 grammar, resolved via the bundled `tree-sitter-language-pack==0.13.0` fallback

--- a/tests/fixtures/cpp_simple/GRAMMAR_EVALUATION.md
+++ b/tests/fixtures/cpp_simple/GRAMMAR_EVALUATION.md
@@ -1,4 +1,4 @@
-# C++ grammar evaluation (M10 prerequisite)
+# C++ grammar evaluation
 
 **Grammar:** `tree-sitter/tree-sitter-cpp`, the official `tree-sitter` GitHub
 org grammar, resolved via the bundled `tree-sitter-language-pack==0.13.0`

--- a/tests/fixtures/php_simple/GRAMMAR_EVALUATION.md
+++ b/tests/fixtures/php_simple/GRAMMAR_EVALUATION.md
@@ -1,4 +1,4 @@
-# PHP grammar evaluation (M6 prerequisite)
+# PHP grammar evaluation
 
 **Grammar:** `tree-sitter/tree-sitter-php` (official, `tree-sitter` GitHub org), resolved via the
 bundled `tree-sitter-language-pack==0.13.0` fallback under the pack name `"php"`

--- a/tests/fixtures/ruby_simple/GRAMMAR_EVALUATION.md
+++ b/tests/fixtures/ruby_simple/GRAMMAR_EVALUATION.md
@@ -1,4 +1,4 @@
-# Ruby grammar evaluation (M7 prerequisite)
+# Ruby grammar evaluation
 
 **Grammar:** bundled Ruby grammar resolved by `tree_sitter_language_pack.get_language("ruby")` and Archex's existing `tree-sitter-language-pack==0.13.0` fallback. No new dependency is required; Ruby already resolves through this grammar at `CHUNK_ONLY` tier.
 

--- a/tests/fixtures/scala_simple/GRAMMAR_EVALUATION.md
+++ b/tests/fixtures/scala_simple/GRAMMAR_EVALUATION.md
@@ -1,4 +1,4 @@
-# Scala grammar evaluation (M8 prerequisite)
+# Scala grammar evaluation
 
 **Grammar:** bundled Scala grammar resolved by `tree_sitter_language_pack.get_language("scala")` and Archex's existing `tree-sitter-language-pack==0.13.0` fallback. No new dependency is required; Scala already resolves through this grammar at `CHUNK_ONLY` tier. The pack maps its `"scala"` key to `tree-sitter/tree-sitter-scala` — an official `tree-sitter` org grammar (the same maturity tier as the bundled Java, Python, and Ruby grammars), not a third-party or single-purpose fork.
 

--- a/tests/parse/adapters/test_html.py
+++ b/tests/parse/adapters/test_html.py
@@ -1,13 +1,13 @@
 """Tests for the HTML STRUCTURED-tier adapter.
 
-`HtmlAdapter` (src/archex/parse/adapters/html.py) builds on the M11
+`HtmlAdapter` (src/archex/parse/adapters/html.py) builds on the shared
 `StructuredAdapter` base to produce an element/script/style outline for
-`.html`/`.htm` files without ever claiming programming symbols. M12's
-tier-flip PR lands `html` at `LanguageTier.STRUCTURED` for real in
-`archex.languages`, so every test below builds `HtmlAdapter()` straight off
-the production registry entry -- no monkeypatched stand-in is needed
-anymore. This module also covers the local `script`/`link`/`img`/`a`
-reference extraction and resolution that ships alongside the tier flip:
+`.html`/`.htm` files without ever claiming programming symbols. `html` is
+registered at `LanguageTier.STRUCTURED` for real in `archex.languages`,
+so every test below builds `HtmlAdapter()` straight off the production
+registry entry -- no monkeypatched stand-in is needed. This module also
+covers the local `script`/`link`/`img`/`a` reference extraction and
+resolution that ships alongside the tier registration:
 `extract_references` and `resolve_import` only ever surface *local*
 file-path references, never a claimed programming symbol.
 """
@@ -62,10 +62,10 @@ def test_satisfies_language_adapter_protocol(adapter: HtmlAdapter) -> None:
 
 
 def test_html_registered_at_structured_tier() -> None:
-    """M12 flips `html` to STRUCTURED for real in `archex.languages` -- this
-    pins that registry fact directly, independent of any single adapter
-    call, so a tier regression fails here even if some other test's mocks
-    would otherwise mask it."""
+    """Pins that `html` is registered at STRUCTURED tier directly in the
+    registry, independent of any single adapter call, so a tier
+    regression fails here even if some other test's mocks would
+    otherwise mask it."""
     assert get_language_tier("html") == LanguageTier.STRUCTURED
 
 
@@ -145,7 +145,7 @@ def test_extract_chunk_ranges_on_realistic_fixture_outlines_the_document_element
 
 
 # ---------------------------------------------------------------------------
-# extract_symbols: never claims programming symbols (M12 invariant)
+# extract_symbols: never claims programming symbols
 # ---------------------------------------------------------------------------
 
 
@@ -185,7 +185,7 @@ def test_extract_symbols_on_realistic_fixture_with_function_and_class_in_script(
 
 
 # ---------------------------------------------------------------------------
-# extract_references: local script/link/img/a reference extraction (M12)
+# extract_references: local script/link/img/a reference extraction
 # ---------------------------------------------------------------------------
 
 
@@ -333,14 +333,14 @@ def test_extract_and_resolve_all_reference_kinds_against_realistic_fixture(
 
 
 # ---------------------------------------------------------------------------
-# Reference extraction never becomes a programming-symbol claim (M12 invariant)
+# Reference extraction never becomes a programming-symbol claim
 # ---------------------------------------------------------------------------
 
 
 def test_extract_symbols_stays_empty_while_extract_references_finds_local_targets(
     engine: TreeSitterEngine, adapter: HtmlAdapter
 ) -> None:
-    """M12 adds reference extraction on top of the M11 STRUCTURED base -- it
+    """Reference extraction is layered on top of the STRUCTURED base -- it
     must not also start claiming programming symbols. On the realistic
     fixture, references are non-empty but symbols remain empty."""
     with open(f"{FIXTURES_DIR}/index.html", "rb") as f:
@@ -355,14 +355,14 @@ def test_extract_symbols_stays_empty_while_extract_references_finds_local_target
 
 
 # ---------------------------------------------------------------------------
-# archex.api.file_outline: end-to-end M12 outline acceptance
+# archex.api.file_outline: end-to-end outline acceptance
 # ---------------------------------------------------------------------------
 
 
 def test_file_outline_returns_html_outline_and_local_references_end_to_end(
     tmp_path: Path,
 ) -> None:
-    """M12 acceptance: `archex.api.file_outline` against the realistic fixture
+    """Acceptance: `archex.api.file_outline` against the realistic fixture
     surfaces the HTML element outline plus the local references its
     `<head>`/`<body>` declare -- without ever claiming a function/class/
     method/interface symbol for markup. File-outline reference resolution uses

--- a/tests/parse/adapters/test_structured.py
+++ b/tests/parse/adapters/test_structured.py
@@ -1,6 +1,6 @@
 """Tests for the shared STRUCTURED-tier base adapter.
 
-`StructuredAdapter` (src/archex/parse/adapters/structured.py) is the M11 base
+`StructuredAdapter` (src/archex/parse/adapters/structured.py) is the shared base
 for outline-plus-native-cross-reference languages: it must never claim
 programming symbols, must produce chunk-node-driven outline ranges the same
 way `ChunkOnlyAdapter` does, and must route `parse_imports` through an
@@ -75,7 +75,7 @@ def _fixture_tree() -> _FakeTree:
 
 
 class _StubStructuredAdapter(StructuredAdapter):
-    """Stands in for a future concrete adapter (e.g. M12's html.py)."""
+    """Stands in for a future concrete adapter (e.g. `html.py`)."""
 
     _language_id = "structured_stub"
 


### PR DESCRIPTION
## Summary

Strips milestone-number labels (M6-M12) out of code comments, docstrings, and shipped docs, per the project's "no plan/phase references in code" convention. Comments should describe what the code does, not which planning milestone introduced it — milestone numbers are ephemeral tracking artifacts, not durable facts about the code.

- `docs/LANGUAGE_PROMOTION_GATE.md`: "Each language milestone (M6–M10, M12, M13)" becomes "Each language-tier promotion milestone".
- `tests/fixtures/{c,cpp,php,ruby,scala}_simple/GRAMMAR_EVALUATION.md`: drop "(M9 prerequisite)"-style heading parentheticals.
- `tests/parse/adapters/test_html.py`, `tests/parse/adapters/test_structured.py`: drop M11/M12 references from module docstrings, test docstrings, and section-header comments; preserve the substantive explanation in each case.

Deliberately excludes `.docs/` (the project's internal planning documents — DEVELOPMENT_PLAN.md, EXECUTION_PROMPTS.md, the enhancement report — whose entire structure is milestone-numbered by design) and PR stack-tracking metadata (titles/bodies), which are process artifacts, not committed code/doc content.

Independent of, and does not conflict with, the open M13 stack (#414-#418), which separately drops its own newly-introduced milestone references as part of its own commits.

## Verification

- `uv run pytest tests/parse/adapters/test_html.py tests/parse/adapters/test_structured.py -q --no-cov` — 39 passed.
- `uv run pytest` — 3258 passed, 4 deselected.
- `uv run ruff check tests/parse/adapters/` — OK.
- `uv run ruff format --check tests/parse/adapters/test_html.py tests/parse/adapters/test_structured.py` — 2 files already formatted.
- `uv run pyright` — 0 errors, 0 warnings.
