### PR TITLE
feat(cli): install/remove Claude Code PreToolUse hook (M19)

### DIFF
--- a/src/archex/cli/install_client_cmd.py
+++ b/src/archex/cli/install_client_cmd.py
@@ -10,11 +10,15 @@ import click
 from archex.client_setup import (
     ClientName,
     ClientScope,
+    HookAction,
     append_agent_guidance,
     build_client_install_plan,
+    build_hook_install_plan,
     render_agent_guidance_preview,
     render_client_install_preview,
+    render_hook_install_preview,
     write_client_install_plan,
+    write_hook_install_plan,
 )
 
 
@@ -42,14 +46,42 @@ from archex.client_setup import (
     default=None,
     help="Append the archex MCP guidance prompt to this agent file (CLAUDE.md, AGENTS.md).",
 )
+@click.option(
+    "--hooks",
+    is_flag=True,
+    default=False,
+    help=(
+        "Install the Claude Code PreToolUse hook that augments Grep/Glob calls with "
+        "archex context (opt-in, never installed without this flag; claude-code only)."
+    ),
+)
+@click.option(
+    "--remove-hooks",
+    is_flag=True,
+    default=False,
+    help="Remove the archex PreToolUse hook previously installed by --hooks.",
+)
 def install_client_cmd(
     client: str,
     source: str | None,
     scope: str | None,
     dry_run: bool,
     agent_file: Path | None,
+    hooks: bool,
+    remove_hooks: bool,
 ) -> None:
     """Install MCP client configuration for archex (preview with --dry-run)."""
+    if hooks and remove_hooks:
+        raise click.ClickException("--hooks and --remove-hooks are mutually exclusive")
+    if hooks or remove_hooks:
+        _run_hook_action(
+            cast("ClientName", client),
+            source,
+            scope=cast("ClientScope | None", scope),
+            dry_run=dry_run,
+            action="install" if hooks else "remove",
+        )
+        return
     try:
         plan = build_client_install_plan(
             cast("ClientName", client),
@@ -71,3 +103,25 @@ def install_client_cmd(
                     click.echo(f"archex MCP guidance already present: {resolved}")
     except (ValueError, OSError) as exc:
         raise click.ClickException(str(exc)) from exc
+
+
+def _run_hook_action(
+    client: ClientName,
+    source: str | None,
+    *,
+    scope: ClientScope | None,
+    dry_run: bool,
+    action: HookAction,
+) -> None:
+    try:
+        plan = build_hook_install_plan(client, source, scope=scope, action=action)
+        if dry_run:
+            click.echo(render_hook_install_preview(plan), nl=False)
+            return
+        target = write_hook_install_plan(plan)
+    except (ValueError, OSError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    if action == "install":
+        click.echo(f"Installed Claude Code PreToolUse hook: {target}")
+    else:
+        click.echo(f"Removed archex PreToolUse hook (if present): {target}")

--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -2,15 +2,26 @@
 
 from __future__ import annotations
 
+import copy
 import json
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, cast
+
+from archex.integrations.hook import HOOK_MATCHER
 
 ClientName = Literal["claude-code", "codex", "cursor", "opencode", "pi", "omp"]
 ClientScope = Literal["project", "user"]
 
 _USER_ONLY_CLIENTS: frozenset[ClientName] = frozenset({"pi", "omp"})
+
+HookAction = Literal["install", "remove"]
+
+#: Substring in a hook handler's ``args`` that identifies it as archex-owned,
+#: so install/remove can find and replace our own entry without disturbing any
+#: other hook the user has configured for the same matcher group.
+_HOOK_ARGS_MARKER = "archex.integrations.hook"
 _OMP_SCHEMA = (
     "https://raw.githubusercontent.com/can1357/oh-my-pi/main/"
     "packages/coding-agent/src/config/mcp-schema.json"
@@ -188,6 +199,185 @@ def render_agent_guidance_preview(agent_file: Path) -> str:
         else "Append archex MCP guidance block (idempotent):"
     )
     return f"Agent file: {agent_file}\n{status}\n\n{render_agent_guidance_block()}"
+
+
+@dataclass(frozen=True)
+class HookInstallPlan:
+    """Install or remove the Claude Code PreToolUse hook (M19; claude-code only)."""
+
+    client: ClientName
+    scope: ClientScope
+    target_path: Path
+    action: HookAction
+    hook_entry: dict[str, object]
+
+
+def build_hook_install_plan(
+    client: ClientName,
+    source: str | Path | None = None,
+    *,
+    scope: ClientScope | None = None,
+    action: HookAction,
+) -> HookInstallPlan:
+    if client != "claude-code":
+        raise ValueError(
+            f"--hooks/--remove-hooks is only supported for claude-code (M19 scope); got {client!r}"
+        )
+    selected_scope = _resolve_scope(client, source, scope)
+    repo_root = Path(source if source is not None else ".").expanduser().resolve()
+    return HookInstallPlan(
+        client=client,
+        scope=selected_scope,
+        target_path=_hook_settings_path(repo_root, selected_scope),
+        action=action,
+        hook_entry=_render_hook_entry(),
+    )
+
+
+def write_hook_install_plan(plan: HookInstallPlan) -> Path:
+    target = plan.target_path
+    existing = _read_json_object(target) if target.exists() else {}
+    updated, changed = _apply_hook_action(existing, plan)
+    if not changed:
+        return target
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(updated, indent=2) + "\n", encoding="utf-8")
+    return target
+
+
+def render_hook_install_preview(plan: HookInstallPlan) -> str:
+    existing = _read_json_object(plan.target_path) if plan.target_path.exists() else {}
+    updated, changed = _apply_hook_action(existing, plan)
+    action_label = "Install" if plan.action == "install" else "Remove"
+    lines = [
+        f"Client: {plan.client}",
+        f"Scope: {plan.scope}",
+        f"Target: {plan.target_path}",
+        f"Action: {action_label} PreToolUse hook (matcher: {HOOK_MATCHER!r})",
+    ]
+    if not changed:
+        lines.append(
+            "No change: hook already in the requested state (idempotent no-op)."
+            if plan.action == "install"
+            else "No change: no archex hook is installed."
+        )
+    else:
+        lines.append("Dry run. Re-run without --dry-run to write this config.")
+    lines.append("")
+    lines.append(json.dumps(updated, indent=2))
+    return "\n".join(lines) + "\n"
+
+
+def _hook_settings_path(repo_root: Path, scope: ClientScope) -> Path:
+    return (
+        repo_root / ".claude" / "settings.json"
+        if scope == "project"
+        else Path.home() / ".claude" / "settings.json"
+    )
+
+
+def _render_hook_entry() -> dict[str, object]:
+    return {
+        "type": "command",
+        "command": sys.executable,
+        "args": ["-m", _HOOK_ARGS_MARKER],
+    }
+
+
+def _is_archex_hook_entry(entry: object) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    args = cast("dict[str, object]", entry).get("args")
+    if not isinstance(args, list):
+        return False
+    items = cast("list[object]", args)
+    return any(isinstance(item, str) and _HOOK_ARGS_MARKER in item for item in items)
+
+
+def _read_json_object(path: Path) -> dict[str, object]:
+    payload_obj: object = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload_obj, dict):
+        raise ValueError(f"expected JSON object in {path}")
+    return cast("dict[str, object]", payload_obj)
+
+
+def _apply_hook_action(
+    payload: dict[str, object], plan: HookInstallPlan
+) -> tuple[dict[str, object], bool]:
+    """Return ``(updated_payload, changed)`` without mutating ``payload``.
+
+    Both install and remove start by stripping every archex-owned hook entry
+    (identified by ``_HOOK_ARGS_MARKER``) out of ``hooks.PreToolUse``, then
+    install re-adds exactly one canonical entry. That makes a second install
+    (even after ``sys.executable`` changed, e.g. a venv move) converge on the
+    same representation instead of accumulating duplicates, and never touches
+    hook entries archex does not own.
+    """
+    updated = copy.deepcopy(payload)
+    hooks_root_obj = updated.get("hooks")
+    if hooks_root_obj is None:
+        hooks_root: dict[str, object] = {}
+        updated["hooks"] = hooks_root
+    elif isinstance(hooks_root_obj, dict):
+        hooks_root = cast("dict[str, object]", hooks_root_obj)
+    else:
+        raise ValueError("expected object at 'hooks' in existing settings")
+
+    pre_tool_use_obj = hooks_root.get("PreToolUse")
+    if pre_tool_use_obj is None:
+        pre_tool_use: list[object] = []
+    elif isinstance(pre_tool_use_obj, list):
+        pre_tool_use = cast("list[object]", pre_tool_use_obj)
+    else:
+        raise ValueError("expected array at 'hooks.PreToolUse' in existing settings")
+
+    stripped_groups = _strip_archex_hook_entries(pre_tool_use)
+    merged_groups = (
+        _merge_hook_entry(stripped_groups, plan.hook_entry)
+        if plan.action == "install"
+        else stripped_groups
+    )
+
+    if merged_groups:
+        hooks_root["PreToolUse"] = merged_groups
+    else:
+        hooks_root.pop("PreToolUse", None)
+    if not hooks_root:
+        updated.pop("hooks", None)
+
+    return updated, updated != payload
+
+
+def _strip_archex_hook_entries(groups: list[object]) -> list[object]:
+    stripped: list[object] = []
+    for group in groups:
+        if not isinstance(group, dict):
+            stripped.append(group)
+            continue
+        group_dict = cast("dict[str, object]", group)
+        handlers_obj = group_dict.get("hooks")
+        if not isinstance(handlers_obj, list):
+            stripped.append(group_dict)
+            continue
+        handlers = cast("list[object]", handlers_obj)
+        kept = [h for h in handlers if not _is_archex_hook_entry(h)]
+        if not kept:
+            continue  # the group only ever held our own entry
+        stripped.append({**group_dict, "hooks": kept} if len(kept) != len(handlers) else group_dict)
+    return stripped
+
+
+def _merge_hook_entry(groups: list[object], hook_entry: dict[str, object]) -> list[object]:
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        group_dict = cast("dict[str, object]", group)
+        if group_dict.get("matcher") == HOOK_MATCHER:
+            handlers_obj = group_dict.get("hooks")
+            handlers = cast("list[object]", handlers_obj) if isinstance(handlers_obj, list) else []
+            group_dict["hooks"] = [*handlers, hook_entry]
+            return groups
+    return [*groups, {"matcher": HOOK_MATCHER, "hooks": [hook_entry]}]
 
 
 def _resolve_scope(

--- a/tests/cli/test_install_client_hooks.py
+++ b/tests/cli/test_install_client_hooks.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+from archex.client_setup import (
+    build_hook_install_plan,
+    render_hook_install_preview,
+    write_hook_install_plan,
+)
+from archex.integrations.hook import HOOK_MATCHER
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from archex.client_setup import ClientName
+
+
+def _seed_payload() -> dict[str, Any]:
+    """Unrelated pre-existing settings.json content the installer must never touch."""
+    return {
+        "otherTopLevelKey": "unrelated-value",
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "echo bash-hook"}],
+                }
+            ],
+            "PostToolUse": [
+                {
+                    "matcher": "*",
+                    "hooks": [{"type": "command", "command": "echo post-hook"}],
+                }
+            ],
+        },
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _hook_group_has_archex_entry(group: object) -> bool:
+    if not isinstance(group, dict):
+        return False
+    handlers = cast("dict[str, object]", group).get("hooks")
+    if not isinstance(handlers, list):
+        return False
+    for handler in cast("list[object]", handlers):
+        if not isinstance(handler, dict):
+            continue
+        args = cast("dict[str, object]", handler).get("args")
+        if not isinstance(args, list):
+            continue
+        items = cast("list[object]", args)
+        if any(isinstance(item, str) and "archex.integrations.hook" in item for item in items):
+            return True
+    return False
+
+
+# --- build_hook_install_plan / write_hook_install_plan / render_hook_install_preview ---
+
+
+def test_build_hook_install_plan_project_scope_produces_expected_shape(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    plan = build_hook_install_plan("claude-code", str(repo), action="install")
+    target = write_hook_install_plan(plan)
+
+    assert plan.scope == "project"
+    assert target == repo / ".claude" / "settings.json"
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload == {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": HOOK_MATCHER,
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": sys.executable,
+                            "args": ["-m", "archex.integrations.hook"],
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+
+
+def test_build_hook_install_plan_user_scope_produces_expected_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    plan = build_hook_install_plan("claude-code", action="install")
+    target = write_hook_install_plan(plan)
+
+    assert plan.scope == "user"
+    assert target == tmp_path / ".claude" / "settings.json"
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    group = payload["hooks"]["PreToolUse"][0]
+    assert group["matcher"] == HOOK_MATCHER
+    assert group["hooks"][0]["args"] == ["-m", "archex.integrations.hook"]
+    assert group["hooks"][0]["command"] == sys.executable
+
+
+def test_write_hook_install_plan_idempotent_on_reinstall(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    plan = build_hook_install_plan("claude-code", str(repo), action="install")
+    target = write_hook_install_plan(plan)
+    after_first = target.read_text(encoding="utf-8")
+    write_hook_install_plan(build_hook_install_plan("claude-code", str(repo), action="install"))
+    after_second = target.read_text(encoding="utf-8")
+
+    assert after_first == after_second
+
+
+def test_write_hook_install_plan_preserves_unrelated_content(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / ".claude" / "settings.json"
+    _write_json(target, _seed_payload())
+
+    write_hook_install_plan(build_hook_install_plan("claude-code", str(repo), action="install"))
+
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["otherTopLevelKey"] == "unrelated-value"
+    assert payload["hooks"]["PostToolUse"] == _seed_payload()["hooks"]["PostToolUse"]
+    pre_tool_use = payload["hooks"]["PreToolUse"]
+    assert {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "echo bash-hook"}],
+    } in pre_tool_use
+    archex_groups = [g for g in pre_tool_use if _hook_group_has_archex_entry(g)]
+    assert len(archex_groups) == 1
+    assert archex_groups[0]["matcher"] == HOOK_MATCHER
+
+
+def test_write_hook_install_plan_config_assertion_matcher_excludes_read(tmp_path: Path) -> None:
+    """M19 acceptance criterion: the archex hook entry is reachable ONLY from a
+    PreToolUse group matched exactly by Glob|Grep -- never from a group whose
+    matcher includes Read, and never from any other hook event.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / ".claude" / "settings.json"
+    seed = _seed_payload()
+    # A pre-existing group that matches Read must never end up carrying the
+    # archex entry.
+    seed["hooks"]["PreToolUse"].append(
+        {"matcher": "Read", "hooks": [{"type": "command", "command": "echo read-hook"}]}
+    )
+    _write_json(target, seed)
+
+    write_hook_install_plan(build_hook_install_plan("claude-code", str(repo), action="install"))
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    hooks_root = payload["hooks"]
+    pre_tool_use = hooks_root["PreToolUse"]
+
+    archex_groups = [g for g in pre_tool_use if _hook_group_has_archex_entry(g)]
+    assert len(archex_groups) == 1, "exactly one PreToolUse group should carry the archex entry"
+    archex_group = archex_groups[0]
+
+    # (a) the archex-carrying group's matcher is exactly Glob|Grep, matching Grep
+    # and Glob only, and nothing else.
+    assert HOOK_MATCHER == "Glob|Grep"
+    assert archex_group["matcher"] == HOOK_MATCHER
+
+    # (b) no matcher that includes "Read" ever carries an archex entry.
+    for group in pre_tool_use:
+        if "Read" in str(group["matcher"]):
+            assert not _hook_group_has_archex_entry(group)
+
+    # (c) the archex entry lives only under PreToolUse -- no other hook event
+    # (e.g. the pre-existing PostToolUse) gained an archex entry from install.
+    for event_name, groups in hooks_root.items():
+        if event_name == "PreToolUse":
+            continue
+        for group in groups:
+            assert not _hook_group_has_archex_entry(group)
+
+
+def test_write_hook_install_plan_remove_reduces_to_empty_object(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / ".claude" / "settings.json"
+    write_hook_install_plan(build_hook_install_plan("claude-code", str(repo), action="install"))
+    assert target.exists()
+
+    write_hook_install_plan(build_hook_install_plan("claude-code", str(repo), action="remove"))
+
+    assert json.loads(target.read_text(encoding="utf-8")) == {}
+
+
+def test_write_hook_install_plan_remove_preserves_unrelated_content(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / ".claude" / "settings.json"
+    _write_json(target, _seed_payload())
+    write_hook_install_plan(build_hook_install_plan("claude-code", str(repo), action="install"))
+
+    write_hook_install_plan(build_hook_install_plan("claude-code", str(repo), action="remove"))
+
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["otherTopLevelKey"] == "unrelated-value"
+    assert payload["hooks"]["PostToolUse"] == _seed_payload()["hooks"]["PostToolUse"]
+    pre_tool_use = payload["hooks"]["PreToolUse"]
+    assert len(pre_tool_use) == 1
+    assert pre_tool_use[0]["matcher"] == "Bash"
+    assert not any(_hook_group_has_archex_entry(g) for g in pre_tool_use)
+
+
+def test_write_hook_install_plan_remove_missing_file_is_noop(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / ".claude" / "settings.json"
+
+    result_target = write_hook_install_plan(
+        build_hook_install_plan("claude-code", str(repo), action="remove")
+    )
+
+    assert result_target == target
+    assert not target.exists()
+    assert not target.parent.exists()
+
+
+def test_write_hook_install_plan_remove_without_archex_entry_is_noop(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / ".claude" / "settings.json"
+    _write_json(target, _seed_payload())
+    before = target.read_text(encoding="utf-8")
+
+    write_hook_install_plan(build_hook_install_plan("claude-code", str(repo), action="remove"))
+
+    assert target.read_text(encoding="utf-8") == before
+
+
+def test_render_hook_install_preview_install_does_not_write(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / ".claude" / "settings.json"
+    plan = build_hook_install_plan("claude-code", str(repo), action="install")
+
+    preview = render_hook_install_preview(plan)
+
+    assert "Install" in preview
+    assert not target.exists()
+
+
+def test_render_hook_install_preview_remove_does_not_write(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / ".claude" / "settings.json"
+    write_hook_install_plan(build_hook_install_plan("claude-code", str(repo), action="install"))
+    before = target.read_text(encoding="utf-8")
+
+    preview = render_hook_install_preview(
+        build_hook_install_plan("claude-code", str(repo), action="remove")
+    )
+
+    assert "Remove" in preview
+    assert target.read_text(encoding="utf-8") == before
+
+
+@pytest.mark.parametrize("client", ["codex", "cursor", "opencode", "pi", "omp"])
+def test_build_hook_install_plan_rejects_non_claude_code_clients(client: ClientName) -> None:
+    with pytest.raises(ValueError) as exc_info:
+        build_hook_install_plan(client, action="install")
+
+    message = str(exc_info.value)
+    assert "claude-code" in message
+    assert "M19" in message
+
+
+# --- CLI wiring: install-client --hooks / --remove-hooks ---
+
+
+def test_cli_hooks_installs_and_exits_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = CliRunner().invoke(cli, ["install-client", "claude-code", "--hooks"])
+
+    assert result.exit_code == 0, result.output
+    assert "Installed" in result.output
+    target = tmp_path / ".claude" / "settings.json"
+    assert target.exists()
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["hooks"]["PreToolUse"][0]["matcher"] == HOOK_MATCHER
+
+
+def test_cli_hooks_dry_run_previews_without_writing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = CliRunner().invoke(cli, ["install-client", "claude-code", "--hooks", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Dry run." in result.output
+    assert not (tmp_path / ".claude" / "settings.json").exists()
+
+
+def test_cli_remove_hooks_removes_and_exits_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    CliRunner().invoke(cli, ["install-client", "claude-code", "--hooks"])
+
+    result = CliRunner().invoke(cli, ["install-client", "claude-code", "--remove-hooks"])
+
+    assert result.exit_code == 0, result.output
+    assert "Removed" in result.output
+    target = tmp_path / ".claude" / "settings.json"
+    assert json.loads(target.read_text(encoding="utf-8")) == {}
+
+
+def test_cli_hooks_and_remove_hooks_are_mutually_exclusive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = CliRunner().invoke(cli, ["install-client", "claude-code", "--hooks", "--remove-hooks"])
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+    assert not (tmp_path / ".claude" / "settings.json").exists()
+
+
+def test_cli_hooks_rejects_non_claude_code_client_and_writes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = CliRunner().invoke(cli, ["install-client", "codex", "--hooks"])
+
+    assert result.exit_code != 0
+    assert "claude-code" in result.output
+    assert "M19" in result.output
+    assert not (tmp_path / ".claude").exists()
+    assert not (tmp_path / ".codex").exists()
+
+
+def test_cli_plain_install_client_still_writes_mcp_config_not_hook_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = CliRunner().invoke(cli, ["install-client", "claude-code"])
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / ".claude.json").exists()
+    assert not (tmp_path / ".claude" / "settings.json").exists()


### PR DESCRIPTION
## Stack

2/3 — `feat/m19-installer-hooks` -> this PR (base: `feat/m19-hook-core`, #436)
1. `feat/m19-hook-core` -> #436 (hook script core)
2. `feat/m19-installer-hooks` -> this PR
3. `feat/m19-hooks-docs` -> #438 (docs + latency evidence)

Depends on: #436
Upstack: #438

## Summary

Milestone M19, installer wiring: `archex install-client claude-code` gets an opt-in `--hooks`/`--remove-hooks` pair that installs/removes the Claude Code `PreToolUse` hook added in #436.

- `src/archex/client_setup.py` — new `HookInstallPlan` dataclass plus `build_hook_install_plan` / `write_hook_install_plan` / `render_hook_install_preview`. Targets Claude Code's `.claude/settings.json` (project) / `~/.claude/settings.json` (user) — a **different file** from the existing MCP server config (`.mcp.json` / `~/.claude.json`). `claude-code` only for now (M19 scope); every other client raises a clear `ValueError`.
- `src/archex/cli/install_client_cmd.py` — wires `--hooks`/`--remove-hooks` flags (mutually exclusive) into `install_client_cmd`, dispatching to a new `_run_hook_action` helper. Plain `install-client claude-code` (no flags) is unchanged — still writes only the MCP config.
- The installed hook entry is identified by `"archex.integrations.hook"` appearing in its `args`, not by object equality, so install/remove always converge on one canonical entry per matcher group (self-healing across venv moves via `sys.executable`) while any other hook already registered — for the same or a different matcher group, or a different event entirely — is left untouched.
- Both install and remove reuse one merge routine (`_apply_hook_action`) that first strips every archex-owned entry, then install re-adds it — so the two operations can never drift apart, and re-running `--hooks` is an idempotent no-op (byte-identical file content).
- The installed matcher comes from `archex.integrations.hook.HOOK_MATCHER` (`"Glob|Grep"`) — the exact same constant the hook filters on at runtime, so the installed config and the hook's own tool-name filter cannot drift apart.

## Config assertion (M19 acceptance criterion)

`tests/cli/test_install_client_hooks.py::test_write_hook_install_plan_config_assertion_matcher_excludes_read` seeds a settings file with an unrelated pre-existing `PreToolUse` group whose matcher includes `Read`, installs the archex hook, and asserts by parsing the real written JSON that: the archex entry's matcher is exactly `Glob|Grep`; no matcher group containing `Read` ever carries an archex entry; and no hook event key besides `PreToolUse` carries one either.

## Verification

```
uv run pytest tests/cli/test_install_client_hooks.py tests/cli/test_install_client.py -v   # 44 passed
uv run pytest                                                                                # 3481 passed (full suite)
uv run ruff check .
uv run pyright                                                                               # 0 errors
```

Manual smoke (idempotent install, non-destructive merge, mutually-exclusive flags, unsupported-client rejection, clean removal) run and confirmed during development — see commit messages for the exact scenarios exercised.
