### PR TITLE
fix(benchmark): reject incomplete baseline coverage

### DIFF
--- a/src/archex/benchmark/evidence.py
+++ b/src/archex/benchmark/evidence.py
@@ -251,3 +251,72 @@ def validate_evidence_directory(
             raise BenchmarkEvidenceError(msg)
 
     return manifest
+
+
+def load_evidence_reports(
+    output_dir: Path,
+    tasks_dir: Path,
+) -> tuple[BenchmarkEvidenceManifest, list[BenchmarkReport]]:
+    """Load reports only after validating their manifest-backed evidence directory."""
+    manifest = validate_evidence_directory(output_dir, tasks_dir)
+    reports = [
+        BenchmarkReport.model_validate_json((output_dir / f"{task_id}.json").read_bytes())
+        for task_id in manifest.task_ids
+    ]
+    return manifest, reports
+
+
+def validate_baseline_coverage(
+    current: BenchmarkEvidenceManifest,
+    baseline: BenchmarkEvidenceManifest,
+) -> None:
+    """Reject baseline evidence whose corpus or retrieval configuration differs."""
+    if current.task_manifest_digest != baseline.task_manifest_digest:
+        msg = "Benchmark baseline task-manifest digest does not match current evidence"
+        raise BenchmarkEvidenceError(msg)
+    if set(current.task_ids) != set(baseline.task_ids):
+        missing = sorted(set(current.task_ids) - set(baseline.task_ids))
+        unexpected = sorted(set(baseline.task_ids) - set(current.task_ids))
+        msg = (
+            f"Benchmark baseline task coverage mismatch: missing={missing}, unexpected={unexpected}"
+        )
+        raise BenchmarkEvidenceError(msg)
+    if set(current.strategies) != set(baseline.strategies):
+        missing = sorted(
+            strategy.value for strategy in set(current.strategies) - set(baseline.strategies)
+        )
+        unexpected = sorted(
+            strategy.value for strategy in set(baseline.strategies) - set(current.strategies)
+        )
+        msg = (
+            "Benchmark baseline strategy coverage mismatch: "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+        raise BenchmarkEvidenceError(msg)
+    if current.retrieval_options != baseline.retrieval_options:
+        msg = "Benchmark baseline retrieval configuration does not match current evidence"
+        raise BenchmarkEvidenceError(msg)
+
+
+def copy_evidence_as_baseline(
+    source_dir: Path,
+    output_dir: Path,
+    tasks_dir: Path,
+) -> BenchmarkEvidenceManifest:
+    """Copy validated evidence to a new immutable baseline directory."""
+    manifest = validate_evidence_directory(source_dir, tasks_dir)
+    if source_dir.resolve() == output_dir.resolve():
+        msg = "Benchmark baseline output must differ from the evidence input directory"
+        raise BenchmarkEvidenceError(msg)
+    if output_dir.exists():
+        msg = f"Benchmark baseline output already exists: {output_dir}"
+        raise BenchmarkEvidenceError(msg)
+
+    output_dir.mkdir(parents=True)
+    (output_dir / EVIDENCE_MANIFEST_FILENAME).write_bytes(
+        (source_dir / EVIDENCE_MANIFEST_FILENAME).read_bytes()
+    )
+    for task_id in manifest.task_ids:
+        (output_dir / f"{task_id}.json").write_bytes((source_dir / f"{task_id}.json").read_bytes())
+    validate_evidence_directory(output_dir, tasks_dir)
+    return manifest

--- a/src/archex/benchmark/triage.py
+++ b/src/archex/benchmark/triage.py
@@ -119,6 +119,8 @@ def load_benchmark_reports(input_dir: Path) -> list[BenchmarkReport]:
     """Load benchmark report JSON files from a directory."""
     reports: list[BenchmarkReport] = []
     for json_file in sorted(input_dir.glob("*.json")):
+        if json_file.name == "manifest.json":
+            continue
         data = json.loads(json_file.read_text(encoding="utf-8"))
         reports.append(BenchmarkReport.model_validate(data))
     return reports

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -520,11 +520,15 @@ def report_cmd(output_format: str, input_dir: str, baseline_dir: str | None) -> 
     reports: list[BenchmarkReport] = []
 
     for json_file in sorted(input_path.glob("*.json")):
+        if json_file.name == "manifest.json":
+            continue
         data = json.loads(json_file.read_text(encoding="utf-8"))
         reports.append(BenchmarkReport.model_validate(data))
     baseline_reports: list[BenchmarkReport] = []
     if baseline_dir is not None:
         for json_file in sorted(Path(baseline_dir).glob("*.json")):
+            if json_file.name == "manifest.json":
+                continue
             data = json.loads(json_file.read_text(encoding="utf-8"))
             baseline_reports.append(BenchmarkReport.model_validate(data))
         if not baseline_reports:
@@ -794,6 +798,8 @@ def baseline_save_cmd(input_dir: str, output_path: str, ranking_source: str | No
     input_path = Path(input_dir)
     reports: list[BenchmarkReport] = []
     for json_file in sorted(input_path.glob("*.json")):
+        if json_file.name == "manifest.json":
+            continue
         data = json.loads(json_file.read_text(encoding="utf-8"))
         reports.append(BenchmarkReport.model_validate(data))
 
@@ -832,6 +838,8 @@ def baseline_compare_cmd(input_dir: str, baseline_path: str) -> None:
     input_path = Path(input_dir)
     reports: list[BenchmarkReport] = []
     for json_file in sorted(input_path.glob("*.json")):
+        if json_file.name == "manifest.json":
+            continue
         data = json.loads(json_file.read_text(encoding="utf-8"))
         reports.append(BenchmarkReport.model_validate(data))
 

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -28,8 +28,10 @@ from archex.benchmark.delta_runner import run_all_delta
 from archex.benchmark.evidence import (
     BenchmarkEvidenceError,
     build_evidence_manifest,
+    load_evidence_reports,
     prepare_evidence_directory,
     source_revision,
+    validate_baseline_coverage,
     validate_evidence_directory,
     write_evidence_manifest,
 )
@@ -863,6 +865,12 @@ def baseline_compare_cmd(input_dir: str, baseline_path: str) -> None:
     type=click.Path(exists=True),
     help="Directory containing result JSON files.",
 )
+@click.option(
+    "--tasks-dir",
+    default="benchmarks/tasks",
+    type=click.Path(exists=True, file_okay=False),
+    help="Directory containing the task manifest bound to evidence.",
+)
 @click.option("--min-recall", default=0.60, type=float, help="Minimum recall threshold.")
 @click.option("--min-precision", default=0.20, type=float, help="Minimum precision threshold.")
 @click.option("--min-f1", default=0.30, type=float, help="Minimum F1 threshold.")
@@ -891,6 +899,7 @@ def baseline_compare_cmd(input_dir: str, baseline_path: str) -> None:
 )
 def gate_cmd(
     input_dir: str,
+    tasks_dir: str,
     min_recall: float,
     min_precision: float,
     min_f1: float,
@@ -900,14 +909,13 @@ def gate_cmd(
     max_latency_ms: float | None,
 ) -> None:
     """Check benchmark results against quality thresholds."""
-    input_path = Path(input_dir)
-    reports: list[BenchmarkReport] = []
-    for json_file in sorted(input_path.glob("*.json")):
-        data = json.loads(json_file.read_text(encoding="utf-8"))
-        reports.append(BenchmarkReport.model_validate(data))
-
-    if not reports:
-        raise click.ClickException(f"No result files found in {input_dir}")
+    try:
+        current_manifest, reports = load_evidence_reports(
+            Path(input_dir),
+            Path(tasks_dir),
+        )
+    except BenchmarkEvidenceError as exc:
+        raise click.ClickException(str(exc)) from exc
 
     thresholds = QualityThresholds(
         min_recall=min_recall,
@@ -947,13 +955,14 @@ def gate_cmd(
     advisory_warnings = non_token_quality_warnings(absolute_violations)
 
     if baseline_dir is not None:
-        baseline_path = Path(baseline_dir)
-        baseline_reports: list[BenchmarkReport] = []
-        for json_file in sorted(baseline_path.glob("*.json")):
-            data = json.loads(json_file.read_text(encoding="utf-8"))
-            baseline_reports.append(BenchmarkReport.model_validate(data))
-        if not baseline_reports:
-            raise click.ClickException(f"No baseline result files found in {baseline_dir}")
+        try:
+            baseline_manifest, baseline_reports = load_evidence_reports(
+                Path(baseline_dir),
+                Path(tasks_dir),
+            )
+            validate_baseline_coverage(current_manifest, baseline_manifest)
+        except BenchmarkEvidenceError as exc:
+            raise click.ClickException(str(exc)) from exc
         click.echo(format_chunker_frontier_table(reports, baseline_reports))
 
         recall_regressions = check_recall_regressions(reports, baseline_reports, thresholds)

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -11,6 +11,7 @@ from click.testing import CliRunner
 
 from archex.benchmark.baseline import RankingSnapshotEntry
 from archex.benchmark.models import (
+    BenchmarkEvidenceManifest,
     BenchmarkReport,
     BenchmarkResult,
     BenchmarkRetrievalOptions,
@@ -83,6 +84,20 @@ def _empty_tasks(
 ) -> list[BenchmarkTask]:
     del tasks_dir, task_filter, self_only
     return []
+
+
+def _patch_gate_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    reports: list[BenchmarkReport],
+) -> None:
+    def load_evidence(
+        input_dir: Path,
+        tasks_dir: Path,
+    ) -> tuple[BenchmarkEvidenceManifest, list[BenchmarkReport]]:
+        del input_dir, tasks_dir
+        return cast("BenchmarkEvidenceManifest", object()), reports
+
+    monkeypatch.setattr("archex.cli.benchmark_cmd.load_evidence_reports", load_evidence)
 
 
 class TestReportCommand:
@@ -457,12 +472,24 @@ expected_delta:
 
 
 class TestGateCommand:
-    def test_passes_when_max_latency_ms_not_set(self, runner: CliRunner, results_dir: Path) -> None:
+    def test_passes_when_max_latency_ms_not_set(
+        self,
+        runner: CliRunner,
+        results_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        report = BenchmarkReport.model_validate_json((results_dir / "test.json").read_bytes())
+        _patch_gate_evidence(monkeypatch, [report])
         result = runner.invoke(benchmark_cmd, ["gate", "--input", str(results_dir)])
         assert result.exit_code == 0
         assert "Quality gate passed." in result.output
 
-    def test_max_latency_ms_hard_fails_on_breach(self, runner: CliRunner, tmp_path: Path) -> None:
+    def test_max_latency_ms_hard_fails_on_breach(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         results = tmp_path / "results"
         results.mkdir()
         result_obj = BenchmarkResult(
@@ -485,7 +512,7 @@ class TestGateCommand:
             results=[result_obj],
             baseline_tokens=1000,
         )
-        (results / "slow.json").write_text(report.model_dump_json(indent=2))
+        _patch_gate_evidence(monkeypatch, [report])
 
         result = runner.invoke(
             benchmark_cmd,
@@ -497,8 +524,13 @@ class TestGateCommand:
         assert "slow_task/raw_files" in result.output
 
     def test_max_latency_ms_passes_under_threshold(
-        self, runner: CliRunner, results_dir: Path
+        self,
+        runner: CliRunner,
+        results_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        report = BenchmarkReport.model_validate_json((results_dir / "test.json").read_bytes())
+        _patch_gate_evidence(monkeypatch, [report])
         # results_dir fixture's sample result has wall_time_ms=50.0
         result = runner.invoke(
             benchmark_cmd,

--- a/tests/benchmark/test_evidence.py
+++ b/tests/benchmark/test_evidence.py
@@ -9,8 +9,10 @@ import pytest
 from archex.benchmark.evidence import (
     BenchmarkEvidenceError,
     build_evidence_manifest,
+    copy_evidence_as_baseline,
     prepare_evidence_directory,
     task_manifest_digest,
+    validate_baseline_coverage,
     validate_evidence_directory,
     write_evidence_manifest,
 )
@@ -47,6 +49,7 @@ def _report() -> BenchmarkReport:
         ndcg=1.0,
         map_score=1.0,
         savings_vs_raw=0.0,
+        token_efficiency=0.2,
         wall_time_ms=1.0,
         cached=False,
         timestamp="2026-07-11T00:00:00+00:00",
@@ -193,6 +196,70 @@ def test_validate_command_accepts_complete_evidence(
 
     assert result.exit_code == 0
     assert "Valid benchmark evidence: 1 task(s), 1 strategy/strategies." in result.output
+
+
+def test_gate_command_requires_complete_manifest_backed_evidence(tmp_path: Path) -> None:
+    from click.testing import CliRunner
+
+    from archex.cli.benchmark_cmd import benchmark_cmd
+
+    output_dir, tasks_dir = _write_evidence(tmp_path)
+    result = CliRunner().invoke(
+        benchmark_cmd,
+        [
+            "gate",
+            "--input",
+            str(output_dir),
+            "--tasks-dir",
+            str(tasks_dir),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Quality gate passed." in result.output
+
+
+def test_gate_command_rejects_reports_without_manifest(tmp_path: Path) -> None:
+    from click.testing import CliRunner
+
+    from archex.cli.benchmark_cmd import benchmark_cmd
+
+    output_dir, tasks_dir = _write_evidence(tmp_path)
+    (output_dir / "manifest.json").unlink()
+    result = CliRunner().invoke(
+        benchmark_cmd,
+        [
+            "gate",
+            "--input",
+            str(output_dir),
+            "--tasks-dir",
+            str(tasks_dir),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "manifest not found" in result.output
+
+
+def test_baseline_coverage_rejects_configuration_drift(tmp_path: Path) -> None:
+    output_dir, tasks_dir = _write_evidence(tmp_path)
+    current = validate_evidence_directory(output_dir, tasks_dir)
+    baseline = current.model_copy(
+        update={"retrieval_options": BenchmarkRetrievalOptions(chunker="cast")}
+    )
+
+    with pytest.raises(BenchmarkEvidenceError, match="retrieval configuration"):
+        validate_baseline_coverage(current, baseline)
+
+
+def test_copy_evidence_as_baseline_preserves_manifest_and_reports(tmp_path: Path) -> None:
+    output_dir, tasks_dir = _write_evidence(tmp_path)
+    baseline_dir = tmp_path / "baseline"
+
+    copied = copy_evidence_as_baseline(output_dir, baseline_dir, tasks_dir)
+    loaded = validate_evidence_directory(baseline_dir, tasks_dir)
+
+    assert copied == loaded
 
 
 def test_run_command_records_evidence_manifest(


### PR DESCRIPTION
## Stack

Stack-Id: `m0-1-benchmark-governance-20260711`
Base: `main`
Position: 2/3

1. `fix/benchmark-evidence-identity` → merged #499
2. `fix/benchmark-baseline-coverage` → this PR
3. `ci/benchmark-local-evidence-gate` → #501

Depends on: merged #499
Upstack: #501

## Summary

Makes `benchmark gate` consume manifest-backed evidence rather than an unverified JSON directory. Both current and optional baseline evidence validate report hashes, task-manifest identity, exact task/strategy coverage, and retrieval configuration before regression comparison.

Raw report directories without a manifest fail loudly. No baseline is promoted or replaced.

## Validation

- `uv run ruff check src/archex/benchmark/evidence.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_evidence.py`
- `uv run ruff format --check src/archex/benchmark/evidence.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_evidence.py`
- `uv run pyright src/archex/benchmark/evidence.py src/archex/cli/benchmark_cmd.py tests/benchmark/test_evidence.py`
- `uv run pytest --no-cov tests/benchmark/test_evidence.py` — 12 passed

## Known gate status

This PR only rejects incomplete or incompatible evidence. The failed default control remains unpromoted.