### PR TITLE
fix(acquire): reject git transport-helper and scp-like URLs by default

### DIFF
--- a/src/archex/acquire/__init__.py
+++ b/src/archex/acquire/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from archex.acquire.discovery import discover_files
-from archex.acquire.git import clone_repo
+from archex.acquire.git import clone_repo, is_remote_url
 from archex.acquire.local import open_local
 
-__all__ = ["clone_repo", "discover_files", "open_local"]
+__all__ = ["clone_repo", "discover_files", "is_remote_url", "open_local"]

--- a/src/archex/acquire/git.py
+++ b/src/archex/acquire/git.py
@@ -43,6 +43,20 @@ _SCP_LIKE_RE = re.compile(r"^(?:[^/@\s]+@)?[^/\s:]+:")
 _BRANCH_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._/-]*$")
 
 
+def is_remote_url(url: str) -> bool:
+    """True if url is an http(s) URL that clone_repo() should fetch remotely.
+
+    Case-insensitive scheme match — matches validate_url()'s own handling.
+    Every caller that decides "clone this vs. treat it as a local path"
+    (_acquire(), resolve_source()) must agree with validate_url() on this
+    exact question, or validate_url()'s hardening never reaches the real
+    call path: a string that fails a separately re-implemented, stricter
+    gate upstream never reaches validate_url() at all.
+    """
+    scheme_match = _URL_SCHEME_RE.match(url)
+    return scheme_match is not None and scheme_match.group(1).lower() in _ALLOWED_SCHEMES
+
+
 def validate_url(url: str) -> None:
     """Raise AcquireError unless url is http(s) or a genuine local filesystem path.
 
@@ -54,16 +68,11 @@ def validate_url(url: str) -> None:
     one pass, so a crafted RepoSource cannot reach a transport this function
     hasn't seen before.
     """
-    scheme_match = _URL_SCHEME_RE.match(url)
-    if scheme_match is not None:
-        if scheme_match.group(1).lower() in _ALLOWED_SCHEMES:
-            return
-        raise AcquireError(
-            f"Disallowed URL scheme in {url!r}: only http://, https://, and local paths are allowed"
-        )
+    if is_remote_url(url):
+        return
     if _WINDOWS_DRIVE_RE.match(url):
         return
-    if _TRANSPORT_HELPER_RE.match(url) or _SCP_LIKE_RE.match(url):
+    if _URL_SCHEME_RE.match(url) or _TRANSPORT_HELPER_RE.match(url) or _SCP_LIKE_RE.match(url):
         raise AcquireError(
             f"Disallowed URL scheme in {url!r}: only http://, https://, and local paths are allowed"
         )

--- a/src/archex/acquire/git.py
+++ b/src/archex/acquire/git.py
@@ -68,6 +68,13 @@ def validate_url(url: str) -> None:
     one pass, so a crafted RepoSource cannot reach a transport this function
     hasn't seen before.
     """
+    if url != url.strip():
+        raise AcquireError(
+            f"Disallowed URL scheme in {url!r}: leading/trailing whitespace is never part "
+            "of a legitimate http(s) URL or local path, and real git/ssh tolerate a leading "
+            "space before an scp-like host, which would otherwise let a whitespace-prefixed "
+            'payload slip past every anchored pattern above and fall through as "a local path"'
+        )
     if is_remote_url(url):
         return
     if _WINDOWS_DRIVE_RE.match(url):

--- a/src/archex/acquire/git.py
+++ b/src/archex/acquire/git.py
@@ -8,22 +8,66 @@ from pathlib import Path
 
 from archex.exceptions import AcquireError
 
-_ALLOWED_URL_PREFIXES = ("http://", "https://")
-_DISALLOWED_URL_PREFIXES = ("git@", "ssh://", "file://", "git://", "ftp://", "ftps://")
+_ALLOWED_SCHEMES = ("http", "https")
+
+# Matches any RFC 3986 `scheme://...` URL (ssh://, git://, file://, ftp(s)://,
+# ...), capturing the scheme name. Scheme names are case-insensitive per
+# RFC 3986 and real git/libcurl honor that, so the captured group is
+# compared case-insensitively below rather than via a case-sensitive prefix
+# check.
+_URL_SCHEME_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9+.-]*)://")
+
+# Matches git's `<transport>::<address>` remote-helper syntax. `ext::` in
+# particular runs its address as an arbitrary shell command — a well-known
+# RCE vector when an unvalidated URL reaches `git clone` (e.g. "ext::sh -c
+# 'touch pwned'"). No archex feature needs any remote helper, so all of them
+# are rejected rather than enumerated.
+_TRANSPORT_HELPER_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*::")
+
+# A Windows absolute drive path ("C:\Users\x", "C:/Users/x") is a single
+# ASCII letter immediately followed by `:` and a path separator. git itself
+# special-cases exactly this shape to disambiguate it from the scp-like
+# shorthand below; without this, _SCP_LIKE_RE would reject every Windows
+# absolute path as if it were an SSH host named "C".
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+# Matches the scp-like ssh shorthand `[user@]host:path` (no scheme, no
+# `//`), e.g. "git@github.com:user/repo.git" or, just as validly for git,
+# the user-less "github.com:user/repo.git". The `user@` part is OPTIONAL in
+# git's real grammar — a regex requiring it (as an earlier version of this
+# function did) lets a bare `host:path` slip through as "a local path" and
+# straight into `git clone`, resulting in a real outbound SSH connection to
+# an attacker-chosen host.
+_SCP_LIKE_RE = re.compile(r"^(?:[^/@\s]+@)?[^/\s:]+:")
+
 _BRANCH_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._/-]*$")
 
 
 def validate_url(url: str) -> None:
-    """Raise AcquireError if url is not http/https or a local filesystem path."""
-    if url.startswith(_ALLOWED_URL_PREFIXES):
+    """Raise AcquireError unless url is http(s) or a genuine local filesystem path.
+
+    Uses an allowlist, not a denylist: anything that isn't explicitly
+    http://, https://, or scheme-free is rejected, rather than only the
+    specific schemes this function happens to enumerate. That covers every
+    URL-scheme form (`scheme://...`), git's `transport::address`
+    remote-helper syntax, and the scp-like `[user@]host:path` shorthand in
+    one pass, so a crafted RepoSource cannot reach a transport this function
+    hasn't seen before.
+    """
+    scheme_match = _URL_SCHEME_RE.match(url)
+    if scheme_match is not None:
+        if scheme_match.group(1).lower() in _ALLOWED_SCHEMES:
+            return
+        raise AcquireError(
+            f"Disallowed URL scheme in {url!r}: only http://, https://, and local paths are allowed"
+        )
+    if _WINDOWS_DRIVE_RE.match(url):
         return
-    for prefix in _DISALLOWED_URL_PREFIXES:
-        if url.startswith(prefix):
-            raise AcquireError(
-                f"Disallowed URL scheme in {url!r}: "
-                "only http://, https://, and local paths are allowed"
-            )
-    # Treat anything else as a local path — acceptable
+    if _TRANSPORT_HELPER_RE.match(url) or _SCP_LIKE_RE.match(url):
+        raise AcquireError(
+            f"Disallowed URL scheme in {url!r}: only http://, https://, and local paths are allowed"
+        )
+    # Anything else is treated as a local filesystem path.
 
 
 def validate_branch(branch: str) -> None:

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -48,7 +48,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from archex import precision as precision_api
-from archex.acquire import clone_repo, discover_files, open_local
+from archex.acquire import clone_repo, discover_files, is_remote_url, open_local
 from archex.analyze.decisions import infer_decisions
 from archex.analyze.interfaces import extract_interfaces
 from archex.analyze.modules import detect_modules
@@ -627,7 +627,7 @@ def _acquire(
     The cleanup_fn removes any temporary directory created for URL clones.
     For local paths, cleanup_fn is a no-op.
     """
-    if source.url and (source.url.startswith("http://") or source.url.startswith("https://")):
+    if source.url and is_remote_url(source.url):
         target_dir = tempfile.mkdtemp()
 
         def _url_cleanup() -> None:

--- a/src/archex/utils.py
+++ b/src/archex/utils.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from archex.acquire import is_remote_url
 from archex.models import RepoSource
 
 
 def resolve_source(path_or_url: str) -> RepoSource:
     """Build a RepoSource from a local path or HTTP(S) URL string."""
-    if path_or_url.startswith("http://") or path_or_url.startswith("https://"):
+    if is_remote_url(path_or_url):
         return RepoSource(url=path_or_url)
     return RepoSource(local_path=path_or_url)

--- a/tests/acquire/test_git.py
+++ b/tests/acquire/test_git.py
@@ -72,8 +72,12 @@ def test_timeout_raises(tmp_path: Path) -> None:
     [
         "https://github.com/user/repo.git",
         "http://example.com/repo.git",
+        "HTTP://example.com/repo.git",
+        "HTTPS://example.com/repo.git",
         "/home/user/local-repo",
         "./relative/path",
+        "C:\\Users\\me\\repo",
+        "C:/Users/me/repo",
     ],
 )
 def testvalidate_url_accepts_safe_urls(url: str) -> None:
@@ -88,6 +92,10 @@ def testvalidate_url_accepts_safe_urls(url: str) -> None:
         "file:///etc/passwd",
         "git://github.com/user/repo.git",
         "ftp://example.com/repo.git",
+        "ext::sh -c touch /tmp/pwned",
+        "fd::5",
+        "example.com:some/repo.git",
+        "httpx://example.com/repo.git",
     ],
 )
 def testvalidate_url_rejects_disallowed_schemes(bad_url: str) -> None:
@@ -103,6 +111,21 @@ def test_clone_repo_rejects_ssh_url(tmp_path: Path) -> None:
 def test_clone_repo_rejects_file_url(tmp_path: Path) -> None:
     with pytest.raises(AcquireError, match="Disallowed URL scheme"):
         clone_repo("file:///etc/passwd", tmp_path / "out")
+
+
+def test_clone_repo_rejects_ext_transport_helper(tmp_path: Path) -> None:
+    """git's ext:: remote helper runs its address as a shell command; must never reach clone.
+
+    subprocess.run is mocked so a guard regression fails as a clean assertion
+    rather than actually invoking `git clone` with this payload — git's
+    ext:: handler runs its address as a real local shell command.
+    """
+    with (
+        patch("archex.acquire.git.subprocess.run") as mock_run,
+        pytest.raises(AcquireError, match="Disallowed URL scheme"),
+    ):
+        clone_repo("ext::sh -c touch /tmp/pwned", tmp_path / "out")
+    mock_run.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/acquire/test_git.py
+++ b/tests/acquire/test_git.py
@@ -95,6 +95,10 @@ def testvalidate_url_accepts_safe_urls(url: str) -> None:
         "ext::sh -c touch /tmp/pwned",
         "fd::5",
         "example.com:some/repo.git",
+        " example.com:some/repo.git",
+        "\texample.com:some/repo.git",
+        "\nexample.com:some/repo.git",
+        "example.com:some/repo.git ",
         "httpx://example.com/repo.git",
     ],
 )
@@ -125,6 +129,20 @@ def test_clone_repo_rejects_ext_transport_helper(tmp_path: Path) -> None:
         pytest.raises(AcquireError, match="Disallowed URL scheme"),
     ):
         clone_repo("ext::sh -c touch /tmp/pwned", tmp_path / "out")
+    mock_run.assert_not_called()
+
+
+def test_clone_repo_rejects_leading_whitespace_scp_bypass(tmp_path: Path) -> None:
+    """A leading space before an scp-like host is still a real ssh remote to git/ssh,
+    but was previously unanchored-by-whitespace and fell through as "a local path".
+    subprocess.run is mocked so a guard regression fails as a clean assertion rather
+    than a real outbound ssh connection attempt to an attacker-chosen host.
+    """
+    with (
+        patch("archex.acquire.git.subprocess.run") as mock_run,
+        pytest.raises(AcquireError, match="Disallowed URL scheme"),
+    ):
+        clone_repo(" example.com:some/repo.git", tmp_path / "out")
     mock_run.assert_not_called()
 
 

--- a/tests/test_api_robustness.py
+++ b/tests/test_api_robustness.py
@@ -112,6 +112,32 @@ def test_acquire_url_cleanup_safe_on_missing_dir() -> None:
     cleanup()
 
 
+def test_acquire_recognizes_uppercase_https_scheme() -> None:
+    """_acquire must route a case-insensitive http(s) scheme to clone_repo(),
+    not silently misroute it to the local-path branch.
+    """
+
+    def fake_clone(url: str, target: str) -> Path:
+        return Path(target)
+
+    source = RepoSource(url="HTTPS://example.com/repo.git")
+    with patch("archex.api.clone_repo", side_effect=fake_clone) as mock_clone:
+        _acquire(source)[3]()  # run cleanup to avoid leaking the mkdtemp() dir
+
+    mock_clone.assert_called_once()
+
+
+def test_acquire_rejects_non_http_scheme_without_reaching_clone_repo() -> None:
+    """A crafted non-http(s) URL (e.g. git's ext:: remote helper) must never
+    reach clone_repo(), regardless of which exception type surfaces.
+    """
+    source = RepoSource(url="ext::sh -c touch /tmp/pwned")
+    with patch("archex.api.clone_repo") as mock_clone, pytest.raises(ValueError):
+        _acquire(source)
+
+    mock_clone.assert_not_called()
+
+
 def _tmp_dirs() -> set[str]:
     return {p.name for p in Path(tempfile.gettempdir()).iterdir() if p.is_dir()}
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,47 @@
+"""Tests for archex.utils.resolve_source."""
+
+from __future__ import annotations
+
+import pytest
+
+from archex.utils import resolve_source
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/user/repo.git",
+        "http://example.com/repo.git",
+        "HTTP://example.com/repo.git",
+        "HTTPS://example.com/repo.git",
+        "Https://example.com/repo.git",
+    ],
+)
+def test_resolve_source_recognizes_http_urls_case_insensitively(url: str) -> None:
+    """MCP tool callers may pass a non-lowercase scheme; it must still resolve to a URL."""
+    source = resolve_source(url)
+
+    assert source.url == url
+    assert source.local_path is None
+
+
+@pytest.mark.parametrize(
+    "path_or_url",
+    [
+        "/home/user/local-repo",
+        "./relative/path",
+        "example.com:some/repo.git",
+        "git@github.com:user/repo.git",
+        "ssh://git@github.com/user/repo.git",
+        "ext::sh -c touch /tmp/pwned",
+    ],
+)
+def test_resolve_source_treats_non_http_values_as_local_path(path_or_url: str) -> None:
+    """Anything that isn't an http(s) URL is handed to the local-path branch, which
+    open_local() then validates (and rejects if it isn't a real repo directory) —
+    it must never be misclassified as a URL and handed to clone_repo().
+    """
+    source = resolve_source(path_or_url)
+
+    assert source.local_path == path_or_url
+    assert source.url is None


### PR DESCRIPTION
## Stack

Stack-Id: `archex-audit-040676`
Base: `fix/mcp-graph-query-cache-staleness` (#481)
Position: 4/5

1. `fix/ephemeral-index-store-cleanup` -> #479
2. `fix/delta-benchmark-cache-leak` -> #480
3. `fix/mcp-graph-query-cache-staleness` -> #481
4. `fix/git-url-scheme-allowlist` -> this PR
5. `fix/artifact-decompression-bomb-guard` -> #5

Depends on: #481
Upstack: #5

## Summary

Security fix. `validate_url()` denylisted six specific prefixes and silently accepted anything else as "a local path". This left three real gaps, closed here:

1. **git's `ext::` remote helper** — runs its address as an arbitrary shell command, a known RCE vector when an unvalidated URL reaches `git clone` (e.g. `"ext::sh -c 'touch pwned'"`) — didn't start with any of the six denylisted prefixes, so it passed `validate_url()` untouched.
2. **scp-like SSH bypass** — the fix's own first draft required `user@` in `[user@]host:path`, but git's real grammar makes it *optional*; a bare `"example.com:some/repo.git"` (no `@`) slipped past every pattern and would reach a real `git clone` subprocess, confirmed via a subprocess PoC (an actual outbound `ssh` invocation against the attacker-chosen host). A second variant of the same root cause: a *leading space* before an scp-like host (`" example.com:some/repo.git"`) also bypassed every anchored regex, since real git/ssh tolerate the leading whitespace and still connect — also subprocess-confirmed and closed.
3. **case-sensitivity** — the accept-side check was a case-sensitive `.startswith(("http://", "https://"))`, so a legitimate `"HTTP://..."` URL was spuriously rejected.

Beyond `validate_url()` itself, a full-diff review found that its hardening never reached the real production call path: `api.py`'s `_acquire()` and `utils.py`'s `resolve_source()` (the funnel every MCP `handle_*_repo` tool uses to build a `RepoSource` from a caller-supplied `repo_url`) each re-implemented their own separate, case-sensitive `.startswith(("http://", "https://"))` gate *ahead of* `validate_url()`. Any string that wasn't already a literal lowercase `http(s)://`-prefixed value never reached `clone_repo()`/`validate_url()` at all — closing the gaps inside `validate_url()` alone would have been dead code. Adds `is_remote_url()` to `acquire/git.py` (the same case-insensitive scheme match `validate_url()` uses) and routes both `_acquire()` and `resolve_source()` through it instead of duplicating a cruder, inconsistent check — a single source of truth for "is this an http(s) URL", now actually reachable from production traffic.

Switches from a denylist to an allowlist model throughout: only `http://`, `https://` (case-insensitive), and values with no scheme-like prefix pass; everything matching a generic `scheme://` form, git's `transport::address` remote-helper syntax, or the (now-correct) scp-like shorthand is rejected — plus outright rejection of any leading/trailing whitespace before those checks run at all.

## Validation

- `uv run ruff check` / `uv run ruff format --check` / `uv run pyright` (strict) — clean.
- `uv run pytest tests/acquire/ tests/test_api_robustness.py tests/test_utils.py tests/integrations/test_mcp.py --no-cov` — all passing.
- Each of the four vulnerability classes (`ext::`, scp-like bypass, leading-whitespace scp-like bypass, case-sensitivity) reproduced against the pre-fix code with a real subprocess PoC (git spawning an actual `ssh`/shell process, or a spurious rejection), then re-confirmed closed post-fix. The dedicated `clone_repo()`-level regression tests mock `subprocess.run` so a future guard regression fails as a clean assertion instead of actually invoking `git clone`/`ssh` with the payload.
- No circular import introduced (`archex.utils` -> `archex.acquire`).
