### PR TITLE
feat(integrations): add Claude Code PreToolUse hook core (M19)

### DIFF
--- a/src/archex/__init__.py
+++ b/src/archex/__init__.py
@@ -3,9 +3,31 @@
 from __future__ import annotations
 
 from importlib.metadata import version
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from archex.api import analyze, compare, query, record_usage_event
 
 __version__ = version("archex")
 
-from archex.api import analyze, compare, query, record_usage_event
-
 __all__ = ["analyze", "query", "compare", "record_usage_event", "__version__"]
+
+_LAZY_API_EXPORTS = frozenset({"analyze", "compare", "query", "record_usage_event"})
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily resolve the `archex.api` re-exports.
+
+    `archex.api` pulls in the full parse/index/retrieval pipeline (tree-sitter
+    grammars, embedders, graph analysis). Importing it eagerly here would make
+    even `import archex.index.store` pay that cost, which matters for
+    latency-sensitive entry points like `archex.integrations.hook` (the M19
+    Claude Code PreToolUse hook, invoked as a subprocess under a ~500ms
+    budget). Deferring the import keeps plain submodule imports cheap while
+    `from archex import query` (and friends) keep working unchanged.
+    """
+    if name in _LAZY_API_EXPORTS:
+        from archex import api
+
+        return getattr(api, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/archex/integrations/hook.py
+++ b/src/archex/integrations/hook.py
@@ -1,0 +1,246 @@
+"""Claude Code PreToolUse hook: augments Grep/Glob with archex search results.
+
+Contract (M19 — non-blocking client hook integration):
+
+- Only `Grep` and `Glob` tool calls are inspected (`AUGMENTED_TOOLS`). Every other
+  tool, including `Read`, is never touched — this hook must never interfere with
+  read-before-edit semantics.
+- Every code path exits 0. A missing/stale index, a timeout, a malformed payload,
+  or an internal error all degrade to a silent no-op from the agent's point of
+  view; the failure is instead written to a local diagnostics log
+  (`_diagnostics_log_path`). Failures are loud in diagnostics, silent to the
+  agent flow — this is the one place "fail fast" is the wrong default, because
+  blocking or erroring the agent over a context-augmentation failure would be
+  worse than returning no extra context.
+- The archex lookup itself runs under a hard wall-clock timeout
+  (`_hook_timeout_seconds`, ~500ms by default). A lookup that is still running
+  past the budget is abandoned in place (its thread is not joined) and the
+  process exits immediately via `os._exit` so a stuck lookup can never block the
+  agent loop.
+- Every injected `additionalContext` block is stamped with a freshness/receipt
+  marker (the index revision and a UTC generation timestamp) so a downstream
+  agent can tell how current the injected context is, mirroring the receipt
+  contract used by `query`/`scout`.
+
+Invoked as a subprocess: `python -m archex.integrations.hook`, reading the
+PreToolUse JSON payload from stdin and writing the hook JSON output to stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from archex.index.store import IndexStore
+from archex.receipt import index_revision_from_store
+from archex.status import inspect_project_status
+
+if TYPE_CHECKING:
+    from archex.models import CodeChunk
+
+HOOK_EVENT_NAME = "PreToolUse"
+
+#: Tools this hook augments. Read is deliberately excluded — see module docstring.
+AUGMENTED_TOOLS: frozenset[str] = frozenset({"Grep", "Glob"})
+
+#: Claude Code hook `matcher` value that selects exactly `AUGMENTED_TOOLS`. The
+#: installer (`archex.client_setup`) reuses this constant so the installed
+#: config and this module's own runtime filter can never drift apart.
+HOOK_MATCHER = "|".join(sorted(AUGMENTED_TOOLS))
+
+DEFAULT_HOOK_TIMEOUT_SECONDS = 0.5
+_TIMEOUT_ENV_VAR = "ARCHEX_HOOK_TIMEOUT_SECONDS"
+
+DEFAULT_DIAGNOSTICS_LOG_PATH = Path.home() / ".archex" / "hook-diagnostics.log"
+_DIAGNOSTICS_LOG_ENV_VAR = "ARCHEX_HOOK_DIAGNOSTICS_LOG"
+
+MAX_RESULTS = 5
+
+_IDENTIFIER_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
+
+
+def main() -> None:
+    """Entry point for `python -m archex.integrations.hook`.
+
+    Guarantees exit 0 on every path, including an exception this module did not
+    anticipate — see the module docstring's non-blocking contract. `os._exit` is
+    used instead of a normal return so a lookup thread still running past the
+    timeout can never delay process exit.
+    """
+    try:
+        _main_impl()
+    except BaseException as exc:  # noqa: BLE001 - the non-blocking contract requires this
+        _log_diagnostic("unhandled_exception", detail=repr(exc))
+    os._exit(0)
+
+
+def _main_impl() -> None:
+    raw = sys.stdin.read()
+    payload = _parse_payload(raw)
+    if payload is None:
+        return
+    result = handle_pre_tool_use(payload)
+    if result is None:
+        return
+    sys.stdout.write(json.dumps(result))
+    sys.stdout.flush()
+
+
+def _parse_payload(raw: str) -> dict[str, Any] | None:
+    if not raw.strip():
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        _log_diagnostic("malformed_payload", detail=f"invalid JSON: {exc}")
+        return None
+    if not isinstance(payload, dict):
+        _log_diagnostic("malformed_payload", detail="payload is not a JSON object")
+        return None
+    return cast("dict[str, Any]", payload)
+
+
+def handle_pre_tool_use(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Core handler: a parsed PreToolUse payload in, hook JSON output or `None` out.
+
+    `None` means "no decision" — Claude Code proceeds exactly as if this hook
+    were not installed. Never raises: any failure degrades to `None` plus a
+    diagnostics log line.
+    """
+    try:
+        tool_name = payload.get("tool_name")
+        if tool_name not in AUGMENTED_TOOLS:
+            return None
+        tool_input = payload.get("tool_input")
+        if not isinstance(tool_input, dict):
+            _log_diagnostic("malformed_payload", detail="tool_input is not a JSON object")
+            return None
+        query = _extract_query(tool_name, cast("dict[str, Any]", tool_input))
+        if not query:
+            return None
+        cwd_raw = payload.get("cwd")
+        cwd = cwd_raw if isinstance(cwd_raw, str) and cwd_raw else os.getcwd()
+        context = _lookup_with_timeout(cwd, query)
+        if context is None:
+            return None
+        return _build_output(context)
+    except Exception as exc:  # noqa: BLE001 - degrade to no-op, never raise
+        _log_diagnostic("internal_error", detail=repr(exc))
+        return None
+
+
+def _extract_query(tool_name: str, tool_input: dict[str, Any]) -> str:
+    pattern = tool_input.get("pattern")
+    if not isinstance(pattern, str) or not pattern.strip():
+        return ""
+    if tool_name == "Grep":
+        return pattern.strip()
+    # Glob patterns are filesystem globs, not search terms — pull identifier-like
+    # tokens out of them so "**/*_service.py" becomes a useful symbol query.
+    return " ".join(_IDENTIFIER_TOKEN_RE.findall(pattern))
+
+
+def _lookup_with_timeout(cwd: str, query: str) -> str | None:
+    timeout = _hook_timeout_seconds()
+    executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="archex-hook")
+    future = executor.submit(_lookup, cwd, query)
+    try:
+        return future.result(timeout=timeout)
+    except TimeoutError:
+        _log_diagnostic("timeout", detail=f"lookup exceeded {timeout}s", cwd=cwd)
+        return None
+    except Exception as exc:  # noqa: BLE001 - degrade to no-op, never raise
+        _log_diagnostic("lookup_error", detail=repr(exc), cwd=cwd)
+        return None
+    finally:
+        # Don't wait for a timed-out lookup thread — main()'s os._exit reclaims it.
+        executor.shutdown(wait=False, cancel_futures=False)
+
+
+def _lookup(cwd: str, query: str) -> str | None:
+    try:
+        status = inspect_project_status(cwd)
+    except ValueError as exc:
+        _log_diagnostic("status_error", detail=str(exc), cwd=cwd)
+        return None
+    if status.state != "fresh":
+        _log_diagnostic("index_not_fresh", detail=f"state={status.state}", cwd=cwd)
+        return None
+
+    store = IndexStore(status.index_path)
+    try:
+        chunks = store.search_symbols(query, limit=MAX_RESULTS)
+        if not chunks:
+            return None
+        revision = index_revision_from_store(store)
+    finally:
+        store.close()
+    return _render_context(query, chunks, revision)
+
+
+def _render_context(query: str, chunks: list[CodeChunk], revision: str) -> str:
+    lines = [
+        f"[archex receipt] index_revision={revision[:12]} generated_at={_utc_now_iso()}",
+        f"archex symbol matches for grep/glob pattern {query!r}:",
+    ]
+    for chunk in chunks:
+        label = chunk.symbol_name or Path(chunk.file_path).name
+        lines.append(f"- {label} — {chunk.file_path}:{chunk.start_line}-{chunk.end_line}")
+    return "\n".join(lines)
+
+
+def _build_output(context: str) -> dict[str, Any]:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": HOOK_EVENT_NAME,
+            "additionalContext": context,
+        }
+    }
+
+
+def _hook_timeout_seconds() -> float:
+    raw = os.environ.get(_TIMEOUT_ENV_VAR)
+    if raw:
+        try:
+            value = float(raw)
+        except ValueError:
+            value = 0.0
+        if value > 0:
+            return value
+    return DEFAULT_HOOK_TIMEOUT_SECONDS
+
+
+def _diagnostics_log_path() -> Path:
+    raw = os.environ.get(_DIAGNOSTICS_LOG_ENV_VAR)
+    return Path(raw).expanduser() if raw else DEFAULT_DIAGNOSTICS_LOG_PATH
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _log_diagnostic(kind: str, *, detail: str, cwd: str | None = None) -> None:
+    try:
+        path = _diagnostics_log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        entry: dict[str, str] = {
+            "timestamp": _utc_now_iso(),
+            "kind": kind,
+            "detail": detail,
+        }
+        if cwd is not None:
+            entry["cwd"] = cwd
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry) + "\n")
+    except OSError:
+        pass  # diagnostics logging must never raise into the hook's exit path
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integrations/test_hooks.py
+++ b/tests/integrations/test_hooks.py
@@ -1,0 +1,399 @@
+"""Tests for the Claude Code PreToolUse hook (M19).
+
+Covers the hook's non-blocking contract end to end: the happy path against a
+real project-local index, every degradation branch (missing/stale index,
+malformed payload, timeout, internal error) with its diagnostics log line, the
+tool-name filter that keeps `Read` untouched, the `_extract_query` glob/grep
+token extraction, and the `python -m archex.integrations.hook` subprocess
+exit-0 contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+from archex.integrations.hook import (
+    AUGMENTED_TOOLS,
+    HOOK_MATCHER,
+    _extract_query,  # pyright: ignore[reportPrivateUsage]
+    _parse_payload,  # pyright: ignore[reportPrivateUsage]
+    handle_pre_tool_use,
+)
+from archex.project import init_project
+from archex.status import inspect_project_status
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def indexed_repo(python_simple_repo: Path) -> Path:
+    """A `python_simple_repo` that has been `archex init`'d and freshly indexed."""
+    init_project(python_simple_repo)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["index", str(python_simple_repo)])
+    assert result.exit_code == 0, result.output
+    return python_simple_repo
+
+
+@pytest.fixture
+def diagnostics_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the hook's diagnostics log to a throwaway file for this test."""
+    log_path = tmp_path / "hook-diagnostics.log"
+    monkeypatch.setenv("ARCHEX_HOOK_DIAGNOSTICS_LOG", str(log_path))
+    return log_path
+
+
+def _read_diagnostics(log_path: Path) -> list[dict[str, Any]]:
+    if not log_path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _run_hook_subprocess(
+    raw_stdin: str, *, cwd: Path, diagnostics_log: Path
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["ARCHEX_HOOK_DIAGNOSTICS_LOG"] = str(diagnostics_log)
+    return subprocess.run(
+        [sys.executable, "-m", "archex.integrations.hook"],
+        input=raw_stdin,
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        env=env,
+        timeout=30,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path (Grep / Glob) against a real project-local index
+# ---------------------------------------------------------------------------
+
+
+def test_grep_happy_path_returns_receipt_stamped_context(indexed_repo: Path) -> None:
+    payload: dict[str, Any] = {
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "AuthService"},
+        "cwd": str(indexed_repo),
+    }
+
+    result = handle_pre_tool_use(payload)
+
+    assert result is not None
+    hook_output = result["hookSpecificOutput"]
+    assert hook_output["hookEventName"] == "PreToolUse"
+    context = hook_output["additionalContext"]
+    assert "AuthService" in context
+    assert re.search(r"index_revision=\S+", context)
+    assert re.search(r"generated_at=\S+", context)
+
+
+def test_glob_happy_path_degrades_gracefully_without_crashing(indexed_repo: Path) -> None:
+    """Glob patterns route through `_extract_query`'s identifier-token extraction
+    rather than a literal search term. For "**/*_service.py" the only token is
+    "_service", which has no exact FTS-token match in this fixture (FTS5's
+    unicode61 tokenizer keeps "AuthService" as a single token and splits
+    "services/auth.py" into "services", not "service") — so the lookup finds
+    nothing. Verified empirically this is a deterministic `None`, not a race;
+    the disjunction below still accepts a match in case indexing behavior ever
+    changes, per the "both outcomes acceptable" contract for Glob.
+    """
+    payload: dict[str, Any] = {
+        "tool_name": "Glob",
+        "tool_input": {"pattern": "**/*_service.py"},
+        "cwd": str(indexed_repo),
+    }
+
+    result = handle_pre_tool_use(payload)
+
+    assert result is None or (
+        result["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+        and isinstance(result["hookSpecificOutput"]["additionalContext"], str)
+        and result["hookSpecificOutput"]["additionalContext"]
+    )
+
+
+def test_glob_pattern_without_identifier_tokens_returns_none(indexed_repo: Path) -> None:
+    payload: dict[str, Any] = {
+        "tool_name": "Glob",
+        "tool_input": {"pattern": "**/*.py"},
+        "cwd": str(indexed_repo),
+    }
+
+    assert handle_pre_tool_use(payload) is None
+
+
+# ---------------------------------------------------------------------------
+# Read (and other non-augmented tools) are never intercepted
+# ---------------------------------------------------------------------------
+
+
+def test_read_tool_returns_none(indexed_repo: Path) -> None:
+    payload: dict[str, Any] = {
+        "tool_name": "Read",
+        "tool_input": {"file_path": "/x"},
+        "cwd": str(indexed_repo),
+    }
+
+    assert handle_pre_tool_use(payload) is None
+
+
+@pytest.mark.parametrize("tool_name", ["Read", "Bash", "Write"])
+def test_non_augmented_tools_short_circuit_before_lookup(tool_name: str) -> None:
+    """Prove the tool-name filter runs before any lookup is attempted.
+
+    `handle_pre_tool_use` catches `Exception` broadly, so a raising lookup
+    would itself be swallowed into a `None` return and prove nothing; a mock
+    call-count assertion is the only way to actually verify the short circuit.
+    """
+    lookup_mock = MagicMock(side_effect=AssertionError("must not be called"))
+    payload: dict[str, Any] = {
+        "tool_name": tool_name,
+        "tool_input": {"file_path": "/x", "pattern": "whatever"},
+        "cwd": "/tmp",
+    }
+
+    with patch("archex.integrations.hook._lookup_with_timeout", lookup_mock):
+        result = handle_pre_tool_use(payload)
+
+    assert result is None
+    lookup_mock.assert_not_called()
+
+
+def test_hook_matcher_and_augmented_tools_constants() -> None:
+    assert "Read" not in AUGMENTED_TOOLS
+    assert {"Grep", "Glob"} == AUGMENTED_TOOLS
+    assert HOOK_MATCHER == "Glob|Grep"
+
+
+# ---------------------------------------------------------------------------
+# Missing / stale index degrades silently and logs diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_missing_index_degrades_silently_and_logs_diagnostic(
+    python_simple_repo: Path, diagnostics_log: Path
+) -> None:
+    """`python_simple_repo` is git-init'd but never `archex init`'d/indexed."""
+    payload: dict[str, Any] = {
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "AuthService"},
+        "cwd": str(python_simple_repo),
+    }
+
+    result = handle_pre_tool_use(payload)
+
+    assert result is None
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries
+    entry = entries[-1]
+    assert entry["kind"] in {"index_not_fresh", "status_error"}
+    assert entry.get("detail")
+    assert entry.get("cwd")
+
+
+def test_stale_index_degrades_silently_and_logs_diagnostic(
+    indexed_repo: Path, diagnostics_log: Path
+) -> None:
+    (indexed_repo / "utils.py").write_text("def dirty_symbol(): return 1\n", encoding="utf-8")
+    status = inspect_project_status(indexed_repo)
+    assert status.state in {"dirty", "stale"}
+
+    payload: dict[str, Any] = {
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "AuthService"},
+        "cwd": str(indexed_repo),
+    }
+    result = handle_pre_tool_use(payload)
+
+    assert result is None
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries
+    entry = entries[-1]
+    assert entry["kind"] == "index_not_fresh"
+    assert f"state={status.state}" in entry["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Malformed payload degradation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["not json at all", "[1, 2, 3]", '"just a string"', "42", "null", "true"],
+    ids=["invalid_json", "list", "string", "number", "null", "boolean"],
+)
+def test_parse_payload_rejects_non_object_input_and_logs_diagnostic(
+    raw: str, diagnostics_log: Path
+) -> None:
+    assert _parse_payload(raw) is None
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries
+    assert entries[-1]["kind"] == "malformed_payload"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"tool_name": "Grep", "cwd": "/tmp"},
+        {"tool_name": "Grep", "tool_input": "not-a-dict", "cwd": "/tmp"},
+        {"tool_name": "Grep", "tool_input": ["a", "list"], "cwd": "/tmp"},
+    ],
+    ids=["missing_tool_input", "string_tool_input", "list_tool_input"],
+)
+def test_handle_pre_tool_use_rejects_non_object_tool_input(
+    payload: dict[str, Any], diagnostics_log: Path
+) -> None:
+    assert handle_pre_tool_use(payload) is None
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries
+    assert entries[-1]["kind"] == "malformed_payload"
+
+
+# ---------------------------------------------------------------------------
+# Timeout degradation
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_timeout_degrades_silently_and_logs_diagnostic(
+    indexed_repo: Path, diagnostics_log: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 0.1ms budget reliably beats even a real SQLite-backed lookup — verified
+    deterministic across repeated local runs (no thread/sleep mocking needed).
+    """
+    monkeypatch.setenv("ARCHEX_HOOK_TIMEOUT_SECONDS", "0.0001")
+    payload: dict[str, Any] = {
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "AuthService"},
+        "cwd": str(indexed_repo),
+    }
+
+    result = handle_pre_tool_use(payload)
+
+    assert result is None
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries
+    assert entries[-1]["kind"] == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# Internal error degradation
+# ---------------------------------------------------------------------------
+
+
+def test_internal_error_opening_store_degrades_silently(
+    indexed_repo: Path, diagnostics_log: Path
+) -> None:
+    assert inspect_project_status(indexed_repo).state == "fresh"
+    payload: dict[str, Any] = {
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "AuthService"},
+        "cwd": str(indexed_repo),
+    }
+
+    with patch("archex.integrations.hook.IndexStore", side_effect=RuntimeError("boom")):
+        result = handle_pre_tool_use(payload)
+
+    assert result is None
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries
+    assert entries[-1]["kind"] in {"lookup_error", "internal_error"}
+
+
+# ---------------------------------------------------------------------------
+# Full subprocess exit-0 contract
+# ---------------------------------------------------------------------------
+
+
+def test_subprocess_grep_payload_exits_zero_with_additional_context(
+    indexed_repo: Path, tmp_path: Path
+) -> None:
+    diagnostics_log = tmp_path / "subprocess-diag.log"
+    raw_stdin = json.dumps(
+        {
+            "tool_name": "Grep",
+            "tool_input": {"pattern": "AuthService"},
+            "cwd": str(indexed_repo),
+        }
+    )
+
+    result = _run_hook_subprocess(raw_stdin, cwd=indexed_repo, diagnostics_log=diagnostics_log)
+
+    assert result.returncode == 0, result.stderr
+    output = json.loads(result.stdout)
+    assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert "AuthService" in output["hookSpecificOutput"]["additionalContext"]
+
+
+def test_subprocess_read_payload_exits_zero_with_empty_stdout(tmp_path: Path) -> None:
+    diagnostics_log = tmp_path / "subprocess-diag.log"
+    raw_stdin = json.dumps({"tool_name": "Read", "tool_input": {"file_path": "/x"}})
+
+    result = _run_hook_subprocess(raw_stdin, cwd=tmp_path, diagnostics_log=diagnostics_log)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+
+
+def test_subprocess_garbage_stdin_exits_zero(tmp_path: Path) -> None:
+    diagnostics_log = tmp_path / "subprocess-diag.log"
+
+    result = _run_hook_subprocess("not json at all", cwd=tmp_path, diagnostics_log=diagnostics_log)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_subprocess_empty_stdin_exits_zero(tmp_path: Path) -> None:
+    diagnostics_log = tmp_path / "subprocess-diag.log"
+
+    result = _run_hook_subprocess("", cwd=tmp_path, diagnostics_log=diagnostics_log)
+
+    assert result.returncode == 0, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# `_extract_query` unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_extract_query_grep_returns_pattern_verbatim_stripped() -> None:
+    assert _extract_query("Grep", {"pattern": "  AuthService  "}) == "AuthService"
+
+
+def test_extract_query_glob_extracts_identifier_tokens() -> None:
+    result = _extract_query("Glob", {"pattern": "**/*_service.py"})
+
+    assert "service" in result
+
+
+def test_extract_query_glob_pattern_without_identifier_tokens_returns_empty_string() -> None:
+    assert _extract_query("Glob", {"pattern": "**/*.py"}) == ""
+
+
+@pytest.mark.parametrize(
+    "tool_input",
+    [{}, {"pattern": 123}, {"pattern": None}, {"pattern": "   "}],
+    ids=["missing", "non_string", "none", "blank"],
+)
+def test_extract_query_missing_or_non_string_pattern_returns_empty_string(
+    tool_input: dict[str, Any],
+) -> None:
+    assert _extract_query("Grep", tool_input) == ""


### PR DESCRIPTION
## Stack

1/3 — `feat/m19-hook-core` -> this PR (base: `main`)
1. `feat/m19-hook-core` -> this PR
2. `feat/m19-installer-hooks` -> #437 (installer wiring)
3. `feat/m19-hooks-docs` -> #438 (docs + latency evidence)

Upstack: #437

## Summary

Milestone M19 (DEVELOPMENT_PLAN.md §4 Section F): non-blocking Claude Code client hook integration. This PR is the hook script core — a new `python -m archex.integrations.hook` subprocess contract that Claude Code's `PreToolUse` event can invoke.

- `src/archex/integrations/hook.py` — reads a `PreToolUse` JSON payload from stdin, augments `Grep`/`Glob` tool calls with archex symbol-search results as `additionalContext`. `Read` and every other tool are never inspected.
- Non-blocking contract: every code path exits 0 via `os._exit`, including an unanticipated exception. The archex lookup (project status check + index open + FTS symbol search) runs under a hard wall-clock timeout (`DEFAULT_HOOK_TIMEOUT_SECONDS = 0.5`, override with `ARCHEX_HOOK_TIMEOUT_SECONDS`) in a single-worker thread; a lookup still running past the budget is abandoned in place rather than joined, so a stuck lookup can never delay process exit.
- A missing, stale, dirty, or corrupt index degrades to a silent no-op (checked via `archex.status.inspect_project_status`, no reindexing is ever triggered).
- Every failure path (malformed payload, timeout, non-fresh index, internal error) is logged to a local diagnostics file (`~/.archex/hook-diagnostics.log` by default, `ARCHEX_HOOK_DIAGNOSTICS_LOG` override) as JSONL — loud in diagnostics, silent to the agent flow.
- Every injected `additionalContext` block carries a freshness/receipt marker (`index_revision=<hash prefix> generated_at=<UTC timestamp>`), mirroring the receipt contract `query`/`scout` already expose.
- `HOOK_MATCHER = "Glob|Grep"` is exported as the single source of truth the installer (#437) reuses for the Claude Code hook `matcher` config, so the installed config and this module's own tool-name filter can never drift apart.

### `archex/__init__.py` — prerequisite perf fix

`archex/__init__.py` eagerly imported `analyze`/`compare`/`query`/`record_usage_event` from `archex.api`, which pulls in the full parse/index/retrieval pipeline (tree-sitter grammars, embedders, graph analysis). That cost was paid by every `archex.*` submodule import — including this hook, which runs as a subprocess under a hard ~500ms budget.

Resolved lazily via module `__getattr__` (PEP 562): `from archex import query` and friends still work unchanged (a `TYPE_CHECKING`-only import keeps static typing precise), but a plain submodule import like `archex.index.store` no longer pays the `archex.api` cost.

Measured: `import archex` dropped from ~406ms to ~35ms in isolation. Full subprocess round-trip for the hook (interpreter start + import + real lookup) dropped from ~350-400ms to ~270-290ms against a small fixture repo — meaningful headroom under the 500ms budget. Full existing suite (3427 tests) re-verified green after this change.

## Verification

```
uv run pytest tests/integrations/test_hooks.py -v   # 32 passed
uv run pytest                                        # 3427 passed (full suite, unaffected)
uv run ruff check src/archex/
uv run pyright
```

Manual invocation (missing-index degradation, since this checkout wasn't re-indexed after the change):

```
echo '{"tool_name":"Grep","tool_input":{"pattern":"compute_delta"}}' | uv run python -m archex.integrations.hook
# exit 0, empty stdout, one diagnostics.log line: kind=index_not_fresh detail=state=uninitialized
```

Manual invocation against a real indexed fixture repo returns, in ~270-290ms total (well under the 500ms budget):

```json
{"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": "[archex receipt] index_revision=a42a5205d59d generated_at=...\narchex symbol matches for grep/glob pattern 'AuthService':\n- AuthService — services/auth.py:11-24\n..."}}
```
