### PR TITLE
feat(client-setup): wire Cursor into the diagnostics-only hook installer

### DIFF
--- a/docs/CLIENT_COMPATIBILITY_MATRIX.md
+++ b/docs/CLIENT_COMPATIBILITY_MATRIX.md
@@ -22,6 +22,7 @@ This matrix separates config-shape verification from actual client smoke tests. 
 | OpenCode | Config shape verified; client smoke unverified | `archex install-client opencode` writes `~/.config/opencode/opencode.json` (global); `archex install-client opencode . --scope project` writes `opencode.json`, setting `mcp.archex = { type = "local", command = ["archex", "mcp"], enabled = true }`. `--dry-run` previews. | Client-dependent; server supports `--watch`. | Same server-side freshness semantics as other stdio clients. | No OpenCode client smoke in this stack. | 2026-06-16 |
 | OpenCode `tool.execute.after` plugin (opt-in) | Config-shape tested end-to-end (install, remove, idempotent reinstall, native-vs-MCP dispatch-table assertion, subagent-dispatch reachability confirmed both structurally and via a live session); confirmed against a real installed `opencode-ai` 1.14.33 client | `archex install-client opencode --hooks` writes a standalone plugin file to `.opencode/plugins/archex-hook.ts` (project scope) or `~/.config/opencode/plugins/archex-hook.ts` (user scope, default) — OpenCode auto-loads local plugin files from these directories, so no `opencode.json` entry is written or needed. `--dry-run` previews, `--remove-hooks` uninstalls. See [below](#opencode-toolexecuteafter-plugin-opt-in) for the full contract, the confirmation-spike findings, and the live verification. | N/A — one subprocess per matched tool call, not a warm process | Same receipt/timeout/diagnostics semantics as the Claude Code hook above — this module shells out to the identical `python -m archex.integrations.hook` subprocess, unmodified. | Opt-in, never installed by default; augments only native `grep`/`glob` tool calls, never `read` or any MCP-routed tool. | 2026-07-06 |
 | Cursor | Config shape verified; client smoke unverified | `archex install-client cursor` writes `~/.cursor/mcp.json` (global); `archex install-client cursor . --scope project` writes `.cursor/mcp.json` with `mcpServers.archex.command = "archex"`, `args = ["mcp"]`. `--dry-run` previews. | Yes — with a warm `archex mcp --watch --watch-path .` process. | Inline query refresh by default; watch keeps a warm process subscribed to file events. | No Cursor UI smoke in this stack. | 2026-06-16 |
+| Cursor `beforeSubmitPrompt` hook (opt-in, diagnostics-only, prompt-level) | Config-shape tested end-to-end (install, remove, idempotent reinstall, preserves unrelated `hooks.json` content, `beforeReadFile`-never-wired assertion); no live Cursor UI smoke | `archex install-client cursor --hooks` writes `~/.cursor/hooks.json` (global) or `.cursor/hooks.json` (project) — a different file from the MCP config above. `--dry-run` previews, `--remove-hooks` uninstalls. See [below](#cursor-beforesubmitprompt-hook-opt-in-diagnostics-only) for the full contract and the confirmation-spike findings. | N/A — one subprocess per submitted prompt, not a warm process | Diagnostics-only — no injected context, ever (see limitations); a missing/stale index degrades to no diagnostic, or the same `index_not_fresh`/`status_error` diagnostic the other hooks log. | Prompt-level, not per-tool-call: fires on every submitted prompt regardless of whether a lookup is relevant. Cursor's `beforeSubmitPrompt` output schema has no context-injection field at all (confirmed against Cursor's own docs), so this is diagnostics-only, unlike the augmenting Claude Code/omp/Pi/OpenCode hooks above. | 2026-07-06 |
 | Dockerized MCP server | Server path tested; client smoke unverified | Run `docker run -d --name archex-mcp -v "$PWD:/workspace" -w /workspace ghcr.io/mathews-tom/archex:slim sleep infinity` then point the client to `docker exec -i archex-mcp archex mcp`. | Yes — run the MCP process with `--watch`. | Same server-side freshness semantics as stdio. | Client-specific Docker registration varies; use the same client config shapes above, but replace the command with `docker` / `exec`. | 2026-06-16 |
 
 ## First-party bootstrap command
@@ -142,7 +143,7 @@ echo '{"tool_name":"Grep","tool_input":{"pattern":"compute_delta"}}' \
 
 A repo with a fresh index returns JSON on stdout shaped `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "additionalContext": "..."}}`. A repo with no index, a stale index, or a `cwd` outside a Git working tree exits 0 with empty stdout and a diagnostics log line instead.
 
-Section G of the development plan (M20–M23) extends this same `python -m archex.integrations.hook` subprocess contract to other clients with per-client installer shims. M20 (oh-my-pi and Pi), M21 (Codex CLI, diagnostics-only), and M22 (OpenCode) are implemented; Cursor's weaker prompt-level mechanism is a planned exception.
+Section G of the development plan (M20–M23) extends this same `python -m archex.integrations.hook` subprocess contract to other clients with per-client installer shims. M20 (oh-my-pi and Pi), M21 (Codex CLI, diagnostics-only), M22 (OpenCode), and M23 (Cursor, diagnostics-only, prompt-level) are all implemented.
 
 ## oh-my-pi (omp) / Pi `tool_result` hook (opt-in)
 
@@ -283,3 +284,61 @@ echo '{"tool_name":"Grep","tool_input":{"pattern":"compute_delta"}}' \
 - **Hard ~500ms lookup timeout**, matching `DEFAULT_HOOK_TIMEOUT_SECONDS`: the plugin's own `setTimeout` guard `SIGKILL`s a subprocess still running past the budget, independent of whatever timeout the subprocess enforces on itself.
 - **No field-name translation needed.** Both `grep` and `glob` already carry their query in a field named `pattern`, so the plugin's mapping onto the subprocess's `{"tool_name": "Grep"|"Glob", "tool_input": {"pattern": ...}}` contract is an identity mapping on the field, keyed only on the tool id.
 - **Subagent-reachable.** The handler registers unconditionally with no `sessionID`/`callID`-based gating, and both source inspection and a live nested-subagent run confirm `tool.execute.after` fires for subagent-issued calls in the verified version — see the confirmation spike above.
+
+## Cursor `beforeSubmitPrompt` hook (opt-in, diagnostics-only)
+
+`archex install-client cursor --hooks` installs `src/archex/integrations/cursor_hook.py` (invoked as `python -m archex.integrations.cursor_hook`) as a Cursor `beforeSubmitPrompt` hook. **This is prompt-level context, not per-tool-call augmentation** — it fires once per submitted prompt, not once per Grep/Glob-equivalent tool call the way the Claude Code/omp/Pi/OpenCode hooks above do, and (per the confirmation spike below) it never injects anything into the conversation at all. It is opt-in — plain `archex install-client cursor` never installs it — and it writes to a *different* file than MCP server registration:
+
+```bash
+archex install-client cursor --hooks                     # global: ~/.cursor/hooks.json
+archex install-client cursor . --hooks --scope project   # repo-local: .cursor/hooks.json
+archex install-client cursor --hooks --dry-run           # preview only, writes nothing
+archex install-client cursor --remove-hooks              # clean uninstall
+```
+
+### Confirmation-spike findings (M23 §2 assumption, corrected)
+
+`.docs/DEVELOPMENT_PLAN.md`'s M23 assumption framed `beforeSubmitPrompt` as Cursor's "content-bearing" prompt-level hook and planned to inject an archex `scout`-style summary through its output. Read directly against Cursor's own official docs (`cursor.com/docs/hooks`, `cursor.com/docs/reference/third-party-hooks`, fetched 2026-07-06), not secondary sources:
+
+- Cursor has no Grep/Glob-equivalent tool-call hook at all — `preToolUse`/`postToolUse` fire generically for every tool with no per-tool augmentation scoping, unlike Claude Code's `Grep`/`Glob` matcher, oh-my-pi/Pi's `grep`/`glob`/`find` dispatch, or OpenCode's native-tool `tool.execute.after`.
+- **`beforeSubmitPrompt`'s own output schema is `{"continue": bool, "user_message": str | None}` only.** There is no context-injection output field, nested or flat. This differs from `sessionStart` and `postToolUse`, which both support an `additional_context`/`additionalContext` output field. The "Response Format Compatibility" section of the third-party-hooks doc documents a Claude-Code-style nested `hookSpecificOutput` translation only for `PreToolUse` and `Stop`/`SubagentStop` — none is documented for `UserPromptSubmit` (which Cursor maps to `beforeSubmitPrompt`), and no `additionalContext` passthrough exists for it despite Claude Code's own `UserPromptSubmit` hook supporting that field.
+- `user_message` is documented as shown only when a submission is blocked (`continue: false`) — deny/blocking behavior is explicitly out of scope for this milestone, so it cannot carry injected context on the normal path either.
+
+**Consequence:** as specified, Cursor cannot deliver prompt-level context injection today — there is no output field to carry it. Per the same discipline M21 applied when Codex's hook schema turned out to have no Grep/Glob-equivalent event to scope augmentation to, this hook ships the plan's own accepted fallback instead: **diagnostics-only**. It performs the same lookup and logs what it would have injected, but never returns it to Cursor and never blocks prompt submission.
+
+### Installed config shape
+
+Unlike Claude Code (a JSON entry merged into `settings.json`) or Codex (a marker-delimited TOML block), this merges a single-entry array under a `hooks.beforeSubmitPrompt` key into `hooks.json` — a key structurally separate from `hooks.beforeReadFile`, so "never touches `beforeReadFile`" is a property of only ever writing under this one key, not something a shared matcher regex has to get right:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeSubmitPrompt": [
+      {
+        "command": "/path/to/venv/bin/python -m archex.integrations.cursor_hook",
+        "timeout": 1
+      }
+    ]
+  }
+}
+```
+
+Contract:
+
+- **Never wires anything to `beforeReadFile`, or any hook besides `beforeSubmitPrompt`.** The installer only ever reads and writes `hooks.beforeSubmitPrompt`; any other `hooks.*` key already present (including `beforeReadFile`) is left byte-for-byte untouched by both install and remove. `tests/cli/test_install_client_hooks.py`'s `test_write_hook_install_plan_cursor_config_assertion_never_wires_before_read_file` and `test_cli_hooks_cursor_installed_file_never_targets_before_read_file` assert this against both the in-memory plan and the file the CLI actually writes, seeded with a pre-existing `beforeReadFile` entry.
+- **Never returns context injection, and never blocks.** No code path in `archex.integrations.cursor_hook` ever sets anything but `{"continue": true}` — there is no field to carry injected context (see the confirmation spike above), and deny/blocking behavior is out of scope for this milestone regardless.
+- **Exits 0 on every path.** A missing/stale index, a malformed payload, a prompt with no identifier-like tokens, a timeout, or any internal error all degrade to no diagnostic (or a diagnostic-only log line) — never a blocked or errored prompt submission.
+- **Reuses `archex.integrations.hook`'s engine in-process.** `lookup_with_timeout`/`log_diagnostic` are called directly (no second subprocess spawned), so freshness/timeout/diagnostics semantics exactly match the Claude Code hook, appending to the same `~/.archex/hook-diagnostics.log` (override with `ARCHEX_HOOK_DIAGNOSTICS_LOG`).
+- **Query extraction picks a single strongest token, not the whole prompt.** `IndexStore.search_symbols` phrase-matches its entire query as one quoted FTS5 phrase, so passing a full natural-language sentence would require that exact word sequence to appear verbatim in the indexed content — true for a single Grep/Glob pattern fragment, never true for prose. `cursor_hook._extract_query` instead picks the single longest identifier-like token in the prompt as a heuristic stand-in for "the symbol the user is probably asking about."
+- **Prompt-level, not per-tool-call.** Every submitted prompt triggers a lookup attempt regardless of whether the agent is about to search for anything — there is no matcher-based scoping the way Grep/Glob-only hooks have, because `beforeSubmitPrompt` is not a per-tool event.
+- **Non-destructive install/uninstall.** Any other `hooks.json` content — other hook types, unrelated top-level keys — is left untouched by both `--hooks` and `--remove-hooks`. Re-running `--hooks` is an idempotent no-op once installed, even across a venv move (the command converges on the active `sys.executable` each time).
+
+Manual verification (bypassing Cursor entirely — this is exactly what the hook receives on stdin for a submitted prompt):
+
+```bash
+echo '{"prompt":"How does compute_delta handle renames?","attachments":[]}' \
+  | python -m archex.integrations.cursor_hook
+```
+
+Always exits 0 with `{"continue": true}` on stdout. A repo with a fresh index and a prompt containing a real identifier appends a `cursor_context_injection_unsupported` diagnostic line to the log describing the withheld match, instead of injecting it; a repo with no index, a stale index, or a prompt with no identifier-like tokens produces no diagnostic (or the same `index_not_fresh`/`status_error` diagnostic the Claude Code hook logs) and no injected context either way.

--- a/src/archex/cli/install_client_cmd.py
+++ b/src/archex/cli/install_client_cmd.py
@@ -53,9 +53,10 @@ from archex.client_setup import (
     help=(
         "Install the archex hook/plugin (opt-in, never installed without this "
         "flag). Augments grep/glob calls with archex context on claude-code, omp, "
-        "pi, opencode; on codex ships a diagnostics-only fallback (no Grep/Glob-"
-        "equivalent tool-call event exists there, so nothing is injected, only "
-        "logged)."
+        "pi, opencode; on codex and cursor ships a diagnostics-only fallback (no "
+        "Grep/Glob-equivalent tool-call event exists on codex, and cursor's "
+        "beforeSubmitPrompt hook has no context-injection output field at all, "
+        "so nothing is injected on either, only logged)."
     ),
 )
 @click.option(

--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -256,10 +256,37 @@ class CodexHookInstallPlan:
     block_content: str
 
 
+@dataclass(frozen=True)
+class CursorHookInstallPlan:
+    """Install or remove the Cursor ``beforeSubmitPrompt`` hook (M23; prompt-level).
+
+    Unlike the Claude Code hook (matcher-grouped entries under
+    ``hooks.PreToolUse``) or the Codex hook (a marker-delimited TOML block
+    appended to ``config.toml``), this merges a single-entry array under
+    ``hooks.beforeSubmitPrompt`` into a *separate* file, ``hooks.json`` —
+    Cursor's own hook config lives apart from ``mcp.json``. Because
+    ``beforeSubmitPrompt`` is its own top-level key, distinct from
+    ``hooks.beforeReadFile``, "never touches ``beforeReadFile``" is a
+    structural property of only ever writing under this one key, rather than
+    something a shared matcher regex has to get right. See
+    ``archex.integrations.cursor_hook`` for why this ships diagnostics-only
+    rather than context injection (Cursor's ``beforeSubmitPrompt`` output
+    schema has no context-injection field at all).
+    """
+
+    client: ClientName
+    scope: ClientScope
+    target_path: Path
+    action: HookAction
+    hook_entry: dict[str, object]
+
+
 #: Either hook install plan shape. ``install_client_cmd.py`` treats both
 #: uniformly; ``write_hook_install_plan``/``render_hook_install_preview``
 #: dispatch on the concrete type.
-HookInstallPlan = ClaudeCodeHookInstallPlan | TsHookInstallPlan | CodexHookInstallPlan
+HookInstallPlan = (
+    ClaudeCodeHookInstallPlan | TsHookInstallPlan | CodexHookInstallPlan | CursorHookInstallPlan
+)
 
 
 def build_hook_install_plan(
@@ -297,9 +324,18 @@ def build_hook_install_plan(
             action=action,
             block_content=_render_codex_hook_block(),
         )
+    if client == "cursor":
+        selected_scope = _resolve_hook_scope(source, scope)
+        return CursorHookInstallPlan(
+            client=client,
+            scope=selected_scope,
+            target_path=_cursor_hook_settings_path(repo_root, selected_scope),
+            action=action,
+            hook_entry=_render_cursor_hook_entry(),
+        )
     raise ValueError(
         "--hooks/--remove-hooks is only supported for claude-code (M19), omp, pi (M20), "
-        f"codex (M21), opencode (M22); got {client!r}"
+        f"codex (M21), opencode (M22), cursor (M23); got {client!r}"
     )
 
 
@@ -308,6 +344,8 @@ def write_hook_install_plan(plan: HookInstallPlan) -> Path:
         return _write_ts_hook_plan(plan)
     if isinstance(plan, CodexHookInstallPlan):
         return _write_codex_hook_plan(plan)
+    if isinstance(plan, CursorHookInstallPlan):
+        return _write_cursor_hook_plan(plan)
     target = plan.target_path
     existing = _read_json_object(target) if target.exists() else {}
     updated, changed = _apply_hook_action(existing, plan)
@@ -347,6 +385,8 @@ def render_hook_install_preview(plan: HookInstallPlan) -> str:
         return _render_ts_hook_preview(plan)
     if isinstance(plan, CodexHookInstallPlan):
         return _render_codex_hook_preview(plan)
+    if isinstance(plan, CursorHookInstallPlan):
+        return _render_cursor_hook_preview(plan)
     existing = _read_json_object(plan.target_path) if plan.target_path.exists() else {}
     updated, changed = _apply_hook_action(existing, plan)
     action_label = "Install" if plan.action == "install" else "Remove"
@@ -995,6 +1035,114 @@ def _apply_codex_hook_block(existing: str, plan: CodexHookInstallPlan) -> str:
     if not without_block.strip():
         return plan.block_content
     return without_block.rstrip("\n") + "\n\n" + plan.block_content
+
+
+#: Substring in a Cursor hook entry's ``command`` string that identifies it
+#: as archex-owned, so install/remove can find and replace our own entry
+#: without disturbing any other ``beforeSubmitPrompt`` hook the user has
+#: configured in the same file.
+_CURSOR_HOOK_COMMAND_MARKER = "archex.integrations.cursor_hook"
+
+
+def _cursor_hook_settings_path(repo_root: Path, scope: ClientScope) -> Path:
+    return (
+        repo_root / ".cursor" / "hooks.json"
+        if scope == "project"
+        else Path.home() / ".cursor" / "hooks.json"
+    )
+
+
+def _render_cursor_hook_entry() -> dict[str, object]:
+    return {
+        "command": f"{sys.executable} -m archex.integrations.cursor_hook",
+        "timeout": 1,
+    }
+
+
+def _is_archex_cursor_hook_entry(entry: object) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    command = cast("dict[str, object]", entry).get("command")
+    return isinstance(command, str) and _CURSOR_HOOK_COMMAND_MARKER in command
+
+
+def _apply_cursor_hook_action(
+    payload: dict[str, object], plan: CursorHookInstallPlan
+) -> tuple[dict[str, object], bool]:
+    """Return ``(updated_payload, changed)`` without mutating ``payload``.
+
+    Both install and remove start by stripping every archex-owned entry out
+    of ``hooks.beforeSubmitPrompt``, then install re-adds exactly one
+    canonical entry -- a second install (even after ``sys.executable``
+    changed, e.g. a venv move) converges on the same representation instead
+    of accumulating duplicates. This never reads or writes any other key
+    under ``hooks`` (in particular, never ``hooks.beforeReadFile``).
+    """
+    updated = copy.deepcopy(payload)
+    if plan.action == "install":
+        updated.setdefault("version", 1)
+    hooks_root_obj = updated.get("hooks")
+    if hooks_root_obj is None:
+        hooks_root: dict[str, object] = {}
+        updated["hooks"] = hooks_root
+    elif isinstance(hooks_root_obj, dict):
+        hooks_root = cast("dict[str, object]", hooks_root_obj)
+    else:
+        raise ValueError("expected object at 'hooks' in existing hooks.json")
+
+    before_submit_obj = hooks_root.get("beforeSubmitPrompt")
+    if before_submit_obj is None:
+        before_submit: list[object] = []
+    elif isinstance(before_submit_obj, list):
+        before_submit = cast("list[object]", before_submit_obj)
+    else:
+        raise ValueError("expected array at 'hooks.beforeSubmitPrompt' in existing hooks.json")
+
+    kept = [entry for entry in before_submit if not _is_archex_cursor_hook_entry(entry)]
+    merged = [*kept, plan.hook_entry] if plan.action == "install" else kept
+
+    if merged:
+        hooks_root["beforeSubmitPrompt"] = merged
+    else:
+        hooks_root.pop("beforeSubmitPrompt", None)
+    if not hooks_root:
+        updated.pop("hooks", None)
+
+    return updated, updated != payload
+
+
+def _write_cursor_hook_plan(plan: CursorHookInstallPlan) -> Path:
+    target = plan.target_path
+    existing = _read_json_object(target) if target.exists() else {}
+    updated, changed = _apply_cursor_hook_action(existing, plan)
+    if not changed:
+        return target
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(updated, indent=2) + "\n", encoding="utf-8")
+    return target
+
+
+def _render_cursor_hook_preview(plan: CursorHookInstallPlan) -> str:
+    existing = _read_json_object(plan.target_path) if plan.target_path.exists() else {}
+    updated, changed = _apply_cursor_hook_action(existing, plan)
+    action_label = "Install" if plan.action == "install" else "Remove"
+    lines = [
+        f"Client: {plan.client}",
+        f"Scope: {plan.scope}",
+        f"Target: {plan.target_path}",
+        f"Action: {action_label} beforeSubmitPrompt hook (prompt-level, diagnostics-only)",
+    ]
+    if not changed:
+        lines.append(
+            "No change: hook already in the requested state (idempotent no-op)."
+            if plan.action == "install"
+            else "No change: no archex hook is installed."
+        )
+    else:
+        lines.append("Dry run. Re-run without --dry-run to write this config.")
+    lines.append("")
+    lines.append(json.dumps(updated, indent=2))
+    return "\n".join(lines) + "\n"
 
 
 def _is_archex_hook_entry(entry: object) -> bool:

--- a/tests/cli/test_install_client_hooks.py
+++ b/tests/cli/test_install_client_hooks.py
@@ -6,12 +6,12 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
-import pytest
 from click.testing import CliRunner
 
 from archex.cli.main import cli
 from archex.client_setup import (
     CodexHookInstallPlan,
+    CursorHookInstallPlan,
     TsHookInstallPlan,
     build_hook_install_plan,
     render_hook_install_preview,
@@ -23,7 +23,7 @@ from archex.integrations.hook import HOOK_MATCHER
 if TYPE_CHECKING:
     from typing import Any
 
-    from archex.client_setup import ClientName
+    import pytest
 
 
 def _seed_payload() -> dict[str, Any]:
@@ -277,18 +277,6 @@ def test_render_hook_install_preview_remove_does_not_write(tmp_path: Path) -> No
 
     assert "Remove" in preview
     assert target.read_text(encoding="utf-8") == before
-
-
-@pytest.mark.parametrize("client", ["cursor"])
-def test_build_hook_install_plan_rejects_unsupported_clients(client: ClientName) -> None:
-    with pytest.raises(ValueError) as exc_info:
-        build_hook_install_plan(client, action="install")
-
-    message = str(exc_info.value)
-    assert "claude-code" in message
-    assert "M19" in message
-    assert "M21" in message
-    assert "M22" in message
 
 
 # --- omp TS hook module (M20) ---
@@ -916,6 +904,194 @@ def test_codex_hook_toml_block_bakes_in_active_python_interpreter(tmp_path: Path
     assert "-m archex.integrations.codex_hook" in plan.block_content
 
 
+# --- Cursor beforeSubmitPrompt hook (M23, diagnostics-only) ---
+#
+# Unlike claude-code (a JSON entry merged into settings.json) or omp/pi/
+# opencode (a standalone .ts module), Cursor's hook lives in its own
+# hooks.json -- a different file from mcp.json. See
+# `archex.integrations.cursor_hook` for why this hook is diagnostics-only
+# (Cursor's beforeSubmitPrompt output schema has no context-injection field
+# at all) rather than injecting context like the claude-code/omp/pi/opencode
+# hooks above.
+
+
+def test_build_hook_install_plan_cursor_project_scope_produces_expected_shape(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    plan = build_hook_install_plan("cursor", str(repo), scope="project", action="install")
+    target = write_hook_install_plan(plan)
+
+    assert isinstance(plan, CursorHookInstallPlan)
+    assert plan.scope == "project"
+    assert target == repo / ".cursor" / "hooks.json"
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload == {
+        "version": 1,
+        "hooks": {
+            "beforeSubmitPrompt": [
+                {
+                    "command": f"{sys.executable} -m archex.integrations.cursor_hook",
+                    "timeout": 1,
+                }
+            ]
+        },
+    }
+
+
+def test_build_hook_install_plan_cursor_user_scope_produces_expected_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    plan = build_hook_install_plan("cursor", action="install")
+    target = write_hook_install_plan(plan)
+
+    assert isinstance(plan, CursorHookInstallPlan)
+    assert plan.scope == "user"
+    assert target == tmp_path / ".cursor" / "hooks.json"
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    entry = payload["hooks"]["beforeSubmitPrompt"][0]
+    assert entry["command"] == f"{sys.executable} -m archex.integrations.cursor_hook"
+
+
+def test_write_hook_install_plan_cursor_idempotent_on_reinstall(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("cursor", str(repo), scope="project", action="install")
+    write_hook_install_plan(plan)
+    after_first = plan.target_path.read_text(encoding="utf-8")
+
+    write_hook_install_plan(plan)
+    after_second = plan.target_path.read_text(encoding="utf-8")
+
+    assert after_first == after_second
+
+
+def test_write_hook_install_plan_cursor_preserves_unrelated_content(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / ".cursor" / "hooks.json"
+    _write_json(
+        target,
+        {
+            "version": 1,
+            "hooks": {
+                "afterFileEdit": [{"command": "./hooks/format.sh"}],
+                "beforeSubmitPrompt": [{"command": "./hooks/audit.sh"}],
+            },
+        },
+    )
+    plan = build_hook_install_plan("cursor", str(repo), scope="project", action="install")
+
+    write_hook_install_plan(plan)
+
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["hooks"]["afterFileEdit"] == [{"command": "./hooks/format.sh"}]
+    before_submit = payload["hooks"]["beforeSubmitPrompt"]
+    assert {"command": "./hooks/audit.sh"} in before_submit
+    assert any("archex.integrations.cursor_hook" in e["command"] for e in before_submit)
+
+
+def test_write_hook_install_plan_cursor_config_assertion_never_wires_before_read_file(
+    tmp_path: Path,
+) -> None:
+    """M23 acceptance criterion: the installed config never wires anything to
+    `beforeReadFile`. Seeded with a pre-existing `beforeReadFile` entry to
+    prove install/remove never even reads that key, let alone writes to it.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / ".cursor" / "hooks.json"
+    seed = {
+        "version": 1,
+        "hooks": {"beforeReadFile": [{"command": "./hooks/gate-secrets.sh"}]},
+    }
+    _write_json(target, seed)
+    plan = build_hook_install_plan("cursor", str(repo), scope="project", action="install")
+
+    write_hook_install_plan(plan)
+
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["hooks"]["beforeReadFile"] == [{"command": "./hooks/gate-secrets.sh"}]
+    assert "archex.integrations.cursor_hook" not in json.dumps(payload["hooks"]["beforeReadFile"])
+    assert any(
+        "archex.integrations.cursor_hook" in entry["command"]
+        for entry in payload["hooks"]["beforeSubmitPrompt"]
+    )
+
+    remove_plan = build_hook_install_plan("cursor", str(repo), scope="project", action="remove")
+    write_hook_install_plan(remove_plan)
+
+    after_remove = json.loads(target.read_text(encoding="utf-8"))
+    assert after_remove["hooks"]["beforeReadFile"] == [{"command": "./hooks/gate-secrets.sh"}]
+    assert "beforeSubmitPrompt" not in after_remove["hooks"]
+
+
+def test_write_hook_install_plan_cursor_remove_leaves_bare_version_stamp(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    install_plan = build_hook_install_plan("cursor", str(repo), scope="project", action="install")
+    target = write_hook_install_plan(install_plan)
+    remove_plan = build_hook_install_plan("cursor", str(repo), scope="project", action="remove")
+
+    write_hook_install_plan(remove_plan)
+
+    assert json.loads(target.read_text(encoding="utf-8")) == {"version": 1}
+
+
+def test_write_hook_install_plan_cursor_remove_missing_file_is_noop(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("cursor", str(repo), scope="project", action="remove")
+
+    result_target = write_hook_install_plan(plan)
+
+    assert not result_target.exists()
+
+
+def test_write_hook_install_plan_cursor_remove_without_archex_entry_is_noop(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = repo / ".cursor" / "hooks.json"
+    seed = {"version": 1, "hooks": {"afterFileEdit": [{"command": "./hooks/format.sh"}]}}
+    _write_json(target, seed)
+    before = target.read_text(encoding="utf-8")
+    plan = build_hook_install_plan("cursor", str(repo), scope="project", action="remove")
+
+    write_hook_install_plan(plan)
+
+    assert target.read_text(encoding="utf-8") == before
+
+
+def test_render_hook_install_preview_cursor_install_does_not_write(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    plan = build_hook_install_plan("cursor", str(repo), scope="project", action="install")
+
+    preview = render_hook_install_preview(plan)
+
+    assert "Dry run." in preview
+    assert not plan.target_path.exists()
+
+
+def test_render_hook_install_preview_cursor_remove_does_not_write(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    install_plan = build_hook_install_plan("cursor", str(repo), scope="project", action="install")
+    write_hook_install_plan(install_plan)
+    before = install_plan.target_path.read_text(encoding="utf-8")
+    remove_plan = build_hook_install_plan("cursor", str(repo), scope="project", action="remove")
+
+    render_hook_install_preview(remove_plan)
+
+    assert install_plan.target_path.read_text(encoding="utf-8") == before
+
+
 # --- CLI wiring: install-client --hooks / --remove-hooks ---
 
 
@@ -968,20 +1144,6 @@ def test_cli_hooks_and_remove_hooks_are_mutually_exclusive(
     assert result.exit_code != 0
     assert "mutually exclusive" in result.output
     assert not (tmp_path / ".claude" / "settings.json").exists()
-
-
-def test_cli_hooks_rejects_unsupported_client_and_writes_nothing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
-
-    result = CliRunner().invoke(cli, ["install-client", "cursor", "--hooks"])
-
-    assert result.exit_code != 0
-    assert "claude-code" in result.output
-    assert "M19" in result.output
-    assert not (tmp_path / ".claude").exists()
-    assert not (tmp_path / ".cursor").exists()
 
 
 def test_cli_plain_install_client_still_writes_mcp_config_not_hook_settings(
@@ -1228,3 +1390,76 @@ def test_opencode_ts_hook_module_subagent_dispatch_reachability(tmp_path: Path) 
 
     assert "sessionID" not in handler_body
     assert "callID" not in handler_body
+
+
+# --- Cursor CLI wiring: install-client cursor --hooks (M23 PR-2) ---
+
+
+def test_cli_hooks_installs_cursor_and_exits_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = CliRunner().invoke(cli, ["install-client", "cursor", "--hooks"])
+
+    assert result.exit_code == 0, result.output
+    assert "Installed" in result.output
+    target = tmp_path / ".cursor" / "hooks.json"
+    assert target.exists()
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    entry = payload["hooks"]["beforeSubmitPrompt"][0]
+    assert "archex.integrations.cursor_hook" in entry["command"]
+
+
+def test_cli_hooks_cursor_dry_run_previews_without_writing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = CliRunner().invoke(cli, ["install-client", "cursor", "--hooks", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Dry run." in result.output
+    assert not (tmp_path / ".cursor" / "hooks.json").exists()
+
+
+def test_cli_remove_hooks_cursor_removes_and_exits_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    CliRunner().invoke(cli, ["install-client", "cursor", "--hooks"])
+    target = tmp_path / ".cursor" / "hooks.json"
+    assert target.exists()
+
+    result = CliRunner().invoke(cli, ["install-client", "cursor", "--remove-hooks"])
+
+    assert result.exit_code == 0, result.output
+    assert "Removed" in result.output
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert "beforeSubmitPrompt" not in payload.get("hooks", {})
+
+
+def test_cli_hooks_cursor_installed_file_never_targets_before_read_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """M23 acceptance criterion (config assertion), proven against the file
+    the CLI actually writes to disk: the installed hooks.json never wires
+    anything under `beforeReadFile`, even when one already existed.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    target = tmp_path / ".cursor" / "hooks.json"
+    _write_json(
+        target,
+        {"version": 1, "hooks": {"beforeReadFile": [{"command": "./hooks/gate-secrets.sh"}]}},
+    )
+
+    result = CliRunner().invoke(cli, ["install-client", "cursor", "--hooks"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["hooks"]["beforeReadFile"] == [{"command": "./hooks/gate-secrets.sh"}]
+    assert "archex.integrations.cursor_hook" not in json.dumps(payload["hooks"]["beforeReadFile"])
+    assert any(
+        "archex.integrations.cursor_hook" in entry["command"]
+        for entry in payload["hooks"]["beforeSubmitPrompt"]
+    )


### PR DESCRIPTION
## Stack

Position: 2/2 — depends on #445

1. #445 `feat/m23-cursor-hook-core` (merged basis — this PR is based on it)
2. `feat/m23-cursor-installer-docs` -> this PR

## Summary

M23 (Cursor hook integration, prompt-level) — installer integration + docs.

Wires `archex install-client cursor --hooks` / `--remove-hooks` to PR-1's diagnostics-only `beforeSubmitPrompt` hook, and documents the mechanism plainly.

## Changes

- `src/archex/client_setup.py`:
  - `CursorHookInstallPlan` dataclass + `HookInstallPlan` union member.
  - `_cursor_hook_settings_path`: `.cursor/hooks.json` (project) / `~/.cursor/hooks.json` (user) — a **different file** from `mcp.json`.
  - `_render_cursor_hook_entry`: `{"command": "<python> -m archex.integrations.cursor_hook", "timeout": 1}`.
  - `_apply_cursor_hook_action`: strip-then-merge exactly one archex-owned entry under `hooks.beforeSubmitPrompt` (identified by an `archex.integrations.cursor_hook` command-string marker). Because `beforeSubmitPrompt` is its own top-level `hooks.json` key, distinct from `hooks.beforeReadFile`, **"never touches `beforeReadFile`" is a structural property of only ever reading/writing this one key** — not something a shared matcher regex has to get right, unlike the Claude Code/Codex hooks.
  - `build_hook_install_plan`/`write_hook_install_plan`/`render_hook_install_preview` dispatch updated; the "unsupported client" error message now lists cursor (M23) alongside M19–M22.
- `src/archex/cli/install_client_cmd.py`: `--hooks` help text now mentions cursor's diagnostics-only fallback alongside codex's.
- `tests/cli/test_install_client_hooks.py`: cursor build/write/render coverage (installed shape at both scopes, idempotent reinstall, unrelated-content preservation, remove-to-bare-`{"version": 1}`, remove-without-entry no-op, dry-run previews that never write) plus the **acceptance-critical `beforeReadFile`-never-wired assertion** — seeded with a pre-existing `beforeReadFile` entry and checked across both install and remove, at both the plan level and the file the CLI actually writes. Drops the now-obsolete "cursor is unsupported" assertions (cursor was the last client without `--hooks`).
- `docs/CLIENT_COMPATIBILITY_MATRIX.md`: new matrix row + a full `## Cursor beforeSubmitPrompt hook (opt-in, diagnostics-only)` section recording the confirmation-spike finding, the installed config shape, the contract, and manual verification steps. States plainly this is **prompt-level context, not per-tool-call augmentation** — and that it never injects context at all, given the confirmed schema. Updates the Section G status line to mark M23 implemented.

## Verification

```
uv run pytest tests/integrations/test_hooks.py -k cursor -v      # 16 passed (PR-1, unchanged)
uv run pytest tests/cli/test_install_client_hooks.py -k cursor -v  # 14 passed
uv run pytest                                                       # 3603 passed, 4 deselected
uv run ruff check src/archex/                                       # OK
uv run ruff format --check src/archex/client_setup.py src/archex/cli/install_client_cmd.py tests/cli/test_install_client_hooks.py   # already formatted
uv run pyright                                                      # 0 errors
```

### Manual verification (fixture repo, bypassing Cursor entirely)

Hook invocation — exit 0, `{"continue": true}` on stdout, withheld match logged to diagnostics, never surfaced:

```
$ echo '{"prompt":"How does AuthService handle login?","attachments":[]}' | python -m archex.integrations.cursor_hook
{"continue": true}
$ echo $?
0
$ cat ~/.archex/hook-diagnostics.log
{"timestamp": "...", "kind": "cursor_context_injection_unsupported", "detail": "prompt lookup found archex matches, but Cursor's beforeSubmitPrompt hook has no context-injection output field to carry them (see docs/CLIENT_COMPATIBILITY_MATRIX.md); withheld: [archex receipt] index_revision=f5eba774f86b generated_at=...\narchex symbol matches for grep/glob pattern 'AuthService':\n- AuthService — src/auth_service.py:1-3\n- login — src/auth_service.py:2-3", "cwd": "/private/tmp/m23-fixture"}
```

Installer, against a fixture `.cursor/hooks.json` seeded with a pre-existing `beforeReadFile` entry:

```
$ archex install-client cursor <fixture> --hooks --scope project
Installed archex hook for cursor: <fixture>/.cursor/hooks.json
$ cat <fixture>/.cursor/hooks.json
{
  "version": 1,
  "hooks": {
    "beforeReadFile": [{"command": "./hooks/gate-secrets.sh"}],
    "beforeSubmitPrompt": [{"command": "<venv>/bin/python3 -m archex.integrations.cursor_hook", "timeout": 1}]
  }
}
$ archex install-client cursor <fixture> --remove-hooks --scope project
Removed archex hook for cursor (if present): <fixture>/.cursor/hooks.json
$ cat <fixture>/.cursor/hooks.json
{
  "version": 1,
  "hooks": {
    "beforeReadFile": [{"command": "./hooks/gate-secrets.sh"}]
  }
}
```

`beforeReadFile` byte-for-byte untouched through both install and remove.

Depends on: #445
Upstack: (none — leaf)
