### PR TITLE
test(benchmark): add M17 identifier-fragment benchmark corpus and baseline

### DIFF
--- a/benchmarks/results/m17_identifier_bm25/BASELINE.md
+++ b/benchmarks/results/m17_identifier_bm25/BASELINE.md
@@ -1,0 +1,84 @@
+# M17 — Identifier-aware BM25 tokenization: pre-fragmentation baseline
+
+Milestone: index-time camelCase/PascalCase/snake_case identifier splitting for the
+BM25 `symbol_name`/`breadcrumbs` FTS columns, additive to the existing
+`content`-column identifier expansion. This records the `archex_query`
+recall/MRR baseline on the identifier-fragment task corpus **before** any
+tokenization change, per the "measure then claim" gate.
+
+## Corpus and method
+
+`benchmarks/tasks/identifier_fragments/*.yaml` — 9 self-repo tasks whose
+`question` is literally the space-separated lowercase fragments of a known
+compound identifier defined in this repository (e.g. `"context bundle"` for
+`ContextBundle`). Each task's `expected_files`/`expected_symbols` point at the
+identifier's actual definition site.
+
+Task selection avoided two known confounders, found by direct inspection of
+the BM25 index and the `archex_query` pipeline before committing any task:
+
+- **Existing hardcoded query-expansion terms.** `archex.api._expand_retrieval_question`
+  injects extra terms when the query contains `query`, `pipeline`, `retrieval`,
+  or `index` — verified absent from every task's fragment set so results
+  reflect BM25 tokenization, not this unrelated expansion heuristic.
+- **File-path term overlap.** `BM25Index._apply_path_bonus` gives an exact-term
+  path-segment bonus independent of identifier tokenization; targets were
+  chosen so query fragments do not already appear as literal path segments
+  (e.g. `ContextBundle` → `models.py`, not `context_bundle.py`).
+
+Six control/reference tasks (`graph_schema_version`, `scoring_weights` variant
+dropped for redundancy, `tree_sitter_engine`, `benchmark_task`, `file_tree`,
+`structural_context`) were included alongside three harder cases with no
+baseline recall (`context_bundle`, `ranked_chunk`, `task_category`,
+`symbol_source`) to give the corpus headroom in both directions.
+
+Each task was run via the product's own `archex_query` strategy (BM25-only,
+`IndexConfig(vector=False)`), matching the milestone's own acceptance
+criterion — not an isolated `BM25Index.search()` call, since a raw-BM25-only
+measurement was found (during investigation) to disagree with the full
+retrieval pipeline's ranking on some queries.
+
+Reproduce:
+
+```
+uv run archex benchmark run --tasks-dir benchmarks/tasks/identifier_fragments \
+  --strategy archex_query --output <dir> --no-progress
+```
+
+## Baseline (no identifier-fragment tokenization) — `archex_query`
+
+| task | symbol | recall | mrr | precision |
+|---|---|---:|---:|---:|
+| idfrag_context_bundle | `ContextBundle` | 0.000 | 0.000 | 0.000 |
+| idfrag_ranked_chunk | `RankedChunk` | 0.000 | 0.000 | 0.000 |
+| idfrag_symbol_source | `SymbolSource` | 0.000 | 0.000 | 0.000 |
+| idfrag_task_category | `TaskCategory` | 0.000 | 0.000 | 0.000 |
+| idfrag_benchmark_task | `BenchmarkTask` | 1.000 | 1.000 | 0.200 |
+| idfrag_file_tree | `FileTree` | 1.000 | 0.500 | 0.200 |
+| idfrag_structural_context | `StructuralContext` | 1.000 | 0.500 | 0.200 |
+| idfrag_graph_schema_version | `GraphSchemaVersion` | 1.000 | 1.000 | 0.250 |
+| idfrag_tree_sitter_engine | `TreeSitterEngine` | 1.000 | 1.000 | 0.200 |
+| **mean** | | **0.556** | **0.444** | |
+
+Four tasks (the "harder" PascalCase multi-word symbols with no already-strong
+content-level signal) score zero — real, demonstrated headroom for an
+identifier-splitting change to close, consistent with the milestone's premise.
+The other five already pass, giving control coverage against regression.
+
+## Unrelated infrastructure fix bundled in this PR
+
+`archex dogfood --all --baseline <path>` (this milestone's required
+verification command) was found to take 20+ minutes / effectively hang on
+this repository. Root cause: the `raw_grepped` diagnostic benchmark strategy
+(`run_raw_grepped` in `src/archex/benchmark/strategies.py`) shells out to
+plain `grep -r` with no `--exclude-dir`, so every keyword search walks the
+entire `.venv` (tens of thousands of vendored `.py` files) and `.git` history
+instead of respecting `.gitignore` the way the `raw_ripgrep` strategy already
+does. Fixed by adding the same exclude list `discover_files` already uses
+(`.git`, `.venv`, `node_modules`, caches, build output, `.archex`) as
+`--exclude-dir` flags. Verified: `run_raw_grepped` on a single task dropped
+from a ~30s-per-keyword timeout risk to ~1.5s total; `archex dogfood --all`
+now completes in ~3 minutes. This is a pre-existing bug, unrelated to BM25
+tokenization, discovered only because it blocked running M17's required gate
+command — included here as measurement infrastructure, not part of the
+tokenization change itself.

--- a/benchmarks/tasks/identifier_fragments/idfrag_benchmark_task.yaml
+++ b/benchmarks/tasks/identifier_fragments/idfrag_benchmark_task.yaml
@@ -1,0 +1,14 @@
+task_id: idfrag_benchmark_task
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "benchmark task"
+expected_files:
+  - src/archex/benchmark/models.py
+expected_symbols:
+  - BenchmarkTask
+token_budget: 8192
+keywords:
+  - benchmark
+  - task

--- a/benchmarks/tasks/identifier_fragments/idfrag_context_bundle.yaml
+++ b/benchmarks/tasks/identifier_fragments/idfrag_context_bundle.yaml
@@ -1,0 +1,14 @@
+task_id: idfrag_context_bundle
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "context bundle"
+expected_files:
+  - src/archex/models.py
+expected_symbols:
+  - ContextBundle
+token_budget: 8192
+keywords:
+  - context
+  - bundle

--- a/benchmarks/tasks/identifier_fragments/idfrag_file_tree.yaml
+++ b/benchmarks/tasks/identifier_fragments/idfrag_file_tree.yaml
@@ -1,0 +1,14 @@
+task_id: idfrag_file_tree
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "file tree"
+expected_files:
+  - src/archex/models.py
+expected_symbols:
+  - FileTree
+token_budget: 8192
+keywords:
+  - file
+  - tree

--- a/benchmarks/tasks/identifier_fragments/idfrag_graph_schema_version.yaml
+++ b/benchmarks/tasks/identifier_fragments/idfrag_graph_schema_version.yaml
@@ -1,0 +1,15 @@
+task_id: idfrag_graph_schema_version
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "graph schema version"
+expected_files:
+  - src/archex/graph_artifact.py
+expected_symbols:
+  - GraphSchemaVersion
+token_budget: 8192
+keywords:
+  - graph
+  - schema
+  - version

--- a/benchmarks/tasks/identifier_fragments/idfrag_ranked_chunk.yaml
+++ b/benchmarks/tasks/identifier_fragments/idfrag_ranked_chunk.yaml
@@ -1,0 +1,14 @@
+task_id: idfrag_ranked_chunk
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "ranked chunk"
+expected_files:
+  - src/archex/models.py
+expected_symbols:
+  - RankedChunk
+token_budget: 8192
+keywords:
+  - ranked
+  - chunk

--- a/benchmarks/tasks/identifier_fragments/idfrag_structural_context.yaml
+++ b/benchmarks/tasks/identifier_fragments/idfrag_structural_context.yaml
@@ -1,0 +1,14 @@
+task_id: idfrag_structural_context
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "structural context"
+expected_files:
+  - src/archex/models.py
+expected_symbols:
+  - StructuralContext
+token_budget: 8192
+keywords:
+  - structural
+  - context

--- a/benchmarks/tasks/identifier_fragments/idfrag_symbol_source.yaml
+++ b/benchmarks/tasks/identifier_fragments/idfrag_symbol_source.yaml
@@ -1,0 +1,14 @@
+task_id: idfrag_symbol_source
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "symbol source"
+expected_files:
+  - src/archex/models.py
+expected_symbols:
+  - SymbolSource
+token_budget: 8192
+keywords:
+  - symbol
+  - source

--- a/benchmarks/tasks/identifier_fragments/idfrag_task_category.yaml
+++ b/benchmarks/tasks/identifier_fragments/idfrag_task_category.yaml
@@ -1,0 +1,14 @@
+task_id: idfrag_task_category
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "task category"
+expected_files:
+  - src/archex/benchmark/models.py
+expected_symbols:
+  - TaskCategory
+token_budget: 8192
+keywords:
+  - task
+  - category

--- a/benchmarks/tasks/identifier_fragments/idfrag_tree_sitter_engine.yaml
+++ b/benchmarks/tasks/identifier_fragments/idfrag_tree_sitter_engine.yaml
@@ -1,0 +1,15 @@
+task_id: idfrag_tree_sitter_engine
+repo: "."
+commit: "HEAD"
+category: self
+languages: [python]
+question: "tree sitter engine"
+expected_files:
+  - src/archex/parse/engine.py
+expected_symbols:
+  - TreeSitterEngine
+token_budget: 8192
+keywords:
+  - tree
+  - sitter
+  - engine

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -422,6 +422,23 @@ def run_raw_files(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     )
 
 
+_GREP_EXCLUDE_DIRS = (
+    ".git",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "dist",
+    "build",
+    ".eggs",
+    "target",
+    ".archex",
+)
+
+
 def run_raw_grepped(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Grep-based strategy: search repo for keywords, read matched files."""
     t0 = time.perf_counter()
@@ -443,6 +460,7 @@ def run_raw_grepped(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
                 "--include=*.kt",
                 "--include=*.cs",
                 "--include=*.swift",
+                *[f"--exclude-dir={name}" for name in _GREP_EXCLUDE_DIRS],
                 "-i",
                 kw,
                 ".",


### PR DESCRIPTION
## Stack

Position: 1/3 of the M17 (Identifier-aware BM25 tokenization) stack.

1. `feat/m17-identifier-benchmark-baseline` -> this PR
2. `feat/m17-bm25-identifier-tokenization` -> depends on this PR
3. `test/m17-identifier-tokenization-decision` -> depends on PR 2

## Summary

Measurement infrastructure for M17 (DEVELOPMENT_PLAN.md Section F). Adds a
9-task self-repo benchmark corpus that queries archex_query with
space-separated fragments of known camelCase/PascalCase identifiers (e.g.
"context bundle" for `ContextBundle`), designed to demonstrate the intended
benefit of identifier-aware BM25 tokenization. Records the pre-fragmentation
baseline: mean recall 0.556, mean MRR 0.444, with four targeted tasks
scoring zero (the headroom this milestone aims to close).

Also fixes an unrelated, pre-existing bug discovered while trying to run the
milestone's required `archex dogfood --all --baseline ...` gate command: the
`raw_grepped` diagnostic strategy shelled out to plain `grep -r` with no
`--exclude-dir`, walking the entire `.venv` and `.git` on every keyword
search and taking `archex dogfood --all` 20+ minutes / effectively hanging.
Fixed by adding the same exclude list `discover_files` already uses.

No retrieval-affecting code changes in this PR — task/benchmark definitions
and one strategy-hygiene fix only.

## Verification

- `uv run pytest` (full suite): 3396 passed
- `uv run ruff check .` / `uv run ruff format --check .`: clean
- `uv run pyright`: 0 errors
- `uv run archex benchmark run --tasks-dir benchmarks/tasks/identifier_fragments --strategy archex_query --no-progress`: baseline numbers recorded in `benchmarks/results/m17_identifier_bm25/BASELINE.md`
- `archex dogfood --all --baseline .archex/baselines/pre-promotion.json` confirmed to complete (~3 min) after the grep fix, vs. 20+ min / hang before
