### PR TITLE
test(benchmark): characterize file coverage misses

### DIFF
--- a/benchmarks/evidence/m0.2-control-coverage.json
+++ b/benchmarks/evidence/m0.2-control-coverage.json
@@ -1,0 +1,90 @@
+{
+  "source_revision": "c62481367f6da70f29ac0fcaa073f413431da93a",
+  "task_manifest_digest": "0ae42fb18f96678b5e79591be8372d83fbeed646c4c08e7cc0f118eba4c2bd09",
+  "strategy": "archex_query",
+  "tasks": [
+    {
+      "task_id": "archex_adapter_registry",
+      "returned_files": [
+        "src/archex/parse/adapters/__init__.py",
+        "src/archex/parse/adapters/html.py",
+        "src/archex/parse/adapters/xml.py",
+        "src/archex/parse/adapters/yaml.py",
+        "src/archex/parse/adapters/css.py"
+      ],
+      "missing_required_files": [
+        "src/archex/parse/adapters/python.py",
+        "src/archex/parse/adapters/base.py"
+      ],
+      "missing_file_admission_state": {
+        "src/archex/parse/adapters/python.py": "not_admitted",
+        "src/archex/parse/adapters/base.py": "seed"
+      }
+    },
+    {
+      "task_id": "archex_project_status",
+      "returned_files": [
+        "src/archex/project.py",
+        "src/archex/status.py",
+        "src/archex/cli/index_cmd.py",
+        "src/archex/index/store.py"
+      ],
+      "missing_required_files": [
+        "src/archex/cli/status_cmd.py",
+        "src/archex/index/delta.py"
+      ],
+      "missing_file_admission_state": {
+        "src/archex/cli/status_cmd.py": "seed",
+        "src/archex/index/delta.py": "graph_expansion"
+      }
+    },
+    {
+      "task_id": "django_middleware",
+      "returned_files": [
+        "django/http/request.py",
+        "django/http/response.py",
+        "django/middleware/common.py",
+        "django/conf/__init__.py",
+        "django/core/handlers/base.py"
+      ],
+      "missing_required_files": [
+        "django/core/handlers/wsgi.py"
+      ],
+      "missing_file_admission_state": {
+        "django/core/handlers/wsgi.py": "graph_expansion"
+      }
+    },
+    {
+      "task_id": "loc_django_username_validator",
+      "returned_files": [
+        "django/contrib/auth/password_validation.py",
+        "django/contrib/auth/__init__.py",
+        "django/contrib/auth/migrations/0004_alter_user_username_opts.py",
+        "django/contrib/auth/forms.py",
+        "django/contrib/auth/migrations/0008_alter_user_username_max_length.py"
+      ],
+      "missing_required_files": [
+        "django/contrib/auth/validators.py"
+      ],
+      "missing_file_admission_state": {
+        "django/contrib/auth/validators.py": "graph_expansion"
+      }
+    },
+    {
+      "task_id": "routing_pl_scoring",
+      "returned_files": [
+        "src/archex/serve/context.py",
+        "src/archex/index/store.py",
+        "src/archex/cache.py",
+        "tests/serve/test_context.py",
+        "tests/serve/test_context_recall.py"
+      ],
+      "missing_required_files": [
+        "src/archex/index/bm25.py"
+      ],
+      "missing_file_admission_state": {
+        "src/archex/index/bm25.py": "seed"
+      }
+    }
+  ]
+}

--- a/src/archex/benchmark/coverage.py
+++ b/src/archex/benchmark/coverage.py
@@ -1,0 +1,64 @@
+"""Read required-file coverage evidence without consulting benchmark task oracles."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from archex.benchmark.models import BenchmarkReport, Strategy
+
+
+@dataclass(frozen=True)
+class RequiredFileCoverage:
+    """Returned-file evidence for one task and one benchmark strategy."""
+
+    task_id: str
+    strategy: Strategy
+    returned_files: tuple[str, ...]
+    missing_required_files: tuple[str, ...]
+    required_file_recall: float
+    completion_adjusted_token_efficiency: float
+    warm_latency_ms: float
+    seed_files: tuple[str, ...]
+    expanded_files: tuple[str, ...]
+
+
+def read_required_file_coverage(
+    reports: Iterable[BenchmarkReport], strategy: Strategy
+) -> list[RequiredFileCoverage]:
+    """Return one required-file evidence row per report for *strategy*.
+
+    The reader uses only fields emitted in benchmark reports. It deliberately
+    does not load benchmark tasks or expected-file definitions.
+    """
+    rows: list[RequiredFileCoverage] = []
+    seen_task_ids: set[str] = set()
+    for report in reports:
+        if report.task_id in seen_task_ids:
+            msg = f"Duplicate benchmark report task ID: {report.task_id}"
+            raise ValueError(msg)
+        seen_task_ids.add(report.task_id)
+        matches = [result for result in report.results if result.strategy is strategy]
+        if len(matches) != 1:
+            msg = (
+                f"Expected exactly one {strategy.value} result for {report.task_id}, "
+                f"found {len(matches)}"
+            )
+            raise ValueError(msg)
+        result = matches[0]
+        rows.append(
+            RequiredFileCoverage(
+                task_id=report.task_id,
+                strategy=strategy,
+                returned_files=tuple(result.result_files),
+                missing_required_files=tuple(result.required_files_missing),
+                required_file_recall=result.required_file_recall,
+                completion_adjusted_token_efficiency=result.token_efficiency_with_completion,
+                warm_latency_ms=result.warm_latency_ms,
+                seed_files=tuple(result.seed_files),
+                expanded_files=tuple(result.expanded_files),
+            )
+        )
+    return rows

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -1,0 +1,105 @@
+"""Tests for benchmark required-file coverage evidence reading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from archex.benchmark.coverage import read_required_file_coverage
+from archex.benchmark.evidence import task_manifest_digest
+from archex.benchmark.models import BenchmarkReport, BenchmarkResult, Strategy
+
+
+def _result(task_id: str, strategy: Strategy) -> BenchmarkResult:
+    return BenchmarkResult(
+        task_id=task_id,
+        strategy=strategy,
+        tokens_total=100,
+        tool_calls=1,
+        files_accessed=2,
+        recall=0.5,
+        precision=0.5,
+        savings_vs_raw=0.0,
+        wall_time_ms=10.0,
+        cached=True,
+        timestamp="2026-07-11T00:00:00+00:00",
+        result_files=["src/returned.py"],
+        required_file_recall=0.5,
+        required_files_missing=["src/missing.py"],
+        token_efficiency_with_completion=0.25,
+        warm_latency_ms=8.0,
+        seed_files=["src/seed.py"],
+        expanded_files=["src/returned.py"],
+    )
+
+
+def _report(task_id: str, strategies: list[Strategy]) -> BenchmarkReport:
+    return BenchmarkReport(
+        task_id=task_id,
+        repo="owner/repo",
+        question="Where is the required file?",
+        results=[_result(task_id, strategy) for strategy in strategies],
+        baseline_tokens=100,
+    )
+
+
+def test_reads_reported_file_coverage_without_task_oracle() -> None:
+    rows = read_required_file_coverage(
+        [_report("coverage_task", [Strategy.ARCHEX_QUERY, Strategy.RAW_FILES])],
+        Strategy.ARCHEX_QUERY,
+    )
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.task_id == "coverage_task"
+    assert row.strategy is Strategy.ARCHEX_QUERY
+    assert row.returned_files == ("src/returned.py",)
+    assert row.missing_required_files == ("src/missing.py",)
+    assert row.required_file_recall == 0.5
+    assert row.completion_adjusted_token_efficiency == 0.25
+    assert row.warm_latency_ms == 8.0
+    assert row.seed_files == ("src/seed.py",)
+    assert row.expanded_files == ("src/returned.py",)
+
+
+def test_rejects_report_without_requested_strategy() -> None:
+    with pytest.raises(ValueError, match="Expected exactly one archex_query result"):
+        read_required_file_coverage(
+            [_report("coverage_task", [Strategy.RAW_FILES])], Strategy.ARCHEX_QUERY
+        )
+
+
+def test_rejects_duplicate_report_task_ids() -> None:
+    reports = [
+        _report("coverage_task", [Strategy.ARCHEX_QUERY]),
+        _report("coverage_task", [Strategy.ARCHEX_QUERY]),
+    ]
+
+    with pytest.raises(ValueError, match="Duplicate benchmark report task ID"):
+        read_required_file_coverage(reports, Strategy.ARCHEX_QUERY)
+
+
+def test_control_coverage_artifact_characterizes_five_reproducible_misses() -> None:
+    root = Path(__file__).parents[2]
+    artifact = root / "benchmarks" / "evidence" / "m0.2-control-coverage.json"
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+
+    assert payload["strategy"] == Strategy.ARCHEX_QUERY.value
+    assert payload["task_manifest_digest"] == task_manifest_digest(root / "benchmarks" / "tasks")
+    observations = {entry["task_id"]: entry for entry in payload["tasks"]}
+    assert set(observations) == {
+        "archex_adapter_registry",
+        "archex_project_status",
+        "django_middleware",
+        "loc_django_username_validator",
+        "routing_pl_scoring",
+    }
+    assert {
+        state
+        for observation in observations.values()
+        for state in observation["missing_file_admission_state"].values()
+    } == {"not_admitted", "seed", "graph_expansion"}
+    for observation in observations.values():
+        assert set(observation["returned_files"]).isdisjoint(observation["missing_required_files"])


### PR DESCRIPTION
## Stack

Stack-Id: `m02-coverage-recovery-20260711`
Base: `main`
Position: 1/4

1. `m02-coverage-characterization` → this PR
2. `m02-candidate-seeds` → pending
3. graph-neighbor admission → pending
4. corpus proof → pending

Depends on: none
Upstack: pending

## Summary

Records immutable control evidence for the five M0.2 coverage cases and adds a report-only reader for required-file recall, completion-adjusted token efficiency, warmed latency, seed files, and expanded files. The reader consumes emitted `BenchmarkReport` fields only; it never loads benchmark tasks or expected-file definitions.

The characterization shows seven missing required files across five tasks and classifies each as not admitted, seed-admitted but excluded, or graph-expanded but excluded. `archex_query` remains unchanged.

## Validation

- `uv run ruff check src/archex/benchmark/coverage.py tests/benchmark/test_coverage.py` — passed
- `uv run ruff format --check src/archex/benchmark/coverage.py tests/benchmark/test_coverage.py` — passed
- `uv run pyright src/archex/benchmark/coverage.py tests/benchmark/test_coverage.py` — 0 errors
- `uv run pytest --no-cov tests/benchmark/test_coverage.py` — 4 passed
- Local review of `bfb66f8` — approved; Stack trailers verified

## Scope

Benchmark-only characterization and evidence reading. No candidate policy, production-default, score-weight, task-oracle runtime, or gate change.