### PR TITLE
feat(integrations): add Cursor beforeSubmitPrompt diagnostics-only hook

### DIFF
--- a/src/archex/integrations/cursor_hook.py
+++ b/src/archex/integrations/cursor_hook.py
@@ -1,0 +1,171 @@
+"""Cursor `beforeSubmitPrompt` hook: diagnostics-only prompt-level lookup (M23).
+
+Confirmation-spike findings (read directly against Cursor's own official
+docs — `https://cursor.com/docs/hooks` and `https://cursor.com/docs/
+reference/third-party-hooks`, fetched 2026-07-06 — not secondary sources):
+
+- Cursor has no Grep/Glob-equivalent tool-call hook at all: `preToolUse`/
+  `postToolUse` fire generically for every tool, with no per-tool
+  augmentation scoping analogous to Claude Code's `Grep`/`Glob` matcher,
+  oh-my-pi/Pi's `grep`/`glob`/`find` `tool_result` dispatch, or OpenCode's
+  native-tool `tool.execute.after`. `beforeSubmitPrompt` is the closest
+  content-adjacent hook that fires on ordinary agent use, matching
+  `DEVELOPMENT_PLAN.md` §2's own framing of it as the necessarily weaker,
+  prompt-level mechanism for this client.
+- `beforeSubmitPrompt`'s own output schema, however, is `{"continue": bool,
+  "user_message": str | None}` ONLY — there is no context-injection output
+  field, nested or flat. This differs from `sessionStart` (which *does*
+  support an `additional_context` output field, but fires once per
+  conversation, not per prompt) and from `postToolUse` (which also supports
+  `additional_context`). Cursor's own "Response Format Compatibility"
+  section (`third-party-hooks.md`) documents a Claude-Code-style nested
+  `hookSpecificOutput` translation only for `PreToolUse` and
+  `Stop`/`SubagentStop` — none is documented for `UserPromptSubmit` (which
+  Cursor maps to `beforeSubmitPrompt`), and no `additionalContext`
+  passthrough exists for it despite Claude Code's own `UserPromptSubmit`
+  hook supporting that field. `user_message` is documented as shown only
+  when a submission is blocked (`continue: false`), which is out of scope
+  for this milestone (deny/blocking behavior is not part of M23) — so it
+  cannot carry injected context on the normal, non-blocking path either.
+- The milestone's own objective describes "prompt-level context injection"
+  as the mechanism; the finding above means that, as specified, Cursor's
+  `beforeSubmitPrompt` cannot deliver it today. Per the same discipline M21
+  applied when Codex's hook schema turned out to have no Grep/Glob-
+  equivalent tool-call event to scope augmentation to, this module ships
+  the plan's own accepted fallback instead: a diagnostics-only hook that
+  performs the same lookup and logs what it would have injected, but never
+  returns it to Cursor and never blocks prompt submission. Every invocation
+  returns exactly `{"continue": true}`.
+
+Every code path exits 0, mirroring `archex.integrations.hook`'s and
+`archex.integrations.codex_hook`'s contract: a missing/stale index, a
+timeout, a malformed payload, or an internal error all degrade to a
+no-injection, non-blocking no-op from Cursor's point of view, logged instead
+to the same local diagnostics log (`ARCHEX_HOOK_DIAGNOSTICS_LOG`, default
+`~/.archex/hook-diagnostics.log`).
+
+This module is a thin per-client shim, per the Section G architecture note
+in `.docs/DEVELOPMENT_PLAN.md` §2: unlike the Claude Code/omp/Pi/OpenCode
+hooks, which translate a *tool-call* payload into a Grep/Glob query, this
+translates a *prompt-submission* payload (free natural-language text, not a
+search pattern) into a query by extracting the single longest
+identifier-like token from the prompt (see `_extract_query`), then calls
+straight into `archex.integrations.hook`'s lookup/timeout/freshness engine
+(`lookup_with_timeout`, `log_diagnostic`, `IDENTIFIER_TOKEN_RE`)
+in-process — no lookup, ranking, or timeout logic is reimplemented here.
+
+Invoked as a subprocess: `python -m archex.integrations.cursor_hook`,
+reading Cursor's `beforeSubmitPrompt` JSON payload (`{"prompt": str,
+"attachments": [...]}`, no `cwd` field — Cursor runs project hooks from the
+project root per its own docs, so `os.getcwd()` is used directly) from
+stdin and always writing `{"continue": true}` to stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any, cast
+
+from archex.integrations.hook import IDENTIFIER_TOKEN_RE, log_diagnostic, lookup_with_timeout
+
+#: Always-continue output. `beforeSubmitPrompt` has no context-injection
+#: field to populate (see module docstring) and deny/blocking behavior is
+#: out of scope for this milestone, so every invocation returns exactly this.
+_ALWAYS_CONTINUE: dict[str, object] = {"continue": True}
+
+
+def _extract_query(prompt: str) -> str:
+    """Pick the single strongest search candidate out of free prompt text.
+
+    `IndexStore.search_symbols` wraps its entire query in one quoted FTS5
+    phrase (see `src/archex/index/store.py`), so a multi-word query only
+    matches when that exact word sequence appears verbatim in the indexed
+    content — true for a single Grep/Glob pattern fragment, never true for a
+    natural-language sentence. The longest identifier-like token in the
+    prompt is used as a heuristic stand-in for "the symbol the user is
+    probably asking about": real identifiers mentioned in prose are
+    typically longer than the surrounding English words.
+    """
+    tokens = IDENTIFIER_TOKEN_RE.findall(prompt)
+    return max(tokens, key=len) if tokens else ""
+
+
+def main() -> None:
+    """Entry point for `python -m archex.integrations.cursor_hook`.
+
+    Guarantees exit 0 and `{"continue": true}` stdout on every path,
+    including an exception this module did not anticipate — see the module
+    docstring's non-blocking, diagnostics-only contract.
+    """
+    try:
+        _main_impl()
+    except BaseException as exc:  # noqa: BLE001 - the non-blocking contract requires this
+        log_diagnostic("cursor_unhandled_exception", detail=repr(exc))
+    sys.stdout.write(json.dumps(_ALWAYS_CONTINUE))
+    sys.stdout.flush()
+    os._exit(0)
+
+
+def _main_impl() -> None:
+    raw = sys.stdin.read()
+    payload = _parse_cursor_payload(raw)
+    if payload is None:
+        return
+    handle_before_submit_prompt(payload)
+
+
+def _parse_cursor_payload(raw: str) -> dict[str, Any] | None:
+    if not raw.strip():
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        log_diagnostic("cursor_malformed_payload", detail=f"invalid JSON: {exc}")
+        return None
+    if not isinstance(payload, dict):
+        log_diagnostic("cursor_malformed_payload", detail="payload is not a JSON object")
+        return None
+    return cast("dict[str, Any]", payload)
+
+
+def handle_before_submit_prompt(payload: dict[str, Any]) -> None:
+    """Diagnostics-only core handler: never returns or applies context injection.
+
+    Extracts the single strongest identifier-like token from the submitted
+    prompt text (see `_extract_query`), looks it up through the shared
+    engine, and logs what it would have injected (see module docstring for
+    why the output field to carry that doesn't exist on this hook). Never
+    mutates or blocks the submission, and never raises — any failure
+    degrades to a diagnostics log line.
+    """
+    try:
+        prompt = payload.get("prompt")
+        if not isinstance(prompt, str) or not prompt.strip():
+            return
+        query = _extract_query(prompt)
+        if not query:
+            return
+        cwd = os.getcwd()
+        context = lookup_with_timeout(cwd, query)
+        if context is None:
+            # A missing/stale index, timeout, or lookup error already logged
+            # its own diagnostic inside `lookup_with_timeout`/`_lookup`.
+            return
+        log_diagnostic(
+            "cursor_context_injection_unsupported",
+            detail=(
+                "prompt lookup found archex matches, but Cursor's "
+                "beforeSubmitPrompt hook has no context-injection output "
+                "field to carry them (see docs/CLIENT_COMPATIBILITY_MATRIX.md); "
+                f"withheld: {context}"
+            ),
+            cwd=cwd,
+        )
+    except Exception as exc:  # noqa: BLE001 - degrade to no-op, never raise
+        log_diagnostic("cursor_internal_error", detail=repr(exc))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integrations/test_hooks.py
+++ b/tests/integrations/test_hooks.py
@@ -33,6 +33,11 @@ from archex.integrations.codex_hook import (
 from archex.integrations.codex_hook import (
     HOOK_MATCHER as CODEX_HOOK_MATCHER,
 )
+from archex.integrations.cursor_hook import (
+    _ALWAYS_CONTINUE,  # pyright: ignore[reportPrivateUsage]
+    _parse_cursor_payload,  # pyright: ignore[reportPrivateUsage]
+    handle_before_submit_prompt,
+)
 from archex.integrations.hook import (
     AUGMENTED_TOOLS,
     DEFAULT_HOOK_TIMEOUT_SECONDS,
@@ -839,3 +844,158 @@ def test_codex_search_command_regex_matches_known_search_tools(command: str) -> 
 )
 def test_codex_search_command_regex_does_not_match_non_search_commands(command: str) -> None:
     assert not _SEARCH_COMMAND_RE.search(command)
+
+
+# ---------------------------------------------------------------------------
+# Cursor `beforeSubmitPrompt` diagnostics-only hook (M23)
+#
+# Confirmation spike (read against Cursor's own official docs directly --
+# `https://cursor.com/docs/hooks` and `https://cursor.com/docs/reference/
+# third-party-hooks`, not secondary sources): `beforeSubmitPrompt`'s output
+# schema is `{"continue": bool, "user_message": str | None}` ONLY -- unlike
+# `sessionStart`/`postToolUse`, it has no `additional_context`/
+# `additionalContext` output field, nested or flat, and Cursor's documented
+# Claude Code `UserPromptSubmit` -> `beforeSubmitPrompt` compatibility
+# mapping does not add one either. Cursor also has no Grep/Glob-equivalent
+# tool-call hook at all. `archex.integrations.cursor_hook` therefore ships
+# the plan's own diagnostics-only fallback: it always returns
+# `{"continue": true}` and logs what an archex lookup for the submitted
+# prompt would have surfaced, instead of injecting it.
+# ---------------------------------------------------------------------------
+
+
+def _run_cursor_hook_subprocess(
+    raw_stdin: str, *, cwd: Path, diagnostics_log: Path
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["ARCHEX_HOOK_DIAGNOSTICS_LOG"] = str(diagnostics_log)
+    return subprocess.run(
+        [sys.executable, "-m", "archex.integrations.cursor_hook"],
+        input=raw_stdin,
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        env=env,
+        timeout=30,
+    )
+
+
+def test_cursor_prompt_with_matches_logs_withheld_diagnostic_not_injection(
+    indexed_repo: Path, diagnostics_log: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(indexed_repo)
+    payload: dict[str, Any] = {
+        "prompt": "How does AuthService handle login?",
+        "attachments": [],
+    }
+
+    result = handle_before_submit_prompt(payload)
+
+    assert result is None  # never returns context injection, ever
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries, "expected a diagnostic line for a prompt with archex matches"
+    entry = entries[-1]
+    assert entry["kind"] == "cursor_context_injection_unsupported"
+    assert "AuthService" in entry["detail"]
+    assert "no context-injection output field" in entry["detail"]
+
+
+def test_cursor_prompt_without_identifier_tokens_is_noop(
+    indexed_repo: Path, diagnostics_log: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(indexed_repo)
+    payload: dict[str, Any] = {"prompt": "?? .. --", "attachments": []}
+
+    assert handle_before_submit_prompt(payload) is None
+    assert _read_diagnostics(diagnostics_log) == []
+
+
+@pytest.mark.parametrize("payload", [{}, {"prompt": None}, {"prompt": 42}, {"prompt": "   "}])
+def test_cursor_missing_or_non_string_prompt_short_circuits_before_lookup(
+    payload: dict[str, Any], diagnostics_log: Path
+) -> None:
+    lookup_mock = MagicMock(side_effect=AssertionError("must not be called"))
+
+    with patch("archex.integrations.cursor_hook.lookup_with_timeout", lookup_mock):
+        assert handle_before_submit_prompt(payload) is None
+
+    lookup_mock.assert_not_called()
+    assert _read_diagnostics(diagnostics_log) == []
+
+
+def test_cursor_missing_index_degrades_silently_and_logs_diagnostic(
+    python_simple_repo: Path, diagnostics_log: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`python_simple_repo` is git-init'd but never `archex init`'d/indexed."""
+    monkeypatch.chdir(python_simple_repo)
+    payload: dict[str, Any] = {"prompt": "Where is compute_delta defined?"}
+
+    assert handle_before_submit_prompt(payload) is None
+
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries
+    assert entries[-1]["kind"] in {"status_error", "index_not_fresh"}
+
+
+@pytest.mark.parametrize("raw", ["not json", "[]", "42", '"a string"'])
+def test_cursor_parse_payload_rejects_non_object_input_and_logs_diagnostic(
+    raw: str, diagnostics_log: Path
+) -> None:
+    assert _parse_cursor_payload(raw) is None
+
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries[-1]["kind"] == "cursor_malformed_payload"
+
+
+def test_cursor_internal_error_degrades_silently_and_logs_diagnostic(
+    indexed_repo: Path, diagnostics_log: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(indexed_repo)
+    payload: dict[str, Any] = {"prompt": "How does AuthService handle login?"}
+
+    with patch(
+        "archex.integrations.cursor_hook.lookup_with_timeout",
+        side_effect=RuntimeError("boom"),
+    ):
+        assert handle_before_submit_prompt(payload) is None
+
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries[-1]["kind"] == "cursor_internal_error"
+
+
+def test_cursor_subprocess_prompt_with_matches_exits_zero_with_continue_true(
+    indexed_repo: Path, tmp_path: Path
+) -> None:
+    diagnostics_log = tmp_path / "cursor-subprocess-diag.log"
+    stdin_payload = json.dumps({"prompt": "How does AuthService handle login?"})
+
+    result = _run_cursor_hook_subprocess(
+        stdin_payload, cwd=indexed_repo, diagnostics_log=diagnostics_log
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {"continue": True}
+    entries = _read_diagnostics(diagnostics_log)
+    assert entries[-1]["kind"] == "cursor_context_injection_unsupported"
+
+
+def test_cursor_subprocess_garbage_stdin_exits_zero_with_continue_true(tmp_path: Path) -> None:
+    diagnostics_log = tmp_path / "cursor-subprocess-diag.log"
+
+    result = _run_cursor_hook_subprocess("not json", cwd=tmp_path, diagnostics_log=diagnostics_log)
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {"continue": True}
+
+
+def test_cursor_subprocess_empty_stdin_exits_zero_with_continue_true(tmp_path: Path) -> None:
+    diagnostics_log = tmp_path / "cursor-subprocess-diag.log"
+
+    result = _run_cursor_hook_subprocess("", cwd=tmp_path, diagnostics_log=diagnostics_log)
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {"continue": True}
+
+
+def test_cursor_always_continue_constant_never_carries_context_or_blocks() -> None:
+    assert _ALWAYS_CONTINUE == {"continue": True}


### PR DESCRIPTION
## Stack

Position: 1/2 — base PR (`main`)

1. `feat/m23-cursor-hook-core` -> this PR
2. `feat/m23-cursor-installer-docs` -> depends on this PR

## Summary

M23 (Cursor hook integration, prompt-level) — hook script core.

Adapts M19's `python -m archex.integrations.hook` subprocess contract to Cursor's `beforeSubmitPrompt` event.

## Confirmation spike (read against Cursor's own official docs, not secondary sources)

Fetched directly from `cursor.com/docs/hooks` and `cursor.com/docs/reference/third-party-hooks` (2026-07-06):

- Cursor has no Grep/Glob-equivalent tool-call hook. `preToolUse`/`postToolUse` fire generically for every tool with no per-tool augmentation scoping.
- **`beforeSubmitPrompt`'s output schema is `{"continue": bool, "user_message": str | None}` only — there is no context-injection field**, nested or flat. This differs from `sessionStart` and `postToolUse`, which both support an `additional_context` output field. The "Response Format Compatibility" section of the third-party-hooks doc documents a Claude-Code-style nested translation only for `PreToolUse` and `Stop`/`SubagentStop`; none exists for `UserPromptSubmit` (Cursor's name for the hook Claude Code maps to `beforeSubmitPrompt`), and no `additionalContext` passthrough is documented for it despite Claude Code's own `UserPromptSubmit` hook supporting that field.
- `user_message` is documented as shown only when a submission is blocked (`continue: false`) — out of scope for this milestone (deny/blocking behavior is explicitly excluded), so it can't carry injected context on the normal path either.

**Consequence:** DEVELOPMENT_PLAN.md's M23 objective describes "prompt-level context injection" via `beforeSubmitPrompt`. As specified, Cursor cannot deliver that today — there is no output field to carry it. Per the same discipline M21 applied when Codex's hook schema turned out to have no Grep/Glob-equivalent event, this PR ships the plan's own accepted fallback: a **diagnostics-only** hook. It performs the same lookup and logs what it would have injected, but never returns it to Cursor and never blocks prompt submission (`{"continue": true}` on every path). PR-2's docs update states this mechanism difference plainly.

## Changes

- `src/archex/integrations/cursor_hook.py` (new): `beforeSubmitPrompt` diagnostics-only hook.
  - `_extract_query`: picks the single longest identifier-like token from the prompt. `IndexStore.search_symbols` phrase-matches its entire query as one quoted FTS5 phrase, so a multi-word natural-language query would need that literal word sequence to appear verbatim in the corpus — true for a single Grep/Glob fragment, never true for a sentence. The longest token is a heuristic stand-in for "the symbol the user is probably asking about."
  - `handle_before_submit_prompt`: calls straight into `archex.integrations.hook`'s `lookup_with_timeout`/`log_diagnostic` (same ~500ms budget, same diagnostics log) — no lookup/ranking/timeout logic reimplemented.
  - `main()`: always writes `{"continue": true}` to stdout and exits 0, including on an unhandled exception.
- `tests/integrations/test_hooks.py`: cursor test section covering the happy path (match found -> `cursor_context_injection_unsupported` diagnostic, never returns context), no-identifier-token prompts, missing/non-string `prompt` short-circuiting before any lookup, missing-index degradation, malformed JSON payloads, an internal-error path, and the full subprocess exit-0 contract (garbage/empty stdin, a real match) always returning exactly `{"continue": true}`.

## Verification

```
uv run pytest tests/integrations/test_hooks.py -k cursor -v   # 16 passed
uv run pytest                                                    # 3591 passed, 4 deselected
uv run ruff check src/archex/                                    # OK
uv run ruff format --check src/archex/integrations/cursor_hook.py tests/integrations/test_hooks.py   # already formatted
uv run pyright                                                   # 0 errors
```

Depends on: (none — root)
Upstack: PR-2 (installer + docs)
