### PR TITLE
feat(parse): resolve Maven POM dependency edges

### DIFF
--- a/src/archex/parse/adapters/xml.py
+++ b/src/archex/parse/adapters/xml.py
@@ -2,23 +2,45 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from archex.parse.adapters.structured import StructuredAdapter
+from archex.parse.adapters.xml_maven import (
+    extract_maven_dependencies,
+    is_maven_pom,
+    resolve_maven_dependency,
+)
+
+if TYPE_CHECKING:
+    from archex.models import ImportStatement
 
 
 class XmlAdapter(StructuredAdapter):
-    """Outline-only adapter for well-formed XML with no dialect assumptions.
+    """Outline-only adapter for well-formed XML with no dialect assumptions,
+    plus the one dialect wired in today: Maven's `pom.xml`.
 
     Generic XML has no universally native cross-file reference syntax --
     unlike HTML's `src`/`href` or CSS's `@import`/`url()`, an attribute that
     looks like a reference (e.g. `ref="other.xml"`) is dialect-specific
     convention, not XML grammar. Claiming it as a cross-reference here would
-    invent semantics the format itself does not define. Dialect-specific
-    mechanisms (Maven POM `<dependency>`, Android manifest components,
-    XInclude, ...) are a separate concern layered on top of this adapter,
-    not a generic-XML feature; see the XML dialect-plugin milestone.
+    invent semantics the format itself does not define. `extract_references`
+    therefore stays empty for anything that is not a recognized dialect.
 
-    This adapter therefore inherits `StructuredAdapter.extract_references`'s
-    empty-list default and only contributes the element outline.
+    `pom.xml` is the one dialect implemented here (`xml_maven.py`): Maven's
+    `<dependency>` declarations are extracted and resolved to sibling repo
+    modules where determinable. Other XML dialects (Android manifest,
+    Spring beans, XInclude, ...) remain unimplemented -- see the XML
+    dialect-plugin milestone.
     """
 
     _language_id = "xml"
+
+    def extract_references(
+        self, tree: object, source: bytes, file_path: str
+    ) -> list[ImportStatement]:
+        if not is_maven_pom(file_path, tree, source):
+            return []
+        return extract_maven_dependencies(tree, source, file_path)
+
+    def resolve_import(self, imp: ImportStatement, file_map: dict[str, str]) -> str | None:
+        return resolve_maven_dependency(imp, file_map)

--- a/src/archex/parse/adapters/xml_maven.py
+++ b/src/archex/parse/adapters/xml_maven.py
@@ -79,6 +79,38 @@ def extract_maven_dependencies(
     return references
 
 
+def resolve_maven_dependency(imp: ImportStatement, file_map: dict[str, str]) -> str | None:
+    """Resolve a Maven coordinate (`groupId:artifactId[:version]`) to
+    another module's `pom.xml` by the widely-followed Maven convention
+    that a module's directory name equals its artifactId.
+
+    This is a bounded heuristic, not a verified groupId/artifactId
+    match: `resolve_import` only ever sees path strings via `file_map`
+    (the shared `LanguageAdapter` contract), so groupId is never itself
+    confirmed. Resolution returns `None` -- "not determinable within the
+    repo" -- when zero or more than one pom.xml lives in a directory
+    named after the artifactId (including every external/Maven Central
+    coordinate, which by construction never matches a repo path), or
+    when the only match is the dependency's own file.
+    """
+    parts = imp.module.split(":")
+    if len(parts) < 2:
+        return None
+    artifact_id = parts[1]
+
+    candidates = {
+        path
+        for path in file_map.values()
+        if posixpath.basename(path) == _POM_FILENAME
+        and posixpath.basename(posixpath.dirname(path)) == artifact_id
+    }
+    if len(candidates) != 1:
+        return None
+
+    resolved = next(iter(candidates))
+    return None if resolved == imp.file_path else resolved
+
+
 # ---------------------------------------------------------------------------
 # tree-sitter-xml node helpers
 # ---------------------------------------------------------------------------

--- a/src/archex/parse/adapters/xml_maven.py
+++ b/src/archex/parse/adapters/xml_maven.py
@@ -1,15 +1,21 @@
 """Maven POM XML dialect plugin.
 
 Layered on top of the generic `XmlAdapter` (M13): detects `pom.xml` files
-by filename *and* root element. Dependency extraction and resolution are
-added on top of this detector separately (see the M14 dependency-edge
-milestone).
+by filename *and* root element, then extracts Maven's `<dependency>`
+declarations as cross-module references.
 
 Detection requires both signals -- filename and root element -- because
 either alone is ambiguous: Apache Ant's `build.xml` also roots on
 `<project>`, and a file that merely happens to be named `pom.xml` is not
 guaranteed to be a real Maven descriptor (e.g. a fixture or unrelated
 config reusing the name).
+
+`<parent>` inheritance and `<dependencyManagement>`/`<profiles>`-scoped
+dependency lists are intentionally excluded from extraction: only
+`<dependency>` elements that are direct children of a `<dependencies>`
+element that is itself a direct child of the `<project>` root count as
+declared dependencies. Resolution of the extracted coordinates to repo
+paths is added separately (see the M14 dependency-edge milestone).
 """
 
 from __future__ import annotations
@@ -17,8 +23,12 @@ from __future__ import annotations
 import posixpath
 from typing import Any
 
+from archex.models import ImportStatement
+
 _POM_FILENAME = "pom.xml"
 _POM_ROOT_TAG = "project"
+_DEPENDENCIES_TAG = "dependencies"
+_DEPENDENCY_TAG = "dependency"
 
 
 def is_maven_pom(file_path: str, tree: object, source: bytes) -> bool:
@@ -31,6 +41,42 @@ def is_maven_pom(file_path: str, tree: object, source: bytes) -> bool:
     if root is None:
         return False
     return _element_tag_name(root, source) == _POM_ROOT_TAG
+
+
+def extract_maven_dependencies(
+    tree: object, source: bytes, file_path: str
+) -> list[ImportStatement]:
+    """Extract `<dependency>` declarations from the project's direct
+    `<dependencies>` block. `<parent>` and any `<dependencyManagement>`- or
+    `<profiles>`-nested dependency lists are not direct children of the
+    root and are therefore never visited -- see module docstring."""
+    root = _root_element(tree)
+    if root is None or _element_tag_name(root, source) != _POM_ROOT_TAG:
+        return []
+
+    dependencies_el = _named_child_element(root, _DEPENDENCIES_TAG, source)
+    if dependencies_el is None:
+        return []
+
+    references: list[ImportStatement] = []
+    for dependency_el in _named_child_elements(dependencies_el, _DEPENDENCY_TAG, source):
+        group_id = _child_text(dependency_el, "groupId", source)
+        artifact_id = _child_text(dependency_el, "artifactId", source)
+        if group_id is None or artifact_id is None:
+            continue
+        version = _child_text(dependency_el, "version", source)
+        coordinate = (
+            f"{group_id}:{artifact_id}:{version}" if version else f"{group_id}:{artifact_id}"
+        )
+        references.append(
+            ImportStatement(
+                module=coordinate,
+                file_path=file_path,
+                line=int(dependency_el.start_point[0]) + 1,
+                is_relative=False,
+            )
+        )
+    return references
 
 
 # ---------------------------------------------------------------------------
@@ -53,6 +99,52 @@ def _element_tag_name(element: Any, source: bytes) -> str | None:
                 if grandchild.type == "Name":
                     return _node_text(grandchild, source)
     return None
+
+
+def _content_child(element: Any) -> Any | None:
+    for child in element.children:
+        if child.type == "content":
+            return child
+    return None
+
+
+def _direct_child_elements(element: Any) -> list[Any]:
+    content = _content_child(element)
+    if content is None:
+        return []
+    return [child for child in content.children if child.type == "element"]
+
+
+def _named_child_element(element: Any, name: str, source: bytes) -> Any | None:
+    for child in _direct_child_elements(element):
+        if _element_tag_name(child, source) == name:
+            return child
+    return None
+
+
+def _named_child_elements(element: Any, name: str, source: bytes) -> list[Any]:
+    return [
+        child
+        for child in _direct_child_elements(element)
+        if _element_tag_name(child, source) == name
+    ]
+
+
+def _element_text(element: Any, source: bytes) -> str | None:
+    content = _content_child(element)
+    if content is None:
+        return None
+    text = "".join(
+        _node_text(child, source) for child in content.children if child.type == "CharData"
+    ).strip()
+    return text or None
+
+
+def _child_text(element: Any, name: str, source: bytes) -> str | None:
+    child = _named_child_element(element, name, source)
+    if child is None:
+        return None
+    return _element_text(child, source)
 
 
 def _node_text(node: Any, source: bytes) -> str:

--- a/tests/parse/adapters/test_xml_maven.py
+++ b/tests/parse/adapters/test_xml_maven.py
@@ -18,7 +18,12 @@ from pathlib import Path
 
 import pytest
 
-from archex.parse.adapters.xml_maven import is_maven_pom
+from archex.models import ImportStatement
+from archex.parse.adapters.xml_maven import (
+    extract_maven_dependencies,
+    is_maven_pom,
+    resolve_maven_dependency,
+)
 from archex.parse.engine import TreeSitterEngine
 
 FIXTURES_DIR = "tests/fixtures/xml_maven"
@@ -106,3 +111,129 @@ def test_is_maven_pom_rejects_pom_xml_named_file_with_non_project_root(
     source = b"<config><setting>value</setting></config>"
 
     assert is_maven_pom("pom.xml", parse(engine, source), source) is False
+
+
+# ---------------------------------------------------------------------------
+# extract_maven_dependencies: groupId/artifactId/version extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_maven_dependencies_captures_group_artifact_version(
+    engine: TreeSitterEngine,
+) -> None:
+    source = _read(f"{FIXTURES_DIR}/module-b/pom.xml")
+
+    references = extract_maven_dependencies(parse(engine, source), source, "module-b/pom.xml")
+
+    assert [ref.module for ref in references] == ["com.example:module-a:1.0.0"]
+    assert all(ref.file_path == "module-b/pom.xml" for ref in references)
+    assert all(ref.is_relative is False for ref in references)
+
+
+def test_extract_maven_dependencies_captures_every_declared_dependency_including_external(
+    engine: TreeSitterEngine,
+) -> None:
+    """module-c depends on module-b (intra-repo) and junit (external) --
+    both are extracted here; whether one stays external is a
+    `resolve_maven_dependency` concern, not extraction's."""
+    source = _read(f"{FIXTURES_DIR}/module-c/pom.xml")
+
+    references = extract_maven_dependencies(parse(engine, source), source, "module-c/pom.xml")
+
+    assert {ref.module for ref in references} == {
+        "com.example:module-b:1.0.0",
+        "junit:junit:4.13.2",
+    }
+
+
+def test_extract_maven_dependencies_ignores_parent_declaration(engine: TreeSitterEngine) -> None:
+    """`<parent>` carries its own groupId/artifactId/version but is not a
+    `<dependency>` -- module-a has no `<dependencies>` block at all, only
+    a `<parent>` reference back to the aggregator, and must yield zero
+    references."""
+    source = _read(f"{FIXTURES_DIR}/module-a/pom.xml")
+
+    assert extract_maven_dependencies(parse(engine, source), source, "module-a/pom.xml") == []
+
+
+def test_extract_maven_dependencies_ignores_dependency_management_block(
+    engine: TreeSitterEngine,
+) -> None:
+    """A `<dependencyManagement><dependencies><dependency>` entry is
+    version-pinning, not a declared usage edge -- it lives two levels
+    below the root, never as a direct child `<dependencies>` block."""
+    source = b"""<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.example</groupId>
+  <artifactId>bom-consumer</artifactId>
+  <version>1.0.0</version>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.example</groupId>
+        <artifactId>should-not-be-extracted</artifactId>
+        <version>1.0.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>
+"""
+
+    assert extract_maven_dependencies(parse(engine, source), source, "pom.xml") == []
+
+
+def test_extract_maven_dependencies_returns_empty_for_non_pom_root(
+    engine: TreeSitterEngine,
+) -> None:
+    source = b"<config><dependencies><dependency>ignored</dependency></dependencies></config>"
+
+    assert extract_maven_dependencies(parse(engine, source), source, "pom.xml") == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_maven_dependency: artifactId-directory convention
+# ---------------------------------------------------------------------------
+
+
+def _file_map() -> dict[str, str]:
+    return {
+        "pom": "pom.xml",
+        "module-a.pom": "module-a/pom.xml",
+        "module-b.pom": "module-b/pom.xml",
+        "module-c.pom": "module-c/pom.xml",
+    }
+
+
+def test_resolve_maven_dependency_resolves_sibling_module_by_artifact_directory() -> None:
+    imp = ImportStatement(
+        module="com.example:module-a:1.0.0", file_path="module-b/pom.xml", line=10
+    )
+
+    assert resolve_maven_dependency(imp, _file_map()) == "module-a/pom.xml"
+
+
+def test_resolve_maven_dependency_returns_none_for_external_coordinate() -> None:
+    imp = ImportStatement(module="junit:junit:4.13.2", file_path="module-c/pom.xml", line=20)
+
+    assert resolve_maven_dependency(imp, _file_map()) is None
+
+
+def test_resolve_maven_dependency_returns_none_when_target_directory_is_ambiguous() -> None:
+    file_map = {**_file_map(), "vendored.module-a.pom": "third_party/module-a/pom.xml"}
+    imp = ImportStatement(
+        module="com.example:module-a:1.0.0", file_path="module-b/pom.xml", line=10
+    )
+
+    assert resolve_maven_dependency(imp, file_map) is None
+
+
+def test_resolve_maven_dependency_returns_none_for_self_reference() -> None:
+    imp = ImportStatement(module="com.example:module-a:1.0.0", file_path="module-a/pom.xml", line=5)
+
+    assert resolve_maven_dependency(imp, _file_map()) is None
+
+
+def test_resolve_maven_dependency_returns_none_for_malformed_coordinate() -> None:
+    imp = ImportStatement(module="not-a-coordinate", file_path="module-b/pom.xml", line=1)
+
+    assert resolve_maven_dependency(imp, _file_map()) is None

--- a/tests/parse/adapters/test_xml_maven.py
+++ b/tests/parse/adapters/test_xml_maven.py
@@ -18,13 +18,16 @@ from pathlib import Path
 
 import pytest
 
-from archex.models import ImportStatement
+from archex.api import index_repository
+from archex.graph_query import GraphQuery
+from archex.models import Config, ImportStatement, RepoSource
 from archex.parse.adapters.xml_maven import (
     extract_maven_dependencies,
     is_maven_pom,
     resolve_maven_dependency,
 )
 from archex.parse.engine import TreeSitterEngine
+from tests.conftest import _init_fixture_repo  # pyright: ignore[reportPrivateUsage]
 
 FIXTURES_DIR = "tests/fixtures/xml_maven"
 GENERIC_XML_FIXTURES_DIR = "tests/fixtures/xml_structured"
@@ -237,3 +240,47 @@ def test_resolve_maven_dependency_returns_none_for_malformed_coordinate() -> Non
     imp = ImportStatement(module="not-a-coordinate", file_path="module-b/pom.xml", line=1)
 
     assert resolve_maven_dependency(imp, _file_map()) is None
+
+
+# ---------------------------------------------------------------------------
+# M14 acceptance: indexing the fixture produces graph edges
+# ---------------------------------------------------------------------------
+
+
+def test_indexing_the_maven_fixture_produces_dependency_edges_via_graph_query(
+    tmp_path: Path,
+) -> None:
+    """Acceptance for M14: indexing the multi-module fixture produces
+    IMPORTS edges matching the declared `<dependency>` relationships,
+    verified the same way `archex graph neighbors`/`archex graph path`
+    and the `graph_neighbors`/`graph_path` MCP tools verify them --
+    through `GraphQuery`, the shared API both are built on."""
+    repo = _init_fixture_repo(tmp_path, "xml_maven")
+    source = RepoSource(local_path=str(repo))
+
+    store = index_repository(source, config=Config(languages=["xml"], cache=False))
+    try:
+        graph_query = GraphQuery.from_store(store, repo_root=repo)
+    finally:
+        store.close()
+
+    module_b_neighbors = graph_query.neighbors("module-b/pom.xml", direction="out")
+    assert [edge.target.path for edge in module_b_neighbors.edges] == ["module-a/pom.xml"]
+    assert module_b_neighbors.edges[0].type == "imports"
+
+    module_c_neighbors = graph_query.neighbors("module-c/pom.xml", direction="out")
+    assert {edge.target.path for edge in module_c_neighbors.edges} == {"module-b/pom.xml"}
+
+    path_result = graph_query.shortest_path("module-c/pom.xml", "module-a/pom.xml", direction="out")
+    assert path_result.found is True
+    assert [node.path for node in path_result.nodes] == [
+        "module-c/pom.xml",
+        "module-b/pom.xml",
+        "module-a/pom.xml",
+    ]
+
+    # The external junit:junit dependency has no repo path to resolve to,
+    # so it never becomes a graph edge -- "where determinable", not a
+    # fabricated node for every declared coordinate.
+    junit_lookup = graph_query.lookup("junit")
+    assert junit_lookup.matches == []


### PR DESCRIPTION
## Stack

Base: `feat/m14-xml-maven-detection` (#420)
Position: 2/2

1. #420 `feat/m14-xml-maven-detection` — Maven POM detection and fixture
2. `feat/m14-xml-maven-dependency-edges` -> this PR

Depends on: #420

## Summary

Part 2/2 of M14 (XML Maven POM dialect plugin). Adds `<dependency>` extraction and repo-relative resolution, and wires both into `XmlAdapter` so `pom.xml` files produce real `IMPORTS` graph edges.

## Design

- **Extraction** (`extract_maven_dependencies`) walks only the project root's *direct* `<dependencies>` block. `<parent>` and any `<dependencyManagement>`/`<profiles>`-nested dependency lists are structurally excluded — they are never direct children of `<project>`.
- **Resolution** (`resolve_maven_dependency`) uses the widely-followed Maven convention that a module's directory name equals its `artifactId`. This is a bounded heuristic, not a verified groupId/artifactId match: `resolve_import` only ever sees path strings via `file_map` (the shared `LanguageAdapter` contract), so groupId is never itself confirmed. A coordinate resolves only when exactly one `pom.xml` in the repo lives in a directory named after the `artifactId`, and never to the dependency's own file. External/Maven Central coordinates never match a repo path and are left unresolved — "where determinable within the repo," matching the milestone's acceptance criterion, not full Maven coordinate resolution.
- No changes to `graph.py`/`imports.py`/`languages.py`: the existing language-agnostic `DependencyGraph.from_parsed_files` already turns any adapter's resolved imports into `EdgeKind.IMPORTS` edges, so wiring `XmlAdapter.extract_references`/`resolve_import` is sufficient.

## Changes

- `src/archex/parse/adapters/xml_maven.py`: `extract_maven_dependencies()`, `resolve_maven_dependency()`, and the element-tree helpers (`_content_child`, `_direct_child_elements`, `_named_child_element(s)`, `_element_text`, `_child_text`) they share with detection.
- `src/archex/parse/adapters/xml.py`: `extract_references`/`resolve_import` now delegate to the Maven dialect module when `is_maven_pom()` is true; every other XML file keeps M13's empty-references behavior unchanged.
- `tests/parse/adapters/test_xml_maven.py`: extraction unit tests (groupId/artifactId/version capture, `<parent>` exclusion, `<dependencyManagement>` exclusion, non-pom-root guard), resolution unit tests (sibling resolution, external non-resolution, ambiguous-match rejection, self-reference rejection, malformed-coordinate rejection), and an end-to-end acceptance test that indexes the multi-module fixture through `archex.api.index_repository` and asserts on `GraphQuery.neighbors`/`shortest_path` — the same API the `archex graph` CLI command and the `graph_neighbors`/`graph_path` MCP tools are built on.

## Verification

```
uv run pytest tests/parse/adapters/test_xml_maven.py -v   # 21 passed
uv run pytest tests/parse/adapters/test_xml.py -v          # 16 passed (M13 regression)
uv run pytest -q                                            # 3349 passed, 91.16% coverage
uv run pyright                                               # 0 errors
```

`archex graph` CLI against a git-initialized copy of the fixture:

```
$ uv run archex graph export <fixture> --output graph.json
$ uv run archex graph neighbors module-b/pom.xml --graph graph.json --direction out --format markdown
| module-b/pom.xml | imports | module-a/pom.xml | extracted (1.00) | resolved import 'com.example:module-a:1.0.0' at module-b/pom.xml:14 |

$ uv run archex graph path module-c/pom.xml module-a/pom.xml --graph graph.json --direction out --format markdown
Found: yes
module-c/pom.xml -> module-b/pom.xml -> module-a/pom.xml
```

Closes DEVELOPMENT_PLAN.md M14.
