### PR TITLE
feat(cli): add setup preflight and plan model

### DIFF
--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -24,6 +24,7 @@ from archex.cli.outline_cmd import outline_cmd
 from archex.cli.query_cmd import query_cmd
 from archex.cli.reset_cmd import reset_cmd
 from archex.cli.scout_cmd import scout_cmd
+from archex.cli.setup_cmd import setup_cmd
 from archex.cli.status_cmd import status_cmd
 from archex.cli.symbol_cmd import symbol_cmd
 from archex.cli.symbols_cmd import symbols_cmd
@@ -44,6 +45,7 @@ cli.add_command(cache_cmd)
 cli.add_command(init_cmd)
 cli.add_command(index_cmd)
 cli.add_command(install_client_cmd)
+cli.add_command(setup_cmd)
 cli.add_command(status_cmd)
 cli.add_command(reset_cmd)
 cli.add_command(doctor_cmd)

--- a/src/archex/cli/setup_cmd.py
+++ b/src/archex/cli/setup_cmd.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import click
+
+from archex.client_setup import discover_agent_files, discover_clients
+from archex.doctor import mcp_runtime_available
+from archex.metrics.policy import resolve_metrics_policy
+from archex.status import inspect_project_status
+
+
+@dataclass
+class PreflightState:
+    has_dot_archex: bool
+    has_index: bool
+    is_index_fresh: bool
+    metrics_enabled: bool
+    metrics_trace_enabled: bool
+    mcp_runtime_available: bool
+    discovered_clients: list[str]
+    discovered_agent_files: list[str]
+
+
+def run_preflight(source: Path) -> PreflightState:
+    source_resolved = source.resolve()
+    dot_archex = source_resolved / ".archex"
+    has_dot_archex = dot_archex.exists() and dot_archex.is_dir()
+
+    status = inspect_project_status(source_resolved)
+    has_index = bool(status.indexed_commit)
+    is_index_fresh = status.state == "fresh"
+
+    metrics_policy = resolve_metrics_policy()
+    metrics_enabled = metrics_policy.metrics_enabled
+    metrics_trace_enabled = metrics_policy.trace_enabled
+
+    mcp_runtime = mcp_runtime_available(source_resolved)
+
+    clients = discover_clients(source_resolved)
+    client_names = [c.client for c in clients]
+
+    agent_files = discover_agent_files(source_resolved)
+    agent_file_strs = [
+        str(f.relative_to(source_resolved)) if f.is_relative_to(source_resolved) else str(f)
+        for f in agent_files
+    ]
+
+    return PreflightState(
+        has_dot_archex=has_dot_archex,
+        has_index=has_index,
+        is_index_fresh=is_index_fresh,
+        metrics_enabled=metrics_enabled,
+        metrics_trace_enabled=metrics_trace_enabled,
+        mcp_runtime_available=mcp_runtime,
+        discovered_clients=client_names,
+        discovered_agent_files=agent_file_strs,
+    )
+
+
+@click.command("setup")
+@click.argument(
+    "source",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    default=Path("."),
+)
+@click.option("--dry-run", is_flag=True, help="Print plan without making changes.")
+@click.option("--yes", is_flag=True, help="Execute default setup without prompting.")
+@click.option("--clients/--no-clients", default=None, help="Install available clients.")
+@click.option("--metrics/--no-metrics", default=None, help="Enable local metrics.")
+@click.option("--hooks", is_flag=True, help="Install optional hooks.")
+@click.option(
+    "--format",
+    "format_",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    help="Output format.",
+)
+def setup_cmd(
+    source: Path,
+    dry_run: bool,
+    yes: bool,
+    clients: bool | None,
+    metrics: bool | None,
+    hooks: bool,
+    format_: Literal["text", "json"],
+) -> None:
+    """Guided onboarding wizard."""
+    preflight = run_preflight(source)
+
+    if format_ == "json":
+        plan: dict[str, Any] = {
+            "preflight": asdict(preflight),
+            "planned_actions": [],
+        }
+        click.echo(json.dumps(plan, indent=2))
+        return
+
+    if dry_run:
+        click.echo("--- Setup Preflight ---")
+        for k, v in asdict(preflight).items():
+            click.echo(f"{k}: {v}")
+        return
+
+    # Non-interactive without --yes
+    if not sys.stdin.isatty() and not sys.stdout.isatty() and not yes:
+        click.echo("setup is interactive by default, but stdin/stdout are not TTY.", err=True)
+        click.echo("Use --dry-run to print a plan, or pass --yes with explicit options.", err=True)
+        sys.exit(1)
+
+    click.echo("Setup is interactive by default, but not yet fully implemented.")
+    click.echo("Use --dry-run or --format json for now.")
+    sys.exit(1)

--- a/src/archex/doctor.py
+++ b/src/archex/doctor.py
@@ -478,6 +478,13 @@ def _grammar_check() -> DoctorCheck:
     )
 
 
+def mcp_runtime_available(repo_root: Path) -> bool:
+    """Return whether the local archex MCP runtime can be started."""
+    return any(
+        check.name == "mcp_runtime" and check.status == "ok" for check in _mcp_checks(repo_root)
+    )
+
+
 def _mcp_checks(repo_root: Path) -> list[DoctorCheck]:
     package_available = importlib.util.find_spec("mcp") is not None
     checked_paths = _mcp_config_candidates(repo_root)

--- a/tests/cli/test_setup_cmd.py
+++ b/tests/cli/test_setup_cmd.py
@@ -1,0 +1,37 @@
+import json
+import subprocess
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+
+
+def test_setup_dry_run(tmp_path: Path) -> None:
+    subprocess.check_call(["git", "init", str(tmp_path)])
+    runner = CliRunner()
+    result = runner.invoke(cli, ["setup", str(tmp_path), "--dry-run"])
+    assert result.exit_code == 0
+    assert "--- Setup Preflight ---" in result.output
+    assert "has_dot_archex: False" in result.output
+
+
+def test_setup_json_format(tmp_path: Path) -> None:
+    subprocess.check_call(["git", "init", str(tmp_path)])
+    runner = CliRunner()
+    result = runner.invoke(cli, ["setup", str(tmp_path), "--format", "json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "preflight" in data
+    assert "planned_actions" in data
+    assert data["preflight"]["has_dot_archex"] is False
+    assert data["preflight"]["has_index"] is False
+
+
+def test_setup_non_tty_error(tmp_path: Path) -> None:
+    subprocess.check_call(["git", "init", str(tmp_path)])
+    runner = CliRunner()
+    # CliRunner simulates non-TTY
+    result = runner.invoke(cli, ["setup", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "setup is interactive by default" in result.output


### PR DESCRIPTION
## Summary
- add the guided setup command with repo preflight state and JSON/dry-run planning
- surface repo/index freshness, metrics policy, MCP runtime readiness, discovered clients, and agent files
- wire setup into the CLI command group

## Verification
- uv run pytest tests/cli/test_setup_cmd.py -q --no-cov
- uv run ruff format --check .
- uv run ruff check .
- uv run pyright .

Stack-Id: m5-setup-wizard
Stack-Position: 1/5