### PR TITLE
test(renderers): add TOON size-comparison and round-trip coverage

### DIFF
--- a/tests/serve/test_renderers.py
+++ b/tests/serve/test_renderers.py
@@ -1,6 +1,9 @@
-"""Tests for markdown and XML renderers covering type definitions, dependencies, and edge cases."""
+"""Tests for markdown, XML, JSON, and TOON renderers covering type definitions,
+dependencies, and edge cases."""
 
 from __future__ import annotations
+
+import toons
 
 from archex.models import (
     CodeChunk,
@@ -29,6 +32,7 @@ from archex.models import (
 from archex.scout import chunk_handle
 from archex.serve.renderers.json import render_json
 from archex.serve.renderers.markdown import render_markdown
+from archex.serve.renderers.toon import render_toon
 from archex.serve.renderers.xml import render_xml
 
 # ---------------------------------------------------------------------------
@@ -482,3 +486,145 @@ def test_json_zero_score_ranked_chunk_present_in_default_and_full() -> None:
 def test_json_minimal_output_smaller_than_full_for_none_heavy_chunk() -> None:
     bundle = _base_bundle(chunks=[_ranked(_none_heavy_chunk())])
     assert len(render_json(bundle)) < len(render_json(bundle, full=True))
+
+
+# ---------------------------------------------------------------------------
+# TOON renderer: size comparison and round-trip coverage (M2)
+# ---------------------------------------------------------------------------
+
+
+def _toon_realistic_chunk(i: int, *, populated: bool) -> CodeChunk:
+    """Build one chunk of a multi-chunk fixture: alternates between a
+    populated symbol match (all fields set) and a markdown-paragraph-style
+    match (mostly None/empty fields), mirroring the mixed shape a real
+    archex query bundle returns.
+    """
+    if populated:
+        return CodeChunk(
+            id=f"src/service_{i}.py:handler_{i}:10",
+            content=(
+                f"def handler_{i}(request: Request) -> Response:\n"
+                f'    """Handle inbound request {i}."""\n'
+                "    return process(request)"
+            ),
+            file_path=f"src/service_{i}.py",
+            start_line=10,
+            end_line=13,
+            symbol_name=f"handler_{i}",
+            symbol_kind=SymbolKind.FUNCTION,
+            language="python",
+            imports_context="import os\nfrom archex.models import Request, Response",
+            token_count=42,
+            symbol_id=f"src/service_{i}.py::handler_{i}#function",
+            qualified_name=f"service_{i}.handler_{i}",
+            visibility="public",
+            signature=f"def handler_{i}(request: Request) -> Response",
+            docstring=f"Handle inbound request {i}.",
+            breadcrumbs=f"service_{i} > handler_{i}",
+            summary=f"Request handler {i}.",
+        )
+    return CodeChunk(
+        id=f"README.md:_module:{i}",
+        content=f"Paragraph {i} describing the architecture in prose with no code symbols.",
+        file_path="README.md",
+        start_line=i,
+        end_line=i + 2,
+        language="markdown",
+        imports_context="",
+        token_count=18,
+    )
+
+
+def _toon_realistic_bundle(n: int = 15) -> ContextBundle:
+    """A 15-chunk fixture mirroring the mixed populated/null shape measured
+    against this repo's own bundles in `.docs/2026-07-06-axi-surface-analysis.md`.
+    """
+    chunks = [
+        RankedChunk(
+            chunk=_toon_realistic_chunk(i, populated=(i % 2 == 0)),
+            relevance_score=round(0.9 - i * 0.03, 2),
+            structural_score=round(0.4 - i * 0.01, 2) if i % 2 == 0 else 0.0,
+            type_coverage_score=0.0,
+            cohesion_score=0.2 if i % 3 == 0 else 0.0,
+            final_score=round(0.85 - i * 0.03, 2),
+        )
+        for i in range(n)
+    ]
+    return ContextBundle(
+        query="how does the request handler pipeline work?",
+        chunks=chunks,
+        structural_context=StructuralContext(
+            file_tree="src/\n  service_0.py\n  service_1.py\nREADME.md"
+        ),
+        type_definitions=[
+            TypeDefinition(
+                symbol="Request",
+                file_path="src/models.py",
+                start_line=1,
+                end_line=5,
+                content="class Request: ...",
+            ),
+            TypeDefinition(
+                symbol="Response",
+                file_path="src/models.py",
+                start_line=7,
+                end_line=11,
+                content="class Response: ...",
+            ),
+        ],
+        dependency_summary=DependencySummary(internal=["src/models.py"], external=["httpx"]),
+        token_count=sum(c.chunk.token_count for c in chunks),
+        token_budget=4000,
+    )
+
+
+def test_toon_smaller_than_json_for_realistic_bundle() -> None:
+    """Measured, non-fixed-threshold reduction (M2 acceptance #3): direction
+    and existence of a byte reduction is the gate, not a specific percentage.
+    On this 15-chunk fixture TOON measures ~17% smaller than JSON.
+    """
+    bundle = _toon_realistic_bundle()
+    json_bytes = render_json(bundle).encode()
+    toon_bytes = render_toon(bundle).encode()
+    assert len(toon_bytes) < len(json_bytes)
+
+
+def test_toon_round_trip_preserves_query_and_chunk_count() -> None:
+    """TOON has no `json.loads`-equivalent schema validation, so decode the
+    output back and check the content that matters survives the round trip.
+    """
+    bundle = _toon_realistic_bundle()
+    decoded = toons.loads(render_toon(bundle))
+    assert decoded["query"] == bundle.query
+    assert len(decoded["chunks"]) == len(bundle.chunks)
+    assert decoded["chunks"][0]["chunk"]["symbol_name"] == "handler_0"
+    assert decoded["token_count"] == bundle.token_count
+    assert decoded["token_budget"] == bundle.token_budget
+
+
+def test_toon_default_omits_none_and_empty_chunk_fields() -> None:
+    bundle = _base_bundle(chunks=[_ranked(_none_heavy_chunk())])
+    decoded = toons.loads(render_toon(bundle))
+    chunk = decoded["chunks"][0]["chunk"]
+    for key in (*_NONE_VALUED_CHUNK_KEYS, *_EMPTY_STRING_CHUNK_KEYS):
+        assert key not in chunk, f"{key} should be omitted from minimal TOON output"
+
+
+def test_toon_full_restores_all_chunk_fields() -> None:
+    bundle = _base_bundle(chunks=[_ranked(_none_heavy_chunk())])
+    decoded = toons.loads(render_toon(bundle, full=True))
+    chunk = decoded["chunks"][0]["chunk"]
+    for key in _NONE_VALUED_CHUNK_KEYS:
+        assert key in chunk
+        assert chunk[key] is None
+    for key in _EMPTY_STRING_CHUNK_KEYS:
+        assert chunk[key] == ""
+
+
+def test_render_toon_exported_from_renderers_package() -> None:
+    """`render_toon` is reachable via the renderers package's lazy
+    `__getattr__`, not just the `archex.serve.renderers.toon` submodule.
+    """
+    from archex.serve.renderers import render_toon as package_render_toon
+
+    assert package_render_toon is render_toon


### PR DESCRIPTION
## Summary

PR-3 (leaf) of the M2 (Optional TOON output format) stack. Adds the dedicated size-comparison and round-trip tests, closing out M2's acceptance criteria.

## Stack

1. `feat/m2-toon-renderer` -> #453
2. `feat/m2-toon-cli-wiring` -> #454
3. `feat/m2-toon-tests` -> this PR (based on #454)

Depends on: #454

## Changes

`tests/serve/test_renderers.py`:

- `_toon_realistic_bundle()` / `_toon_realistic_chunk()`: a 15-chunk fixture alternating populated symbol matches (all 17 nested-chunk fields set) and markdown-paragraph-style matches (8 of 17 null/empty), mirroring the mixed shape `.docs/2026-07-06-axi-surface-analysis.md` measured against this repo's own bundles.
- `test_toon_smaller_than_json_for_realistic_bundle`: renders the fixture via both `render_json` and `render_toon`, asserts `len(toon_bytes) < len(json_bytes)`. No fixed percentage is asserted (format-library version churn could shift the exact number) — only the direction/existence of a reduction, per the milestone's own acceptance criterion.
- `test_toon_round_trip_preserves_query_and_chunk_count`: TOON has no `json.loads`-equivalent schema guarantee, so this decodes `render_toon`'s output via `toons.loads` and checks `query`, chunk count, first chunk's `symbol_name`, `token_count`, and `token_budget` survive.
- `test_toon_default_omits_none_and_empty_chunk_fields` / `test_toon_full_restores_all_chunk_fields`: mirror the existing M1 JSON tests, decoded via `toons.loads` instead of `json.loads` — confirms TOON actually reuses M1's `minimal_dump` convention rather than reintroducing the null-field bloat M1 removed from JSON (M2's stated dependency on M1).
- `test_render_toon_exported_from_renderers_package`: confirms `render_toon` is reachable through the renderers package's lazy `__getattr__` (PR-1), not just the `toon` submodule directly.

## Measured result

On the 15-chunk fixture: **JSON 13,770 bytes vs TOON 11,383 bytes — 17.3% smaller.** (Separately spot-checked against a live 15-chunk bundle from this repo's own index for the query `"how does query work"`: JSON 67,753 bytes vs TOON 58,501 bytes — 13.8% smaller. Both measurements are directionally consistent and well short of the vendor's generic 30-60% claim, which this milestone deliberately does not cite — archex's bundle shape is deeply nested with many null fields, a worse case for TOON's tabular-array optimization than a flat list of uniform records.)

## Verification

- `uv run pytest tests/serve/test_renderers.py --no-cov` — 25 passed (20 existing + 5 new).
- `uv run pytest --junitxml=results.xml --cov-report=xml` — 3619 passed, 4 deselected; coverage 91.09% (gate 85%); `src/archex/serve/renderers/toon.py` at 100%.
- `uv run ruff check .` / `uv run ruff format --check .` — clean.
- `uv run pyright src/archex tests` — 0 errors.

## Cumulative stack verification (all 4 M2 acceptance criteria)

1. `archex query "authentication" --format toon` (or any query) succeeds and prints non-empty TOON text with the `toon` extra installed — verified in #454 (58,498 bytes on a real 15-chunk bundle from this repo's own index).
2. Without the extra, `archex query ... --format toon` fails with `Error: TOON output requires the 'toons' package. Install it with: uv add 'archex[toon]'`, not a raw traceback — verified in #454 against a clean `pip install .` venv.
3. The size-comparison test in this PR passes, proving a measured non-zero reduction (17.3% on the fixture) — the exact number is recorded here, not asserted as a fixed threshold.
4. `smoke-min-install` is unaffected: `toon` is an optional extra never referenced by core-install code paths; `toons` only imports inside `render_toon`/the CLI's toon branch.

Refs: M2 in `.docs/DEVELOPMENT_PLAN.md` §4 Section A.
