### PR TITLE
feat(index): manage .gitattributes and document artifact wall-time evidence

### DIFF
--- a/docs/PORTABLE_INDEX_ARTIFACT.md
+++ b/docs/PORTABLE_INDEX_ARTIFACT.md
@@ -76,6 +76,93 @@ Version comparison is a minimal dotted-integer-tuple comparator (not a full
 PEP 440/semver parser) — sufficient for archex's plain `MAJOR.MINOR.PATCH`
 versioning and avoids adding a dependency for it.
 
+## Delta-sync after import and the staleness fallback
+
+`archex init --from-artifact` does not leave the imported store pinned at
+the artifact's export-time revision. Immediately after import, it runs
+`sync_imported_artifact()`:
+
+1. `compute_working_tree_delta()` compares the artifact's imported
+   `file_states` (content hashes) against the current working tree —
+   whatever commit that happens to be at, since the comparison is
+   content-hash-based rather than a git commit diff. This is what makes it
+   correct even when the artifact's recorded revision is unreachable in a
+   shallow clone.
+2. If nothing changed, syncing is a no-op (`strategy: "clean"`).
+3. If the change ratio is **below** `config.delta_threshold` (default
+   `0.5`, the same knob the ordinary delta-indexing path already exposes),
+   a targeted `apply_delta()` updates only the affected chunks, edges, and
+   FTS rows — proportional to the delta, not the repo.
+4. If the change ratio is **at or above** `config.delta_threshold`, the
+   imported store is discarded and an ordinary full re-index runs in its
+   place instead, logged as a loud warning (`strategy: "full_reindex"`).
+   Past that point a targeted delta costs more than starting fresh, and a
+   loud, deterministic fallback is safer than silently syncing an index
+   that is technically "delta-applied" but has drifted so far it no longer
+   resembles the artifact it started from.
+
+`archex init --from-artifact` reports the chosen strategy, files changed,
+and sync time.
+
+## `.gitattributes` management
+
+Committing a binary artifact into git risks merge conflicts every time two
+branches both regenerate it. `archex index --export-artifact <path>`
+auto-manages a `merge=ours -diff` entry in `.gitattributes` for the
+artifact's repo-relative path whenever it is exported *inside* the repo (an
+artifact exported elsewhere, e.g. `/tmp`, has no repo-relative path to
+attach a strategy to, and is skipped):
+
+```gitattributes
+# archex portable index artifact — never diff/merge-conflict
+.archex-artifact.xz merge=ours -diff
+```
+
+This is written to disk only — never staged or committed automatically.
+Committing it (alongside the artifact itself) is a deliberate, separate
+decision.
+
+`merge=ours` names a custom merge driver git must be told about via the
+`merge.ours.driver` git config key — deliberately **local, non-shareable**
+config, by git's own design (a committed config that redefines a merge
+driver could otherwise let a malicious repo silently turn every merge into
+a no-op). Export best-effort registers it on the exporting machine
+(`git config merge.ours.driver true`), but every other clone must run that
+same one-line command once:
+
+```console
+$ git config merge.ours.driver true
+```
+
+Without it, `merge=ours` is a no-op attribute and git falls back to its
+normal (conflict-prone) binary merge behavior for the artifact path.
+
+## Wall-time evidence
+
+Measured on archex's own repository as the benchmark fixture — the same
+self-referential `repo: "."`, pinned-commit-pair methodology
+`benchmarks/delta_tasks/archex_delta_large.yaml` already uses for the M2
+delta-indexing benchmark (`base_commit` → `delta_commit`, 174 files, 2995
+chunks, 15 files changed in the delta):
+
+| Metric | Value |
+|---|---|
+| Raw index size | 4,780,032 bytes |
+| Artifact size (compressed) | ~595,000 bytes |
+| Compression ratio | ~8.0x |
+| Import + delta-sync wall time | ~690–730 ms |
+| Full re-index wall time | ~1,740–1,850 ms |
+| Speedup | ~2.5x |
+| Correctness | Synced store and an independent full re-index of the same final commit produce identical file/chunk counts (174 files, 2995 chunks) |
+
+Two independent runs produced consistent results (2.54x speedup both
+times; compression ratio 8.03–8.04x). Reproduce via `prepare_repo(".",
+base_commit)` (from `archex.benchmark.delta_strategies`, the same helper
+the M2 delta benchmark uses) plus `export_artifact` /
+`import_artifact` / `sync_imported_artifact` timed around a checkout to
+`delta_commit`, compared against an independent `_full_index` call at the
+same commit.
+
 ## CLI usage
 
 ```console
@@ -85,8 +172,17 @@ Indexed repository: /path/to/repo
 Artifact exported:  .archex-artifact.xz
 Artifact revision:  a1b2c3d4...
 Artifact size:      123456 bytes
+Updated .gitattributes: /path/to/repo/.gitattributes
 
 $ archex init --from-artifact .archex-artifact.xz
+Initialized archex project at /path/to/repo/.archex
+...
+Imported index artifact: .archex-artifact.xz
+Artifact revision:       a1b2c3d4...
+Artifact corpus:         174 files, 2995 chunks
+Delta-sync strategy:     delta
+Files changed since export: 15
+Sync time:               687.0 ms
 ```
 
 Export never runs automatically — it is an explicit, opt-in flag on

--- a/src/archex/cli/index_cmd.py
+++ b/src/archex/cli/index_cmd.py
@@ -12,7 +12,7 @@ from archex.api import index_repository
 from archex.cache import CacheManager
 from archex.config import load_config, load_index_config, persist_project_index_settings
 from archex.exceptions import ArchexError
-from archex.index.artifact import export_artifact
+from archex.index.artifact import ensure_artifact_gitattributes, export_artifact
 from archex.models import PipelineTiming, RepoSource
 from archex.project import uses_project_cache_layout
 
@@ -146,6 +146,9 @@ def index_cmd(
             summary["artifact_path"] = str(export_artifact_path)
             summary["artifact_index_revision"] = artifact_header.index_revision
             summary["artifact_size_bytes"] = export_artifact_path.stat().st_size
+            summary["gitattributes_updated"] = ensure_artifact_gitattributes(
+                repo_root, export_artifact_path
+            )
     finally:
         store.close()
 
@@ -173,3 +176,5 @@ def index_cmd(
         click.echo(f"Artifact exported:  {summary['artifact_path']}")
         click.echo(f"Artifact revision:  {summary['artifact_index_revision']}")
         click.echo(f"Artifact size:      {summary['artifact_size_bytes']} bytes")
+        if summary["gitattributes_updated"]:
+            click.echo(f"Updated .gitattributes: {repo_root / '.gitattributes'}")

--- a/src/archex/index/artifact.py
+++ b/src/archex/index/artifact.py
@@ -460,3 +460,68 @@ def sync_imported_artifact(
         delta_meta=delta_meta,
         sync_time_ms=round((time.perf_counter() - t_start) * 1000, 1),
     )
+
+
+_GITATTRIBUTES_COMMENT = "# archex portable index artifact — never diff/merge-conflict"
+
+
+def _ensure_local_merge_ours_driver(repo_root: Path) -> None:
+    """Best-effort: register the "ours" merge driver in this machine's local git config.
+
+    `.gitattributes`' `merge=ours` names a driver git must be told about via
+    `merge.ours.driver` — deliberately local, non-shareable config (a
+    security boundary: a malicious repo's committed config could otherwise
+    silently make merges no-ops). Every clone must set this once; the
+    one-line command is documented in docs/PORTABLE_INDEX_ARTIFACT.md for
+    teammates on a fresh clone. Never raises — a failure here (e.g. no git
+    binary, not a git repo) is not a reason to fail the export.
+    """
+    import contextlib
+    import subprocess
+
+    with contextlib.suppress(OSError):
+        subprocess.run(
+            ["git", "config", "merge.ours.driver", "true"],
+            cwd=repo_root,
+            check=False,
+            capture_output=True,
+            timeout=5,
+        )
+
+
+def ensure_artifact_gitattributes(repo_root: Path, artifact_path: str | Path) -> bool:
+    """Ensure a `merge=ours` `.gitattributes` entry exists for an exported artifact.
+
+    Only touches `.gitattributes` when `artifact_path` resolves inside
+    `repo_root` — an artifact exported outside the repo (e.g. to `/tmp`) has
+    no repo-relative path to attach a merge strategy to, so this is a no-op.
+    The edit is written to disk only; it is never staged or committed —
+    export is opt-in, and so is deciding to commit its side effects.
+
+    Returns True if `.gitattributes` was created or modified.
+    """
+    repo_root = repo_root.resolve()
+    try:
+        relative = Path(artifact_path).resolve().relative_to(repo_root)
+    except ValueError:
+        return False
+
+    entry = f"{relative.as_posix()} merge=ours -diff"
+    gitattributes_path = repo_root / ".gitattributes"
+    lines = (
+        gitattributes_path.read_text(encoding="utf-8").splitlines()
+        if gitattributes_path.exists()
+        else []
+    )
+
+    _ensure_local_merge_ours_driver(repo_root)
+
+    if entry in {line.strip() for line in lines}:
+        return False
+
+    if lines and lines[-1] != "":
+        lines.append("")
+    lines.append(_GITATTRIBUTES_COMMENT)
+    lines.append(entry)
+    gitattributes_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return True

--- a/tests/index/test_artifact.py
+++ b/tests/index/test_artifact.py
@@ -20,6 +20,7 @@ from archex.index.artifact import (
     ARTIFACT_FORMAT_VERSION,
     ARTIFACT_MAGIC,
     ArtifactHeader,
+    ensure_artifact_gitattributes,
     export_artifact,
     import_artifact,
     read_artifact_header,
@@ -33,6 +34,11 @@ from archex.project import init_project
 
 def _git(repo: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+def _git_output(repo: Path, *args: str) -> str:
+    result = subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
 
 
 def _build_store(repo: Path, cache_dir: Path) -> IndexStore:
@@ -619,3 +625,128 @@ class TestFromArtifactCliSync:
             assert any("added_after_export" in c.content for c in chunks)
         finally:
             store.close()
+
+
+class TestEnsureArtifactGitattributes:
+    def test_creates_entry_for_artifact_inside_repo(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = python_simple_repo / ".archex-artifact.xz"
+            export_artifact(store, artifact_path)
+        finally:
+            store.close()
+
+        changed = ensure_artifact_gitattributes(python_simple_repo, artifact_path)
+
+        assert changed is True
+        gitattributes = (python_simple_repo / ".gitattributes").read_text(encoding="utf-8")
+        assert ".archex-artifact.xz merge=ours -diff" in gitattributes
+
+    def test_is_idempotent(self, python_simple_repo: Path, tmp_path: Path) -> None:
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = python_simple_repo / ".archex-artifact.xz"
+            export_artifact(store, artifact_path)
+        finally:
+            store.close()
+
+        first = ensure_artifact_gitattributes(python_simple_repo, artifact_path)
+        content_after_first = (python_simple_repo / ".gitattributes").read_text(encoding="utf-8")
+        second = ensure_artifact_gitattributes(python_simple_repo, artifact_path)
+        content_after_second = (python_simple_repo / ".gitattributes").read_text(encoding="utf-8")
+
+        assert first is True
+        assert second is False
+        assert content_after_first == content_after_second
+
+    def test_noop_for_artifact_outside_repo(self, python_simple_repo: Path, tmp_path: Path) -> None:
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = tmp_path / "outside" / "artifact.xz"
+            export_artifact(store, artifact_path)
+        finally:
+            store.close()
+
+        changed = ensure_artifact_gitattributes(python_simple_repo, artifact_path)
+
+        assert changed is False
+        assert not (python_simple_repo / ".gitattributes").exists()
+
+    def test_appends_to_existing_gitattributes(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        (python_simple_repo / ".gitattributes").write_text("*.png binary\n", encoding="utf-8")
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = python_simple_repo / ".archex-artifact.xz"
+            export_artifact(store, artifact_path)
+        finally:
+            store.close()
+
+        ensure_artifact_gitattributes(python_simple_repo, artifact_path)
+
+        content = (python_simple_repo / ".gitattributes").read_text(encoding="utf-8")
+        assert "*.png binary" in content
+        assert ".archex-artifact.xz merge=ours -diff" in content
+
+    def test_sets_local_merge_ours_driver_config(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = python_simple_repo / ".archex-artifact.xz"
+            export_artifact(store, artifact_path)
+        finally:
+            store.close()
+
+        ensure_artifact_gitattributes(python_simple_repo, artifact_path)
+
+        driver = _git_output(python_simple_repo, "config", "--get", "merge.ours.driver")
+        assert driver == "true"
+
+
+class TestExportArtifactCliGitattributes:
+    def test_index_export_artifact_inside_repo_updates_gitattributes(
+        self, python_simple_repo: Path
+    ) -> None:
+        init_project(python_simple_repo)
+        artifact_path = python_simple_repo / ".archex-artifact.xz"
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "index",
+                str(python_simple_repo),
+                "--export-artifact",
+                str(artifact_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Updated .gitattributes" in result.output
+        gitattributes = (python_simple_repo / ".gitattributes").read_text(encoding="utf-8")
+        assert ".archex-artifact.xz merge=ours -diff" in gitattributes
+
+    def test_index_export_artifact_outside_repo_skips_gitattributes(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        init_project(python_simple_repo)
+        artifact_path = tmp_path / "artifact.xz"
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli,
+            [
+                "index",
+                str(python_simple_repo),
+                "--export-artifact",
+                str(artifact_path),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Updated .gitattributes" not in result.output
+        assert not (python_simple_repo / ".gitattributes").exists()


### PR DESCRIPTION
## Summary

M16 (Portable index artifact for team-shared bootstrap), PR 4 of 4 — final PR in the stack, based on #427.

`archex index --export-artifact` now auto-manages a `merge=ours -diff` `.gitattributes` entry for the artifact's repo-relative path, so committing a regenerated artifact never produces a binary merge conflict:

- `ensure_artifact_gitattributes()` writes/appends the entry idempotently, and is a no-op when the artifact is exported outside the repo (nothing to attach a merge strategy to).
- Best-effort registers the local `merge.ours.driver` git config on the exporting machine — `.gitattributes` alone cannot enable the `ours` strategy; that's deliberately local, non-shareable git config (a committed config that redefines a merge driver could otherwise let a malicious repo silently no-op every merge). Documented the one-line command every other clone needs to run once.
- The `.gitattributes` edit is written to disk only — never staged or committed automatically, consistent with export itself being opt-in.

Also completes `docs/PORTABLE_INDEX_ARTIFACT.md` with the delta-sync/staleness-fallback behavior PR 3 shipped (not previously documented) and measured wall-time evidence.

## Wall-time evidence

Measured on archex's own repository as the benchmark fixture, reusing the exact self-referential `repo: "."`, pinned-commit-pair methodology `benchmarks/delta_tasks/archex_delta_large.yaml` already uses for the M2 delta-indexing benchmark:

| Metric | Value |
|---|---|
| Raw index size | 4,780,032 bytes |
| Artifact size (compressed) | ~595,000 bytes |
| Compression ratio | ~8.0x |
| Import + delta-sync wall time | ~690–730 ms |
| Full re-index wall time | ~1,740–1,850 ms |
| Speedup | ~2.5x |
| Correctness | Synced store and an independent full re-index of the same final commit produce identical file/chunk counts (174 files, 2995 chunks) |

Two independent runs produced consistent results (2.54x speedup both times; 8.03–8.04x compression). Full methodology and reproduction steps in the doc.

## Tests

`tests/index/test_artifact.py` (`TestEnsureArtifactGitattributes`, `TestExportArtifactCliGitattributes`): entry creation, idempotency, no-op for an artifact exported outside the repo, appending to a pre-existing `.gitattributes`, the local `merge.ours.driver` config, and both text/JSON `archex index --export-artifact` CLI reporting paths.

## Verification

- `uv run pytest tests/index/test_artifact.py -v` — 35 passed.
- Manual round trip on a scratch fixture repo: `archex index --export-artifact` → `archex init --from-artifact` on a fresh clone, confirming exit 0, the `.gitattributes` entry, and the registered `merge.ours.driver` local config.
- `uv run pytest` — 3388 passed.
- `uv run ruff check .` / `uv run ruff format --check .` — clean.
- `uv run pyright` — 0 errors, 0 warnings.

## Stack (complete)

1. `feat/m16-artifact-format` → `main` (#425) — artifact format, export, header validation
2. `feat/m16-artifact-import` → PR 1 (#426) — import, compat-range enforcement, derived-index rebuild
3. `feat/m16-artifact-sync` → PR 2 (#427) — working-tree delta-sync after import, staleness fallback
4. `feat/m16-artifact-gitattributes` → PR 3 (this PR) — `.gitattributes` management, wall-time evidence, docs
