### PR TITLE
feat(renderers): minimal-by-default JSON chunk output

### DIFF
--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -836,8 +836,12 @@ class ContextBundle(BaseModel):
     retrieval_metadata: RetrievalMetadata = RetrievalMetadata()
     receipt: ContextReceipt | None = None
 
-    def to_prompt(self, format: str = "xml") -> str:
-        """Render the context bundle as an LLM prompt string."""
+    def to_prompt(self, format: str = "xml", *, full: bool = False) -> str:
+        """Render the context bundle as an LLM prompt string.
+
+        `full` only affects `format="json"`: by default the JSON renderer
+        drops unset/empty chunk fields; `full=True` restores every field.
+        """
         from archex.serve.renderers.json import render_json
         from archex.serve.renderers.markdown import render_markdown
         from archex.serve.renderers.xml import render_xml
@@ -847,7 +851,7 @@ class ContextBundle(BaseModel):
         if format == "markdown":
             return render_markdown(self)
         if format == "json":
-            return render_json(self)
+            return render_json(self, full=full)
         raise ValueError(f"Unknown format: {format}")
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/archex/serve/renderers/json.py
+++ b/src/archex/serve/renderers/json.py
@@ -2,12 +2,67 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+from typing import TYPE_CHECKING, TypeAlias
 
 if TYPE_CHECKING:
+    from pydantic import BaseModel
+
     from archex.models import ContextBundle
 
+JsonValue: TypeAlias = "dict[str, JsonValue] | list[JsonValue] | str | int | float | bool | None"
 
-def render_json(bundle: ContextBundle) -> str:
-    """Render a ContextBundle as a JSON string."""
-    return bundle.model_dump_json(indent=2)
+# `CodeChunk`/`ScoutSymbol`-style fields that default to `None` when unset.
+# Safe to drop unconditionally: a real value is always truthy JSON, so
+# dropping only `None` never hides a meaningful falsy value (unlike, say,
+# `RankedChunk.structural_score`, which defaults to `0.0` — a real score,
+# not absence — and is intentionally excluded from this set).
+_OMIT_WHEN_NONE = frozenset(
+    {
+        "symbol_name",
+        "symbol_kind",
+        "symbol_id",
+        "qualified_name",
+        "visibility",
+        "signature",
+        "docstring",
+        "summary",
+    }
+)
+# Fields that default to `""` rather than `None` but carry the same
+# "unset" meaning (mirrors the truthy-check convention `render_xml` uses).
+_OMIT_WHEN_EMPTY = frozenset({"imports_context", "breadcrumbs"})
+
+
+def render_json(bundle: ContextBundle, *, full: bool = False) -> str:
+    """Render a ContextBundle as a JSON string.
+
+    By default, chunk/symbol fields that are unset (`None`) or empty
+    (`""`) are dropped to keep the bundle token-lean. Pass `full=True` to
+    restore the unfiltered dump (all fields present, `None` included).
+    """
+    if full:
+        return bundle.model_dump_json(indent=2)
+    return json.dumps(minimal_dump(bundle), indent=2)
+
+
+def minimal_dump(model: BaseModel, *, exclude: set[str] | None = None) -> JsonValue:
+    """Dump `model` to a JSON-shaped structure with noise fields stripped.
+
+    Shared by `render_json` and `archex.scout.render_scout`'s JSON branch
+    so both surfaces apply the same minimal-by-default field selection.
+    """
+    return _strip_noise(model.model_dump(mode="json", exclude=exclude))
+
+
+def _strip_noise(value: JsonValue) -> JsonValue:
+    if isinstance(value, dict):
+        return {
+            key: _strip_noise(val)
+            for key, val in value.items()
+            if not (key in _OMIT_WHEN_NONE and val is None)
+            and not (key in _OMIT_WHEN_EMPTY and val == "")
+        }
+    if isinstance(value, list):
+        return [_strip_noise(item) for item in value]
+    return value

--- a/tests/serve/test_renderers.py
+++ b/tests/serve/test_renderers.py
@@ -357,3 +357,128 @@ def test_json_uncompressed_row_has_null_compression() -> None:
     assert rows  # non-empty so the assertion below actually runs
     for item in rows:
         assert item["compression"] is None
+
+
+# ---------------------------------------------------------------------------
+# JSON renderer: minimal-by-default field selection (M1)
+# ---------------------------------------------------------------------------
+
+_NONE_VALUED_CHUNK_KEYS = (
+    "symbol_name",
+    "symbol_kind",
+    "symbol_id",
+    "qualified_name",
+    "visibility",
+    "signature",
+    "docstring",
+    "summary",
+)
+_EMPTY_STRING_CHUNK_KEYS = ("imports_context", "breadcrumbs")
+
+
+def _none_heavy_chunk() -> CodeChunk:
+    return CodeChunk(
+        id="c-none",
+        content="def run(): pass",
+        file_path="src/app.py",
+        start_line=1,
+        end_line=5,
+        language="python",
+        symbol_name=None,
+        symbol_kind=None,
+        symbol_id=None,
+        qualified_name=None,
+        visibility=None,
+        signature=None,
+        docstring=None,
+        summary=None,
+        imports_context="",
+        breadcrumbs="",
+    )
+
+
+def test_json_default_omits_none_and_empty_chunk_fields() -> None:
+    import json
+
+    bundle = _base_bundle(chunks=[_ranked(_none_heavy_chunk())])
+    data = json.loads(render_json(bundle))
+    chunk = data["chunks"][0]["chunk"]
+    for key in (*_NONE_VALUED_CHUNK_KEYS, *_EMPTY_STRING_CHUNK_KEYS):
+        assert key not in chunk, f"{key} should be omitted from minimal output"
+
+
+def test_json_full_restores_all_chunk_fields() -> None:
+    import json
+
+    bundle = _base_bundle(chunks=[_ranked(_none_heavy_chunk())])
+    data = json.loads(render_json(bundle, full=True))
+    chunk = data["chunks"][0]["chunk"]
+    for key in _NONE_VALUED_CHUNK_KEYS:
+        assert key in chunk
+        assert chunk[key] is None
+    for key in _EMPTY_STRING_CHUNK_KEYS:
+        assert chunk[key] == ""
+
+
+def test_json_default_keeps_populated_chunk_fields() -> None:
+    import json
+
+    populated = CodeChunk(
+        id="c-populated",
+        content="def run(): pass",
+        file_path="src/app.py",
+        start_line=1,
+        end_line=5,
+        language="python",
+        symbol_name="run",
+        symbol_kind=SymbolKind.FUNCTION,
+        symbol_id="src/app.py::run#function",
+        qualified_name="app.run",
+        visibility="public",
+        signature="def run() -> None",
+        docstring="Run the app.",
+        summary="Entry point.",
+        imports_context="import os",
+        breadcrumbs="app > run",
+    )
+    bundle = _base_bundle(chunks=[_ranked(populated)])
+    data = json.loads(render_json(bundle))
+    chunk = data["chunks"][0]["chunk"]
+    assert chunk["symbol_name"] == "run"
+    assert chunk["symbol_kind"] == "function"
+    assert chunk["symbol_id"] == "src/app.py::run#function"
+    assert chunk["qualified_name"] == "app.run"
+    assert chunk["visibility"] == "public"
+    assert chunk["signature"] == "def run() -> None"
+    assert chunk["docstring"] == "Run the app."
+    assert chunk["summary"] == "Entry point."
+    assert chunk["imports_context"] == "import os"
+    assert chunk["breadcrumbs"] == "app > run"
+
+
+def test_json_zero_score_ranked_chunk_present_in_default_and_full() -> None:
+    import json
+
+    zero_ranked = RankedChunk(
+        chunk=_none_heavy_chunk(),
+        relevance_score=0.0,
+        structural_score=0.0,
+        type_coverage_score=0.0,
+        cohesion_score=0.0,
+        final_score=0.0,
+    )
+    bundle = _base_bundle(chunks=[zero_ranked])
+
+    minimal = json.loads(render_json(bundle))["chunks"][0]
+    full = json.loads(render_json(bundle, full=True))["chunks"][0]
+    for payload in (minimal, full):
+        assert payload["relevance_score"] == 0.0
+        assert payload["structural_score"] == 0.0
+        assert payload["type_coverage_score"] == 0.0
+        assert payload["cohesion_score"] == 0.0
+        assert payload["final_score"] == 0.0
+
+
+def test_json_minimal_output_smaller_than_full_for_none_heavy_chunk() -> None:
+    bundle = _base_bundle(chunks=[_ranked(_none_heavy_chunk())])
+    assert len(render_json(bundle)) < len(render_json(bundle, full=True))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -546,6 +546,23 @@ def test_context_bundle_to_prompt_json() -> None:
     assert isinstance(parsed, dict)
 
 
+def test_context_bundle_to_prompt_json_full_flag_restores_none_fields() -> None:
+    """to_prompt('json', full=True) restores None-valued fields M1 hides by default."""
+    import json
+
+    bundle = _make_bundle("list modules")
+    minimal = json.loads(bundle.to_prompt(format="json"))
+    full = json.loads(bundle.to_prompt(format="json", full=True))
+    minimal_chunk = minimal["chunks"][0]["chunk"]
+    full_chunk = full["chunks"][0]["chunk"]
+    assert "qualified_name" not in minimal_chunk
+    assert full_chunk["qualified_name"] is None
+    # A populated field (symbol_name="fn", set by _make_bundle) must survive
+    # the minimal path unchanged -- only unset/empty fields are dropped.
+    assert minimal_chunk["symbol_name"] == "fn"
+    assert full_chunk["symbol_name"] == "fn"
+
+
 def test_context_bundle_to_prompt_unknown_format_raises() -> None:
     """to_prompt raises ValueError for unrecognised format."""
     import pytest as _pytest


### PR DESCRIPTION
## Summary

Part of stacked delivery for milestone M1 (Minimal-by-default JSON chunk output), `.docs/DEVELOPMENT_PLAN.md` §4 Section A.

`render_json` previously dumped `ContextBundle` verbatim (`bundle.model_dump_json(indent=2)`), including every `None`-valued `CodeChunk` field (`symbol_name`, `symbol_kind`, `symbol_id`, `qualified_name`, `visibility`, `signature`, `docstring`, `summary`) and empty-string field (`imports_context`, `breadcrumbs`) even when unset. This PR adds a shared field-selection helper that drops those fields by default while always keeping `RankedChunk`'s score fields (`structural_score`, `type_coverage_score`, `cohesion_score`, `relevance_score`, `final_score`) regardless of value, since `0.0` is a real score, not absence.

A new `full: bool = False` parameter on `render_json` and `ContextBundle.to_prompt` restores the previous unfiltered dump for callers that need every field.

## Scope

- `src/archex/serve/renderers/json.py`: `minimal_dump`/`_strip_noise` helper + `render_json(..., full: bool = False)`. Named `minimal_dump` (not `_minimal_dump`) so `scout.py` can import it in the follow-up PR without tripping `reportPrivateUsage` under `pyright --strict`.
- `src/archex/models.py`: `ContextBundle.to_prompt(format, *, full: bool = False)`.
- `render_xml`, `render_markdown`, and MCP tool output (`integrations/mcp.py` calls `render_xml` directly) are untouched.

## Stack

1. `feat/m1-minimal-json-renderer` -> this PR
2. `feat/m1-scout-cli-full-flag` -> depends on this PR (applies the same helper to `scout.py`'s JSON branch and adds `--full` to `archex query`/`archex scout`)

## Tests

- `tests/serve/test_renderers.py`: default-slim output omits unset/empty chunk fields; `full=True` restores them; zero-valued score fields stay present in both modes; minimal output is strictly smaller than full for a None-heavy chunk; a **populated** chunk (every field set to a real value) survives the minimal path unchanged (positive-path coverage, added after internal review flagged the gap).
- `tests/test_models.py`: `to_prompt(format="json", full=True)` restores fields hidden by default; a populated field (`symbol_name`) survives the minimal path.

## Verification

- `uv run pytest tests/serve/test_renderers.py tests/test_models.py --no-cov` — pass
- `uv run pytest --junitxml=results.xml --cov-report=xml` (full suite) — 3614 passed, coverage 91.09% (gate 85%)
- `uv run ruff check .` / `uv run ruff format --check .` — clean
- `uv run pyright src/archex tests` — 0 errors

## Review history

Ran three internal review passes (per-PR + cumulative stack) before opening. Findings and resolutions:
- Coverage gap: no test proved a *populated* field survives the minimal path (only None/zero-score fixtures were tested) — fixed by adding `test_json_default_keeps_populated_chunk_fields` and a positive assertion in `test_context_bundle_to_prompt_json_full_flag_restores_none_fields`.
- `pyright --strict` flagged the original `_minimal_dump` name as `reportPrivateUsage` once PR #452 imports it cross-module — renamed to `minimal_dump`.
