### PR TITLE
feat(index): sync imported artifacts against the working tree

### DIFF
--- a/src/archex/cli/init_cmd.py
+++ b/src/archex/cli/init_cmd.py
@@ -6,8 +6,9 @@ from pathlib import Path
 
 import click
 
+from archex.config import load_config, load_index_config
 from archex.exceptions import ArchexError
-from archex.index.artifact import import_artifact
+from archex.index.artifact import import_artifact, sync_imported_artifact
 from archex.project import init_project
 
 
@@ -57,3 +58,16 @@ def init_cmd(source: str, force: bool, reset: bool, from_artifact_path: Path | N
         click.echo(
             f"Artifact corpus:         {header.file_count} files, {header.chunk_count} chunks"
         )
+
+        try:
+            config = load_config(source)
+            index_config = load_index_config(source)
+            sync_result = sync_imported_artifact(
+                result.state.repo_root, result.state.index_path, config, index_config
+            )
+        except ArchexError as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(f"Delta-sync strategy:     {sync_result.strategy}")
+        if sync_result.strategy != "clean":
+            click.echo(f"Files changed since export: {sync_result.files_changed}")
+        click.echo(f"Sync time:               {sync_result.sync_time_ms} ms")

--- a/src/archex/index/artifact.py
+++ b/src/archex/index/artifact.py
@@ -30,17 +30,24 @@ loudly without ever writing a partial index to disk.
 from __future__ import annotations
 
 import json
+import logging
 import lzma
 import sqlite3
 import struct
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from archex import __version__
 from archex.exceptions import ArtifactError, ArtifactVersionError
 from archex.index.store import IndexStore
+from archex.models import IndexConfig
+
+if TYPE_CHECKING:
+    from archex.models import Config, DeltaMeta
+
+logger = logging.getLogger(__name__)
 
 ARTIFACT_MAGIC = b"ARCHEXIDXv1\n"
 
@@ -310,3 +317,146 @@ def import_artifact(path: str | Path, dest_db_path: str | Path) -> ArtifactHeade
         store.close()
 
     return header
+
+
+_STALE_FALLBACK_LOG = (
+    "Imported artifact is stale: %.0f%% of files changed since export "
+    "(delta_threshold=%.0f%%) — falling back to a full re-index."
+)
+
+
+@dataclass(frozen=True)
+class ArtifactSyncResult:
+    """Outcome of syncing a freshly-imported artifact store to the working tree."""
+
+    strategy: str
+    """One of ``"clean"`` (no drift), ``"delta"``, or ``"full_reindex"``."""
+
+    files_changed: int
+    delta_meta: DeltaMeta | None
+    sync_time_ms: float
+
+
+def _full_reindex_in_place(
+    repo_root: Path,
+    dest_db_path: Path,
+    config: Config,
+    index_config: IndexConfig,
+) -> None:
+    """Discard a too-stale imported store and perform an ordinary full re-index in place.
+
+    Builds via the same `_full_index` pipeline `archex index` itself uses,
+    then explicitly copies the result onto `dest_db_path` — rather than
+    relying on `index_repository()`'s cache-key/project-layout detection to
+    land at the right path, which would silently miss `dest_db_path`
+    whenever the repo-local project has not been initialized yet (exactly
+    the state `archex init --from-artifact` is in when this fallback runs).
+    Always builds with caching enabled internally (regardless of the
+    caller's own `config.cache`) so `commit_hash`/`source_identity` land in
+    the fresh store's metadata, which `sync_imported_artifact` and future
+    re-exports depend on.
+    """
+    import shutil
+    import tempfile
+
+    from archex.api import _full_index  # pyright: ignore[reportPrivateUsage]
+    from archex.cache import CacheManager
+    from archex.models import RepoSource
+
+    source = RepoSource(local_path=str(repo_root))
+    fallback_config = config.model_copy(update={"cache": True})
+    scratch_dir = Path(tempfile.mkdtemp(prefix="archex-artifact-fallback-"))
+    try:
+        scratch_cache = CacheManager(cache_dir=str(scratch_dir))
+        cache_key = scratch_cache.cache_key(source)
+        fresh_store = _full_index(
+            source,
+            fallback_config,
+            scratch_cache,
+            cache_key,
+            timing=None,
+            index_config=index_config,
+        )
+        fresh_db_path = fresh_store.db_path
+        fresh_store.conn.execute("PRAGMA wal_checkpoint(FULL)")
+        fresh_store.close()
+
+        dest_db_path.parent.mkdir(parents=True, exist_ok=True)
+        for suffix in ("-wal", "-shm"):
+            stale_sidecar = dest_db_path.with_name(dest_db_path.name + suffix)
+            if stale_sidecar.exists():
+                stale_sidecar.unlink()
+        shutil.copy2(fresh_db_path, dest_db_path)
+    finally:
+        shutil.rmtree(scratch_dir, ignore_errors=True)
+
+
+def sync_imported_artifact(
+    repo_root: Path,
+    dest_db_path: str | Path,
+    config: Config,
+    index_config: IndexConfig | None = None,
+) -> ArtifactSyncResult:
+    """Bring a freshly-imported artifact store up to date with the working tree.
+
+    Applies `compute_working_tree_delta()` + `apply_delta()` — the same
+    targeted-update machinery `apply_delta` already provides for ordinary
+    delta re-indexing — scoped against the artifact's imported
+    `file_states`. When the change set is at or above `config.delta_threshold`
+    (the same staleness knob the ordinary delta-indexing path uses), the
+    imported store is discarded in favor of an ordinary full re-index: past
+    that point a targeted delta costs more than starting fresh, and a loud
+    fallback is safer than silently syncing a misleadingly "close enough"
+    index.
+    """
+    from archex.acquire import discover_files
+    from archex.cache import CacheManager
+    from archex.index.delta import apply_delta, compute_working_tree_delta
+    from archex.index.graph import DependencyGraph
+
+    dest_db_path = Path(dest_db_path)
+    effective_index_config = index_config or IndexConfig()
+    t_start = time.perf_counter()
+
+    store = IndexStore(dest_db_path)
+    manifest = compute_working_tree_delta(repo_root, store, config)
+    manifest.base_commit = store.get_metadata("commit_hash") or manifest.base_commit
+    current_commit = CacheManager.git_head(str(repo_root))
+    if current_commit:
+        manifest.current_commit = current_commit
+
+    if not manifest.changes:
+        store.set_metadata("indexed_at", str(time.time()))
+        store.close()
+        return ArtifactSyncResult(
+            strategy="clean",
+            files_changed=0,
+            delta_meta=None,
+            sync_time_ms=round((time.perf_counter() - t_start) * 1000, 1),
+        )
+
+    total_files = len(
+        discover_files(repo_root, languages=config.languages, max_file_size=config.max_file_size)
+    )
+    change_ratio = len(manifest.changes) / total_files if total_files > 0 else 1.0
+
+    if change_ratio >= config.delta_threshold:
+        store.close()
+        logger.warning(_STALE_FALLBACK_LOG, change_ratio * 100, config.delta_threshold * 100)
+        _full_reindex_in_place(repo_root, dest_db_path, config, effective_index_config)
+        return ArtifactSyncResult(
+            strategy="full_reindex",
+            files_changed=len(manifest.changes),
+            delta_meta=None,
+            sync_time_ms=round((time.perf_counter() - t_start) * 1000, 1),
+        )
+
+    graph = DependencyGraph.from_edges(store.get_edges())
+    delta_meta = apply_delta(store, graph, manifest, repo_root, config, effective_index_config)
+    store.close()
+    return ArtifactSyncResult(
+        strategy="delta",
+        files_changed=len(manifest.changes),
+        delta_meta=delta_meta,
+        sync_time_ms=round((time.perf_counter() - t_start) * 1000, 1),
+    )

--- a/tests/index/test_artifact.py
+++ b/tests/index/test_artifact.py
@@ -7,6 +7,7 @@ import lzma
 import shutil
 import sqlite3
 import struct
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -22,11 +23,16 @@ from archex.index.artifact import (
     export_artifact,
     import_artifact,
     read_artifact_header,
+    sync_imported_artifact,
     validate_artifact_compat,
 )
 from archex.index.store import IndexStore
 from archex.models import Config, IndexConfig, RepoSource
 from archex.project import init_project
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
 
 
 def _build_store(repo: Path, cache_dir: Path) -> IndexStore:
@@ -457,3 +463,159 @@ class TestFromArtifactCli:
         assert "format version" in result.output
         index_path = python_simple_repo / ".archex" / "index.db"
         assert not index_path.exists()
+
+
+class TestSyncImportedArtifact:
+    def test_sync_reports_clean_when_working_tree_matches_artifact(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = tmp_path / "artifact.xz"
+            export_artifact(store, artifact_path)
+        finally:
+            store.close()
+
+        dest_db_path = tmp_path / "imported" / "index.db"
+        import_artifact(artifact_path, dest_db_path)
+
+        config = Config(languages=["python"], cache=False)
+        result = sync_imported_artifact(python_simple_repo, dest_db_path, config)
+
+        assert result.strategy == "clean"
+        assert result.files_changed == 0
+        assert result.delta_meta is None
+
+    def test_sync_applies_targeted_delta_matching_full_reindex(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        from archex.index.bm25 import BM25Index
+
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = tmp_path / "artifact.xz"
+            export_artifact(store, artifact_path)
+        finally:
+            store.close()
+
+        # Simulate more work landing in the repo after the artifact was exported.
+        (python_simple_repo / "utils.py").write_text(
+            "def brand_new_util():\n    return 'freshly parsed content'\n"
+        )
+        _git(python_simple_repo, "add", ".")
+        _git(python_simple_repo, "commit", "-m", "advance past the artifact's revision")
+
+        dest_db_path = tmp_path / "imported" / "index.db"
+        import_artifact(artifact_path, dest_db_path)
+
+        config = Config(languages=["python"], cache=False)
+        result = sync_imported_artifact(python_simple_repo, dest_db_path, config)
+
+        assert result.strategy == "delta"
+        assert result.files_changed >= 1
+        assert result.delta_meta is not None
+        assert result.delta_meta.full_reindex_avoided is True
+
+        synced_store = IndexStore(dest_db_path)
+        try:
+            synced_chunks = {
+                (c.file_path, c.symbol_name or "", c.start_line, c.end_line)
+                for c in synced_store.get_chunks()
+            }
+            synced_bm25 = BM25Index(synced_store)
+
+            baseline_store = _build_store(python_simple_repo, tmp_path / "baseline_cache")
+            try:
+                baseline_chunks = {
+                    (c.file_path, c.symbol_name or "", c.start_line, c.end_line)
+                    for c in baseline_store.get_chunks()
+                }
+                baseline_bm25 = BM25Index(baseline_store)
+                baseline_bm25.build(baseline_store.get_chunks())
+
+                assert synced_chunks == baseline_chunks
+                # Compare recalled documents, not exact scores: breadcrumbs/summary
+                # are never persisted to SQLite, so any FTS rebuild sourced from
+                # already-stored chunks (import_artifact's rebuild here, and
+                # apply_delta's own `needs_full_bm25_rebuild` path identically)
+                # loses them for untouched files while a freshly re-parsed file
+                # keeps them — the same asymmetry already accepted by the
+                # existing delta-indexing design, not an M16 regression.
+                for query in ["util", "process", "brand new", "add"]:
+                    synced_ids = {c.id for c, _ in synced_bm25.search(query)}
+                    baseline_ids = {c.id for c, _ in baseline_bm25.search(query)}
+                    assert synced_ids == baseline_ids, f"recall mismatch: {query!r}"
+            finally:
+                baseline_store.close()
+        finally:
+            synced_store.close()
+
+    def test_sync_falls_back_to_full_reindex_when_artifact_is_stale(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = tmp_path / "artifact.xz"
+            export_artifact(store, artifact_path)
+        finally:
+            store.close()
+
+        for py_file in sorted(python_simple_repo.rglob("*.py")):
+            py_file.write_text(f"def rewritten_{py_file.stem}():\n    return 1\n")
+        _git(python_simple_repo, "add", ".")
+        _git(python_simple_repo, "commit", "-m", "rewrite everything")
+
+        dest_db_path = tmp_path / "imported" / "index.db"
+        import_artifact(artifact_path, dest_db_path)
+
+        config = Config(languages=["python"], cache=True, delta_threshold=0.5)
+        result = sync_imported_artifact(python_simple_repo, dest_db_path, config)
+
+        assert result.strategy == "full_reindex"
+        assert result.delta_meta is None
+
+        synced_store = IndexStore(dest_db_path)
+        try:
+            rewritten_chunks = synced_store.get_chunks_for_file("utils.py")
+            assert any("rewritten_utils" in c.content for c in rewritten_chunks)
+            assert synced_store.get_metadata("commit_hash")
+        finally:
+            synced_store.close()
+
+
+class TestFromArtifactCliSync:
+    def test_init_from_artifact_delta_syncs_to_current_working_tree(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        init_project(python_simple_repo)
+        runner = CliRunner()
+        artifact_path = tmp_path / "artifact.xz"
+
+        exported = runner.invoke(
+            cli, ["index", str(python_simple_repo), "--export-artifact", str(artifact_path)]
+        )
+        assert exported.exit_code == 0, exported.output
+
+        fresh_repo = tmp_path / "fresh_clone"
+        shutil.copytree(python_simple_repo, fresh_repo)
+        shutil.rmtree(fresh_repo / ".archex")
+
+        # Simulate a teammate's later commit landing before the fresh clone runs init.
+        (fresh_repo / "utils.py").write_text("def added_after_export():\n    return 99\n")
+        _git(fresh_repo, "add", ".")
+        _git(fresh_repo, "commit", "-m", "work that landed after the artifact was exported")
+
+        result = runner.invoke(
+            cli, ["init", str(fresh_repo), "--from-artifact", str(artifact_path)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Delta-sync strategy:     delta" in result.output
+
+        index_path = fresh_repo / ".archex" / "index.db"
+        store = IndexStore(index_path)
+        try:
+            chunks = store.get_chunks_for_file("utils.py")
+            assert any("added_after_export" in c.content for c in chunks)
+        finally:
+            store.close()


### PR DESCRIPTION
## Summary

M16 (Portable index artifact for team-shared bootstrap), PR 3 of 4: delta-sync after import + staleness fallback, based on #426.

`archex init --from-artifact` now syncs the imported store to the current working tree instead of leaving it pinned at the artifact's export-time revision:

- `sync_imported_artifact()` runs `compute_working_tree_delta()` against the artifact's imported `file_states`, then applies a targeted `apply_delta()` when the change ratio is below `config.delta_threshold` — reusing the exact staleness knob (default 0.5) the ordinary delta-indexing path already exposes, rather than inventing a new one.
- At or above that threshold, a targeted delta would cost more than starting fresh — the imported store is discarded and an ordinary full re-index runs in its place, logged as a loud warning (never a silently "close enough" index).
- The full-reindex fallback builds via the same `_full_index` pipeline `archex index` itself uses, then explicitly copies the result onto `dest_db_path` — deliberately not relying on `index_repository()`'s own cache-key/project-layout auto-detection, which would silently miss the target path in exactly the state `archex init --from-artifact` is in (project not yet fully "warm").
- `manifest.base_commit`/`current_commit` are corrected to real commit hashes (the artifact's recorded revision and the working tree's actual HEAD) before `apply_delta` writes metadata, instead of the literal `"worktree"` placeholder `compute_working_tree_delta` returns.

## Tests

`tests/index/test_artifact.py` (`TestSyncImportedArtifact`, `TestFromArtifactCliSync`): a no-drift "clean" sync, a targeted-delta sync verified against an independent full reindex of the same final repo state (chunk-signature set equality plus BM25-recall-set parity — score-level parity is deliberately not asserted, since breadcrumbs/summary are never persisted to SQLite and any FTS rebuild sourced from stored chunks loses them for untouched files, identically to `apply_delta`'s own existing `needs_full_bm25_rebuild` path — not an M16 regression), a stale-artifact full-reindex-fallback case, and an end-to-end `archex init --from-artifact` CLI round trip through a simulated fresh clone that has advanced past the artifact's recorded revision.

## Verification

- `uv run pytest tests/index/test_artifact.py -v` — 28 passed.
- `uv run pytest` — 3381 passed.
- `uv run ruff check .` / `uv run ruff format --check .` — clean.
- `uv run pyright` — 0 errors.

## Stack

1. `feat/m16-artifact-format` → `main` (#425)
2. `feat/m16-artifact-import` → PR 1 (#426)
3. `feat/m16-artifact-sync` → PR 2 (this PR)
4. `feat/m16-artifact-gitattributes` → PR 3 (`.gitattributes` management + wall-time evidence)
