### PR TITLE
feat(integrations): OpenCode tool.execute.after plugin core

### DIFF
--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -215,12 +215,16 @@ class ClaudeCodeHookInstallPlan:
 
 @dataclass(frozen=True)
 class TsHookInstallPlan:
-    """Install or remove the shared TS ``tool_result`` hook module (M20; omp/pi).
+    """Install or remove the shared TS hook module (M20 omp/pi; M22 opencode).
 
     Unlike the Claude Code hook (a JSON command entry merged into an existing
-    settings file), this installs a standalone TypeScript extension module —
-    see ``_render_ts_hook_module`` for the implementation both clients load
-    unmodified.
+    settings file), this installs a standalone TypeScript module — see
+    ``_render_ts_hook_module`` for the per-client template dispatch. omp and
+    pi share one module (``_TS_HOOK_MODULE_TEMPLATE``, a
+    ``pi.on("tool_result", ...)`` handler returning a content patch);
+    opencode uses a structurally different one
+    (``_OPENCODE_HOOK_MODULE_TEMPLATE``, a ``tool.execute.after`` plugin
+    that mutates its output argument in place instead).
     """
 
     client: ClientName
@@ -275,14 +279,14 @@ def build_hook_install_plan(
             action=action,
             hook_entry=_render_hook_entry(),
         )
-    if client in {"omp", "pi"}:
+    if client in {"omp", "pi", "opencode"}:
         selected_scope = _resolve_hook_scope(source, scope)
         return TsHookInstallPlan(
             client=client,
             scope=selected_scope,
             target_path=_ts_hook_module_path(client, repo_root, selected_scope),
             action=action,
-            module_content=_render_ts_hook_module(),
+            module_content=_render_ts_hook_module(client),
         )
     if client == "codex":
         selected_scope = _resolve_hook_scope(source, scope)
@@ -295,7 +299,7 @@ def build_hook_install_plan(
         )
     raise ValueError(
         "--hooks/--remove-hooks is only supported for claude-code (M19), omp, pi (M20), "
-        f"codex (M21); got {client!r}"
+        f"codex (M21), opencode (M22); got {client!r}"
     )
 
 
@@ -373,7 +377,10 @@ def _render_ts_hook_preview(plan: TsHookInstallPlan) -> str:
         f"Client: {plan.client}",
         f"Scope: {plan.scope}",
         f"Target: {target}",
-        f"Action: {action_label} archex tool_result hook module (grep/glob-equivalent tools only)",
+        (
+            f"Action: {action_label} archex {_ts_hook_event_label(plan.client)} "
+            "(grep/glob-equivalent tools only)"
+        ),
     ]
     if plan.action == "install":
         lines.append(
@@ -451,11 +458,28 @@ def _ts_hook_module_path(client: ClientName, repo_root: Path, scope: ClientScope
             if scope == "project"
             else Path.home() / ".pi" / "agent" / "extensions" / _TS_HOOK_MODULE_FILENAME
         )
+    if client == "opencode":
+        return (
+            repo_root / ".opencode" / "plugins" / _TS_HOOK_MODULE_FILENAME
+            if scope == "project"
+            else Path.home() / ".config" / "opencode" / "plugins" / _TS_HOOK_MODULE_FILENAME
+        )
     raise ValueError(f"unsupported TS hook client: {client}")
 
 
-def _render_ts_hook_module() -> str:
-    return _TS_HOOK_MODULE_TEMPLATE.replace("__ARCHEX_PYTHON_COMMAND__", json.dumps(sys.executable))
+def _ts_hook_event_label(client: ClientName) -> str:
+    """Preview wording for the two structurally different TS hook shapes.
+
+    omp/pi install a `tool_result` handler returning a content patch;
+    opencode installs a `tool.execute.after` plugin that mutates its output
+    argument in place (see `_OPENCODE_HOOK_MODULE_TEMPLATE`).
+    """
+    return "tool.execute.after plugin" if client == "opencode" else "tool_result hook module"
+
+
+def _render_ts_hook_module(client: ClientName) -> str:
+    template = _OPENCODE_HOOK_MODULE_TEMPLATE if client == "opencode" else _TS_HOOK_MODULE_TEMPLATE
+    return template.replace("__ARCHEX_PYTHON_COMMAND__", json.dumps(sys.executable))
 
 
 _TS_HOOK_MODULE_TEMPLATE = r"""/**
@@ -691,6 +715,228 @@ export default function archexHook(pi: HookHost): void {
     }
   });
 }
+"""
+
+
+_OPENCODE_HOOK_MODULE_TEMPLATE = r"""/**
+ * archex OpenCode `tool.execute.after` plugin (M22 — OpenCode hook integration).
+ *
+ * Installed by `archex install-client opencode --hooks` (opt-in; never
+ * installed by default) as a standalone plugin file OpenCode auto-loads from
+ * its native plugin directory -- `.opencode/plugins/archex-hook.ts`
+ * (project-local) or `~/.config/opencode/plugins/archex-hook.ts` (global).
+ * No `opencode.json` entry is required: per OpenCode's own docs, files in
+ * these directories "are automatically loaded at startup."
+ *
+ * Mirrors the oh-my-pi/Pi `tool_result` hook (M20, `_TS_HOOK_MODULE_TEMPLATE`)
+ * which this module shells out to unmodified -- no lookup/ranking/freshness
+ * logic lives here, only the `python -m archex.integrations.hook` subprocess
+ * contract from M19.
+ *
+ * Contract:
+ * - Only OpenCode's native `grep` and `glob` tools are inspected
+ *   (`ARCHEX_AUGMENTED_TOOLS`, this module's only tool-name dispatch).
+ *   `read` is never touched, and an MCP-routed tool call can never match
+ *   this table: OpenCode registers every MCP tool under a mandatory
+ *   `{server}_{tool}` id (confirmed against the installed `opencode-ai`
+ *   1.14.33's own MCP tool-registration code), so an exact `"grep"`/`"glob"`
+ *   collision with an MCP tool id is structurally impossible, not merely
+ *   unlikely.
+ * - `tool.execute.after`'s contract differs structurally from oh-my-pi/Pi's
+ *   `tool_result`: its handler signature is `(input, output) => Promise<void>`
+ *   -- it mutates the `output.output` string IN PLACE rather than returning
+ *   a patch object. A degraded path (spawn failure, timeout, malformed
+ *   subprocess response, or any thrown error) simply returns without
+ *   touching `output`, leaving the native tool's own result untouched.
+ * - Every path resolves without throwing past this handler. A missing/stale
+ *   index, a spawn failure, a timeout, or a malformed subprocess response
+ *   all degrade to leaving `output` untouched; failures are appended to the
+ *   same diagnostics log the Python subprocess and the M20 TS module use
+ *   (`ARCHEX_HOOK_DIAGNOSTICS_LOG` or `~/.archex/hook-diagnostics.log`),
+ *   never surfaced to the agent flow.
+ * - The lookup runs under the same ~500ms wall-clock budget as the Python
+ *   hook's own internal timeout; this module additionally guards the
+ *   subprocess call itself so a hung `python` process can never block the
+ *   host agent past the budget.
+ *
+ * Two OpenCode-side reliability gaps this milestone's own tests assert
+ * against rather than assume away (`.docs/DEVELOPMENT_PLAN.md` §2), both
+ * confirmed by reading `opencode-ai` 1.14.33's own tool-resolution source
+ * (the version installed during development), not secondary documentation:
+ * - MCP tool calls DO trigger `tool.execute.after`, but the hook receives
+ *   the tool's raw MCP `CallToolResult` as `output` (a `{content, metadata}`
+ *   shape), not the `{title, output, metadata}` shape this type declares --
+ *   the text actually sent to the model is rebuilt from `result.content`
+ *   AFTER the hook runs, discarding any `output.output` mutation. Moot for
+ *   this plugin: its dispatch table never contains an MCP-shaped tool id.
+ * - A Task-tool-spawned subagent's own turn is processed by the exact same
+ *   tool-resolution code path as a top-level turn (the subagent's prompt
+ *   loop is a recursive call into the identical function that built the
+ *   top-level session's own tool table), so a subagent-issued `grep`/`glob`
+ *   call triggers `tool.execute.after` identically to a top-level one in
+ *   the version this was verified against. This module itself makes no
+ *   session/agent distinction either way -- see the installer test suite
+ *   for the specific structural check and its citation.
+ */
+
+import type { Plugin } from "@opencode-ai/plugin";
+import type { ChildProcess } from "node:child_process";
+import { spawn } from "node:child_process";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+// --- Baked in at install time (`archex install-client opencode --hooks`) ---
+
+/** Python interpreter active when `--hooks` ran -- mirrors the Claude Code
+ * JSON hook's `command`, so this always runs in the same environment archex
+ * was installed into. */
+const ARCHEX_PYTHON_COMMAND = __ARCHEX_PYTHON_COMMAND__;
+const ARCHEX_PYTHON_ARGS = ["-m", "archex.integrations.hook"];
+
+/** Matches `DEFAULT_HOOK_TIMEOUT_SECONDS` in `archex.integrations.hook`. */
+const ARCHEX_HOOK_TIMEOUT_MS = 500;
+
+const ARCHEX_DIAGNOSTICS_LOG_ENV_VAR = "ARCHEX_HOOK_DIAGNOSTICS_LOG";
+
+// --- OpenCode native tool id -> archex subprocess Claude-shape tool_name ---
+//
+// OpenCode's `grep` and `glob` tools both carry their query pattern in an
+// `args.pattern` field (confirmed against the bundled tool definitions) --
+// both translate directly onto the subprocess's existing
+// `{"tool_name": "Grep"|"Glob", "tool_input": {"pattern": ...}}` contract.
+// This table is this module's *only* tool-name dispatch: `read`, every
+// other native tool, and every MCP-routed tool id fall through unmatched.
+const ARCHEX_AUGMENTED_TOOLS: Readonly<Record<string, "Grep" | "Glob">> = {
+  grep: "Grep",
+  glob: "Glob",
+};
+
+// --- Diagnostics (parity with hook.py's `log_diagnostic`) ---
+
+function logDiagnostic(kind: string, detail: string, cwd?: string): void {
+  try {
+    const override = process.env[ARCHEX_DIAGNOSTICS_LOG_ENV_VAR];
+    const path = override && override.trim().length > 0
+      ? override
+      : join(homedir(), ".archex", "hook-diagnostics.log");
+    mkdirSync(dirname(path), { recursive: true });
+    const entry: Record<string, string> = {
+      timestamp: new Date().toISOString(),
+      kind,
+      detail,
+    };
+    if (cwd) entry.cwd = cwd;
+    appendFileSync(path, `${JSON.stringify(entry)}\n`, "utf-8");
+  } catch {
+    // Diagnostics logging must never raise into the hook's return path.
+  }
+}
+
+// --- Subprocess call: `python -m archex.integrations.hook` ---
+
+function runArchexHookSubprocess(
+  payload: Record<string, unknown>,
+  cwd: string,
+): Promise<string | null> {
+  const { promise, resolve } = Promise.withResolvers<string | null>();
+  let settled = false;
+  const finish = (value: string | null): void => {
+    if (settled) return;
+    settled = true;
+    resolve(value);
+  };
+
+  let child: ChildProcess;
+  try {
+    child = spawn(ARCHEX_PYTHON_COMMAND, ARCHEX_PYTHON_ARGS, {
+      cwd,
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+  } catch (err) {
+    logDiagnostic("ts_spawn_error", String(err), cwd);
+    finish(null);
+    return promise;
+  }
+
+  const timer = setTimeout(() => {
+    logDiagnostic("ts_timeout", `lookup exceeded ${ARCHEX_HOOK_TIMEOUT_MS}ms`, cwd);
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // Already exited.
+    }
+    finish(null);
+  }, ARCHEX_HOOK_TIMEOUT_MS);
+
+  let stdout = "";
+  child.stdout?.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString("utf-8");
+  });
+  child.on("error", (err) => {
+    clearTimeout(timer);
+    logDiagnostic("ts_spawn_error", String(err), cwd);
+    finish(null);
+  });
+  child.on("close", () => {
+    clearTimeout(timer);
+    finish(stdout.length > 0 ? stdout : null);
+  });
+
+  try {
+    child.stdin?.write(JSON.stringify(payload));
+    child.stdin?.end();
+  } catch (err) {
+    clearTimeout(timer);
+    logDiagnostic("ts_stdin_error", String(err), cwd);
+    finish(null);
+  }
+
+  return promise;
+}
+
+function extractAdditionalContext(rawStdout: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(rawStdout);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const hookSpecificOutput = (parsed as Record<string, unknown>).hookSpecificOutput;
+    if (typeof hookSpecificOutput !== "object" || hookSpecificOutput === null) return null;
+    const context = (hookSpecificOutput as Record<string, unknown>).additionalContext;
+    return typeof context === "string" && context.length > 0 ? context : null;
+  } catch {
+    return null;
+  }
+}
+
+// --- Plugin entry point ---
+
+export const ArchexHookPlugin: Plugin = async ({ directory }) => {
+  return {
+    "tool.execute.after": async (input, output) => {
+      try {
+        const claudeToolName = ARCHEX_AUGMENTED_TOOLS[input.tool];
+        if (!claudeToolName) return; // never "read", never an MCP-routed tool
+
+        const args = (input.args ?? {}) as Record<string, unknown>;
+        const pattern = args.pattern;
+        if (typeof pattern !== "string" || pattern.trim().length === 0) return;
+
+        const rawStdout = await runArchexHookSubprocess(
+          { tool_name: claudeToolName, tool_input: { pattern }, cwd: directory },
+          directory,
+        );
+        if (rawStdout === null) return;
+
+        const context = extractAdditionalContext(rawStdout);
+        if (context === null) return;
+
+        output.output = `${output.output}\n\n${context}`;
+      } catch (err) {
+        logDiagnostic("ts_internal_error", String(err));
+      }
+    },
+  };
+};
 """
 
 

--- a/tests/cli/test_install_client_hooks.py
+++ b/tests/cli/test_install_client_hooks.py
@@ -279,7 +279,7 @@ def test_render_hook_install_preview_remove_does_not_write(tmp_path: Path) -> No
     assert target.read_text(encoding="utf-8") == before
 
 
-@pytest.mark.parametrize("client", ["cursor", "opencode"])
+@pytest.mark.parametrize("client", ["cursor"])
 def test_build_hook_install_plan_rejects_unsupported_clients(client: ClientName) -> None:
     with pytest.raises(ValueError) as exc_info:
         build_hook_install_plan(client, action="install")
@@ -288,6 +288,7 @@ def test_build_hook_install_plan_rejects_unsupported_clients(client: ClientName)
     assert "claude-code" in message
     assert "M19" in message
     assert "M21" in message
+    assert "M22" in message
 
 
 # --- omp TS hook module (M20) ---
@@ -557,6 +558,183 @@ def test_render_hook_install_preview_pi_install_does_not_write(tmp_path: Path) -
 
     assert "Install" in preview
     assert not plan.target_path.exists()
+
+
+# --- OpenCode `tool.execute.after` plugin (M22) ---
+#
+# Structurally different from the omp/pi `tool_result` module: OpenCode's
+# hook contract is `(input, output) => Promise<void>` -- it mutates
+# `output.output` in place rather than returning a patch object, and its
+# dispatch table (`ARCHEX_AUGMENTED_TOOLS`) is keyed directly on OpenCode's
+# own native tool ids (`grep`, `glob`), not a `{claudeToolName, field}`
+# translation record, since both tools already carry their query in a field
+# named `pattern`. See `_OPENCODE_HOOK_MODULE_TEMPLATE` in `client_setup.py`.
+
+
+def test_build_hook_install_plan_opencode_project_scope_produces_ts_module_path(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("opencode", str(repo), action="install")
+    assert isinstance(plan, TsHookInstallPlan)
+    assert plan.scope == "project"
+    assert plan.target_path == repo / ".opencode" / "plugins" / "archex-hook.ts"
+    assert plan.module_content  # non-empty
+
+
+def test_build_hook_install_plan_opencode_user_scope_produces_ts_module_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    plan = build_hook_install_plan("opencode", action="install")
+    assert isinstance(plan, TsHookInstallPlan)
+    assert plan.scope == "user"
+    assert plan.target_path == tmp_path / ".config" / "opencode" / "plugins" / "archex-hook.ts"
+
+
+def test_write_hook_install_plan_opencode_writes_ts_module_file(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("opencode", str(repo), action="install")
+
+    target = write_hook_install_plan(plan)
+
+    assert isinstance(plan, TsHookInstallPlan)
+    assert target == plan.target_path
+    assert target.read_text(encoding="utf-8") == plan.module_content
+
+
+def test_write_hook_install_plan_opencode_idempotent_on_reinstall(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = write_hook_install_plan(
+        build_hook_install_plan("opencode", str(repo), action="install")
+    )
+    mtime_first = target.stat().st_mtime_ns
+
+    write_hook_install_plan(build_hook_install_plan("opencode", str(repo), action="install"))
+
+    assert target.stat().st_mtime_ns == mtime_first
+
+
+def test_write_hook_install_plan_opencode_remove_deletes_file(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = write_hook_install_plan(
+        build_hook_install_plan("opencode", str(repo), action="install")
+    )
+    assert target.exists()
+
+    write_hook_install_plan(build_hook_install_plan("opencode", str(repo), action="remove"))
+
+    assert not target.exists()
+
+
+def test_write_hook_install_plan_opencode_remove_missing_file_is_noop(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("opencode", str(repo), action="remove")
+
+    result_target = write_hook_install_plan(plan)
+
+    assert not result_target.exists()
+
+
+def test_render_hook_install_preview_opencode_install_does_not_write(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("opencode", str(repo), action="install")
+    assert isinstance(plan, TsHookInstallPlan)
+
+    preview = render_hook_install_preview(plan)
+
+    assert "Install" in preview
+    assert "tool.execute.after" in preview
+    assert not plan.target_path.exists()
+
+
+def test_render_hook_install_preview_opencode_remove_does_not_write(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    write_hook_install_plan(build_hook_install_plan("opencode", str(repo), action="install"))
+    before = (repo / ".opencode" / "plugins" / "archex-hook.ts").read_text(encoding="utf-8")
+
+    plan = build_hook_install_plan("opencode", str(repo), action="remove")
+    render_hook_install_preview(plan)
+
+    assert (repo / ".opencode" / "plugins" / "archex-hook.ts").read_text(encoding="utf-8") == before
+
+
+def _augmented_tools_keys(module_content: str) -> set[str]:
+    """Extract the ``ARCHEX_AUGMENTED_TOOLS`` table's keys from generated
+    OpenCode plugin source.
+
+    Same rationale as ``_query_field_keys`` above: this table is the
+    plugin's *only* tool-name dispatch (no if/else chain on ``input.tool``),
+    so its key set precisely determines which tools are ever touched --
+    stronger than a substring search, which would false-positive on the
+    module's own prose comments quoting the exact tool names/ids that must
+    never match.
+    """
+    match = re.search(
+        r'ARCHEX_AUGMENTED_TOOLS: Readonly<Record<string, "Grep" \| "Glob">> = \{(.*?)\n\};',
+        module_content,
+        re.DOTALL,
+    )
+    assert match is not None, "ARCHEX_AUGMENTED_TOOLS table not found in generated module"
+    return set(re.findall(r"^\s*(\w+):", match.group(1), re.MULTILINE))
+
+
+def test_opencode_ts_hook_module_native_vs_mcp_tool_routing(tmp_path: Path) -> None:
+    """M22 acceptance criterion (native-vs-MCP routing): the plugin's only
+    tool-name dispatch is ``ARCHEX_AUGMENTED_TOOLS``, keyed exactly on
+    OpenCode's two native search tool ids. OpenCode registers every MCP tool
+    under a mandatory ``{server}_{tool}`` id (confirmed against the
+    installed `opencode-ai` 1.14.33's own MCP tool-registration code), so no
+    realistic MCP-routed id -- including one from archex's own MCP server --
+    can ever collide with this table.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("opencode", str(repo), action="install")
+    assert isinstance(plan, TsHookInstallPlan)
+
+    keys = _augmented_tools_keys(plan.module_content)
+
+    assert keys == {"grep", "glob"}
+    assert "read" not in keys
+    mcp_shaped_ids = {"archex_query_repo", "archex_scout_repo", "github_create_issue"}
+    assert keys.isdisjoint(mcp_shaped_ids)
+
+
+def test_opencode_ts_hook_module_bakes_in_active_python_interpreter(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("opencode", str(repo), action="install")
+    assert isinstance(plan, TsHookInstallPlan)
+
+    assert json.dumps(sys.executable) in plan.module_content
+    assert '["-m", "archex.integrations.hook"]' in plan.module_content
+
+
+def test_opencode_ts_hook_module_registers_exactly_one_tool_execute_after_and_never_before(
+    tmp_path: Path,
+) -> None:
+    """The plugin only ever registers a `tool.execute.after` handler -- it
+    never wires `tool.execute.before` (the hook OpenCode's own documented
+    subagent-bypass bug affects), and registers no session/agent-type
+    conditional gating that handler, matching the M20 omp/pi module's
+    unconditional-registration precedent.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("opencode", str(repo), action="install")
+    assert isinstance(plan, TsHookInstallPlan)
+    content = plan.module_content
+
+    assert content.count('"tool.execute.after"') == 1
+    assert '"tool.execute.before"' not in content
 
 
 # --- Codex CLI diagnostics-only hook (M21) ---

--- a/tests/integrations/test_hooks.py
+++ b/tests/integrations/test_hooks.py
@@ -240,6 +240,70 @@ def test_hook_py_stays_client_agnostic_after_m20(indexed_repo: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# M22 client-shim payload translation (OpenCode)
+#
+# Unlike omp's `glob` (field `path`) or Pi's `find` (a different tool name),
+# OpenCode's native `grep` and `glob` tools both already carry their query in
+# a field named `pattern` -- confirmed against the installed `opencode-ai`
+# 1.14.33's own tool definitions. The OpenCode plugin's translation is
+# therefore an identity mapping onto this subprocess's own Grep/Glob
+# contract, exercised here with the exact payload shape the plugin sends.
+# ---------------------------------------------------------------------------
+
+
+def test_opencode_grep_shim_payload_returns_receipt_stamped_context(indexed_repo: Path) -> None:
+    payload: dict[str, Any] = {
+        "tool_name": "Grep",
+        "tool_input": {"pattern": "AuthService"},
+        "cwd": str(indexed_repo),
+    }
+
+    result = handle_pre_tool_use(payload)
+
+    assert result is not None
+    assert "AuthService" in result["hookSpecificOutput"]["additionalContext"]
+
+
+def test_opencode_glob_shim_payload_returns_receipt_stamped_context(indexed_repo: Path) -> None:
+    """OpenCode's `glob` tool carries its query in a field already named
+    `pattern`, so the plugin's translation onto the subprocess's Glob
+    contract is an identity mapping -- exercised here with a glob-shaped
+    pattern, mirroring the same lenient assertion M20's equivalent omp test
+    uses, since whether a specific glob-derived identifier token happens to
+    match any indexed symbol is a BM25/corpus concern, not a translation one.
+    """
+    payload: dict[str, Any] = {
+        "tool_name": "Glob",
+        "tool_input": {"pattern": "**/*_service.py"},
+        "cwd": str(indexed_repo),
+    }
+
+    result = handle_pre_tool_use(payload)
+
+    assert result is None or (
+        isinstance(result["hookSpecificOutput"]["additionalContext"], str)
+        and result["hookSpecificOutput"]["additionalContext"]
+    )
+
+
+def test_hook_py_stays_client_agnostic_after_m22(indexed_repo: Path) -> None:
+    """M22 reuses this subprocess contract unmodified, same as M20/M21: it
+    still recognizes only the capitalized Claude Code tool names, never
+    OpenCode's native lowercase `grep`/`glob` (already proven by M20's
+    `test_hook_py_stays_client_agnostic_after_m20`) nor an MCP-routed,
+    `{server}_{tool}`-prefixed id such as an archex MCP tool call would use.
+    """
+    assert {"Grep", "Glob"} == AUGMENTED_TOOLS
+    for native_tool_name in ("grep", "glob", "archex_query_repo", "archex_scout_repo"):
+        payload: dict[str, Any] = {
+            "tool_name": native_tool_name,
+            "tool_input": {"pattern": "AuthService"},
+            "cwd": str(indexed_repo),
+        }
+        assert handle_pre_tool_use(payload) is None
+
+
+# ---------------------------------------------------------------------------
 # Read (and other non-augmented tools) are never intercepted
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

M22 PR-1: OpenCode `tool.execute.after` plugin core, per `.docs/DEVELOPMENT_PLAN.md` §4 Section G M22.

Delivers `_OPENCODE_HOOK_MODULE_TEMPLATE` in `src/archex/client_setup.py`, a standalone plugin module `archex install-client opencode --hooks` writes to `.opencode/plugins/archex-hook.ts` (project) or `~/.config/opencode/plugins/archex-hook.ts` (user). OpenCode auto-loads local plugin files from these directories, so — unlike the `mcp.archex` config entry — no `opencode.json` change is required. The plugin shells out to the existing M19 `python -m archex.integrations.hook` subprocess unmodified, exactly like M20's omp/pi module.

## Why this isn't the omp/pi module verbatim

OpenCode's hook contract is structurally different from oh-my-pi/Pi's `tool_result`:

- Signature is `(input, output) => Promise<void>` — the handler mutates `output.output` (a string) **in place**, it does not return a patch object.
- `input` carries `{tool, sessionID, callID, args}`; there is no client-side field-name translation needed here since OpenCode's `grep` and `glob` tools both already carry their query in a field named `pattern` (confirmed against `opencode-ai@1.14.33`'s bundled tool definitions — unlike oh-my-pi's `glob`, which needs a `path`→`pattern` remap).

`ARCHEX_AUGMENTED_TOOLS` is this module's only tool-name dispatch, keyed exactly on `{"grep", "glob"}`. `read` is never in it, and it structurally can't collide with an MCP-routed call.

## Confirmation spike: reading `opencode-ai@1.14.33` source directly (the version installed during development, not secondary docs)

The plan's own risk note flagged two OpenCode-side reliability gaps to test against rather than assume. Both were resolved by reading the actual installed version's `packages/opencode/src/session/prompt.ts`:

1. **MCP tool calls DO trigger `tool.execute.after`, but with the wrong output shape.** The MCP tool-execution branch triggers the hook with the raw MCP `CallToolResult` (`{content, metadata}`) as `output`, not the `{title, output, metadata}` shape the type declares — the text actually sent to the model is rebuilt from `result.content` *after* the hook runs, discarding any `output.output` mutation. This is moot for this plugin: `ARCHEX_AUGMENTED_TOOLS` never contains an MCP-shaped id, and every MCP tool is registered under a mandatory `{server}_{tool}` prefix (`result[sanitize(clientName) + "_" + sanitize(mcpTool.name)] = ...`), so an exact `"grep"`/`"glob"` collision is structurally impossible, not merely unlikely.
2. **Subagent (Task-tool) dispatch reaches the hook too.** `TaskTool`'s `ops.prompt({sessionID: nextSession.id, ...})` is bound to the exact same `prompt()` closure that processes the top-level session's own turn (`ops().prompt = (input) => prompt(input)`), which in turn calls the same `resolveTools()` that wraps every native tool's `execute` with the `tool.execute.before`/`.after` triggers. There is no subagent-specific branch that skips this. (PR-2 adds the dedicated test + doc citation for this finding, per the plan's own PR split — this PR's plugin code makes no session/agent distinction to begin with, so nothing here depends on the finding either way.)

## Manual verification (live, real OpenCode, real credentials, free model — not part of the pytest suite; no Node/Bun in CI)

Installed the real generated plugin (`archex install-client opencode <fixture> --hooks`) into a fixture repo and ran real `opencode run --model opencode/deepseek-v4-flash-free` sessions:

- **Native `grep`** for `AuthService`: exported session JSON shows the tool's own `state.output` field literally containing the archex receipt block appended after the grep results.
- **Native `glob`** for `**/*_service.py`: same — archex context appended in place.
- **`read`**: exported `state.output` is the exact raw file content, byte-for-byte, no archex text anywhere.
- **Missing index** (fresh git repo, never `archex init`'d): plugin invocation directly (bypassing OpenCode) returns unmodified output plus an `index_not_fresh` diagnostic line, ~440ms including cold Python interpreter start.
- **Timeout** (subprocess replaced with a 30s sleep): output stays unmodified, `ts_timeout` diagnostic logged at ~526ms (the 500ms guard fired and `SIGKILL`ed the hung process).
- **Malformed subprocess stdout** (non-JSON): output stays unmodified, no throw.
- **`--remove-hooks`**: deletes the installed file cleanly.

```
echo '{"tool_name":"Grep","tool_input":{"pattern":"AuthService"},"cwd":"<fixture>"}' \
  | uv run python -m archex.integrations.hook
# {"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": "[archex receipt] ..."}}
```

## Verification

```
uv run pytest tests/integrations/test_hooks.py -k opencode -v   # 3 passed
uv run pytest tests/cli/test_install_client_hooks.py -k opencode -v   # 11 passed
uv run pytest tests/cli/test_install_client_hooks.py tests/integrations/test_hooks.py -v   # 143 passed
uv run pytest   # 3570 passed, 91% coverage
uv run ruff check src/archex/
uv run ruff format --check src/archex/client_setup.py tests/cli/test_install_client_hooks.py tests/integrations/test_hooks.py
uv run pyright
```

## Out of scope (PR-2, based on this branch)

Installer CLI help-text wording, the CLI-level installed-file config-assertion test, the subagent-dispatch test + written citation, and `docs/CLIENT_COMPATIBILITY_MATRIX.md` documentation land in PR-2.
