### PR TITLE
feat(index): implement portable index artifact export format

### DIFF
--- a/docs/PORTABLE_INDEX_ARTIFACT.md
+++ b/docs/PORTABLE_INDEX_ARTIFACT.md
@@ -1,0 +1,93 @@
+# Portable Index Artifact
+
+`archex index --export-artifact <path>` writes a compacted, compressed,
+versioned snapshot of a repo's `.archex/index.db`. A teammate (or CI) on a
+fresh clone runs `archex init --from-artifact <path>` to bootstrap their
+local index from that snapshot instead of paying a full cold-start reindex,
+then delta-syncs to their current working tree.
+
+This mirrors the highest-leverage team-workflow feature observed in
+`DeusData/codebase-memory-mcp`'s committed `.codebase-memory/graph.db.zst`
+artifact, adapted to archex's SQLite + FTS5 index and stdlib-only dependency
+policy (`lzma`, not `zstd`).
+
+## Format
+
+An artifact is **not** a bare `.xz` file — it is a small custom frame around
+an LZMA-compressed payload, so a reader can validate compatibility before
+paying the cost of decompressing a potentially large index:
+
+```text
++-----------------------------+
+| MAGIC (12 bytes)            |  b"ARCHEXIDXv1\n"
++-----------------------------+
+| header_len (4 bytes, u32be) |
++-----------------------------+
+| header (UTF-8 JSON)         |
++-----------------------------+
+| payload (LZMA stream)       |  VACUUM INTO-compacted SQLite database,
+|                             |  FTS5 tables stripped
++-----------------------------+
+```
+
+### Header fields
+
+| Field | Meaning |
+|---|---|
+| `format_version` | Container format version (framing + payload shape). |
+| `created_by_version` | The `archex` version that produced the artifact. |
+| `compat_min_version` / `compat_max_version` | Inclusive `archex` version range declared able to import this artifact. |
+| `index_revision` | The `commit_hash` the index reflects at export time — the base revision `init --from-artifact` delta-syncs from. |
+| `schema_version` | The store's SQLite schema version at export time (informational). |
+| `chunk_count` / `file_count` | Corpus size at export time (informational, shown in CLI output). |
+| `created_at` | Unix timestamp of export. |
+
+The header is read and validated in full **before** the payload is
+decompressed. An artifact whose `format_version` or `archex` compat range
+this build does not support raises `ArtifactVersionError` immediately —
+never a silent or partial import.
+
+### What gets stripped
+
+`chunks_fts` and `symbols_fts` (both FTS5 virtual tables) are dropped from
+the compacted copy before compression and rebuilt locally on import. They
+are fully derivable from the `chunks` table; shipping them would duplicate
+the corpus text in the artifact and bake in a build-specific FTS5 binary
+shape that has no reason to travel between machines. `VACUUM INTO` compacts
+the copy; dropping the FTS5 tables and running a second `VACUUM` reclaims
+the space they occupied.
+
+## Compatibility ranges
+
+`ARTIFACT_FORMAT_VERSION` (in `src/archex/index/artifact.py`) versions the
+container itself. `ARTIFACT_MIN_COMPAT_VERSION` / `ARTIFACT_MAX_COMPAT_VERSION`
+declare which `archex` versions this build's format is compatible with.
+Both checks run on import:
+
+1. The artifact's `format_version` must equal this build's
+   `ARTIFACT_FORMAT_VERSION` — a future breaking format change bumps this
+   constant, and older archex builds refuse the new artifact shape outright.
+2. The *running* `archex.__version__` must fall within the artifact's own
+   `compat_min_version..compat_max_version` range — an artifact exported by
+   a version outside what this build declares itself compatible with is
+   rejected.
+
+Version comparison is a minimal dotted-integer-tuple comparator (not a full
+PEP 440/semver parser) — sufficient for archex's plain `MAJOR.MINOR.PATCH`
+versioning and avoids adding a dependency for it.
+
+## CLI usage
+
+```console
+$ archex index --export-artifact .archex-artifact.xz
+Indexed repository: /path/to/repo
+...
+Artifact exported:  .archex-artifact.xz
+Artifact revision:  a1b2c3d4...
+Artifact size:      123456 bytes
+
+$ archex init --from-artifact .archex-artifact.xz
+```
+
+Export never runs automatically — it is an explicit, opt-in flag on
+`archex index`, and the resulting file is never committed automatically.

--- a/src/archex/cli/index_cmd.py
+++ b/src/archex/cli/index_cmd.py
@@ -12,6 +12,7 @@ from archex.api import index_repository
 from archex.cache import CacheManager
 from archex.config import load_config, load_index_config, persist_project_index_settings
 from archex.exceptions import ArchexError
+from archex.index.artifact import export_artifact
 from archex.models import PipelineTiming, RepoSource
 from archex.project import uses_project_cache_layout
 
@@ -57,6 +58,13 @@ def _language_counts(file_metadata: list[dict[str, str | int]]) -> dict[str, int
     type=click.Choice(["2", "4"]),
     help="TurboQuant bit-width for vector indexes.",
 )
+@click.option(
+    "--export-artifact",
+    "export_artifact_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Export a compacted, compressed, portable index artifact to PATH after indexing.",
+)
 def index_cmd(
     source: str,
     output_format: str,
@@ -65,6 +73,7 @@ def index_cmd(
     allow_remote_code: bool,
     quantize_vectors: bool | None,
     quantize_bits: str | None,
+    export_artifact_path: Path | None,
 ) -> None:
     """Build or refresh the index for SOURCE without running a query."""
     repo_source = RepoSource(local_path=source)
@@ -129,6 +138,14 @@ def index_cmd(
             "embedding_cache_hits": int(store.get_metadata("embedding_cache_hits") or "0"),
             "embedding_cache_misses": int(store.get_metadata("embedding_cache_misses") or "0"),
         }
+        if export_artifact_path is not None:
+            try:
+                artifact_header = export_artifact(store, export_artifact_path)
+            except ArchexError as exc:
+                raise click.ClickException(str(exc)) from exc
+            summary["artifact_path"] = str(export_artifact_path)
+            summary["artifact_index_revision"] = artifact_header.index_revision
+            summary["artifact_size_bytes"] = export_artifact_path.stat().st_size
     finally:
         store.close()
 
@@ -152,3 +169,7 @@ def index_cmd(
         f"hits={summary['embedding_cache_hits']}, misses={summary['embedding_cache_misses']}"
     )
     click.echo(f"Duration:           {summary['duration_ms']} ms")
+    if export_artifact_path is not None:
+        click.echo(f"Artifact exported:  {summary['artifact_path']}")
+        click.echo(f"Artifact revision:  {summary['artifact_index_revision']}")
+        click.echo(f"Artifact size:      {summary['artifact_size_bytes']} bytes")

--- a/src/archex/exceptions.py
+++ b/src/archex/exceptions.py
@@ -45,3 +45,15 @@ class LSAPError(ArchexError):
 
 class BenchmarkCloneError(ArchexError):
     """Raised when cloning or checking out a benchmark task repository fails."""
+
+
+class ArtifactError(ArchexError):
+    """Raised when portable index artifact export or import fails."""
+
+
+class ArtifactVersionError(ArtifactError):
+    """Raised when an artifact's format or archex-version compat range is unsupported.
+
+    Always a loud, hard failure — an out-of-range artifact must never be
+    imported partially or silently.
+    """

--- a/src/archex/index/artifact.py
+++ b/src/archex/index/artifact.py
@@ -1,0 +1,250 @@
+"""Portable, compressed index artifact for team-shared bootstrap.
+
+A repo can commit a compacted, compressed copy of its `.archex/index.db`
+(the "artifact") so a fresh clone can `archex init --from-artifact` and
+delta-sync to HEAD instead of paying a full cold-start reindex.
+
+File layout (NOT a bare `.xz` stream — a small custom framing wraps a raw
+LZMA payload so a reader can validate compatibility before paying the cost
+of decompressing a potentially large index):
+
+    +----------------------------+
+    | MAGIC (12 bytes)           |  b"ARCHEXIDXv1\\n"
+    +----------------------------+
+    | header_len (4 bytes, u32be)|
+    +----------------------------+
+    | header (UTF-8 JSON)        |  ArtifactHeader.to_json()
+    +----------------------------+
+    | payload (LZMA stream)      |  a VACUUM INTO-compacted copy of the
+    |                            |  index's SQLite database with derived
+    |                            |  FTS5 structures (chunks_fts,
+    |                            |  symbols_fts) stripped — rebuilt
+    |                            |  locally on import.
+    +----------------------------+
+
+The header is read and validated (format version + archex-version compat
+range) BEFORE the payload is touched, so an incompatible artifact fails
+loudly without ever writing a partial index to disk.
+"""
+
+from __future__ import annotations
+
+import json
+import lzma
+import sqlite3
+import struct
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from archex import __version__
+from archex.exceptions import ArtifactError, ArtifactVersionError
+
+if TYPE_CHECKING:
+    from archex.index.store import IndexStore
+
+ARTIFACT_MAGIC = b"ARCHEXIDXv1\n"
+
+#: Container format version. Bumped only when the framing or payload shape
+#: (not the SQLite schema, which is versioned independently via the store's
+#: own `schema_version` metadata) changes incompatibly.
+ARTIFACT_FORMAT_VERSION = 1
+
+#: archex versions declared able to import an artifact written at
+#: ARTIFACT_FORMAT_VERSION. Widen ARTIFACT_MAX_COMPAT_VERSION as later
+#: archex releases confirm they still read this format; bump both when a
+#: future format break requires a new ARTIFACT_FORMAT_VERSION.
+ARTIFACT_MIN_COMPAT_VERSION = "0.15.0"
+ARTIFACT_MAX_COMPAT_VERSION = "0.99.99"
+
+#: LZMA preset: balances export latency against compression ratio for
+#: SQLite-shaped content (mostly text — source chunks, symbol metadata).
+_LZMA_PRESET = 6
+
+_HEADER_LENGTH_STRUCT = struct.Struct(">I")
+
+# Tables dropped before compression and rebuilt locally on import. Both are
+# FTS5 virtual tables fully derivable from `chunks` — shipping them would
+# duplicate the corpus text and bake in a tokenizer/build-specific binary
+# shape that does not need to travel between machines.
+_DERIVED_TABLES = ("chunks_fts", "symbols_fts")
+
+
+def _parse_version(version: str) -> tuple[int, ...]:
+    """Parse a dotted version string into a comparable tuple of ints.
+
+    Deliberately not a full PEP 440/semver parser — archex versions are
+    plain `MAJOR.MINOR.PATCH`, and this only needs to order those correctly
+    for a compat-range check.
+    """
+    parts: list[int] = []
+    for segment in version.split("."):
+        digits = "".join(ch for ch in segment if ch.isdigit())
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+def _version_in_range(version: str, min_version: str, max_version: str) -> bool:
+    parsed = _parse_version(version)
+    return _parse_version(min_version) <= parsed <= _parse_version(max_version)
+
+
+@dataclass(frozen=True)
+class ArtifactHeader:
+    """Versioned metadata written ahead of an artifact's compressed payload."""
+
+    format_version: int
+    created_by_version: str
+    compat_min_version: str
+    compat_max_version: str
+    index_revision: str
+    schema_version: str | None
+    chunk_count: int
+    file_count: int
+    created_at: float
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "format_version": self.format_version,
+            "created_by_version": self.created_by_version,
+            "compat_min_version": self.compat_min_version,
+            "compat_max_version": self.compat_max_version,
+            "index_revision": self.index_revision,
+            "schema_version": self.schema_version,
+            "chunk_count": self.chunk_count,
+            "file_count": self.file_count,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> ArtifactHeader:
+        try:
+            return cls(
+                format_version=int(data["format_version"]),
+                created_by_version=str(data["created_by_version"]),
+                compat_min_version=str(data["compat_min_version"]),
+                compat_max_version=str(data["compat_max_version"]),
+                index_revision=str(data["index_revision"]),
+                schema_version=(
+                    str(data["schema_version"]) if data.get("schema_version") is not None else None
+                ),
+                chunk_count=int(data["chunk_count"]),
+                file_count=int(data["file_count"]),
+                created_at=float(data["created_at"]),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ArtifactError(f"Malformed artifact header: {exc}") from exc
+
+
+def _read_header(handle: Any, path: Path) -> ArtifactHeader:
+    """Read and parse the header from an open, position-0 binary file handle."""
+    magic = handle.read(len(ARTIFACT_MAGIC))
+    if magic != ARTIFACT_MAGIC:
+        raise ArtifactError(f"Not an archex index artifact (bad magic): {path}")
+    length_bytes = handle.read(_HEADER_LENGTH_STRUCT.size)
+    if len(length_bytes) != _HEADER_LENGTH_STRUCT.size:
+        raise ArtifactError(f"Truncated artifact header: {path}")
+    (header_len,) = _HEADER_LENGTH_STRUCT.unpack(length_bytes)
+    header_bytes = handle.read(header_len)
+    if len(header_bytes) != header_len:
+        raise ArtifactError(f"Truncated artifact header: {path}")
+    try:
+        raw = json.loads(header_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ArtifactError(f"Corrupt artifact header: {path}") from exc
+    return ArtifactHeader.from_json(raw)
+
+
+def read_artifact_header(path: str | Path) -> ArtifactHeader:
+    """Read and parse just the header of an artifact, without touching the payload."""
+    path = Path(path)
+    with path.open("rb") as handle:
+        return _read_header(handle, path)
+
+
+def validate_artifact_compat(header: ArtifactHeader) -> None:
+    """Raise `ArtifactVersionError` if this archex build cannot safely import the artifact.
+
+    Checked BEFORE decompression so an incompatible artifact never produces
+    a partial import — the failure is loud and immediate.
+    """
+    if header.format_version != ARTIFACT_FORMAT_VERSION:
+        raise ArtifactVersionError(
+            f"Artifact format version {header.format_version} is not supported by this "
+            f"archex build (supports format version {ARTIFACT_FORMAT_VERSION}). Re-export "
+            "the artifact with a compatible archex version."
+        )
+    if not _version_in_range(__version__, header.compat_min_version, header.compat_max_version):
+        raise ArtifactVersionError(
+            f"Artifact requires archex {header.compat_min_version}..{header.compat_max_version}, "
+            f"but this is archex {__version__}. Upgrade or downgrade archex, or re-export the "
+            "artifact from a compatible version."
+        )
+
+
+def _vacuum_into_stripped(store: IndexStore, dest_path: Path) -> None:
+    """Write a compacted copy of `store`'s database to `dest_path`, dropping FTS5 tables."""
+    if dest_path.exists():
+        dest_path.unlink()
+    store.conn.execute("VACUUM INTO ?", (str(dest_path),))
+    conn = sqlite3.connect(dest_path)
+    try:
+        for table in _DERIVED_TABLES:
+            conn.execute(f"DROP TABLE IF EXISTS {table}")
+        conn.commit()
+        conn.execute("VACUUM")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def export_artifact(store: IndexStore, output_path: str | Path) -> ArtifactHeader:
+    """Export a compacted, compressed, portable copy of `store` to `output_path`.
+
+    Raises `ArtifactError` if the store has no recorded `commit_hash` (an
+    artifact with no revision cannot be delta-synced after import).
+    """
+    output_path = Path(output_path)
+    index_revision = store.get_metadata("commit_hash") or ""
+    if not index_revision:
+        raise ArtifactError(
+            "Cannot export an artifact: the index has no recorded commit_hash. "
+            "Index a git-tracked repository first (`archex index` inside a git checkout)."
+        )
+
+    schema_version = store.get_metadata("schema_version")
+    chunk_count = store.get_chunk_count()
+    file_count = store.get_file_count()
+
+    header = ArtifactHeader(
+        format_version=ARTIFACT_FORMAT_VERSION,
+        created_by_version=__version__,
+        compat_min_version=ARTIFACT_MIN_COMPAT_VERSION,
+        compat_max_version=ARTIFACT_MAX_COMPAT_VERSION,
+        index_revision=index_revision,
+        schema_version=schema_version,
+        chunk_count=chunk_count,
+        file_count=file_count,
+        created_at=time.time(),
+    )
+    header_bytes = json.dumps(header.to_json(), sort_keys=True).encode("utf-8")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    compact_path = output_path.with_name(f".{output_path.name}.compact.tmp")
+    try:
+        _vacuum_into_stripped(store, compact_path)
+        compressed = lzma.compress(compact_path.read_bytes(), preset=_LZMA_PRESET)
+    finally:
+        if compact_path.exists():
+            compact_path.unlink()
+
+    tmp_output = output_path.with_name(f".{output_path.name}.tmp")
+    with tmp_output.open("wb") as handle:
+        handle.write(ARTIFACT_MAGIC)
+        handle.write(_HEADER_LENGTH_STRUCT.pack(len(header_bytes)))
+        handle.write(header_bytes)
+        handle.write(compressed)
+    tmp_output.replace(output_path)
+
+    return header

--- a/tests/index/test_artifact.py
+++ b/tests/index/test_artifact.py
@@ -1,0 +1,250 @@
+"""Tests for the portable index artifact: export format, header, compat validation."""
+
+from __future__ import annotations
+
+import json
+import lzma
+import sqlite3
+import struct
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from archex.api import index_repository
+from archex.cli.main import cli
+from archex.exceptions import ArtifactError, ArtifactVersionError
+from archex.index.artifact import (
+    ARTIFACT_FORMAT_VERSION,
+    ARTIFACT_MAGIC,
+    ArtifactHeader,
+    export_artifact,
+    read_artifact_header,
+    validate_artifact_compat,
+)
+from archex.index.store import IndexStore
+from archex.models import Config, IndexConfig, RepoSource
+from archex.project import init_project
+
+
+def _build_store(repo: Path, cache_dir: Path) -> IndexStore:
+    source = RepoSource(local_path=str(repo))
+    config = Config(languages=["python"], cache=True, cache_dir=str(cache_dir))
+    return index_repository(source, config=config, index_config=IndexConfig())
+
+
+def _decompress_payload(artifact_path: Path) -> bytes:
+    with artifact_path.open("rb") as handle:
+        handle.read(len(ARTIFACT_MAGIC))
+        (header_len,) = struct.unpack(">I", handle.read(4))
+        handle.read(header_len)
+        payload = handle.read()
+    return lzma.decompress(payload)
+
+
+class TestExportArtifact:
+    def test_export_header_fields(self, python_simple_repo: Path, tmp_path: Path) -> None:
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = tmp_path / "artifact.xz"
+            header = export_artifact(store, artifact_path)
+
+            assert header.format_version == ARTIFACT_FORMAT_VERSION
+            assert header.index_revision == store.get_metadata("commit_hash")
+            assert header.index_revision
+            assert header.chunk_count == store.get_chunk_count()
+            assert header.file_count == store.get_file_count()
+            assert header.created_by_version
+            assert header.created_at > 0
+        finally:
+            store.close()
+
+    def test_export_writes_readable_header_without_decompressing(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = tmp_path / "artifact.xz"
+            export_artifact(store, artifact_path)
+
+            header = read_artifact_header(artifact_path)
+
+            assert header.index_revision == store.get_metadata("commit_hash")
+            validate_artifact_compat(header)  # does not raise
+        finally:
+            store.close()
+
+    def test_export_requires_commit_hash(self, tmp_path: Path) -> None:
+        store = IndexStore(tmp_path / "bare.db")
+        try:
+            with pytest.raises(ArtifactError, match="commit_hash"):
+                export_artifact(store, tmp_path / "artifact.xz")
+        finally:
+            store.close()
+
+    def test_export_strips_derived_fts_tables_and_preserves_chunks(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            assert store.get_chunk_count() > 0
+            artifact_path = tmp_path / "artifact.xz"
+            export_artifact(store, artifact_path)
+
+            raw_db = tmp_path / "decompressed.db"
+            raw_db.write_bytes(_decompress_payload(artifact_path))
+
+            conn = sqlite3.connect(raw_db)
+            try:
+                tables = {
+                    row[0]
+                    for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+                }
+                assert "chunks_fts" not in tables
+                assert "symbols_fts" not in tables
+                assert "chunks" in tables
+                assert "edges" in tables
+                assert "file_states" in tables
+                chunk_count = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+                assert chunk_count == store.get_chunk_count()
+            finally:
+                conn.close()
+        finally:
+            store.close()
+
+    def test_export_compresses_smaller_than_raw_db(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = tmp_path / "artifact.xz"
+            export_artifact(store, artifact_path)
+
+            raw_size = store.db_path.stat().st_size
+            artifact_size = artifact_path.stat().st_size
+            assert artifact_size < raw_size
+        finally:
+            store.close()
+
+    def test_export_rejects_reading_header_from_bogus_file(self, tmp_path: Path) -> None:
+        bogus = tmp_path / "bogus.xz"
+        bogus.write_bytes(b"not an archex artifact at all")
+        with pytest.raises(ArtifactError, match="bad magic"):
+            read_artifact_header(bogus)
+
+    def test_export_creates_parent_directories(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = tmp_path / "nested" / "dir" / "artifact.xz"
+            export_artifact(store, artifact_path)
+            assert artifact_path.exists()
+        finally:
+            store.close()
+
+
+class TestArtifactHeaderRoundtrip:
+    def _sample(self, **overrides: object) -> ArtifactHeader:
+        defaults: dict[str, object] = {
+            "format_version": 1,
+            "created_by_version": "0.15.2",
+            "compat_min_version": "0.15.0",
+            "compat_max_version": "0.99.99",
+            "index_revision": "abc123",
+            "schema_version": "5",
+            "chunk_count": 10,
+            "file_count": 3,
+            "created_at": 1_700_000_000.0,
+        }
+        defaults.update(overrides)
+        return ArtifactHeader(**defaults)  # type: ignore[arg-type]
+
+    def test_to_json_from_json_roundtrip(self) -> None:
+        header = self._sample()
+        restored = ArtifactHeader.from_json(json.loads(json.dumps(header.to_json())))
+        assert restored == header
+
+    def test_from_json_raises_on_missing_field(self) -> None:
+        with pytest.raises(ArtifactError, match="Malformed artifact header"):
+            ArtifactHeader.from_json({"format_version": 1})
+
+    def test_from_json_tolerates_missing_schema_version(self) -> None:
+        header = self._sample(schema_version=None)
+        restored = ArtifactHeader.from_json(json.loads(json.dumps(header.to_json())))
+        assert restored.schema_version is None
+
+
+class TestValidateArtifactCompat:
+    def _sample(self, **overrides: object) -> ArtifactHeader:
+        defaults: dict[str, object] = {
+            "format_version": ARTIFACT_FORMAT_VERSION,
+            "created_by_version": "0.15.2",
+            "compat_min_version": "0.15.0",
+            "compat_max_version": "0.99.99",
+            "index_revision": "abc123",
+            "schema_version": "5",
+            "chunk_count": 1,
+            "file_count": 1,
+            "created_at": 0.0,
+        }
+        defaults.update(overrides)
+        return ArtifactHeader(**defaults)  # type: ignore[arg-type]
+
+    def test_accepts_matching_format_and_in_range_version(self) -> None:
+        validate_artifact_compat(self._sample())  # does not raise
+
+    def test_rejects_unsupported_format_version(self) -> None:
+        header = self._sample(format_version=ARTIFACT_FORMAT_VERSION + 1)
+        with pytest.raises(ArtifactVersionError, match="format version"):
+            validate_artifact_compat(header)
+
+    def test_rejects_archex_version_below_compat_min(self) -> None:
+        header = self._sample(compat_min_version="99.0.0", compat_max_version="99.99.99")
+        with pytest.raises(ArtifactVersionError, match="archex"):
+            validate_artifact_compat(header)
+
+    def test_rejects_archex_version_above_compat_max(self) -> None:
+        header = self._sample(compat_min_version="0.0.0", compat_max_version="0.0.1")
+        with pytest.raises(ArtifactVersionError, match="archex"):
+            validate_artifact_compat(header)
+
+
+class TestExportArtifactCli:
+    def test_index_export_artifact_flag_writes_file_and_reports_revision(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        init_project(python_simple_repo)
+        artifact_path = tmp_path / "artifact.xz"
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "index",
+                str(python_simple_repo),
+                "--export-artifact",
+                str(artifact_path),
+                "--format",
+                "json",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        summary = json.loads(result.output)
+        assert artifact_path.exists()
+        assert summary["artifact_path"] == str(artifact_path)
+        assert summary["artifact_index_revision"]
+        assert summary["artifact_size_bytes"] > 0
+
+    def test_index_without_export_artifact_flag_omits_artifact_fields(
+        self, python_simple_repo: Path
+    ) -> None:
+        init_project(python_simple_repo)
+        runner = CliRunner()
+
+        result = runner.invoke(cli, ["index", str(python_simple_repo), "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        summary = json.loads(result.output)
+        assert "artifact_path" not in summary


### PR DESCRIPTION
## Summary

M16 (Portable index artifact for team-shared bootstrap), PR 1 of 4: the artifact export format itself.

`archex index --export-artifact <path>` writes a compacted, compressed, versioned snapshot of the current `.archex/index.db`:

- `VACUUM INTO`-compacts the store's SQLite database.
- Strips the two FTS5 derived tables (`chunks_fts`, `symbols_fts`) — fully rebuildable from `chunks`, so shipping them would duplicate the corpus text and bake in a build-specific FTS5 binary shape.
- Compresses the result with stdlib `lzma` (zero new dependencies, per the constraint).
- Wraps it in a small custom frame — magic bytes, then a length-prefixed JSON header, then the LZMA payload — so a reader can validate compatibility (`format_version`, an `archex` version compat range, `index_revision`) before ever decompressing the (potentially large) payload.

Format documented in `docs/PORTABLE_INDEX_ARTIFACT.md`.

## Tests

`tests/index/test_artifact.py`: header field roundtrip, FTS5 table stripping + chunk-count preservation across the strip, compression smaller than raw DB, missing-`commit_hash` failure (an index with no recorded revision can't be delta-synced later), malformed/bogus-file header failure, format-version and archex-version compat-range rejection, and the `archex index --export-artifact` CLI flag end-to-end.

## Verification

- `uv run pytest tests/index/test_artifact.py -v` — 16 passed.
- `uv run pytest` — 3369 passed.
- `uv run ruff check .` / `uv run ruff format --check .` — clean.
- `uv run pyright` — 0 errors.

## Stack

1. `feat/m16-artifact-format` → `main` (this PR)
2. `feat/m16-artifact-import` → PR 1 (import + derived-index rebuild + compat validation)
3. `feat/m16-artifact-sync` → PR 2 (working-tree delta-sync after import + staleness fallback)
4. `feat/m16-artifact-gitattributes` → PR 3 (`.gitattributes` management + wall-time evidence)
