### PR TITLE
docs: refresh quickstart and installation trust docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,18 @@ archex does not ask the downstream agent to trust ranking alone. Every query/sco
 
 ```bash
 uv tool install archex
-archex doctor
+archex setup
 archex query "How does authentication work?" --format xml
 ```
 
-`archex doctor` reports whether the local index, grammar support, model cache, MCP registration, and `.archex/` state are healthy. Repo-local commands default to the current working directory. If the repo has not been initialized yet:
+`archex setup` is the primary guided onboarding command. It initializes repo-local state, builds the first index, checks MCP runtime health, and offers to configure detected clients and agent guidance.
+
+`archex doctor` reports whether the local index, grammar support, model cache, MCP registration, and `.archex/` state are healthy. Repo-local commands default to the current working directory.
+
+For explicit repo initialization without the full guided setup:
 
 ```bash
 archex init
-archex index
 archex query "How does authentication work?" --format xml
 ```
 

--- a/docs/INSTALLATION_TRUST_CONTRACT.md
+++ b/docs/INSTALLATION_TRUST_CONTRACT.md
@@ -17,17 +17,29 @@ Expected-compatible but not claimed as fully verified here:
 - MCP clients that support stdio servers with JSON config shaped like `mcpServers.<name>.command` plus `args`
 - Headless MCP runners. Treat these as unverified until `archex doctor`, `archex mcp`, and one `archex scout` call pass in that runner.
 
-## CLI-only setup
+## Guided setup
 
-Install the CLI globally with uv:
+Install the CLI globally with uv and run the primary onboarding command:
 
 ```bash
 uv tool install archex
-archex doctor .
+archex setup
+archex query "Where is cache invalidation handled?" --format xml
+```
+
+`archex setup` is the primary interactive onboarding flow. It initializes the repository, builds the first index, checks the MCP runtime (which is a standard dependency), and offers to install MCP client registrations.
+
+## CLI-only init path
+
+For explicit repo initialization without the full guided setup, such as in scripts:
+
+```bash
+uv tool install archex
 archex init .
-archex index .
 archex query . "Where is cache invalidation handled?" --format xml
 ```
+
+`archex init` configures repo-local state and builds the first index by default. `archex index` remains available for explicit refresh and advanced indexing options.
 
 Project dependency setup:
 
@@ -49,10 +61,15 @@ The client-by-client tested/unverified matrix and bootstrap paths live in [CLIEN
 
 ## MCP setup
 
-Install the MCP extra:
+The MCP runtime is a standard dependency of archex.
+
+If your installation is damaged or missing the `mcp` package, `archex doctor` and `archex mcp` will explicitly report the missing runtime. Remediation:
 
 ```bash
-uv tool install "archex[mcp]"
+# For uv tool installations:
+uv tool install --force archex
+# For project dependencies:
+uv add archex
 ```
 
 Register the stdio server exactly as:


### PR DESCRIPTION
Refreshes onboarding paths.

- Adds guided setup quickstart to README
- Documents CLI-only init path
- Adds MCP runtime remediation steps