### PR TITLE
chore(release): prepare 0.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.19.2] - 2026-07-11
+
+### Fixed
+
+- **M0: verified index publication and lifecycle integrity.** Index generation now publishes verified retrieval state atomically with a generation manifest and provenance for parsed symbols, edges, unresolved imports, and exclusions. Total parser-worker failure fails closed; strict parsing reaches the orchestrator; repository identity is canonical across equivalent local paths; reset removes SQLite WAL/SHM sidecars; `doctor` validates enabled retrieval stores; and CI exercises a clean-install BM25 index/query smoke path.
+
 
 ## [0.19.1] - 2026-07-10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archex"
-version = "0.19.1"
+version = "0.19.2"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "archex"
-version = "0.19.1"
+version = "0.19.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Bump the package and lockfile version from 0.19.1 to 0.19.2.
- Add the M0 verified index-generation integrity fix to the 0.19.2 changelog section.

## Validation

- uv sync --all-extras
- uv run ruff check .
- uv run ruff format --check .
- uv run pyright

This release-preparation PR contains no product-code changes.