### PR TITLE
docs(benchmark): record M17 measurement and flag-off merge decision

### DIFF
--- a/benchmarks/results/m17_identifier_bm25/DECISION.md
+++ b/benchmarks/results/m17_identifier_bm25/DECISION.md
@@ -1,0 +1,88 @@
+# M17 — Identifier-aware BM25 tokenization: measurement and merge decision
+
+Continues `BASELINE.md`. Records `archex_query` recall/MRR on the same
+identifier-fragment corpus **with** `identifier_fragment_tokenization`
+enabled (index-time camelCase/PascalCase splitting of the `symbol_name` and
+`breadcrumbs` FTS columns, additive — the original token is preserved
+alongside the lowercase fragments), and the resulting merge decision.
+
+## What was implemented
+
+`src/archex/index/bm25.py`: `BM25Index._insert_rows` now additionally runs
+the existing `expand_identifiers()` helper (already used for the `content`
+column since well before this milestone) over `symbol_name` and
+`breadcrumbs` when `identifier_fragment_tokenization` is enabled. An FTS
+content-schema version (`bm25_content_version`, composed with the flag value)
+is stamped in store metadata and checked on every `BM25Index` construction;
+a mismatch — stale schema, a version bump, or a flipped flag — drops and
+rebuilds `chunks_fts`, and the existing `has_data`-driven delta path
+(`src/archex/index/delta.py`) then performs one full `build()` instead of a
+targeted `update()`, so re-indexing existing stores transparently picks up
+the new tokenization. `build()` and `update()` share the same
+`_insert_rows`, so the delta path and full-build path always tokenize
+identically by construction (`test_update_path_expands_symbol_name_fragments_same_as_build`).
+
+The flag (`IndexConfig.identifier_fragment_tokenization`) is threaded through
+every `BM25Index` construction site that has an `IndexConfig` in scope
+(`api.py` query-time cache-hit and cache-miss paths, `delta.py`
+`apply_delta`). It defaults to **`False`** — see "Decision" below.
+
+## Method
+
+Same corpus, same `archex_query` (BM25-only) strategy, same token budget, as
+`BASELINE.md`. The only variable changed is
+`identifier_fragment_tokenization` (`False` → `True`); reproduced with a
+`git stash` toggle of the implementation commits against an otherwise
+identical working tree, so no other confound (cache state, task set, code
+version elsewhere) differs between the two runs.
+
+```
+uv run archex benchmark run --tasks-dir benchmarks/tasks/identifier_fragments \
+  --strategy archex_query --output <dir> --no-progress
+```
+
+## Results
+
+| task | symbol | baseline recall | with-tokenization recall | Δ | baseline mrr | with-tokenization mrr | Δ |
+|---|---|---:|---:|---:|---:|---:|---:|
+| idfrag_context_bundle | `ContextBundle` | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |
+| idfrag_ranked_chunk | `RankedChunk` | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |
+| idfrag_symbol_source | `SymbolSource` | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |
+| idfrag_task_category | `TaskCategory` | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |
+| idfrag_benchmark_task | `BenchmarkTask` | 1.000 | 0.000 | **−1.000** | 1.000 | 0.000 | **−1.000** |
+| idfrag_file_tree | `FileTree` | 1.000 | 0.000 | **−1.000** | 0.500 | 0.000 | **−0.500** |
+| idfrag_structural_context | `StructuralContext` | 1.000 | 1.000 | 0.000 | 0.500 | 0.500 | 0.000 |
+| idfrag_graph_schema_version | `GraphSchemaVersion` | 1.000 | 1.000 | 0.000 | 1.000 | 1.000 | 0.000 |
+| idfrag_tree_sitter_engine | `TreeSitterEngine` | 1.000 | 1.000 | 0.000 | 1.000 | 1.000 | 0.000 |
+| **mean** | | **0.556** | **0.333** | **−0.222** | **0.444** | **0.278** | **−0.167** |
+
+None of the four zero-recall tasks improved. Two previously-passing tasks
+regressed to zero. Net: **recall −0.222, MRR −0.167** on the corpus this
+milestone built specifically to demonstrate the intended improvement.
+
+### Root cause of the regression
+
+Traced (`archex query . "benchmark task" --strategy bm25 --format json`,
+`retrieval_metadata.seed_file_paths`) to **fragment collision**: splitting
+`symbol_name` on case boundaries makes multiple *related but distinct*
+PascalCase symbols expose overlapping fragment sets that used to be
+disjoint, unsplit tokens:
+
+- `BenchmarkTask`, `_BenchmarkTaskLike` (a structural-typing `Protocol`),
+  `ArchitectureBenchmarkTask`, and `DeltaBenchmarkTask` all decompose to
+  include `{"benchmark", "task"}`. Pre-fragmentation, FTS5's native
+  `unicode61` tokenizer already splits on underscore (verified empirically:
+  `parse_imports` tokenizes to `parse`+`imports` today, no code change
+  needed) but never splits camelCase, so `_BenchmarkTaskLike` indexed as one
+  opaque token (`benchmarktasklike`) and never competed with `BenchmarkTask`.
+  Splitting it newly exposes it — and its siblings — as equally strong
+  10×-weighted `symbol_name` matches for the query "benchmark task",
+  outranking the one file (`benchmark/models.py`) that used to win outright.
+- The same mechanism applies to `FileTree` inside a module with several
+  other tree/file-related symbols.
+
+This is not a tuning bug in this implementation — it is the identifier
+tokenization technique's own well-known precision/recall tradeoff for a
+codebase with a family of derived/related type names (`X`, `XLike`,
+`FooX`, `BarX`), which is common in this repository given its dataclass and
+protocol-heavy style.

--- a/benchmarks/results/m17_identifier_bm25/DECISION.md
+++ b/benchmarks/results/m17_identifier_bm25/DECISION.md
@@ -86,3 +86,49 @@ tokenization technique's own well-known precision/recall tradeoff for a
 codebase with a family of derived/related type names (`X`, `XLike`,
 `FooX`, `BarX`), which is common in this repository given its dataclass and
 protocol-heavy style.
+
+## M5 gate — general-corpus regression check
+
+`uv run archex dogfood --all --baseline .archex/baselines/pre-promotion.json`
+(after fixing the unrelated `raw_grepped` hang documented in `BASELINE.md`)
+reports 9 metric regressions against `pre-promotion.json` and 0 ranking
+(`structural_centrality`/`symbol_count`) violations.
+
+**All 9 are pre-existing baseline drift, confirmed unrelated to this
+milestone**: re-run on an unmodified `main` checkout (`git stash` of every
+M17 commit) reproduces the identical regressed values — e.g.
+`archex_adapter_registry`/`archex_query` recall is `0.333` on both
+unmodified `main` and this stack's flagged-off default. `pre-promotion.json`
+predates the M11–M13 STRUCTURED-tier adapters (HTML/XML/YAML/Markdown); those
+adapters now compete as additional candidates for "adapter registry"-style
+queries, which is expected drift from later, independently-gated milestones,
+not something this milestone introduces or is responsible for re-baselining.
+
+With `identifier_fragment_tokenization` at its shipped default (`False`),
+`archex_query`'s `IndexConfig` is unchanged from before this milestone, so
+this stack changes **zero** bytes of BM25-indexed content and reproduces
+byte-for-byte identical `archex_query` results to unmodified `main` on every
+spot-checked task (`archex_adapter_registry` verified explicitly). No new
+regression is introduced by this stack.
+
+Reproduce:
+
+```
+uv run archex dogfood --all --baseline .archex/baselines/pre-promotion.json
+```
+
+## Decision
+
+**Do not enable by default.** The milestone's own corpus — built specifically
+to demonstrate this feature's benefit — shows a net regression (recall
+−0.222, MRR −0.167), with zero of the four targeted zero-recall cases
+recovering and two previously-passing cases breaking. Per the milestone's
+stated fallback: `identifier_fragment_tokenization` ships as an
+`IndexConfig` flag, **defaulting to `False`**, so every store's BM25 content
+is byte-for-byte unchanged from pre-M17 behavior unless a caller opts in.
+The tokenization implementation, schema-versioning/rebuild-on-flip
+machinery, and delta/full-build parity are still merged and tested — real,
+reusable infrastructure for a future, more targeted approach (e.g. scoping
+fragmentation to symbols without a same-file/same-module sibling sharing a
+fragment, or applying it only to non-derived/non-Protocol type names) — but
+the always-on behavior this milestone originally proposed is not shipped.


### PR DESCRIPTION
## Stack

Position: 3/3 of the M17 (Identifier-aware BM25 tokenization) stack.

1. `feat/m17-identifier-benchmark-baseline` -> #429
2. `feat/m17-bm25-identifier-tokenization` -> #430
3. `test/m17-identifier-tokenization-decision` -> this PR

Depends on: #430
Base: `feat/m17-bm25-identifier-tokenization`

## Summary

Measurement and merge decision for M17. Re-runs PR 1's identifier-fragment
corpus with `identifier_fragment_tokenization` enabled and records the
comparison, then runs the M5 regression gate
(`archex dogfood --all --baseline .archex/baselines/pre-promotion.json`)
and confirms the shipped flagged-off default introduces no new regression.

**Result: net regression on the corpus this milestone built to demonstrate
the feature (mean recall 0.556 -> 0.333, mean MRR 0.444 -> 0.278).** None of
the four targeted zero-recall tasks improved; two previously-passing tasks
regressed to zero. Root-caused to fragment collision: splitting
`symbol_name` on case boundaries makes related PascalCase symbols
(`BenchmarkTask`/`_BenchmarkTaskLike`/`ArchitectureBenchmarkTask`/`DeltaBenchmarkTask`)
newly compete for the same fragment set, where before they tokenized to
distinct opaque tokens.

The M5 gate reports 9 metric regressions, all confirmed pre-existing
baseline drift unrelated to this stack (reproduces identically on
unmodified `main`; `.archex/baselines/pre-promotion.json` predates the
M11-M13 STRUCTURED-tier adapters) — with `identifier_fragment_tokenization`
at its shipped `False` default, this stack changes zero bytes of
BM25-indexed content and introduces no new regression versus `main`.

**Decision: do not enable by default.** Ships with the flag defaulting to
`False`, per the milestone's documented fallback for a measured regression.
Full writeup: `benchmarks/results/m17_identifier_bm25/DECISION.md`.

## Verification

- `uv run pytest tests/index/test_bm25.py -v --no-cov`: 64 passed
- `uv run archex dogfood --all --baseline .archex/baselines/pre-promotion.json`: completes (~3 min after PR 1's grep fix), 9 pre-existing-drift regressions (confirmed unrelated, see DECISION.md), 0 ranking violations
- `uv run pytest` (full suite): 3396 passed
- `uv run ruff check .` / `uv run ruff format --check .`: clean
- `uv run pyright`: 0 errors
