### PR TITLE
feat(benchmark): admit evidence-backed file neighbors

### DIFF
--- a/src/archex/benchmark/coverage_candidate.py
+++ b/src/archex/benchmark/coverage_candidate.py
@@ -9,9 +9,12 @@ from typing import TYPE_CHECKING
 
 from archex.models import (
     ContextBundle,
+    ContextReceiptEdge,
     ContextReceiptItem,
     ContextSkippedCandidate,
     ContextSkippedReason,
+    EdgeConfidence,
+    EdgeKind,
     RankedChunk,
 )
 from archex.reporting import count_tokens
@@ -19,6 +22,7 @@ from archex.scout import chunk_handle
 from archex.serve.context import generic_query_terms
 
 if TYPE_CHECKING:
+    from archex.benchmark.graph_multihop import GraphEdge
     from archex.index.store import IndexStore
     from archex.models import CodeChunk
 
@@ -30,6 +34,11 @@ class CoverageSeedDecision:
     file: str
     score: int
     evidence: tuple[str, ...]
+    kind: str = "seed"
+    via: str | None = None
+    edge_source: str | None = None
+    edge_target: str | None = None
+    edge_confidence: float | None = None
 
 
 @dataclass(frozen=True)
@@ -59,6 +68,10 @@ _GENERIC_QUERY_TERMS = frozenset(
 )
 
 
+_NEIGHBOR_MIN_CONFIDENCE = 0.5
+_EVIDENCE_HIT_CAP = 64
+
+
 def coverage_seed_decisions(
     question: str, store: IndexStore, *, limit: int
 ) -> list[CoverageSeedDecision]:
@@ -84,14 +97,14 @@ def coverage_seed_decisions(
 
     bm25 = BM25Index(store)
     for identifier in _explicit_identifiers(question):
-        for chunk in store.search_symbols(identifier, limit=12):
+        for chunk in store.search_symbols(identifier, limit=_EVIDENCE_HIT_CAP):
             if not _is_test_path(chunk.file_path):
                 evidence_by_file[chunk.file_path].add(f"identifier:{identifier.lower()}")
     for term in terms:
-        for chunk in store.search_symbols(term, limit=12):
+        for chunk in store.search_symbols(term, limit=_EVIDENCE_HIT_CAP):
             if not _is_test_path(chunk.file_path):
                 evidence_by_file[chunk.file_path].add(f"symbol:{term}")
-        for chunk, _score in bm25.search(term, top_k=12):
+        for chunk, _score in bm25.search(term, top_k=_EVIDENCE_HIT_CAP):
             if not _is_test_path(chunk.file_path):
                 evidence_by_file[chunk.file_path].add(f"lexical:{term}")
 
@@ -117,6 +130,53 @@ def coverage_seed_decisions(
         for file_path, evidence in evidence_by_file.items()
     ]
     return sorted(decisions, key=lambda decision: (-decision.score, decision.file))[:limit]
+
+
+def coverage_neighbor_decisions(
+    edges: list[GraphEdge],
+    *,
+    seed_files: set[str],
+    existing_files: set[str],
+    direct_decisions: list[CoverageSeedDecision],
+    limit: int,
+) -> list[CoverageSeedDecision]:
+    """Rank bounded direct graph neighbors using extracted edges and seed evidence."""
+    if limit < 1:
+        return []
+
+    direct_by_file = {decision.file: decision for decision in direct_decisions}
+    candidates: dict[str, CoverageSeedDecision] = {}
+    for edge in edges:
+        if edge.confidence < _NEIGHBOR_MIN_CONFIDENCE:
+            continue
+        routes: list[tuple[str, str, str, int]] = []
+        if edge.source in seed_files:
+            routes.append((edge.target, edge.source, "graph_import", 20))
+        if edge.target in seed_files:
+            routes.append((edge.source, edge.target, "graph_importer", 10))
+        for file_path, via, relation, direction_bonus in routes:
+            if file_path in seed_files or file_path in existing_files or _is_test_path(file_path):
+                continue
+            direct = direct_by_file.get(file_path)
+            direct_evidence = direct.evidence if direct is not None else ()
+            decision = CoverageSeedDecision(
+                file=file_path,
+                score=round(edge.confidence * 100) + direction_bonus,
+                evidence=(f"{relation}:{via}", *direct_evidence),
+                kind="neighbor",
+                via=via,
+                edge_source=via if relation == "graph_import" else file_path,
+                edge_target=file_path if relation == "graph_import" else via,
+                edge_confidence=edge.confidence,
+            )
+            existing = candidates.get(file_path)
+            if existing is None or (decision.score, decision.via or "") > (
+                existing.score,
+                existing.via or "",
+            ):
+                candidates[file_path] = decision
+    ordered = sorted(candidates.values(), key=lambda decision: (-decision.score, decision.file))
+    return ordered[:limit]
 
 
 def apply_coverage_seed_admission(
@@ -156,9 +216,28 @@ def apply_coverage_seed_admission(
                 start_line=chunk.start_line,
                 end_line=chunk.end_line,
                 content_hash=_chunk_content_hash(chunk),
-                reason_codes=[f"coverage_seed:{reason}" for reason in decision.evidence],
+                reason_codes=[f"coverage_{decision.kind}:{reason}" for reason in decision.evidence],
             )
         )
+
+    neighbor_edges = [
+        ContextReceiptEdge(
+            source=decision.edge_source,
+            target=decision.edge_target,
+            kind=EdgeKind.IMPORTS,
+            confidence=EdgeConfidence.EXTRACTED,
+            confidence_score=decision.edge_confidence
+            if decision.edge_confidence is not None
+            else 1.0,
+            evidence=[f"coverage graph evidence: {','.join(decision.evidence)}"],
+        )
+        for decision in admitted
+        if (
+            decision.kind == "neighbor"
+            and decision.edge_source is not None
+            and decision.edge_target is not None
+        )
+    ]
 
     receipt = bundle.receipt
     if receipt is not None:
@@ -168,16 +247,19 @@ def apply_coverage_seed_admission(
                 file_path=decision.file,
                 reason=ContextSkippedReason.OVER_BUDGET,
                 score=float(decision.score),
-                detail=f"coverage seed evidence: {','.join(decision.evidence)}",
+                detail=f"coverage {decision.kind} evidence: {','.join(decision.evidence)}",
             )
             for decision in budget_cuts
         )
         returned_context = [*receipt.returned_context, *receipt_items]
+        included_edges = [*receipt.included_edges, *neighbor_edges]
         receipt = receipt.model_copy(
             update={
                 "returned_context": returned_context,
                 "returned_total": len(returned_context),
                 "skipped_candidates": skipped,
+                "included_edges": included_edges,
+                "included_edges_total": len(included_edges),
                 "skipped_total": len(skipped),
                 "token_budget": receipt.token_budget.model_copy(
                     update={"consumed": bundle.token_count + added_tokens}
@@ -211,7 +293,11 @@ def _path_parts(file_path: str) -> set[str]:
 
 
 def _is_test_path(file_path: str) -> bool:
-    return file_path.startswith("tests/") or "/tests/" in file_path
+    return (
+        file_path.startswith(("tests/", "benchmarks/"))
+        or "/tests/" in file_path
+        or "/benchmarks/" in file_path
+    )
 
 
 def _evidence_score(evidence: set[str], frequency: Counter[str]) -> int:
@@ -232,7 +318,7 @@ def _select_evidence_chunk(chunks: list[CodeChunk], decision: CoverageSeedDecisi
         )
         return (
             -len(symbol_terms & evidence_terms),
-            -(chunk.token_count or count_tokens(chunk.content)),
+            chunk.token_count or count_tokens(chunk.content),
             chunk.start_line,
         )
 

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -27,6 +27,9 @@ from archex.benchmark.coverage_candidate import (
     apply_coverage_seed_admission as _apply_coverage_seed_admission,
 )
 from archex.benchmark.coverage_candidate import (
+    coverage_neighbor_decisions as _coverage_neighbor_decisions,
+)
+from archex.benchmark.coverage_candidate import (
     coverage_seed_decisions as _coverage_seed_decisions,
 )
 from archex.benchmark.graph_multihop import (
@@ -3107,12 +3110,15 @@ def run_archex_query_graph_multihop(task: BenchmarkTask, repo_path: Path) -> Ben
     return result
 
 
-_COVERAGE_SEED_CAP = 3
+_COVERAGE_SEED_CAP = 32
+_COVERAGE_DIRECT_EVIDENCE_CAP = 64
+_COVERAGE_NEIGHBOR_CAP = 24
 
 
 def run_archex_query_coverage_candidate(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Benchmark-only bounded seed-admission candidate; product defaults stay unchanged."""
     from archex.api import index_repository
+    from archex.index.graph import DependencyGraph
     from archex.models import Config
 
     strategy = Strategy.ARCHEX_QUERY_COVERAGE_CANDIDATE
@@ -3131,15 +3137,34 @@ def run_archex_query_coverage_candidate(task: BenchmarkTask, repo_path: Path) ->
         index_config=effective_config,
     )
     try:
-        decisions = _coverage_seed_decisions(
+        direct_decisions = _coverage_seed_decisions(
             task.question,
             store,
-            limit=_COVERAGE_SEED_CAP,
+            limit=_COVERAGE_DIRECT_EVIDENCE_CAP,
         )
-        admission = _apply_coverage_seed_admission(
+        seed_decisions = direct_decisions[:_COVERAGE_SEED_CAP]
+        seed_admission = _apply_coverage_seed_admission(
             bundle,
             store,
-            decisions,
+            seed_decisions,
+            token_budget=task.token_budget,
+        )
+        graph = DependencyGraph.from_edges(store.get_edges())
+        edges = [
+            GraphEdge(edge.source, edge.target, edge.confidence_score)
+            for edge in graph.file_edges()
+        ]
+        neighbor_decisions = _coverage_neighbor_decisions(
+            edges,
+            seed_files={decision.file for decision in seed_decisions},
+            existing_files={ranked.chunk.file_path for ranked in seed_admission.bundle.chunks},
+            direct_decisions=direct_decisions,
+            limit=_COVERAGE_NEIGHBOR_CAP,
+        )
+        neighbor_admission = _apply_coverage_seed_admission(
+            seed_admission.bundle,
+            store,
+            neighbor_decisions,
             token_budget=task.token_budget,
         )
     finally:
@@ -3151,7 +3176,7 @@ def run_archex_query_coverage_candidate(task: BenchmarkTask, repo_path: Path) ->
         repo_path,
         strategy=strategy,
         index_config=effective_config,
-        bundle=admission.bundle,
+        bundle=neighbor_admission.bundle,
         timing=timing,
         wall_ms=wall_ms,
         include_completion=True,
@@ -3159,13 +3184,30 @@ def run_archex_query_coverage_candidate(task: BenchmarkTask, repo_path: Path) ->
     )
     result.provenance = {
         "candidate_seed_cap": str(_COVERAGE_SEED_CAP),
-        "candidate_seed_decisions": str(len(decisions)),
-        "candidate_seed_admitted": ",".join(decision.file for decision in admission.admitted)
+        "candidate_seed_decisions": str(len(seed_decisions)),
+        "candidate_seed_admitted": ",".join(decision.file for decision in seed_admission.admitted)
         or "none",
-        "candidate_seed_budget_cuts": ",".join(decision.file for decision in admission.budget_cuts)
+        "candidate_seed_budget_cuts": ",".join(
+            decision.file for decision in seed_admission.budget_cuts
+        )
         or "none",
         "candidate_seed_evidence": ";".join(
-            f"{decision.file}:{','.join(decision.evidence)}" for decision in admission.admitted
+            f"{decision.file}:{','.join(decision.evidence)}" for decision in seed_admission.admitted
+        )
+        or "none",
+        "candidate_neighbor_cap": str(_COVERAGE_NEIGHBOR_CAP),
+        "candidate_neighbor_decisions": str(len(neighbor_decisions)),
+        "candidate_neighbor_admitted": ",".join(
+            decision.file for decision in neighbor_admission.admitted
+        )
+        or "none",
+        "candidate_neighbor_budget_cuts": ",".join(
+            decision.file for decision in neighbor_admission.budget_cuts
+        )
+        or "none",
+        "candidate_neighbor_evidence": ";".join(
+            f"{decision.file}<-{decision.via}:{','.join(decision.evidence)}"
+            for decision in neighbor_admission.admitted
         )
         or "none",
     }

--- a/tests/benchmark/test_coverage_candidate.py
+++ b/tests/benchmark/test_coverage_candidate.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from archex.benchmark.coverage_candidate import CoverageSeedDecision as _CoverageSeedDecision
 from archex.benchmark.models import BenchmarkTask, Strategy
 from archex.benchmark.strategies import (
+    _COVERAGE_DIRECT_EVIDENCE_CAP,  # pyright: ignore[reportPrivateUsage]
+    _COVERAGE_SEED_CAP,  # pyright: ignore[reportPrivateUsage]
     _apply_coverage_seed_admission,  # pyright: ignore[reportPrivateUsage]
     _coverage_seed_decisions,  # pyright: ignore[reportPrivateUsage]
     default_strategy_registry,
@@ -168,6 +170,10 @@ def test_candidate_is_available_but_not_default() -> None:
     )
     assert Strategy.ARCHEX_QUERY_COVERAGE_CANDIDATE in AVAILABLE_STRATEGIES
     assert Strategy.ARCHEX_QUERY_COVERAGE_CANDIDATE not in DEFAULT_STRATEGIES
+
+
+def test_candidate_seed_frontier_is_bounded_below_evidence_pool() -> None:
+    assert 0 < _COVERAGE_SEED_CAP < _COVERAGE_DIRECT_EVIDENCE_CAP
 
 
 def test_candidate_returned_files_do_not_depend_on_expected_files(

--- a/tests/benchmark/test_coverage_graph.py
+++ b/tests/benchmark/test_coverage_graph.py
@@ -1,0 +1,216 @@
+"""Regression tests for evidence-backed coverage graph-neighbor admission."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from archex.api import index_repository
+from archex.benchmark.coverage_candidate import (
+    CoverageSeedDecision,
+    _select_evidence_chunk,  # pyright: ignore[reportPrivateUsage]
+    apply_coverage_seed_admission,
+    coverage_neighbor_decisions,
+    coverage_seed_decisions,
+)
+from archex.benchmark.graph_multihop import GraphEdge
+from archex.models import (
+    CodeChunk,
+    Config,
+    ContextBundle,
+    ContextReceipt,
+    ContextReceiptTokenBudget,
+    IndexConfig,
+    RepoSource,
+)
+from archex.serve.context import generic_query_terms
+
+
+def test_neighbor_admission_requires_confident_graph_evidence() -> None:
+    decisions = coverage_neighbor_decisions(
+        [
+            GraphEdge("entry.py", "validation.py", 0.9),
+            GraphEdge("entry.py", "boundary.py", 0.5),
+            GraphEdge("entry.py", "unrelated.py", 0.2),
+        ],
+        seed_files={"entry.py"},
+        existing_files=set(),
+        direct_decisions=[
+            CoverageSeedDecision(
+                file="validation.py",
+                score=8,
+                evidence=("symbol:validateinvoice",),
+            )
+        ],
+        limit=3,
+    )
+
+    assert [decision.file for decision in decisions] == ["validation.py", "boundary.py"]
+    decision = decisions[0]
+    assert decision.kind == "neighbor"
+    assert decision.via == "entry.py"
+    assert "graph_import:entry.py" in decision.evidence
+    assert "symbol:validateinvoice" in decision.evidence
+
+
+def test_neighbor_admission_is_bounded_and_deterministic() -> None:
+    edges = [
+        GraphEdge("entry.py", "b.py", 0.9),
+        GraphEdge("entry.py", "a.py", 0.9),
+        GraphEdge("entry.py", "c.py", 0.9),
+    ]
+
+    decisions = coverage_neighbor_decisions(
+        edges,
+        seed_files={"entry.py"},
+        existing_files={"b.py"},
+        direct_decisions=[
+            CoverageSeedDecision(file="c.py", score=1_000, evidence=("symbol:entry",))
+        ],
+        limit=2,
+    )
+
+    assert [decision.file for decision in decisions] == ["a.py", "c.py"]
+
+
+def test_generic_candidate_terms_do_not_apply_semantic_synonyms() -> None:
+    terms = set(generic_query_terms("How does middleware process a request?"))
+
+    assert "middleware" in terms
+    assert {"asgi", "wsgi", "hook", "interceptor"}.isdisjoint(terms)
+
+
+def test_admission_selects_smallest_equally_evidenced_chunk() -> None:
+    decision = CoverageSeedDecision(
+        file="catalog.py",
+        score=1,
+        evidence=("symbol:invoicematcher",),
+    )
+    chunks = [
+        CodeChunk(
+            id="catalog.py:large:1",
+            content="class InvoiceMatcher:\n    pass\n",
+            file_path="catalog.py",
+            start_line=1,
+            end_line=2,
+            language="python",
+            token_count=100,
+            symbol_name="InvoiceMatcher",
+        ),
+        CodeChunk(
+            id="catalog.py:small:10",
+            content="class InvoiceMatcher:\n    pass\n",
+            file_path="catalog.py",
+            start_line=10,
+            end_line=11,
+            language="python",
+            token_count=10,
+            symbol_name="InvoiceMatcher",
+        ),
+    ]
+
+    assert _select_evidence_chunk(chunks, decision).id == "catalog.py:small:10"
+
+
+def test_seed_decisions_exclude_benchmark_artifacts(
+    python_simple_repo: Path,
+) -> None:
+    benchmark_file = python_simple_repo / "benchmarks" / "task.py"
+    benchmark_file.parent.mkdir()
+    benchmark_file.write_text("class BenchmarkRegistry:\n    pass\n")
+    store = index_repository(
+        RepoSource(
+            local_path=str(python_simple_repo),
+            stable_identity="coverage-benchmark-artifact-test@1",
+        ),
+        config=Config(cache=False),
+        index_config=IndexConfig(vector=False),
+    )
+    try:
+        decisions = coverage_seed_decisions("Where is the BenchmarkRegistry class?", store, limit=3)
+    finally:
+        store.close()
+
+    assert "benchmarks/task.py" not in {decision.file for decision in decisions}
+
+
+def test_neighbor_admission_records_receipt_provenance(
+    python_simple_repo: Path,
+) -> None:
+    store = index_repository(
+        RepoSource(
+            local_path=str(python_simple_repo),
+            stable_identity="coverage-graph-receipt-test@1",
+        ),
+        config=Config(cache=False),
+        index_config=IndexConfig(vector=False),
+    )
+    try:
+        importer = coverage_neighbor_decisions(
+            [GraphEdge("main.py", "models.py", 0.9)],
+            seed_files={"models.py"},
+            existing_files=set(),
+            direct_decisions=[],
+            limit=1,
+        )[0]
+        assert importer.file == "main.py"
+        assert importer.via == "models.py"
+        assert importer.edge_source == "main.py"
+        assert importer.edge_target == "models.py"
+        admitted = apply_coverage_seed_admission(
+            ContextBundle(
+                query="Where is AuthService?",
+                chunks=[],
+                token_count=0,
+                receipt=ContextReceipt(
+                    query="Where is AuthService?",
+                    token_budget=ContextReceiptTokenBudget(requested=1024, consumed=0),
+                    index_revision="coverage-graph-receipt-test",
+                ),
+            ),
+            store,
+            [
+                CoverageSeedDecision(
+                    file="models.py",
+                    score=100,
+                    evidence=("graph_import:entry.py",),
+                    kind="neighbor",
+                    via="entry.py",
+                    edge_source="entry.py",
+                    edge_target="models.py",
+                ),
+                importer,
+            ],
+            token_budget=1024,
+        )
+    finally:
+        store.close()
+
+    assert admitted.bundle.receipt is not None
+    edges = {(edge.source, edge.target) for edge in admitted.bundle.receipt.included_edges}
+    edge_confidences = {
+        (edge.source, edge.target): edge.confidence_score
+        for edge in admitted.bundle.receipt.included_edges
+    }
+    assert edge_confidences[("entry.py", "models.py")] == 1.0
+    assert edge_confidences[("main.py", "models.py")] == 0.9
+    assert edges == {("entry.py", "models.py"), ("main.py", "models.py")}
+    returned = {
+        item.file_path: item.reason_codes for item in admitted.bundle.receipt.returned_context
+    }
+    assert returned["models.py"] == ["coverage_neighbor:graph_import:entry.py"]
+    assert returned["main.py"] == ["coverage_neighbor:graph_importer:models.py"]
+
+
+def test_neighbor_score_rounds_fractional_confidence_and_propagates_it() -> None:
+    decisions = coverage_neighbor_decisions(
+        [GraphEdge("entry.py", "target.py", 0.876)],
+        seed_files={"entry.py"},
+        existing_files=set(),
+        direct_decisions=[],
+        limit=1,
+    )
+
+    decision = decisions[0]
+    assert decision.score == round(87.6) + 20
+    assert decision.score != int(87.6) + 20
+    assert decision.edge_confidence == 0.876


### PR DESCRIPTION
## Stack

Stack-Id: `m02-coverage-recovery-20260711`
Base: `m02-candidate-seeds`
Position: 3/4

1. `m02-coverage-characterization` -> #502
2. `m02-candidate-seeds` -> #503
3. `m02-graph-neighbors` -> this PR
4. `m02-corpus-proof` -> #505

Depends on: #503
Upstack: #505

## Summary

Adds a candidate-only, evidence-backed direct-neighbor pass after bounded seed admission. It uses only extracted index graph edges and query/index-derived direct evidence. A neighbor must meet the extracted-edge confidence floor (inclusive at `0.5`), cannot be a test/benchmark-artifact file, a current seed, or already present in the bundle, and is capped deterministically. Receipts record neighbor provenance as directional imported graph edges (`graph_import` vs `graph_importer` produce correctly oriented `source`/`target` fields) with the real extracted edge confidence propagated into `confidence_score`.

## Post-review corrections (two review passes)

1. `_COVERAGE_SEED_CAP` had drifted to equal `_COVERAGE_DIRECT_EVIDENCE_CAP` (both `64`), making the seed-narrowing slice a no-op and silently widening graph-neighbor traversal scope. Corrected: `_COVERAGE_SEED_CAP = 32` (materially below the 64-file evidence-gathering cap), with `test_candidate_seed_frontier_is_bounded_below_evidence_pool` asserting `0 < _COVERAGE_SEED_CAP < _COVERAGE_DIRECT_EVIDENCE_CAP`.
2. Added an exact `confidence == 0.5` boundary case to `test_neighbor_admission_requires_confident_graph_evidence`.
3. Replaced the truncating `int(edge.confidence * 100)` neighbor score with `round(...)`, and added `test_neighbor_score_rounds_fractional_confidence_and_propagates_it` using a fractional confidence (`0.876`) that only passes under `round()`, not `int()`.
4. Neighbor receipt edges previously hardcoded `confidence_score=1.0` instead of the real extracted-edge confidence. `CoverageSeedDecision` now carries `edge_confidence`, threaded from the source `GraphEdge.confidence` through to `ContextReceiptEdge.confidence_score`. Covered by an extended `test_neighbor_admission_records_receipt_provenance` asserting the real `0.9` propagates (vs. the `1.0` default for a hand-built decision without a source edge).

## Validation

- `uv run ruff check`, `uv run ruff format --check`, `uv run pyright` on all touched files - passed
- `uv run pytest --no-cov tests/benchmark/test_coverage_candidate.py tests/benchmark/test_coverage_graph.py` - 12 passed
- Mutation proofs (isolated `git worktree`, restored after each):
  - Raising `_NEIGHBOR_MIN_CONFIDENCE` to `1.1` fails the confidence-floor regression.
  - Restoring `_COVERAGE_SEED_CAP = 64` (no-op) fails the cap-bound regression.
  - Widening the confidence comparison to `<=` fails the `0.5`-boundary assertion.
  - Reverting `round()` to `int()` fails the fractional-confidence regression.
  - Hardcoding `confidence_score=1.0` fails the receipt-provenance regression.
- Full project gates on final stack state: `uv run ruff format --check .`, `uv run ruff check .`, `uv run pyright`, `uv run pytest --no-cov` - 3722 passed, 7 deselected.

## Scope

No default strategy change, global scoring change, task-oracle runtime read, task-vocabulary branch, hosted inference, gate change, or M1 work.