### PR TITLE
fix(parse): resolve HTML local references to exact file paths

### DIFF
--- a/src/archex/parse/adapters/html.py
+++ b/src/archex/parse/adapters/html.py
@@ -7,7 +7,7 @@ from typing import Any
 from urllib.parse import urlsplit
 
 from archex.models import ImportStatement
-from archex.parse.adapters.structured import StructuredAdapter
+from archex.parse.adapters.structured import StructuredAdapter, resolve_path_reference
 
 _REFERENCE_ATTRIBUTES = {
     "a": "href",
@@ -142,10 +142,9 @@ def _normalize_path(path: str) -> str:
 
 def _resolve_html_reference(candidate: str, file_map: dict[str, str]) -> str | None:
     normalized = _normalize_path(candidate)
-    if normalized in file_map:
-        return file_map[normalized]
+    resolved = resolve_path_reference(normalized, file_map)
+    if resolved is not None:
+        return resolved
     module_key, _ = posixpath.splitext(normalized)
     dotted_key = module_key.replace("/", ".")
-    if dotted_key in file_map:
-        return file_map[dotted_key]
-    return None
+    return file_map.get(dotted_key)

--- a/src/archex/parse/adapters/structured.py
+++ b/src/archex/parse/adapters/structured.py
@@ -101,6 +101,23 @@ def make_structured_adapter(language_id: str) -> type[StructuredAdapter]:
     return _Adapter
 
 
+def resolve_path_reference(candidate: str, file_map: dict[str, str]) -> str | None:
+    """Resolve a normalized repo-relative path reference to an exact file path.
+
+    Path-based references (HTML/CSS local file targets) carry their file
+    extension explicitly, unlike Python-style dotted module imports — so
+    they resolve via ``build_file_map``'s literal-path keys, not its
+    extension-stripped dotted module keys. The dotted keys alone collide
+    across different extensions sharing a directory and basename (e.g.
+    ``app.js`` / ``app.css`` both collapse to the module key ``app``),
+    silently resolving a reference to the wrong sibling file. Shared by
+    adapters (HTML) whose native reference syntax is always a literal
+    path, never a dotted module name.
+    """
+    normalized = os.path.normpath(candidate).replace(os.sep, "/")
+    return file_map.get(normalized)
+
+
 def _resolve_direct_reference(module: str, file_map: dict[str, str]) -> str | None:
     normalized = os.path.normpath(module).replace(os.sep, "/")
     values = {os.path.normpath(path).replace(os.sep, "/"): path for path in file_map.values()}

--- a/src/archex/parse/imports.py
+++ b/src/archex/parse/imports.py
@@ -178,4 +178,16 @@ def build_file_map(files: list[DiscoveredFile]) -> dict[str, str]:
                     file_map[stripped_key] = path
                 break
 
+    # Also register each file's literal repo-relative path (extension
+    # preserved) as its own lookup key. Path-based references (HTML/CSS
+    # local file targets) carry their extension explicitly, unlike
+    # Python-style dotted module names built above — so they must resolve
+    # to an exact path, not an extension-stripped module key, which can
+    # collide across different extensions sharing a directory and
+    # basename (e.g. ``app.js`` / ``app.css`` both collapse to the module
+    # key ``app``). ``setdefault`` never overwrites an existing dotted-key
+    # entry, so this cannot regress module-style resolution.
+    for f in files:
+        file_map.setdefault(f.path.replace(os.sep, "/"), f.path)
+
     return file_map

--- a/tests/index/test_graph.py
+++ b/tests/index/test_graph.py
@@ -165,6 +165,35 @@ def test_structured_tier_parsed_file_emits_import_edge_without_symbols(
     assert edge.confidence == EdgeConfidence.EXTRACTED
 
 
+def test_cross_language_html_to_js_and_css_edges_resolve_to_correct_targets(
+    tmp_path: Path,
+) -> None:
+    """An HTML file's `script src`/`link href` references become IMPORTS
+    edges to the exact JS/CSS files they name, even when the JS and CSS
+    sibling both share a directory and basename -- a collision that a
+    naive extension-stripped module-key lookup would resolve to only one
+    of the two targets, silently dropping (or misdirecting) the other."""
+    from archex.models import Config
+    from archex.parse.adapters import default_adapter_registry
+    from archex.pipeline.service import parse_repository
+
+    (tmp_path / "assets").mkdir()
+    (tmp_path / "index.html").write_text(
+        '<html><head><link rel="stylesheet" href="assets/app.css">'
+        '<script src="assets/app.js"></script></head><body></body></html>'
+    )
+    (tmp_path / "assets" / "app.js").write_text("console.log('app');\n")
+    (tmp_path / "assets" / "app.css").write_text("body { color: black; }\n")
+
+    config = Config(languages=["html", "javascript", "css"], parallel=False)
+    adapters = default_adapter_registry.build_all()
+    artifacts = parse_repository(tmp_path, config, adapters)
+
+    graph = DependencyGraph.from_parsed_files(artifacts.parsed_files, artifacts.resolved_imports)
+
+    assert graph.imports_of("index.html") == {"assets/app.js", "assets/app.css"}
+
+
 def test_neighborhood_bfs() -> None:
     parsed = _make_parsed_files()
     import_map = _make_import_map()

--- a/tests/parse/adapters/test_html.py
+++ b/tests/parse/adapters/test_html.py
@@ -304,6 +304,27 @@ def test_resolve_import_returns_none_for_unresolvable_local_reference(adapter: H
     assert adapter.resolve_import(imp, {"pages/about.html": "pages/about.html"}) is None
 
 
+def test_resolve_import_does_not_collide_across_extensions_sharing_a_basename(
+    adapter: HtmlAdapter,
+) -> None:
+    """`script src="assets/app.js"` and `link href="assets/app.css"` must
+    resolve to their own distinct targets even though both files share the
+    same directory and basename -- a naive extension-stripped module-key
+    lookup would collapse both references onto whichever file happened to
+    occupy that shared key, silently misrouting one of the two edges."""
+    file_map = {"assets/app.js": "assets/app.js", "assets/app.css": "assets/app.css"}
+
+    js_ref = ImportStatement(
+        module="assets/app.js", file_path="index.html", line=1, is_relative=True
+    )
+    css_ref = ImportStatement(
+        module="assets/app.css", file_path="index.html", line=2, is_relative=True
+    )
+
+    assert adapter.resolve_import(js_ref, file_map) == "assets/app.js"
+    assert adapter.resolve_import(css_ref, file_map) == "assets/app.css"
+
+
 def test_extract_and_resolve_all_reference_kinds_against_realistic_fixture(
     engine: TreeSitterEngine, adapter: HtmlAdapter
 ) -> None:

--- a/tests/parse/test_imports.py
+++ b/tests/parse/test_imports.py
@@ -320,6 +320,45 @@ def test_build_file_map_non_python_extension() -> None:
     assert result["cmd.main"] == "cmd/main.go"
 
 
+def test_build_file_map_registers_literal_path_for_each_file() -> None:
+    """Every discovered file gets its own literal repo-relative path as a
+    lookup key, in addition to the extension-stripped dotted module key --
+    so path-based adapters (HTML/CSS) can resolve an exact reference even
+    when two files share a directory and basename across extensions."""
+    files = [
+        DiscoveredFile(
+            path="assets/app.js",
+            absolute_path="/tmp/assets/app.js",
+            language="typescript",
+        ),
+        DiscoveredFile(
+            path="assets/app.css",
+            absolute_path="/tmp/assets/app.css",
+            language="css",
+        ),
+    ]
+    result = build_file_map(files)
+    assert result["assets/app.js"] == "assets/app.js"
+    assert result["assets/app.css"] == "assets/app.css"
+
+
+def test_build_file_map_literal_path_never_overwrites_existing_dotted_key() -> None:
+    """A literal-path key is only added via ``setdefault`` -- it must not
+    clobber an existing dotted-module-key entry belonging to another file."""
+    files = [
+        DiscoveredFile(
+            path="pkg/mod.py",
+            absolute_path="/tmp/pkg/mod.py",
+            language="python",
+        ),
+    ]
+    result = build_file_map(files)
+    # Sanity: the dotted module key still resolves as before.
+    assert result["pkg.mod"] == "pkg/mod.py"
+    # And the literal path is also registered for path-based lookups.
+    assert result["pkg/mod.py"] == "pkg/mod.py"
+
+
 def test_strict_parallel_raises_on_bad_file(
     tmp_path: Path,
     engine: TreeSitterEngine,


### PR DESCRIPTION
## Summary

`HtmlAdapter.resolve_import` fell back to `build_file_map()`'s extension-stripped, dotted module-style key when a reference didn't match a real path directly. That direct-match branch was dead code — `file_map`'s keys are dotted module names, never literal paths — so every HTML local reference actually resolved through the dotted key. Two files that share a directory and basename across extensions (e.g. `app.js` / `app.css`, a common static-asset pattern) collapse onto the same dotted key, so `build_file_map()` could only retain one of the two: the other reference silently resolved to nothing, or to the wrong sibling file depending on file-discovery order.

Confirmed via a graph-level probe on `main` before this fix: an HTML file referencing both `app.js` and `app.css` produced only one `IMPORTS` edge, misdirected to whichever file discovery processed last.

### Fix

- `build_file_map()` (`src/archex/parse/imports.py`) now also registers each file's literal repo-relative path (extension preserved) as its own lookup key, via `setdefault` so it can never overwrite an existing dotted-key entry — purely additive, zero risk to existing Python/Go/Rust/etc. dotted-module resolution.
- `structured.py` exposes this as the shared `resolve_path_reference()` helper: path-based references always carry their extension explicitly, unlike Python-style dotted imports, so they resolve via the literal path key, not the collision-prone dotted one.
- `HtmlAdapter._resolve_html_reference` tries the literal-path helper first, falling back to the dotted key only when no exact file exists.

### No change needed in graph.py / delta.py

Both already treat every adapter's resolved imports identically regardless of language tier (`DependencyGraph.from_parsed_files` / `index/delta.py`'s edge machinery), so HTML-to-JS/CSS edges flow into the main dependency graph automatically once resolution itself is correct. The new cross-language test in `tests/index/test_graph.py` verifies this end-to-end.

## Tests

- `tests/index/test_graph.py`: end-to-end test running the real `discover_files` → `parse_repository` → `DependencyGraph.from_parsed_files` pipeline against an on-disk fixture where an HTML file references a same-basename JS and CSS sibling, asserting both `IMPORTS` edges resolve to their correct, distinct targets.
- `tests/parse/adapters/test_html.py`: `resolve_import` unit test pinning that script/link references to same-basename JS/CSS files never collide.
- `tests/parse/test_imports.py`: `build_file_map` unit tests pinning the new literal-path key behavior and that it never overwrites an existing dotted-module-key entry.

## Verification

- `uv run pytest tests/index/test_graph.py -k cross_language -v` — 1 passed.
- `uv run pytest tests/parse/adapters/test_html.py tests/parse/adapters/test_css.py tests/parse/test_imports.py tests/index/test_graph.py -q` — all passing (99 in this subset).
- `uv run pytest` — 3353 passed.
- `uv run ruff check .` / `uv run ruff format --check .` — clean.
- `uv run pyright` — 0 errors.

## Stack

1. `feat/m15-polyglot-benchmark-fixture` → `main` (#422)
2. `fix/m15-html-cross-language-edge-collision` → PR 1 (this PR)
3. `docs/m15-polyglot-benchmark-comparison` → this PR

Benchmark comparison (before/after this fix) lands in PR 3.
