### PR TITLE
fix(mcp): invalidate cached graph query handles on artifact re-export

### DIFF
--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -7,7 +7,7 @@ import json
 import logging
 import threading
 import time
-from functools import lru_cache
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any
 
@@ -874,14 +874,73 @@ def handle_graph_hubs(
     )
 
 
-@lru_cache(maxsize=16)
+_GRAPH_QUERY_CACHE_MAXSIZE = 16
+_graph_query_cache: OrderedDict[tuple[str, int], tuple[tuple[int, int], GraphQuery]] = OrderedDict()
+_graph_query_cache_lock = threading.Lock()
+
+
+def _graph_artifact_cache_token(graph_path: str) -> tuple[int, int]:
+    """Cache-busting token for `_cached_graph_query`: (mtime_ns, size_bytes).
+
+    `graph_path` normally names a fixed, repeatedly re-exported project path
+    (`archex graph export` writes there). A long-running `archex mcp` process
+    would otherwise keep serving the first snapshot it loaded for that path
+    forever, even after the user re-exports fresh data. Keying the cache on
+    the artifact's mtime and size makes a re-export a cache miss. Pairing
+    size with mtime — both free from the same stat() call — narrows the
+    (unavoidable, filesystem-timestamp-resolution-dependent) collision
+    window: two re-exports landing within one mtime tick on a coarse
+    filesystem still typically differ in byte size. Falls back to (0, 0)
+    for a missing/unreadable path so the eventual `GraphArtifactError` from
+    `GraphQuery.from_artifact` still surfaces normally instead of raising
+    here.
+    """
+    try:
+        st = Path(graph_path).expanduser().resolve().stat()
+        return (st.st_mtime_ns, st.st_size)
+    except OSError:
+        return (0, 0)
+
+
 def _cached_graph_query(graph_path: str, hub_degree: int) -> GraphQuery:
-    return GraphQuery.from_artifact(Path(graph_path).expanduser().resolve(), hub_degree=hub_degree)
+    """Return a cached GraphQuery for (graph_path, hub_degree), rebuilding on re-export.
+
+    Deliberately not a plain `functools.lru_cache`: keying on the artifact
+    token as part of the cache key (rather than checking it explicitly)
+    would let every re-export of the same path accumulate a new,
+    never-superseded lru_cache slot instead of replacing the stale one —
+    trading the staleness bug for a bounded-but-real memory-footprint
+    regression for exactly the frequent-re-export workflow this exists to
+    serve well. This cache holds at most one live GraphQuery per distinct
+    (graph_path, hub_degree) pair, evicting the least-recently-used pair
+    once more than `_GRAPH_QUERY_CACHE_MAXSIZE` distinct pairs are resident.
+    """
+    key = (graph_path, hub_degree)
+    token = _graph_artifact_cache_token(graph_path)
+    with _graph_query_cache_lock:
+        cached = _graph_query_cache.get(key)
+        if cached is not None and cached[0] == token:
+            _graph_query_cache.move_to_end(key)
+            return cached[1]
+
+    # Built outside the lock: from_artifact() parses a JSON artifact and
+    # builds adjacency indices, which must not serialize every concurrent
+    # graph-tool call across every repo behind one lock while it runs.
+    # A concurrent re-check for the same key is a redundant rebuild, not a
+    # correctness issue — whichever result is stored last simply wins.
+    query = GraphQuery.from_artifact(Path(graph_path).expanduser().resolve(), hub_degree=hub_degree)
+    with _graph_query_cache_lock:
+        _graph_query_cache[key] = (token, query)
+        _graph_query_cache.move_to_end(key)
+        while len(_graph_query_cache) > _GRAPH_QUERY_CACHE_MAXSIZE:
+            _graph_query_cache.popitem(last=False)
+    return query
 
 
 def clear_graph_query_cache() -> None:
     """Clear cached graph artifact handles used by MCP graph tools."""
-    _cached_graph_query.cache_clear()
+    with _graph_query_cache_lock:
+        _graph_query_cache.clear()
 
 
 def _graph_tool_response(

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import json
+import os
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -995,6 +997,65 @@ class TestGraphQueryHandlers:
             "pkg/models.py",
             "pkg/db.py",
         ]
+
+    def test_reexported_artifact_busts_stale_cache(self, tmp_path: Path) -> None:
+        """A long-running MCP daemon must not keep serving a pre-re-export snapshot.
+
+        `archex graph export` writes to a fixed, repeatedly-overwritten path; the
+        cached GraphQuery handle must be keyed on more than the path string or a
+        daemon that already answered a query for this path never sees the update.
+        """
+        artifact = _write_mcp_graph_artifact(tmp_path)
+        first = json.loads(handle_graph_stats(str(artifact)))
+        assert first["content"]["nodes"] == 4
+
+        solo = file_node_id("solo.py")
+        smaller = ArchGraph(
+            project=GraphProject(name="mcp-graph", languages={"python": 1}, total_files=1),
+            metadata=GraphExportMetadata(archex_version="0.8.0"),
+            nodes=[
+                GraphNode(id=solo, type=GraphNodeType.FILE, label="solo.py", path="solo.py"),
+            ],
+            edges=[],
+        )
+        artifact.write_text(smaller.to_json(), encoding="utf-8")
+        # Force the mtime strictly forward so the write is observable even on
+        # filesystems/CI runners with coarse mtime resolution.
+        newer = time.time() + 5
+        os.utime(artifact, (newer, newer))
+
+        second = json.loads(handle_graph_stats(str(artifact)))
+        assert second["content"]["nodes"] == 1
+
+    def test_reexport_replaces_stale_entry_without_accumulating(self, tmp_path: Path) -> None:
+        """Repeated re-exports of one path must replace, not accumulate, cache slots.
+
+        A composite (path, hub_degree, token) cache key would let every re-export
+        of the same logical artifact occupy a fresh, never-superseded slot instead
+        of replacing the stale one for that (path, hub_degree) pair.
+        """
+        artifact = _write_mcp_graph_artifact(tmp_path)
+        handle_graph_stats(str(artifact))
+        assert len(mcp_integration._graph_query_cache) == 1  # pyright: ignore[reportPrivateUsage]
+
+        for i in range(4):
+            solo = file_node_id(f"solo{i}.py")
+            graph = ArchGraph(
+                project=GraphProject(name="mcp-graph", languages={"python": 1}, total_files=1),
+                metadata=GraphExportMetadata(archex_version="0.8.0"),
+                nodes=[
+                    GraphNode(
+                        id=solo, type=GraphNodeType.FILE, label=f"solo{i}.py", path=f"solo{i}.py"
+                    ),
+                ],
+                edges=[],
+            )
+            artifact.write_text(graph.to_json(), encoding="utf-8")
+            newer = time.time() + 5 + i
+            os.utime(artifact, (newer, newer))
+            handle_graph_stats(str(artifact))
+
+        assert len(mcp_integration._graph_query_cache) == 1  # pyright: ignore[reportPrivateUsage]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stack

Stack-Id: `archex-audit-040676`
Base: `fix/delta-benchmark-cache-leak` (#480)
Position: 3/5

1. `fix/ephemeral-index-store-cleanup` -> #479
2. `fix/delta-benchmark-cache-leak` -> #480
3. `fix/mcp-graph-query-cache-staleness` -> this PR
4. `fix/git-url-scheme-allowlist` -> #4
5. `fix/artifact-decompression-bomb-guard` -> #5

Depends on: #480
Upstack: #4

## Summary

`_cached_graph_query()` was an `lru_cache` keyed only on `(graph_path, hub_degree)`. `archex graph export` writes to a fixed, repeatedly overwritten project path by design, so a long-running `archex mcp` process that already answered one `graph_lookup`/`graph_neighbors`/`graph_path`/`graph_stats`/`graph_hubs` call for that path kept serving the first snapshot it ever loaded, silently ignoring every later re-export for the lifetime of the daemon.

Replaces the `lru_cache` with a small explicit cache keyed on `(graph_path, hub_degree)`, storing the artifact's `(mtime, size)` — both free from one `stat()` call — alongside the built `GraphQuery`. A token mismatch discards and rebuilds the entry in place instead of adding a new one, so at most one `GraphQuery` stays resident per distinct `(graph_path, hub_degree)` pair, bounded by the same `maxsize=16` the previous `lru_cache` used. (Keying the token as part of the composite cache key — the more obvious `lru_cache`-compatible fix — would have closed the staleness gap but let every re-export of the same path pile up a fresh, never-superseded cache slot instead of replacing the old one, trading one bug for a bounded-but-real memory-footprint regression.)

Handlers run concurrently via the MCP server's executor threads, so the cache dict is guarded by a lock; the artifact parse and adjacency-index build happens outside the lock so it never serializes unrelated concurrent graph-tool calls.

## Validation

- `uv run ruff check` / `uv run ruff format --check` / `uv run pyright` (strict) — clean.
- `uv run pytest tests/integrations/test_mcp.py --no-cov` — all 74 passing, including two new regression tests: one proving a re-export busts the stale cache (reproduced the pre-fix bug against the old `lru_cache` implementation directly to confirm the test is non-vacuous), one proving repeated re-exports of the same key replace rather than accumulate cache entries.
- Concurrency smoke test: 16 threads issuing 20 concurrent `handle_graph_stats` calls each against 5 rotating artifact paths — no errors, no corruption.
