### PR TITLE
feat(cli): make archex init index the repository by default

### DIFF
--- a/src/archex/cli/init_cmd.py
+++ b/src/archex/cli/init_cmd.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import click
 
+from archex.cli.indexing import run_indexing_and_get_summary
 from archex.config import load_config, load_index_config
 from archex.exceptions import ArchexError
 from archex.index.artifact import import_artifact, sync_imported_artifact
@@ -28,7 +29,15 @@ from archex.project import init_project
     default=None,
     help="Bootstrap the local index from a portable index artifact instead of cold-start reindex.",
 )
-def init_cmd(source: str, force: bool, reset: bool, from_artifact_path: Path | None) -> None:
+@click.option(
+    "--index/--no-index",
+    is_flag=True,
+    default=True,
+    help="Build or refresh the repository index after initialization (default: true).",
+)
+def init_cmd(
+    source: str, force: bool, reset: bool, from_artifact_path: Path | None, index: bool
+) -> None:
     """Initialize repo-local archex project state."""
     try:
         result = init_project(source, force=force, reset=reset)
@@ -71,3 +80,20 @@ def init_cmd(source: str, force: bool, reset: bool, from_artifact_path: Path | N
         if sync_result.strategy != "clean":
             click.echo(f"Files changed since export: {sync_result.files_changed}")
         click.echo(f"Sync time:               {sync_result.sync_time_ms} ms")
+    elif index:
+        try:
+            summary = run_indexing_and_get_summary(source=source)
+        except ArchexError as exc:
+            raise click.ClickException(str(exc)) from exc
+
+        click.echo(f"Indexed repository: {summary['repo_root']}")
+        click.echo(f"Strategy:           {summary['strategy']}")
+        click.echo(f"Files indexed:      {summary['files_indexed']}")
+        click.echo(f"Chunks indexed:     {summary['chunks_indexed']}")
+        if summary["languages"]:
+            language_summary = ", ".join(
+                f"{language}={count}" for language, count in summary["languages"].items()
+            )
+        else:
+            language_summary = "none"
+        click.echo(f"Languages:          {language_summary}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -35,8 +35,7 @@ def test_help_contains_subcommands() -> None:
 
 def test_init_command_creates_project_state(python_simple_repo: Path) -> None:
     runner = CliRunner()
-
-    result = runner.invoke(cli, ["init", str(python_simple_repo)])
+    result = runner.invoke(cli, ["init", str(python_simple_repo), "--no-index"])
 
     assert result.exit_code == 0, result.output
     assert "Initialized archex project" in result.output
@@ -45,10 +44,44 @@ def test_init_command_creates_project_state(python_simple_repo: Path) -> None:
     assert ".archex/" in (python_simple_repo / ".gitignore").read_text(encoding="utf-8")
 
 
+@patch("archex.cli.init_cmd.run_indexing_and_get_summary")
+def test_init_command_indexes_by_default(mock_run: Mock, python_simple_repo: Path) -> None:
+    runner = CliRunner()
+    mock_run.return_value = {
+        "repo_root": str(python_simple_repo),
+        "strategy": "full",
+        "files_indexed": 3,
+        "chunks_indexed": 6,
+        "languages": {"python": 3},
+    }
+
+    result = runner.invoke(cli, ["init", str(python_simple_repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "Initialized archex project" in result.output
+    assert "Indexed repository" in result.output
+    assert "Files indexed:      3" in result.output
+    assert "Chunks indexed:     6" in result.output
+    assert "Languages:          python=3" in result.output
+    mock_run.assert_called_once_with(source=str(python_simple_repo))
+
+
+@patch("archex.cli.init_cmd.run_indexing_and_get_summary")
+def test_init_command_no_index_skips_indexing(mock_run: Mock, python_simple_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["init", str(python_simple_repo), "--no-index"])
+
+    assert result.exit_code == 0, result.output
+    assert "Initialized archex project" in result.output
+    assert "Indexed repository" not in result.output
+    mock_run.assert_not_called()
+
+
 def test_init_command_is_idempotent(python_simple_repo: Path) -> None:
     runner = CliRunner()
-    first = runner.invoke(cli, ["init", str(python_simple_repo)])
-    second = runner.invoke(cli, ["init", str(python_simple_repo)])
+    first = runner.invoke(cli, ["init", str(python_simple_repo), "--no-index"])
+    second = runner.invoke(cli, ["init", str(python_simple_repo), "--no-index"])
 
     assert first.exit_code == 0, first.output
     assert second.exit_code == 0, second.output


### PR DESCRIPTION
## Stack

Stack-Id: `m2-init-index`
Base: `main`
Position: 2/3

1. `m2/pr-1` -> #462
2. `m2/pr-2` -> this PR
3. `m2/pr-3` -> #464

Depends on: #462
