### PR TITLE
feat(cli): add bare install-client flows

### DIFF
--- a/src/archex/cli/install_client_cmd.py
+++ b/src/archex/cli/install_client_cmd.py
@@ -22,12 +22,28 @@ from archex.client_setup import (
 )
 
 
+def _is_interactive() -> bool:
+    import sys
+
+    return sys.stdin.isatty()
+
+
 @click.command("install-client")
-@click.argument(
-    "client",
-    type=click.Choice(["claude-code", "codex", "cursor", "opencode", "pi", "omp"]),
+@click.argument("client_or_source", required=False)
+@click.argument("source_opt", required=False)
+@click.option(
+    "--all-detected",
+    is_flag=True,
+    default=False,
+    help="Install configuration for all detected possible clients.",
 )
-@click.argument("source", required=False, default=None)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip interactive confirmation prompts.",
+)
 @click.option(
     "--scope",
     type=click.Choice(["project", "user"]),
@@ -72,19 +88,38 @@ from archex.client_setup import (
     help="Install client config even if the archex mcp runtime is missing.",
 )
 def install_client_cmd(
-    client: str,
-    source: str | None,
+    client_or_source: str | None,
+    source_opt: str | None,
     scope: str | None,
     dry_run: bool,
     agent_file: Path | None,
     hooks: bool,
     remove_hooks: bool,
     allow_missing_mcp: bool,
+    all_detected: bool,
+    yes: bool,
 ) -> None:
     """Install MCP client configuration for archex (preview with --dry-run)."""
     if hooks and remove_hooks:
         raise click.ClickException("--hooks and --remove-hooks are mutually exclusive")
+    valid_clients = ["claude-code", "codex", "cursor", "opencode", "pi", "omp"]
+
+    client: str | None = None
+    source: str | None = None
+
+    if client_or_source is not None:
+        if client_or_source in valid_clients:
+            client = client_or_source
+            source = source_opt
+        else:
+            if source_opt is not None:
+                raise click.ClickException(f"Invalid client: {client_or_source}")
+            client = None
+            source = client_or_source
+
     if hooks or remove_hooks:
+        if client is None:
+            raise click.ClickException("Must specify a client when using --hooks")
         _run_hook_action(
             cast("ClientName", client),
             source,
@@ -97,13 +132,102 @@ def install_client_cmd(
 
     if not allow_missing_mcp and importlib.util.find_spec("mcp") is None:
         raise click.ClickException(
-            f"Cannot register archex MCP for {client} because this archex installation "
+            "Cannot register archex MCP because this archex installation "
             "cannot start `archex mcp`.\n\n"
             "Fix for uv tool users:\n  uv tool install --force 'archex[mcp]'\n\n"
             "Fix for project users:\n  uv add 'archex[mcp]'\n\n"
             "Or use --allow-missing-mcp to bypass this check."
         )
     try:
+        if all_detected:
+            if client:
+                raise click.ClickException(
+                    "Cannot specify a specific client when using --all-detected"
+                )
+            from archex.client_setup import (
+                build_discovered_install_plans,
+                discover_clients,
+                render_multiple_install_preview,
+            )
+
+            discovered = discover_clients(source)
+            plans = build_discovered_install_plans(discovered, source)
+            if dry_run:
+                click.echo(render_multiple_install_preview(plans), nl=False)
+                if agent_file is not None:
+                    click.echo(render_agent_guidance_preview(agent_file.expanduser()), nl=False)
+                return
+
+            if not yes and not _is_interactive():
+                raise click.ClickException(
+                    "Refusing to write to all detected clients in a non-TTY without --yes."
+                )
+            for plan in plans:
+                target = write_client_install_plan(plan)
+                click.echo(f"Wrote {plan.client} config: {target}")
+            if agent_file is not None:
+                resolved = agent_file.expanduser()
+                if append_agent_guidance(resolved):
+                    click.echo(f"Appended archex MCP guidance: {resolved}")
+                else:
+                    click.echo(f"archex MCP guidance already present: {resolved}")
+            return
+
+        if client is None:
+            # Interactive flow
+            if not _is_interactive() and not yes:
+                raise click.ClickException(
+                    "install-client is interactive by default, but stdin/stdout are not TTY.\n"
+                    "Use --all-detected --yes, or specify a client explicitly."
+                )
+
+            from archex.client_setup import (
+                build_discovered_install_plans,
+                discover_clients,
+                render_multiple_install_preview,
+            )
+
+            discovered = discover_clients(source)
+
+            click.echo("Detected possible clients:\n")
+            for d in discovered:
+                checkbox = "[x]" if d.is_installed else "[ ]"
+                click.echo(f"{checkbox} {d.client.ljust(12)} {d.evidence}")
+            if not any(d.is_installed for d in discovered):
+                click.echo("\nNo configured clients found.")
+                return
+
+            plans = build_discovered_install_plans(discovered, source)
+            click.echo(
+                f"\nInstall archex MCP registration for {len(plans)} detected clients? [y/N] ",
+                nl=False,
+            )
+            if not yes:
+                resp = input().strip().lower()
+                if resp not in ("y", "yes"):
+                    click.echo("Aborted.")
+                    return
+
+            click.echo(render_multiple_install_preview(plans), nl=False)
+            if not yes:
+                click.echo("Proceed? [Y/n] ", nl=False)
+                resp = input().strip().lower()
+                if resp in ("n", "no"):
+                    click.echo("Aborted.")
+                    return
+
+            for plan in plans:
+                target = write_client_install_plan(plan)
+                click.echo(f"Wrote {plan.client} config: {target}")
+
+            if agent_file is not None:
+                resolved = agent_file.expanduser()
+                if append_agent_guidance(resolved):
+                    click.echo(f"Appended archex MCP guidance: {resolved}")
+                else:
+                    click.echo(f"archex MCP guidance already present: {resolved}")
+            return
+
         plan = build_client_install_plan(
             cast("ClientName", client),
             source,

--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -152,6 +152,35 @@ def discover_clients(source: str | Path | None = None) -> list[DiscoveredClient]
     return discovered
 
 
+def build_discovered_install_plans(
+    discovered: list[DiscoveredClient],
+    source: str | Path | None = None,
+) -> list[ClientInstallPlan]:
+    plans: list[ClientInstallPlan] = []
+    for d in discovered:
+        if d.is_installed:
+            s = source if d.scope == "project" else None
+            plans.append(build_client_install_plan(d.client, s, scope=d.scope))
+    return plans
+
+
+def render_multiple_install_preview(plans: list[ClientInstallPlan]) -> str:
+    if not plans:
+        return "No client configurations detected to update.\n"
+
+    lines = ["Will write:"]
+    for plan in plans:
+        if _is_toml_plan(plan):
+            lines.append(f"- {plan.target_path}: add [mcp_servers.archex]")
+        elif plan.client == "opencode":
+            lines.append(f"- {plan.target_path}: add mcp.archex")
+        else:
+            lines.append(f"- {plan.target_path}: add mcpServers.archex")
+
+    lines.append("\nNo existing non-archex entries will be removed.")
+    return "\n".join(lines) + "\n"
+
+
 def build_client_install_plan(
     client: ClientName,
     source: str | Path | None = None,

--- a/tests/cli/test_install_client.py
+++ b/tests/cli/test_install_client.py
@@ -416,3 +416,77 @@ def test_install_client_discovery(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
         d for d in discovered_with_some if d.client == "claude-code" and d.scope == "user"
     )
     assert not claude_user.is_installed
+
+
+def test_install_client_all_detected_dry_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".codex" / "config.toml").write_text("", encoding="utf-8")
+    (repo / ".mcp.json").write_text('{"mcpServers": {}}', encoding="utf-8")
+
+    result = CliRunner().invoke(cli, ["install-client", "--all-detected", "--dry-run", str(repo)])
+
+    assert result.exit_code == 0
+    assert "Will write:" in result.output
+    assert ".codex/config.toml: add [mcp_servers.archex]" in result.output
+    assert ".mcp.json: add mcpServers.archex" in result.output
+
+    # Ensure nothing was written
+    assert (tmp_path / ".codex" / "config.toml").read_text(encoding="utf-8") == ""
+
+
+def test_install_client_all_detected_yes_writes_detected_configs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    codex_config = tmp_path / ".codex" / "config.toml"
+    codex_config.parent.mkdir()
+    codex_config.write_text('model = "gpt-5"\n', encoding="utf-8")
+    claude_config = repo / ".mcp.json"
+    claude_config.write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+
+    result = CliRunner().invoke(cli, ["install-client", "--all-detected", "--yes", str(repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "Wrote codex config" in result.output
+    assert "Wrote claude-code config" in result.output
+    assert "[mcp_servers.archex]" in codex_config.read_text(encoding="utf-8")
+    payload = json.loads(claude_config.read_text(encoding="utf-8"))
+    assert payload["mcpServers"]["archex"] == {"command": "archex", "args": ["mcp"]}
+
+
+def test_install_client_non_tty_behavior(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Not a TTY, no --yes, no --all-detected
+    result = CliRunner().invoke(cli, ["install-client"])
+    assert result.exit_code != 0
+    assert "install-client is interactive by default, but stdin/stdout are not TTY" in result.output
+
+
+def test_install_client_interactive_flow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".codex" / "config.toml").write_text("", encoding="utf-8")
+
+    # Simulate TTY and 'yes' response to both prompts
+    from unittest.mock import patch
+
+    runner = CliRunner()
+    with patch("archex.cli.install_client_cmd._is_interactive", return_value=True):
+        result = runner.invoke(cli, ["install-client"], input="y\ny\n")
+
+    assert result.exit_code == 0
+    assert "Detected possible clients:" in result.output
+    assert "codex" in result.output
+    assert "Install archex MCP registration for" in result.output
+    assert "Wrote codex config" in result.output
+
+    # Confirm it actually wrote
+    content = (tmp_path / ".codex" / "config.toml").read_text(encoding="utf-8")
+    assert "[mcp_servers.archex]" in content


### PR DESCRIPTION
## Summary
- Add bare `archex install-client` planning for all discovered clients.
- Add safe noninteractive paths through `--all-detected`, `--yes`, and `--dry-run`.
- Preserve direct `install-client <client>` compatibility.

## Stack

Stack-Id: `archex-m3-onboarding-20260708`
Base: `main`
Position: 2/3

1. `pr1-client-discovery` ->  #465
2. `pr2-bare-install-client` -> this PR
3. `pr4-agent-guidance` ->  #467

Depends on: #465
Upstack: #467

## Validation
- `uv run pytest tests/cli/test_install_client.py tests/cli/test_install_client_hooks.py -q` — passed, 111 passed.
- `uv run ruff check .` — passed.
- `uv run pyright .` — passed.
