### PR TITLE
feat(impact): resolve git diff hunks to changed symbols

### DIFF
--- a/src/archex/impact.py
+++ b/src/archex/impact.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
+from collections import defaultdict
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -91,6 +93,88 @@ def git_changed_files(repo_root: Path, base_ref: str) -> list[ImpactFileChange]:
         stderr = completed.stderr.strip() or completed.stdout.strip()
         raise ImpactError(f"git diff failed for base {base_ref}: {stderr}")
     return [_parse_name_status(line) for line in completed.stdout.splitlines() if line.strip()]
+
+
+_HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+_NEW_FILE_PATH_RE = re.compile(r"^\+\+\+ b/(.+)$")
+
+
+def git_diff_hunks(repo_root: Path, ref: str) -> dict[str, list[tuple[int, int]]]:
+    """Return per-file new-side line ranges touched by a diff (ref vs. working tree).
+
+    Parses ``git diff --unified=0`` hunk headers. A pure-deletion hunk (zero new
+    lines) has no corresponding new-file line range; it is recorded as a
+    single-line marker at the deletion point so it can still be intersected
+    against symbol spans.
+    """
+    command = ["git", "diff", "--unified=0", "--no-color", ref]
+    completed = subprocess.run(
+        command,
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip() or completed.stdout.strip()
+        raise ImpactError(f"git diff failed for ref {ref}: {stderr}")
+
+    hunks: dict[str, list[tuple[int, int]]] = defaultdict(list)
+    current_path: str | None = None
+    for line in completed.stdout.splitlines():
+        if line.startswith("+++ "):
+            match = _NEW_FILE_PATH_RE.match(line)
+            current_path = match.group(1) if match else None
+            continue
+        if current_path is None:
+            continue
+        hunk_match = _HUNK_HEADER_RE.match(line)
+        if hunk_match is None:
+            continue
+        new_start = int(hunk_match.group(1))
+        new_length = int(hunk_match.group(2)) if hunk_match.group(2) is not None else 1
+        if new_length == 0:
+            point = max(new_start, 1)
+            hunks[current_path].append((point, point))
+        else:
+            hunks[current_path].append((new_start, new_start + new_length - 1))
+    return dict(hunks)
+
+
+def _symbols_touched_by_hunks(
+    chunks: list[CodeChunk], hunks: list[tuple[int, int]]
+) -> list[CodeChunk]:
+    """Return chunks whose line span overlaps at least one hunk range."""
+    return [
+        chunk
+        for chunk in chunks
+        if chunk.symbol_name is not None
+        and any(chunk.start_line <= end and start <= chunk.end_line for start, end in hunks)
+    ]
+
+
+def resolve_diff_symbols(
+    store: IndexStore,
+    changes: list[ImpactFileChange],
+    hunks: dict[str, list[tuple[int, int]]],
+) -> list[CodeChunk]:
+    """Map a diff's changed files to the indexed symbols (chunks) their hunks touch.
+
+    Deleted files have no symbols to resolve against the current index (which
+    reflects the post-diff state) and are skipped; the file itself is still
+    reported through the enclosing file-level ``ImpactReport``.
+    """
+    touched: list[CodeChunk] = []
+    for change in changes:
+        if change.status == "D":
+            continue
+        file_hunks = hunks.get(change.path)
+        if not file_hunks:
+            continue
+        chunks = store.get_chunks_for_files([change.path])
+        touched.extend(_symbols_touched_by_hunks(chunks, file_hunks))
+    touched.sort(key=lambda chunk: (chunk.file_path, chunk.start_line, chunk.symbol_name or ""))
+    return touched
 
 
 def analyze_impact(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,3 +204,15 @@ def go_simple_repo(tmp_path: Path) -> Path:
 def monorepo_simple_repo(tmp_path: Path) -> Path:
     """Copy tests/fixtures/monorepo_simple to a temp dir and initialise a git repo."""
     return _init_fixture_repo(tmp_path, "monorepo_simple")
+
+
+@pytest.fixture
+def impact_diff_repo(tmp_path: Path) -> Path:
+    """Copy tests/fixtures/impact_diff to a temp dir and initialise a git repo.
+
+    Graph shape: hub.py is imported by four files (leaf.py, consumer_a/b/c.py)
+    plus transitively reachable from the entry point main.py -- a deliberate
+    hub for diff-scoped risk classification tests. leaf.py has zero importers
+    and is unreachable from any entry point within a bounded distance.
+    """
+    return _init_fixture_repo(tmp_path, "impact_diff")

--- a/tests/fixtures/impact_diff/consumer_a.py
+++ b/tests/fixtures/impact_diff/consumer_a.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from hub import shared_helper
+
+
+def use_a(value: int) -> int:
+    return shared_helper(value)

--- a/tests/fixtures/impact_diff/consumer_b.py
+++ b/tests/fixtures/impact_diff/consumer_b.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from hub import shared_helper
+
+
+def use_b(value: int) -> int:
+    return shared_helper(value)

--- a/tests/fixtures/impact_diff/consumer_c.py
+++ b/tests/fixtures/impact_diff/consumer_c.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from hub import shared_helper
+
+
+def use_c(value: int) -> int:
+    return shared_helper(value)

--- a/tests/fixtures/impact_diff/hub.py
+++ b/tests/fixtures/impact_diff/hub.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+def shared_helper(value: int) -> int:
+    return value * 2
+
+
+def other_helper(value: int) -> int:
+    return value + 1

--- a/tests/fixtures/impact_diff/leaf.py
+++ b/tests/fixtures/impact_diff/leaf.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from hub import shared_helper
+
+
+def isolated(value: int) -> int:
+    return shared_helper(value) - 1

--- a/tests/fixtures/impact_diff/main.py
+++ b/tests/fixtures/impact_diff/main.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from consumer_a import use_a
+from hub import other_helper
+
+
+def run() -> None:
+    print(use_a(1))
+    print(other_helper(2))
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/fixtures/impact_diff/pyproject.toml
+++ b/tests/fixtures/impact_diff/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "impact-diff-app"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = []

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -1,0 +1,161 @@
+"""Backend tests for diff-scoped impact analysis (git_diff_hunks, resolve_diff_symbols)."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+from archex.api import index_repository
+from archex.impact import git_changed_files, git_diff_hunks, resolve_diff_symbols
+from archex.models import Config, IndexConfig, RepoSource
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from archex.index.store import IndexStore
+
+
+def _index(repo_path: Path) -> IndexStore:
+    source = RepoSource(local_path=str(repo_path), stable_identity="impact-diff-test@1")
+    return index_repository(
+        source, config=Config(cache=False), index_config=IndexConfig(vector=False)
+    )
+
+
+# ---------------------------------------------------------------------------
+# git_diff_hunks
+# ---------------------------------------------------------------------------
+
+
+def test_git_diff_hunks_maps_single_line_edit(impact_diff_repo: Path) -> None:
+    hub = impact_diff_repo / "hub.py"
+    hub.write_text(hub.read_text().replace("value * 2", "value * 3"))
+
+    hunks = git_diff_hunks(impact_diff_repo, "HEAD")
+
+    assert hunks == {"hub.py": [(5, 5)]}
+
+
+def test_git_diff_hunks_covers_whole_added_file(impact_diff_repo: Path) -> None:
+    new_file = impact_diff_repo / "extra.py"
+    new_file.write_text("def extra() -> int:\n    return 1\n")
+    subprocess.run(["git", "add", "extra.py"], cwd=impact_diff_repo, check=True)
+
+    hunks = git_diff_hunks(impact_diff_repo, "HEAD")
+
+    assert hunks == {"extra.py": [(1, 2)]}
+
+
+def test_git_diff_hunks_skips_deleted_files(impact_diff_repo: Path) -> None:
+    (impact_diff_repo / "leaf.py").unlink()
+
+    hunks = git_diff_hunks(impact_diff_repo, "HEAD")
+
+    assert "leaf.py" not in hunks
+
+
+def test_git_diff_hunks_records_pure_deletion_as_point(impact_diff_repo: Path) -> None:
+    hub = impact_diff_repo / "hub.py"
+    lines = hub.read_text().splitlines(keepends=True)
+    # Drop the blank separator line between the two functions (a pure deletion,
+    # zero new lines added at that position).
+    del lines[6]
+    hub.write_text("".join(lines))
+
+    hunks = git_diff_hunks(impact_diff_repo, "HEAD")
+
+    assert hunks == {"hub.py": [(6, 6)]}
+
+
+# ---------------------------------------------------------------------------
+# resolve_diff_symbols
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_diff_symbols_hub_file_touches_only_changed_function(
+    impact_diff_repo: Path,
+) -> None:
+    hub = impact_diff_repo / "hub.py"
+    hub.write_text(hub.read_text().replace("value * 2", "value * 3"))
+
+    changes = git_changed_files(impact_diff_repo, "HEAD")
+    hunks = git_diff_hunks(impact_diff_repo, "HEAD")
+    store = _index(impact_diff_repo)
+    try:
+        touched = resolve_diff_symbols(store, changes, hunks)
+    finally:
+        store.close()
+
+    assert [(chunk.file_path, chunk.symbol_name) for chunk in touched] == [
+        ("hub.py", "shared_helper")
+    ]
+
+
+def test_resolve_diff_symbols_leaf_file_touches_only_changed_function(
+    impact_diff_repo: Path,
+) -> None:
+    leaf = impact_diff_repo / "leaf.py"
+    old_text = leaf.read_text()
+    leaf.write_text(old_text.replace("shared_helper(value) - 1", "shared_helper(value) - 2"))
+
+    changes = git_changed_files(impact_diff_repo, "HEAD")
+    hunks = git_diff_hunks(impact_diff_repo, "HEAD")
+    store = _index(impact_diff_repo)
+    try:
+        touched = resolve_diff_symbols(store, changes, hunks)
+    finally:
+        store.close()
+
+    assert [(chunk.file_path, chunk.symbol_name) for chunk in touched] == [("leaf.py", "isolated")]
+
+
+def test_resolve_diff_symbols_added_file_reports_all_symbols(impact_diff_repo: Path) -> None:
+    new_file = impact_diff_repo / "extra.py"
+    new_file.write_text(
+        "def extra_a() -> int:\n    return 1\n\n\ndef extra_b() -> int:\n    return 2\n"
+    )
+    subprocess.run(["git", "add", "extra.py"], cwd=impact_diff_repo, check=True)
+
+    changes = git_changed_files(impact_diff_repo, "HEAD")
+    hunks = git_diff_hunks(impact_diff_repo, "HEAD")
+    store = _index(impact_diff_repo)
+    try:
+        touched = resolve_diff_symbols(store, changes, hunks)
+    finally:
+        store.close()
+
+    assert {chunk.symbol_name for chunk in touched} == {"extra_a", "extra_b"}
+
+
+def test_resolve_diff_symbols_skips_deleted_files(impact_diff_repo: Path) -> None:
+    (impact_diff_repo / "leaf.py").unlink()
+
+    changes = git_changed_files(impact_diff_repo, "HEAD")
+    hunks = git_diff_hunks(impact_diff_repo, "HEAD")
+    store = _index(impact_diff_repo)
+    try:
+        touched = resolve_diff_symbols(store, changes, hunks)
+    finally:
+        store.close()
+
+    assert touched == []
+
+
+def test_resolve_diff_symbols_ignores_untouched_symbols_in_changed_file(
+    impact_diff_repo: Path,
+) -> None:
+    """Editing one function in hub.py must not report the sibling function as touched."""
+    hub = impact_diff_repo / "hub.py"
+    hub.write_text(hub.read_text().replace("value + 1", "value + 2"))
+
+    changes = git_changed_files(impact_diff_repo, "HEAD")
+    hunks = git_diff_hunks(impact_diff_repo, "HEAD")
+    store = _index(impact_diff_repo)
+    try:
+        touched = resolve_diff_symbols(store, changes, hunks)
+    finally:
+        store.close()
+
+    symbol_names = {chunk.symbol_name for chunk in touched}
+    assert symbol_names == {"other_helper"}
+    assert "shared_helper" not in symbol_names


### PR DESCRIPTION
## Stack

Position: 1/3 of the M18 (Diff-scoped impact with risk classification) stack.

1. `feat/m18-diff-symbol-resolution` -> this PR
2. `feat/m18-risk-classifier` -> depends on this PR
3. `feat/m18-cli-mcp-diff-surface` -> depends on PR 2

Depends on: (none - root)
Base: `main`

## Summary

First slice of M18 (diff-scoped impact analysis). Adds the diff-to-symbol
resolution primitives to the impact backend (`src/archex/impact.py`), with
no CLI/MCP wiring yet:

- `git_diff_hunks(repo_root, ref)` parses `git diff --unified=0` hunk headers
  into per-file new-side line ranges (ref vs. working tree). A pure-deletion
  hunk (zero new lines) is recorded as a single-line marker at the deletion
  point so it still intersects the enclosing symbol's span.
- `resolve_diff_symbols(store, changes, hunks)` maps those ranges onto the
  `CodeChunk`s (symbols) they overlap, via the existing
  `IndexStore.get_chunks_for_files()`. Deleted files are skipped (the index
  reflects post-diff state and no longer has their chunks); added files
  resolve to every symbol in the file since the diff covers it in full.

A new `tests/fixtures/impact_diff/` fixture provides a deliberate graph
shape for this and the following two PRs: `hub.py` is imported by four
files and transitively reachable from the entry point `main.py`; `leaf.py`
has zero importers and is unreachable from any entry point within a
bounded distance.

Only additive, currently-unused backend functions land in this PR — no
behavior change for any existing consumer.

## Validation

- `uv run pytest tests/test_impact.py -v` — 9 passed
- `uv run ruff check src/archex/impact.py tests/test_impact.py tests/conftest.py`
- `uv run ruff format --check src/archex/impact.py tests/test_impact.py tests/conftest.py`
- `uv run pyright src/archex/impact.py tests/test_impact.py`
