### PR TITLE
docs: correct tracked repository status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **M1: Benchmark and runtime measurements distinguished timing and retained provenance.** Benchmark metric models (`QueryTiming`, `PipelineTiming`) explicitly separate cold from warm timing phases, preserving `n/a` for unmeasured operations rather than inventing fallback values. Output artifacts and reporters record complete provenance (`BenchmarkProvenance`) including engine version, system profile, hardware, and runtime configuration. Production expansion logic (`_expand_retrieval_question`) propagates generalization provenance without hardcoding benchmark-specific vocabulary.
+
+
 ## [0.19.2] - 2026-07-11
 
 ### Fixed

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1189,29 +1189,24 @@ def _bm25_search_with_boosts(
     max_bm25 = max((s for _, s in results), default=1.0)
     path_boost = _file_path_boost(
         store,
+        expanded_question,
         bm25_ids,
-        max_bm25,
-        question,
-        all_chunks,
-        index_config.path_boost_multiplier,
+        max_bm25_score=max_bm25,
     )
-    symbol_boost = _symbol_search_seeds(
-        store,
-        bm25_ids,
-        max_bm25,
-        question,
-        all_chunks,
-        index_config.symbol_boost_multiplier,
-    )
+    all_existing = bm25_ids | {c.id for c, _ in path_boost}
+    symbol_seeds = [
+        (c, s)
+        for c, s in _symbol_search_seeds(store, expanded_question, max_bm25_score=max_bm25)
+        if c.id not in all_existing
+    ]
     module_boost = _module_prefilter_boosts(
-        store,
-        modules,
-        bm25_ids,
-        max_bm25,
-        question,
-        index_config.module_boost_multiplier,
+        modules if index_config.module_prefilter else [],
+        all_chunks,
+        expanded_question,
+        all_existing | {c.id for c, _ in symbol_seeds},
+        max_bm25_score=max_bm25,
     )
-    return results, path_boost, symbol_boost, module_boost, expanded_question, provenance
+    return results, path_boost, symbol_seeds, module_boost, expanded_question, provenance
 
 
 def _cached_vectors_by_content_hash(
@@ -1927,6 +1922,8 @@ def query(
                 # SQLite connections are not thread-safe; the vector path uses only
                 # pre-loaded numpy arrays and requires no store access.
                 with ThreadPoolExecutor(max_workers=1) as _pool:
+                    expanded_query = None
+                    expansion_prov = {}
                     _vec_future = _pool.submit(
                         _vector_search_precomputed,
                         cached_npz,
@@ -2318,10 +2315,12 @@ def query(
                     index_config,
                     vector_top_k,
                 )
+                expanded_query_miss = None
+                expansion_prov_miss = {}
                 if index_config.bm25:
                     (
-                        bm25_miss_raw,
-                        path_boost_miss,
+                        _bm25_raw,
+                        path_boost,
                         symbol_seeds_miss,
                         module_boost_miss,
                         expanded_query_miss,
@@ -2335,9 +2334,7 @@ def query(
                         modules_miss,
                         index_config,
                     )
-                    search_results = (
-                        bm25_miss_raw + path_boost_miss + symbol_seeds_miss + module_boost_miss
-                    )
+                    search_results = _bm25_raw + path_boost + symbol_seeds_miss + module_boost_miss
                 else:
                     search_results = []
                     path_boost = []
@@ -2428,6 +2425,7 @@ def query(
         bundle.retrieval_metadata.expanded_query = expanded_query_miss
         bundle.retrieval_metadata.expansion_provenance = expansion_prov_miss
         return _finalize_context_bundle(
+            bundle,
             label="",
             started_at=t0,
             timing=timing,

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -1214,7 +1214,6 @@ def _bm25_search_with_boosts(
     return results, path_boost, symbol_boost, module_boost, expanded_question, provenance
 
 
-
 def _cached_vectors_by_content_hash(
     npz_path: Path,
     chunks: list[CodeChunk],
@@ -2336,7 +2335,9 @@ def query(
                         modules_miss,
                         index_config,
                     )
-                    search_results = bm25_miss_raw + path_boost_miss + symbol_seeds_miss + module_boost_miss
+                    search_results = (
+                        bm25_miss_raw + path_boost_miss + symbol_seeds_miss + module_boost_miss
+                    )
                 else:
                     search_results = []
                     path_boost = []

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -947,30 +947,32 @@ _INDEX_QUERY_EXPANSIONS = (
 )
 
 
-def _expand_retrieval_question(question: str) -> str:
+def _expand_retrieval_question(question: str) -> tuple[str, dict[str, str]]:
     """Add code-level terms for retrieval architecture queries.
 
-    Natural-language architecture questions often use product terms such as
-    "query pipeline" while the implementation files use algorithm and assembly
-    names. Expand only from known retrieval terms so ordinary symbol lookups do
-    not inherit broad search vocabulary.
+    Returns a tuple of (expanded_question, provenance_dict).
     """
     import re
 
     raw_terms = {w.lower() for w in re.findall(r"[a-zA-Z_][a-zA-Z0-9_]{2,}", question)}
     expansions: list[str] = []
+    provenance: dict[str, str] = {}
+
     for term, candidates in _RETRIEVAL_QUERY_EXPANSIONS.items():
         if term not in raw_terms:
             continue
         expansions.extend(candidates)
+        provenance[term] = ",".join(candidates)
 
     if {"query", "pipeline"} <= raw_terms:
         expansions.extend(_QUERY_PIPELINE_EXPANSIONS)
+        provenance["query pipeline"] = ",".join(_QUERY_PIPELINE_EXPANSIONS)
     if "index" in raw_terms:
         expansions.extend(_INDEX_QUERY_EXPANSIONS)
+        provenance["index"] = ",".join(_INDEX_QUERY_EXPANSIONS)
 
     if not expansions:
-        return question
+        return question, {}
 
     existing = {w.lower() for w in re.findall(r"[a-zA-Z_][a-zA-Z0-9_]{2,}", question)}
     ordered_unique: list[str] = []
@@ -982,8 +984,8 @@ def _expand_retrieval_question(question: str) -> str:
         ordered_unique.append(term)
 
     if not ordered_unique:
-        return question
-    return f"{question} {' '.join(ordered_unique)}"
+        return question, {}
+    return f"{question} {' '.join(ordered_unique)}", provenance
 
 
 def _file_path_boost(
@@ -1172,36 +1174,45 @@ def _bm25_search_with_boosts(
     list[tuple[CodeChunk, float]],
     list[tuple[CodeChunk, float]],
     list[tuple[CodeChunk, float]],
+    str,
+    dict[str, str],
 ]:
     """Run BM25 search plus candidate-pool boosts.
 
     Returns retrieval legs as separate lists so
     callers can record individual counts for observability, then combine them.
+    Also returns the expanded question and its provenance.
     """
-    expanded_question = _expand_retrieval_question(question)
+    expanded_question, provenance = _expand_retrieval_question(question)
     results = bm25.search(expanded_question, top_k=top_k)
     bm25_ids = {c.id for c, _ in results}
     max_bm25 = max((s for _, s in results), default=1.0)
     path_boost = _file_path_boost(
         store,
-        expanded_question,
         bm25_ids,
-        max_bm25_score=max_bm25,
-    )
-    all_existing = bm25_ids | {c.id for c, _ in path_boost}
-    symbol_seeds = [
-        (c, s)
-        for c, s in _symbol_search_seeds(store, expanded_question, max_bm25_score=max_bm25)
-        if c.id not in all_existing
-    ]
-    module_boost = _module_prefilter_boosts(
-        modules if index_config.module_prefilter else [],
+        max_bm25,
+        question,
         all_chunks,
-        expanded_question,
-        all_existing | {c.id for c, _ in symbol_seeds},
-        max_bm25_score=max_bm25,
+        index_config.path_boost_multiplier,
     )
-    return results, path_boost, symbol_seeds, module_boost
+    symbol_boost = _symbol_search_seeds(
+        store,
+        bm25_ids,
+        max_bm25,
+        question,
+        all_chunks,
+        index_config.symbol_boost_multiplier,
+    )
+    module_boost = _module_prefilter_boosts(
+        store,
+        modules,
+        bm25_ids,
+        max_bm25,
+        question,
+        index_config.module_boost_multiplier,
+    )
+    return results, path_boost, symbol_boost, module_boost, expanded_question, provenance
+
 
 
 def _cached_vectors_by_content_hash(
@@ -1931,6 +1942,8 @@ def query(
                             path_boost,
                             symbol_seeds,
                             module_boost,
+                            expanded_query,
+                            expansion_prov,
                         ) = _bm25_search_with_boosts(
                             bm25,
                             store,
@@ -2026,6 +2039,8 @@ def query(
                     rerank_candidate_limit=index_config.rerank_candidate_limit,
                     apply_intent_budget=False,
                 )
+                bundle.retrieval_metadata.expanded_query = expanded_query
+                bundle.retrieval_metadata.expansion_provenance = expansion_prov
                 return _finalize_context_bundle(
                     bundle,
                     label="cached",
@@ -2306,10 +2321,12 @@ def query(
                 )
                 if index_config.bm25:
                     (
-                        _bm25_raw,
-                        path_boost,
+                        bm25_miss_raw,
+                        path_boost_miss,
                         symbol_seeds_miss,
                         module_boost_miss,
+                        expanded_query_miss,
+                        expansion_prov_miss,
                     ) = _bm25_search_with_boosts(
                         bm25,
                         store,
@@ -2319,7 +2336,7 @@ def query(
                         modules_miss,
                         index_config,
                     )
-                    search_results = _bm25_raw + path_boost + symbol_seeds_miss + module_boost_miss
+                    search_results = bm25_miss_raw + path_boost_miss + symbol_seeds_miss + module_boost_miss
                 else:
                     search_results = []
                     path_boost = []
@@ -2407,8 +2424,9 @@ def query(
         finally:
             store.close()
 
+        bundle.retrieval_metadata.expanded_query = expanded_query_miss
+        bundle.retrieval_metadata.expansion_provenance = expansion_prov_miss
         return _finalize_context_bundle(
-            bundle,
             label="",
             started_at=t0,
             timing=timing,

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -489,10 +489,8 @@ class BenchmarkResult(BaseModel):
     token_efficiency: float = 0.0
     tokens_raw_baseline: int = 0
     savings_vs_raw: float
-    cold_latency_ms: float | None = None
-    warm_latency_ms: float | None = None
     wall_time_ms: float | None = None
-    cached: bool
+    cached: bool = False
     timing: PipelineTiming | None = None
     timestamp: str
     # Seed vs expansion diagnostics

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -701,6 +701,8 @@ class RankedChunk(BaseModel):
 
 
 class RetrievalMetadata(BaseModel):
+    expanded_query: str | None = None
+    expansion_provenance: dict[str, str] = {}
     candidates_found: int = 0
     candidates_after_expansion: int = 0
     chunks_included: int = 0
@@ -829,6 +831,8 @@ class ContextSkippedCandidate(BaseModel):
 
 class ContextReceipt(BaseModel):
     query: str
+    expanded_query: str | None = None
+    expansion_provenance: dict[str, str] = {}
     token_budget: ContextReceiptTokenBudget
     index_revision: str
     freshness: ContextFreshness = ContextFreshness.UNKNOWN

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -703,6 +703,7 @@ class RankedChunk(BaseModel):
 class RetrievalMetadata(BaseModel):
     expanded_query: str | None = None
     expansion_provenance: dict[str, str] = {}
+
     candidates_found: int = 0
     candidates_after_expansion: int = 0
     chunks_included: int = 0
@@ -833,6 +834,7 @@ class ContextReceipt(BaseModel):
     query: str
     expanded_query: str | None = None
     expansion_provenance: dict[str, str] = {}
+
     token_budget: ContextReceiptTokenBudget
     index_revision: str
     freshness: ContextFreshness = ContextFreshness.UNKNOWN

--- a/src/archex/receipt.py
+++ b/src/archex/receipt.py
@@ -99,6 +99,8 @@ def build_context_receipt(
     )[:_MAX_RECEIPT_INCLUDED_EDGES]
     return ContextReceipt(
         query=bundle.query,
+        expanded_query=bundle.retrieval_metadata.expanded_query,
+        expansion_provenance=bundle.retrieval_metadata.expansion_provenance,
         token_budget=ContextReceiptTokenBudget(
             requested=bundle.token_budget,
             consumed=bundle.token_count,

--- a/tests/benchmark/test_ablations.py
+++ b/tests/benchmark/test_ablations.py
@@ -1,4 +1,4 @@
-from archex.api import _expand_retrieval_question
+from archex.api import _expand_retrieval_question  # pyright: ignore[reportPrivateUsage]
 
 
 def test_vocabulary_disjoint_ablations() -> None:

--- a/tests/benchmark/test_ablations.py
+++ b/tests/benchmark/test_ablations.py
@@ -3,7 +3,7 @@ from archex.api import _expand_retrieval_question
 
 def test_vocabulary_disjoint_ablations() -> None:
     """Ensure benchmark terms and domain queries are disjoint in expansion.
-    
+
     Production heuristic generalization (like 'query pipeline' -> 'assemble_context')
     must work, but benchmark vocabulary must not trigger any specialized heuristic
     pathways, proving the heuristic is disjoint from benchmark identity.
@@ -12,7 +12,7 @@ def test_vocabulary_disjoint_ablations() -> None:
     expanded, prov = _expand_retrieval_question("how does the query pipeline work?")
     assert "assemble_context" in expanded
     assert "query pipeline" in prov
-    
+
     # 2. Benchmark vocabulary is completely disjoint and triggers no expansions
     banned_terms = [
         "swe_bench",

--- a/tests/benchmark/test_ablations.py
+++ b/tests/benchmark/test_ablations.py
@@ -1,0 +1,30 @@
+from archex.api import _expand_retrieval_question
+
+
+def test_vocabulary_disjoint_ablations() -> None:
+    """Ensure benchmark terms and domain queries are disjoint in expansion.
+    
+    Production heuristic generalization (like 'query pipeline' -> 'assemble_context')
+    must work, but benchmark vocabulary must not trigger any specialized heuristic
+    pathways, proving the heuristic is disjoint from benchmark identity.
+    """
+    # 1. Domain vocabulary expands correctly (heuristic generalization)
+    expanded, prov = _expand_retrieval_question("how does the query pipeline work?")
+    assert "assemble_context" in expanded
+    assert "query pipeline" in prov
+    
+    # 2. Benchmark vocabulary is completely disjoint and triggers no expansions
+    banned_terms = [
+        "swe_bench",
+        "swebench",
+        "human_eval",
+        "humaneval",
+        "mbpp",
+        "bird",
+        "spider",
+        "defects4j",
+    ]
+    for term in banned_terms:
+        banned_expanded, banned_prov = _expand_retrieval_question(f"run {term}")
+        assert banned_expanded == f"run {term}"
+        assert not banned_prov

--- a/tests/serve/test_query_normalization.py
+++ b/tests/serve/test_query_normalization.py
@@ -198,19 +198,20 @@ def _chunk(
 def test_retrieval_question_expands_query_pipeline_terms() -> None:
     from archex.api import _expand_retrieval_question
 
-    expanded = _expand_retrieval_question("How does archex implement the query pipeline?")
+    expanded, prov = _expand_retrieval_question("How does archex implement the query pipeline?")
 
     assert "api" in expanded
     assert "bm25" in expanded
     assert "BM25Index" in expanded
     assert "assemble_context" in expanded
     assert "context" in expanded
+    assert prov
 
 
 def test_retrieval_question_expands_index_terms() -> None:
     from archex.api import _expand_retrieval_question
 
-    expanded = _expand_retrieval_question(
+    expanded, prov = _expand_retrieval_question(
         "How does archex explicitly build or refresh a repo-local index?"
     )
 
@@ -218,14 +219,16 @@ def test_retrieval_question_expands_index_terms() -> None:
     assert "config" in expanded
     assert "project" in expanded
     assert "CacheManager" in expanded
+    assert prov
 
 
 def test_non_retrieval_question_is_not_expanded() -> None:
     from archex.api import _expand_retrieval_question
 
     question = "Where is User defined?"
-
-    assert _expand_retrieval_question(question) == question
+    expanded, prov = _expand_retrieval_question(question)
+    assert expanded == question
+    assert not prov
 
 
 def test_path_terms_expand_query_pipeline_keywords() -> None:


### PR DESCRIPTION
## Summary

Completes the M1 integration slice: carries API timing through query results and receipts, records expansion provenance, adds vocabulary-disjoint ablation coverage, and corrects the tracked project status and changelog entry.

## Scope

- Query timing and receipt propagation.
- Expansion provenance and vocabulary-disjoint policy coverage.
- Test expectation updates required by the timing contract.
- M1 changelog and repository-status correction.

## Validation

- `uv sync --all-extras`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pytest --junitxml=results.xml --cov-report=xml` — 3,702 passed; 7 deselected; 91.13% coverage.
- GitHub CI: green on all four PRs, including Python 3.11/3.12/3.13, clean-install smoke, and slim/full Docker builds.
- `uv run archex benchmark run --tasks-dir benchmarks/tasks --output /tmp/archex-m1-final-gate --strategy archex_query` — 64 reports written.
- The required benchmark gate currently fails with 44 metric violations (for example, `archex_adapter_registry` recall 0.333 < 0.600 and `loc_django_username_validator` recall 0.000 < 0.600). No retrieval-policy or threshold change was made in this measurement-truthfulness milestone.

## Merge status

The stack is CI-green but **not merge-ready** under M1's explicit acceptance criterion: the required benchmark gate must exit 0. Leave the stack open while the quality baseline is reconciled in the appropriate retrieval-quality work.

## Stack

Stack-Id: `m1-measurement-truth-491`

1. `M1-pr1` → #491
2. `M1-pr2` → #492
3. `M1-pr3` → #493
4. `M1-pr4` → this PR

Depends on: #493