### PR TITLE
feat(metrics): add interactive setup command

### DIFF
--- a/src/archex/cli/metrics_cmd.py
+++ b/src/archex/cli/metrics_cmd.py
@@ -106,6 +106,59 @@ def export_cmd(output: Path, since: str, include_local_paths: bool) -> None:
     click.echo(f"Exported metrics to {output}")
 
 
+def _is_tty() -> bool:
+    import sys
+
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+@metrics_cmd.command("setup")
+@click.option("--yes", is_flag=True, help="Apply default settings without prompting.")
+def setup_cmd(yes: bool) -> None:
+    """Configure local metrics and traces interactively."""
+
+    is_tty = _is_tty()
+    if not is_tty and not yes:
+        raise click.UsageError(
+            "metrics setup is interactive by default, but stdin/stdout are not TTY.\n"
+            "Pass --yes to apply default settings."
+        )
+
+    if not yes:
+        click.echo("Configure local token-savings metrics?")
+        click.echo()
+        click.echo("Local metrics:")
+        click.echo("- stored only at ~/.archex/usage.sqlite")
+        click.echo("- no hosted upload")
+        click.echo("- no LLM calls")
+        click.echo(
+            "- counters do not store query text, file paths, snippets, prompts, Git remotes, "
+            "org names, or repo names"
+        )
+        click.echo()
+        counters_yes = click.confirm("Enable local counters?", default=True)
+
+        click.echo()
+        click.echo("Detailed traces:")
+        click.echo("- local only")
+        click.echo("- retained for 14 days")
+        click.echo("- can include query text and returned file paths")
+        click.echo("- useful for debugging MCP/CLI usage")
+        click.echo("- not needed for normal savings totals")
+        click.echo()
+        trace_yes = click.confirm("Enable detailed traces?", default=False)
+    else:
+        counters_yes = True
+        trace_yes = False
+
+    set_metrics_enabled(counters_yes)
+    set_trace_enabled(trace_yes)
+
+    click.echo()
+    click.echo(f"Metrics counters: {'enabled' if counters_yes else 'disabled'}")
+    click.echo(f"Metrics trace: {'enabled' if trace_yes else 'disabled'}")
+
+
 @metrics_cmd.command("enable")
 def enable_cmd() -> None:
     """Enable anonymous local metrics counters."""

--- a/tests/metrics/test_metrics_cli.py
+++ b/tests/metrics/test_metrics_cli.py
@@ -164,6 +164,58 @@ def test_metrics_export_redacts_paths_by_default(
     assert pathful_payload["repos"][0]["repo_root"] == str(repo_root.resolve())
 
 
+def test_metrics_setup_interactive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("archex.cli.metrics_cmd._is_tty", lambda: True)
+
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["metrics", "setup"], input="y\ny\n")
+    assert result.exit_code == 0
+    assert "Configure local token-savings metrics?" in result.output
+    assert "Metrics counters: enabled" in result.output
+    assert "Metrics trace: enabled" in result.output
+
+    # Check that settings are persisted
+    from archex.metrics.policy import resolve_metrics_policy
+
+    assert resolve_metrics_policy().metrics_enabled is True
+    assert resolve_metrics_policy().trace_enabled is True
+
+
+def test_metrics_setup_noninteractive_requires_yes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    runner = CliRunner()
+
+    monkeypatch.setattr("archex.cli.metrics_cmd._is_tty", lambda: False)
+
+    result = runner.invoke(cli, ["metrics", "setup"])
+    assert result.exit_code != 0
+    assert "metrics setup is interactive by default, but stdin/stdout are not TTY" in result.output
+
+
+def test_metrics_setup_yes_applies_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    runner = CliRunner()
+
+    monkeypatch.setattr("archex.cli.metrics_cmd._is_tty", lambda: False)
+
+    result = runner.invoke(cli, ["metrics", "setup", "--yes"])
+    assert result.exit_code == 0
+    assert "Metrics counters: enabled" in result.output
+    assert "Metrics trace: disabled" in result.output
+
+    # Check that defaults are persisted
+    from archex.metrics.policy import resolve_metrics_policy
+
+    assert resolve_metrics_policy().metrics_enabled is True
+    assert resolve_metrics_policy().trace_enabled is False
+
+
 def test_metrics_controls_enable_disable_trace_and_delete(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Stack

Stack-Id: `m4-metrics-setup`
Base: `main`
Position: 1/2

1. `feat/m4-metrics-setup` -> this PR
2. `feat/m4-metrics-privacy-output` -> (pending)

Depends on: (none - root)

## Summary
Adds an interactive `metrics setup` command to configure local counters and traces with privacy-aware prompts. Handles TTY and non-TTY contexts appropriately.