### PR TITLE
fix(benchmark): model timing classes explicitly

### DIFF
--- a/src/archex/benchmark/competitive.py
+++ b/src/archex/benchmark/competitive.py
@@ -75,6 +75,11 @@ def _optional_mean(values: list[float | None], *, digits: int = 2) -> str:
     return _num(_mean(present), digits=digits) if present else "n/a"
 
 
+def _optional_percentile(values: list[float | None], quantile: float, *, digits: int = 2) -> str:
+    present = [value for value in values if value is not None]
+    return _num(_percentile(present, quantile), digits=digits) if present else "n/a"
+
+
 def _optional_rate(flags: list[bool | None]) -> str:
     present = [1.0 if flag else 0.0 for flag in flags if flag is not None]
     return _num(_mean(present)) if present else "n/a"
@@ -85,8 +90,8 @@ def _gated_rate(flags: list[bool], measured: list[bool]) -> str:
     return _num(_mean(present)) if present else "n/a"
 
 
-def _warm_latency(results: list[BenchmarkResult]) -> list[float]:
-    return [r.warm_latency_ms or r.wall_time_ms for r in results]
+def _warm_latency(results: list[BenchmarkResult]) -> list[float | None]:
+    return [result.warm_latency_ms for result in results]
 
 
 def _retrieval_row(label: str, layer: ComparisonLayerType, results: list[BenchmarkResult]) -> str:
@@ -108,8 +113,8 @@ def _retrieval_row(label: str, layer: ComparisonLayerType, results: list[Benchma
             [r.freshness_measured for r in results],
         ),
         _num(_mean([r.cold_start_ms for r in results]), digits=0),
-        _num(_percentile(latencies, 0.50), digits=0),
-        _num(_percentile(latencies, 0.95), digits=0),
+        _optional_percentile(latencies, 0.50, digits=0),
+        _optional_percentile(latencies, 0.95, digits=0),
     ]
     return "| " + " | ".join(cells) + " |"
 

--- a/src/archex/benchmark/gate.py
+++ b/src/archex/benchmark/gate.py
@@ -303,7 +303,7 @@ def check_latency_warnings(
     warnings: list[LatencyWarning] = []
     for report in reports:
         for r in report.results:
-            if r.wall_time_ms > thresholds.warn_latency_ms:
+            if r.wall_time_ms is not None and r.wall_time_ms > thresholds.warn_latency_ms:
                 warnings.append(
                     LatencyWarning(
                         task_id=r.task_id,
@@ -334,7 +334,7 @@ def check_latency_violations(
     violations: list[LatencyViolation] = []
     for report in reports:
         for r in report.results:
-            if r.wall_time_ms > max_latency_ms:
+            if r.wall_time_ms is not None and r.wall_time_ms > max_latency_ms:
                 violations.append(
                     LatencyViolation(
                         task_id=r.task_id,

--- a/src/archex/benchmark/headtohead.py
+++ b/src/archex/benchmark/headtohead.py
@@ -522,10 +522,13 @@ def format_headtohead_markdown(
                         provenance,
                         "token_efficiency_with_completion",
                     ),
-                    _integer_metric_cell(
-                        _mean([r.warm_latency_ms or r.wall_time_ms for r in results]),
+                    _optional_metric_cell(
+                        _mean([r.warm_latency_ms for r in results if r.warm_latency_ms is not None])
+                        if any(r.warm_latency_ms is not None for r in results)
+                        else None,
                         provenance,
                         "warm_latency_ms",
+                        digits=0,
                     ),
                     _integer_metric_cell(
                         _mean([r.cold_start_ms for r in results]),

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -462,6 +462,14 @@ class TaskCompletionResult(StrEnum):
     UNKNOWN = "unknown"
 
 
+class QueryTiming(BaseModel):
+    """Explicit timing representation for query execution."""
+
+    cold_ms: float | None = None
+    warm_ms: float | None = None
+    wall_ms: float | None = None
+
+
 class BenchmarkResult(BaseModel):
     task_id: str
     strategy: Strategy
@@ -481,7 +489,9 @@ class BenchmarkResult(BaseModel):
     token_efficiency: float = 0.0
     tokens_raw_baseline: int = 0
     savings_vs_raw: float
-    wall_time_ms: float
+    cold_latency_ms: float | None = None
+    warm_latency_ms: float | None = None
+    wall_time_ms: float | None = None
     cached: bool
     timing: PipelineTiming | None = None
     timestamp: str
@@ -527,8 +537,8 @@ class BenchmarkResult(BaseModel):
     bundle_completion_files: list[str] = []
     token_efficiency_with_completion: float = 0.0
     cold_start_ms: float = 0.0
-    warm_latency_ms: float = 0.0
     provenance: dict[str, str] = {}
+    warm_latency_ms: float | None = None
     freshness_latency_ms: float = 0.0
     freshness_measured: bool = False
     freshness_correct: bool = False

--- a/src/archex/benchmark/readiness.py
+++ b/src/archex/benchmark/readiness.py
@@ -195,8 +195,14 @@ def build_readiness_report(
     mean_precision = _mean([result.precision for result in metric_results])
     mean_f1 = _mean([result.f1_score for result in metric_results])
     mean_mrr = _mean([result.mrr for result in metric_results])
-    median_latency_ms = _percentile([result.wall_time_ms for result in metric_results], 0.50)
-    p95_latency_ms = _percentile([result.wall_time_ms for result in metric_results], 0.95)
+    median_latency_ms = _percentile(
+        [result.wall_time_ms for result in metric_results if result.wall_time_ms is not None],
+        0.50,
+    )
+    p95_latency_ms = _percentile(
+        [result.wall_time_ms for result in metric_results if result.wall_time_ms is not None],
+        0.95,
+    )
     tokens_total = sum(result.tokens_total for result in metric_results)
     token_efficiency = _mean([result.token_efficiency for result in metric_results])
     savings_vs_raw = _mean([result.savings_vs_raw for result in metric_results])

--- a/src/archex/benchmark/reporter.py
+++ b/src/archex/benchmark/reporter.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import math
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -62,17 +64,20 @@ def _mean(values: list[float]) -> float:
     return sum(values) / len(values)
 
 
-def _percentile(values: list[float], quantile: float) -> float:
-    if not values:
-        return 0.0
-    ordered = sorted(values)
-    if len(ordered) == 1:
-        return ordered[0]
-    position = (len(ordered) - 1) * quantile
-    lower = int(position)
-    upper = min(lower + 1, len(ordered) - 1)
-    fraction = position - lower
-    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+def _percentile(values: Sequence[float | None], quantile: float) -> float | None:
+    present = [v for v in values if v is not None]
+    if not present:
+        return None
+
+    sorted_values = sorted(present)
+    k = (len(sorted_values) - 1) * quantile
+    f = int(k)
+    c = int(math.ceil(k))
+    if f == c:
+        return sorted_values[f]
+    d0 = sorted_values[f] * (c - k)
+    d1 = sorted_values[c] * (k - f)
+    return d0 + d1
 
 
 def _receipt_accuracy_label(value: bool | None) -> str:
@@ -90,11 +95,11 @@ def _has_region_metrics(reports: list[BenchmarkReport]) -> bool:
 
 
 def _fmt_opt(value: float | None, *, digits: int = 3) -> str:
-    return "unknown" if value is None else f"{value:.{digits}f}"
+    return "n/a" if value is None else f"{value:.{digits}f}"
 
 
 def _fmt_opt_int(value: int | None) -> str:
-    return "unknown" if value is None else f"{value:,}"
+    return "n/a" if value is None else f"{value:,}"
 
 
 def _mean_optional(values: list[float | None]) -> float | None:
@@ -358,7 +363,7 @@ def _advanced_lanes_appendix(report: BenchmarkReport) -> list[str]:
             f"| {result.token_efficiency_with_completion:.2f} "
             f"| {result.required_file_recall:.2f} "
             f"| {_fmt_opt(result.region_recall)} "
-            f"| {result.wall_time_ms:.0f} "
+            f"| {_fmt_opt(result.wall_time_ms, digits=0)} "
             f"| {_advanced_lane_note(result)} |"
         )
     return lines
@@ -427,7 +432,7 @@ def _packing_lane_comparison(reports: list[BenchmarkReport]) -> list[str]:
         lines.append(
             f"| {_PACKING_LANE_LABELS[name]} | {name} | {efficiency:.3f} "
             f"| {_fmt_opt(region_rel, digits=2)} | {_fmt_opt(ratio)} "
-            f"| {p95:.0f} | {len(results)} |"
+            f"| {_fmt_opt(p95, digits=0)} | {len(results)} |"
         )
     lines.append("")
     return lines
@@ -486,7 +491,7 @@ def format_markdown(report: BenchmarkReport) -> str:
             f"| {r.missed_required_file_rate:.2f} | {r.missed_required_task_rate:.2f} "
             f"| {all_required} | {r.task_completion_result.value} | {receipt_accuracy} "
             f"| {r.recall:.2f} | {r.precision:.2f} "
-            f"| {r.f1_score:.2f} | {r.wall_time_ms:.0f} |"
+            f"| {r.f1_score:.2f} | {_fmt_opt(r.wall_time_ms, digits=0)} |"
         )
     lines.extend(_missing_required_file_appendix(report))
     lines.extend(_bundle_only_eval_appendix(report))
@@ -720,7 +725,7 @@ def format_baseline_comparison(
         return "No baseline comparison available."
 
     baseline_by_task = {report.task_id: report for report in baseline_reports}
-    rows: list[tuple[str, float, float, float, float, float, float]] = []
+    rows: list[tuple[str, float, float, float, float, float | None, float]] = []
     compression_ratios: list[float] = []
     for candidate_report in candidate_reports:
         baseline_report = baseline_by_task.get(candidate_report.task_id)
@@ -740,7 +745,9 @@ def format_baseline_comparison(
                 candidate.mrr - baseline.mrr,
                 candidate.f1_score - baseline.f1_score,
                 candidate.required_file_recall - baseline.required_file_recall,
-                candidate.wall_time_ms - baseline.wall_time_ms,
+                (candidate.wall_time_ms - baseline.wall_time_ms)
+                if candidate.wall_time_ms is not None and baseline.wall_time_ms is not None
+                else None,
                 compression_ratio,
             )
         )
@@ -767,11 +774,14 @@ def format_baseline_comparison(
         compression,
     ) in rows:
         compression_cell = f"{compression:.2f}x" if compression else "n/a"
+        latency_cell = "n/a" if latency_delta is None else f"{latency_delta:+.0f}"
         lines.append(
             f"| {task_id} | {recall_delta:+.3f} | {mrr_delta:+.3f} "
             f"| {f1_delta:+.3f} | {required_delta:+.3f} "
-            f"| {latency_delta:+.0f} | {compression_cell} |"
+            f"| {latency_cell} | {compression_cell} |"
         )
+    aggregate_latency = _mean_optional([row[5] for row in rows])
+    latency_summary = "n/a" if aggregate_latency is None else f"{aggregate_latency:+.0f}"
 
     lines.extend(
         [
@@ -782,7 +792,7 @@ def format_baseline_comparison(
             f"- MRR Δ: {_mean([row[2] for row in rows]):+.3f}",
             f"- F1 Δ: {_mean([row[3] for row in rows]):+.3f}",
             f"- Required recall Δ: {_mean([row[4] for row in rows]):+.3f}",
-            f"- Latency Δ ms: {_mean([row[5] for row in rows]):+.0f}",
+            f"- Latency Δ ms: {latency_summary}",
             f"- Compression: {_mean(compression_ratios):.2f}x"
             if compression_ratios
             else "- Compression: n/a",
@@ -969,7 +979,8 @@ def format_chunker_frontier_table(
             rows[key]["precision"].append(result.precision)
             rows[key]["f1_score"].append(result.f1_score)
             rows[key]["token_efficiency"].append(result.token_efficiency)
-            rows[key]["wall_time_ms"].append(result.wall_time_ms)
+            if result.wall_time_ms is not None:
+                rows[key]["wall_time_ms"].append(result.wall_time_ms)
             rows[key]["index_chunk_count"].append(float(result.index_chunk_count))
             rows[key]["mean_chunk_tokens"].append(result.mean_chunk_tokens)
 
@@ -986,7 +997,7 @@ def format_chunker_frontier_table(
             f"| {strategy} | {chunker} | {_mean(metrics['recall']):.3f} "
             f"| {_mean(metrics['precision']):.3f} | {_mean(metrics['f1_score']):.3f} "
             f"| {_mean(metrics['token_efficiency']):.3f} "
-            f"| {_percentile(metrics['wall_time_ms'], 0.95):.0f} "
+            f"| {_fmt_opt(_percentile(metrics['wall_time_ms'], 0.95), digits=0)} "
             f"| {_mean(metrics['index_chunk_count']):.0f} "
             f"| {_mean(metrics['mean_chunk_tokens']):.1f} |"
         )

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -314,11 +314,11 @@ def run_benchmark(
             results=results,
             baseline_tokens=baseline_tokens,
             median_latency_ms=_percentile(
-                [result.wall_time_ms for result in results],
+                [result.wall_time_ms for result in results if result.wall_time_ms is not None],
                 0.50,
             ),
             p95_latency_ms=_percentile(
-                [result.wall_time_ms for result in results],
+                [result.wall_time_ms for result in results if result.wall_time_ms is not None],
                 0.95,
             ),
         )

--- a/tests/benchmark/test_bounded_rerank_strategy.py
+++ b/tests/benchmark/test_bounded_rerank_strategy.py
@@ -330,6 +330,7 @@ class TestRunBoundedRerankFixture:
 
         assert result.strategy == Strategy.ARCHEX_QUERY_BOUNDED_RERANK
         assert result.tool_calls == 1
+        assert result.wall_time_ms is not None
         assert result.wall_time_ms >= 0.0
         prov = result.provenance
         # No model is loaded in a fresh benchmark process: the lane skips the CE.

--- a/tests/benchmark/test_competitive_report.py
+++ b/tests/benchmark/test_competitive_report.py
@@ -165,6 +165,23 @@ def test_competitive_report_includes_all_lanes_and_layer_labels() -> None:
     assert "layer=headroom" in output
 
 
+def test_competitive_report_renders_unmeasured_warm_latency_as_na() -> None:
+    reports = _reports_one_repo()
+    archex_result = reports[0].results[0]
+    archex_result.warm_latency_ms = None
+    archex_result.wall_time_ms = 999.0
+
+    output = format_competitive_markdown(_manifest(), reports)
+    archex_row = next(
+        line
+        for line in output.splitlines()
+        if line.startswith("| archex | retrieval |") and line.count("|") > 10
+    )
+    cells = [cell.strip() for cell in archex_row.strip("|").split("|")]
+
+    assert cells[13:15] == ["n/a", "n/a"]
+
+
 def test_competitive_report_includes_graphify_lanes_and_fairness_frame() -> None:
     manifest = HeadToHeadManifest(
         name="competitive",

--- a/tests/benchmark/test_dual_transform_strategy.py
+++ b/tests/benchmark/test_dual_transform_strategy.py
@@ -247,6 +247,7 @@ class TestRunDualTransformFixture:
         assert result.tool_calls == 1
         assert 0.0 <= result.required_file_recall <= 1.0
         # Added latency is reported like every other lane.
+        assert result.wall_time_ms is not None
         assert result.wall_time_ms >= 0.0
         prov = result.provenance
         assert prov["subquery_structural"]

--- a/tests/benchmark/test_external_mcp.py
+++ b/tests/benchmark/test_external_mcp.py
@@ -146,5 +146,6 @@ if __name__ == "__main__":
     assert result.recall == 1.0
     assert result.precision == 0.5
     assert result.tool_calls == 1
+    assert result.warm_latency_ms is not None
     assert result.warm_latency_ms >= 0.0
     assert result.provenance["external_tool_version"] == "1.0.0"

--- a/tests/benchmark/test_reporter.py
+++ b/tests/benchmark/test_reporter.py
@@ -21,6 +21,7 @@ from archex.benchmark.models import (
     TaskFamily,
 )
 from archex.benchmark.reporter import (
+    format_baseline_comparison,
     format_bucketed_summary,
     format_chunker_frontier_table,
     format_cross_tool_comparison,
@@ -50,6 +51,7 @@ def _make_result(
     chunker: ChunkerName = "default",
     index_chunk_count: int = 10,
     mean_chunk_tokens: float = 50.0,
+    wall_time_ms: float | None = 50.0,
     category: TaskCategory | None = None,
 ) -> BenchmarkResult:
     return BenchmarkResult(
@@ -67,7 +69,7 @@ def _make_result(
         recall=recall,
         precision=precision,
         savings_vs_raw=savings,
-        wall_time_ms=50.0,
+        wall_time_ms=wall_time_ms,
         cached=False,
         timestamp="2025-01-01T00:00:00Z",
         chunker=chunker,
@@ -233,6 +235,21 @@ class TestFormatStrategyComparison:
         report = _make_report()
         result = format_strategy_comparison([report])
         assert "Best Strategy per Metric" in result
+
+
+class TestFormatBaselineComparison:
+    def test_renders_unmeasured_latency_as_na(self) -> None:
+        candidate = _make_report([_make_result(Strategy.ARCHEX_QUERY, wall_time_ms=None)])
+        baseline = _make_report([_make_result(Strategy.RAW_FILES, wall_time_ms=None)])
+
+        output = format_baseline_comparison(
+            [candidate],
+            [baseline],
+            candidate_strategy=Strategy.ARCHEX_QUERY.value,
+            baseline_strategy=Strategy.RAW_FILES.value,
+        )
+
+        assert "n/a" in output
 
 
 class TestFormatBucketedSummary:

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -629,6 +629,7 @@ class TestRunRawRipgrep:
             keywords=["import"],
         )
         result = run_raw_ripgrep(task, python_simple_repo)
+        assert result.wall_time_ms is not None
         assert result.wall_time_ms >= 0
         assert result.cached is False
         assert result.savings_vs_raw == 0.0  # Not yet backfilled


### PR DESCRIPTION
## Summary

Makes M1 benchmark timing truthful end-to-end. Measured timing remains numeric; absent warm or wall timing remains absent through renderers, aggregate reports, and latency gates, which render `n/a` rather than substitute cold wall time. Restores the existing freshness-latency result field and adds regression coverage for unmeasured benchmark timing.

## Scope

- `BenchmarkResult` timing/freshness contract.
- Benchmark reporter, competitive, head-to-head, readiness, runner, and gate handling for optional timing.
- Legacy timing assertions updated to prove a value exists before numeric comparison.
- Regression coverage for unmeasured baseline and competitive-report latency.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- Focused benchmark timing/reporter/competitive/strategy tests: 194 passed.
- GitHub CI restarted after the repaired root commit.

## Stack

Stack-Id: `m1-measurement-truth-491`

1. `M1-pr1` → this PR
2. `M1-pr2` → #492
3. `M1-pr3` → #493
4. `M1-pr4` → #494

Depends on: none
Upstack: #492