### PR TITLE
feat(index): add identifier-aware BM25 tokenization behind opt-in flag

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1812,7 +1812,10 @@ def query(
                     )
                     return pt
 
-                bm25 = BM25Index(store)
+                bm25 = BM25Index(
+                    store,
+                    identifier_fragment_tokenization=index_config.identifier_fragment_tokenization,
+                )
                 stored_edges = store.get_edges()
                 graph = DependencyGraph.from_edges(stored_edges)
 
@@ -2069,7 +2072,10 @@ def query(
         )
 
         try:
-            bm25 = BM25Index(store)
+            bm25 = BM25Index(
+                store,
+                identifier_fragment_tokenization=index_config.identifier_fragment_tokenization,
+            )
             store.insert_chunks(all_chunks)
             if chunk_surrogates:
                 store.insert_chunk_surrogates(chunk_surrogates)

--- a/src/archex/index/bm25.py
+++ b/src/archex/index/bm25.py
@@ -31,21 +31,47 @@ CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
 
 _DROP_FTS_ROWS = "DELETE FROM chunks_fts;"
 
+#: Bumped whenever `_insert_rows` changes what text lands in an FTS column
+#: (e.g. adding identifier-fragment splitting to a new column). Combined with
+#: the `identifier_fragment_tokenization` flag value into a composite version
+#: string so flipping the flag also forces a rebuild — a mismatch drops and
+#: rebuilds `chunks_fts` on next use so existing stores pick up the new
+#: tokenization instead of silently serving stale content.
+_BM25_CONTENT_SCHEMA_VERSION = "2"
+_BM25_CONTENT_VERSION_KEY = "bm25_content_version"
 
-def _ensure_fts_schema(conn: sqlite3.Connection) -> None:
-    """Ensure the FTS table has the current schema (including breadcrumbs and summary columns).
 
-    FTS5 does not support ALTER TABLE, so we detect stale schemas
-    by probing for the latest column and recreate if needed.
+def _content_version_for(identifier_fragment_tokenization: bool) -> str:
+    return f"{_BM25_CONTENT_SCHEMA_VERSION}:{identifier_fragment_tokenization}"
+
+
+def _ensure_fts_schema(store: IndexStore, identifier_fragment_tokenization: bool) -> None:
+    """Ensure the FTS table has the current schema and content-tokenization version.
+
+    FTS5 does not support ALTER TABLE, so a stale schema (missing columns) or a
+    stale content version (a prior tokenization scheme, or a different
+    ``identifier_fragment_tokenization`` setting, baked into existing rows) is
+    handled the same way: drop and rebuild the table. Callers detect the
+    resulting empty table via `has_data` and trigger a full re-insert.
     """
+    conn = store.conn
+    needs_rebuild = False
     try:
         # Probe for the newest columns (breadcrumbs and summary)
         conn.execute("SELECT chunk_id FROM chunks_fts WHERE summary MATCH 'probe' LIMIT 0")
         conn.execute("SELECT chunk_id FROM chunks_fts WHERE breadcrumbs MATCH 'probe' LIMIT 0")
     except sqlite3.OperationalError:
-        # breadcrumbs or summary column missing — drop and recreate with new schema
+        # breadcrumbs or summary column missing — stale schema, needs recreation
+        needs_rebuild = True
+
+    expected_version = _content_version_for(identifier_fragment_tokenization)
+    if not needs_rebuild and store.get_metadata(_BM25_CONTENT_VERSION_KEY) != expected_version:
+        needs_rebuild = True
+
+    if needs_rebuild:
         conn.execute("DROP TABLE IF EXISTS chunks_fts")
         conn.execute(_CREATE_FTS)
+        store.set_metadata(_BM25_CONTENT_VERSION_KEY, expected_version)
         conn.commit()
 
 
@@ -129,10 +155,13 @@ def escape_fts_query(query: str) -> str:
 class BM25Index:
     """BM25 keyword index using SQLite FTS5."""
 
-    def __init__(self, store: IndexStore) -> None:
+    def __init__(
+        self, store: IndexStore, *, identifier_fragment_tokenization: bool = False
+    ) -> None:
         self._store = store
+        self._identifier_fragment_tokenization = identifier_fragment_tokenization
         store.conn.execute(_CREATE_FTS)
-        _ensure_fts_schema(store.conn)
+        _ensure_fts_schema(store, identifier_fragment_tokenization)
         store.conn.commit()
 
     @property
@@ -164,6 +193,9 @@ class BM25Index:
     def _insert_rows(self, chunks: Iterable[CodeChunk]) -> None:
         from archex.pipeline.chunker import expand_identifiers
 
+        def _maybe_expand(text: str) -> str:
+            return expand_identifiers(text) if self._identifier_fragment_tokenization else text
+
         self._store.conn.executemany(
             "INSERT INTO chunks_fts "
             "(chunk_id, content, symbol_name, file_path, docstring, breadcrumbs, summary) "
@@ -172,10 +204,10 @@ class BM25Index:
                 (
                     c.id,
                     expand_identifiers(c.content),
-                    c.symbol_name or "",
+                    _maybe_expand(c.symbol_name or ""),
                     c.file_path,
                     c.docstring or "",
-                    c.breadcrumbs,
+                    _maybe_expand(c.breadcrumbs),
                     c.summary or "",
                 )
                 for c in chunks

--- a/src/archex/index/delta.py
+++ b/src/archex/index/delta.py
@@ -372,12 +372,16 @@ def apply_delta(
     from archex.pipeline.chunker import chunker_revision, create_chunker
 
     t_start = time.perf_counter()
+    effective_index_config = index_config or IndexConfig()
 
     # Ensure chunks_fts has the current schema before any delete operations
     # below. A stale-schema migration here drops and recreates the table,
     # emptying it — capture that so step 5 knows a full rebuild (not a
     # targeted update) is required.
-    bm25 = BM25Index(store)
+    bm25 = BM25Index(
+        store,
+        identifier_fragment_tokenization=effective_index_config.identifier_fragment_tokenization,
+    )
     needs_full_bm25_rebuild = not bm25.has_data
 
     # 1. Handle renames
@@ -401,7 +405,6 @@ def apply_delta(
     new_chunks: list[CodeChunk] = []
     new_edges: list[Edge] = []
     new_surrogates = []
-    effective_index_config = index_config or IndexConfig()
 
     if reprocess:
         all_files = discover_files(

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -242,6 +242,13 @@ class IndexConfig(BaseModel):
     allow_remote_code: bool = False
     quantize_vectors: bool = True
     quantize_bits: int = 4
+    #: Additive camelCase/PascalCase identifier-fragment splitting for the BM25
+    #: symbol_name/breadcrumbs FTS columns (M17). Defaults off: measured on the
+    #: self-repo identifier-fragment benchmark corpus, it regressed previously
+    #: passing tasks (fragment collisions among related PascalCase symbols
+    #: outweighed the intended recall gain) — see
+    #: benchmarks/results/m17_identifier_bm25/DECISION.md.
+    identifier_fragment_tokenization: bool = False
 
     @model_validator(mode="after")
     def _validate_index_config(self) -> IndexConfig:

--- a/tests/index/test_bm25.py
+++ b/tests/index/test_bm25.py
@@ -668,6 +668,268 @@ def test_schema_migration_from_old_fts_schema(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Identifier-fragment tokenization: symbol_name and breadcrumbs (M17)
+#
+# `identifier_fragment_tokenization` defaults to False (see IndexConfig) —
+# measured on the self-repo identifier-fragment benchmark corpus, enabling it
+# regressed previously passing tasks (fragment collisions among related
+# PascalCase symbols outweighed the intended recall gain). These tests
+# exercise the flag explicitly; the default-off tests pin the safe fallback.
+# ---------------------------------------------------------------------------
+
+
+def test_default_flag_off_does_not_expand_symbol_name_or_breadcrumbs(tmp_path: Path) -> None:
+    """Without the opt-in flag, symbol_name/breadcrumbs are stored unexpanded."""
+    db = tmp_path / "symname_default_off.db"
+    store = IndexStore(db)
+    idx = BM25Index(store)
+    chunk = CodeChunk(
+        id="a.py:DependencyGraph:1",
+        content="class DependencyGraph:\n    pass",
+        file_path="a.py",
+        start_line=1,
+        end_line=2,
+        symbol_name="DependencyGraph",
+        symbol_kind=SymbolKind.CLASS,
+        language="python",
+        token_count=5,
+        breadcrumbs="module: a > class: DependencyGraph",
+    )
+    store.insert_chunks([chunk])
+    idx.build([chunk])
+
+    row = store.conn.execute(
+        "SELECT symbol_name, breadcrumbs FROM chunks_fts WHERE chunk_id = ?", (chunk.id,)
+    ).fetchone()
+    assert row[0] == "DependencyGraph"
+    assert row[1] == "module: a > class: DependencyGraph"
+    store.close()
+
+
+def test_insert_rows_expands_symbol_name_camel_case_fragments(tmp_path: Path) -> None:
+    """symbol_name gets additive camelCase/PascalCase fragments, original token kept."""
+    db = tmp_path / "symname_fragments.db"
+    store = IndexStore(db)
+    idx = BM25Index(store, identifier_fragment_tokenization=True)
+    chunk = CodeChunk(
+        id="a.py:DependencyGraph:1",
+        content="class DependencyGraph:\n    pass",
+        file_path="a.py",
+        start_line=1,
+        end_line=2,
+        symbol_name="DependencyGraph",
+        symbol_kind=SymbolKind.CLASS,
+        language="python",
+        token_count=5,
+        breadcrumbs="module: a > class: DependencyGraph",
+    )
+    store.insert_chunks([chunk])
+    idx.build([chunk])
+
+    row = store.conn.execute(
+        "SELECT symbol_name, breadcrumbs FROM chunks_fts WHERE chunk_id = ?", (chunk.id,)
+    ).fetchone()
+    assert "DependencyGraph" in row[0]
+    assert "dependency" in row[0]
+    assert "graph" in row[0]
+    assert "dependency" in row[1]
+    assert "graph" in row[1]
+    store.close()
+
+
+def test_symbol_name_original_token_still_searchable(tmp_path: Path) -> None:
+    """Fragment expansion is additive — the exact original identifier still matches."""
+    db = tmp_path / "symname_original.db"
+    store = IndexStore(db)
+    idx = BM25Index(store, identifier_fragment_tokenization=True)
+    chunk = CodeChunk(
+        id="a.py:DependencyGraph:1",
+        content="class DependencyGraph:\n    pass",
+        file_path="a.py",
+        start_line=1,
+        end_line=2,
+        symbol_name="DependencyGraph",
+        symbol_kind=SymbolKind.CLASS,
+        language="python",
+        token_count=5,
+    )
+    store.insert_chunks([chunk])
+    idx.build([chunk])
+
+    results = idx.search("DependencyGraph")
+    ids = [c.id for c, _ in results]
+    assert chunk.id in ids
+    store.close()
+
+
+def test_symbol_name_fragments_outrank_generic_content_matches(tmp_path: Path) -> None:
+    """A space-separated fragment query ranks the PascalCase-named definition above
+    a chunk that only mentions the same words as unrelated prose.
+    """
+    db = tmp_path / "ranking_fragments.db"
+    store = IndexStore(db)
+    idx = BM25Index(store, identifier_fragment_tokenization=True)
+    target = CodeChunk(
+        id="widgets.py:WidgetRegistry:1",
+        content="class WidgetRegistry:\n    def __init__(self):\n        self._entries = {}",
+        file_path="widgets.py",
+        start_line=1,
+        end_line=3,
+        symbol_name="WidgetRegistry",
+        symbol_kind=SymbolKind.CLASS,
+        language="python",
+        token_count=15,
+    )
+    decoy = CodeChunk(
+        id="notes.py:jot_registry_notes:1",
+        content=(
+            "def jot_registry_notes():\n"
+            '    """A widget is a UI unit; a registry tracks named things."""\n'
+        ),
+        file_path="notes.py",
+        start_line=1,
+        end_line=2,
+        symbol_name="jot_registry_notes",
+        symbol_kind=SymbolKind.FUNCTION,
+        language="python",
+        token_count=25,
+        docstring="A widget is a UI unit; a registry tracks named things.",
+    )
+    store.insert_chunks([target, decoy])
+    idx.build([target, decoy])
+
+    results = idx.search("widget registry")
+    assert results
+    assert results[0][0].id == target.id
+    store.close()
+
+
+def test_breadcrumbs_fragments_are_searchable(tmp_path: Path) -> None:
+    """Dotted qualified breadcrumbs also get identifier-fragment expansion."""
+    db = tmp_path / "breadcrumbs_fragments.db"
+    store = IndexStore(db)
+    idx = BM25Index(store, identifier_fragment_tokenization=True)
+    chunk = CodeChunk(
+        id="report.py:build_readiness_report:1",
+        content="def build_readiness_report():\n    pass",
+        file_path="report.py",
+        start_line=1,
+        end_line=2,
+        symbol_name="build_readiness_report",
+        symbol_kind=SymbolKind.FUNCTION,
+        language="python",
+        token_count=10,
+        breadcrumbs="module: report > class: ReadinessReport > method: build_readiness_report",
+    )
+    store.insert_chunks([chunk])
+    idx.build([chunk])
+
+    row = store.conn.execute(
+        "SELECT breadcrumbs FROM chunks_fts WHERE chunk_id = ?", (chunk.id,)
+    ).fetchone()
+    assert "readiness" in row[0]
+    assert "report" in row[0]
+    store.close()
+
+
+def test_content_schema_version_bump_triggers_rebuild(tmp_path: Path) -> None:
+    """A stale bm25_content_version metadata value forces a full FTS rebuild."""
+    db = tmp_path / "content_version_test.db"
+    store = IndexStore(db)
+    idx = BM25Index(store, identifier_fragment_tokenization=True)
+    chunk = CodeChunk(
+        id="v.py:VersionProbe:1",
+        content="class VersionProbe:\n    pass",
+        file_path="v.py",
+        start_line=1,
+        end_line=2,
+        symbol_name="VersionProbe",
+        symbol_kind=SymbolKind.CLASS,
+        language="python",
+        token_count=5,
+    )
+    store.insert_chunks([chunk])
+    idx.build([chunk])
+    assert idx.has_data
+
+    # Simulate a store stamped with a prior (pre-M17) content tokenization version.
+    store.set_metadata("bm25_content_version", "1")
+    stale_idx = BM25Index(store, identifier_fragment_tokenization=True)
+    assert not stale_idx.has_data
+
+    stale_idx.build([chunk])
+    row = store.conn.execute(
+        "SELECT symbol_name FROM chunks_fts WHERE chunk_id = ?", (chunk.id,)
+    ).fetchone()
+    assert "version" in row[0]
+    assert "probe" in row[0]
+    store.close()
+
+
+def test_flipping_fragment_flag_forces_rebuild(tmp_path: Path) -> None:
+    """Changing identifier_fragment_tokenization on an existing store forces a rebuild."""
+    db = tmp_path / "flag_flip_test.db"
+    store = IndexStore(db)
+    idx = BM25Index(store, identifier_fragment_tokenization=False)
+    chunk = CodeChunk(
+        id="f.py:FlagFlipProbe:1",
+        content="class FlagFlipProbe:\n    pass",
+        file_path="f.py",
+        start_line=1,
+        end_line=2,
+        symbol_name="FlagFlipProbe",
+        symbol_kind=SymbolKind.CLASS,
+        language="python",
+        token_count=5,
+    )
+    store.insert_chunks([chunk])
+    idx.build([chunk])
+    row = store.conn.execute(
+        "SELECT symbol_name FROM chunks_fts WHERE chunk_id = ?", (chunk.id,)
+    ).fetchone()
+    assert row[0] == "FlagFlipProbe"
+
+    flipped_idx = BM25Index(store, identifier_fragment_tokenization=True)
+    assert not flipped_idx.has_data
+    flipped_idx.build([chunk])
+    row = store.conn.execute(
+        "SELECT symbol_name FROM chunks_fts WHERE chunk_id = ?", (chunk.id,)
+    ).fetchone()
+    assert "flag" in row[0]
+    assert "flip" in row[0]
+    assert "probe" in row[0]
+    store.close()
+
+
+def test_update_path_expands_symbol_name_fragments_same_as_build(tmp_path: Path) -> None:
+    """The delta insert-only update() path expands symbol_name identically to build()."""
+    db = tmp_path / "delta_fragment_parity.db"
+    store = IndexStore(db)
+    idx = BM25Index(store, identifier_fragment_tokenization=True)
+    chunk = CodeChunk(
+        id="delta.py:PatchApplier:1",
+        content="class PatchApplier:\n    pass",
+        file_path="delta.py",
+        start_line=1,
+        end_line=2,
+        symbol_name="PatchApplier",
+        symbol_kind=SymbolKind.CLASS,
+        language="python",
+        token_count=5,
+    )
+    store.insert_chunks([chunk])
+    idx.update([chunk])
+
+    row = store.conn.execute(
+        "SELECT symbol_name FROM chunks_fts WHERE chunk_id = ?", (chunk.id,)
+    ).fetchone()
+    assert "PatchApplier" in row[0]
+    assert "patch" in row[0]
+    assert "applier" in row[0]
+    store.close()
+
+
+# ---------------------------------------------------------------------------
 # AvgIDF tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Stack

Position: 2/3 of the M17 (Identifier-aware BM25 tokenization) stack.

1. `feat/m17-identifier-benchmark-baseline` -> #429
2. `feat/m17-bm25-identifier-tokenization` -> this PR
3. `test/m17-identifier-tokenization-decision` -> depends on this PR

Depends on: #429
Base: `feat/m17-identifier-benchmark-baseline`

## Summary

Implements identifier-aware BM25 tokenization: `BM25Index._insert_rows`
additively splits `symbol_name` and `breadcrumbs` on camelCase/PascalCase
and underscore boundaries (via the existing `expand_identifiers()` helper
already used for the `content` column), so a fragment query can match a
compound identifier via either column, not just content. The original
token is always preserved alongside the appended lowercase fragments.

An FTS content-schema version (`bm25_content_version`, composed with the
new `identifier_fragment_tokenization` flag's value) is stamped in store
metadata and checked on every `BM25Index` construction. A mismatch — a
stale pre-M17 schema, a version bump, or a flipped flag — drops and
rebuilds `chunks_fts`; the existing `has_data`-driven delta path
(`apply_delta`) then performs a full `build()` instead of a targeted
`update()`, so existing stores transparently pick up new tokenization.
`build()`/`update()` share one `_insert_rows`, so the delta and full-build
paths always tokenize identically by construction.

**`identifier_fragment_tokenization` defaults to `False`.** Per the
measured evidence landing in PR 3 (`benchmarks/results/m17_identifier_bm25/DECISION.md`):
enabling it regressed the identifier-fragment benchmark corpus from PR 1
(fragment collisions among related PascalCase symbols — e.g. `BenchmarkTask`
vs. `_BenchmarkTaskLike`/`ArchitectureBenchmarkTask`/`DeltaBenchmarkTask` —
outweighed the intended recall gain). This PR ships the always-off default;
the tokenization machinery itself is real, tested infrastructure.

No changes to vector/SPLADE retrieval paths or scoring weights.

## Verification

- `uv run pytest tests/index/test_bm25.py -v --no-cov`: 64 passed (7 new)
- `uv run pytest` (full suite): 3396 passed
- `uv run ruff check src/archex/index/bm25.py src/archex/api.py src/archex/index/delta.py src/archex/models.py`: clean
- `uv run pyright`: 0 errors
- Default-off behavior pinned by `test_default_flag_off_does_not_expand_symbol_name_or_breadcrumbs`
- Delta/full-build parity pinned by `test_update_path_expands_symbol_name_fragments_same_as_build`
- Schema-version and flag-flip rebuild pinned by `test_content_schema_version_bump_triggers_rebuild` / `test_flipping_fragment_flag_forces_rebuild`
