### PR TITLE
feat(impact): classify per-symbol risk from deterministic graph signals

### DIFF
--- a/src/archex/impact.py
+++ b/src/archex/impact.py
@@ -12,9 +12,14 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
+from archex.index.graph import DependencyGraph
+from archex.models import DiscoveredFile
+from archex.parse.adapters import default_adapter_registry
+
 if TYPE_CHECKING:
     from archex.index.store import IndexStore
     from archex.models import CodeChunk, Edge
+    from archex.parse.adapters import LanguageAdapter
 
 
 class ImpactError(ValueError):
@@ -38,6 +43,28 @@ class ImpactRisk(BaseModel):
     reasons: list[str] = []
 
 
+class SymbolRiskLevel(StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class SymbolRiskSignal(BaseModel):
+    name: str
+    detail: str
+
+
+class SymbolImpact(BaseModel):
+    file_path: str
+    symbol_name: str | None = None
+    qualified_name: str | None = None
+    symbol_kind: str | None = None
+    start_line: int
+    end_line: int
+    level: SymbolRiskLevel
+    signals: list[SymbolRiskSignal] = []
+
+
 class ImpactReport(BaseModel):
     changed_files: list[ImpactFileChange] = []
     affected_files: list[str] = []
@@ -46,9 +73,15 @@ class ImpactReport(BaseModel):
     affected_tests: list[str] = []
     unmapped_files: list[str] = []
     risk: ImpactRisk = Field(default_factory=lambda: ImpactRisk(level=ImpactRiskLevel.LOW))
+    diff_ref: str | None = None
+    affected_symbols: list[SymbolImpact] = []
 
     def to_json(self) -> str:
-        return json.dumps(self.model_dump(mode="json"), indent=2, sort_keys=True)
+        data = self.model_dump(mode="json")
+        if self.diff_ref is None:
+            data.pop("diff_ref", None)
+            data.pop("affected_symbols", None)
+        return json.dumps(data, indent=2, sort_keys=True)
 
     def to_markdown(self) -> str:
         lines = [
@@ -77,6 +110,17 @@ class ImpactReport(BaseModel):
         lines.extend(f"- `{reason}`" for reason in self.risk.reasons)
         lines.extend(["", "## Unmapped Files", ""])
         lines.extend(_path_lines(self.unmapped_files))
+        if self.diff_ref is not None:
+            lines.extend(["", f"## Symbol Risk (diff: `{self.diff_ref}`)", ""])
+            if not self.affected_symbols:
+                lines.append("- None")
+            for symbol in self.affected_symbols:
+                label = symbol.qualified_name or symbol.symbol_name or "<unnamed>"
+                lines.append(
+                    f"- `{symbol.level.value}` `{symbol.file_path}::{label}` "
+                    f"(lines {symbol.start_line}-{symbol.end_line})"
+                )
+                lines.extend(f"  - {signal.name}: {signal.detail}" for signal in symbol.signals)
         return "\n".join(lines).rstrip() + "\n"
 
 
@@ -175,6 +219,196 @@ def resolve_diff_symbols(
         touched.extend(_symbols_touched_by_hunks(chunks, file_hunks))
     touched.sort(key=lambda chunk: (chunk.file_path, chunk.start_line, chunk.symbol_name or ""))
     return touched
+
+
+_HUB_CENTRALITY_RATIO = 2.0
+_HIGH_FAN_IN_THRESHOLD = 3
+_ENTRY_POINT_MAX_DEPTH = 2
+
+
+def _nearest_entry_point(
+    graph: DependencyGraph,
+    repo_root: Path,
+    file_path: str,
+    path_to_language: dict[str, str],
+    adapters: dict[str, LanguageAdapter],
+    max_depth: int,
+) -> tuple[int, str] | None:
+    """Reverse-BFS from ``file_path`` over import predecessors, bounded to
+    ``max_depth`` hops, looking for the nearest file an adapter identifies as
+    an entry point. Returns ``(depth, entry_point_path)`` or ``None``.
+    """
+    entry_cache: dict[str, bool] = {}
+
+    def is_entry(path: str) -> bool:
+        if path in entry_cache:
+            return entry_cache[path]
+        language = path_to_language.get(path)
+        result = False
+        if language is not None:
+            adapter = adapters.get(language)
+            if adapter is not None:
+                discovered = DiscoveredFile(
+                    path=path, absolute_path=str(repo_root / path), language=language
+                )
+                try:
+                    result = path in adapter.detect_entry_points([discovered])
+                except OSError:
+                    result = False
+        entry_cache[path] = result
+        return result
+
+    visited = {file_path}
+    frontier = [file_path]
+    for depth in range(max_depth + 1):
+        for path in sorted(frontier):
+            if is_entry(path):
+                return depth, path
+        next_frontier: list[str] = []
+        for path in frontier:
+            for predecessor in graph.imported_by(path):
+                if predecessor not in visited:
+                    visited.add(predecessor)
+                    next_frontier.append(predecessor)
+        if not next_frontier:
+            return None
+        frontier = next_frontier
+    return None
+
+
+def _classify_file_risk(
+    file_path: str,
+    graph: DependencyGraph,
+    centrality: dict[str, float],
+    mean_centrality: float,
+    repo_root: Path,
+    path_to_language: dict[str, str],
+    adapters: dict[str, LanguageAdapter],
+) -> tuple[SymbolRiskLevel, list[SymbolRiskSignal]]:
+    """Classify a file's risk tier from deterministic graph signals only.
+
+    Three signals, each file-scoped (edges are file-to-file; no CALLS edges
+    exist to derive symbol-level blast radius):
+
+    - structural_centrality: PageRank share >= _HUB_CENTRALITY_RATIO x the
+      graph's mean node centrality.
+    - fan_in: count of distinct files that directly import this file >=
+      _HIGH_FAN_IN_THRESHOLD.
+    - entry_point_proximity: an adapter-identified entry point is reachable
+      within _ENTRY_POINT_MAX_DEPTH import hops (upstream) of this file.
+
+    HIGH if the file *is* an entry point, or if 2+ signals fire; MEDIUM if
+    exactly 1 fires; LOW if none fire.
+    """
+    signals: list[SymbolRiskSignal] = []
+    fired = 0
+
+    file_centrality = centrality.get(file_path, 0.0)
+    hub_threshold = mean_centrality * _HUB_CENTRALITY_RATIO
+    is_hub = mean_centrality > 0 and file_centrality >= hub_threshold
+    signals.append(
+        SymbolRiskSignal(
+            name="structural_centrality",
+            detail=(
+                f"centrality={file_centrality:.4f} "
+                f"{'>=' if is_hub else '<'} threshold={hub_threshold:.4f} "
+                f"({_HUB_CENTRALITY_RATIO}x graph mean {mean_centrality:.4f})"
+            ),
+        )
+    )
+    fired += int(is_hub)
+
+    fan_in = len(graph.imported_by(file_path))
+    is_high_fan_in = fan_in >= _HIGH_FAN_IN_THRESHOLD
+    signals.append(
+        SymbolRiskSignal(
+            name="fan_in",
+            detail=(
+                f"fan_in={fan_in} {'>=' if is_high_fan_in else '<'} "
+                f"threshold={_HIGH_FAN_IN_THRESHOLD}"
+            ),
+        )
+    )
+    fired += int(is_high_fan_in)
+
+    nearest = _nearest_entry_point(
+        graph, repo_root, file_path, path_to_language, adapters, _ENTRY_POINT_MAX_DEPTH
+    )
+    is_entry_itself = nearest is not None and nearest[0] == 0
+    if nearest is not None:
+        depth, entry_path = nearest
+        entry_detail = (
+            f"entry_point_distance={depth} <= max_depth={_ENTRY_POINT_MAX_DEPTH} "
+            f"(nearest entry point: {entry_path})"
+        )
+    else:
+        entry_detail = f"no entry point within max_depth={_ENTRY_POINT_MAX_DEPTH}"
+    signals.append(SymbolRiskSignal(name="entry_point_proximity", detail=entry_detail))
+    fired += int(nearest is not None)
+
+    if is_entry_itself or fired >= 2:
+        level = SymbolRiskLevel.HIGH
+    elif fired == 1:
+        level = SymbolRiskLevel.MEDIUM
+    else:
+        level = SymbolRiskLevel.LOW
+    return level, signals
+
+
+def analyze_diff_impact(
+    store: IndexStore,
+    repo_root: Path,
+    changes: list[ImpactFileChange],
+    hunks: dict[str, list[tuple[int, int]]],
+    diff_ref: str,
+) -> ImpactReport:
+    """Extend the file-level impact report with per-symbol risk classification.
+
+    Reuses ``analyze_impact()`` for the existing file-level fields, then adds
+    ``diff_ref`` and ``affected_symbols`` -- only the symbols the diff's hunks
+    directly touch, each tagged with a deterministic risk tier and the
+    signal rationale that produced it.
+    """
+    base_report = analyze_impact(store, changes)
+    touched = resolve_diff_symbols(store, changes, hunks)
+    if not touched:
+        return base_report.model_copy(update={"diff_ref": diff_ref})
+
+    graph = DependencyGraph.from_edges(store.get_edges())
+    centrality = graph.structural_centrality()
+    mean_centrality = sum(centrality.values()) / len(centrality) if centrality else 0.0
+    path_to_language = {
+        str(item["file_path"]): str(item["language"]) for item in store.get_file_metadata()
+    }
+    adapters = default_adapter_registry.build_all()
+
+    risk_cache: dict[str, tuple[SymbolRiskLevel, list[SymbolRiskSignal]]] = {}
+    symbol_impacts: list[SymbolImpact] = []
+    for chunk in touched:
+        if chunk.file_path not in risk_cache:
+            risk_cache[chunk.file_path] = _classify_file_risk(
+                chunk.file_path,
+                graph,
+                centrality,
+                mean_centrality,
+                repo_root,
+                path_to_language,
+                adapters,
+            )
+        level, signals = risk_cache[chunk.file_path]
+        symbol_impacts.append(
+            SymbolImpact(
+                file_path=chunk.file_path,
+                symbol_name=chunk.symbol_name,
+                qualified_name=chunk.qualified_name,
+                symbol_kind=str(chunk.symbol_kind) if chunk.symbol_kind is not None else None,
+                start_line=chunk.start_line,
+                end_line=chunk.end_line,
+                level=level,
+                signals=signals,
+            )
+        )
+    return base_report.model_copy(update={"diff_ref": diff_ref, "affected_symbols": symbol_impacts})
 
 
 def analyze_impact(

--- a/tests/test_impact.py
+++ b/tests/test_impact.py
@@ -1,17 +1,33 @@
-"""Backend tests for diff-scoped impact analysis (git_diff_hunks, resolve_diff_symbols)."""
+"""Backend tests for diff-scoped impact analysis.
+
+Covers diff-to-symbol resolution (git_diff_hunks, resolve_diff_symbols) and
+risk classification (_classify_file_risk, analyze_diff_impact).
+"""
 
 from __future__ import annotations
 
+import json
 import subprocess
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from archex.api import index_repository
-from archex.impact import git_changed_files, git_diff_hunks, resolve_diff_symbols
+from archex.impact import (
+    ImpactReport,
+    SymbolImpact,
+    SymbolRiskLevel,
+    SymbolRiskSignal,
+    _classify_file_risk,  # pyright: ignore[reportPrivateUsage]
+    analyze_diff_impact,
+    git_changed_files,
+    git_diff_hunks,
+    resolve_diff_symbols,
+)
+from archex.index.graph import DependencyGraph
 from archex.models import Config, IndexConfig, RepoSource
+from archex.parse.adapters import default_adapter_registry
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from archex.index.store import IndexStore
 
 
@@ -159,3 +175,240 @@ def test_resolve_diff_symbols_ignores_untouched_symbols_in_changed_file(
     symbol_names = {chunk.symbol_name for chunk in touched}
     assert symbol_names == {"other_helper"}
     assert "shared_helper" not in symbol_names
+
+
+# ---------------------------------------------------------------------------
+# _classify_file_risk -- tier boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_classify_file_risk_zero_signals_is_low() -> None:
+    graph = DependencyGraph()
+    graph.add_file_node("solo.py")
+
+    level, signals = _classify_file_risk(
+        "solo.py",
+        graph,
+        centrality={"solo.py": 0.1},
+        mean_centrality=0.1,
+        repo_root=Path("/nonexistent"),
+        path_to_language={},
+        adapters={},
+    )
+
+    assert level == SymbolRiskLevel.LOW
+    assert {signal.name for signal in signals} == {
+        "structural_centrality",
+        "fan_in",
+        "entry_point_proximity",
+    }
+
+
+def test_classify_file_risk_one_signal_fan_in_is_medium() -> None:
+    graph = DependencyGraph()
+    for i in range(3):
+        graph.add_file_edge(f"importer_{i}.py", "target.py")
+
+    level, _signals = _classify_file_risk(
+        "target.py",
+        graph,
+        centrality={"target.py": 0.1},
+        mean_centrality=0.1,  # ratio 1.0x, below the 2.0x hub threshold
+        repo_root=Path("/nonexistent"),
+        path_to_language={},
+        adapters={},
+    )
+
+    assert level == SymbolRiskLevel.MEDIUM
+
+
+def test_classify_file_risk_two_signals_is_high() -> None:
+    graph = DependencyGraph()
+    for i in range(3):
+        graph.add_file_edge(f"importer_{i}.py", "target.py")
+
+    level, _signals = _classify_file_risk(
+        "target.py",
+        graph,
+        centrality={"target.py": 0.5},
+        mean_centrality=0.1,  # ratio 5.0x, above the 2.0x hub threshold
+        repo_root=Path("/nonexistent"),
+        path_to_language={},
+        adapters={},
+    )
+
+    assert level == SymbolRiskLevel.HIGH
+
+
+def test_classify_file_risk_entry_point_itself_forces_high(tmp_path: Path) -> None:
+    (tmp_path / "main_entry.py").write_text('if __name__ == "__main__":\n    pass\n')
+    graph = DependencyGraph()
+    graph.add_file_node("main_entry.py")
+    adapters = default_adapter_registry.build_all()
+
+    level, signals = _classify_file_risk(
+        "main_entry.py",
+        graph,
+        centrality={"main_entry.py": 0.01},
+        mean_centrality=0.5,  # deliberately high so centrality does not fire
+        repo_root=tmp_path,
+        path_to_language={"main_entry.py": "python"},
+        adapters=adapters,
+    )
+
+    assert level == SymbolRiskLevel.HIGH
+    entry_signal = next(s for s in signals if s.name == "entry_point_proximity")
+    assert "entry_point_distance=0" in entry_signal.detail
+
+
+def test_classify_file_risk_entry_proximity_alone_is_medium(tmp_path: Path) -> None:
+    (tmp_path / "entry.py").write_text('if __name__ == "__main__":\n    pass\n')
+    (tmp_path / "target.py").write_text("value = 1\n")
+    graph = DependencyGraph()
+    graph.add_file_edge("entry.py", "target.py")
+    adapters = default_adapter_registry.build_all()
+
+    level, signals = _classify_file_risk(
+        "target.py",
+        graph,
+        centrality={"target.py": 0.01, "entry.py": 0.01},
+        mean_centrality=0.5,
+        repo_root=tmp_path,
+        path_to_language={"target.py": "python", "entry.py": "python"},
+        adapters=adapters,
+    )
+
+    assert level == SymbolRiskLevel.MEDIUM
+    entry_signal = next(s for s in signals if s.name == "entry_point_proximity")
+    assert "entry_point_distance=1" in entry_signal.detail
+
+
+def test_classify_file_risk_entry_point_beyond_max_depth_does_not_fire() -> None:
+    graph = DependencyGraph()
+    graph.add_file_edge("entry.py", "mid.py")
+    graph.add_file_edge("mid.py", "far.py")
+    graph.add_file_edge("far.py", "target.py")
+
+    level, signals = _classify_file_risk(
+        "target.py",
+        graph,
+        centrality={"target.py": 0.1},
+        mean_centrality=0.1,
+        repo_root=Path("/nonexistent"),
+        path_to_language={},  # no language info -> entry detection never fires anyway
+        adapters={},
+    )
+
+    assert level == SymbolRiskLevel.LOW
+    entry_signal = next(s for s in signals if s.name == "entry_point_proximity")
+    assert "no entry point within max_depth" in entry_signal.detail
+
+
+# ---------------------------------------------------------------------------
+# analyze_diff_impact -- end-to-end acceptance (hub file -> HIGH, leaf -> LOW)
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_diff_impact_hub_file_edit_is_high_risk(impact_diff_repo: Path) -> None:
+    hub = impact_diff_repo / "hub.py"
+    hub.write_text(hub.read_text().replace("value * 2", "value * 3"))
+
+    changes = git_changed_files(impact_diff_repo, "HEAD")
+    hunks = git_diff_hunks(impact_diff_repo, "HEAD")
+    store = _index(impact_diff_repo)
+    try:
+        report = analyze_diff_impact(store, impact_diff_repo, changes, hunks, "HEAD")
+    finally:
+        store.close()
+
+    assert report.diff_ref == "HEAD"
+    assert [(s.file_path, s.symbol_name, s.level) for s in report.affected_symbols] == [
+        ("hub.py", "shared_helper", SymbolRiskLevel.HIGH)
+    ]
+    fired = report.affected_symbols[0].signals
+    assert {signal.name for signal in fired} == {
+        "structural_centrality",
+        "fan_in",
+        "entry_point_proximity",
+    }
+
+
+def test_analyze_diff_impact_leaf_file_edit_is_low_risk(impact_diff_repo: Path) -> None:
+    leaf = impact_diff_repo / "leaf.py"
+    old_text = leaf.read_text()
+    leaf.write_text(old_text.replace("shared_helper(value) - 1", "shared_helper(value) - 2"))
+
+    changes = git_changed_files(impact_diff_repo, "HEAD")
+    hunks = git_diff_hunks(impact_diff_repo, "HEAD")
+    store = _index(impact_diff_repo)
+    try:
+        report = analyze_diff_impact(store, impact_diff_repo, changes, hunks, "HEAD")
+    finally:
+        store.close()
+
+    assert [(s.file_path, s.symbol_name, s.level) for s in report.affected_symbols] == [
+        ("leaf.py", "isolated", SymbolRiskLevel.LOW)
+    ]
+
+
+def test_analyze_diff_impact_no_touched_symbols_still_sets_diff_ref(
+    impact_diff_repo: Path,
+) -> None:
+    (impact_diff_repo / "README.md").write_text("docs only\n")
+    subprocess.run(["git", "add", "README.md"], cwd=impact_diff_repo, check=True)
+
+    changes = git_changed_files(impact_diff_repo, "HEAD")
+    hunks = git_diff_hunks(impact_diff_repo, "HEAD")
+    store = _index(impact_diff_repo)
+    try:
+        report = analyze_diff_impact(store, impact_diff_repo, changes, hunks, "HEAD")
+    finally:
+        store.close()
+
+    assert report.diff_ref == "HEAD"
+    assert report.affected_symbols == []
+
+
+# ---------------------------------------------------------------------------
+# ImpactReport rendering -- additive-only when diff mode is unused
+# ---------------------------------------------------------------------------
+
+
+def test_impact_report_to_json_excludes_diff_fields_when_not_used() -> None:
+    payload = json.loads(ImpactReport().to_json())
+
+    assert "diff_ref" not in payload
+    assert "affected_symbols" not in payload
+
+
+def test_impact_report_to_json_includes_diff_fields_when_used() -> None:
+    payload = json.loads(ImpactReport(diff_ref="HEAD").to_json())
+
+    assert payload["diff_ref"] == "HEAD"
+    assert payload["affected_symbols"] == []
+
+
+def test_impact_report_to_markdown_omits_symbol_risk_section_when_not_used() -> None:
+    assert "Symbol Risk" not in ImpactReport().to_markdown()
+
+
+def test_impact_report_to_markdown_includes_symbol_risk_section_when_used() -> None:
+    report = ImpactReport(
+        diff_ref="HEAD",
+        affected_symbols=[
+            SymbolImpact(
+                file_path="hub.py",
+                symbol_name="shared_helper",
+                start_line=4,
+                end_line=5,
+                level=SymbolRiskLevel.HIGH,
+                signals=[SymbolRiskSignal(name="fan_in", detail="fan_in=5 >= threshold=3")],
+            )
+        ],
+    )
+
+    markdown = report.to_markdown()
+
+    assert "Symbol Risk" in markdown
+    assert "shared_helper" in markdown
+    assert "high" in markdown


### PR DESCRIPTION
## Stack

Position: 2/3 of the M18 (Diff-scoped impact with risk classification) stack.

1. `feat/m18-diff-symbol-resolution` -> #432
2. `feat/m18-risk-classifier` -> this PR
3. `feat/m18-cli-mcp-diff-surface` -> depends on this PR

Depends on: #432
Base: `feat/m18-diff-symbol-resolution`

## Summary

Second slice of M18. Adds the deterministic risk classifier and wires it
together with PR-1's diff-to-symbol resolution into a single
`analyze_diff_impact()` entry point. Still no CLI/MCP wiring — that lands
in PR-3.

New models: `SymbolRiskLevel` (`low`/`medium`/`high`), `SymbolRiskSignal`
(`name`, `detail`), `SymbolImpact` (file/symbol/lines/level/signals).
`ImpactReport` gains `diff_ref` and `affected_symbols`, both additive:
`to_json()`/`to_markdown()` omit both entirely when `diff_ref` is `None`.

`_classify_file_risk()` combines three signals, each file-scoped because
`IMPORTS`/`CO_DIRECTORY` edges are file-to-file — there is no `CALLS` edge
to derive a finer blast radius (the deepen-track GAP is explicitly out of
scope for this milestone):

- **structural_centrality** — PageRank share ≥ 2.0× the graph's mean node
  centrality, via the existing `DependencyGraph.structural_centrality()`
  (same signal `benchmark/baseline.py` already uses).
- **fan_in** — distinct direct importers ≥ 3, matching this module's
  existing file-level `high_fan_in` threshold.
- **entry_point_proximity** — an adapter-identified entry point
  (`LanguageAdapter.detect_entry_points`, already implemented and unit
  tested per-adapter but never previously invoked from the
  indexing/analysis path) reachable within 2 import hops upstream, found
  via a bounded reverse-BFS over `DependencyGraph.imported_by()`.

Tiering: a file that is itself an entry point is always `HIGH`; otherwise
`HIGH` needs 2+ signals, `MEDIUM` exactly 1, `LOW` none. Every signal's
fired/not-fired rationale and threshold is recorded regardless of outcome
(the receipt requirement from the milestone).

## Validation

- `uv run pytest tests/test_impact.py -v` — 22 passed, including the
  milestone's literal acceptance case: editing the `impact_diff` fixture's
  hub file classifies `HIGH` (all three signals fire) with the correct
  affected-symbol set (`hub.py::shared_helper` only), and editing the leaf
  file classifies `LOW`.
- `uv run ruff check src/archex/impact.py tests/test_impact.py`
- `uv run ruff format --check src/archex/impact.py tests/test_impact.py`
- `uv run pyright src/archex/impact.py tests/test_impact.py`
