### PR TITLE
feat(cli): add deterministic client discovery model

### DIFF
--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -66,6 +66,92 @@ class ClientInstallPlan:
     last_verified: str
 
 
+@dataclass(frozen=True)
+class DiscoveredClient:
+    client: ClientName
+    scope: ClientScope
+    config_path: Path
+    is_installed: bool
+    evidence: str
+
+
+def get_client_config_candidates(
+    client: ClientName, repo_root: Path, scope: ClientScope
+) -> list[Path]:
+    home = Path.home()
+    if scope == "project":
+        if client == "claude-code":
+            return [repo_root / ".mcp.json"]
+        if client == "cursor":
+            return [repo_root / ".cursor" / "mcp.json"]
+        if client == "codex":
+            return [repo_root / ".codex" / "config.toml"]
+        if client == "opencode":
+            return [repo_root / "opencode.json"]
+        return []
+    else:
+        if client == "claude-code":
+            return [
+                home / ".claude.json",
+                home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json",
+                home / ".config" / "claude" / "claude_desktop_config.json",
+            ]
+        if client == "cursor":
+            return [home / ".cursor" / "mcp.json"]
+        if client == "codex":
+            return [home / ".codex" / "config.toml"]
+        if client == "opencode":
+            return [home / ".config" / "opencode" / "opencode.json"]
+        if client == "pi":
+            return [home / ".pi" / "agent" / "mcp.json"]
+        if client == "omp":
+            return [home / ".omp" / "agent" / "mcp.json"]
+        return []
+
+
+def discover_clients(source: str | Path | None = None) -> list[DiscoveredClient]:
+    repo_root = Path(source if source is not None else ".").expanduser().resolve()
+    discovered: list[DiscoveredClient] = []
+
+    # Order based on the spec
+    all_clients: list[ClientName] = ["omp", "codex", "claude-code", "cursor", "opencode", "pi"]
+
+    for client in all_clients:
+        scopes: list[ClientScope] = (
+            ["user"] if client in _USER_ONLY_CLIENTS else ["user", "project"]
+        )
+        for scope in scopes:
+            candidates = get_client_config_candidates(client, repo_root, scope)
+            found = False
+            for candidate in candidates:
+                if candidate.exists():
+                    discovered.append(
+                        DiscoveredClient(
+                            client=client,
+                            scope=scope,
+                            config_path=candidate,
+                            is_installed=True,
+                            evidence=f"{candidate} exists",
+                        )
+                    )
+                    found = True
+                    break
+            if not found and candidates:
+                # Pick the first one as the default to display if none found
+                default_path = candidates[0]
+                discovered.append(
+                    DiscoveredClient(
+                        client=client,
+                        scope=scope,
+                        config_path=default_path,
+                        is_installed=False,
+                        evidence=f"{default_path} not found",
+                    )
+                )
+
+    return discovered
+
+
 def build_client_install_plan(
     client: ClientName,
     source: str | Path | None = None,

--- a/tests/cli/test_install_client.py
+++ b/tests/cli/test_install_client.py
@@ -377,3 +377,42 @@ def test_install_client_agent_file_directory_errors_cleanly(tmp_path: Path) -> N
     assert result.exit_code != 0
     assert "Error" in result.output
     assert "Traceback" not in result.output
+
+
+def test_install_client_discovery(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from archex.client_setup import discover_clients
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    # None of them exist initially
+    discovered = discover_clients(source=repo)
+    assert len(discovered) == 10
+
+    assert all(not d.is_installed for d in discovered)
+    assert discovered[0].client == "omp"
+    assert discovered[0].scope == "user"
+    assert "not found" in discovered[0].evidence
+
+    # Create some configs
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".codex" / "config.toml").write_text("", encoding="utf-8")
+    (repo / ".mcp.json").write_text("", encoding="utf-8")
+
+    discovered_with_some = discover_clients(source=repo)
+
+    codex_user = next(d for d in discovered_with_some if d.client == "codex" and d.scope == "user")
+    assert codex_user.is_installed
+    assert "exists" in codex_user.evidence
+
+    claude_project = next(
+        d for d in discovered_with_some if d.client == "claude-code" and d.scope == "project"
+    )
+    assert claude_project.is_installed
+    assert "exists" in claude_project.evidence
+
+    claude_user = next(
+        d for d in discovered_with_some if d.client == "claude-code" and d.scope == "user"
+    )
+    assert not claude_user.is_installed


### PR DESCRIPTION
## Summary
- Add deterministic possible-client discovery for supported MCP clients.
- Model discovery evidence, confidence, scope, and install status.
- Cover config-path and project-path evidence in install-client tests.

## Stack

Stack-Id: `archex-m3-onboarding-20260708`
Base: `main`
Position: 1/3

1. `pr1-client-discovery` -> this PR
2. `pr2-bare-install-client` ->  #466
3. `pr4-agent-guidance` ->  #467

Depends on: none
Upstack: #466

## Validation
- `uv run pytest tests/cli/test_install_client.py tests/cli/test_install_client_hooks.py -q` — passed, 111 passed.
- `uv run ruff check .` — passed.
- `uv run pyright .` — passed.
