### PR TITLE
feat(cli): carry advanced init indexing options

### DIFF
--- a/src/archex/cli/init_cmd.py
+++ b/src/archex/cli/init_cmd.py
@@ -35,8 +35,49 @@ from archex.project import init_project
     default=True,
     help="Build or refresh the repository index after initialization (default: true).",
 )
+@click.option("--splade", is_flag=True, default=False, help="Build the opt-in SPLADE index.")
+@click.option(
+    "--module-prefilter",
+    is_flag=True,
+    default=False,
+    help="Build opt-in module responsibility summaries.",
+)
+@click.option(
+    "--allow-remote-code",
+    is_flag=True,
+    default=False,
+    help="Allow explicitly selected pinned model paths that require Hugging Face remote code.",
+)
+@click.option(
+    "--quantize-vectors/--no-quantize-vectors",
+    default=None,
+    help="Build vector indexes with TurboQuant compression.",
+)
+@click.option(
+    "--quantize-bits",
+    default=None,
+    type=click.Choice(["2", "4"]),
+    help="TurboQuant bit-width for vector indexes.",
+)
+@click.option(
+    "--export-artifact",
+    "export_artifact_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Export a compacted, compressed, portable index artifact to PATH after indexing.",
+)
 def init_cmd(
-    source: str, force: bool, reset: bool, from_artifact_path: Path | None, index: bool
+    source: str,
+    force: bool,
+    reset: bool,
+    from_artifact_path: Path | None,
+    index: bool,
+    splade: bool,
+    module_prefilter: bool,
+    allow_remote_code: bool,
+    quantize_vectors: bool | None,
+    quantize_bits: str | None,
+    export_artifact_path: Path | None,
 ) -> None:
     """Initialize repo-local archex project state."""
     try:
@@ -82,7 +123,15 @@ def init_cmd(
         click.echo(f"Sync time:               {sync_result.sync_time_ms} ms")
     elif index:
         try:
-            summary = run_indexing_and_get_summary(source=source)
+            summary = run_indexing_and_get_summary(
+                source=source,
+                splade=splade,
+                module_prefilter=module_prefilter,
+                allow_remote_code=allow_remote_code,
+                quantize_vectors=quantize_vectors,
+                quantize_bits=quantize_bits,
+                export_artifact_path=export_artifact_path,
+            )
         except ArchexError as exc:
             raise click.ClickException(str(exc)) from exc
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -45,7 +45,7 @@ def test_init_command_creates_project_state(python_simple_repo: Path) -> None:
 
 
 @patch("archex.cli.init_cmd.run_indexing_and_get_summary")
-def test_init_command_indexes_by_default(mock_run: Mock, python_simple_repo: Path) -> None:
+def test_init_command_indexes_by_default(mock_run: MagicMock, python_simple_repo: Path) -> None:
     runner = CliRunner()
     mock_run.return_value = {
         "repo_root": str(python_simple_repo),
@@ -62,12 +62,52 @@ def test_init_command_indexes_by_default(mock_run: Mock, python_simple_repo: Pat
     assert "Indexed repository" in result.output
     assert "Files indexed:      3" in result.output
     assert "Chunks indexed:     6" in result.output
-    assert "Languages:          python=3" in result.output
-    mock_run.assert_called_once_with(source=str(python_simple_repo))
+    mock_run.assert_called_once()
+    assert mock_run.call_args.kwargs["source"] == str(python_simple_repo)
 
 
 @patch("archex.cli.init_cmd.run_indexing_and_get_summary")
-def test_init_command_no_index_skips_indexing(mock_run: Mock, python_simple_repo: Path) -> None:
+def test_init_command_passes_indexing_options(
+    mock_run: MagicMock, python_simple_repo: Path
+) -> None:
+    runner = CliRunner()
+    mock_run.return_value = {
+        "repo_root": str(python_simple_repo),
+        "strategy": "full",
+        "files_indexed": 3,
+        "chunks_indexed": 6,
+        "languages": {"python": 3},
+    }
+
+    result = runner.invoke(
+        cli,
+        [
+            "init",
+            str(python_simple_repo),
+            "--splade",
+            "--module-prefilter",
+            "--allow-remote-code",
+            "--quantize-vectors",
+            "--quantize-bits",
+            "4",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_run.assert_called_once()
+    kwargs = mock_run.call_args.kwargs
+    assert kwargs["source"] == str(python_simple_repo)
+    assert kwargs["splade"] is True
+    assert kwargs["module_prefilter"] is True
+    assert kwargs["allow_remote_code"] is True
+    assert kwargs["quantize_vectors"] is True
+    assert kwargs["quantize_bits"] == "4"
+
+
+@patch("archex.cli.init_cmd.run_indexing_and_get_summary")
+def test_init_command_no_index_skips_indexing(
+    mock_run: MagicMock, python_simple_repo: Path
+) -> None:
     runner = CliRunner()
 
     result = runner.invoke(cli, ["init", str(python_simple_repo), "--no-index"])


### PR DESCRIPTION
## Stack

Stack-Id: `m2-init-index`
Base: `main`
Position: 3/3

1. `m2/pr-1` -> #462
2. `m2/pr-2` -> #463
3. `m2/pr-3` -> this PR

Depends on: #463
