### PR TITLE
docs: backfill v0.18.0 changelog and README for minimal JSON + TOON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.18.0] - 2026-07-06
+
+### Added
+
+- **Minimal-by-default JSON chunk output, `--full` escape hatch.** `archex query --format json` and `archex scout --format json` now omit `CodeChunk`/`RankedChunk` fields that are unset (`None`) or empty (`""`) — `symbol_name`, `symbol_kind`, `symbol_id`, `qualified_name`, `visibility`, `signature`, `docstring`, `summary`, `imports_context`, `breadcrumbs` — while always keeping `structural_score`/`type_coverage_score`/`cohesion_score`/`relevance_score`/`final_score` regardless of value, since a real `0.0` score is signal, not absence. A new `--full` flag on both commands restores the previous unconditional dump. `render_xml` and `render_markdown` are unchanged — XML was already minimal by hand-curation before this change. This only affects callers who pass `--format json`; the CLI's default format remains `xml`.
+- **Optional TOON output format (`archex query --format toon`).** A new token-oriented encoding, gated behind the optional `archex[toon]` extra (`toons>=0.7.0`) so the core install and `smoke-min-install` CI job are unaffected. Reuses the JSON renderer's minimal-by-default field selection, so TOON inherits the same slim/`--full` behavior. Running the command without the extra installed fails with an actionable `uv add 'archex[toon]'` message instead of a raw traceback. Measured on the representative fixture bundle in `tests/serve/test_renderers.py::test_toon_smaller_than_json_for_realistic_bundle`: TOON output is ~17% smaller than the already-slimmed default JSON output for the same bundle — a per-bundle, opt-in reduction that requires explicitly choosing `--format toon`, not a change to any default output path.
+
 ## [0.17.0] - 2026-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PyPI](https://img.shields.io/pypi/v/archex)](https://pypi.org/project/archex/)
 [![Downloads](https://img.shields.io/pypi/dm/archex)](https://pypi.org/project/archex/)
 [![Python](https://img.shields.io/pypi/pyversions/archex)](https://pypi.org/project/archex/)
-[![Tests](https://img.shields.io/badge/tests-3603_passing-brightgreen)](https://github.com/Mathews-Tom/archex/actions/workflows/ci.yml)
+[![Tests](https://img.shields.io/badge/tests-3619_passing-brightgreen)](https://github.com/Mathews-Tom/archex/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-91.1%25-brightgreen)](https://github.com/Mathews-Tom/archex/actions/workflows/ci.yml)
 [![Languages](https://img.shields.io/badge/languages-26-orange)](#language-support)
 [![MCP tools](https://img.shields.io/badge/MCP_tools-17-purple)](#mcp-and-claude-code)
@@ -20,7 +20,7 @@
 
 AI coding agents usually start by opening a file, following an import, checking a type definition, and backtracking through the repo until the context window is partly spent before the real task starts. archex does that retrieval and structural expansion up front and returns a ranked, token-budgeted context bundle plus a receipt that records what was included, what was skipped, and whether the bundle is complete enough to act on.
 
-It runs locally, uses deterministic retrieval and analysis, and does not require hosted inference or an API key. The v0.16 line adds five full-tier language promotions (PHP, Ruby, Scala, C, C++), a new `structured` tier for markup/config languages (HTML, XML, YAML, Markdown, CSS) with a Maven POM dependency-graph plugin, portable index artifacts for team-shared bootstrap, and diff-scoped blast-radius analysis with per-symbol risk classification. The v0.17 line adds opt-in, non-blocking tool-call hooks across six clients (Claude Code, oh-my-pi, Pi, OpenCode, Codex CLI, Cursor) that augment `grep`/`glob`-shaped calls with archex results — or, where a client has no matching hook to augment, log a diagnostics-only trace instead of claiming a capability that isn't there.
+It runs locally, uses deterministic retrieval and analysis, and does not require hosted inference or an API key. The v0.16 line adds five full-tier language promotions (PHP, Ruby, Scala, C, C++), a new `structured` tier for markup/config languages (HTML, XML, YAML, Markdown, CSS) with a Maven POM dependency-graph plugin, portable index artifacts for team-shared bootstrap, and diff-scoped blast-radius analysis with per-symbol risk classification. The v0.17 line adds opt-in, non-blocking tool-call hooks across six clients (Claude Code, oh-my-pi, Pi, OpenCode, Codex CLI, Cursor) that augment `grep`/`glob`-shaped calls with archex results — or, where a client has no matching hook to augment, log a diagnostics-only trace instead of claiming a capability that isn't there. The v0.18 line slims the default `--format json` chunk output (unset/empty fields dropped, `--full` to restore) and adds an opt-in `--format toon` encoding for further token savings on top of that.
 
 **Start:** [30-second quickstart](#30-second-quickstart) · [MCP and Claude Code](#mcp-and-claude-code) · [Python API](#python-api) · [Local metrics](docs/LOCAL_METRICS.md) · [Compatibility matrix](docs/CLIENT_COMPATIBILITY_MATRIX.md) · [Installation trust contract](docs/INSTALLATION_TRUST_CONTRACT.md) · [Security policy](SECURITY.md)
 
@@ -102,7 +102,7 @@ class User: ...
 </context>
 ```
 
-The bundle carries ranked chunks, import context, referenced type definitions, dependency edges, token counts, and provenance. Use `--format json` or `--format markdown` when XML is not the right downstream envelope.
+The bundle carries ranked chunks, import context, referenced type definitions, dependency edges, token counts, and provenance. Use `--format json` or `--format markdown` when XML is not the right downstream envelope, or `--format toon` (optional `archex[toon]` extra) for a smaller-still encoding built on the same field selection. `json` and `toon` output omit unset/empty chunk fields by default — pass `--full` to restore every field.
 
 Small receipt example:
 
@@ -155,6 +155,7 @@ archex is a selection and assembly layer. Compression tools can shrink the final
 ```bash
 archex query "Where is cache invalidation handled?" --format xml
 archex scout "How does authentication flow through this repo?" --budget 1000 --format json
+archex query "How does authentication work?" --format toon   # requires: uv add "archex[toon]"
 archex index --quantize-vectors --quantize-bits 4 --allow-remote-code
 archex graph export --output .archex/archgraph.json
 archex graph neighbors src/auth/middleware.py --graph .archex/archgraph.json --format markdown
@@ -312,6 +313,7 @@ TurboQuant evidence is measured separately with `archex_query_hybrid_quantized_4
 - **Coverage stays close to raw search without paying raw-search token cost.** `raw-ripgrep/read` reaches `1.00` required-file recall, but it does so at `0.00` token efficiency. archex lands at `0.95` required-file recall with `0.76` token efficiency, so the returned bundle stays close to exhaustive file coverage without filling the prompt with every textual match.
 - **Missed-task failures drop sharply versus `ccc`.** archex's missed task rate is `0.16`; `ccc` lands at `0.79`. In the published C1 run, that is the difference between usually returning the files an agent needs and often requiring a second pass before the task can finish.
 - **Vector storage got much smaller without a measured retrieval-quality change.** The published 4-bit TurboQuant run reports `7.07×` mean vector `.npz` compression (`6.98×` minimum) with recall Δ `+0.000`, MRR Δ `+0.000`, and F1 Δ `+0.000`, so local vector indexes take far less disk without a measured quality regression in that benchmark.
+- **`--format toon` trims the bundle further, on request.** `--format json`/`--format scout json` already drop unset/empty chunk fields by default (`--full` restores them); `--format toon` (optional `archex[toon]` extra) measures ~17% smaller than that default JSON output on the representative bundle in `tests/serve/test_renderers.py::test_toon_smaller_than_json_for_realistic_bundle`. Both are opt-in — the CLI's default format stays `xml`, which was already minimal before either change.
 
 ## Advanced workflows
 
@@ -357,13 +359,14 @@ uv tool install "archex[mcp]"             # MCP server
 uv add "archex[langchain]"                # LangChain retriever
 uv add "archex[llamaindex]"               # LlamaIndex retriever
 uv add "archex[lsap]"                     # LSP type enrichment
+uv add "archex[toon]"                     # TOON output format (token-lean encoding)
 
 # Local retrieval extras
 uv add "archex[vector-fast]"              # FastEmbed (ONNX-backed, ~50MB)
 uv add "archex[vector-torch]"             # sentence-transformers / torch
 uv add "archex[splade]"                   # SPLADE sparse retrieval
 uv add "archex[graph]"                    # Leiden graph clustering
-# Core extras bundle: graph, MCP, LangChain, LlamaIndex
+# Bundles every extra: vector-fast, graph, vector-torch, splade, mcp, langchain, llamaindex, lsap, toon
 uv add "archex[all]"
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archex"
-version = "0.17.0"
+version = "0.18.0"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "archex"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Backfills the release documentation for two features that were already merged to `main` (minimal-by-default JSON chunk output plus a new `--full` escape hatch, and an optional TOON output format) but never got a version bump, a changelog entry, or a README mention. No behavior changes — this is documentation and versioning only.

## What's in this branch (3 commits)

### `build: bump version to 0.18.0`
- `pyproject.toml`: `version = "0.17.0"` → `"0.18.0"`
- `uv.lock`: matching `archex` package `version` field
- Non-breaking new features (a new CLI flag, a new opt-in output format) warrant a minor bump. `__version__` is read dynamically via `importlib.metadata.version("archex")`, so no source or test hardcodes the old string — the bump alone can't break anything.

### `docs(changelog): record minimal JSON output and optional TOON format`
- New `## [0.18.0]` entry at the top of `CHANGELOG.md`, describing:
  - `archex query`/`archex scout --format json` now omit `CodeChunk`/`RankedChunk` fields that are unset (`None`) or empty (`""`) by default (`symbol_name`, `docstring`, `imports_context`, etc.), while always keeping score fields (`structural_score`, `relevance_score`, ...) even when `0.0`, since a real zero is signal, not absence. A new `--full` flag on both commands restores the old unconditional dump.
  - A new `--format toon` option on `archex query`, gated behind the optional `archex[toon]` extra (`toons>=0.7.0`) so the core install and the `smoke-min-install` CI job are unaffected. Missing the extra fails with an actionable `uv add 'archex[toon]'` message, not a raw traceback.
- The entry explicitly states the measured number is the one already checked into `tests/serve/test_renderers.py::test_toon_smaller_than_json_for_realistic_bundle` (~17% smaller than the already-slimmed default JSON, on that test's representative fixture) — not a rounded-up or vendor-supplied figure — and calls out that both changes are opt-in and do not touch the CLI's default `xml` output path.

### `docs(readme): surface --full flag and --format toon usage`
- Tests badge: `3603_passing` → `3619_passing` (actual current full-suite pass count; coverage badge unchanged at 91.1%, which still matches a fresh run).
- "What archex returns" section: the format-selection sentence now mentions `--format toon` and the `--full` flag alongside the existing `json`/`markdown` mention.
- CLI quick-reference block: added `archex query "How does authentication work?" --format toon   # requires: uv add "archex[toon]"`.
- "Optional extras and integrations" table: added `uv add "archex[toon]"`, and fixed the `all`-bundle summary comment, which had drifted out of sync with `pyproject.toml`'s actual `all` extra list (it was missing `vector-fast`, `vector-torch`, `splade`, and `lsap` even before this change).
- "Measured results → What this means for your workflow": added one bullet on `--format toon`, citing the same checked-in test number as the changelog entry, with the same opt-in/default-path caveat.
- Intro paragraph's running "the vX.Y line adds..." sentence: appended a v0.18 clause matching the existing v0.16/v0.17 sentences already there.

## Scope note — deliberately narrow claims

Neither change touches the CLI's default output format (`xml`), which was already minimal before this work — confirmed at code level (`render_xml` already hand-curates fields; only the JSON renderer had the gap). Real-world impact:
- `--format json` callers get a smaller payload automatically, no flag needed: modest (single-digit percent).
- `--format toon` adopters (opt-in extra + flag) get a further reduction on top of that, per the checked-in test.
- Everyone using the default (`--format xml`, unset): no change.

The changelog and README wording reflects this scope intentionally — no "significant"/"major" language, no unqualified percentages.

## Verification

- `uv run pytest -q --no-cov`: 3619 passed, 0 failed (matches the badge update)
- `uv run pytest --cov-report=term`: 91.09% coverage, gate (85%) holds
- `uv run ruff check .` / `uv run ruff format --check .`: clean
- `uv run pyright src/archex tests` (the config's actual `include` scope): 0 errors
- Confirmed no hardcoded `0.17.0` version string exists anywhere in `src/` or `tests/` that the bump could break (`__version__` test asserts against the live import, not a literal)
- Confirmed `toon` extra is correctly declared as optional in `pyproject.toml` (not in core `dependencies`, present in `all`)

## Out of scope

- No code changes — the underlying features (minimal JSON, `--full`, `--format toon`) were already merged in earlier PRs (#451–#455).
- Not squashed into a single `chore(release)` commit, per this repo's usual pattern for release-doc batches — kept as three single-purpose commits per request.
