### PR TITLE
feat(parse): add Maven POM dialect detection

### DIFF
--- a/src/archex/parse/adapters/xml_maven.py
+++ b/src/archex/parse/adapters/xml_maven.py
@@ -1,0 +1,59 @@
+"""Maven POM XML dialect plugin.
+
+Layered on top of the generic `XmlAdapter` (M13): detects `pom.xml` files
+by filename *and* root element. Dependency extraction and resolution are
+added on top of this detector separately (see the M14 dependency-edge
+milestone).
+
+Detection requires both signals -- filename and root element -- because
+either alone is ambiguous: Apache Ant's `build.xml` also roots on
+`<project>`, and a file that merely happens to be named `pom.xml` is not
+guaranteed to be a real Maven descriptor (e.g. a fixture or unrelated
+config reusing the name).
+"""
+
+from __future__ import annotations
+
+import posixpath
+from typing import Any
+
+_POM_FILENAME = "pom.xml"
+_POM_ROOT_TAG = "project"
+
+
+def is_maven_pom(file_path: str, tree: object, source: bytes) -> bool:
+    """True when `file_path` is a real Maven POM: named `pom.xml` with a
+    `<project>` root element. Neither signal alone is sufficient -- see
+    module docstring."""
+    if posixpath.basename(file_path.replace("\\", "/")) != _POM_FILENAME:
+        return False
+    root = _root_element(tree)
+    if root is None:
+        return False
+    return _element_tag_name(root, source) == _POM_ROOT_TAG
+
+
+# ---------------------------------------------------------------------------
+# tree-sitter-xml node helpers
+# ---------------------------------------------------------------------------
+
+
+def _root_element(tree: object) -> Any | None:
+    parsed_tree: Any = tree
+    for child in parsed_tree.root_node.children:
+        if child.type == "element":
+            return child
+    return None
+
+
+def _element_tag_name(element: Any, source: bytes) -> str | None:
+    for child in element.children:
+        if child.type in ("STag", "EmptyElemTag"):
+            for grandchild in child.children:
+                if grandchild.type == "Name":
+                    return _node_text(grandchild, source)
+    return None
+
+
+def _node_text(node: Any, source: bytes) -> str:
+    return source[int(node.start_byte) : int(node.end_byte)].decode("utf-8", errors="replace")

--- a/tests/fixtures/xml_maven/build.xml
+++ b/tests/fixtures/xml_maven/build.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="fixture-build" default="compile">
+  <target name="compile">
+    <echo message="compiling"/>
+  </target>
+</project>

--- a/tests/fixtures/xml_maven/module-a/pom.xml
+++ b/tests/fixtures/xml_maven/module-a/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>fixture-aggregator</artifactId>
+    <version>1.0.0</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>module-a</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+</project>

--- a/tests/fixtures/xml_maven/module-b/pom.xml
+++ b/tests/fixtures/xml_maven/module-b/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>fixture-aggregator</artifactId>
+    <version>1.0.0</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>module-b</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>module-a</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/tests/fixtures/xml_maven/module-c/pom.xml
+++ b/tests/fixtures/xml_maven/module-c/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>fixture-aggregator</artifactId>
+    <version>1.0.0</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>module-c</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>module-b</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/tests/fixtures/xml_maven/pom.xml
+++ b/tests/fixtures/xml_maven/pom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>fixture-aggregator</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>module-a</module>
+    <module>module-b</module>
+    <module>module-c</module>
+  </modules>
+</project>

--- a/tests/parse/adapters/test_xml_maven.py
+++ b/tests/parse/adapters/test_xml_maven.py
@@ -1,0 +1,108 @@
+"""Tests for the Maven POM XML dialect plugin (M14).
+
+`is_maven_pom` (src/archex/parse/adapters/xml_maven.py) gates every other
+function this dialect plugin adds: a file only ever gets Maven-specific
+treatment when it is named `pom.xml` *and* its root element is
+`<project>`. Both signals are required independently -- Apache Ant's
+`build.xml` also roots on `<project>` but is not named `pom.xml`, and a
+file that happens to be named `pom.xml` but is not a real Maven
+descriptor must not be treated as one either. The false-positive checks
+below run detection directly against M13's generic-XML fixtures
+(`tests/fixtures/xml_structured/`) to confirm the dialect plugin never
+claims ordinary XML.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from archex.parse.adapters.xml_maven import is_maven_pom
+from archex.parse.engine import TreeSitterEngine
+
+FIXTURES_DIR = "tests/fixtures/xml_maven"
+GENERIC_XML_FIXTURES_DIR = "tests/fixtures/xml_structured"
+
+
+@pytest.fixture()
+def engine() -> TreeSitterEngine:
+    return TreeSitterEngine()
+
+
+def parse(engine: TreeSitterEngine, source: bytes) -> object:
+    return engine.parse_bytes(source, "xml")
+
+
+def _read(path: str) -> bytes:
+    return Path(path).read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# is_maven_pom: positive detection across the multi-module fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "pom.xml",
+        "module-a/pom.xml",
+        "module-b/pom.xml",
+        "module-c/pom.xml",
+    ],
+)
+def test_is_maven_pom_detects_every_pom_in_the_multi_module_fixture(
+    engine: TreeSitterEngine, relative_path: str
+) -> None:
+    source = _read(f"{FIXTURES_DIR}/{relative_path}")
+
+    assert is_maven_pom(relative_path, parse(engine, source), source) is True
+
+
+# ---------------------------------------------------------------------------
+# is_maven_pom: false-positive guards
+# ---------------------------------------------------------------------------
+
+
+def test_is_maven_pom_rejects_ant_build_xml_despite_matching_project_root(
+    engine: TreeSitterEngine,
+) -> None:
+    """Apache Ant's `build.xml` also roots on `<project>` -- filename must
+    still gate detection even when the root-element signal matches."""
+    source = _read(f"{FIXTURES_DIR}/build.xml")
+
+    assert is_maven_pom("build.xml", parse(engine, source), source) is False
+
+
+@pytest.mark.parametrize("filename", ["catalog.xml", "library.xml"])
+def test_is_maven_pom_rejects_m13_generic_xml_fixtures_by_filename(
+    engine: TreeSitterEngine, filename: str
+) -> None:
+    """Neither M13 generic-XML fixture is named `pom.xml`, so filename
+    alone must reject both regardless of root-element shape."""
+    source = _read(f"{GENERIC_XML_FIXTURES_DIR}/{filename}")
+
+    assert is_maven_pom(filename, parse(engine, source), source) is False
+
+
+@pytest.mark.parametrize("filename", ["catalog.xml", "library.xml"])
+def test_is_maven_pom_rejects_m13_generic_xml_content_even_when_renamed_to_pom_xml(
+    engine: TreeSitterEngine, filename: str
+) -> None:
+    """Isolates the root-element signal: even if one of M13's fixtures
+    were renamed to `pom.xml`, neither `<catalog>` nor `<library>` is a
+    `<project>` root, so detection must still reject them."""
+    source = _read(f"{GENERIC_XML_FIXTURES_DIR}/{filename}")
+
+    assert is_maven_pom("pom.xml", parse(engine, source), source) is False
+
+
+def test_is_maven_pom_rejects_pom_xml_named_file_with_non_project_root(
+    engine: TreeSitterEngine,
+) -> None:
+    """A file literally named `pom.xml` whose root element is not
+    `<project>` (e.g. mis-generated tooling output) is not a Maven POM."""
+    source = b"<config><setting>value</setting></config>"
+
+    assert is_maven_pom("pom.xml", parse(engine, source), source) is False


### PR DESCRIPTION
## Summary

Part 1/2 of M14 (XML Maven POM dialect plugin). Adds `is_maven_pom()` — filename-and-root-element detection for `pom.xml` files, layered on top of M13's generic `XmlAdapter` — plus a representative multi-module Maven fixture. Dependency extraction and resolution land in a follow-up PR based on this one.

## Why both signals

Detection requires **both** the `pom.xml` filename **and** a `<project>` root element. Neither alone is sufficient: Apache Ant's `build.xml` also roots on `<project>`, and a file merely named `pom.xml` is not guaranteed to be a real Maven descriptor.

## Changes

- `src/archex/parse/adapters/xml_maven.py` (new): `is_maven_pom()` plus tree-sitter-xml node-walking helpers (`_root_element`, `_element_tag_name`, `_node_text`) that the follow-up dependency-extraction PR reuses.
- `tests/fixtures/xml_maven/` (new): aggregator `pom.xml` (`packaging=pom`, `<modules>`), three child modules (`module-a` with no dependencies, `module-b` depending on `module-a`, `module-c` depending on `module-b` and an external `junit` coordinate), and an Ant-style `build.xml` for false-positive coverage.
- `tests/parse/adapters/test_xml_maven.py` (new): positive detection across every `pom.xml` in the fixture; false-positive guards against Ant's `build.xml`, M13's generic-XML fixtures (`tests/fixtures/xml_structured/catalog.xml`/`library.xml`) both by filename and — by re-parsing their content under a `pom.xml` path — by root element in isolation; and a `pom.xml`-named non-project-root guard.

No production behavior change: `XmlAdapter` is not wired to this module yet.

## Verification

```
uv run pytest tests/parse/adapters/test_xml_maven.py -v   # 10 passed
uv run ruff check src/archex/parse/adapters/xml_maven.py tests/parse/adapters/test_xml_maven.py
uv run ruff format --check src/archex/parse/adapters/xml_maven.py tests/parse/adapters/test_xml_maven.py
uv run pyright src/archex/parse/adapters/xml_maven.py tests/parse/adapters/test_xml_maven.py   # 0 errors
```

Refs: DEVELOPMENT_PLAN.md M14.
