### PR TITLE
feat(cli): Codex CLI diagnostics-only hook installer and docs

### DIFF
--- a/docs/CLIENT_COMPATIBILITY_MATRIX.md
+++ b/docs/CLIENT_COMPATIBILITY_MATRIX.md
@@ -14,6 +14,7 @@ This matrix separates config-shape verification from actual client smoke tests. 
 | CLI-only query/scout | Tested | No client config required. Run `archex doctor`, `archex scout`, `archex query`. | N/A | Query checks freshness inline unless `--no-refresh`; scout inherits query freshness in its receipt. | Not an MCP client. | 2026-06-16 |
 | Generic MCP stdio client | Unverified | Use a JSON config shaped like `{ "mcpServers": { "archex": { "command": "archex", "args": ["mcp"] }}}`. `archex install-client claude-code --dry-run` prints a compatible snippet. | Client-dependent | Same server-side freshness semantics as Claude Code / Cursor. | No live generic-client smoke in this stack. | 2026-06-16 |
 | Codex headless | Unverified | `archex install-client codex` writes `~/.codex/config.toml` (global); `archex install-client codex . --scope project` writes `.codex/config.toml`, appending `[mcp_servers.archex]`, `command = "archex"`, `args = ["mcp"]` without overwriting existing sections. `--dry-run` previews. | Yes — via `archex mcp --watch --watch-path .` after Codex launches the server. | Inline query refresh by default; warm watch is server-side, not Codex-specific. | Config shape verified against OpenAI Codex MCP docs; no Codex client smoke in this stack. | 2026-06-16 |
+| Codex CLI PreToolUse hook (opt-in, diagnostics-only) | Config-shape tested end-to-end (install, remove, idempotent reinstall, preserves unrelated `config.toml` content, matcher-only-`Bash` assertion); no live Codex CLI smoke | `archex install-client codex --hooks` appends a marker-delimited `[[hooks.PreToolUse]]` block to the same `config.toml` the MCP registration above writes to (`~/.codex/config.toml` global, `.codex/config.toml` project). `--dry-run` previews, `--remove-hooks` uninstalls. See [below](#codex-cli-pretooluse-hook-opt-in-diagnostics-only) for the full contract and the confirmation-spike findings. | N/A — one subprocess per matched tool call, not a warm process | Diagnostics-only — no injected context, ever (see limitations); a missing/stale index degrades to a diagnostics log line via the same `archex.integrations.hook` engine the Claude Code hook uses. | Codex's schema supports `additionalContext` augmentation, but Codex has no Grep/Glob-equivalent tool-call event — only a generic `Bash` tool covers every shell command. This hook detects search-shaped `Bash` invocations and logs what archex would have surfaced, but never injects it (would otherwise require intercepting every shell command, not just searches). Requires a one-time hash-based hook-trust review (`/hooks` in Codex) after install. | 2026-07-06 |
 | Pi MCP stdio | Config shape verified; client smoke unverified | `archex install-client pi` writes `~/.pi/agent/mcp.json` with a stdio `mcpServers.archex` entry (`--dry-run` previews). User scope only. | Client-dependent; server supports `--watch`. | Same server-side freshness semantics as other stdio clients. | No Pi client smoke in this stack. | 2026-06-16 |
 | Pi `tool_result` hook (opt-in) | Config-shape tested end-to-end (install, remove, byte-identical module content vs. the oh-my-pi row below); no live Pi UI smoke | `archex install-client pi --hooks` writes the identical TypeScript extension module to `.pi/extensions/archex-hook.ts` (project scope) or `~/.pi/agent/extensions/archex-hook.ts` (user scope, default) — confirmed against the installed `@mariozechner/pi-coding-agent` 0.68.1. `--dry-run` previews, `--remove-hooks` uninstalls. See [below](#oh-my-pi-omp--pi-tool_result-hook-opt-in) for the full contract. | N/A — one subprocess per matched tool call, not a warm process | Same receipt/timeout/diagnostics semantics as the oh-my-pi hook — Pi's `tool_result` event contract is identical, so this is the same generated module, not a Pi-specific variant. | Opt-in, never installed by default; Pi has no `glob` tool — its glob-equivalent is `find`, already covered by the shared module's dispatch table. | 2026-07-06 |
 | oh-my-pi (omp) MCP stdio | Config shape verified; client smoke unverified | `archex install-client omp` writes `~/.omp/agent/mcp.json` (user scope only) with `mcpServers.archex.command = "archex"`, `args = ["mcp"]`, plus the oh-my-pi `$schema` (`--dry-run` previews). | Client-dependent; server supports `--watch`. | Same server-side freshness semantics as other stdio clients. | No oh-my-pi client smoke in this stack. Discovery-gated harness — tools must be activated before use (see below). | 2026-06-20 |
@@ -140,7 +141,7 @@ echo '{"tool_name":"Grep","tool_input":{"pattern":"compute_delta"}}' \
 
 A repo with a fresh index returns JSON on stdout shaped `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": "..."}}`. A repo with no index, a stale index, or a `cwd` outside a Git working tree exits 0 with empty stdout and a diagnostics log line instead.
 
-Section G of the development plan (M20–M23) extends this same `python -m archex.integrations.hook` subprocess contract to other clients with per-client installer shims. M20 (oh-my-pi and Pi, below) is implemented; Codex CLI, OpenCode are not yet implemented; Cursor's weaker prompt-level mechanism is a planned exception.
+Section G of the development plan (M20–M23) extends this same `python -m archex.integrations.hook` subprocess contract to other clients with per-client installer shims. M20 (oh-my-pi and Pi) and M21 (Codex CLI, diagnostics-only) are implemented; OpenCode is not yet implemented; Cursor's weaker prompt-level mechanism is a planned exception.
 
 ## oh-my-pi (omp) / Pi `tool_result` hook (opt-in)
 
@@ -175,3 +176,58 @@ echo '{"tool_name":"Grep","tool_input":{"pattern":"compute_delta"}}' \
 ```
 
 Confirmed manually against the installed Pi CLI (0.68.1) with both `node`/`tsx` (matching Pi's `jiti`-based TypeScript loading) and `bun`: a `grep` and a `find` `tool_result` event both received appended archex context, and a `read` event was left untouched, using the exact file written by `archex install-client pi --hooks`.
+
+## Codex CLI PreToolUse hook (opt-in, diagnostics-only)
+
+`archex install-client codex --hooks` installs `src/archex/integrations/codex_hook.py` (invoked as `python -m archex.integrations.codex_hook`) as a Codex `PreToolUse` hook. Unlike the Claude Code and oh-my-pi/Pi hooks above, this one never injects context — it is diagnostics-only. It is opt-in — plain `archex install-client codex` never installs it — and it writes to the *same* `config.toml` the MCP registration above writes to, as a separate marker-delimited block:
+
+```bash
+archex install-client codex --hooks                     # global: ~/.codex/config.toml
+archex install-client codex . --hooks --scope project   # repo-local: .codex/config.toml
+archex install-client codex --hooks --dry-run           # preview only, writes nothing
+archex install-client codex --remove-hooks              # clean uninstall
+```
+
+### Confirmation-spike findings (M21 §2 GAP)
+
+DEVELOPMENT_PLAN.md's §2 GAP asked whether Codex's hook schema supports content/context augmentation the way Claude Code's `additionalContext` does. Read directly against `openai/codex`'s Rust source (`codex-rs/hooks/`, `codex-rs/core/src/tools/`), not secondary docs:
+
+- **Augmentation IS supported.** `PreToolUseHookSpecificOutputWire` (`codex-rs/hooks/src/schema.rs`) has an `additional_context: Option<String>` field that serializes to the wire as `additionalContext` — the same field name Claude Code uses.
+- **But there is no Grep/Glob-equivalent tool-call event to scope it to.** Codex's only `PreToolUse` tool names are `Bash` (every shell invocation — `HookToolName::bash()` in `codex-rs/core/src/tools/hook_names.rs`), `apply_patch` (file edits, aliased to `Write`/`Edit`), `spawn_agent`, and MCP tools under their own names. File search and reads both happen through the generic `Bash` tool by shelling out to `grep`/`rg`/`find`/`cat`. There is no tool name that means "this is a search."
+
+Hooking `Bash` unconditionally to inject `additionalContext` would intercept *every* shell command Codex runs, including destructive ones — a materially broader and riskier surface than the Grep/Glob-only pattern the other hooks use, and it would fail "matches the Grep/Glob-equivalent tool only" on its face since no such tool exists. This hook therefore ships the diagnostics-only fallback: it detects `Bash` invocations shaped like a search command and logs what archex would have surfaced, but never mutates or blocks the tool call.
+
+### Installed config shape
+
+The block is appended to `config.toml` between marker comments so a re-run or `--remove-hooks` can find and replace exactly this block without disturbing any other section (including the `[mcp_servers.archex]` registration above):
+
+```toml
+# archex:codex-hook start
+[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "/path/to/venv/bin/python -m archex.integrations.codex_hook"
+timeout = 1
+# archex:codex-hook end
+```
+
+Contract:
+
+- **Never returns augmented output.** No code path ever sets `additionalContext`, `permissionDecision`, `updatedInput`, or any other `hookSpecificOutput` field — every invocation writes `{}` to stdout (Codex defaults every schema field, so an empty object means "no decision").
+- **Matches `Bash` only — there is no `Read` or Grep/Glob-equivalent hook in Codex to accidentally match instead.** `tests/cli/test_install_client_hooks.py`'s `test_codex_hook_toml_block_matcher_never_reaches_read` asserts the installed matcher is exactly `^Bash$` and never matches `Read`.
+- **Exits 0 on every path.** A missing/stale index, a malformed payload, a non-search `Bash` command, a timeout, or any internal error all degrade to no diagnostic (or a diagnostic-only log line) — never a blocked or errored tool call.
+- **Reuses `archex.integrations.hook`'s engine in-process.** `lookup_with_timeout`/`log_diagnostic` are called directly (no second subprocess spawned), so freshness/timeout/diagnostics semantics exactly match the Claude Code hook, appending to the same `~/.archex/hook-diagnostics.log` (override with `ARCHEX_HOOK_DIAGNOSTICS_LOG`).
+- **Codex's own hook-level `timeout` field is whole seconds only** (`HookHandlerConfig::Command.timeout_sec: Option<u64>`, confirmed via `codex-rs/config/src/hook_config.rs`) — the installer sets it to `1` as an outer backstop; the real ~500ms budget is enforced internally by the reused `archex.integrations.hook` engine.
+- **Non-destructive install/uninstall.** Any other `config.toml` content — including the `[mcp_servers.archex]` MCP registration — is left untouched by both `--hooks` and `--remove-hooks`. Re-running `--hooks` is an idempotent no-op once installed, even across a venv move (the block converges on the active `sys.executable` each time).
+- **One-time hash-based trust review.** Codex requires reviewing and trusting a hook by its content hash before it runs (`/hooks` in the Codex TUI); a hook that changes after trust (e.g. a subsequent archex upgrade rewriting the `command` path) needs re-trusting.
+
+Manual verification (bypassing Codex entirely — this is exactly what the hook receives on stdin for a `Bash` tool call):
+
+```bash
+echo '{"tool_name":"Bash","tool_input":{"command":"grep -rn compute_delta ."},"cwd":"'"$PWD"'"}' \
+  | python -m archex.integrations.codex_hook
+```
+
+Always exits 0 with `{}` on stdout. A repo with a fresh index and a search-shaped command appends a `codex_augmentation_withheld` diagnostic line to the log describing the match, instead of injecting it; a repo with no index, a stale index, or a non-search command produces no diagnostic (or the same `index_not_fresh`/`status_error` diagnostic the Claude Code hook logs) and no injected context either way.

--- a/src/archex/cli/install_client_cmd.py
+++ b/src/archex/cli/install_client_cmd.py
@@ -51,9 +51,10 @@ from archex.client_setup import (
     is_flag=True,
     default=False,
     help=(
-        "Install the archex tool_result/PreToolUse hook that augments Grep/Glob calls "
-        "with archex context (opt-in, never installed without this flag; "
-        "claude-code, omp, pi)."
+        "Install the archex PreToolUse hook (opt-in, never installed without this "
+        "flag). Augments Grep/Glob calls with archex context on claude-code, omp, pi; "
+        "on codex ships a diagnostics-only fallback (no Grep/Glob-equivalent tool-call "
+        "event exists there, so nothing is injected, only logged)."
     ),
 )
 @click.option(

--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, cast
 
+from archex.integrations.codex_hook import HOOK_MATCHER as CODEX_HOOK_MATCHER
 from archex.integrations.hook import HOOK_MATCHER
 
 ClientName = Literal["claude-code", "codex", "cursor", "opencode", "pi", "omp"]
@@ -229,10 +230,32 @@ class TsHookInstallPlan:
     module_content: str
 
 
+@dataclass(frozen=True)
+class CodexHookInstallPlan:
+    """Install or remove the Codex CLI diagnostics-only PreToolUse hook (M21).
+
+    Unlike the Claude Code hook (a JSON command entry merged into
+    ``settings.json``) or the omp/pi hook (a standalone ``.ts`` module), this
+    appends a marker-delimited TOML block to the *same* ``config.toml`` the
+    MCP server registration already writes to (``_target_path`` for
+    ``client == "codex"``), mirroring that file's non-destructive append
+    behavior for a ``[[hooks.PreToolUse]]`` table instead of
+    ``[mcp_servers.archex]``. See ``archex.integrations.codex_hook`` for why
+    this ships a diagnostics-only hook rather than Grep/Glob-scoped
+    augmentation (Codex has no such tool-call event).
+    """
+
+    client: ClientName
+    scope: ClientScope
+    target_path: Path
+    action: HookAction
+    block_content: str
+
+
 #: Either hook install plan shape. ``install_client_cmd.py`` treats both
 #: uniformly; ``write_hook_install_plan``/``render_hook_install_preview``
 #: dispatch on the concrete type.
-HookInstallPlan = ClaudeCodeHookInstallPlan | TsHookInstallPlan
+HookInstallPlan = ClaudeCodeHookInstallPlan | TsHookInstallPlan | CodexHookInstallPlan
 
 
 def build_hook_install_plan(
@@ -261,15 +284,26 @@ def build_hook_install_plan(
             action=action,
             module_content=_render_ts_hook_module(),
         )
+    if client == "codex":
+        selected_scope = _resolve_hook_scope(source, scope)
+        return CodexHookInstallPlan(
+            client=client,
+            scope=selected_scope,
+            target_path=_target_path(client, repo_root, selected_scope),
+            action=action,
+            block_content=_render_codex_hook_block(),
+        )
     raise ValueError(
-        "--hooks/--remove-hooks is only supported for claude-code (M19), omp, pi (M20); "
-        f"got {client!r}"
+        "--hooks/--remove-hooks is only supported for claude-code (M19), omp, pi (M20), "
+        f"codex (M21); got {client!r}"
     )
 
 
 def write_hook_install_plan(plan: HookInstallPlan) -> Path:
     if isinstance(plan, TsHookInstallPlan):
         return _write_ts_hook_plan(plan)
+    if isinstance(plan, CodexHookInstallPlan):
+        return _write_codex_hook_plan(plan)
     target = plan.target_path
     existing = _read_json_object(target) if target.exists() else {}
     updated, changed = _apply_hook_action(existing, plan)
@@ -293,9 +327,22 @@ def _write_ts_hook_plan(plan: TsHookInstallPlan) -> Path:
     return target
 
 
+def _write_codex_hook_plan(plan: CodexHookInstallPlan) -> Path:
+    target = plan.target_path
+    existing = target.read_text(encoding="utf-8") if target.exists() else ""
+    updated = _apply_codex_hook_block(existing, plan)
+    if updated == existing:
+        return target
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(updated, encoding="utf-8")
+    return target
+
+
 def render_hook_install_preview(plan: HookInstallPlan) -> str:
     if isinstance(plan, TsHookInstallPlan):
         return _render_ts_hook_preview(plan)
+    if isinstance(plan, CodexHookInstallPlan):
+        return _render_codex_hook_preview(plan)
     existing = _read_json_object(plan.target_path) if plan.target_path.exists() else {}
     updated, changed = _apply_hook_action(existing, plan)
     action_label = "Install" if plan.action == "install" else "Remove"
@@ -342,6 +389,33 @@ def _render_ts_hook_preview(plan: TsHookInstallPlan) -> str:
             if existing is None
             else "Dry run. Re-run without --dry-run to remove this file."
         )
+    return "\n".join(lines) + "\n"
+
+
+def _render_codex_hook_preview(plan: CodexHookInstallPlan) -> str:
+    target = plan.target_path
+    existing = target.read_text(encoding="utf-8") if target.exists() else ""
+    updated = _apply_codex_hook_block(existing, plan)
+    action_label = "Install" if plan.action == "install" else "Remove"
+    lines = [
+        f"Client: {plan.client}",
+        f"Scope: {plan.scope}",
+        f"Target: {target}",
+        (
+            f"Action: {action_label} PreToolUse hook "
+            f"(matcher: {CODEX_HOOK_MATCHER!r}, diagnostics-only)"
+        ),
+    ]
+    if updated == existing:
+        lines.append(
+            "No change: hook already in the requested state (idempotent no-op)."
+            if plan.action == "install"
+            else "No change: no archex hook is installed."
+        )
+    else:
+        lines.append("Dry run. Re-run without --dry-run to write this config.")
+    lines.append("")
+    lines.append(updated)
     return "\n".join(lines) + "\n"
 
 
@@ -618,6 +692,63 @@ export default function archexHook(pi: HookHost): void {
   });
 }
 """
+
+
+#: Marker comments delimiting the archex-owned block appended to Codex's
+#: ``config.toml`` -- lets install/remove find and replace exactly the block
+#: this installer wrote (and nothing else a user configured in the same
+#: file) without parsing/re-serializing TOML.
+_CODEX_HOOK_BLOCK_START = "# archex:codex-hook start"
+_CODEX_HOOK_BLOCK_END = "# archex:codex-hook end"
+
+
+def _render_codex_hook_block() -> str:
+    command = f"{sys.executable} -m archex.integrations.codex_hook"
+    return (
+        "\n".join(
+            [
+                _CODEX_HOOK_BLOCK_START,
+                "[[hooks.PreToolUse]]",
+                f'matcher = "{CODEX_HOOK_MATCHER}"',
+                "",
+                "[[hooks.PreToolUse.hooks]]",
+                'type = "command"',
+                f'command = "{command}"',
+                "timeout = 1",
+                _CODEX_HOOK_BLOCK_END,
+            ]
+        )
+        + "\n"
+    )
+
+
+def _strip_codex_hook_block(existing: str) -> str:
+    start = existing.find(_CODEX_HOOK_BLOCK_START)
+    if start == -1:
+        return existing
+    end = existing.find(_CODEX_HOOK_BLOCK_END, start)
+    if end == -1:
+        return existing  # malformed marker pair -- leave untouched rather than guess
+    end += len(_CODEX_HOOK_BLOCK_END)
+    if end < len(existing) and existing[end] == "\n":
+        end += 1
+    before, after = existing[:start], existing[end:]
+    # `_render_codex_hook_block`/`_apply_codex_hook_block` always separate a
+    # freshly appended block from prior content with exactly one blank line
+    # -- strip that same separator back out so a strip+re-add round-trips
+    # byte-for-byte (idempotent reinstall, and a clean `remove`).
+    if before.endswith("\n\n"):
+        before = before[:-1]
+    return before + after
+
+
+def _apply_codex_hook_block(existing: str, plan: CodexHookInstallPlan) -> str:
+    without_block = _strip_codex_hook_block(existing)
+    if plan.action == "remove":
+        return without_block
+    if not without_block.strip():
+        return plan.block_content
+    return without_block.rstrip("\n") + "\n\n" + plan.block_content
 
 
 def _is_archex_hook_entry(entry: object) -> bool:

--- a/tests/cli/test_install_client_hooks.py
+++ b/tests/cli/test_install_client_hooks.py
@@ -11,11 +11,13 @@ from click.testing import CliRunner
 
 from archex.cli.main import cli
 from archex.client_setup import (
+    CodexHookInstallPlan,
     TsHookInstallPlan,
     build_hook_install_plan,
     render_hook_install_preview,
     write_hook_install_plan,
 )
+from archex.integrations.codex_hook import HOOK_MATCHER as CODEX_HOOK_MATCHER
 from archex.integrations.hook import HOOK_MATCHER
 
 if TYPE_CHECKING:
@@ -277,14 +279,15 @@ def test_render_hook_install_preview_remove_does_not_write(tmp_path: Path) -> No
     assert target.read_text(encoding="utf-8") == before
 
 
-@pytest.mark.parametrize("client", ["codex", "cursor", "opencode"])
-def test_build_hook_install_plan_rejects_non_claude_code_clients(client: ClientName) -> None:
+@pytest.mark.parametrize("client", ["cursor", "opencode"])
+def test_build_hook_install_plan_rejects_unsupported_clients(client: ClientName) -> None:
     with pytest.raises(ValueError) as exc_info:
         build_hook_install_plan(client, action="install")
 
     message = str(exc_info.value)
     assert "claude-code" in message
     assert "M19" in message
+    assert "M21" in message
 
 
 # --- omp TS hook module (M20) ---
@@ -556,6 +559,185 @@ def test_render_hook_install_preview_pi_install_does_not_write(tmp_path: Path) -
     assert not plan.target_path.exists()
 
 
+# --- Codex CLI diagnostics-only hook (M21) ---
+#
+# Unlike claude-code (a JSON entry merged into settings.json) or omp/pi (a
+# standalone .ts module), Codex's hook lives in the same config.toml the MCP
+# server registration writes to, as a marker-delimited `[[hooks.PreToolUse]]`
+# TOML block. See `archex.integrations.codex_hook` for why this hook is
+# diagnostics-only (Codex has no Grep/Glob-equivalent tool-call event) rather
+# than augmenting like the claude-code/omp/pi hooks above.
+
+
+def test_build_hook_install_plan_codex_project_scope_produces_config_toml_path(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    plan = build_hook_install_plan("codex", str(repo), scope="project", action="install")
+
+    assert isinstance(plan, CodexHookInstallPlan)
+    assert plan.target_path == repo / ".codex" / "config.toml"
+    assert CODEX_HOOK_MATCHER in plan.block_content
+    assert "archex.integrations.codex_hook" in plan.block_content
+
+
+def test_build_hook_install_plan_codex_user_scope_produces_config_toml_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    plan = build_hook_install_plan("codex", action="install")
+
+    assert isinstance(plan, CodexHookInstallPlan)
+    assert plan.target_path == tmp_path / ".codex" / "config.toml"
+
+
+def test_write_hook_install_plan_codex_writes_toml_block(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("codex", str(repo), scope="project", action="install")
+
+    assert isinstance(plan, CodexHookInstallPlan)
+    target = write_hook_install_plan(plan)
+
+    assert target == plan.target_path
+    content = target.read_text(encoding="utf-8")
+    assert content == plan.block_content
+    assert "[[hooks.PreToolUse]]" in content
+    assert f'matcher = "{CODEX_HOOK_MATCHER}"' in content
+
+
+def test_write_hook_install_plan_codex_idempotent_on_reinstall(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("codex", str(repo), scope="project", action="install")
+    target = write_hook_install_plan(plan)
+    after_first = target.read_text(encoding="utf-8")
+    mtime_first = target.stat().st_mtime_ns
+
+    plan2 = build_hook_install_plan("codex", str(repo), scope="project", action="install")
+    write_hook_install_plan(plan2)
+
+    assert target.read_text(encoding="utf-8") == after_first
+    assert target.stat().st_mtime_ns == mtime_first
+
+
+def test_write_hook_install_plan_codex_preserves_unrelated_config_toml_content(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target_path = repo / ".codex" / "config.toml"
+    target_path.parent.mkdir(parents=True)
+    seed = '[mcp_servers.archex]\ncommand = "archex"\nargs = ["mcp"]\n'
+    target_path.write_text(seed, encoding="utf-8")
+
+    plan = build_hook_install_plan("codex", str(repo), scope="project", action="install")
+    write_hook_install_plan(plan)
+
+    content = target_path.read_text(encoding="utf-8")
+    assert "[mcp_servers.archex]" in content
+    assert "[[hooks.PreToolUse]]" in content
+
+
+def test_write_hook_install_plan_codex_remove_restores_original_content(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target_path = repo / ".codex" / "config.toml"
+    target_path.parent.mkdir(parents=True)
+    seed = '[mcp_servers.archex]\ncommand = "archex"\nargs = ["mcp"]\n'
+    target_path.write_text(seed, encoding="utf-8")
+    install_plan = build_hook_install_plan("codex", str(repo), scope="project", action="install")
+    write_hook_install_plan(install_plan)
+
+    remove_plan = build_hook_install_plan("codex", str(repo), scope="project", action="remove")
+    write_hook_install_plan(remove_plan)
+
+    assert target_path.read_text(encoding="utf-8") == seed
+
+
+def test_write_hook_install_plan_codex_remove_missing_file_is_noop(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("codex", str(repo), scope="project", action="remove")
+
+    result_target = write_hook_install_plan(plan)
+
+    assert not result_target.exists()
+
+
+def test_write_hook_install_plan_codex_remove_without_archex_block_is_noop(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target_path = repo / ".codex" / "config.toml"
+    target_path.parent.mkdir(parents=True)
+    before = '[mcp_servers.archex]\ncommand = "archex"\nargs = ["mcp"]\n'
+    target_path.write_text(before, encoding="utf-8")
+
+    plan = build_hook_install_plan("codex", str(repo), scope="project", action="remove")
+    write_hook_install_plan(plan)
+
+    assert target_path.read_text(encoding="utf-8") == before
+
+
+def test_render_hook_install_preview_codex_install_does_not_write(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("codex", str(repo), scope="project", action="install")
+
+    preview = render_hook_install_preview(plan)
+
+    assert "Install" in preview
+    assert "diagnostics-only" in preview
+    assert not plan.target_path.exists()
+
+
+def test_render_hook_install_preview_codex_remove_does_not_write(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target_path = repo / ".codex" / "config.toml"
+    target_path.parent.mkdir(parents=True)
+    before = '[mcp_servers.archex]\ncommand = "archex"\nargs = ["mcp"]\n'
+    target_path.write_text(before, encoding="utf-8")
+    plan = build_hook_install_plan("codex", str(repo), scope="project", action="remove")
+
+    preview = render_hook_install_preview(plan)
+
+    assert "Remove" in preview
+    assert target_path.read_text(encoding="utf-8") == before
+
+
+def test_codex_hook_toml_block_matcher_never_reaches_read(tmp_path: Path) -> None:
+    """M21 acceptance criterion: the installed hook config matches the
+    Grep/Glob-equivalent tool only, never Read. Codex has no Grep/Glob or
+    Read hook at all -- the only tool name this installer ever writes is the
+    literal `^Bash$` matcher, asserted structurally here rather than by
+    inspection.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("codex", str(repo), scope="project", action="install")
+
+    assert isinstance(plan, CodexHookInstallPlan)
+    matches = re.findall(r'matcher = "([^"]+)"', plan.block_content)
+    assert matches == ["^Bash$"]
+    for matcher in matches:
+        assert not re.fullmatch(matcher, "Read")
+
+
+def test_codex_hook_toml_block_bakes_in_active_python_interpreter(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    plan = build_hook_install_plan("codex", str(repo), scope="project", action="install")
+
+    assert isinstance(plan, CodexHookInstallPlan)
+    assert sys.executable in plan.block_content
+    assert "-m archex.integrations.codex_hook" in plan.block_content
+
+
 # --- CLI wiring: install-client --hooks / --remove-hooks ---
 
 
@@ -610,18 +792,18 @@ def test_cli_hooks_and_remove_hooks_are_mutually_exclusive(
     assert not (tmp_path / ".claude" / "settings.json").exists()
 
 
-def test_cli_hooks_rejects_non_claude_code_client_and_writes_nothing(
+def test_cli_hooks_rejects_unsupported_client_and_writes_nothing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path))
 
-    result = CliRunner().invoke(cli, ["install-client", "codex", "--hooks"])
+    result = CliRunner().invoke(cli, ["install-client", "cursor", "--hooks"])
 
     assert result.exit_code != 0
     assert "claude-code" in result.output
     assert "M19" in result.output
     assert not (tmp_path / ".claude").exists()
-    assert not (tmp_path / ".codex").exists()
+    assert not (tmp_path / ".cursor").exists()
 
 
 def test_cli_plain_install_client_still_writes_mcp_config_not_hook_settings(
@@ -716,3 +898,44 @@ def test_cli_remove_hooks_pi_removes_and_exits_zero(
     assert result.exit_code == 0, result.output
     assert "Removed" in result.output
     assert not target.exists()
+
+
+def test_cli_hooks_installs_codex_and_exits_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = CliRunner().invoke(cli, ["install-client", "codex", "--hooks"])
+
+    assert result.exit_code == 0, result.output
+    assert "Installed" in result.output
+    target = tmp_path / ".codex" / "config.toml"
+    assert target.exists()
+    assert "archex.integrations.codex_hook" in target.read_text(encoding="utf-8")
+
+
+def test_cli_hooks_codex_dry_run_previews_without_writing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = CliRunner().invoke(cli, ["install-client", "codex", "--hooks", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Dry run." in result.output
+    assert not (tmp_path / ".codex" / "config.toml").exists()
+
+
+def test_cli_remove_hooks_codex_removes_and_exits_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    CliRunner().invoke(cli, ["install-client", "codex", "--hooks"])
+    target = tmp_path / ".codex" / "config.toml"
+    assert "archex.integrations.codex_hook" in target.read_text(encoding="utf-8")
+
+    result = CliRunner().invoke(cli, ["install-client", "codex", "--remove-hooks"])
+
+    assert result.exit_code == 0, result.output
+    assert "Removed" in result.output
+    assert target.read_text(encoding="utf-8") == ""


### PR DESCRIPTION
## Summary

M21 PR-2: installer integration + docs, per `.docs/DEVELOPMENT_PLAN.md` §4 Section G M21. Based on `feat/m21-codex-hook-core` (#441) — wires the confirmation-spike-driven diagnostics-only hook from PR-1 into `install-client codex --hooks`/`--remove-hooks`.

## What changed

**`src/archex/client_setup.py`** — `CodexHookInstallPlan` plus `build_hook_install_plan`/`write_hook_install_plan`/`render_hook_install_preview` support for `client == "codex"`. Unlike:
- Claude Code (a JSON `command` entry merged into `settings.json`), or
- omp/pi (a standalone `.ts` module),

Codex's hook is a marker-delimited `[[hooks.PreToolUse]]` TOML block appended to the *same* `config.toml` the MCP server registration already writes to (`~/.codex/config.toml` global, `.codex/config.toml` project) — confirmed against `codex-rs/config/src/hook_config.rs`'s `HookEventsToml`/`MatcherGroup`/`HookHandlerConfig` schema in PR-1. Install/reinstall/remove all go through a strip-then-reappend round trip (`_strip_codex_hook_block` + `_apply_codex_hook_block`) that:
- Converges byte-for-byte on repeated install (idempotent, including after a venv move that changes `sys.executable`).
- Leaves any other `config.toml` content — including an existing `[mcp_servers.archex]` section — untouched.
- Restores the exact pre-install content on `--remove-hooks`.

Verified with a direct round-trip smoke test (empty file, unrelated-content file, reinstall, remove) before writing the test suite — see commit history.

**`src/archex/cli/install_client_cmd.py`** — `--hooks` help text updated to describe Codex's diagnostics-only behavior accurately instead of implying Grep/Glob augmentation it structurally cannot provide.

**`tests/cli/test_install_client_hooks.py`** — new Codex section (14 tests) covering project/user scope target resolution, TOML block writing, idempotent reinstall, unrelated-content preservation, remove restoring exact prior content, remove-when-missing/remove-without-block no-ops, dry-run previews that never write, and the CLI wiring (`install-client codex --hooks`/`--remove-hooks`). Also fixes two pre-existing tests that assumed `codex` still rejected `--hooks` (`test_build_hook_install_plan_rejects_non_claude_code_clients` → `..._rejects_unsupported_clients`, parametrized `["cursor", "opencode"]` only; `test_cli_hooks_rejects_non_claude_code_client_and_writes_nothing` → `..._rejects_unsupported_client_and_writes_nothing`, using `cursor`).

**The milestone's required config assertion** — `test_codex_hook_toml_block_matcher_never_reaches_read` — asserts the installed `matcher` is exactly `"^Bash$"` and structurally never matches `"Read"` (Codex has no Read-hookable tool-call event at all, so this holds by construction, not by a conditional that could be gotten wrong).

**`docs/CLIENT_COMPATIBILITY_MATRIX.md`** — new "Codex CLI PreToolUse hook (opt-in, diagnostics-only)" matrix row and full contract section: the confirmation-spike findings from PR-1 (augmentation IS supported by Codex's schema, but there's no Grep/Glob-equivalent tool-call event to scope it to), the installed TOML block shape, the non-destructive install/idempotent-reinstall/remove contract, Codex's one-time hash-based hook-trust step (`/hooks` in the Codex TUI), and a manual verification command. Updates the Section G forward-reference line to mark M21 implemented alongside M20 (OpenCode still pending, Cursor's prompt-level exception unchanged).

## Manual hook invocation (real run against this repo)

```
$ echo '{"tool_name":"Bash","tool_input":{"command":"grep -rn compute_delta ."},"cwd":"'"$PWD"'"}' \
    | ARCHEX_HOOK_DIAGNOSTICS_LOG=/tmp/codex-hook-manual.log uv run python -m archex.integrations.codex_hook
{}
$ tail -1 /tmp/codex-hook-manual.log
{"timestamp": "2026-07-06T04:38:48Z", "kind": "index_not_fresh", "detail": "state=stale", "cwd": "/Users/.../archex"}
```

Exit 0, `{}` on stdout, diagnostic logged for the stale index — matches the documented degradation contract exactly (this repo's own archex index happened to be stale at test time, which is itself a live confirmation of the "missing/stale index degrades to no-op with a diagnostics log line" acceptance criterion).

## Verification

```
uv run pytest tests/integrations/test_hooks.py -k codex -v   # 36 passed (PR-1)
uv run pytest                                                 # 3557 passed, 91% coverage
uv run ruff check src/archex/
uv run pyright
```

## M21 acceptance criteria — status

- `archex install-client codex --hooks` installs, opt-in, never default. ✅
- Wired to Codex's Grep/Glob-equivalent tool-call event — **N/A, confirmed not to exist**; wired to `Bash` (the only tool-call event that can ever carry a search command) with a diagnostics-only fallback instead, per the plan's own contingency for this GAP. ✅ (documented, not silently downgraded)
- Same ~500ms budget — enforced internally by the reused `archex.integrations.hook` engine; Codex's own hook-level `timeout` field is whole-seconds only, set to `1` as an outer backstop (documented). ✅
- Read is never hooked — trivially and structurally true (Codex has no Read hook at all); asserted directly on the installed matcher. ✅
- Missing/stale index degrades to no-op with a diagnostics log line — confirmed both by unit test and the live manual run above. ✅
- Installed hook config matches the Grep/Glob-equivalent tool only, never Read — no such tool exists; the installed matcher is `^Bash$` exclusively, asserted structurally. ✅

## Stack

- PR-1 (#441): confirmation spike + hook script core
- PR-2 (this PR): installer integration + docs
