### PR TITLE
feat(renderers): add optional TOON output renderer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,8 @@ mcp = ["mcp>=1.0"]
 langchain = ["langchain-core>=0.2"]
 llamaindex = ["llama-index-core>=0.10"]
 lsap = ["lsp-client>=0.3; python_version >= '3.12'"]
-all = ["archex[vector-fast,graph,vector-torch,splade,mcp,langchain,llamaindex,lsap]"]
+toon = ["toons>=0.7.0"]
+all = ["archex[vector-fast,graph,vector-torch,splade,mcp,langchain,llamaindex,lsap,toon]"]
 
 [project.scripts]
 archex = "archex.cli.main:cli"

--- a/src/archex/serve/renderers/__init__.py
+++ b/src/archex/serve/renderers/__init__.py
@@ -1,9 +1,26 @@
-"""Renderers package: XML, JSON, and Markdown output formatters."""
+"""Renderers package: XML, JSON, Markdown, and (optional) TOON output formatters."""
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from archex.serve.renderers.json import render_json
 from archex.serve.renderers.markdown import render_markdown
 from archex.serve.renderers.xml import render_xml
 
-__all__ = ["render_json", "render_markdown", "render_xml"]
+if TYPE_CHECKING:
+    from archex.serve.renderers.toon import render_toon as render_toon
+
+__all__ = ["render_json", "render_markdown", "render_toon", "render_xml"]
+
+
+def __getattr__(name: str) -> object:
+    """Lazily import `render_toon` so the optional `toons` dependency is
+    only required when this attribute is actually accessed, keeping the
+    package import (and thus every other renderer) extras-independent.
+    """
+    if name == "render_toon":
+        from archex.serve.renderers.toon import render_toon
+
+        return render_toon
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/archex/serve/renderers/toon.py
+++ b/src/archex/serve/renderers/toon.py
@@ -1,0 +1,30 @@
+"""TOON renderer: serialize ContextBundle to Token-Oriented Object Notation.
+
+Requires the optional ``toons`` package (Rust/PyO3, TOON spec v3.0):
+``uv add 'archex[toon]'``. This module is only imported when
+``--format toon`` is requested, so the core install is unaffected.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import toons
+
+from archex.serve.renderers.json import minimal_dump
+
+if TYPE_CHECKING:
+    from archex.models import ContextBundle
+
+
+def render_toon(bundle: ContextBundle, *, full: bool = False) -> str:
+    """Render a ContextBundle as a TOON string.
+
+    Reuses `render_json`'s minimal-by-default field selection (M1): by
+    default, chunk/symbol fields that are unset (`None`) or empty (`""`)
+    are dropped to keep the bundle token-lean. Pass `full=True` to
+    restore the unfiltered dump (all fields present, `None` included).
+    """
+    if full:
+        return toons.dumps(bundle.model_dump(mode="json"))
+    return toons.dumps(minimal_dump(bundle))

--- a/uv.lock
+++ b/uv.lock
@@ -208,6 +208,7 @@ all = [
     { name = "mcp" },
     { name = "python-igraph" },
     { name = "sentence-transformers" },
+    { name = "toons" },
     { name = "torch" },
     { name = "transformers" },
 ]
@@ -230,6 +231,9 @@ mcp = [
 splade = [
     { name = "torch" },
     { name = "transformers" },
+]
+toon = [
+    { name = "toons" },
 ]
 vector-fast = [
     { name = "fastembed" },
@@ -255,7 +259,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "archex", extras = ["vector-fast", "graph", "vector-torch", "splade", "mcp", "langchain", "llamaindex", "lsap"], marker = "extra == 'all'" },
+    { name = "archex", extras = ["vector-fast", "graph", "vector-torch", "splade", "mcp", "langchain", "llamaindex", "lsap", "toon"], marker = "extra == 'all'" },
     { name = "click", specifier = ">=8.1" },
     { name = "fastembed", marker = "extra == 'vector-fast'", specifier = ">=0.4" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=0.2" },
@@ -272,6 +276,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.11.2" },
     { name = "sentence-transformers", marker = "extra == 'vector-torch'", specifier = ">=5.2,<6" },
     { name = "tiktoken", specifier = ">=0.7" },
+    { name = "toons", marker = "extra == 'toon'", specifier = ">=0.7.0" },
     { name = "torch", marker = "extra == 'splade'", specifier = ">=2.0" },
     { name = "transformers", marker = "extra == 'splade'", specifier = ">=4.41,<5" },
     { name = "transformers", marker = "extra == 'vector-torch'", specifier = ">=4.41,<5" },
@@ -287,7 +292,7 @@ requires-dist = [
     { name = "tree-sitter-typescript", specifier = ">=0.23" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
-provides-extras = ["vector-fast", "graph", "vector-torch", "splade", "mcp", "langchain", "llamaindex", "lsap", "all"]
+provides-extras = ["vector-fast", "graph", "vector-torch", "splade", "mcp", "langchain", "llamaindex", "lsap", "toon", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3492,6 +3497,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504 },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561 },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477 },
+]
+
+[[package]]
+name = "toons"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/23/1d9a6fdc56dccf9c7d22377618adff8d25a12a9214a8fab5c8286e50c527/toons-0.7.0.tar.gz", hash = "sha256:d196a29319bf4ec1481d1f06a05017b859652d112a52eb7071d33c6da28b8193", size = 234510 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/23/b45ad15a8eb21a9109e7fe9bbd04e005b4ea8c35b9dea98023f1a585baeb/toons-0.7.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:08f380080e3a54ad53ed6baa1eaa35d4767a7e31436bd05af97b3cc00a6936b5", size = 304442 },
+    { url = "https://files.pythonhosted.org/packages/41/36/dff71444f52f82031c8f4a86f2a212d8d7bdb05e00f8559144e6ff3b31b7/toons-0.7.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30bb78650744dfe53a080d683e5b55c3e90fa24d8f1713bb4237d66282e92d9c", size = 300813 },
+    { url = "https://files.pythonhosted.org/packages/19/93/7d5162a15f46ddc794f16aeb0eb8b12e39d02c6a585b13ff2425b8758970/toons-0.7.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b28eb732f13b1909eb0ac9d32f4e39b6f279081fdaf24f0bce320dbf4cde015f", size = 332617 },
+    { url = "https://files.pythonhosted.org/packages/fe/24/806d3b3c9d86ca202a858d5dcaa862616cd3ee5e52cf9507b2fe6e3acb4f/toons-0.7.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5468da364bbb3eadd860495148b035f74f9e51b3c83ed8ea9f761938b2a602d1", size = 340984 },
+    { url = "https://files.pythonhosted.org/packages/ee/ff/de05d3bbe0c8b860c71d4d025b6306ee66a988efc1bcd3fe43a419cb717a/toons-0.7.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1bb17238ac0853b92f01452c1cf438157b0b4d602ec2e2c9f425ee57cd81a41b", size = 508422 },
+    { url = "https://files.pythonhosted.org/packages/7b/7b/ecefbc3fd2d89a8240c347bcc81bd19fb821c9b141c3ec3479ce0c9e5af4/toons-0.7.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:637994ae2e58782a35d0c5ab0b16c802624c3e6850da41250ba3c953118bce49", size = 543302 },
+    { url = "https://files.pythonhosted.org/packages/27/a6/948b6b2639849d488a6f4310c8f9abb3486250d130e467e758f9ce79b0b2/toons-0.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b987602c142b945745b2379b8079171fd6d928b4edd6e2162a3f735db6ca73d7", size = 196411 },
+    { url = "https://files.pythonhosted.org/packages/4c/4f/4b627ec63f45cafd071b449678567ca57342715dff797159dc34b6e91fa4/toons-0.7.0-cp314-cp314t-win_arm64.whl", hash = "sha256:cac4faa2f3f8da96bc13ccad8cf554f82810f681b02ea27d0a4f79bed3e7ac83", size = 190350 },
+    { url = "https://files.pythonhosted.org/packages/bc/43/2d4d6cd43635130154a57fd45cee8494fd66c4ae73d0d9c17331ebf30637/toons-0.7.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7933216d41175af1747d4475ae2f947178ac45fd7f8b839a5bcbda57b5c99301", size = 312469 },
+    { url = "https://files.pythonhosted.org/packages/97/e6/cd600e0461cc9e7b74d8723e010da92efe90136350d9835af1a9f10bfa0e/toons-0.7.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:10681fd930ee555df213fe0a19675ddd1095f4291999ab507adb0833fa01e47d", size = 308194 },
+    { url = "https://files.pythonhosted.org/packages/fd/e5/032c014b33cf954ef502326de78466e6ce440f3419b6c9d54721a895936a/toons-0.7.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b45b0a429c22e3b0e7f658d8cbfeb03b1ab4798b2323c7c119fe5029fdaaf1c", size = 339568 },
+    { url = "https://files.pythonhosted.org/packages/41/39/6e3c0752b7a1f693fb7082ecc5d3757884537a102d2c846a5a24d7de4b47/toons-0.7.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18fd8f455c2bfa6655c4eaf931dd8e321be0b53a4f2acbc91e77f72843a0f7b9", size = 348803 },
+    { url = "https://files.pythonhosted.org/packages/5d/bd/d495738cc5e1c201a864a75b0520fdb74fcd2a8c631a61efc993fb8f992f/toons-0.7.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7e92ed900fee3a7db0467573bba29c876a1701827836b895d13891a3f5d04567", size = 516042 },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/bb5f09db2100631bef2ab39545611958545f6ef3b7d0f56d85af341fd0f8/toons-0.7.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:611d3db35614ec8f5f7c00accb38787c4db0e34f98bdbc0746e196cab32d45ba", size = 551947 },
+    { url = "https://files.pythonhosted.org/packages/65/fa/43f86b3862448159ca6434942822aa31dec02b848967474e94cc1f568154/toons-0.7.0-cp37-abi3-win_amd64.whl", hash = "sha256:56c79eb7e3a9155a564f5ca1fe10f2a93e0e534c82bc9d7c7c047267e472a2f5", size = 202369 },
+    { url = "https://files.pythonhosted.org/packages/04/9e/bfa4d07d215ea248818b85bc1bec8664eec1728e0704c773a252c4ac7d82/toons-0.7.0-cp37-abi3-win_arm64.whl", hash = "sha256:b1f53e0c9f40439f426050050f34a1e8b495ff4f702bfa460142929ad7e08c8c", size = 196225 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

PR-1 of the M2 (Optional TOON output format) stack. Adds `render_toon` and the `toon` optional extra. No CLI wiring yet (PR-2) and no dedicated tests yet (PR-3) — this PR only introduces the renderer and its dependency, both unreachable from any code path today.

## Stack

1. `feat/m2-toon-renderer` -> this PR
2. `feat/m2-toon-cli-wiring` -> depends on this PR
3. `feat/m2-toon-tests` -> depends on PR-2

Base: `main` (M1 already merged — #450, #451, #452)

## Changes

- `src/archex/serve/renderers/toon.py`: new `render_toon(bundle, *, full=False)` built on the `toons` package (Rust/PyO3, TOON spec v3.0) and M1's `minimal_dump` field-selection helper, so the same null/empty-field stripping applies to both JSON and TOON.
- `src/archex/serve/renderers/__init__.py`: exports `render_toon` via a module-level `__getattr__` (PEP 562) instead of an eager import, so importing the renderers package — which every existing renderer already does implicitly — never requires the `toons` package to be installed.
- `pyproject.toml`: new `toon = ["toons>=0.7.0"]` optional extra, appended to `all`.

## Why the lazy `__getattr__` in `__init__.py`

Every submodule import (e.g. `from archex.serve.renderers.json import render_json`) runs the parent package's `__init__.py` first. An eager `from archex.serve.renderers.toon import render_toon` at the top of `__init__.py` would therefore break every existing renderer call site — including the `smoke-min-install` CI job — on a core install without the `toon` extra. The `__getattr__` hook defers the `import toons` until something actually accesses `archex.serve.renderers.render_toon`.

## Verification

- `uv sync --all-extras` — `toons==0.7.0` installs from a prebuilt `cp37-abi3` wheel (covers Python 3.11–3.13 on Linux/macOS/Windows; verified via the PyPI JSON API before pinning).
- Manual smoke test: `render_toon` on a representative `ContextBundle` produces valid TOON text in both minimal and `full=True` modes (tabular chunk arrays, `null` handling, nested objects all render correctly).
- `uv run ruff check .` / `uv run ruff format --check .` — clean.
- `uv run pyright src/archex tests` — 0 errors (`uv run pyright .` also picks up ~236 pre-existing errors in gitignored local scratch files under `.archex/`/`.docs/`, unrelated to this change and not present in the CI checkout).
- `uv run pytest tests/serve/test_renderers.py --no-cov` — 20 passed (unchanged; no test additions in this PR, see PR-3).

Refs: M2 in `.docs/DEVELOPMENT_PLAN.md` §4 Section A.
