### PR TITLE
fix(index): close ephemeral index-store scratch directories reliably

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -299,7 +299,7 @@ def _full_index(
                 timing.strategy = "full"
 
             return store
-        except Exception:
+        except BaseException:
             store.close()
             raise
     finally:
@@ -344,21 +344,25 @@ def _ensure_index(
     cached_db = cache.get(cache_key) if config.cache else None
     if cached_db is not None:
         store = IndexStore(cached_db)
-        store_signature = store.get_metadata("working_tree_signature")
-        signature_matches = (
-            working_tree_signature is None or store_signature == working_tree_signature
-        )
-        needs_reindex = store.needs_reindex()
-        metadata_matches = _index_config_metadata_matches(store, effective_index_config)
-        if not needs_reindex and signature_matches and metadata_matches:
-            if timing is not None:
-                timing.cached = True
-                timing.strategy = "cached"
-                timing.index_ms = _elapsed_ms(t_start)
-            return store
-        store.close()
-        if needs_reindex or not metadata_matches:
-            cache.invalidate(cache_key)
+        try:
+            store_signature = store.get_metadata("working_tree_signature")
+            signature_matches = (
+                working_tree_signature is None or store_signature == working_tree_signature
+            )
+            needs_reindex = store.needs_reindex()
+            metadata_matches = _index_config_metadata_matches(store, effective_index_config)
+            if not needs_reindex and signature_matches and metadata_matches:
+                if timing is not None:
+                    timing.cached = True
+                    timing.strategy = "cached"
+                    timing.index_ms = _elapsed_ms(t_start)
+                return store
+            store.close()
+            if needs_reindex or not metadata_matches:
+                cache.invalidate(cache_key)
+        except BaseException:
+            store.close()
+            raise
 
     # Path 2: Delta path — same repo, different commit (local repos only)
     delta_store = _try_delta_index(
@@ -444,14 +448,20 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
 
         if not manifest.changes and same_commit:
             clean_store = IndexStore(db_path)
-            if attempt.working_tree_signature is not None:
-                clean_store.set_metadata("working_tree_signature", attempt.working_tree_signature)
-            clean_store.set_metadata("indexed_at", str(time.time()))
-            if attempt.timing is not None:
-                attempt.timing.cached = True
-                attempt.timing.strategy = "cached"
-                attempt.timing.index_ms = _elapsed_ms(attempt.t_start)
-            return clean_store
+            try:
+                if attempt.working_tree_signature is not None:
+                    clean_store.set_metadata(
+                        "working_tree_signature", attempt.working_tree_signature
+                    )
+                clean_store.set_metadata("indexed_at", str(time.time()))
+                if attempt.timing is not None:
+                    attempt.timing.cached = True
+                    attempt.timing.strategy = "cached"
+                    attempt.timing.index_ms = _elapsed_ms(attempt.t_start)
+                return clean_store
+            except BaseException:
+                clean_store.close()
+                raise
 
         total_files = len(
             discover_files(
@@ -467,93 +477,97 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
         if attempt.timing is not None:
             attempt.timing.delta_attempted = True
         store = IndexStore(db_path)
-        index_config = attempt.index_config or IndexConfig()
-        old_chunks = store.get_chunks() if index_config.vector else []
-        cache_vector_path = attempt.cache.vector_path(
-            attempt.cache_key,
-            vector_mode=index_config.vector_mode,
-            surrogate_version=index_config.surrogate_version,
-        )
-        old_vector_path = (
-            cache_vector_path
-            if cache_vector_path.exists()
-            else store.vector_index_path_for(
+        try:
+            index_config = attempt.index_config or IndexConfig()
+            old_chunks = store.get_chunks() if index_config.vector else []
+            cache_vector_path = attempt.cache.vector_path(
+                attempt.cache_key,
                 vector_mode=index_config.vector_mode,
                 surrogate_version=index_config.surrogate_version,
             )
-        )
-        graph = DependencyGraph.from_edges(store.get_edges())
-        delta_meta = apply_delta(
-            store,
-            graph,
-            manifest,
-            repo_path,
-            config,
-            index_config=index_config,
-        )
-        if index_config.vector:
-            embedder = _get_embedder(index_config)
-            if embedder is not None:
-                from archex.index.vector import VectorIndex
-
-                new_chunks = store.get_chunks()
-                vector_chunks = embedding_eligible_chunks(new_chunks)
-                new_surrogates = _surrogate_lookup(store, vector_chunks, index_config)
-                cached_vectors = _cached_vectors_by_content_hash(
-                    old_vector_path,
-                    old_chunks,
-                    index_config,
-                    embedder,
-                )
-                vec_idx = VectorIndex(
-                    quantize=index_config.quantize_vectors,
-                    quantize_bits=index_config.quantize_bits,
-                )
-                cache_hits, cache_misses = vec_idx.build(
-                    vector_chunks,
-                    embedder,
-                    surrogates_by_chunk_id=new_surrogates,
-                    vector_mode=index_config.vector_mode,
-                    cached_vectors_by_content_hash=cached_vectors,
-                )
-                vector_path = attempt.cache.vector_path(
-                    attempt.cache_key,
+            old_vector_path = (
+                cache_vector_path
+                if cache_vector_path.exists()
+                else store.vector_index_path_for(
                     vector_mode=index_config.vector_mode,
                     surrogate_version=index_config.surrogate_version,
                 )
-                if vector_chunks:
-                    vec_idx.save(
-                        vector_path,
-                        embedder_name=index_config.embedder or "",
-                        vector_dim=embedder.dimension,
+            )
+            graph = DependencyGraph.from_edges(store.get_edges())
+            delta_meta = apply_delta(
+                store,
+                graph,
+                manifest,
+                repo_path,
+                config,
+                index_config=index_config,
+            )
+            if index_config.vector:
+                embedder = _get_embedder(index_config)
+                if embedder is not None:
+                    from archex.index.vector import VectorIndex
+
+                    new_chunks = store.get_chunks()
+                    vector_chunks = embedding_eligible_chunks(new_chunks)
+                    new_surrogates = _surrogate_lookup(store, vector_chunks, index_config)
+                    cached_vectors = _cached_vectors_by_content_hash(
+                        old_vector_path,
+                        old_chunks,
+                        index_config,
+                        embedder,
+                    )
+                    vec_idx = VectorIndex(
+                        quantize=index_config.quantize_vectors,
+                        quantize_bits=index_config.quantize_bits,
+                    )
+                    cache_hits, cache_misses = vec_idx.build(
+                        vector_chunks,
+                        embedder,
+                        surrogates_by_chunk_id=new_surrogates,
+                        vector_mode=index_config.vector_mode,
+                        cached_vectors_by_content_hash=cached_vectors,
+                    )
+                    vector_path = attempt.cache.vector_path(
+                        attempt.cache_key,
                         vector_mode=index_config.vector_mode,
                         surrogate_version=index_config.surrogate_version,
                     )
-                elif vector_path.exists():
-                    vector_path.unlink()
-                store.set_metadata("embedding_cache_hits", str(cache_hits))
-                store.set_metadata("embedding_cache_misses", str(cache_misses))
-        identity = source.url or source.local_path or ""
-        store.set_metadata("commit_hash", current_commit)
-        store.set_metadata("source_identity", identity)
-        store.set_metadata("indexed_at", str(time.time()))
-        if attempt.working_tree_signature is not None:
-            store.set_metadata("working_tree_signature", attempt.working_tree_signature)
-        store.conn.execute("PRAGMA wal_checkpoint(FULL)")
-        attempt.cache.put(
-            attempt.cache_key,
-            db_path,
-            resolved_commit=current_commit,
-            source_identity=identity,
-        )
-        if attempt.timing is not None:
-            attempt.timing.delta_ms = delta_meta.delta_time_ms
-            attempt.timing.delta_meta = delta_meta
-            attempt.timing.index_ms = _elapsed_ms(attempt.t_start)
-            attempt.timing.delta_succeeded = True
-            attempt.timing.strategy = "delta"
-        logger.info("Delta index applied in %.0fms", delta_meta.delta_time_ms)
-        return store
+                    if vector_chunks:
+                        vec_idx.save(
+                            vector_path,
+                            embedder_name=index_config.embedder or "",
+                            vector_dim=embedder.dimension,
+                            vector_mode=index_config.vector_mode,
+                            surrogate_version=index_config.surrogate_version,
+                        )
+                    elif vector_path.exists():
+                        vector_path.unlink()
+                    store.set_metadata("embedding_cache_hits", str(cache_hits))
+                    store.set_metadata("embedding_cache_misses", str(cache_misses))
+            identity = source.url or source.local_path or ""
+            store.set_metadata("commit_hash", current_commit)
+            store.set_metadata("source_identity", identity)
+            store.set_metadata("indexed_at", str(time.time()))
+            if attempt.working_tree_signature is not None:
+                store.set_metadata("working_tree_signature", attempt.working_tree_signature)
+            store.conn.execute("PRAGMA wal_checkpoint(FULL)")
+            attempt.cache.put(
+                attempt.cache_key,
+                db_path,
+                resolved_commit=current_commit,
+                source_identity=identity,
+            )
+            if attempt.timing is not None:
+                attempt.timing.delta_ms = delta_meta.delta_time_ms
+                attempt.timing.delta_meta = delta_meta
+                attempt.timing.index_ms = _elapsed_ms(attempt.t_start)
+                attempt.timing.delta_succeeded = True
+                attempt.timing.strategy = "delta"
+            logger.info("Delta index applied in %.0fms", delta_meta.delta_time_ms)
+            return store
+        except BaseException:
+            store.close()
+            raise
     except DeltaIndexError:
         if attempt.timing is not None:
             attempt.timing.delta_attempted = True

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -209,95 +209,99 @@ def _full_index(
         from archex.index.delta import compute_file_states
 
         db_path = Path(tempfile.mkdtemp()) / "index.db"
-        store = IndexStore(db_path)
-        store.insert_chunks(all_chunks)
-        chunk_surrogates = (
-            build_chunk_surrogates(
-                all_chunks,
-                version=effective_index_config.surrogate_version,
+        store = IndexStore(db_path, delete_dir_on_close=True)
+        try:
+            store.insert_chunks(all_chunks)
+            chunk_surrogates = (
+                build_chunk_surrogates(
+                    all_chunks,
+                    version=effective_index_config.surrogate_version,
+                )
+                if _surrogates_required(effective_index_config)
+                else []
             )
-            if _surrogates_required(effective_index_config)
-            else []
-        )
-        if chunk_surrogates:
-            store.insert_chunk_surrogates(chunk_surrogates)
-        edges = graph.file_edges()
-        store.replace_file_states(compute_file_states(repo_path, files))
-        store.insert_edges(edges)
-        _build_splade_index(store, all_chunks, effective_index_config)
-        _build_module_summaries(store, graph, parsed_files, effective_index_config)
-        if effective_index_config.vector:
-            embedder = _get_embedder(effective_index_config)
-            if embedder is not None:
-                from archex.index.vector import VectorIndex
+            if chunk_surrogates:
+                store.insert_chunk_surrogates(chunk_surrogates)
+            edges = graph.file_edges()
+            store.replace_file_states(compute_file_states(repo_path, files))
+            store.insert_edges(edges)
+            _build_splade_index(store, all_chunks, effective_index_config)
+            _build_module_summaries(store, graph, parsed_files, effective_index_config)
+            if effective_index_config.vector:
+                embedder = _get_embedder(effective_index_config)
+                if embedder is not None:
+                    from archex.index.vector import VectorIndex
 
-                surrogate_lookup = (
-                    {surrogate.chunk_id: surrogate for surrogate in chunk_surrogates}
-                    if chunk_surrogates
-                    else None
-                )
-                vector_chunks = embedding_eligible_chunks(all_chunks)
-                vec_idx = VectorIndex(
-                    quantize=effective_index_config.quantize_vectors,
-                    quantize_bits=effective_index_config.quantize_bits,
-                )
-                cache_hits, cache_misses = vec_idx.build(
-                    vector_chunks,
-                    embedder,
-                    surrogates_by_chunk_id=surrogate_lookup,
-                    vector_mode=effective_index_config.vector_mode,
-                )
-                store.set_metadata("embedding_cache_hits", str(cache_hits))
-                store.set_metadata("embedding_cache_misses", str(cache_misses))
-                npz_path = (
-                    cache.vector_path(
-                        cache_key,
-                        vector_mode=effective_index_config.vector_mode,
-                        surrogate_version=effective_index_config.surrogate_version,
+                    surrogate_lookup = (
+                        {surrogate.chunk_id: surrogate for surrogate in chunk_surrogates}
+                        if chunk_surrogates
+                        else None
                     )
-                    if config.cache
-                    else store.vector_index_path_for(
-                        vector_mode=effective_index_config.vector_mode,
-                        surrogate_version=effective_index_config.surrogate_version,
+                    vector_chunks = embedding_eligible_chunks(all_chunks)
+                    vec_idx = VectorIndex(
+                        quantize=effective_index_config.quantize_vectors,
+                        quantize_bits=effective_index_config.quantize_bits,
                     )
+                    cache_hits, cache_misses = vec_idx.build(
+                        vector_chunks,
+                        embedder,
+                        surrogates_by_chunk_id=surrogate_lookup,
+                        vector_mode=effective_index_config.vector_mode,
+                    )
+                    store.set_metadata("embedding_cache_hits", str(cache_hits))
+                    store.set_metadata("embedding_cache_misses", str(cache_misses))
+                    npz_path = (
+                        cache.vector_path(
+                            cache_key,
+                            vector_mode=effective_index_config.vector_mode,
+                            surrogate_version=effective_index_config.surrogate_version,
+                        )
+                        if config.cache
+                        else store.vector_index_path_for(
+                            vector_mode=effective_index_config.vector_mode,
+                            surrogate_version=effective_index_config.surrogate_version,
+                        )
+                    )
+                    if vector_chunks:
+                        vec_idx.save(
+                            npz_path,
+                            embedder_name=effective_index_config.embedder or "",
+                            vector_dim=embedder.dimension,
+                            vector_mode=effective_index_config.vector_mode,
+                            surrogate_version=effective_index_config.surrogate_version,
+                        )
+                    elif npz_path.exists():
+                        npz_path.unlink()
+
+            total_repo_tokens = sum(chunk.token_count for chunk in all_chunks)
+            _set_index_config_metadata(store, effective_index_config)
+            store.set_metadata("repo_total_tokens", str(total_repo_tokens))
+            store.set_metadata("chunk_count", str(len(all_chunks)))
+            file_count = len({chunk.file_path for chunk in all_chunks})
+            store.set_metadata("file_count", str(file_count))
+
+            if config.cache:
+                commit = cloned_head or cache.git_head(source.local_path) or source.commit or ""
+                identity = source.url or source.local_path or ""
+                store.set_metadata("commit_hash", commit)
+                store.set_metadata("source_identity", identity)
+                store.set_metadata("indexed_at", str(time.time()))
+                _set_working_tree_signature(store, repo_path, config)
+                store.conn.execute("PRAGMA wal_checkpoint(FULL)")
+                cache.put(
+                    cache_key,
+                    db_path,
+                    resolved_commit=commit,
+                    source_identity=identity,
                 )
-                if vector_chunks:
-                    vec_idx.save(
-                        npz_path,
-                        embedder_name=effective_index_config.embedder or "",
-                        vector_dim=embedder.dimension,
-                        vector_mode=effective_index_config.vector_mode,
-                        surrogate_version=effective_index_config.surrogate_version,
-                    )
-                elif npz_path.exists():
-                    npz_path.unlink()
+            if timing is not None:
+                timing.index_ms = _elapsed_ms(t_idx)
+                timing.strategy = "full"
 
-        total_repo_tokens = sum(chunk.token_count for chunk in all_chunks)
-        _set_index_config_metadata(store, effective_index_config)
-        store.set_metadata("repo_total_tokens", str(total_repo_tokens))
-        store.set_metadata("chunk_count", str(len(all_chunks)))
-        file_count = len({chunk.file_path for chunk in all_chunks})
-        store.set_metadata("file_count", str(file_count))
-
-        if config.cache:
-            commit = cloned_head or cache.git_head(source.local_path) or source.commit or ""
-            identity = source.url or source.local_path or ""
-            store.set_metadata("commit_hash", commit)
-            store.set_metadata("source_identity", identity)
-            store.set_metadata("indexed_at", str(time.time()))
-            _set_working_tree_signature(store, repo_path, config)
-            store.conn.execute("PRAGMA wal_checkpoint(FULL)")
-            cache.put(
-                cache_key,
-                db_path,
-                resolved_commit=commit,
-                source_identity=identity,
-            )
-        if timing is not None:
-            timing.index_ms = _elapsed_ms(t_idx)
-            timing.strategy = "full"
-
-        return store
+            return store
+        except Exception:
+            store.close()
+            raise
     finally:
         cleanup()
 
@@ -2056,22 +2060,22 @@ def query(
         effective_budget = _compute_dynamic_budget(total_repo_tokens, token_budget, intent_budget)
 
         db_path = Path(tempfile.mkdtemp()) / "index.db"
-        store = IndexStore(db_path)
-        chunk_surrogates = (
-            build_chunk_surrogates(
-                all_chunks,
-                version=index_config.surrogate_version,
-            )
-            if _surrogates_required(index_config)
-            else []
-        )
-        surrogate_lookup = (
-            {surrogate.chunk_id: surrogate for surrogate in chunk_surrogates}
-            if chunk_surrogates
-            else None
-        )
-
+        store = IndexStore(db_path, delete_dir_on_close=True)
         try:
+            chunk_surrogates = (
+                build_chunk_surrogates(
+                    all_chunks,
+                    version=index_config.surrogate_version,
+                )
+                if _surrogates_required(index_config)
+                else []
+            )
+            surrogate_lookup = (
+                {surrogate.chunk_id: surrogate for surrogate in chunk_surrogates}
+                if chunk_surrogates
+                else None
+            )
+
             bm25 = BM25Index(
                 store,
                 identifier_fragment_tokenization=index_config.identifier_fragment_tokenization,

--- a/src/archex/cli/index_cmd.py
+++ b/src/archex/cli/index_cmd.py
@@ -80,7 +80,7 @@ def index_cmd(
         return
 
     click.echo(f"Indexed repository: {summary['repo_root']}")
-    click.echo(f"Index path:         {summary['index_path']}")
+    click.echo(f"Index path:         {summary['index_path'] or '(ephemeral, not cached to disk)'}")
     click.echo(f"Commit:             {summary['commit_hash'] or 'none'}")
     click.echo(f"Strategy:           {summary['strategy']}")
     click.echo(f"Files indexed:      {summary['files_indexed']}")

--- a/src/archex/cli/indexing.py
+++ b/src/archex/cli/indexing.py
@@ -83,10 +83,16 @@ def run_indexing_and_get_summary(
         languages = _language_counts(file_metadata)
         cached_path = cache.get(cache_key) if cache is not None and cache_key is not None else None
         duration_ms = int((time.perf_counter() - started) * 1000)
+        # `store.db_path` lives under a scratch directory that `store.close()` removes
+        # when the store has no durable cache entry (`ephemeral` is True) — reporting
+        # that path here would hand back a location that no longer exists the moment
+        # this function returns.
+        ephemeral_untracked = cached_path is None and store.ephemeral
+        index_path = None if ephemeral_untracked else (cached_path or store.db_path)
 
         summary = {
             "repo_root": str(repo_root),
-            "index_path": str(cached_path or store.db_path),
+            "index_path": str(index_path) if index_path is not None else None,
             "commit_hash": store.get_metadata("commit_hash") or "",
             "strategy": timing.strategy or "full",
             "files_indexed": store.get_file_count(),

--- a/src/archex/index/artifact.py
+++ b/src/archex/index/artifact.py
@@ -377,16 +377,18 @@ def _full_reindex_in_place(
             timing=None,
             index_config=index_config,
         )
-        fresh_db_path = fresh_store.db_path
-        fresh_store.conn.execute("PRAGMA wal_checkpoint(FULL)")
+        try:
+            fresh_db_path = fresh_store.db_path
+            fresh_store.conn.execute("PRAGMA wal_checkpoint(FULL)")
 
-        dest_db_path.parent.mkdir(parents=True, exist_ok=True)
-        for suffix in ("-wal", "-shm"):
-            stale_sidecar = dest_db_path.with_name(dest_db_path.name + suffix)
-            if stale_sidecar.exists():
-                stale_sidecar.unlink()
-        shutil.copy2(fresh_db_path, dest_db_path)
-        fresh_store.close()
+            dest_db_path.parent.mkdir(parents=True, exist_ok=True)
+            for suffix in ("-wal", "-shm"):
+                stale_sidecar = dest_db_path.with_name(dest_db_path.name + suffix)
+                if stale_sidecar.exists():
+                    stale_sidecar.unlink()
+            shutil.copy2(fresh_db_path, dest_db_path)
+        finally:
+            fresh_store.close()
     finally:
         shutil.rmtree(scratch_dir, ignore_errors=True)
 
@@ -419,47 +421,53 @@ def sync_imported_artifact(
     t_start = time.perf_counter()
 
     store = IndexStore(dest_db_path)
-    manifest = compute_working_tree_delta(repo_root, store, config)
-    manifest.base_commit = store.get_metadata("commit_hash") or manifest.base_commit
-    current_commit = CacheManager.git_head(str(repo_root))
-    if current_commit:
-        manifest.current_commit = current_commit
+    try:
+        manifest = compute_working_tree_delta(repo_root, store, config)
+        manifest.base_commit = store.get_metadata("commit_hash") or manifest.base_commit
+        current_commit = CacheManager.git_head(str(repo_root))
+        if current_commit:
+            manifest.current_commit = current_commit
 
-    if not manifest.changes:
-        store.set_metadata("indexed_at", str(time.time()))
-        store.close()
-        return ArtifactSyncResult(
-            strategy="clean",
-            files_changed=0,
-            delta_meta=None,
-            sync_time_ms=round((time.perf_counter() - t_start) * 1000, 1),
+        if not manifest.changes:
+            store.set_metadata("indexed_at", str(time.time()))
+            store.close()
+            return ArtifactSyncResult(
+                strategy="clean",
+                files_changed=0,
+                delta_meta=None,
+                sync_time_ms=round((time.perf_counter() - t_start) * 1000, 1),
+            )
+
+        total_files = len(
+            discover_files(
+                repo_root, languages=config.languages, max_file_size=config.max_file_size
+            )
         )
+        change_ratio = len(manifest.changes) / total_files if total_files > 0 else 1.0
 
-    total_files = len(
-        discover_files(repo_root, languages=config.languages, max_file_size=config.max_file_size)
-    )
-    change_ratio = len(manifest.changes) / total_files if total_files > 0 else 1.0
+        if change_ratio >= config.delta_threshold:
+            store.close()
+            logger.warning(_STALE_FALLBACK_LOG, change_ratio * 100, config.delta_threshold * 100)
+            _full_reindex_in_place(repo_root, dest_db_path, config, effective_index_config)
+            return ArtifactSyncResult(
+                strategy="full_reindex",
+                files_changed=len(manifest.changes),
+                delta_meta=None,
+                sync_time_ms=round((time.perf_counter() - t_start) * 1000, 1),
+            )
 
-    if change_ratio >= config.delta_threshold:
+        graph = DependencyGraph.from_edges(store.get_edges())
+        delta_meta = apply_delta(store, graph, manifest, repo_root, config, effective_index_config)
         store.close()
-        logger.warning(_STALE_FALLBACK_LOG, change_ratio * 100, config.delta_threshold * 100)
-        _full_reindex_in_place(repo_root, dest_db_path, config, effective_index_config)
         return ArtifactSyncResult(
-            strategy="full_reindex",
+            strategy="delta",
             files_changed=len(manifest.changes),
-            delta_meta=None,
+            delta_meta=delta_meta,
             sync_time_ms=round((time.perf_counter() - t_start) * 1000, 1),
         )
-
-    graph = DependencyGraph.from_edges(store.get_edges())
-    delta_meta = apply_delta(store, graph, manifest, repo_root, config, effective_index_config)
-    store.close()
-    return ArtifactSyncResult(
-        strategy="delta",
-        files_changed=len(manifest.changes),
-        delta_meta=delta_meta,
-        sync_time_ms=round((time.perf_counter() - t_start) * 1000, 1),
-    )
+    except BaseException:
+        store.close()
+        raise
 
 
 _GITATTRIBUTES_COMMENT = "# archex portable index artifact — never diff/merge-conflict"

--- a/src/archex/index/artifact.py
+++ b/src/archex/index/artifact.py
@@ -379,7 +379,6 @@ def _full_reindex_in_place(
         )
         fresh_db_path = fresh_store.db_path
         fresh_store.conn.execute("PRAGMA wal_checkpoint(FULL)")
-        fresh_store.close()
 
         dest_db_path.parent.mkdir(parents=True, exist_ok=True)
         for suffix in ("-wal", "-shm"):
@@ -387,6 +386,7 @@ def _full_reindex_in_place(
             if stale_sidecar.exists():
                 stale_sidecar.unlink()
         shutil.copy2(fresh_db_path, dest_db_path)
+        fresh_store.close()
     finally:
         shutil.rmtree(scratch_dir, ignore_errors=True)
 

--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import logging
+import shutil
 import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -20,6 +22,8 @@ from archex.models import (
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from types import TracebackType
+
+logger = logging.getLogger(__name__)
 
 
 _CREATE_CHUNKS = """
@@ -181,8 +185,18 @@ def _decode_edge_evidence(raw: object) -> list[str]:
 class IndexStore:
     """SQLite-backed persistence for chunks, edges, and metadata."""
 
-    def __init__(self, db_path: str | Path) -> None:
+    def __init__(self, db_path: str | Path, *, delete_dir_on_close: bool = False) -> None:
+        """Open (creating if absent) the SQLite store at `db_path`.
+
+        `delete_dir_on_close` opts into deleting `db_path`'s *entire parent
+        directory* — not just the files this store wrote — when `close()`
+        runs. Only pass it for a `db_path` under a directory dedicated
+        exclusively to this store (e.g. a fresh `tempfile.mkdtemp()`); a
+        shared or otherwise meaningful directory would have its other
+        contents silently deleted too.
+        """
         self._db_path = str(db_path)
+        self._delete_dir_on_close = delete_dir_on_close
         self._conn = sqlite3.connect(self._db_path)
         try:
             self._conn.execute("PRAGMA journal_mode=WAL")
@@ -856,6 +870,11 @@ class IndexStore:
         return Path(self._db_path)
 
     @property
+    def ephemeral(self) -> bool:
+        """True when closing this store deletes its backing scratch directory."""
+        return self._delete_dir_on_close
+
+    @property
     def vector_index_path(self) -> Path:
         """Backward-compatible raw vector index path."""
         return self.vector_index_path_for()
@@ -866,6 +885,14 @@ class IndexStore:
 
     def close(self) -> None:
         self._conn.close()
+        if self._delete_dir_on_close:
+            scratch_dir = self.db_path.parent
+            try:
+                shutil.rmtree(scratch_dir)
+            except OSError:
+                logger.warning(
+                    "failed to remove ephemeral index dir %s", scratch_dir, exc_info=True
+                )
 
     def __enter__(self) -> IndexStore:
         return self

--- a/tests/cli/test_index_cmd.py
+++ b/tests/cli/test_index_cmd.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import tempfile
 import tomllib
 from pathlib import Path
 from unittest.mock import patch
@@ -13,6 +14,7 @@ from archex.project import init_project
 
 class FakeStore:
     db_path = Path("/tmp/archex-index.db")
+    ephemeral = False
 
     def get_file_metadata(self) -> list[dict[str, str | int]]:
         return []
@@ -80,3 +82,50 @@ def test_index_no_quantize_vectors_persists_false(python_simple_repo: Path) -> N
     assert result.exit_code == 0, result.output
     settings = tomllib.loads((python_simple_repo / ".archex" / "settings.toml").read_text())
     assert settings["index"]["quantize_vectors"] is False
+
+
+def test_index_ephemeral_no_cache_cleans_up_scratch_dir(python_simple_repo: Path) -> None:
+    """`archex index` with caching disabled must not leak its scratch tempdir and
+    must not report an `index_path` that no longer exists once the command returns.
+    """
+    init_project(python_simple_repo)
+    settings_path = python_simple_repo / ".archex" / "settings.toml"
+    content = settings_path.read_text(encoding="utf-8")
+    settings_path.write_text(
+        content.replace("[index]\n", "[index]\ncache = false\n", 1), encoding="utf-8"
+    )
+
+    created_dirs: list[Path] = []
+    real_mkdtemp = tempfile.mkdtemp
+
+    def _tracking_mkdtemp() -> str:
+        created = real_mkdtemp()
+        created_dirs.append(Path(created))
+        return created
+
+    runner = CliRunner()
+    with patch("archex.api.tempfile.mkdtemp", side_effect=_tracking_mkdtemp):
+        result = runner.invoke(cli, ["index", str(python_simple_repo), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    summary = json.loads(result.output)
+    assert summary["index_path"] is None
+
+    assert created_dirs, "expected the ephemeral full-index path to allocate a scratch dir"
+    for scratch_dir in created_dirs:
+        assert not scratch_dir.exists(), f"leaked ephemeral scratch dir: {scratch_dir}"
+
+
+def test_index_ephemeral_no_cache_text_output_is_clear(python_simple_repo: Path) -> None:
+    init_project(python_simple_repo)
+    settings_path = python_simple_repo / ".archex" / "settings.toml"
+    content = settings_path.read_text(encoding="utf-8")
+    settings_path.write_text(
+        content.replace("[index]\n", "[index]\ncache = false\n", 1), encoding="utf-8"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["index", str(python_simple_repo)])
+
+    assert result.exit_code == 0, result.output
+    assert "Index path:         (ephemeral, not cached to disk)" in result.output

--- a/tests/index/test_artifact.py
+++ b/tests/index/test_artifact.py
@@ -9,6 +9,7 @@ import sqlite3
 import struct
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
@@ -587,6 +588,73 @@ class TestSyncImportedArtifact:
             assert synced_store.get_metadata("commit_hash")
         finally:
             synced_store.close()
+
+    def test_sync_closes_store_on_mid_pipeline_exception(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        """store must close even when a step after opening it raises."""
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = tmp_path / "artifact.xz"
+            export_artifact(store, artifact_path)
+        finally:
+            store.close()
+
+        dest_db_path = tmp_path / "imported" / "index.db"
+        import_artifact(artifact_path, dest_db_path)
+        config = Config(languages=["python"], cache=False)
+
+        close_calls: list[IndexStore] = []
+        real_close = IndexStore.close
+
+        def tracking_close(self: IndexStore) -> None:
+            close_calls.append(self)
+            real_close(self)
+
+        with (
+            patch.object(IndexStore, "close", tracking_close),
+            patch(
+                "archex.index.delta.compute_working_tree_delta",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            sync_imported_artifact(python_simple_repo, dest_db_path, config)
+
+        assert close_calls, "store.close() must run even when a sync step raises"
+
+    def test_full_reindex_fallback_cleans_up_fresh_store_on_exception(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        """A failure during the stale-artifact full-reindex fallback must not
+        leak the fresh ephemeral store's scratch directory."""
+        import tempfile
+
+        store = _build_store(python_simple_repo, tmp_path / "cache")
+        try:
+            artifact_path = tmp_path / "artifact.xz"
+            export_artifact(store, artifact_path)
+        finally:
+            store.close()
+
+        for py_file in sorted(python_simple_repo.rglob("*.py")):
+            py_file.write_text(f"def rewritten_{py_file.stem}():\n    return 1\n")
+        _git(python_simple_repo, "add", ".")
+        _git(python_simple_repo, "commit", "-m", "rewrite everything")
+
+        dest_db_path = tmp_path / "imported" / "index.db"
+        import_artifact(artifact_path, dest_db_path)
+        config = Config(languages=["python"], cache=True, delta_threshold=0.5)
+
+        before = {p.name for p in Path(tempfile.gettempdir()).iterdir() if p.is_dir()}
+        with (
+            patch("shutil.copy2", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            sync_imported_artifact(python_simple_repo, dest_db_path, config)
+        after = {p.name for p in Path(tempfile.gettempdir()).iterdir() if p.is_dir()}
+
+        assert after == before, f"leaked scratch dirs: {after - before}"
 
 
 class TestFromArtifactCliSync:

--- a/tests/index/test_artifact.py
+++ b/tests/index/test_artifact.py
@@ -628,6 +628,7 @@ class TestSyncImportedArtifact:
     ) -> None:
         """A failure during the stale-artifact full-reindex fallback must not
         leak the fresh ephemeral store's scratch directory."""
+        import shutil
         import tempfile
 
         store = _build_store(python_simple_repo, tmp_path / "cache")
@@ -646,14 +647,35 @@ class TestSyncImportedArtifact:
         import_artifact(artifact_path, dest_db_path)
         config = Config(languages=["python"], cache=True, delta_threshold=0.5)
 
+        # _full_index()'s own cache.put() (forced on internally by
+        # _full_reindex_in_place's fallback_config) calls shutil.copy2 once
+        # before fresh_store is even bound; only the SECOND call is
+        # _full_reindex_in_place's own `shutil.copy2(fresh_db_path,
+        # dest_db_path)`, the one that actually exercises the guard under
+        # test. Failing indiscriminately on every call would trip the first
+        # one and never reach fresh_store's own try/finally at all.
+        real_copy2 = shutil.copy2
+        call_count = 0
+
+        def copy2_fail_on_second_call(*args: object, **kwargs: object) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise RuntimeError("boom")
+            return real_copy2(*args, **kwargs)  # type: ignore[arg-type]
+
         before = {p.name for p in Path(tempfile.gettempdir()).iterdir() if p.is_dir()}
         with (
-            patch("shutil.copy2", side_effect=RuntimeError("boom")),
+            patch("shutil.copy2", side_effect=copy2_fail_on_second_call),
             pytest.raises(RuntimeError, match="boom"),
         ):
             sync_imported_artifact(python_simple_repo, dest_db_path, config)
         after = {p.name for p in Path(tempfile.gettempdir()).iterdir() if p.is_dir()}
 
+        assert call_count >= 2, (
+            "expected the fault to fire on _full_reindex_in_place's own copy2 call, "
+            "not just the earlier cache.put() one"
+        )
         assert after == before, f"leaked scratch dirs: {after - before}"
 
 

--- a/tests/index/test_store.py
+++ b/tests/index/test_store.py
@@ -265,6 +265,43 @@ def test_context_manager(tmp_path: Path) -> None:
     assert len(result) == 1
 
 
+# ---------------------------------------------------------------------------
+# Ephemeral scratch-directory cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_ephemeral_property_defaults_false(tmp_path: Path) -> None:
+    db = tmp_path / "default.db"
+    with IndexStore(db) as s:
+        assert s.ephemeral is False
+
+
+def test_close_removes_scratch_dir_when_ephemeral(tmp_path: Path) -> None:
+    """close() deletes the store's parent directory when delete_dir_on_close is set."""
+    scratch_dir = tmp_path / "scratch"
+    scratch_dir.mkdir()
+    db = scratch_dir / "index.db"
+    s = IndexStore(db, delete_dir_on_close=True)
+    assert s.ephemeral is True
+    assert scratch_dir.exists()
+
+    s.close()
+
+    assert not scratch_dir.exists()
+
+
+def test_close_preserves_dir_when_not_ephemeral(tmp_path: Path) -> None:
+    """close() leaves the backing directory alone by default (e.g. cached stores)."""
+    scratch_dir = tmp_path / "cached"
+    scratch_dir.mkdir()
+    db = scratch_dir / "index.db"
+    s = IndexStore(db)
+
+    s.close()
+
+    assert scratch_dir.exists()
+
+
 def test_insert_edges(store: IndexStore) -> None:
     store.insert_edges(SAMPLE_EDGES)
     edges = store.get_edges()

--- a/tests/test_api_robustness.py
+++ b/tests/test_api_robustness.py
@@ -142,6 +142,32 @@ def test_full_index_closes_ephemeral_store_on_mid_pipeline_exception(
     assert after == before, f"leaked scratch dirs: {after - before}"
 
 
+def test_full_index_closes_ephemeral_store_on_keyboard_interrupt(
+    python_simple_repo: Path,
+) -> None:
+    """A Ctrl-C (KeyboardInterrupt) mid-pipeline must also not leak the scratch dir.
+
+    `except Exception` does not catch KeyboardInterrupt/SystemExit/GeneratorExit
+    (they subclass BaseException, not Exception) — a guard using the narrower
+    clause would skip cleanup for exactly this case. Distinct from the
+    RuntimeError-based test above, which cannot tell the two clauses apart.
+    """
+    source = RepoSource(local_path=str(python_simple_repo))
+    config = Config(cache=False)
+    cache = CacheManager(cache_dir=str(python_simple_repo.parent / "cache"))
+    cache_key = cache.cache_key(source)
+
+    before = _tmp_dirs()
+    with (
+        patch("archex.index.store.IndexStore.insert_chunks", side_effect=KeyboardInterrupt),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        _full_index(source, config, cache, cache_key, timing=None)
+    after = _tmp_dirs()
+
+    assert after == before, f"leaked scratch dirs: {after - before}"
+
+
 def test_query_closes_ephemeral_store_on_mid_pipeline_exception(python_simple_repo: Path) -> None:
     """query()'s ephemeral store must not leak its scratch dir on a mid-pipeline failure."""
     source = RepoSource(local_path=str(python_simple_repo))
@@ -168,6 +194,34 @@ def _close_tracker() -> tuple[list[IndexStore], object]:
         real_close(self)
 
     return close_calls, tracking_close
+
+
+def _instance_tracker() -> tuple[list[IndexStore], list[IndexStore], object, object]:
+    """Wrap IndexStore.__init__ and .close to record every instance created and closed.
+
+    _try_delta_index opens several IndexStore instances in sequence before the
+    one under test (candidate_store, a manifest-computation store), each
+    already correctly closed by pre-existing, unrelated guards. A test that
+    only asserts "some store was closed" (via `_close_tracker` above) passes
+    vacuously off those unrelated closes even when the store actually under
+    test is never closed. Asserting `created[-1] in closed` instead pins the
+    check to the store constructed last — the one the test is actually
+    exercising.
+    """
+    created: list[IndexStore] = []
+    closed: list[IndexStore] = []
+    real_init = IndexStore.__init__
+    real_close = IndexStore.close
+
+    def tracking_init(self: IndexStore, *args: object, **kwargs: object) -> None:
+        real_init(self, *args, **kwargs)  # type: ignore[arg-type]
+        created.append(self)
+
+    def tracking_close(self: IndexStore) -> None:
+        closed.append(self)
+        real_close(self)
+
+    return created, closed, tracking_init, tracking_close
 
 
 def _set_metadata_raise_if_indexed_at(key: str, value: str) -> None:
@@ -225,8 +279,9 @@ def test_try_delta_index_clean_store_closes_on_mid_pipeline_exception(
         t_start=0.0,
     )
 
-    close_calls, tracking_close = _close_tracker()
+    created, closed, tracking_init, tracking_close = _instance_tracker()
     with (
+        patch.object(IndexStore, "__init__", tracking_init),
         patch.object(IndexStore, "close", tracking_close),
         patch.object(
             IndexStore,
@@ -237,7 +292,11 @@ def test_try_delta_index_clean_store_closes_on_mid_pipeline_exception(
     ):
         _try_delta_index(attempt)
 
-    assert close_calls, "clean_store.close() must run even when a delta-clean step raises"
+    assert created, "expected _try_delta_index to construct at least one IndexStore"
+    assert created[-1] in closed, (
+        "clean_store (the last-constructed store, not an earlier unrelated one) "
+        "must close even when a delta-clean step raises"
+    )
 
 
 def test_try_delta_index_main_store_closes_on_mid_pipeline_exception(
@@ -268,12 +327,17 @@ def test_try_delta_index_main_store_closes_on_mid_pipeline_exception(
         t_start=0.0,
     )
 
-    close_calls, tracking_close = _close_tracker()
+    created, closed, tracking_init, tracking_close = _instance_tracker()
     with (
+        patch.object(IndexStore, "__init__", tracking_init),
         patch.object(IndexStore, "close", tracking_close),
         patch("archex.index.delta.apply_delta", side_effect=RuntimeError("boom")),
         pytest.raises(RuntimeError, match="boom"),
     ):
         _try_delta_index(attempt)
 
-    assert close_calls, "store.close() must run even when apply_delta raises"
+    assert created, "expected _try_delta_index to construct at least one IndexStore"
+    assert created[-1] in closed, (
+        "the main apply-delta store (the last-constructed store, not an earlier "
+        "unrelated one) must close even when apply_delta raises"
+    )

--- a/tests/test_api_robustness.py
+++ b/tests/test_api_robustness.py
@@ -1,14 +1,16 @@
-"""Robustness tests for api._acquire: cleanup on success and exception paths."""
+"""Robustness tests for api._acquire and ephemeral IndexStore cleanup on failure."""
 
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from archex.api import _acquire  # pyright: ignore[reportPrivateUsage]
-from archex.models import RepoSource
+from archex.api import _acquire, _full_index, query  # pyright: ignore[reportPrivateUsage]
+from archex.cache import CacheManager
+from archex.models import Config, RepoSource
 
 
 def test_acquire_local_path_returns_noop_cleanup(tmp_path: Path) -> None:
@@ -99,3 +101,49 @@ def test_acquire_url_cleanup_safe_on_missing_dir() -> None:
 
     # Dir was never actually created; cleanup with ignore_errors=True should not raise
     cleanup()
+
+
+def _tmp_dirs() -> set[str]:
+    return {p.name for p in Path(tempfile.gettempdir()).iterdir() if p.is_dir()}
+
+
+def test_full_index_closes_ephemeral_store_on_mid_pipeline_exception(
+    python_simple_repo: Path,
+) -> None:
+    """A pipeline failure after the ephemeral store opens must not leak its scratch dir.
+
+    _full_index() builds its IndexStore under a fresh mkdtemp() directory with
+    delete_dir_on_close=True; that cleanup only fires on close(), so a failure
+    anywhere in the pipeline between construction and the normal return must
+    still close (and thus clean up) the store rather than leaving it open.
+    """
+    source = RepoSource(local_path=str(python_simple_repo))
+    config = Config(cache=False)
+    cache = CacheManager(cache_dir=str(python_simple_repo.parent / "cache"))
+    cache_key = cache.cache_key(source)
+
+    before = _tmp_dirs()
+    with (
+        patch("archex.index.store.IndexStore.insert_chunks", side_effect=RuntimeError("boom")),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        _full_index(source, config, cache, cache_key, timing=None)
+    after = _tmp_dirs()
+
+    assert after == before, f"leaked scratch dirs: {after - before}"
+
+
+def test_query_closes_ephemeral_store_on_mid_pipeline_exception(python_simple_repo: Path) -> None:
+    """query()'s ephemeral store must not leak its scratch dir on a mid-pipeline failure."""
+    source = RepoSource(local_path=str(python_simple_repo))
+    config = Config(cache=False)
+
+    before = _tmp_dirs()
+    with (
+        patch("archex.index.store.IndexStore.insert_chunks", side_effect=RuntimeError("boom")),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        query(source, "how does auth work?", config=config)
+    after = _tmp_dirs()
+
+    assert after == before, f"leaked scratch dirs: {after - before}"

--- a/tests/test_api_robustness.py
+++ b/tests/test_api_robustness.py
@@ -8,8 +8,17 @@ from unittest.mock import patch
 
 import pytest
 
-from archex.api import _acquire, _full_index, query  # pyright: ignore[reportPrivateUsage]
+from archex.api import (
+    _acquire,  # pyright: ignore[reportPrivateUsage]
+    _DeltaIndexAttempt,  # pyright: ignore[reportPrivateUsage]
+    _ensure_index,  # pyright: ignore[reportPrivateUsage]
+    _full_index,  # pyright: ignore[reportPrivateUsage]
+    _try_delta_index,  # pyright: ignore[reportPrivateUsage]
+    index_repository,
+    query,
+)
 from archex.cache import CacheManager
+from archex.index.store import IndexStore
 from archex.models import Config, RepoSource
 
 
@@ -147,3 +156,124 @@ def test_query_closes_ephemeral_store_on_mid_pipeline_exception(python_simple_re
     after = _tmp_dirs()
 
     assert after == before, f"leaked scratch dirs: {after - before}"
+
+
+def _close_tracker() -> tuple[list[IndexStore], object]:
+    """Wrap IndexStore.close to record every call while still closing for real."""
+    close_calls: list[IndexStore] = []
+    real_close = IndexStore.close
+
+    def tracking_close(self: IndexStore) -> None:
+        close_calls.append(self)
+        real_close(self)
+
+    return close_calls, tracking_close
+
+
+def _set_metadata_raise_if_indexed_at(key: str, value: str) -> None:
+    """set_metadata side effect that only fails for clean_store's own write.
+
+    IndexStore.__init__ -> _migrate_schema() calls set_metadata("schema_version", ...)
+    for every store construction, so a blanket "always raise" patch would
+    fail before the code path under test is ever reached.
+    """
+    del value
+    if key == "indexed_at":
+        raise RuntimeError("boom")
+
+
+def test_ensure_index_cache_hit_closes_store_on_mid_pipeline_exception(
+    python_simple_repo: Path, tmp_path: Path
+) -> None:
+    """A cache-hit pipeline failure must still close the (non-ephemeral) cached store."""
+    source = RepoSource(local_path=str(python_simple_repo))
+    config = Config(cache=True, cache_dir=str(tmp_path / "cache"))
+
+    index_repository(source, config=config).close()
+
+    close_calls, tracking_close = _close_tracker()
+    with (
+        patch.object(IndexStore, "close", tracking_close),
+        patch.object(IndexStore, "needs_reindex", side_effect=RuntimeError("boom")),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        _ensure_index(source, config=config)
+
+    assert close_calls, "store.close() must run even when a cache-hit pipeline step raises"
+
+
+def test_try_delta_index_clean_store_closes_on_mid_pipeline_exception(
+    python_simple_repo: Path, tmp_path: Path
+) -> None:
+    """The delta path's 'no working-tree changes' clean_store must close even
+    when a step after opening it raises."""
+    source = RepoSource(local_path=str(python_simple_repo))
+    config = Config(cache=True, cache_dir=str(tmp_path / "cache"))
+    cache = CacheManager(cache_dir=str(tmp_path / "cache"))
+    cache_key = cache.cache_key(source)
+
+    index_repository(source, config=config).close()
+
+    attempt = _DeltaIndexAttempt(
+        source=source,
+        config=config,
+        cache=cache,
+        cache_key=cache_key,
+        working_tree_signature=None,
+        timing=None,
+        index_config=None,
+        t_start=0.0,
+    )
+
+    close_calls, tracking_close = _close_tracker()
+    with (
+        patch.object(IndexStore, "close", tracking_close),
+        patch.object(
+            IndexStore,
+            "set_metadata",
+            side_effect=_set_metadata_raise_if_indexed_at,
+        ),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        _try_delta_index(attempt)
+
+    assert close_calls, "clean_store.close() must run even when a delta-clean step raises"
+
+
+def test_try_delta_index_main_store_closes_on_mid_pipeline_exception(
+    python_simple_repo: Path, tmp_path: Path
+) -> None:
+    """The delta path's main apply-delta store must close even when a step
+    after opening it raises."""
+    source = RepoSource(local_path=str(python_simple_repo))
+    config = Config(cache=True, cache_dir=str(tmp_path / "cache"))
+    cache = CacheManager(cache_dir=str(tmp_path / "cache"))
+    cache_key = cache.cache_key(source)
+
+    index_repository(source, config=config).close()
+
+    # A real content change so compute_working_tree_delta reports a non-empty
+    # manifest and _try_delta_index reaches the main apply-delta store instead
+    # of the "no changes" clean_store branch.
+    (python_simple_repo / "utils.py").write_text("def freshly_changed(): return 1\n")
+
+    attempt = _DeltaIndexAttempt(
+        source=source,
+        config=config,
+        cache=cache,
+        cache_key=cache_key,
+        working_tree_signature=None,
+        timing=None,
+        index_config=None,
+        t_start=0.0,
+    )
+
+    close_calls, tracking_close = _close_tracker()
+    with (
+        patch.object(IndexStore, "close", tracking_close),
+        patch("archex.index.delta.apply_delta", side_effect=RuntimeError("boom")),
+        pytest.raises(RuntimeError, match="boom"),
+    ):
+        _try_delta_index(attempt)
+
+    assert close_calls, "store.close() must run even when apply_delta raises"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,6 +139,7 @@ def test_init_command_reset_requires_force(python_simple_repo: Path) -> None:
 
 class FakeIndexStore:
     db_path = Path("/tmp/archex-index.db")
+    ephemeral = False
 
     def __init__(self) -> None:
         self.closed = False


### PR DESCRIPTION
## Stack

Stack-Id: `archex-audit-040676`
Base: `main`
Position: 1/5

1. `fix/ephemeral-index-store-cleanup` -> this PR
2. `fix/delta-benchmark-cache-leak` -> #2
3. `fix/mcp-graph-query-cache-staleness` -> #3
4. `fix/git-url-scheme-allowlist` -> #4
5. `fix/artifact-decompression-bomb-guard` -> #5

Depends on: (none - root)
Upstack: #2

## Summary

`_full_index()` (in `api.py`) always builds its working `IndexStore` under a fresh `tempfile.mkdtemp()` directory, whether or not the result gets promoted into the durable on-disk cache. When caching is disabled — or the build is a throwaway comparison, as in delta-benchmark and artifact-fallback reindexing — nothing ever removed that scratch directory once the store closed, leaking one directory per call. Confirmed on disk: dozens of orphaned `archex-*` scratch directories in `$TMPDIR`.

This PR:

- Adds an opt-in `delete_dir_on_close` flag to `IndexStore` that removes its parent directory once the SQLite connection closes, set on the two ephemeral stores `api.py` builds directly from `mkdtemp()`. Exposes it as a read-only `ephemeral` property and documents the invariant on `__init__` (the parent directory must be dedicated exclusively to that store).
- Fixes a read-after-close race this change would otherwise introduce in `index/artifact.py`'s `_full_reindex_in_place`: the freshly-built store must close *after* `shutil.copy2` reads its database file, not before.
- Audits every other `IndexStore(...)` construction across `api.py` and `index/artifact.py` for the same class of bug — a store opened, more pipeline work run against it, and only the happy path closing it — and finds five more sites with the identical gap: `_ensure_index()`'s cache-hit path (the single most common path for a warm-cache query/index), `_try_delta_index()`'s two stores (previously guarded only by `except DeltaIndexError`, which skips cleanup for every other exception type), `_full_reindex_in_place()`'s fallback store, and `sync_imported_artifact()`'s store. Each now guarantees `close()` before the exception propagates — using `except BaseException` (not `except Exception`, which misses `KeyboardInterrupt`/`SystemExit`/`GeneratorExit`) where the store must stay open on the success path, and plain `finally` where it's only ever consumed internally.
- Fixes `cli/indexing.py`'s `run_indexing_and_get_summary`: with the ephemeral-cleanup fix in place, reporting `store.db_path` as `index_path` when the store has no durable cache entry would hand back a path that's already been deleted by the time the CLI command returns. Reports `None`/"(ephemeral, not cached to disk)" instead.

## Validation

- `uv run ruff check` / `uv run ruff format --check` / `uv run pyright` (strict) — clean on all changed files.
- `uv run pytest tests/index/test_store.py tests/index/test_artifact.py tests/cli/test_index_cmd.py tests/test_cli.py tests/test_api_robustness.py tests/test_query_pipeline.py tests/test_integration.py tests/test_api_precision.py --no-cov` — all passing.
- Every guarded call site has a dedicated regression test verified genuinely non-vacuous via mutation testing (guard temporarily reverted in a scratch worktree, test re-run, confirmed it fails without the fix, confirmed it passes with the fix restored).
- Manual repro: patched `IndexStore.insert_chunks` to raise mid-pipeline and confirmed via `$TMPDIR` snapshot diff that no scratch directory survives the exception, for both the ephemeral (ephemeral scratch dir) and non-ephemeral (open-connection) cases.
