### PR TITLE
feat(integrations): Codex CLI diagnostics-only PreToolUse hook core

### DIFF
--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -488,7 +488,7 @@ interface HookHost {
   on(event: "tool_result", handler: ToolResultHandler): unknown;
 }
 
-// --- Diagnostics (parity with hook.py's `_log_diagnostic`) ---
+// --- Diagnostics (parity with hook.py's `log_diagnostic`) ---
 
 function diagnosticsLogPath(): string {
   const override = process.env[ARCHEX_DIAGNOSTICS_LOG_ENV_VAR];

--- a/src/archex/integrations/codex_hook.py
+++ b/src/archex/integrations/codex_hook.py
@@ -1,0 +1,176 @@
+"""Codex CLI PreToolUse hook: diagnostics-only fallback (M21).
+
+Confirmation-spike findings (read against the `openai/codex` Rust source,
+`codex-rs/hooks/` and `codex-rs/core/src/tools/`, not secondary docs):
+
+- Codex's `PreToolUse` hook output schema DOES support content/context
+  augmentation. `PreToolUseHookSpecificOutputWire` (`codex-rs/hooks/src/
+  schema.rs`) has an `additional_context: Option<String>` field that
+  serializes to the wire as `additionalContext` — the same field name
+  Claude Code's own `PreToolUse` hook uses. The DEVELOPMENT_PLAN.md §2 GAP
+  about augmentation-field support is resolved: augmentation IS supported.
+- However, Codex has no Grep/Glob-equivalent tool-call event to scope that
+  augmentation to. Codex's hookable `PreToolUse` tool names are exactly:
+  `Bash` (every shell invocation — `HookToolName::bash()` in
+  `codex-rs/core/src/tools/hook_names.rs`), `apply_patch` (file edits,
+  matcher-aliased to `Write`/`Edit`), `spawn_agent`, and MCP tools under
+  their own canonical names. There is no tool name that means "this is a
+  search," the way Claude Code's `Grep`/`Glob` or oh-my-pi/Pi's
+  `grep`/`glob`/`find` do — file search and reads both happen through the
+  generic `Bash` tool by shelling out to `grep`/`rg`/`find`/`cat`/etc.
+- Hooking `Bash` unconditionally to inject `additionalContext` would
+  intercept every shell command Codex runs, including destructive ones
+  (`rm`, `git push --force`, arbitrary scripts) — a materially broader and
+  riskier surface than M19/M20's read-only Grep/Glob-only pattern, and it
+  would not satisfy "the installed hook config matches the Grep/Glob-
+  equivalent tool only" (there is no such tool to match). Per the plan's
+  own contingency for this GAP and the "never claim augmentation that
+  wasn't verified" constraint, this module ships the documented
+  diagnostics-only fallback instead: it recognizes `Bash` invocations
+  shaped like a search command and logs what archex could have surfaced
+  (or why it couldn't), purely for operator observability. It never
+  returns `additionalContext`, `permissionDecision`, `updatedInput`, or any
+  other `hookSpecificOutput` field, and never mutates or blocks the tool
+  call.
+
+Every code path exits 0, mirroring `archex.integrations.hook`'s contract: a
+missing/stale index, a timeout, a malformed payload, or an internal error
+all degrade to a silent no-op from Codex's point of view, logged instead to
+the same local diagnostics log `archex.integrations.hook` already uses
+(`ARCHEX_HOOK_DIAGNOSTICS_LOG`, default `~/.archex/hook-diagnostics.log`).
+
+This module is a thin per-client shim, per the Section G architecture note
+in `.docs/DEVELOPMENT_PLAN.md` §2: it translates Codex's `PreToolUse`
+payload into a query and calls straight into `archex.integrations.hook`'s
+lookup/timeout/freshness engine (`lookup_with_timeout`, `log_diagnostic`,
+`IDENTIFIER_TOKEN_RE`) in-process — no lookup, ranking, or timeout logic is
+reimplemented here, and no second subprocess is spawned.
+
+Invoked as a subprocess: `python -m archex.integrations.codex_hook`, reading
+Codex's `PreToolUse` JSON payload from stdin and always writing `{}` to
+stdout (Codex's hook output schema defaults every field, so an empty object
+means "no decision" — `continue: true`, no `hookSpecificOutput`).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from typing import Any, cast
+
+from archex.integrations.hook import IDENTIFIER_TOKEN_RE, log_diagnostic, lookup_with_timeout
+
+#: Codex's canonical `PreToolUse` tool name for every shell invocation
+#: (`HookToolName::bash()` in `codex-rs/core/src/tools/hook_names.rs`).
+#: Codex has no distinct Grep/Glob-equivalent tool name — this is the only
+#: `PreToolUse` event that can ever carry a search-shaped command.
+DIAGNOSED_TOOL_NAME = "Bash"
+
+#: `matcher` regex the installer (`archex.client_setup`) writes into
+#: `config.toml`'s `[[hooks.PreToolUse]]` table, kept alongside this
+#: module's own runtime filter so the installed config and the runtime
+#: dispatch can never drift apart. Codex matches `matcher` as a regex
+#: against the tool name (confirmed via `codex-rs/config/src/
+#: config_requirements.rs`'s own `matcher = "^Bash$"` fixture).
+HOOK_MATCHER = f"^{DIAGNOSED_TOOL_NAME}$"
+
+#: Leading-token detector for shell commands shaped like a search
+#: invocation (optionally after `sudo`, and optionally following a
+#: `;`/`&`/`|` separator so `cd x && grep ...` and `cat f | grep ...` both
+#: match). Detection only — this never builds a query that gets surfaced to
+#: the agent, only a diagnostics log line.
+_SEARCH_COMMAND_RE = re.compile(r"(?:^|[;&|]\s*)(?:sudo\s+)?(?:git\s+grep|rg|ag|grep|find|fd)\b")
+
+#: Tokens from the recognized command name/verbs/flags themselves that would
+#: otherwise pollute the extracted query (every matched command contains one
+#: of these, so leaving them in would dilute or dominate the BM25 lookup).
+_COMMAND_NOISE_TOKENS = frozenset({"sudo", "git", "grep", "rg", "ag", "find", "fd", "name"})
+
+
+def main() -> None:
+    """Entry point for `python -m archex.integrations.codex_hook`.
+
+    Guarantees exit 0 and valid JSON stdout on every path, including an
+    exception this module did not anticipate — see the module docstring's
+    non-blocking, diagnostics-only contract.
+    """
+    try:
+        _main_impl()
+    except BaseException as exc:  # noqa: BLE001 - the non-blocking contract requires this
+        log_diagnostic("codex_unhandled_exception", detail=repr(exc))
+    sys.stdout.write("{}")
+    sys.stdout.flush()
+    os._exit(0)
+
+
+def _main_impl() -> None:
+    raw = sys.stdin.read()
+    payload = _parse_codex_payload(raw)
+    if payload is None:
+        return
+    handle_codex_pre_tool_use(payload)
+
+
+def _parse_codex_payload(raw: str) -> dict[str, Any] | None:
+    if not raw.strip():
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        log_diagnostic("codex_malformed_payload", detail=f"invalid JSON: {exc}")
+        return None
+    if not isinstance(payload, dict):
+        log_diagnostic("codex_malformed_payload", detail="payload is not a JSON object")
+        return None
+    return cast("dict[str, Any]", payload)
+
+
+def handle_codex_pre_tool_use(payload: dict[str, Any]) -> None:
+    """Diagnostics-only core handler: never returns or applies augmentation.
+
+    Detects `Bash` invocations shaped like a search command and logs what
+    archex would have surfaced (or why it couldn't) purely for operator
+    observability. Never mutates or blocks the tool call, and never raises —
+    any failure degrades to a diagnostics log line.
+    """
+    try:
+        if payload.get("tool_name") != DIAGNOSED_TOOL_NAME:
+            return
+        tool_input = payload.get("tool_input")
+        if not isinstance(tool_input, dict):
+            return
+        command = cast("dict[str, Any]", tool_input).get("command")
+        if not isinstance(command, str) or not _SEARCH_COMMAND_RE.search(command):
+            return
+        query = " ".join(
+            token
+            for token in IDENTIFIER_TOKEN_RE.findall(command)
+            if token.lower() not in _COMMAND_NOISE_TOKENS
+        )
+        if not query:
+            return
+        cwd_raw = payload.get("cwd")
+        cwd = cwd_raw if isinstance(cwd_raw, str) and cwd_raw else os.getcwd()
+        context = lookup_with_timeout(cwd, query)
+        if context is None:
+            # A missing/stale index, timeout, or lookup error already logged
+            # its own diagnostic inside `lookup_with_timeout`/`_lookup`.
+            return
+        log_diagnostic(
+            "codex_augmentation_withheld",
+            detail=(
+                f"Bash command looked like a search ({command!r}); archex has "
+                "matches but Codex has no Grep/Glob-equivalent tool-call event "
+                "to scope augmentation to safely — see "
+                "docs/CLIENT_COMPATIBILITY_MATRIX.md"
+            ),
+            cwd=cwd,
+        )
+    except Exception as exc:  # noqa: BLE001 - degrade to no-op, never raise
+        log_diagnostic("codex_internal_error", detail=repr(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/archex/integrations/hook.py
+++ b/src/archex/integrations/hook.py
@@ -62,7 +62,7 @@ _DIAGNOSTICS_LOG_ENV_VAR = "ARCHEX_HOOK_DIAGNOSTICS_LOG"
 
 MAX_RESULTS = 5
 
-_IDENTIFIER_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
+IDENTIFIER_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{2,}")
 
 
 def main() -> None:
@@ -76,7 +76,7 @@ def main() -> None:
     try:
         _main_impl()
     except BaseException as exc:  # noqa: BLE001 - the non-blocking contract requires this
-        _log_diagnostic("unhandled_exception", detail=repr(exc))
+        log_diagnostic("unhandled_exception", detail=repr(exc))
     os._exit(0)
 
 
@@ -98,10 +98,10 @@ def _parse_payload(raw: str) -> dict[str, Any] | None:
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError as exc:
-        _log_diagnostic("malformed_payload", detail=f"invalid JSON: {exc}")
+        log_diagnostic("malformed_payload", detail=f"invalid JSON: {exc}")
         return None
     if not isinstance(payload, dict):
-        _log_diagnostic("malformed_payload", detail="payload is not a JSON object")
+        log_diagnostic("malformed_payload", detail="payload is not a JSON object")
         return None
     return cast("dict[str, Any]", payload)
 
@@ -119,19 +119,19 @@ def handle_pre_tool_use(payload: dict[str, Any]) -> dict[str, Any] | None:
             return None
         tool_input = payload.get("tool_input")
         if not isinstance(tool_input, dict):
-            _log_diagnostic("malformed_payload", detail="tool_input is not a JSON object")
+            log_diagnostic("malformed_payload", detail="tool_input is not a JSON object")
             return None
         query = _extract_query(tool_name, cast("dict[str, Any]", tool_input))
         if not query:
             return None
         cwd_raw = payload.get("cwd")
         cwd = cwd_raw if isinstance(cwd_raw, str) and cwd_raw else os.getcwd()
-        context = _lookup_with_timeout(cwd, query)
+        context = lookup_with_timeout(cwd, query)
         if context is None:
             return None
         return _build_output(context)
     except Exception as exc:  # noqa: BLE001 - degrade to no-op, never raise
-        _log_diagnostic("internal_error", detail=repr(exc))
+        log_diagnostic("internal_error", detail=repr(exc))
         return None
 
 
@@ -143,20 +143,20 @@ def _extract_query(tool_name: str, tool_input: dict[str, Any]) -> str:
         return pattern.strip()
     # Glob patterns are filesystem globs, not search terms — pull identifier-like
     # tokens out of them so "**/*_service.py" becomes a useful symbol query.
-    return " ".join(_IDENTIFIER_TOKEN_RE.findall(pattern))
+    return " ".join(IDENTIFIER_TOKEN_RE.findall(pattern))
 
 
-def _lookup_with_timeout(cwd: str, query: str) -> str | None:
+def lookup_with_timeout(cwd: str, query: str) -> str | None:
     timeout = _hook_timeout_seconds()
     executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="archex-hook")
     future = executor.submit(_lookup, cwd, query)
     try:
         return future.result(timeout=timeout)
     except TimeoutError:
-        _log_diagnostic("timeout", detail=f"lookup exceeded {timeout}s", cwd=cwd)
+        log_diagnostic("timeout", detail=f"lookup exceeded {timeout}s", cwd=cwd)
         return None
     except Exception as exc:  # noqa: BLE001 - degrade to no-op, never raise
-        _log_diagnostic("lookup_error", detail=repr(exc), cwd=cwd)
+        log_diagnostic("lookup_error", detail=repr(exc), cwd=cwd)
         return None
     finally:
         # Don't wait for a timed-out lookup thread — main()'s os._exit reclaims it.
@@ -167,10 +167,10 @@ def _lookup(cwd: str, query: str) -> str | None:
     try:
         status = inspect_project_status(cwd)
     except ValueError as exc:
-        _log_diagnostic("status_error", detail=str(exc), cwd=cwd)
+        log_diagnostic("status_error", detail=str(exc), cwd=cwd)
         return None
     if status.state != "fresh":
-        _log_diagnostic("index_not_fresh", detail=f"state={status.state}", cwd=cwd)
+        log_diagnostic("index_not_fresh", detail=f"state={status.state}", cwd=cwd)
         return None
 
     store = IndexStore(status.index_path)
@@ -225,7 +225,7 @@ def _utc_now_iso() -> str:
     return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _log_diagnostic(kind: str, *, detail: str, cwd: str | None = None) -> None:
+def log_diagnostic(kind: str, *, detail: str, cwd: str | None = None) -> None:
     try:
         path = _diagnostics_log_path()
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/integrations/test_hooks.py
+++ b/tests/integrations/test_hooks.py
@@ -24,6 +24,15 @@ import pytest
 from click.testing import CliRunner
 
 from archex.cli.main import cli
+from archex.integrations.codex_hook import (
+    _SEARCH_COMMAND_RE,  # pyright: ignore[reportPrivateUsage]
+    DIAGNOSED_TOOL_NAME,
+    _parse_codex_payload,  # pyright: ignore[reportPrivateUsage]
+    handle_codex_pre_tool_use,
+)
+from archex.integrations.codex_hook import (
+    HOOK_MATCHER as CODEX_HOOK_MATCHER,
+)
 from archex.integrations.hook import (
     AUGMENTED_TOOLS,
     DEFAULT_HOOK_TIMEOUT_SECONDS,
@@ -542,3 +551,227 @@ def test_default_timeout_budget_holds_on_realistic_fixture(
         f"lookup took {elapsed * 1000:.1f}ms, more than half of the {budget * 1000:.0f}ms "
         "default timeout budget on a small fixture"
     )
+
+
+# ---------------------------------------------------------------------------
+# Codex CLI diagnostics-only fallback (M21)
+#
+# Confirmation spike (read against `openai/codex`'s Rust source, not
+# secondary docs): `PreToolUseHookSpecificOutputWire.additionalContext` DOES
+# exist on Codex's wire schema (`codex-rs/hooks/src/schema.rs`) -- Codex
+# hooks support content/context augmentation. But Codex has no
+# Grep/Glob-equivalent `PreToolUse` tool name: its only hookable tool names
+# are `Bash` (every shell invocation, `HookToolName::bash()` in
+# `codex-rs/core/src/tools/hook_names.rs`), `apply_patch`, `spawn_agent`, and
+# MCP tools under their own names. There is no way to scope augmentation to
+# "search calls only" the way Claude Code's Grep/Glob or oh-my-pi/Pi's
+# grep/glob/find do -- hooking `Bash` unconditionally would intercept every
+# shell command, including destructive ones. `archex.integrations.codex_hook`
+# therefore ships the plan's own diagnostics-only fallback: it detects
+# search-shaped `Bash` commands and logs what archex could have surfaced,
+# but never returns or applies any `hookSpecificOutput`.
+# ---------------------------------------------------------------------------
+
+
+def _run_codex_hook_subprocess(
+    raw_stdin: str, *, cwd: Path, diagnostics_log: Path
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["ARCHEX_HOOK_DIAGNOSTICS_LOG"] = str(diagnostics_log)
+    return subprocess.run(
+        [sys.executable, "-m", "archex.integrations.codex_hook"],
+        input=raw_stdin,
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        env=env,
+        timeout=30,
+    )
+
+
+def test_codex_search_shaped_bash_command_logs_withheld_diagnostic_not_augmentation(
+    indexed_repo: Path, diagnostics_log: Path
+) -> None:
+    payload: dict[str, Any] = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "grep -rn AuthService ."},
+        "cwd": str(indexed_repo),
+    }
+
+    result = handle_codex_pre_tool_use(payload)
+
+    assert result is None  # never returns augmented output, ever
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries, "expected a diagnostic line for a search-shaped Bash command"
+    entry = entries[-1]
+    assert entry["kind"] == "codex_augmentation_withheld"
+    assert "AuthService" in entry["detail"]
+    assert "Grep/Glob-equivalent" in entry["detail"]
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["ls -la", "npm test", "git status", "echo grepping along nicely"],
+)
+def test_codex_non_search_bash_commands_never_log_a_diagnostic(
+    indexed_repo: Path, diagnostics_log: Path, command: str
+) -> None:
+    payload: dict[str, Any] = {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": str(indexed_repo),
+    }
+
+    assert handle_codex_pre_tool_use(payload) is None
+    assert _read_diagnostics(diagnostics_log) == []
+
+
+@pytest.mark.parametrize("tool_name", ["Read", "apply_patch", "spawn_agent", "Grep", "Glob"])
+def test_codex_non_bash_tool_names_short_circuit_before_lookup(
+    tool_name: str, diagnostics_log: Path
+) -> None:
+    """Codex exposes no `Read` hook at all, but this asserts defense in depth:
+    the dispatch table only ever matches `Bash`, never `Read` or anything else,
+    regardless of what a payload claims.
+    """
+    lookup_mock = MagicMock(side_effect=AssertionError("must not be called"))
+    payload: dict[str, Any] = {
+        "tool_name": tool_name,
+        "tool_input": {"command": "grep -rn foo ."},
+        "cwd": "/tmp",
+    }
+
+    with patch("archex.integrations.codex_hook.lookup_with_timeout", lookup_mock):
+        assert handle_codex_pre_tool_use(payload) is None
+
+    lookup_mock.assert_not_called()
+    assert _read_diagnostics(diagnostics_log) == []
+
+
+def test_codex_missing_index_degrades_silently_and_logs_diagnostic(
+    python_simple_repo: Path, diagnostics_log: Path
+) -> None:
+    """`python_simple_repo` is git-init'd but never `archex init`'d/indexed."""
+    payload: dict[str, Any] = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "grep -rn foo ."},
+        "cwd": str(python_simple_repo),
+    }
+
+    assert handle_codex_pre_tool_use(payload) is None
+
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries
+    assert entries[-1]["kind"] in {"status_error", "index_not_fresh"}
+
+
+@pytest.mark.parametrize("raw", ["not json", "[]", "42", '"a string"'])
+def test_codex_parse_payload_rejects_non_object_input_and_logs_diagnostic(
+    raw: str, diagnostics_log: Path
+) -> None:
+    assert _parse_codex_payload(raw) is None
+
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries[-1]["kind"] == "codex_malformed_payload"
+
+
+def test_codex_handle_pre_tool_use_rejects_non_object_tool_input(diagnostics_log: Path) -> None:
+    payload: dict[str, Any] = {"tool_name": "Bash", "tool_input": "grep foo", "cwd": "/tmp"}
+
+    assert handle_codex_pre_tool_use(payload) is None
+    assert _read_diagnostics(diagnostics_log) == []
+
+
+def test_codex_internal_error_degrades_silently_and_logs_diagnostic(
+    indexed_repo: Path, diagnostics_log: Path
+) -> None:
+    payload: dict[str, Any] = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "grep -rn foo ."},
+        "cwd": str(indexed_repo),
+    }
+
+    with patch(
+        "archex.integrations.codex_hook.lookup_with_timeout",
+        side_effect=RuntimeError("boom"),
+    ):
+        assert handle_codex_pre_tool_use(payload) is None
+
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries[-1]["kind"] == "codex_internal_error"
+
+
+def test_codex_subprocess_search_command_exits_zero_with_empty_object_stdout(
+    indexed_repo: Path, tmp_path: Path
+) -> None:
+    diagnostics_log = tmp_path / "codex-subprocess-diag.log"
+    stdin_payload = json.dumps(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "grep -rn AuthService ."},
+            "cwd": str(indexed_repo),
+        }
+    )
+
+    result = _run_codex_hook_subprocess(
+        stdin_payload, cwd=indexed_repo, diagnostics_log=diagnostics_log
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {}
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries[-1]["kind"] == "codex_augmentation_withheld"
+
+
+def test_codex_subprocess_garbage_stdin_exits_zero_with_empty_object_stdout(tmp_path: Path) -> None:
+    diagnostics_log = tmp_path / "codex-subprocess-diag.log"
+
+    result = _run_codex_hook_subprocess("not json", cwd=tmp_path, diagnostics_log=diagnostics_log)
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {}
+
+
+def test_codex_subprocess_empty_stdin_exits_zero_with_empty_object_stdout(tmp_path: Path) -> None:
+    diagnostics_log = tmp_path / "codex-subprocess-diag.log"
+
+    result = _run_codex_hook_subprocess("", cwd=tmp_path, diagnostics_log=diagnostics_log)
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {}
+
+
+def test_codex_hook_matcher_targets_bash_only() -> None:
+    assert CODEX_HOOK_MATCHER == "^Bash$"
+    assert DIAGNOSED_TOOL_NAME == "Bash"
+    matcher_re = re.compile(CODEX_HOOK_MATCHER)
+    assert matcher_re.fullmatch("Bash")
+    for other in ["Read", "Grep", "Glob", "apply_patch", "spawn_agent", "bash", "Bashing"]:
+        assert not matcher_re.fullmatch(other)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "grep -rn AuthService .",
+        "rg AuthService",
+        "ag AuthService",
+        "git grep AuthService",
+        "find . -name '*.py'",
+        "fd '.py$'",
+        "sudo grep -rn AuthService .",
+        "cat file.txt | grep foo",
+        "cd src && grep -rn foo .",
+        "ls; grep -rn foo .",
+    ],
+)
+def test_codex_search_command_regex_matches_known_search_tools(command: str) -> None:
+    assert _SEARCH_COMMAND_RE.search(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["ls -la", "npm test", "git status", "echo grepping along nicely", "python -c 'print(1)'"],
+)
+def test_codex_search_command_regex_does_not_match_non_search_commands(command: str) -> None:
+    assert not _SEARCH_COMMAND_RE.search(command)

--- a/tests/integrations/test_hooks.py
+++ b/tests/integrations/test_hooks.py
@@ -260,7 +260,7 @@ def test_non_augmented_tools_short_circuit_before_lookup(tool_name: str) -> None
         "cwd": "/tmp",
     }
 
-    with patch("archex.integrations.hook._lookup_with_timeout", lookup_mock):
+    with patch("archex.integrations.hook.lookup_with_timeout", lookup_mock):
         result = handle_pre_tool_use(payload)
 
     assert result is None


### PR DESCRIPTION
## Summary

M21 PR-1: confirmation spike + hook script core, per `.docs/DEVELOPMENT_PLAN.md` §4 Section G M21.

Delivers `src/archex/integrations/codex_hook.py`, the Codex CLI counterpart to M19's `archex.integrations.hook` and M20's shared TS module — plus the confirmation-spike findings that determined its shape.

## Confirmation spike (read against `openai/codex`'s actual Rust source, not secondary docs)

DEVELOPMENT_PLAN.md's §2 GAP framed this milestone around one open question: does Codex's hook schema support content/context augmentation? The spike resolves that question, and surfaces a second, more consequential one the plan didn't anticipate.

**1. Augmentation IS supported.** `PreToolUseHookSpecificOutputWire` in `codex-rs/hooks/src/schema.rs` has an `additional_context: Option<String>` field that serializes to the wire as `additionalContext` — the exact field name Claude Code's own `PreToolUse` hook uses. Confirmed directly against the generated JSON schema fixture (`codex-rs/hooks/schema/generated/pre-tool-use.command.output.schema.json`) and the unit tests in `codex-rs/hooks/src/schema.rs` that assert the wire shape. The GAP is resolved in the affirmative on this axis.

**2. There is no Grep/Glob-equivalent tool-call event to scope it to.** Codex's hookable `PreToolUse` tool names are exactly:
- `Bash` — every shell invocation (`HookToolName::bash()` in `codex-rs/core/src/tools/hook_names.rs`)
- `apply_patch` — file edits (matcher-aliased to `Write`/`Edit`)
- `spawn_agent` — sub-agent creation
- MCP tools, under their own canonical names

Confirmed by walking `codex-rs/core/src/tools/handlers/` (the full handler directory: `agent_jobs`, `apply_patch`, `mcp` (generic), `mcp_resource`, `multi_agents`, `multi_agents_v2`, `shell`, `unified_exec`, `current_time`, `dynamic` — no `read_file`, `grep`, `glob`, or `list_dir` handler exists) and `codex-rs/core/src/tools/registry.rs`'s `pre_tool_use_payload` default implementation. File search and file reads both happen through the generic `Bash`/`shell_command`/`exec_command` tool by shelling out to `grep`/`rg`/`find`/`cat`/etc. There is no tool name that means "this is a search," the way Claude Code's `Grep`/`Glob` or oh-my-pi/Pi's `grep`/`glob`/`find` do.

**Why this changes the deliverable.** Hooking `Bash` unconditionally to inject `additionalContext` would intercept *every* shell command Codex runs — including destructive ones (`rm`, `git push --force`, arbitrary scripts) — a materially broader and riskier surface than M19/M20's read-only Grep/Glob-only pattern. It would also fail the milestone's own acceptance bar ("the installed hook config matches the Grep/Glob-equivalent tool only") on its face, since no such tool exists to match. Per the plan's own contingency for this GAP and the "never claim augmentation that wasn't verified" constraint, this PR ships the documented diagnostics-only fallback — applied to this specific (not originally anticipated) shape of the gap, rather than the augmentation path the objective describes as the default outcome.

## What `codex_hook.py` does

- Detects `Bash` invocations shaped like a search command (`grep`, `rg`, `ag`, `git grep`, `find`, `fd`, optionally after `sudo` or a `;`/`&`/`|` separator).
- For a detected search command, calls straight into `archex.integrations.hook`'s `lookup_with_timeout`/`log_diagnostic` engine in-process (no lookup/ranking/timeout logic is reimplemented, no second subprocess spawned) and logs a `codex_augmentation_withheld` diagnostic describing what archex found and why it wasn't surfaced.
- Never returns `additionalContext`, `permissionDecision`, `updatedInput`, or any other `hookSpecificOutput` field. Always writes `{}` to stdout (Codex's own schema defaults every field, so an empty object means "no decision").
- Every path — malformed payload, non-`Bash` tool name, non-search command, missing/stale index, timeout, internal error — degrades silently and exits 0, mirroring `hook.py`'s non-blocking contract exactly.

## Refactor: promoting `hook.py`'s engine helpers

`lookup_with_timeout`, `log_diagnostic`, and `IDENTIFIER_TOKEN_RE` were module-private in `hook.py`. Per the plan's own Section G architecture note ("each additional client gets a thin per-client shim... reusing the core logic"), these are now the shared engine two hook implementations import — renamed (dropped the leading underscore) so `codex_hook.py` can reuse them without tripping `pyright --strict`'s `reportPrivateUsage`. No behavior change; call sites inside `hook.py` updated mechanically.

## Testing

`tests/integrations/test_hooks.py` (`-k codex`, 36 tests): search-shaped Bash commands log the withheld-augmentation diagnostic without ever returning augmented output; non-search Bash commands and every non-`Bash` tool name (including `Read`, defensively, even though Codex exposes no `Read` hook at all) short-circuit before any lookup; missing/stale index, malformed payload, and internal-error paths degrade silently with the expected diagnostic kind; the `python -m archex.integrations.codex_hook` subprocess exits 0 with `{}` on stdout for a real search command, garbage stdin, and empty stdin; the `^Bash$` matcher and search-command detection regex are covered directly.

## Verification

```
uv run pytest tests/integrations/test_hooks.py -k codex -v   # 36 passed
uv run pytest                                                 # 3543 passed, 91% coverage
uv run ruff check src/archex/
uv run pyright
```

## Out of scope (PR-2)

Installer wiring (`install-client codex --hooks`/`--remove-hooks`), the `config.toml` `[[hooks.PreToolUse]]` write/merge/remove logic, the config-assertion test proving the installed matcher never reaches `Read`, and `docs/CLIENT_COMPATIBILITY_MATRIX.md` documentation (including the hash-based hook-trust step) land in PR-2, based on this branch.
