### PR TITLE
feat(cli): wire --format toon into query command with install guidance

### DIFF
--- a/src/archex/cli/query_cmd.py
+++ b/src/archex/cli/query_cmd.py
@@ -35,14 +35,14 @@ logger = logging.getLogger(__name__)
     "--format",
     "output_format",
     default="xml",
-    type=click.Choice(["xml", "json", "markdown"]),
+    type=click.Choice(["xml", "json", "markdown", "toon"]),
     help="Output format.",
 )
 @click.option(
     "--full",
     is_flag=True,
     default=False,
-    help="Restore the unfiltered --format json dump (all chunk fields, including None/empty).",
+    help="Restore the unfiltered --format json/toon dump (all chunk fields, including None/empty).",
 )
 @click.option("-l", "--language", multiple=True, help="Filter to specific languages.")
 @click.option(
@@ -130,7 +130,16 @@ def query_cmd(
     except ArchexError as exc:
         raise click.ClickException(str(exc)) from exc
 
-    click.echo(bundle.to_prompt(format=output_format, full=full))
+    if output_format == "toon":
+        try:
+            from archex.serve.renderers.toon import render_toon
+        except ImportError as exc:
+            raise click.ClickException(
+                "TOON output requires the 'toons' package. Install it with: uv add 'archex[toon]'"
+            ) from exc
+        click.echo(render_toon(bundle, full=full))
+    else:
+        click.echo(bundle.to_prompt(format=output_format, full=full))
 
     unique_files = list({c.chunk.file_path for c in bundle.chunks})
     raw_tokens: int | None = None

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -839,8 +839,10 @@ class ContextBundle(BaseModel):
     def to_prompt(self, format: str = "xml", *, full: bool = False) -> str:
         """Render the context bundle as an LLM prompt string.
 
-        `full` only affects `format="json"`: by default the JSON renderer
-        drops unset/empty chunk fields; `full=True` restores every field.
+        `full` affects `format="json"` and `format="toon"`: by default
+        these renderers drop unset/empty chunk fields; `full=True`
+        restores every field. `format="toon"` requires the optional
+        `toons` package (`uv add 'archex[toon]'`).
         """
         from archex.serve.renderers.json import render_json
         from archex.serve.renderers.markdown import render_markdown
@@ -852,6 +854,10 @@ class ContextBundle(BaseModel):
             return render_markdown(self)
         if format == "json":
             return render_json(self, full=full)
+        if format == "toon":
+            from archex.serve.renderers.toon import render_toon
+
+            return render_toon(self, full=full)
         raise ValueError(f"Unknown format: {format}")
 
     def to_dict(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

PR-2 of the M2 (Optional TOON output format) stack. Wires `--format toon` into `archex query` and `ContextBundle.to_prompt`, with an actionable error when the `toon` extra isn't installed.

## Stack

1. `feat/m2-toon-renderer` -> #453
2. `feat/m2-toon-cli-wiring` -> this PR (based on #453)
3. `feat/m2-toon-tests` -> depends on this PR

Depends on: #453

## Changes

- `src/archex/models.py`: `ContextBundle.to_prompt` gains an `elif format == "toon"` branch. The `render_toon` import is lazy and scoped inside that branch only, so calling `to_prompt` with `format="json"`/`"xml"`/`"markdown"` never touches the `toons` package.
- `src/archex/cli/query_cmd.py`:
  - `--format` `Choice` extended to `["xml", "json", "markdown", "toon"]`.
  - `--full` help text updated — it now documents both `json` and `toon`.
  - Before rendering, if `output_format == "toon"` the command pre-imports `render_toon` and turns an `ImportError` into `click.ClickException("TOON output requires the 'toons' package. Install it with: uv add 'archex[toon]'")`, mirroring `mcp_cmd.py`'s existing MCP install-guidance pattern. The Python API (`ContextBundle.to_prompt` called directly, outside the CLI) still raises a plain `ImportError` — consistent with how the other lazy-import call sites in this codebase behave for direct API use.

## Verification

- `uv run ruff check .` / `uv run ruff format --check .` — clean.
- `uv run pyright src/archex tests` — 0 errors.
- `uv run pytest tests/serve/test_renderers.py tests/test_scout.py --no-cov` — 38 passed (unchanged; dedicated TOON tests land in PR-3).
- Extras isolation, exercised against a clean venv with only `pip install .` (no extras):
  ```text
  $ archex query "how does query work" --format toon
  Error: TOON output requires the 'toons' package. Install it with: uv add 'archex[toon]'
  ```
  Actionable message, not a raw traceback — exit code 1.
- Same command against this repo's own index with `--all-extras` installed: succeeds, prints non-empty TOON text (58,498 bytes for a 15-chunk bundle on the query `"how does query work"`).

Refs: M2 in `.docs/DEVELOPMENT_PLAN.md` §4 Section A.
