### PR TITLE
ci(benchmark): validate bounded evidence contracts

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,17 +1,17 @@
-name: Benchmark
+name: Benchmark contract
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 6 * * 1" # Weekly on Monday at 06:00 UTC
+    - cron: "0 6 * * 1"
 
 permissions:
   contents: read
 
 jobs:
-  benchmark-bm25:
+  benchmark-contract:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4
@@ -29,100 +29,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Run benchmarks (bm25, all tasks)
-        run: |
-          uv run archex benchmark run \
-            --tasks-dir benchmarks/tasks \
-            --output "$RUNNER_TEMP/archex-benchmark-results/bm25" \
-            --strategy archex_query
+      - name: Validate task definitions
+        run: uv run archex benchmark validate --kind tasks --tasks-dir benchmarks/tasks
 
-      - name: Quality gate (bm25)
-        run: |
-          uv run archex benchmark gate \
-            --input "$RUNNER_TEMP/archex-benchmark-results/bm25" \
-            --min-recall 0.60 \
-            --min-f1 0.30 \
-            --min-mrr 0.55
-
-      - name: Upload bm25 results
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-results-bm25
-          path: ${{ runner.temp }}/archex-benchmark-results/bm25/
-
-  benchmark-fusion:
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
-      - name: Run benchmarks (fusion, all tasks)
-        run: |
-          uv run archex benchmark run \
-            --tasks-dir benchmarks/tasks \
-            --output "$RUNNER_TEMP/archex-benchmark-results/fusion" \
-            --strategy archex_query_fusion
-
-      - name: Quality gate (fusion)
-        run: |
-          uv run archex benchmark gate \
-            --input "$RUNNER_TEMP/archex-benchmark-results/fusion" \
-            --min-recall 0.60 \
-            --min-f1 0.30 \
-            --min-mrr 0.55
-
-      - name: Upload fusion results
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-results-fusion
-          path: ${{ runner.temp }}/archex-benchmark-results/fusion/
-
-  benchmark-delta:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          # Delta tasks under benchmarks/delta_tasks checkout specific past
-          # commits of this repo (repo: ".") to benchmark against — a shallow
-          # clone would not contain them.
-          fetch-depth: 0
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
-      - name: Install dependencies
-        run: uv sync --all-extras
-
-      - name: Run delta benchmark + quality gate
-        run: uv run archex benchmark delta
-
-      - name: Upload delta results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-results-delta
-          path: .archex/delta-results/
-
+      - name: Validate bounded evidence contracts
+        run: uv run pytest --no-cov tests/benchmark/test_evidence.py

--- a/docs/LOCAL_BENCHMARK_EVIDENCE.md
+++ b/docs/LOCAL_BENCHMARK_EVIDENCE.md
@@ -1,0 +1,36 @@
+# Local benchmark evidence
+
+Run the complete corpus only as a local operator. GitHub Actions validates task definitions and bounded evidence contracts; it never executes the 64-task retrieval corpus.
+
+## Procedure
+
+1. Start from a clean committed source tree. The evidence manifest records the resolved source SHA and refuses a dirty tracked tree.
+2. Validate the declared corpus:
+
+```text
+uv run archex benchmark validate --kind tasks --tasks-dir benchmarks/tasks
+```
+
+3. Choose a new, empty evidence directory and run the default control:
+
+```text
+uv run archex benchmark run --tasks-dir benchmarks/tasks --output <evidence-dir> --strategy archex_query
+```
+
+The command writes exactly one raw report per completed task and `manifest.json`. The manifest records source SHA, task-manifest digest, Archex version, selected strategies, retrieval configuration, report SHA-256 values, generation timestamp, and hardware advisory.
+
+4. Validate retained evidence before inspecting or comparing it:
+
+```text
+uv run archex benchmark validate --kind evidence --tasks-dir benchmarks/tasks --input <evidence-dir>
+```
+
+5. Record the absolute-gate result without replacing a canonical baseline:
+
+```text
+uv run archex benchmark gate --input <evidence-dir> --min-recall 0.60 --min-f1 0.30 --min-mrr 0.55
+```
+
+A non-zero gate result is evidence. Preserve the manifest and all 64 reports with the failing result. Do not promote or overwrite a baseline until the declared promotion milestone verifies a passing full-corpus result.
+
+Evidence is invalid when its source revision, task digest, report hashes, task coverage, strategy coverage, or retrieval configuration differs from the manifest.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,8 @@ pythonVersion = "3.11"
 typeCheckingMode = "strict"
 include = ["src/archex", "tests"]
 # assets/archex_explainer.py depends on optional Manim rendering packages and is validated by render smoke when edited.
-exclude = ["tests/fixtures/", ".venv/", "assets/"]
+# Generated approval-test state is not repository source and is not type-checked.
+exclude = ["tests/fixtures/", ".venv/", "assets/", ".approval_tests_temp/"]
 venvPath = "."
 venv = ".venv"
 


### PR DESCRIPTION
## Stack

Stack-Id: `m0-1-benchmark-governance-20260711`
Base: `fix/benchmark-baseline-coverage`
Position: 3/3

1. `fix/benchmark-evidence-identity` → #499
2. `fix/benchmark-baseline-coverage` → #500
3. `ci/benchmark-local-evidence-gate` → this PR

Depends on: #500
Upstack: (none — leaf)

## Summary

Replaces scheduled full-corpus BM25, fusion, and delta benchmark execution with bounded task-definition and evidence-contract validation. Adds the local-operator procedure for the immutable 64-task control artifact and explicit preservation of its gate result without promotion.

CI contains no `archex benchmark run`, `gate`, or delta full-corpus command.

## Validation

- `uv run pre-commit run check-yaml --files .github/workflows/benchmark.yml`
- `uv run pytest --no-cov tests/benchmark/test_evidence.py` — 12 passed
- `uv run archex benchmark validate --kind tasks --tasks-dir benchmarks/tasks` — 64 tasks valid

## Local operator gate

The documented operator command performs the full corpus outside CI and writes an identity-bearing manifest. The initial default control remains unpromoted regardless of its absolute-gate result.