### PR TITLE
fix(artifact): bound artifact decompression against decompression bombs

### DIFF
--- a/src/archex/index/artifact.py
+++ b/src/archex/index/artifact.py
@@ -67,6 +67,31 @@ ARTIFACT_MAX_COMPAT_VERSION = "0.99.99"
 #: SQLite-shaped content (mostly text — source chunks, symbol metadata).
 _LZMA_PRESET = 6
 
+#: Chunk size streamed per LZMADecompressor.decompress() call when bounding
+#: an artifact payload (see _decompress_artifact_payload). Small enough to
+#: check the running total frequently, large enough to keep call overhead
+#: negligible for a legitimate multi-megabyte payload.
+_DECOMPRESS_CHUNK_BYTES = 4 * 1024 * 1024
+
+#: Hard ceiling on a decompressed artifact payload. `lzma.decompress()`'s
+#: `memlimit` bounds only the decoder's internal dictionary/filter-chain
+#: memory — which is dictated by the *compression* preset used to write the
+#: artifact, not by how many bytes of output it produces — so a payload
+#: compressed at a low preset can pass any memlimit while still
+#: decompressing to gigabytes. `_decompress_artifact_payload` streams
+#: through `LZMADecompressor` instead, checking the running output total,
+#: so an oversized payload is rejected before being fully materialized. 1
+#: GiB comfortably exceeds any legitimate index this format is meant to
+#: carry (a compacted, FTS5-stripped SQLite database of source chunks and
+#: symbol metadata).
+_MAX_DECOMPRESSED_ARTIFACT_BYTES = 1024**3
+
+#: Hard ceiling on the artifact header itself. Real headers are a small
+#: flat JSON dict (well under 1 KiB); this only guards against a crafted
+#: artifact declaring an absurd header_len (up to ~4.29 GiB, the u32 max)
+#: that forces a multi-gigabyte read before any validation has run.
+_MAX_HEADER_BYTES = 64 * 1024
+
 _HEADER_LENGTH_STRUCT = struct.Struct(">I")
 
 # Tables dropped before compression and rebuilt locally on import. Both are
@@ -151,6 +176,11 @@ def _read_header(handle: Any, path: Path) -> ArtifactHeader:
     if len(length_bytes) != _HEADER_LENGTH_STRUCT.size:
         raise ArtifactError(f"Truncated artifact header: {path}")
     (header_len,) = _HEADER_LENGTH_STRUCT.unpack(length_bytes)
+    if header_len > _MAX_HEADER_BYTES:
+        raise ArtifactError(
+            f"Artifact header for {path} declares {header_len} bytes, "
+            f"exceeding the {_MAX_HEADER_BYTES} byte limit"
+        )
     header_bytes = handle.read(header_len)
     if len(header_bytes) != header_len:
         raise ArtifactError(f"Truncated artifact header: {path}")
@@ -277,6 +307,40 @@ def _rebuild_symbols_fts(store: IndexStore) -> None:
     conn.commit()
 
 
+def _decompress_artifact_payload(compressed_payload: bytes, path: Path) -> bytes:
+    """Decompress an artifact payload, bounded against a decompression bomb.
+
+    Streams through `LZMADecompressor` in `_DECOMPRESS_CHUNK_BYTES` chunks
+    and checks the running output total after every chunk, aborting before
+    an oversized payload is ever fully materialized. `lzma.decompress()`'s
+    `memlimit` cannot do this: it bounds the decoder's internal dictionary
+    memory, which depends on the *compression* preset used to write the
+    payload, not on how many bytes of output it produces — a payload
+    compressed at a low preset passes any memlimit while still
+    decompressing to gigabytes.
+    """
+    decompressor = lzma.LZMADecompressor()
+    remaining = compressed_payload
+    chunks: list[bytes] = []
+    total = 0
+    try:
+        while not decompressor.eof:
+            out = decompressor.decompress(remaining, max_length=_DECOMPRESS_CHUNK_BYTES)
+            remaining = b""
+            total += len(out)
+            if total > _MAX_DECOMPRESSED_ARTIFACT_BYTES:
+                raise ArtifactError(
+                    f"Artifact payload for {path} decompresses beyond the "
+                    f"{_MAX_DECOMPRESSED_ARTIFACT_BYTES} byte limit"
+                )
+            chunks.append(out)
+            if decompressor.needs_input and not decompressor.eof:
+                raise ArtifactError(f"Truncated or corrupt artifact payload: {path}")
+    except lzma.LZMAError as exc:
+        raise ArtifactError(f"Artifact payload for {path} is corrupt: {exc}") from exc
+    return b"".join(chunks)
+
+
 def import_artifact(path: str | Path, dest_db_path: str | Path) -> ArtifactHeader:
     """Import a portable index artifact, writing a ready-to-use store at `dest_db_path`.
 
@@ -299,7 +363,7 @@ def import_artifact(path: str | Path, dest_db_path: str | Path) -> ArtifactHeade
         validate_artifact_compat(header)
         compressed_payload = handle.read()
 
-    decompressed = lzma.decompress(compressed_payload)
+    decompressed = _decompress_artifact_payload(compressed_payload, path)
 
     dest_db_path.parent.mkdir(parents=True, exist_ok=True)
     for suffix in ("-wal", "-shm"):

--- a/tests/index/test_artifact.py
+++ b/tests/index/test_artifact.py
@@ -21,6 +21,7 @@ from archex.index.artifact import (
     ARTIFACT_FORMAT_VERSION,
     ARTIFACT_MAGIC,
     ArtifactHeader,
+    _decompress_artifact_payload,  # pyright: ignore[reportPrivateUsage]
     ensure_artifact_gitattributes,
     export_artifact,
     import_artifact,
@@ -304,6 +305,18 @@ _INCOMPATIBLE_VERSION_HEADER: dict[str, object] = {
     "created_at": 0.0,
 }
 
+_COMPATIBLE_HEADER: dict[str, object] = {
+    "format_version": ARTIFACT_FORMAT_VERSION,
+    "created_by_version": "0.0.0",
+    "compat_min_version": "0.0.0",
+    "compat_max_version": "99.99.99",
+    "index_revision": "deadbeef",
+    "schema_version": "5",
+    "chunk_count": 1,
+    "file_count": 1,
+    "created_at": 0.0,
+}
+
 
 class TestImportArtifact:
     def test_import_produces_ready_to_use_store(
@@ -422,6 +435,77 @@ class TestImportArtifact:
             import_artifact(artifact_path, dest)
 
         assert dest.read_bytes() == original_bytes
+
+    def test_import_rejects_payload_beyond_decompression_limit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A crafted artifact with a small compressed, huge decompressed payload
+        (a decompression bomb) must fail cleanly instead of exhausting memory,
+        end to end through import_artifact().
+
+        Compresses at preset=0 (the smallest LZMA dictionary) so the bomb
+        payload's compressed size has no bearing on the guard — proving the
+        guard tracks actual decompressed output, not a compression-preset-derived
+        proxy for it (a real memlimit-based bound would not have caught this).
+        """
+        import archex.index.artifact as artifact_module
+
+        monkeypatch.setattr(artifact_module, "_MAX_DECOMPRESSED_ARTIFACT_BYTES", 1024)
+
+        bomb_payload = b"\x00" * (10 * 1024 * 1024)
+        header_bytes = json.dumps(_COMPATIBLE_HEADER, sort_keys=True).encode("utf-8")
+        artifact_path = tmp_path / "bomb.xz"
+        with artifact_path.open("wb") as handle:
+            handle.write(ARTIFACT_MAGIC)
+            handle.write(struct.pack(">I", len(header_bytes)))
+            handle.write(header_bytes)
+            handle.write(lzma.compress(bomb_payload, preset=0))
+        dest = tmp_path / "dest" / "index.db"
+
+        with pytest.raises(ArtifactError, match="decompress"):
+            import_artifact(artifact_path, dest)
+
+        assert not dest.exists()
+
+
+class TestDecompressArtifactPayload:
+    """Direct unit tests for the bomb-bounding decompression helper.
+
+    Complements TestImportArtifact's end-to-end coverage by exercising the
+    guard in isolation: a rejection case and an acceptance case under the
+    exact same cap, proving it is proportional to actual decompressed
+    output size rather than a blanket reject.
+    """
+
+    def test_rejects_output_beyond_the_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import archex.index.artifact as artifact_module
+
+        monkeypatch.setattr(artifact_module, "_MAX_DECOMPRESSED_ARTIFACT_BYTES", 1024)
+        bomb = lzma.compress(b"\x00" * (10 * 1024 * 1024), preset=0)
+
+        with pytest.raises(ArtifactError, match="decompresses beyond"):
+            _decompress_artifact_payload(bomb, Path("bomb.xz"))
+
+    def test_accepts_output_within_the_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import archex.index.artifact as artifact_module
+
+        monkeypatch.setattr(artifact_module, "_MAX_DECOMPRESSED_ARTIFACT_BYTES", 1024)
+        payload = b"a small payload well under the cap"
+        compressed = lzma.compress(payload)
+
+        result = _decompress_artifact_payload(compressed, Path("small.xz"))
+
+        assert result == payload
+
+    def test_rejects_truncated_input(self) -> None:
+        compressed = lzma.compress(b"hello world" * 100)
+
+        with pytest.raises(ArtifactError, match="[Tt]runcated|corrupt"):
+            _decompress_artifact_payload(compressed[:20], Path("truncated.xz"))
+
+    def test_rejects_garbage_input(self) -> None:
+        with pytest.raises(ArtifactError, match="corrupt"):
+            _decompress_artifact_payload(b"not lzma data at all", Path("garbage.xz"))
 
 
 class TestFromArtifactCli:

--- a/tests/index/test_artifact.py
+++ b/tests/index/test_artifact.py
@@ -468,6 +468,24 @@ class TestImportArtifact:
         assert not dest.exists()
 
 
+class TestReadHeader:
+    """Direct unit test for _read_header()'s header_len ceiling."""
+
+    def test_rejects_oversized_header_length(self, tmp_path: Path) -> None:
+        """A crafted artifact declaring an absurd header_len must be rejected
+        before any read of that size is attempted — the same length-prefixed-
+        read bomb class the payload decompression guard closes, one field
+        earlier in the same file.
+        """
+        artifact_path = tmp_path / "oversized_header.xz"
+        with artifact_path.open("wb") as handle:
+            handle.write(ARTIFACT_MAGIC)
+            handle.write(struct.pack(">I", 2**32 - 1))  # max u32: ~4.29 GiB declared header
+
+        with pytest.raises(ArtifactError, match="exceeding"):
+            read_artifact_header(artifact_path)
+
+
 class TestDecompressArtifactPayload:
     """Direct unit tests for the bomb-bounding decompression helper.
 


### PR DESCRIPTION
## Stack

Stack-Id: `archex-audit-040676`
Base: `fix/git-url-scheme-allowlist` (#482)
Position: 5/5

1. `fix/ephemeral-index-store-cleanup` -> #479
2. `fix/delta-benchmark-cache-leak` -> #480
3. `fix/mcp-graph-query-cache-staleness` -> #481
4. `fix/git-url-scheme-allowlist` -> #482
5. `fix/artifact-decompression-bomb-guard` -> this PR (leaf)

Depends on: #482
Upstack: (none - leaf)

## Summary

Security fix. `import_artifact()` ran `lzma.decompress()` on the artifact payload with no real bound on its output size, and read the header's declared length straight off the untrusted file with no ceiling either. Both are classic decompression/length-prefix bomb shapes: a crafted artifact with a small compressed payload and a pathologically repetitive decompressed form can expand to gigabytes before this function does anything with the result — a memory-exhaustion DoS against whoever runs `archex init --from-artifact` on a malicious or compromised artifact file (e.g. one committed to a shared repo, per this format's own intended team-sharing workflow).

The first draft of this fix used `lzma.decompress(data, memlimit=N)`. This does **not** bound output size: `memlimit` only bounds the decoder's internal dictionary/filter-chain memory, which is dictated by the *compression preset* used to write the artifact, not by how many bytes of output it produces. Reproduced directly: a payload compressed at `preset=0` (tiny declared dictionary) passed a 1 MiB `memlimit` untouched while still decompressing to 200+ MiB. Replaced with `_decompress_artifact_payload()`, which streams through `LZMADecompressor` in bounded chunks and checks the running *output* total against a 1 GiB ceiling, aborting before an oversized payload is ever fully materialized — verified this actually bounds peak memory (tracemalloc) and wall time, not just the dictionary-derived floor the `memlimit` approach was silently gated by.

Also caps the artifact header at 64 KiB before reading it (real headers are a small flat JSON dict) — the same length-prefixed-read bomb class, one field earlier in the same file, closed the same way: reject before the oversized read is attempted.

## Validation

- `uv run ruff check` / `uv run ruff format --check` / `uv run pyright` (strict) — clean.
- `uv run pytest tests/index/test_artifact.py --no-cov` — all 44 passing.
- Independent reproduction: a `preset=0`-compressed 100+ MiB payload against a monkeypatched cap is rejected in milliseconds with bounded peak memory (confirmed via `tracemalloc`), proving the guard tracks actual decompressed output rather than a compression-preset-derived proxy for it — the exact scenario the `memlimit` approach silently failed. A legitimate payload under the same cap round-trips byte-for-byte, proving proportional (not blanket) bounding. Against the real 1 GiB production cap: a payload that genuinely exceeds it is rejected in ~5.6s (bounded by the cap, not by the attacker's chosen compression ratio); a 200 MiB payload well under the cap correctly succeeds.
- `_read_header`'s oversized-`header_len` guard verified directly: a crafted magic + max-`u32` length prefix is rejected before any read of that declared size is attempted (a stub handle whose `.read(n)` asserts `n <= 1024` never trips).
