### PR TITLE
fix(benchmark): clean up delta-benchmark scratch cache directory

### DIFF
--- a/src/archex/benchmark/delta_strategies.py
+++ b/src/archex/benchmark/delta_strategies.py
@@ -103,63 +103,75 @@ def run_delta_benchmark(
     from archex.models import Config, PipelineTiming, RepoSource
 
     config = Config(cache=False)
-    cache = CacheManager(cache_dir=str(Path(tempfile.mkdtemp(prefix="archex-delta-cache-"))))
+    cache_dir = Path(tempfile.mkdtemp(prefix="archex-delta-cache-"))
+    base_store: IndexStore | None = None
+    full_store: IndexStore | None = None
+    try:
+        cache = CacheManager(cache_dir=str(cache_dir))
 
-    # 1. Full index at base_commit
-    _checkout(repo_path, task.base_commit)
-    source = RepoSource(local_path=str(repo_path))
-    cache_key = cache.cache_key(source)
-    base_store = _full_index(source, config, cache, cache_key, timing=None)
+        # 1. Full index at base_commit
+        _checkout(repo_path, task.base_commit)
+        source = RepoSource(local_path=str(repo_path))
+        cache_key = cache.cache_key(source)
+        base_store = _full_index(source, config, cache, cache_key, timing=None)
 
-    # 2. Delta index: checkout delta_commit, compute + apply delta
-    _checkout(repo_path, task.delta_commit)
-    t_delta_start = time.perf_counter()
-    manifest = compute_delta(repo_path, task.base_commit, task.delta_commit)
-    graph = DependencyGraph.from_edges(base_store.get_edges())
-    delta_meta = apply_delta(base_store, graph, manifest, repo_path, config)
-    delta_time_ms = (time.perf_counter() - t_delta_start) * 1000
+        # 2. Delta index: checkout delta_commit, compute + apply delta
+        _checkout(repo_path, task.delta_commit)
+        t_delta_start = time.perf_counter()
+        manifest = compute_delta(repo_path, task.base_commit, task.delta_commit)
+        graph = DependencyGraph.from_edges(base_store.get_edges())
+        delta_meta = apply_delta(base_store, graph, manifest, repo_path, config)
+        delta_time_ms = (time.perf_counter() - t_delta_start) * 1000
 
-    # Collect delta state
-    delta_chunks, delta_edges = _collect_store_state(base_store)
-    base_store.close()
+        # Collect delta state
+        delta_chunks, delta_edges = _collect_store_state(base_store)
+        base_store.close()
+        base_store = None
 
-    # 3. Full re-index at delta_commit for ground truth
-    t_full_start = time.perf_counter()
-    timing_full = PipelineTiming()
-    full_store = _full_index(source, config, cache, f"{cache_key}_full", timing=timing_full)
-    full_reindex_time_ms = (time.perf_counter() - t_full_start) * 1000
+        # 3. Full re-index at delta_commit for ground truth
+        t_full_start = time.perf_counter()
+        timing_full = PipelineTiming()
+        full_store = _full_index(source, config, cache, f"{cache_key}_full", timing=timing_full)
+        full_reindex_time_ms = (time.perf_counter() - t_full_start) * 1000
 
-    full_chunks, full_edges = _collect_store_state(full_store)
-    total_files = len(full_store.get_file_metadata())
-    full_store.close()
+        full_chunks, full_edges = _collect_store_state(full_store)
+        total_files = len(full_store.get_file_metadata())
+        full_store.close()
+        full_store = None
 
-    # 4. Correctness: chunk signatures must match (primary retrieval data).
-    # Edge equivalence is tracked separately — delta only re-resolves imports for
-    # changed files, so edges from unchanged files referencing changed files may differ.
-    correctness = delta_chunks == full_chunks
+        # 4. Correctness: chunk signatures must match (primary retrieval data).
+        # Edge equivalence is tracked separately — delta only re-resolves imports for
+        # changed files, so edges from unchanged files referencing changed files may differ.
+        correctness = delta_chunks == full_chunks
 
-    # 5. Compute metrics
-    delta_files = len(manifest.changes)
-    delta_pct = (delta_files / total_files * 100) if total_files > 0 else 0.0
-    speedup = full_reindex_time_ms / delta_time_ms if delta_time_ms > 0 else 0.0
+        # 5. Compute metrics
+        delta_files = len(manifest.changes)
+        delta_pct = (delta_files / total_files * 100) if total_files > 0 else 0.0
+        speedup = full_reindex_time_ms / delta_time_ms if delta_time_ms > 0 else 0.0
 
-    chunks_in_common = delta_chunks & full_chunks
-    chunks_only_in_full = full_chunks - delta_chunks
-    edges_changed = len(delta_edges.symmetric_difference(full_edges))
+        chunks_in_common = delta_chunks & full_chunks
+        chunks_only_in_full = full_chunks - delta_chunks
+        edges_changed = len(delta_edges.symmetric_difference(full_edges))
 
-    return DeltaBenchmarkResult(
-        task_id=task.task_id,
-        strategy=DeltaStrategy.DELTA_INDEX,
-        delta_files=delta_files,
-        total_files=total_files,
-        delta_pct=round(delta_pct, 1),
-        delta_time_ms=round(delta_time_ms, 1),
-        full_reindex_time_ms=round(full_reindex_time_ms, 1),
-        speedup_factor=round(speedup, 2),
-        correctness=correctness,
-        chunks_updated=len(chunks_only_in_full) + len(delta_chunks - full_chunks),
-        chunks_unchanged=len(chunks_in_common),
-        edges_updated=edges_changed,
-        timestamp=_now_iso(),
-        delta_meta=delta_meta,
-    )
+        return DeltaBenchmarkResult(
+            task_id=task.task_id,
+            strategy=DeltaStrategy.DELTA_INDEX,
+            delta_files=delta_files,
+            total_files=total_files,
+            delta_pct=round(delta_pct, 1),
+            delta_time_ms=round(delta_time_ms, 1),
+            full_reindex_time_ms=round(full_reindex_time_ms, 1),
+            speedup_factor=round(speedup, 2),
+            correctness=correctness,
+            chunks_updated=len(chunks_only_in_full) + len(delta_chunks - full_chunks),
+            chunks_unchanged=len(chunks_in_common),
+            edges_updated=edges_changed,
+            timestamp=_now_iso(),
+            delta_meta=delta_meta,
+        )
+    finally:
+        if base_store is not None:
+            base_store.close()
+        if full_store is not None:
+            full_store.close()
+        shutil.rmtree(cache_dir, ignore_errors=True)

--- a/tests/benchmark/test_delta_strategies.py
+++ b/tests/benchmark/test_delta_strategies.py
@@ -320,3 +320,28 @@ class TestRunDeltaBenchmark:
         after = {p.name for p in Path(tempfile.gettempdir()).glob("archex-delta-cache-*")}
 
         assert after == before, f"leaked scratch dirs after exception: {after - before}"
+
+    def test_cleans_up_scratch_cache_dir_on_exception_after_full_store_opens(
+        self, tmp_path: Path
+    ) -> None:
+        """A failure after full_store opens (but before its own close()) must not leak either."""
+        repo, base_commit, delta_commit = _make_delta_repo(tmp_path)
+        task = DeltaBenchmarkTask(
+            task_id="cleanup_exception_full_store_test",
+            repo=".",
+            base_commit=base_commit,
+            delta_commit=delta_commit,
+        )
+
+        before = {p.name for p in Path(tempfile.gettempdir()).glob("archex-delta-cache-*")}
+        with (
+            patch(
+                "archex.index.store.IndexStore.get_file_metadata",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            run_delta_benchmark(task, repo)
+        after = {p.name for p in Path(tempfile.gettempdir()).glob("archex-delta-cache-*")}
+
+        assert after == before, f"leaked scratch dirs after exception: {after - before}"

--- a/tests/benchmark/test_delta_strategies.py
+++ b/tests/benchmark/test_delta_strategies.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -230,27 +232,36 @@ class TestDeltaReporter:
 # ---------------------------------------------------------------------------
 
 
+def _make_delta_repo(tmp_path: Path) -> tuple[Path, str, str]:
+    """Create a 2-commit repo fixture for delta-benchmark tests.
+
+    Returns (repo_path, base_commit, delta_commit).
+    """
+    src = FIXTURES_DIR / "python_simple"
+    repo = tmp_path / "bench_repo"
+    shutil.copytree(src, repo)
+
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "test@archex.test")
+    _git(repo, "config", "user.name", "archex-test")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "initial")
+    base_commit = _git_head(repo)
+
+    # Make a change: modify utils.py and add a new file
+    (repo / "utils.py").write_text("def updated_util(): return 42\n")
+    (repo / "extra.py").write_text("def extra_func(): pass\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "delta changes")
+    delta_commit = _git_head(repo)
+    return repo, base_commit, delta_commit
+
+
 @pytest.mark.slow
 class TestRunDeltaBenchmark:
     def test_delta_vs_full_correctness(self, tmp_path: Path) -> None:
         """Create a 2-commit repo, run delta benchmark, verify correctness."""
-        src = FIXTURES_DIR / "python_simple"
-        repo = tmp_path / "bench_repo"
-        shutil.copytree(src, repo)
-
-        _git(repo, "init")
-        _git(repo, "config", "user.email", "test@archex.test")
-        _git(repo, "config", "user.name", "archex-test")
-        _git(repo, "add", ".")
-        _git(repo, "commit", "-m", "initial")
-        base_commit = _git_head(repo)
-
-        # Make a change: modify utils.py and add a new file
-        (repo / "utils.py").write_text("def updated_util(): return 42\n")
-        (repo / "extra.py").write_text("def extra_func(): pass\n")
-        _git(repo, "add", ".")
-        _git(repo, "commit", "-m", "delta changes")
-        delta_commit = _git_head(repo)
+        repo, base_commit, delta_commit = _make_delta_repo(tmp_path)
 
         task = DeltaBenchmarkTask(
             task_id="integration_test",
@@ -268,3 +279,44 @@ class TestRunDeltaBenchmark:
         assert result.delta_time_ms > 0
         assert result.full_reindex_time_ms > 0
         assert result.delta_meta is not None
+
+    def test_cleans_up_scratch_cache_dir_on_success(self, tmp_path: Path) -> None:
+        """run_delta_benchmark must not leak its archex-delta-cache- scratch dir."""
+
+        repo, base_commit, delta_commit = _make_delta_repo(tmp_path)
+        task = DeltaBenchmarkTask(
+            task_id="cleanup_test",
+            repo=".",
+            base_commit=base_commit,
+            delta_commit=delta_commit,
+        )
+
+        before = {p.name for p in Path(tempfile.gettempdir()).glob("archex-delta-cache-*")}
+        run_delta_benchmark(task, repo)
+        after = {p.name for p in Path(tempfile.gettempdir()).glob("archex-delta-cache-*")}
+
+        assert after == before, f"leaked scratch dirs: {after - before}"
+
+    def test_cleans_up_scratch_cache_dir_on_exception(self, tmp_path: Path) -> None:
+        """A mid-run failure must still remove the scratch cache dir and open stores."""
+
+        repo, base_commit, delta_commit = _make_delta_repo(tmp_path)
+        task = DeltaBenchmarkTask(
+            task_id="cleanup_exception_test",
+            repo=".",
+            base_commit=base_commit,
+            delta_commit=delta_commit,
+        )
+
+        before = {p.name for p in Path(tempfile.gettempdir()).glob("archex-delta-cache-*")}
+        with (
+            patch(
+                "archex.index.delta.compute_delta",
+                side_effect=RuntimeError("boom"),
+            ),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            run_delta_benchmark(task, repo)
+        after = {p.name for p in Path(tempfile.gettempdir()).glob("archex-delta-cache-*")}
+
+        assert after == before, f"leaked scratch dirs after exception: {after - before}"


### PR DESCRIPTION
## Stack

Stack-Id: `archex-audit-040676`
Base: `fix/ephemeral-index-store-cleanup` (#479)
Position: 2/5

1. `fix/ephemeral-index-store-cleanup` -> #479
2. `fix/delta-benchmark-cache-leak` -> this PR
3. `fix/mcp-graph-query-cache-staleness` -> #3
4. `fix/git-url-scheme-allowlist` -> #4
5. `fix/artifact-decompression-bomb-guard` -> #5

Depends on: #479
Upstack: #3

## Summary

`run_delta_benchmark()` built a throwaway `CacheManager` under `tempfile.mkdtemp(prefix="archex-delta-cache-")` purely to derive a cache key (`Config(cache=False)` means nothing is ever written there), then never removed the directory on any exit path. Every delta benchmark run — CI and local — leaked one empty scratch directory forever; `$TMPDIR` held stale entries from days-old runs (confirmed: 8+ `archex-delta-cache-*` directories dated 6 days prior to this audit).

Wraps the run in `try/finally` so the cache directory, and any store opened before a mid-run exception, are always cleaned up. Guards `base_store`/`full_store` with `None` sentinels so an exception between opening a store and its ordinary `close()` call doesn't leak that store's own ephemeral scratch directory either.

## Validation

- `uv run ruff check` / `uv run ruff format --check` / `uv run pyright` (strict) — clean.
- `uv run pytest tests/benchmark/test_delta_strategies.py --no-cov` (including `-m slow`) — all passing.
- Behavioral smoke test: `$TMPDIR` snapshot before/after a real `run_delta_benchmark()` call confirms zero new `archex-delta-cache-*` directories on both the success path and a forced mid-run exception (two dedicated tests, one failing after `base_store` opens, one after `full_store` opens).
- Manual repro against a real 2-commit git fixture confirms no leaked directory.
