### PR TITLE
fix(ci): make benchmark workflow executable

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,12 +25,119 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Install ripgrep
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ripgrep
 
       - name: Install dependencies
         run: uv sync --all-extras
 
       - name: Validate task definitions
         run: uv run archex benchmark validate --kind tasks --tasks-dir benchmarks/tasks
+      - name: Run benchmarks (bm25, all tasks)
+        run: |
+          uv run archex benchmark run \
+            --tasks-dir benchmarks/tasks \
+            --output "$RUNNER_TEMP/archex-benchmark-results/bm25" \
+            --strategy archex_query
+
+      - name: Quality gate (bm25)
+        run: |
+          uv run archex benchmark gate \
+            --input "$RUNNER_TEMP/archex-benchmark-results/bm25" \
+            --min-recall 0.60 \
+            --min-f1 0.30 \
+            --min-mrr 0.55
+
+      - name: Upload bm25 results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-bm25
+          path: ${{ runner.temp }}/archex-benchmark-results/bm25/
+
+  benchmark-fusion:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Install ripgrep
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ripgrep
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run benchmarks (fusion, all tasks)
+        run: |
+          uv run archex benchmark run \
+            --tasks-dir benchmarks/tasks \
+            --output "$RUNNER_TEMP/archex-benchmark-results/fusion" \
+            --strategy archex_query_fusion \
+            --allow-remote-code
+
+      - name: Quality gate (fusion)
+        run: |
+          uv run archex benchmark gate \
+            --input "$RUNNER_TEMP/archex-benchmark-results/fusion" \
+            --min-recall 0.60 \
+            --min-f1 0.30 \
+            --min-mrr 0.55
+
+      - name: Upload fusion results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-fusion
+          path: ${{ runner.temp }}/archex-benchmark-results/fusion/
+
+  benchmark-delta:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Delta tasks under benchmarks/delta_tasks checkout specific past
+          # commits of this repo (repo: ".") to benchmark against — a shallow
+          # clone would not contain them.
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run delta benchmark + quality gate
+        run: uv run archex benchmark delta
+
+      - name: Upload delta results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-delta
+          path: .archex/delta-results/
 
       - name: Validate bounded evidence contracts
         run: uv run pytest --no-cov tests/benchmark/test_evidence.py


### PR DESCRIPTION
## Stack

Stack-Id: `benchmark-quality-20260711`
Base: `main`
Position: 1/6

1. `fix/benchmark-workflow-execution` -> this PR
2. `refactor/benchmark-baseline-contract` -> pending
3. `test/benchmark-failure-characterization` -> pending
4. `feat/benchmark-localization-candidate` -> pending
5. `fix/retrieval-quality-tail` -> pending
6. `ci/benchmark-quality-enforcement` -> pending

Depends on: (none - root)
Upstack: pending

## Summary

Restores executable BM25 and fusion benchmark jobs without changing quality floors. BM25 installs `ripgrep`; fusion passes the existing pinned-model remote-code opt-in; artifacts upload on every outcome.

## Validation

- `uv run pre-commit run check-yaml --files .github/workflows/benchmark.yml`: passed
- `uv run archex benchmark run --help`: passed; confirms `--allow-remote-code` is the existing CLI opt-in
- Manual workflow dispatch: pending

## Known remaining gate status

- The absolute BM25 and fusion quality floors are intentionally unchanged and expected to expose current retrieval-quality failures until PRs 3–5 complete.
