### PR TITLE
feat(cli,mcp): wire --diff surface for diff-scoped symbol risk

### DIFF
--- a/src/archex/cli/impact_cmd.py
+++ b/src/archex/cli/impact_cmd.py
@@ -12,8 +12,10 @@ from archex.exceptions import ArchexError
 from archex.impact import (
     ImpactError,
     ImpactFileChange,
+    analyze_diff_impact,
     analyze_impact,
     git_changed_files,
+    git_diff_hunks,
     render_impact_report,
 )
 from archex.models import RepoSource
@@ -29,25 +31,47 @@ from archex.models import RepoSource
     help="Changed file path. Repeat to bypass git diff mode.",
 )
 @click.option(
+    "--diff",
+    "diff_ref",
+    is_flag=False,
+    flag_value="HEAD",
+    help=(
+        "Enable diff-scoped symbol impact: resolve the diff to touched symbols and "
+        "classify each with a LOW/MEDIUM/HIGH risk tier from deterministic graph "
+        "signals. Optional ref to diff against (default: HEAD, i.e. uncommitted "
+        "working tree changes). Adds affected_symbols to the report; output is "
+        "unchanged when omitted. Cannot be combined with --changed-file or --base."
+    ),
+)
+@click.option(
     "--format",
     "output_format",
     default="markdown",
     type=click.Choice(["markdown", "json"]),
     help="Output format.",
 )
+@click.pass_context
 def impact_cmd(
+    ctx: click.Context,
     source: str,
     base: str,
     changed_files: tuple[str, ...],
+    diff_ref: str | None,
     output_format: str,
 ) -> None:
     """Analyze deterministic blast radius for changed files."""
+    if diff_ref is not None:
+        if changed_files:
+            raise click.UsageError("--diff cannot be combined with --changed-file.")
+        if ctx.get_parameter_source("base") is click.core.ParameterSource.COMMANDLINE:
+            raise click.UsageError("--diff cannot be combined with --base.")
+
     repo_root = Path(source).expanduser().resolve()
     if changed_files:
         changes = [ImpactFileChange(path=path) for path in changed_files]
     else:
         try:
-            changes = git_changed_files(repo_root, base)
+            changes = git_changed_files(repo_root, diff_ref if diff_ref is not None else base)
         except ImpactError as exc:
             raise click.ClickException(str(exc)) from exc
 
@@ -57,7 +81,11 @@ def impact_cmd(
     try:
         store = index_repository(repo_source, config=config, index_config=index_config)
         try:
-            report = analyze_impact(store, changes)
+            if diff_ref is not None:
+                hunks = git_diff_hunks(repo_root, diff_ref)
+                report = analyze_diff_impact(store, repo_root, changes, hunks, diff_ref)
+            else:
+                report = analyze_impact(store, changes)
         finally:
             store.close()
     except (ArchexError, ImpactError) as exc:

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -57,8 +57,10 @@ from archex.graph_query import (
 from archex.impact import (
     ImpactError,
     ImpactFileChange,
+    analyze_diff_impact,
     analyze_impact,
     git_changed_files,
+    git_diff_hunks,
     render_impact_report,
 )
 from archex.metrics.capture import record_query_usage, record_scout_usage, record_structural_usage
@@ -508,6 +510,7 @@ def handle_get_impact(
     base: str = "main",
     changed_files: list[str] | None = None,
     output_format: str = "json",
+    diff_ref: str | None = None,
 ) -> str:
     """Analyze deterministic blast radius for changed files.
 
@@ -515,25 +518,35 @@ def handle_get_impact(
         repo_url: Local filesystem path of the repository. Git diff mode
             (the default, when changed_files is omitted) requires a local
             checkout with the given base ref reachable.
-        base: Base ref for git diff mode. Ignored when changed_files is given.
+        base: Base ref for git diff mode. Ignored when changed_files or
+            diff_ref is given.
         changed_files: Explicit changed file paths, bypassing git diff mode.
+            Cannot be combined with diff_ref.
         output_format: Output format — 'json' or 'markdown'. Defaults to 'json'.
+        diff_ref: Enable diff-scoped symbol impact: resolve the diff (this ref
+            vs. the working tree) to touched symbols and classify each with a
+            LOW/MEDIUM/HIGH risk tier from deterministic graph signals. Adds
+            affected_symbols to the report; output is unchanged when omitted.
 
     Returns:
         JSON envelope with ImpactReport content and _meta efficiency block.
     """
     _validate_output_format(output_format)
+    if changed_files and diff_ref is not None:
+        raise ImpactError("get_impact: diff_ref cannot be combined with changed_files")
     source = resolve_source(repo_url)
+    repo_root: Path | None = None
+    if source.local_path is not None:
+        repo_root = Path(source.local_path).expanduser().resolve()
     if changed_files:
         changes = [ImpactFileChange(path=path) for path in changed_files]
     else:
-        if source.local_path is None:
+        if repo_root is None:
             raise ImpactError(
                 "get_impact requires changed_files for a remote repo_url; "
                 "git diff mode needs a local checkout"
             )
-        repo_root = Path(source.local_path).expanduser().resolve()
-        changes = git_changed_files(repo_root, base)
+        changes = git_changed_files(repo_root, diff_ref if diff_ref is not None else base)
 
     started = time.perf_counter()
     config = load_config(source)
@@ -541,7 +554,12 @@ def handle_get_impact(
     pt = PipelineTiming()
     store = index_repository(source, config=config, timing=pt, index_config=index_config)
     try:
-        report = analyze_impact(store, changes)
+        if diff_ref is not None:
+            assert repo_root is not None  # guaranteed: local checkout resolved above
+            hunks = git_diff_hunks(repo_root, diff_ref)
+            report = analyze_diff_impact(store, repo_root, changes, hunks, diff_ref)
+        else:
+            report = analyze_impact(store, changes)
     finally:
         store.close()
     query_time_ms = (time.perf_counter() - started) * 1000
@@ -1118,8 +1136,9 @@ async def _run_mcp_tool(
         base: str = arguments.get("base", "main")
         impact_changed_files: list[str] | None = arguments.get("changed_files")
         fmt = arguments.get("format", "json")
+        impact_diff_ref: str | None = arguments.get("diff")
         return await loop.run_in_executor(
-            None, handle_get_impact, repo_url, base, impact_changed_files, fmt
+            None, handle_get_impact, repo_url, base, impact_changed_files, fmt, impact_diff_ref
         )
     if name == "explain_target":
         explain_repo_url: str | None = arguments.get("repo_url")
@@ -1507,7 +1526,9 @@ def build_server() -> Any:
                 description=(
                     "Analyze deterministic blast radius for changed files: affected files, "
                     "modules, public interfaces, test surface, and a risk assessment. Uses "
-                    "git diff against a base ref, or an explicit changed-file list."
+                    "git diff against a base ref, or an explicit changed-file list. Pass "
+                    "'diff' to additionally resolve the diff to touched symbols and classify "
+                    "each with a LOW/MEDIUM/HIGH risk tier from deterministic graph signals."
                 ),
                 inputSchema={
                     "type": "object",
@@ -1524,14 +1545,15 @@ def build_server() -> Any:
                             "default": "main",
                             "description": (
                                 "Base ref for git diff mode. Ignored when changed_files "
-                                "is provided."
+                                "or diff is provided."
                             ),
                         },
                         "changed_files": {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": (
-                                "Explicit changed file paths, bypassing git diff mode."
+                                "Explicit changed file paths, bypassing git diff mode. "
+                                "Cannot be combined with diff."
                             ),
                         },
                         "format": {
@@ -1539,6 +1561,16 @@ def build_server() -> Any:
                             "enum": ["json", "markdown"],
                             "default": "json",
                             "description": "Output format for the impact report.",
+                        },
+                        "diff": {
+                            "type": "string",
+                            "description": (
+                                "Enable diff-scoped symbol impact: resolve the diff (this "
+                                "ref vs. the working tree) to touched symbols with a "
+                                "per-symbol risk tier. Adds affected_symbols to the report; "
+                                "output is unchanged when omitted. Cannot be combined with "
+                                "changed_files."
+                            ),
                         },
                     },
                     "required": ["repo_url"],

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -1025,6 +1025,46 @@ class TestHandleGetImpact:
         with pytest.raises(ImpactError, match="requires changed_files"):
             handle_get_impact("https://example.com/repo.git")
 
+    def test_matches_cli_output_for_diff_json(self, impact_diff_repo: Path) -> None:
+        from click.testing import CliRunner
+
+        from archex.cli.main import cli
+
+        hub = impact_diff_repo / "hub.py"
+        hub.write_text(hub.read_text().replace("value * 2", "value * 3"))
+
+        runner = CliRunner()
+        cli_result = runner.invoke(
+            cli,
+            ["impact", str(impact_diff_repo), "--diff", "HEAD", "--format", "json"],
+        )
+        assert cli_result.exit_code == 0, cli_result.output
+        cli_data = json.loads(cli_result.output)
+
+        mcp_result = handle_get_impact(str(impact_diff_repo), diff_ref="HEAD", output_format="json")
+        envelope = json.loads(mcp_result)
+        mcp_data = json.loads(envelope["content"])
+
+        assert mcp_data == cli_data
+        assert mcp_data["diff_ref"] == "HEAD"
+        assert mcp_data["affected_symbols"][0]["level"] == "high"
+
+    def test_diff_ref_rejects_changed_files_combination(self) -> None:
+        from archex.impact import ImpactError
+
+        with pytest.raises(ImpactError, match="cannot be combined with changed_files"):
+            handle_get_impact("/fake/repo", changed_files=["a.py"], diff_ref="HEAD")
+
+    def test_without_diff_ref_output_has_no_diff_fields(self, python_simple_repo: Path) -> None:
+        mcp_result = handle_get_impact(
+            str(python_simple_repo), changed_files=["utils.py"], output_format="json"
+        )
+        envelope = json.loads(mcp_result)
+        mcp_data = json.loads(envelope["content"])
+
+        assert "diff_ref" not in mcp_data
+        assert "affected_symbols" not in mcp_data
+
 
 # ---------------------------------------------------------------------------
 # explain_target handler tests

--- a/tests/test_impact_cli.py
+++ b/tests/test_impact_cli.py
@@ -79,3 +79,104 @@ def test_impact_git_error_is_not_hidden(python_simple_repo: Path) -> None:
 
     assert result.exit_code != 0
     assert "git diff failed for base missing-ref" in result.output
+
+
+def test_impact_diff_classifies_hub_edit_as_high(impact_diff_repo: Path) -> None:
+    hub = impact_diff_repo / "hub.py"
+    hub.write_text(hub.read_text().replace("value * 2", "value * 3"))
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["impact", str(impact_diff_repo), "--diff", "HEAD", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["diff_ref"] == "HEAD"
+    assert [
+        (symbol["file_path"], symbol["symbol_name"], symbol["level"])
+        for symbol in data["affected_symbols"]
+    ] == [("hub.py", "shared_helper", "high")]
+
+
+def test_impact_diff_classifies_leaf_edit_as_low(impact_diff_repo: Path) -> None:
+    leaf = impact_diff_repo / "leaf.py"
+    old_text = leaf.read_text()
+    leaf.write_text(old_text.replace("shared_helper(value) - 1", "shared_helper(value) - 2"))
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["impact", str(impact_diff_repo), "--diff", "HEAD", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert [
+        (symbol["file_path"], symbol["symbol_name"], symbol["level"])
+        for symbol in data["affected_symbols"]
+    ] == [("leaf.py", "isolated", "low")]
+
+
+def test_impact_diff_bare_flag_defaults_to_head(impact_diff_repo: Path) -> None:
+    hub = impact_diff_repo / "hub.py"
+    hub.write_text(hub.read_text().replace("value * 2", "value * 3"))
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["impact", str(impact_diff_repo), "--diff", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["diff_ref"] == "HEAD"
+    assert data["affected_symbols"] != []
+
+
+def test_impact_diff_rejects_changed_file_combination(impact_diff_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["impact", str(impact_diff_repo), "--diff", "HEAD", "--changed-file", "hub.py"],
+    )
+
+    assert result.exit_code != 0
+    assert "--diff cannot be combined with --changed-file" in result.output
+
+
+def test_impact_diff_rejects_explicit_base_combination(impact_diff_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["impact", str(impact_diff_repo), "--diff", "HEAD", "--base", "main"],
+    )
+
+    assert result.exit_code != 0
+    assert "--diff cannot be combined with --base" in result.output
+
+
+def test_impact_without_diff_flag_output_has_no_diff_fields(python_simple_repo: Path) -> None:
+    """Backward compatibility: omitting --diff must not add diff_ref/affected_symbols."""
+    runner = CliRunner()
+
+    changed_file_result = runner.invoke(
+        cli,
+        ["impact", str(python_simple_repo), "--changed-file", "utils.py", "--format", "json"],
+    )
+    assert changed_file_result.exit_code == 0, changed_file_result.output
+    changed_file_data = json.loads(changed_file_result.output)
+    assert "diff_ref" not in changed_file_data
+    assert "affected_symbols" not in changed_file_data
+
+    base_result = runner.invoke(
+        cli,
+        ["impact", str(python_simple_repo), "--base", "HEAD", "--format", "json"],
+    )
+    assert base_result.exit_code == 0, base_result.output
+    base_data = json.loads(base_result.output)
+    assert "diff_ref" not in base_data
+    assert "affected_symbols" not in base_data


### PR DESCRIPTION
## Stack

Position: 3/3 of the M18 (Diff-scoped impact with risk classification) stack.

1. `feat/m18-diff-symbol-resolution` -> #432
2. `feat/m18-risk-classifier` -> #433
3. `feat/m18-cli-mcp-diff-surface` -> this PR

Depends on: #433
Base: `feat/m18-risk-classifier`

## Summary

Final slice of M18. Wires PR-2's `analyze_diff_impact()` through both
consumer surfaces:

- **CLI** (`archex impact --diff [<ref>]`): `--diff` is an optional-value
  option (bare `--diff` defaults to `HEAD`, i.e. uncommitted working tree
  changes; `--diff <ref>` diffs that ref against the working tree,
  mirroring `--base`'s existing semantics). Rejects `--diff` combined with
  `--changed-file`, and `--diff` combined with an *explicitly-passed*
  `--base` (detected via `ctx.get_parameter_source`, so the untouched
  default doesn't trip the check) — no silent shadowing of one flag by
  another.
- **MCP** (`get_impact`): new optional `diff` string field, dispatched to
  a new `diff_ref` parameter on `handle_get_impact` (default `None`).
  Same rejection rule for `diff` + `changed_files`.

Omitting `--diff`/`diff` is byte-identical to pre-change output: the
JSON payload doesn't gain `diff_ref`/`affected_symbols` keys at all
(mechanism landed in PR-2's `to_json()`/`to_markdown()`), and every
existing CLI/MCP impact test in the repo passes unmodified.

## Manual verification (real repo self-scan)

```
$ uv run archex impact --diff HEAD~1
```
run from the archex repo root against its own history — resolves the
prior commit's changed test files to their touched symbols, classifies
them (all `low`, correctly — test files have no importers and aren't
adapter-detected entry points), completes in ~1s, exits 0.

## Validation

- `uv run pytest tests/test_impact.py -v` — 22 passed
- `uv run pytest tests/integrations/test_mcp.py -k impact -v` — 7 passed
- `uv run archex impact --diff HEAD~1` — see above
- `uv run pytest` — 3427 passed, coverage 91.21% (gate: 85%)
- `uv run pyright` — 0 errors
- `uv run ruff check .` / `uv run ruff format --check .` — clean

## Hub/leaf fixture acceptance (M18 acceptance criteria, full stack)

```
$ uv run archex impact <impact_diff fixture> --diff HEAD --format json
```
- Editing `hub.py` -> `affected_symbols` = `[{"file_path": "hub.py",
  "symbol_name": "shared_helper", "level": "high", ...}]`, with all three
  signals firing (`structural_centrality`, `fan_in`, `entry_point_proximity`).
- Editing `leaf.py` -> `affected_symbols` = `[{"file_path": "leaf.py",
  "symbol_name": "isolated", "level": "low", ...}]`, no signals firing.
- Omitting `--diff` on either fixture or on `python_simple_repo` -> JSON
  output has no `diff_ref` / `affected_symbols` keys at all.
