### PR TITLE
fix(benchmark): record immutable evidence identity

### DIFF
--- a/src/archex/benchmark/evidence.py
+++ b/src/archex/benchmark/evidence.py
@@ -1,0 +1,253 @@
+"""Create and validate immutable local benchmark evidence directories."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import subprocess
+from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from archex.benchmark.models import (
+    BenchmarkEvidenceManifest,
+    BenchmarkReport,
+    BenchmarkRetrievalOptions,
+    BenchmarkTask,
+    Strategy,
+)
+
+EVIDENCE_MANIFEST_FILENAME = "manifest.json"
+
+
+class BenchmarkEvidenceError(ValueError):
+    """Raised when local benchmark evidence lacks a verifiable identity."""
+
+
+def task_manifest_digest(tasks_dir: Path) -> str:
+    """Return a stable digest of every top-level benchmark task file."""
+    task_files = sorted(tasks_dir.glob("*.yaml"))
+    if not task_files:
+        msg = f"No benchmark task files found in {tasks_dir}"
+        raise BenchmarkEvidenceError(msg)
+
+    digest = hashlib.sha256()
+    for task_file in task_files:
+        digest.update(task_file.name.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(task_file.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def source_revision(repo_root: Path) -> str:
+    """Resolve the clean Git revision that produced local benchmark evidence."""
+    revision = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if revision.returncode != 0:
+        detail = revision.stderr.strip() or "unknown git error"
+        msg = f"Cannot resolve benchmark source revision: {detail}"
+        raise BenchmarkEvidenceError(msg)
+
+    status = subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=no"],
+        cwd=repo_root,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if status.returncode != 0:
+        detail = status.stderr.strip() or "unknown git error"
+        msg = f"Cannot inspect benchmark source cleanliness: {detail}"
+        raise BenchmarkEvidenceError(msg)
+    if status.stdout:
+        msg = "Cannot record immutable benchmark evidence from a dirty source tree"
+        raise BenchmarkEvidenceError(msg)
+
+    return revision.stdout.strip()
+
+
+def archex_version() -> str:
+    """Return the installed Archex distribution version used by the benchmark run."""
+    try:
+        installed_version = version("archex")
+    except PackageNotFoundError as exc:
+        msg = "Cannot resolve the installed archex distribution version"
+        raise BenchmarkEvidenceError(msg) from exc
+    if not installed_version:
+        msg = "Cannot record an empty archex distribution version"
+        raise BenchmarkEvidenceError(msg)
+    return installed_version
+
+
+def prepare_evidence_directory(output_dir: Path) -> None:
+    """Create an empty output directory without mixing a new run with stale reports."""
+    if output_dir.exists():
+        if not output_dir.is_dir():
+            msg = f"Benchmark output path is not a directory: {output_dir}"
+            raise BenchmarkEvidenceError(msg)
+        if any(output_dir.iterdir()):
+            msg = f"Benchmark output directory is not empty: {output_dir}"
+            raise BenchmarkEvidenceError(msg)
+        return
+    output_dir.mkdir(parents=True)
+
+
+def build_evidence_manifest(
+    reports: list[BenchmarkReport],
+    tasks: list[BenchmarkTask],
+    strategies: list[Strategy],
+    retrieval_options: BenchmarkRetrievalOptions,
+    *,
+    source_sha: str,
+    tasks_dir: Path,
+    hardware_advisory: str | None = None,
+) -> BenchmarkEvidenceManifest:
+    """Build a manifest after asserting exact task and strategy coverage."""
+    task_ids = [task.task_id for task in tasks]
+    report_by_task = {report.task_id: report for report in reports}
+    if len(report_by_task) != len(reports):
+        msg = "Benchmark evidence contains duplicate report task IDs"
+        raise BenchmarkEvidenceError(msg)
+    if set(report_by_task) != set(task_ids):
+        missing = sorted(set(task_ids) - set(report_by_task))
+        unexpected = sorted(set(report_by_task) - set(task_ids))
+        msg = f"Benchmark report coverage mismatch: missing={missing}, unexpected={unexpected}"
+        raise BenchmarkEvidenceError(msg)
+
+    expected_strategies = set(strategies)
+    for report in reports:
+        actual_strategies = {result.strategy for result in report.results}
+        if actual_strategies != expected_strategies or len(report.results) != len(
+            actual_strategies
+        ):
+            missing = sorted(strategy.value for strategy in expected_strategies - actual_strategies)
+            unexpected = sorted(
+                strategy.value for strategy in actual_strategies - expected_strategies
+            )
+            msg = (
+                f"Benchmark strategy coverage mismatch for {report.task_id}: "
+                f"missing={missing}, unexpected={unexpected}"
+            )
+            raise BenchmarkEvidenceError(msg)
+
+    report_hashes = {
+        report.task_id: hashlib.sha256(report.model_dump_json(indent=2).encode("utf-8")).hexdigest()
+        for report in reports
+    }
+    return BenchmarkEvidenceManifest(
+        source_revision=source_sha,
+        archex_version=archex_version(),
+        task_manifest_digest=task_manifest_digest(tasks_dir),
+        task_ids=task_ids,
+        strategies=strategies,
+        retrieval_options=retrieval_options,
+        generated_at=datetime.now(tz=UTC).isoformat(),
+        hardware_advisory=hardware_advisory
+        or f"{platform.system()} {platform.release()} {platform.machine()}",
+        report_hashes=report_hashes,
+    )
+
+
+def write_evidence_manifest(output_dir: Path, manifest: BenchmarkEvidenceManifest) -> Path:
+    """Write the manifest only after the reports already exist in *output_dir*."""
+    manifest_path = output_dir / EVIDENCE_MANIFEST_FILENAME
+    if manifest_path.exists():
+        msg = f"Benchmark evidence manifest already exists: {manifest_path}"
+        raise BenchmarkEvidenceError(msg)
+    manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+    return manifest_path
+
+
+def validate_evidence_directory(
+    output_dir: Path,
+    tasks_dir: Path,
+    *,
+    expected_source_sha: str | None = None,
+) -> BenchmarkEvidenceManifest:
+    """Validate manifest schema, task identity, report hashes, and exact coverage."""
+    manifest_path = output_dir / EVIDENCE_MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        msg = f"Benchmark evidence manifest not found: {manifest_path}"
+        raise BenchmarkEvidenceError(msg)
+    try:
+        raw_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest = BenchmarkEvidenceManifest.model_validate(raw_manifest)
+    except (OSError, json.JSONDecodeError, ValidationError) as exc:
+        msg = f"Invalid benchmark evidence manifest {manifest_path}: {exc}"
+        raise BenchmarkEvidenceError(msg) from exc
+
+    actual_task_digest = task_manifest_digest(tasks_dir)
+    if manifest.task_manifest_digest != actual_task_digest:
+        msg = (
+            "Benchmark evidence task-manifest digest mismatch: "
+            f"expected={manifest.task_manifest_digest}, actual={actual_task_digest}"
+        )
+        raise BenchmarkEvidenceError(msg)
+    if expected_source_sha is not None and manifest.source_revision != expected_source_sha:
+        msg = (
+            "Benchmark evidence source revision mismatch: "
+            f"expected={expected_source_sha}, actual={manifest.source_revision}"
+        )
+        raise BenchmarkEvidenceError(msg)
+
+    report_paths = {
+        path.stem: path
+        for path in output_dir.glob("*.json")
+        if path.name != EVIDENCE_MANIFEST_FILENAME
+    }
+    expected_task_ids = set(manifest.task_ids)
+    actual_task_ids = set(report_paths)
+    if actual_task_ids != expected_task_ids:
+        missing = sorted(expected_task_ids - actual_task_ids)
+        unexpected = sorted(actual_task_ids - expected_task_ids)
+        msg = (
+            f"Benchmark evidence file coverage mismatch: missing={missing}, unexpected={unexpected}"
+        )
+        raise BenchmarkEvidenceError(msg)
+
+    expected_strategies = set(manifest.strategies)
+    for task_id, report_path in report_paths.items():
+        raw_report = report_path.read_bytes()
+        actual_digest = hashlib.sha256(raw_report).hexdigest()
+        expected_digest = manifest.report_hashes[task_id]
+        if actual_digest != expected_digest:
+            msg = (
+                f"Benchmark evidence report hash mismatch for {report_path.name}: "
+                f"expected={expected_digest}, actual={actual_digest}"
+            )
+            raise BenchmarkEvidenceError(msg)
+        try:
+            report = BenchmarkReport.model_validate_json(raw_report)
+        except ValidationError as exc:
+            msg = f"Invalid benchmark report {report_path}: {exc}"
+            raise BenchmarkEvidenceError(msg) from exc
+        if report.task_id != task_id:
+            msg = (
+                "Benchmark report filename/task ID mismatch: "
+                f"{report_path.name} != {report.task_id}"
+            )
+            raise BenchmarkEvidenceError(msg)
+        report_strategies = {result.strategy for result in report.results}
+        if report_strategies != expected_strategies or len(report.results) != len(
+            report_strategies
+        ):
+            missing = sorted(strategy.value for strategy in expected_strategies - report_strategies)
+            unexpected = sorted(
+                strategy.value for strategy in report_strategies - expected_strategies
+            )
+            msg = (
+                f"Benchmark evidence strategy coverage mismatch for {task_id}: "
+                f"missing={missing}, unexpected={unexpected}"
+            )
+            raise BenchmarkEvidenceError(msg)
+
+    return manifest

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -300,6 +301,41 @@ class BenchmarkRetrievalOptions(BaseModel):
     # the blend weight on the cross-encoder vs the symbolic evidence signal.
     symbolic_rerank_mode: SymbolicRerankMode = SymbolicRerankMode.BLEND
     symbolic_rerank_alpha: float = 0.5
+
+
+class BenchmarkEvidenceManifest(BenchmarkSpecModel):
+    """Immutable identity and integrity record for one benchmark evidence directory."""
+
+    evidence_version: Literal[1] = 1
+    source_revision: str = Field(pattern=r"^[0-9a-f]{40}$")
+    archex_version: str = Field(min_length=1)
+    task_manifest_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    task_ids: list[str] = Field(min_length=1)
+    strategies: list[Strategy] = Field(min_length=1)
+    retrieval_options: BenchmarkRetrievalOptions
+    generated_at: str = Field(min_length=1)
+    hardware_advisory: str = Field(min_length=1)
+    report_hashes: dict[str, str] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_coverage(self) -> BenchmarkEvidenceManifest:
+        if len(self.task_ids) != len(set(self.task_ids)):
+            msg = "task_ids must not contain duplicates"
+            raise ValueError(msg)
+        if any(not task_id.strip() for task_id in self.task_ids):
+            msg = "task_ids must not contain empty values"
+            raise ValueError(msg)
+        if len(self.strategies) != len(set(self.strategies)):
+            msg = "strategies must not contain duplicates"
+            raise ValueError(msg)
+        if set(self.report_hashes) != set(self.task_ids):
+            msg = "report_hashes keys must match task_ids exactly"
+            raise ValueError(msg)
+        for task_id, digest in self.report_hashes.items():
+            if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
+                msg = f"report_hashes[{task_id!r}] must be a lowercase SHA-256 digest"
+                raise ValueError(msg)
+        return self
 
 
 class ComparisonLayerType(StrEnum):

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -25,6 +25,14 @@ from archex.benchmark.bundle_eval import BundleOnlyEvaluatorError, run_bundle_on
 from archex.benchmark.competitive import format_competitive_markdown, load_compression_results
 from archex.benchmark.cross_tool import NaiveBaselineModel, run_cross_tool
 from archex.benchmark.delta_runner import run_all_delta
+from archex.benchmark.evidence import (
+    BenchmarkEvidenceError,
+    build_evidence_manifest,
+    prepare_evidence_directory,
+    source_revision,
+    validate_evidence_directory,
+    write_evidence_manifest,
+)
 from archex.benchmark.gate import (
     DeltaQualityThresholds,
     LatencyViolation,
@@ -272,6 +280,13 @@ def run_cmd(
 
     tasks_path = Path(tasks_dir)
     tasks = load_selected_tasks(tasks_path, task_filter=task_id, self_only=self_only)
+    if tasks:
+        output_path = Path(output_dir)
+        try:
+            prepare_evidence_directory(output_path)
+        except BenchmarkEvidenceError as exc:
+            raise click.ClickException(str(exc)) from exc
+
     try:
         with BenchmarkProgress(tasks, force_disable=no_progress) as progress:
             reports = run_all(
@@ -286,6 +301,30 @@ def run_cmd(
             )
     except ArchexError as exc:
         raise click.ClickException(str(exc)) from exc
+
+    if reports:
+        try:
+            source_sha = source_revision(Path.cwd())
+        except BenchmarkEvidenceError as exc:
+            raise click.ClickException(str(exc)) from exc
+        try:
+            manifest = build_evidence_manifest(
+                reports,
+                tasks,
+                strategies,
+                retrieval_options,
+                source_sha=source_sha,
+                tasks_dir=tasks_path,
+            )
+            manifest_path = write_evidence_manifest(Path(output_dir), manifest)
+            validate_evidence_directory(
+                Path(output_dir),
+                tasks_path,
+                expected_source_sha=source_sha,
+            )
+        except BenchmarkEvidenceError as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(f"Recorded benchmark evidence manifest at {manifest_path}", err=True)
 
     click.echo(f"\nCompleted {len(reports)} benchmark(s).", err=True)
 
@@ -618,15 +657,45 @@ def readiness_cmd(input_dir: str, tasks_dir: str, strategy_name: str, output_for
     help="Directory containing delta task YAML files.",
 )
 @click.option(
+    "--input",
+    "input_dir",
+    default=None,
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Evidence directory to validate when --kind evidence is selected.",
+)
+@click.option(
     "--kind",
     default="tasks",
-    type=click.Choice(["tasks", "arch", "delta", "all"]),
+    type=click.Choice(["tasks", "arch", "delta", "all", "evidence"]),
     show_default=True,
-    help="Task definition family to validate.",
+    help="Task definition or evidence family to validate.",
 )
-def validate_cmd(tasks_dir: str, arch_tasks_dir: str, delta_tasks_dir: str, kind: str) -> None:
+def validate_cmd(
+    tasks_dir: str,
+    arch_tasks_dir: str,
+    delta_tasks_dir: str,
+    input_dir: str | None,
+    kind: str,
+) -> None:
     """Validate benchmark task definitions."""
     repo_root = Path.cwd()
+    if kind == "evidence":
+        if input_dir is None:
+            raise click.ClickException("--input is required when --kind evidence is selected")
+        try:
+            manifest = validate_evidence_directory(
+                Path(input_dir),
+                Path(tasks_dir),
+                expected_source_sha=source_revision(repo_root),
+            )
+        except BenchmarkEvidenceError as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(
+            f"Valid benchmark evidence: {len(manifest.task_ids)} task(s), "
+            f"{len(manifest.strategies)} strategy/strategies."
+        )
+        return
+
     validated_counts: list[tuple[str, int]] = []
 
     if kind in {"tasks", "all"}:

--- a/tests/benchmark/test_evidence.py
+++ b/tests/benchmark/test_evidence.py
@@ -1,0 +1,271 @@
+"""Tests for immutable benchmark evidence directories."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from archex.benchmark.evidence import (
+    BenchmarkEvidenceError,
+    build_evidence_manifest,
+    prepare_evidence_directory,
+    task_manifest_digest,
+    validate_evidence_directory,
+    write_evidence_manifest,
+)
+from archex.benchmark.models import (
+    BenchmarkReport,
+    BenchmarkResult,
+    BenchmarkRetrievalOptions,
+    BenchmarkTask,
+    Strategy,
+)
+
+
+def _task() -> BenchmarkTask:
+    return BenchmarkTask(
+        task_id="evidence_task",
+        repo="owner/repo",
+        commit="0123456789abcdef",
+        question="Where is the evidence contract?",
+        expected_files=["src/evidence.py"],
+    )
+
+
+def _report() -> BenchmarkReport:
+    result = BenchmarkResult(
+        task_id="evidence_task",
+        strategy=Strategy.ARCHEX_QUERY,
+        tokens_total=100,
+        tool_calls=1,
+        files_accessed=1,
+        recall=1.0,
+        precision=1.0,
+        f1_score=1.0,
+        mrr=1.0,
+        ndcg=1.0,
+        map_score=1.0,
+        savings_vs_raw=0.0,
+        wall_time_ms=1.0,
+        cached=False,
+        timestamp="2026-07-11T00:00:00+00:00",
+    )
+    return BenchmarkReport(
+        task_id="evidence_task",
+        repo="owner/repo",
+        question="Where is the evidence contract?",
+        results=[result],
+        baseline_tokens=100,
+    )
+
+
+def _write_task(tasks_dir: Path) -> None:
+    tasks_dir.mkdir()
+    (tasks_dir / "evidence_task.yaml").write_text(
+        "\n".join(
+            [
+                "task_id: evidence_task",
+                "repo: owner/repo",
+                "commit: 0123456789abcdef",
+                "question: Where is the evidence contract?",
+                "expected_files:",
+                "  - src/evidence.py",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_evidence(tmp_path: Path) -> tuple[Path, Path]:
+    tasks_dir = tmp_path / "tasks"
+    _write_task(tasks_dir)
+    output_dir = tmp_path / "evidence"
+    prepare_evidence_directory(output_dir)
+    report = _report()
+    (output_dir / "evidence_task.json").write_text(
+        report.model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+    manifest = build_evidence_manifest(
+        [report],
+        [_task()],
+        [Strategy.ARCHEX_QUERY],
+        BenchmarkRetrievalOptions(),
+        source_sha="a" * 40,
+        tasks_dir=tasks_dir,
+        hardware_advisory="test hardware",
+    )
+    write_evidence_manifest(output_dir, manifest)
+    return output_dir, tasks_dir
+
+
+def test_evidence_manifest_binds_reports_tasks_and_configuration(tmp_path: Path) -> None:
+    output_dir, tasks_dir = _write_evidence(tmp_path)
+
+    manifest = validate_evidence_directory(
+        output_dir,
+        tasks_dir,
+        expected_source_sha="a" * 40,
+    )
+
+    assert manifest.task_ids == ["evidence_task"]
+    assert manifest.strategies == [Strategy.ARCHEX_QUERY]
+    assert manifest.task_manifest_digest == task_manifest_digest(tasks_dir)
+    assert set(manifest.report_hashes) == {"evidence_task"}
+    assert manifest.retrieval_options == BenchmarkRetrievalOptions()
+
+
+def test_evidence_validation_rejects_tampered_report(tmp_path: Path) -> None:
+    output_dir, tasks_dir = _write_evidence(tmp_path)
+    (output_dir / "evidence_task.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(BenchmarkEvidenceError, match="report hash mismatch"):
+        validate_evidence_directory(output_dir, tasks_dir)
+
+
+def test_evidence_validation_rejects_incomplete_report_coverage(tmp_path: Path) -> None:
+    output_dir, tasks_dir = _write_evidence(tmp_path)
+    (output_dir / "evidence_task.json").unlink()
+
+    with pytest.raises(BenchmarkEvidenceError, match="file coverage mismatch"):
+        validate_evidence_directory(output_dir, tasks_dir)
+
+
+def test_evidence_validation_rejects_stale_task_manifest(tmp_path: Path) -> None:
+    output_dir, tasks_dir = _write_evidence(tmp_path)
+    task_path = tasks_dir / "evidence_task.yaml"
+    task_path.write_text(
+        task_path.read_text(encoding="utf-8") + "keywords:\n  - stale\n", encoding="utf-8"
+    )
+
+    with pytest.raises(BenchmarkEvidenceError, match="task-manifest digest mismatch"):
+        validate_evidence_directory(output_dir, tasks_dir)
+
+
+def test_evidence_validation_rejects_stale_source_revision(tmp_path: Path) -> None:
+    output_dir, tasks_dir = _write_evidence(tmp_path)
+
+    with pytest.raises(BenchmarkEvidenceError, match="source revision mismatch"):
+        validate_evidence_directory(
+            output_dir,
+            tasks_dir,
+            expected_source_sha="b" * 40,
+        )
+
+
+def test_prepare_evidence_directory_rejects_stale_output(tmp_path: Path) -> None:
+    output_dir = tmp_path / "evidence"
+    output_dir.mkdir()
+    (output_dir / "old.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(BenchmarkEvidenceError, match="not empty"):
+        prepare_evidence_directory(output_dir)
+
+
+def test_validate_command_accepts_complete_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from click.testing import CliRunner
+
+    from archex.cli import benchmark_cmd as benchmark_module
+
+    def fixed_source_revision(_repo_root: Path) -> str:
+        return "a" * 40
+
+    output_dir, tasks_dir = _write_evidence(tmp_path)
+    monkeypatch.setattr(benchmark_module, "source_revision", fixed_source_revision)
+
+    result = CliRunner().invoke(
+        benchmark_module.benchmark_cmd,
+        [
+            "validate",
+            "--kind",
+            "evidence",
+            "--tasks-dir",
+            str(tasks_dir),
+            "--input",
+            str(output_dir),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Valid benchmark evidence: 1 task(s), 1 strategy/strategies." in result.output
+
+
+def test_run_command_records_evidence_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from click.testing import CliRunner
+
+    from archex.cli import benchmark_cmd as benchmark_module
+
+    tasks_dir = tmp_path / "tasks"
+    _write_task(tasks_dir)
+    output_dir = tmp_path / "evidence"
+    task = _task()
+    base_report = _report()
+    report = base_report.model_copy(
+        update={
+            "results": [
+                base_report.results[0].model_copy(update={"strategy": strategy})
+                for strategy in (
+                    Strategy.RAW_FILES,
+                    Strategy.RAW_RIPGREP,
+                    Strategy.ARCHEX_QUERY,
+                )
+            ]
+        }
+    )
+
+    def no_preflight(
+        _strategies: list[Strategy],
+        _retrieval_options: BenchmarkRetrievalOptions,
+    ) -> list[str]:
+        return []
+
+    def selected_tasks(
+        _tasks_dir: Path,
+        *,
+        task_filter: str | None = None,
+        self_only: bool = False,
+    ) -> list[BenchmarkTask]:
+        del task_filter, self_only
+        return [task]
+
+    def fixed_source_revision(_repo_root: Path) -> str:
+        return "a" * 40
+
+    def fake_run_all(
+        tasks_dir: Path,
+        output_dir: Path,
+        strategies: list[Strategy] | None = None,
+        task_filter: str | None = None,
+        self_only: bool = False,
+        progress: object | None = None,
+        tasks: list[BenchmarkTask] | None = None,
+        retrieval_options: BenchmarkRetrievalOptions | None = None,
+    ) -> list[BenchmarkReport]:
+        del tasks_dir, strategies, task_filter, self_only, progress, tasks, retrieval_options
+        (output_dir / "evidence_task.json").write_text(
+            report.model_dump_json(indent=2),
+            encoding="utf-8",
+        )
+        return [report]
+
+    monkeypatch.setattr(benchmark_module, "warm_benchmark_models", no_preflight)
+    monkeypatch.setattr(benchmark_module, "load_selected_tasks", selected_tasks)
+    monkeypatch.setattr(benchmark_module, "run_all", fake_run_all)
+    monkeypatch.setattr(benchmark_module, "source_revision", fixed_source_revision)
+
+    result = CliRunner().invoke(
+        benchmark_module.benchmark_cmd,
+        ["run", "--tasks-dir", str(tasks_dir), "--output", str(output_dir), "--no-progress"],
+    )
+
+    assert result.exit_code == 0
+    assert "Recorded benchmark evidence manifest" in result.output
+    validate_evidence_directory(output_dir, tasks_dir, expected_source_sha="a" * 40)


### PR DESCRIPTION
## Stack

Stack-Id: `m0-1-benchmark-governance-20260711`
Base: `main`
Position: 1/3

1. `fix/benchmark-evidence-identity` → this PR
2. `fix/benchmark-baseline-coverage` → pending
3. `ci/benchmark-local-evidence-gate` → pending

Depends on: (none — root)
Upstack: pending

## Summary

Records immutable identity for every local benchmark evidence directory. A manifest binds the clean source SHA, task-manifest digest, installed Archex version, selected strategies, retrieval configuration, generation timestamp, hardware advisory, exact task/strategy coverage, and SHA-256 hash of every raw report.

`archex benchmark run` refuses non-empty output directories, writes the manifest after complete report generation, and validates the resulting evidence. `archex benchmark validate --kind evidence` rejects malformed, stale, missing, unexpected, or hash-drifted evidence.

No retrieval scoring, default strategy, quality floor, task oracle, or held draft stack changed.

## Validation

- `uv run ruff check src/archex/benchmark/models.py src/archex/benchmark/evidence.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_evidence.py`
- `uv run ruff format --check src/archex/benchmark/models.py src/archex/benchmark/evidence.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_evidence.py`
- `uv run pyright src/archex/benchmark/models.py src/archex/benchmark/evidence.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_evidence.py`
- `uv run pytest --no-cov tests/benchmark/test_evidence.py tests/benchmark/test_cli.py` — 45 passed
- `uv run archex benchmark validate --kind tasks --tasks-dir benchmarks/tasks` — 64 tasks valid
- Local review: approved; no blockers.

## Known gate status

The current 64-task default control remains unpromoted. This PR records and validates evidence only; it does not normalize a failed absolute gate into a baseline.