### PR TITLE
feat(deps): move mcp into default dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "click>=8.1",
     "pyyaml>=6.0",
     "rich==14.3.3",
+    "mcp>=1.0",
     "watchdog>=6.0.0",
 ]
 
@@ -54,7 +55,7 @@ splade = [
     "transformers>=4.41,<5",
     "torch>=2.0",
 ]
-mcp = ["mcp>=1.0"]
+mcp = [] # Preserved for backwards compatibility with archex[mcp]
 langchain = ["langchain-core>=0.2"]
 llamaindex = ["llama-index-core>=0.10"]
 lsap = ["lsp-client>=0.3; python_version >= '3.12'"]

--- a/uv.lock
+++ b/uv.lock
@@ -178,6 +178,7 @@ version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "mcp" },
     { name = "networkx" },
     { name = "numpy" },
     { name = "pydantic" },
@@ -205,7 +206,6 @@ all = [
     { name = "leidenalg" },
     { name = "llama-index-core" },
     { name = "lsp-client", marker = "python_full_version >= '3.12'" },
-    { name = "mcp" },
     { name = "python-igraph" },
     { name = "sentence-transformers" },
     { name = "toons" },
@@ -224,9 +224,6 @@ llamaindex = [
 ]
 lsap = [
     { name = "lsp-client", marker = "python_full_version >= '3.12'" },
-]
-mcp = [
-    { name = "mcp" },
 ]
 splade = [
     { name = "torch" },
@@ -266,7 +263,7 @@ requires-dist = [
     { name = "leidenalg", marker = "extra == 'graph'", specifier = ">=0.10" },
     { name = "llama-index-core", marker = "extra == 'llamaindex'", specifier = ">=0.10" },
     { name = "lsp-client", marker = "python_full_version >= '3.12' and extra == 'lsap'", specifier = ">=0.3" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
+    { name = "mcp", specifier = ">=1.0" },
     { name = "networkx", specifier = ">=3.3" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "pydantic", specifier = ">=2.7" },


### PR DESCRIPTION
Resolves issue #457 by making MCP a default runtime dependency. Preserves optional-extra compatibility for archex[mcp].