### PR TITLE
feat(cli): integrate install-client agent guidance

### DIFF
--- a/src/archex/cli/install_client_cmd.py
+++ b/src/archex/cli/install_client_cmd.py
@@ -193,6 +193,7 @@ def install_client_cmd(
             for d in discovered:
                 checkbox = "[x]" if d.is_installed else "[ ]"
                 click.echo(f"{checkbox} {d.client.ljust(12)} {d.evidence}")
+
             if not any(d.is_installed for d in discovered):
                 click.echo("\nNo configured clients found.")
                 return
@@ -226,6 +227,29 @@ def install_client_cmd(
                     click.echo(f"Appended archex MCP guidance: {resolved}")
                 else:
                     click.echo(f"archex MCP guidance already present: {resolved}")
+            else:
+                from archex.client_setup import discover_agent_files
+
+                agent_files = discover_agent_files(
+                    Path(source if source is not None else ".").expanduser().resolve()
+                )
+                if agent_files:
+                    click.echo(
+                        "\nAppend archex MCP guidance to detected agent instruction files? [Y/n] ",
+                        nl=False,
+                    )
+                    if not yes:
+                        resp = input().strip().lower()
+                        if resp in ("n", "no"):
+                            return
+                    click.echo("Detected:")
+                    for af in agent_files:
+                        click.echo(f"- {af}")
+                    for af in agent_files:
+                        if append_agent_guidance(af):
+                            click.echo(f"Appended archex MCP guidance: {af}")
+                        else:
+                            click.echo(f"archex MCP guidance already present: {af}")
             return
 
         plan = build_client_install_plan(

--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -109,6 +109,18 @@ def get_client_config_candidates(
         return []
 
 
+def discover_agent_files(repo_root: Path) -> list[Path]:
+    home = Path.home()
+    candidates = [
+        home / ".omp" / "agent" / "AGENTS.md",
+        home / ".pi" / "agent" / "AGENTS.md",
+        repo_root / "AGENTS.md",
+        repo_root / "CLAUDE.md",
+        repo_root / ".cursorrules",
+    ]
+    return [p for p in candidates if p.exists() and p.is_file()]
+
+
 def discover_clients(source: str | Path | None = None) -> list[DiscoveredClient]:
     repo_root = Path(source if source is not None else ".").expanduser().resolve()
     discovered: list[DiscoveredClient] = []

--- a/tests/cli/test_install_client.py
+++ b/tests/cli/test_install_client.py
@@ -490,3 +490,75 @@ def test_install_client_interactive_flow(tmp_path: Path, monkeypatch: pytest.Mon
     # Confirm it actually wrote
     content = (tmp_path / ".codex" / "config.toml").read_text(encoding="utf-8")
     assert "[mcp_servers.archex]" in content
+
+
+def test_install_client_blocks_missing_mcp_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import importlib.util
+    from importlib.machinery import ModuleSpec
+
+    def missing_spec(name: str, package: str | None = None) -> ModuleSpec | None:
+        return None
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".codex" / "config.toml").write_text("", encoding="utf-8")
+    monkeypatch.setattr(importlib.util, "find_spec", missing_spec)
+
+    result = CliRunner().invoke(cli, ["install-client", "codex", str(repo)])
+
+    assert result.exit_code != 0
+    assert "Cannot register archex MCP" in result.output
+    assert "uv tool install --force 'archex[mcp]'" in result.output
+    assert "--allow-missing-mcp" in result.output
+    assert (tmp_path / ".codex" / "config.toml").read_text(encoding="utf-8") == ""
+
+
+def test_install_client_allow_missing_mcp_runtime_writes_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import importlib.util
+    from importlib.machinery import ModuleSpec
+
+    def missing_spec(name: str, package: str | None = None) -> ModuleSpec | None:
+        return None
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    codex_config = tmp_path / ".codex" / "config.toml"
+    codex_config.parent.mkdir()
+    codex_config.write_text("", encoding="utf-8")
+    monkeypatch.setattr(importlib.util, "find_spec", missing_spec)
+
+    result = CliRunner().invoke(cli, ["install-client", "codex", "--allow-missing-mcp"])
+
+    assert result.exit_code == 0, result.output
+    assert "[mcp_servers.archex]" in codex_config.read_text(encoding="utf-8")
+
+
+def test_install_client_discovers_agent_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".codex" / "config.toml").write_text("", encoding="utf-8")
+    agent_file = repo / "CLAUDE.md"
+    agent_file.write_text("Hello\n", encoding="utf-8")
+
+    runner = CliRunner()
+    from unittest.mock import patch
+
+    with patch("archex.cli.install_client_cmd._is_interactive", return_value=True):
+        # Answer 'y' to install clients, 'y' to append guidance
+        result = runner.invoke(cli, ["install-client", str(repo)], input="y\ny\ny\n")
+
+    assert result.exit_code == 0
+    assert "Append archex MCP guidance to detected agent instruction files?" in result.output
+    assert str(agent_file) in result.output
+
+    content = agent_file.read_text(encoding="utf-8")
+    assert "<!-- archex:mcp-guidance start -->" in content


### PR DESCRIPTION
## Summary
- Integrate agent guidance detection and idempotent guidance appends into install-client onboarding.
- Keep config writes non-destructive and prompt-gated.
- Exercise the M1 MCP runtime gate through the expanded install-client flow.

## Stack

Stack-Id: `archex-m3-onboarding-20260708`
Base: `main`
Position: 3/3

1. `pr1-client-discovery` ->  #465
2. `pr2-bare-install-client` ->  #466
3. `pr4-agent-guidance` -> this PR

Depends on: #466
Upstack: none

## Validation
- `uv run pytest tests/cli/test_install_client.py tests/cli/test_install_client_hooks.py -q` — passed, 111 passed.
- `uv run ruff check .` — passed.
- `uv run pyright .` — passed.
