### PR TITLE
feat(index): import portable index artifacts

### DIFF
--- a/src/archex/cli/init_cmd.py
+++ b/src/archex/cli/init_cmd.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import click
 
+from archex.exceptions import ArchexError
+from archex.index.artifact import import_artifact
 from archex.project import init_project
 
 
@@ -16,7 +20,14 @@ from archex.project import init_project
     default=False,
     help="Delete existing .archex state before initialization. Requires --force.",
 )
-def init_cmd(source: str, force: bool, reset: bool) -> None:
+@click.option(
+    "--from-artifact",
+    "from_artifact_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Bootstrap the local index from a portable index artifact instead of cold-start reindex.",
+)
+def init_cmd(source: str, force: bool, reset: bool, from_artifact_path: Path | None) -> None:
     """Initialize repo-local archex project state."""
     try:
         result = init_project(source, force=force, reset=reset)
@@ -35,3 +46,14 @@ def init_cmd(source: str, force: bool, reset: bool) -> None:
 
     if result.gitignore_updated:
         click.echo(f"Updated ignore rules: {result.state.gitignore_path}")
+
+    if from_artifact_path is not None:
+        try:
+            header = import_artifact(from_artifact_path, result.state.index_path)
+        except ArchexError as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(f"Imported index artifact: {from_artifact_path}")
+        click.echo(f"Artifact revision:       {header.index_revision}")
+        click.echo(
+            f"Artifact corpus:         {header.file_count} files, {header.chunk_count} chunks"
+        )

--- a/src/archex/index/artifact.py
+++ b/src/archex/index/artifact.py
@@ -36,13 +36,11 @@ import struct
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from archex import __version__
 from archex.exceptions import ArtifactError, ArtifactVersionError
-
-if TYPE_CHECKING:
-    from archex.index.store import IndexStore
+from archex.index.store import IndexStore
 
 ARTIFACT_MAGIC = b"ARCHEXIDXv1\n"
 
@@ -246,5 +244,69 @@ def export_artifact(store: IndexStore, output_path: str | Path) -> ArtifactHeade
         handle.write(header_bytes)
         handle.write(compressed)
     tmp_output.replace(output_path)
+
+    return header
+
+
+def _rebuild_symbols_fts(store: IndexStore) -> None:
+    """Repopulate `symbols_fts` from `chunks` after an artifact import.
+
+    `chunks_fts` has a store-provided rebuild path (`BM25Index.build()`);
+    `symbols_fts` (symbol-name search) has no equivalent helper on
+    `IndexStore`, so it is rebuilt directly here from the chunks the
+    artifact already carries.
+    """
+    conn = store.conn
+    conn.execute("DELETE FROM symbols_fts")
+    conn.executemany(
+        "INSERT INTO symbols_fts (symbol_id, symbol_name, qualified_name, file_path) "
+        "VALUES (?, ?, ?, ?)",
+        (
+            (chunk.symbol_id, chunk.symbol_name, chunk.qualified_name, chunk.file_path)
+            for chunk in store.iter_chunks()
+            if chunk.symbol_id is not None
+        ),
+    )
+    conn.commit()
+
+
+def import_artifact(path: str | Path, dest_db_path: str | Path) -> ArtifactHeader:
+    """Import a portable index artifact, writing a ready-to-use store at `dest_db_path`.
+
+    The artifact's header is read and its format/compat range validated
+    BEFORE the payload is decompressed — an out-of-range artifact raises
+    `ArtifactVersionError` and never touches `dest_db_path`, so a failed
+    import is always loud and never partial.
+
+    The two FTS5 derived tables stripped at export time (`chunks_fts`,
+    `symbols_fts`) are rebuilt locally from the imported `chunks` table
+    once the database is on disk.
+    """
+    from archex.index.bm25 import BM25Index
+
+    path = Path(path)
+    dest_db_path = Path(dest_db_path)
+
+    with path.open("rb") as handle:
+        header = _read_header(handle, path)
+        validate_artifact_compat(header)
+        compressed_payload = handle.read()
+
+    decompressed = lzma.decompress(compressed_payload)
+
+    dest_db_path.parent.mkdir(parents=True, exist_ok=True)
+    for suffix in ("-wal", "-shm"):
+        sidecar = dest_db_path.with_name(dest_db_path.name + suffix)
+        if sidecar.exists():
+            sidecar.unlink()
+    dest_db_path.write_bytes(decompressed)
+
+    store = IndexStore(dest_db_path)
+    try:
+        bm25 = BM25Index(store)
+        bm25.build(store.iter_chunks())
+        _rebuild_symbols_fts(store)
+    finally:
+        store.close()
 
     return header

--- a/tests/index/test_artifact.py
+++ b/tests/index/test_artifact.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import lzma
+import shutil
 import sqlite3
 import struct
 from pathlib import Path
@@ -19,6 +20,7 @@ from archex.index.artifact import (
     ARTIFACT_MAGIC,
     ArtifactHeader,
     export_artifact,
+    import_artifact,
     read_artifact_header,
     validate_artifact_compat,
 )
@@ -40,6 +42,21 @@ def _decompress_payload(artifact_path: Path) -> bytes:
         handle.read(header_len)
         payload = handle.read()
     return lzma.decompress(payload)
+
+
+def _write_raw_artifact(path: Path, header: dict[str, object], payload: bytes) -> None:
+    """Hand-frame an artifact file from an arbitrary header, bypassing export_artifact.
+
+    Used to construct headers `export_artifact` would never itself produce
+    (an out-of-range format/compat version) so compat validation can be
+    tested independently of the export path.
+    """
+    header_bytes = json.dumps(header, sort_keys=True).encode("utf-8")
+    with path.open("wb") as handle:
+        handle.write(ARTIFACT_MAGIC)
+        handle.write(struct.pack(">I", len(header_bytes)))
+        handle.write(header_bytes)
+        handle.write(lzma.compress(payload))
 
 
 class TestExportArtifact:
@@ -248,3 +265,195 @@ class TestExportArtifactCli:
         assert result.exit_code == 0, result.output
         summary = json.loads(result.output)
         assert "artifact_path" not in summary
+
+
+_INCOMPATIBLE_FORMAT_HEADER: dict[str, object] = {
+    "format_version": ARTIFACT_FORMAT_VERSION + 1,
+    "created_by_version": "99.0.0",
+    "compat_min_version": "0.0.0",
+    "compat_max_version": "99.99.99",
+    "index_revision": "deadbeef",
+    "schema_version": "5",
+    "chunk_count": 1,
+    "file_count": 1,
+    "created_at": 0.0,
+}
+
+_INCOMPATIBLE_VERSION_HEADER: dict[str, object] = {
+    "format_version": ARTIFACT_FORMAT_VERSION,
+    "created_by_version": "99.0.0",
+    "compat_min_version": "99.0.0",
+    "compat_max_version": "99.99.99",
+    "index_revision": "deadbeef",
+    "schema_version": "5",
+    "chunk_count": 1,
+    "file_count": 1,
+    "created_at": 0.0,
+}
+
+
+class TestImportArtifact:
+    def test_import_produces_ready_to_use_store(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = tmp_path / "artifact.xz"
+            export_artifact(store, artifact_path)
+            original_chunks = {
+                (c.file_path, c.symbol_name or "", c.start_line, c.end_line)
+                for c in store.get_chunks()
+            }
+            original_edges = {(e.source, e.target, e.kind.value) for e in store.get_edges()}
+        finally:
+            store.close()
+
+        dest_db_path = tmp_path / "imported" / "index.db"
+        header = import_artifact(artifact_path, dest_db_path)
+
+        assert header.index_revision
+
+        imported = IndexStore(dest_db_path)
+        try:
+            imported_chunks = {
+                (c.file_path, c.symbol_name or "", c.start_line, c.end_line)
+                for c in imported.get_chunks()
+            }
+            imported_edges = {(e.source, e.target, e.kind.value) for e in imported.get_edges()}
+            assert imported_chunks == original_chunks
+            assert imported_edges == original_edges
+
+            fts_count = imported.conn.execute("SELECT COUNT(*) FROM chunks_fts").fetchone()[0]
+            assert fts_count == imported.get_chunk_count()
+            symbols_fts_count = imported.conn.execute(
+                "SELECT COUNT(*) FROM symbols_fts"
+            ).fetchone()[0]
+            assert symbols_fts_count > 0
+        finally:
+            imported.close()
+
+    def test_import_bm25_search_parity_with_original(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        from archex.index.bm25 import BM25Index
+
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = tmp_path / "artifact.xz"
+            export_artifact(store, artifact_path)
+            original_bm25 = BM25Index(store)
+            original_bm25.build(store.get_chunks())
+            queries = ["util", "process", "add", "compute"]
+            original_results = {
+                q: [(c.id, score) for c, score in original_bm25.search(q)] for q in queries
+            }
+        finally:
+            store.close()
+
+        dest_db_path = tmp_path / "imported" / "index.db"
+        import_artifact(artifact_path, dest_db_path)
+
+        imported = IndexStore(dest_db_path)
+        try:
+            imported_bm25 = BM25Index(imported)
+            for query in queries:
+                imported_results = [(c.id, score) for c, score in imported_bm25.search(query)]
+                assert imported_results == original_results[query], f"parity mismatch: {query!r}"
+        finally:
+            imported.close()
+
+    def test_import_rejects_bogus_file_without_writing_dest(self, tmp_path: Path) -> None:
+        bogus = tmp_path / "bogus.xz"
+        bogus.write_bytes(b"definitely not an artifact")
+        dest = tmp_path / "dest" / "index.db"
+
+        with pytest.raises(ArtifactError, match="bad magic"):
+            import_artifact(bogus, dest)
+
+        assert not dest.exists()
+
+    def test_import_rejects_unsupported_format_version_without_writing_dest(
+        self, tmp_path: Path
+    ) -> None:
+        artifact_path = tmp_path / "future.xz"
+        _write_raw_artifact(artifact_path, _INCOMPATIBLE_FORMAT_HEADER, b"irrelevant payload")
+        dest = tmp_path / "dest" / "index.db"
+
+        with pytest.raises(ArtifactVersionError, match="format version"):
+            import_artifact(artifact_path, dest)
+
+        assert not dest.exists()
+
+    def test_import_rejects_out_of_range_archex_version_without_writing_dest(
+        self, tmp_path: Path
+    ) -> None:
+        artifact_path = tmp_path / "incompatible.xz"
+        _write_raw_artifact(artifact_path, _INCOMPATIBLE_VERSION_HEADER, b"irrelevant payload")
+        dest = tmp_path / "dest" / "index.db"
+
+        with pytest.raises(ArtifactVersionError, match="archex"):
+            import_artifact(artifact_path, dest)
+
+        assert not dest.exists()
+
+    def test_import_never_overwrites_existing_dest_on_compat_failure(self, tmp_path: Path) -> None:
+        """A stale, incompatible artifact must never clobber an already-good index."""
+        dest = tmp_path / "index.db"
+        dest.write_bytes(b"pretend this is a valid, already-good index file")
+        original_bytes = dest.read_bytes()
+
+        artifact_path = tmp_path / "incompatible.xz"
+        _write_raw_artifact(artifact_path, _INCOMPATIBLE_FORMAT_HEADER, b"irrelevant payload")
+
+        with pytest.raises(ArtifactVersionError):
+            import_artifact(artifact_path, dest)
+
+        assert dest.read_bytes() == original_bytes
+
+
+class TestFromArtifactCli:
+    def test_init_from_artifact_bootstraps_project_index(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        init_project(python_simple_repo)
+        runner = CliRunner()
+        artifact_path = tmp_path / "artifact.xz"
+
+        exported = runner.invoke(
+            cli, ["index", str(python_simple_repo), "--export-artifact", str(artifact_path)]
+        )
+        assert exported.exit_code == 0, exported.output
+
+        fresh_repo = tmp_path / "fresh_clone"
+        shutil.copytree(python_simple_repo, fresh_repo)
+        shutil.rmtree(fresh_repo / ".archex")
+
+        result = runner.invoke(
+            cli, ["init", str(fresh_repo), "--from-artifact", str(artifact_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Imported index artifact" in result.output
+        index_path = fresh_repo / ".archex" / "index.db"
+        assert index_path.exists()
+        store = IndexStore(index_path)
+        try:
+            assert store.get_chunk_count() > 0
+        finally:
+            store.close()
+
+    def test_init_from_artifact_fails_loudly_on_incompatible_artifact(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        artifact_path = tmp_path / "incompatible.xz"
+        _write_raw_artifact(artifact_path, _INCOMPATIBLE_FORMAT_HEADER, b"irrelevant payload")
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli, ["init", str(python_simple_repo), "--from-artifact", str(artifact_path)]
+        )
+
+        assert result.exit_code != 0
+        assert "format version" in result.output
+        index_path = python_simple_repo / ".archex" / "index.db"
+        assert not index_path.exists()


### PR DESCRIPTION
## Summary

M16 (Portable index artifact for team-shared bootstrap), PR 2 of 4: import + derived-index rebuild, based on #425.

`archex init --from-artifact <path>` bootstraps `.archex/index.db` from a portable artifact instead of a cold-start reindex:

- `import_artifact()` reads and validates the header (`format_version`, `archex` compat range) **before decompressing the payload** — an out-of-range artifact raises `ArtifactVersionError` and `dest_db_path` is never touched, so a rejected import is always loud and never partial.
- On success, writes the decompressed database and rebuilds the two FTS5 derived tables locally: `chunks_fts` via the existing `BM25Index.build()`, `symbols_fts` via a small direct rebuild (no equivalent helper existed on `IndexStore`).
- `archex init` still performs its normal project-state initialization (`settings.toml`, `metadata.json`, `.gitignore`) regardless of `--from-artifact`; the artifact import only bootstraps the index database.

## Tests

`tests/index/test_artifact.py` (`TestImportArtifact`, `TestFromArtifactCli`): chunk/edge parity and rebuilt FTS row counts after import, BM25 search parity with the pre-export store, the out-of-range format-version and archex-version negative cases (asserting the destination file is never written), a bogus/non-artifact file rejection, and `archex init --from-artifact` end-to-end including its loud-failure path (asserts `.archex/index.db` is never created on a rejected import).

## Verification

- `uv run pytest tests/index/test_artifact.py -v` — 24 passed.
- `uv run pytest` — 3377 passed.
- `uv run ruff check .` / `uv run ruff format --check .` — clean.
- `uv run pyright` — 0 errors.

## Stack

1. `feat/m16-artifact-format` → `main` (#425)
2. `feat/m16-artifact-import` → PR 1 (this PR)
3. `feat/m16-artifact-sync` → PR 2 (working-tree delta-sync after import + staleness fallback)
4. `feat/m16-artifact-gitattributes` → PR 3 (`.gitattributes` management + wall-time evidence)
