### PR TITLE
feat(cli): apply minimal JSON output to scout, add --full flag

### DIFF
--- a/src/archex/cli/query_cmd.py
+++ b/src/archex/cli/query_cmd.py
@@ -38,6 +38,12 @@ logger = logging.getLogger(__name__)
     type=click.Choice(["xml", "json", "markdown"]),
     help="Output format.",
 )
+@click.option(
+    "--full",
+    is_flag=True,
+    default=False,
+    help="Restore the unfiltered --format json dump (all chunk fields, including None/empty).",
+)
 @click.option("-l", "--language", multiple=True, help="Filter to specific languages.")
 @click.option(
     "--strategy",
@@ -76,6 +82,7 @@ def query_cmd(
     args: tuple[str, ...],
     budget: int | None,
     output_format: str,
+    full: bool,
     language: tuple[str, ...],
     strategy: str | None,
     timing: bool,
@@ -123,7 +130,7 @@ def query_cmd(
     except ArchexError as exc:
         raise click.ClickException(str(exc)) from exc
 
-    click.echo(bundle.to_prompt(format=output_format))
+    click.echo(bundle.to_prompt(format=output_format, full=full))
 
     unique_files = list({c.chunk.file_path for c in bundle.chunks})
     raw_tokens: int | None = None

--- a/src/archex/cli/scout_cmd.py
+++ b/src/archex/cli/scout_cmd.py
@@ -39,6 +39,12 @@ if TYPE_CHECKING:
     help="Output format.",
 )
 @click.option(
+    "--full",
+    is_flag=True,
+    default=False,
+    help="Restore the unfiltered --format json dump (all fields, including None/empty).",
+)
+@click.option(
     "--no-refresh",
     is_flag=True,
     default=False,
@@ -48,6 +54,7 @@ def scout_cmd(
     args: tuple[str, ...],
     budget: int,
     output_format: ScoutFormat,
+    full: bool,
     no_refresh: bool,
 ) -> None:
     """Return a compact no-body structural map for a repository question."""
@@ -63,7 +70,7 @@ def scout_cmd(
         )
     except (ArchexError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc
-    rendered = render_scout(result, output_format=output_format)
+    rendered = render_scout(result, output_format=output_format, full=full)
     click.echo(rendered, nl=False)
     _record_metrics(repo_source, result, rendered)
 

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -201,7 +201,10 @@ def handle_scout_repo(
         output_format=output_format,
         timing=pt,
     )
-    rendered = render_scout(result, output_format=output_format, include_receipt=False)
+    # M1 narrowed render_scout's default to a minimal JSON dump; the MCP
+    # surface is explicitly out of scope for that change, so pin full=True
+    # to keep this tool's response shape unchanged.
+    rendered = render_scout(result, output_format=output_format, include_receipt=False, full=True)
     content = json.loads(rendered) if output_format == "json" else rendered
     raw = get_repo_total_tokens(source)
     meta = compute_meta(

--- a/src/archex/scout.py
+++ b/src/archex/scout.py
@@ -12,6 +12,7 @@ from archex.graph_query import GraphQuery, GraphQueryError
 from archex.models import CodeChunk, ContextReceipt, Module, RankedChunk, SymbolKind
 from archex.reporting import count_tokens
 from archex.serve.intent import QueryIntent, classify_intent
+from archex.serve.renderers.json import minimal_dump
 
 if TYPE_CHECKING:
     from archex.index.store import IndexStore
@@ -345,14 +346,16 @@ def render_scout(
     *,
     output_format: ScoutFormat = "markdown",
     include_receipt: bool = True,
+    full: bool = False,
 ) -> str:
     if output_format == "json":
         exclude = None if include_receipt else {"receipt"}
-        rendered = json.dumps(
-            result.model_dump(mode="json", exclude=exclude),
-            indent=2,
-            sort_keys=True,
+        data = (
+            result.model_dump(mode="json", exclude=exclude)
+            if full
+            else minimal_dump(result, exclude=exclude)
         )
+        rendered = json.dumps(data, indent=2, sort_keys=True)
         return f"{rendered}\n"
     if output_format == "markdown":
         return _render_markdown(result, include_receipt=include_receipt)
@@ -411,12 +414,18 @@ def _scout_shape(
 
 
 def _stable_rendered_token_count(result: ScoutResult, *, output_format: ScoutFormat) -> int:
+    # Always measure the unfiltered (full=True) render, never the minimal
+    # default: `_strip_noise` only ever removes keys, so a minimal render is
+    # provably <= the full render in token count for the same ScoutResult.
+    # Sizing against the worst case guarantees the trimmed result fits the
+    # requested budget regardless of which mode `render_scout` is finally
+    # called with (default minimal, or `--full`).
     for _ in range(4):
-        token_count = count_tokens(render_scout(result, output_format=output_format))
+        token_count = count_tokens(render_scout(result, output_format=output_format, full=True))
         if token_count == result.budget.token_count:
             return token_count
         result.budget.token_count = token_count
-    return count_tokens(render_scout(result, output_format=output_format))
+    return count_tokens(render_scout(result, output_format=output_format, full=True))
 
 
 def _rank_files(

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -391,6 +391,40 @@ class TestHandleScoutRepo:
         assert "receipt" not in parsed["content"]
         assert parsed["receipt"]["index_revision"] == "rev"
 
+    def test_scout_json_always_uses_full_dump_regardless_of_m1_default(self) -> None:
+        """M1 narrowed render_scout's default JSON dump; the MCP scout_repo tool
+        must keep its pre-M1 contract (every field present, `None` included)."""
+        from archex.models import SymbolKind
+        from archex.scout import ScoutBudget, ScoutResult, ScoutSymbol, chunk_handle, file_handle
+
+        result_model = ScoutResult(
+            query="delta indexing",
+            symbols=[
+                ScoutSymbol(
+                    name="run",
+                    kind=SymbolKind.FUNCTION,
+                    file_path="src/app.py",
+                    start_line=1,
+                    end_line=2,
+                    chunk_id="c1",
+                    file_handle=file_handle("src/app.py"),
+                    chunk_handle=chunk_handle("c1"),
+                )
+            ],
+            budget=ScoutBudget(token_budget=120),
+        )
+        with (
+            patch("archex.integrations.mcp.scout", return_value=result_model),
+            patch("archex.integrations.mcp.get_repo_total_tokens", return_value=1000),
+        ):
+            output = handle_scout_repo("/fake/repo", "delta indexing", output_format="json")
+
+        parsed = json.loads(output)
+        symbol = parsed["content"]["symbols"][0]
+        assert symbol["signature"] is None
+        assert symbol["visibility"] is None
+        assert symbol["symbol_id"] is None
+
 
 class TestHandleCompareRepos:
     def test_returns_json_with_meta(self) -> None:

--- a/tests/metrics/test_instrumentation.py
+++ b/tests/metrics/test_instrumentation.py
@@ -29,7 +29,7 @@ class FakeBundle:
     receipt = None
     retrieval_metadata = SimpleNamespace(seed_file_paths=[], expanded_file_paths=[])
 
-    def to_prompt(self, format: str = "xml") -> str:
+    def to_prompt(self, format: str = "xml", *, full: bool = False) -> str:
         return "FAKE CONTEXT"
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -438,7 +438,7 @@ def test_query_command_defaults_source_to_cwd(
         chunks: list[object] = []
         token_count = 0
 
-        def to_prompt(self, *, format: str) -> str:
+        def to_prompt(self, *, format: str, full: bool = False) -> str:
             return f"format={format}"
 
     init_project(python_simple_repo)
@@ -462,7 +462,7 @@ def test_query_command_no_refresh_disables_inline_refresh(
         chunks: list[object] = []
         token_count = 0
 
-        def to_prompt(self, *, format: str) -> str:
+        def to_prompt(self, *, format: str, full: bool = False) -> str:
             return f"format={format}"
 
     runner = CliRunner()
@@ -484,7 +484,7 @@ def test_query_command_allow_remote_code_flag_enables_policy(
         chunks: list[object] = []
         token_count = 0
 
-        def to_prompt(self, *, format: str) -> str:
+        def to_prompt(self, *, format: str, full: bool = False) -> str:
             return f"format={format}"
 
     runner = CliRunner()
@@ -600,7 +600,7 @@ def test_query_uses_project_config_when_cli_args_omitted(python_simple_repo: Pat
         chunks: list[object] = []
         token_count = 0
 
-        def to_prompt(self, *, format: str) -> str:
+        def to_prompt(self, *, format: str, full: bool = False) -> str:
             return f"format={format}"
 
     init_project(python_simple_repo)
@@ -632,7 +632,7 @@ def test_query_budget_flag_overrides_intent_routing(python_simple_repo: Path) ->
         chunks: list[object] = []
         token_count = 0
 
-        def to_prompt(self, *, format: str) -> str:
+        def to_prompt(self, *, format: str, full: bool = False) -> str:
             return f"format={format}"
 
     init_project(python_simple_repo)
@@ -656,7 +656,7 @@ def test_query_cli_options_override_project_config(python_simple_repo: Path) -> 
         chunks: list[object] = []
         token_count = 0
 
-        def to_prompt(self, *, format: str) -> str:
+        def to_prompt(self, *, format: str, full: bool = False) -> str:
             return f"format={format}"
 
     init_project(python_simple_repo)

--- a/tests/test_scout.py
+++ b/tests/test_scout.py
@@ -589,3 +589,80 @@ def test_scout_explicit_file_limit_overrides_intent_classification(tmp_path: Pat
     assert len(result.ranked_files) == 3
     assert result.budget.truncated is False
     assert result.budget.omitted_files == 3
+
+
+# ---------------------------------------------------------------------------
+# render_scout JSON: minimal-by-default field selection (M1)
+# ---------------------------------------------------------------------------
+
+
+def _scout_result_with_none_symbol_fields() -> ScoutResult:
+    from archex.scout import ScoutBudget, ScoutSymbol
+
+    return ScoutResult(
+        query="q",
+        symbols=[
+            ScoutSymbol(
+                name="run",
+                kind=SymbolKind.FUNCTION,
+                file_path="src/app.py",
+                start_line=1,
+                end_line=2,
+                chunk_id="c1",
+                file_handle=file_handle("src/app.py"),
+                chunk_handle=chunk_handle("c1"),
+            )
+        ],
+        budget=ScoutBudget(token_budget=500),
+    )
+
+
+def test_render_scout_json_default_omits_none_symbol_fields() -> None:
+    import json
+
+    result = _scout_result_with_none_symbol_fields()
+    data = json.loads(render_scout(result, output_format="json"))
+    symbol = data["symbols"][0]
+    for key in ("signature", "visibility", "symbol_id"):
+        assert key not in symbol, f"{key} should be omitted from minimal scout output"
+    # `symbol_handle` isn't in M1's targeted field set; it stays present.
+    assert symbol["symbol_handle"] is None
+    assert symbol["score"] == 0.0
+
+
+def test_render_scout_json_full_restores_none_symbol_fields() -> None:
+    import json
+
+    result = _scout_result_with_none_symbol_fields()
+    data = json.loads(render_scout(result, output_format="json", full=True))
+    symbol = data["symbols"][0]
+    assert symbol["signature"] is None
+    assert symbol["visibility"] is None
+    assert symbol["symbol_id"] is None
+    assert symbol["symbol_handle"] is None
+
+
+def test_render_scout_json_minimal_smaller_than_full() -> None:
+    result = _scout_result_with_none_symbol_fields()
+    minimal = render_scout(result, output_format="json")
+    full = render_scout(result, output_format="json", full=True)
+    assert len(minimal) < len(full)
+
+
+def test_scout_json_budget_fitting_accounts_for_full_render(tmp_path: Path) -> None:
+    """Budget-fitting must size against the worst-case (full) render, since a
+    caller can request `--full` after the trim loop already picked an item
+    count; otherwise `full=True` output could silently exceed the budget."""
+    with _populate_store(tmp_path / "index.db") as store:
+        result = assemble_scout_from_store(
+            store,
+            "how does app loading work",
+            token_budget=300,
+            output_format="json",
+        )
+
+    minimal = render_scout(result, output_format="json")
+    full = render_scout(result, output_format="json", full=True)
+
+    assert count_tokens(minimal) <= 300
+    assert count_tokens(full) <= 300


### PR DESCRIPTION
## Summary

Part of stacked delivery for milestone M1 (Minimal-by-default JSON chunk output), `.docs/DEVELOPMENT_PLAN.md` §4 Section A. Second (leaf) PR in the stack, based on #451.

Applies #451's `minimal_dump` helper to `scout.py`'s `render_scout` JSON branch, and adds a `--full` flag to both `archex query` and `archex scout` so callers can opt back into the unfiltered dump.

## Scope

- `src/archex/scout.py`: `render_scout(..., full: bool = False)` — default now calls `minimal_dump`, `full=True` restores the previous `result.model_dump(mode="json", exclude=exclude)`. Also fixes the internal token-budget-fitting loop (see "Review history" below).
- `src/archex/cli/query_cmd.py` / `src/archex/cli/scout_cmd.py`: new `--full` flag, wired through to `to_prompt`/`render_scout`.
- `src/archex/integrations/mcp.py`: pin `full=True` in the `scout_repo` MCP tool (see "Review history").
- `tests/test_cli.py`, `tests/metrics/test_instrumentation.py`: update `FakeBundle.to_prompt` test doubles to accept the new keyword argument (required since `query_cmd` now always passes `full=`).

## Tests

- `tests/test_scout.py`: default JSON output omits unset symbol fields (`signature`, `visibility`, `symbol_id`); `full=True` restores them; minimal output is strictly smaller than full; both minimal and full renders respect a tight `--budget` (regression test for the budget-fitting fix below).
- `tests/integrations/test_mcp.py`: `scout_repo`'s JSON response keeps `None`-valued symbol fields present (regression test for the MCP contract-preservation fix below).

## Verification

- `uv run pytest tests/serve/test_renderers.py tests/test_scout.py tests/test_models.py tests/integrations/test_mcp.py --no-cov` — 194 passed
- `uv run pytest --junitxml=results.xml --cov-report=xml` (full suite) — 3614 passed, coverage 91.09% (gate 85%)
- `uv run ruff check .` / `uv run ruff format --check .` — clean
- `uv run pyright src/archex tests` — 0 errors

Manual smoke (this repo's own index):

```
$ archex query "authentication" --format json | wc -c
46229
$ archex query "authentication" --format json --full | wc -c
48913
```

Both parse via `json.loads`. Dropped chunk fields on this repo's data: `breadcrumbs`, `docstring`, `imports_context`, `qualified_name`, `signature`, `summary`, `symbol_kind`, `symbol_name`.

## Review history

Ran three internal review passes (per-PR + cumulative stack diff) before opening, using this repo's own data plus targeted fixtures. Two blocking findings, both fixed in the `feat(scout)` commit:

1. **MCP `scout_repo` contract silently changed.** `handle_scout_repo` (`integrations/mcp.py`) calls `render_scout`'s JSON branch directly with no `full`/unfiltered opt-out exposed on its own tool surface — unlike `handle_query_repo`, which always goes through `render_xml` and was correctly identified as out of scope. `render_scout`'s new default therefore silently dropped fields from MCP responses. Fixed by pinning `full=True` at that one call site, preserving the pre-M1 MCP contract exactly, plus a regression test.
2. **`--full` could silently exceed `--budget`.** The internal token-budget trimming loop (`enforce_scout_token_budget` / `_stable_rendered_token_count`) always measured against the minimal render. Since minimal <= full in size, a caller requesting `--full` after trimming converged on a minimal-sized estimate could get an unfiltered payload that exceeds the requested budget with no error. Fixed by always sizing the trim loop against the full (worst-case) render — safe for either final render mode since minimal is provably <= full — plus a regression test with a tight budget exercised against both render modes.

`archex scout "authentication" --format json` / `--full` were also smoke-tested end-to-end (both valid JSON, exit 0); the two outputs happened to be byte-identical for that specific query because none of this repo's real symbols currently have unset `signature`/`visibility`/`symbol_id` — the field-drop mechanism itself, and the two fixes above, are proven by the new unit/regression tests using fixtures with unset fields and a tight budget.

Closes the M1 milestone. Cumulative stack diff (#451 + this PR) satisfies all 4 DEVELOPMENT_PLAN.md M1 acceptance criteria.
