### PR TITLE
test(benchmark): characterize ranking and result-set noise

### DIFF
--- a/benchmarks/evidence/m0.3-control-ranking.json
+++ b/benchmarks/evidence/m0.3-control-ranking.json
@@ -1,0 +1,1005 @@
+{
+  "source_revision": "bb71b668fe89750d278f59171fa56dc4c1839dac",
+  "task_manifest_digest": "0ae42fb18f96678b5e79591be8372d83fbeed646c4c08e7cc0f118eba4c2bd09",
+  "gate_thresholds": {
+    "min_recall": 0.6,
+    "min_precision": 0.2,
+    "min_f1": 0.3,
+    "min_mrr": 0.55
+  },
+  "strategies": [
+    {
+      "strategy": "archex_query",
+      "rank_below_first_count": 14,
+      "broad_result_set_count": 9,
+      "tasks": [
+        {
+          "task_id": "celery_task_dispatch",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.6,
+          "f1_score": 0.7499999999999999,
+          "mrr": 0.5,
+          "required_file_recall": 1.0,
+          "result_file_count": 5,
+          "required_file_count": 3,
+          "failure_classes": [
+            "below_mrr_floor",
+            "rank_below_first"
+          ]
+        },
+        {
+          "task_id": "express_error_handling",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.6,
+          "f1_score": 0.7499999999999999,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 5,
+          "required_file_count": 3,
+          "failure_classes": [
+            "below_mrr_floor",
+            "rank_below_first"
+          ]
+        },
+        {
+          "task_id": "fastapi_routing",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.6,
+          "f1_score": 0.7499999999999999,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 5,
+          "required_file_count": 3,
+          "failure_classes": [
+            "below_mrr_floor",
+            "rank_below_first"
+          ]
+        },
+        {
+          "task_id": "loc_celery_task_retry",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.16666666666666666,
+          "f1_score": 0.2857142857142857,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 6,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_click_param_process",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.125,
+          "f1_score": 0.2222222222222222,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 8,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_express_error_middleware",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.2,
+          "f1_score": 0.33333333333333337,
+          "mrr": 0.5,
+          "required_file_recall": 1.0,
+          "result_file_count": 5,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_mrr_floor",
+            "rank_below_first"
+          ]
+        },
+        {
+          "task_id": "loc_fastapi_jsonable_encoder",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.125,
+          "f1_score": 0.2222222222222222,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 8,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_fastapi_solve_dependencies",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.5,
+          "f1_score": 0.6666666666666666,
+          "mrr": 0.5,
+          "required_file_recall": 1.0,
+          "result_file_count": 2,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_mrr_floor",
+            "rank_below_first"
+          ]
+        },
+        {
+          "task_id": "loc_flask_full_dispatch",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.125,
+          "f1_score": 0.2222222222222222,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 8,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_httpx_pool_transport",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.16666666666666666,
+          "f1_score": 0.2857142857142857,
+          "mrr": 0.2,
+          "required_file_recall": 1.0,
+          "result_file_count": 6,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_httpx_redirect_headers",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.125,
+          "f1_score": 0.2222222222222222,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 8,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_mini_redis_command_from_frame",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.2,
+          "f1_score": 0.33333333333333337,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 5,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_mrr_floor",
+            "rank_below_first"
+          ]
+        },
+        {
+          "task_id": "loc_requests_adapter_send",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.125,
+          "f1_score": 0.2222222222222222,
+          "mrr": 0.14285714285714285,
+          "required_file_recall": 1.0,
+          "result_file_count": 8,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_requests_redirect_auth",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.16666666666666666,
+          "f1_score": 0.2857142857142857,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 6,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_sqlalchemy_session_merge",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.125,
+          "f1_score": 0.2222222222222222,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 8,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "react_hooks",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.25,
+          "f1_score": 0.4,
+          "mrr": 0.16666666666666666,
+          "required_file_recall": 1.0,
+          "result_file_count": 8,
+          "required_file_count": 2,
+          "failure_classes": [
+            "below_mrr_floor",
+            "rank_below_first"
+          ]
+        },
+        {
+          "task_id": "routing_mixed_chunker",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.2,
+          "f1_score": 0.33333333333333337,
+          "mrr": 0.5,
+          "required_file_recall": 1.0,
+          "result_file_count": 5,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_mrr_floor",
+            "rank_below_first"
+          ]
+        }
+      ]
+    },
+    {
+      "strategy": "archex_query_coverage_candidate",
+      "rank_below_first_count": 16,
+      "broad_result_set_count": 38,
+      "tasks": [
+        {
+          "task_id": "archex_adapter_registry",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.05357142857142857,
+          "f1_score": 0.10169491525423728,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 56,
+          "required_file_count": 3,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "archex_delta_index_lifecycle",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.15789473684210525,
+          "f1_score": 0.2727272727272727,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 19,
+          "required_file_count": 3,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "archex_delta_indexing",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.06060606060606061,
+          "f1_score": 0.1142857142857143,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 33,
+          "required_file_count": 2,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "archex_graph_expansion",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.125,
+          "f1_score": 0.2222222222222222,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 16,
+          "required_file_count": 2,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "archex_pattern_detection",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.034482758620689655,
+          "f1_score": 0.06666666666666667,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 58,
+          "required_file_count": 2,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "archex_project_config_resolution",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.07017543859649122,
+          "f1_score": 0.13114754098360656,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 57,
+          "required_file_count": 4,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "archex_project_index",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.08771929824561403,
+          "f1_score": 0.16129032258064516,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 57,
+          "required_file_count": 5,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "archex_project_init",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.07017543859649122,
+          "f1_score": 0.13114754098360656,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 57,
+          "required_file_count": 4,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "archex_project_reset",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.05357142857142857,
+          "f1_score": 0.10169491525423728,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 56,
+          "required_file_count": 3,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "archex_project_status",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.07017543859649122,
+          "f1_score": 0.13114754098360656,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 57,
+          "required_file_count": 4,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "archex_query_pipeline",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.057692307692307696,
+          "f1_score": 0.1090909090909091,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 52,
+          "required_file_count": 3,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "archex_vector_cache_lifecycle",
+          "family": "comprehension",
+          "recall": 0.6,
+          "precision": 0.07142857142857142,
+          "f1_score": 0.1276595744680851,
+          "mrr": 1.0,
+          "required_file_recall": 0.6,
+          "result_file_count": 42,
+          "required_file_count": 5,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "celery_task_dispatch",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.16666666666666666,
+          "f1_score": 0.2857142857142857,
+          "mrr": 0.5,
+          "required_file_recall": 1.0,
+          "result_file_count": 18,
+          "required_file_count": 3,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "click_decorators",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.1875,
+          "f1_score": 0.3157894736842105,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 16,
+          "required_file_count": 3,
+          "failure_classes": [
+            "below_precision_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "django_middleware",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.15,
+          "f1_score": 0.2608695652173913,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 20,
+          "required_file_count": 3,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "express_error_handling",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.2727272727272727,
+          "f1_score": 0.42857142857142855,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 11,
+          "required_file_count": 3,
+          "failure_classes": [
+            "below_mrr_floor",
+            "rank_below_first"
+          ]
+        },
+        {
+          "task_id": "fastapi_routing",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.6,
+          "f1_score": 0.7499999999999999,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 5,
+          "required_file_count": 3,
+          "failure_classes": [
+            "below_mrr_floor",
+            "rank_below_first"
+          ]
+        },
+        {
+          "task_id": "loc_celery_task_retry",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.16666666666666666,
+          "f1_score": 0.2857142857142857,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 6,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_click_param_process",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.09090909090909091,
+          "f1_score": 0.16666666666666669,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 11,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_django_queryset_filter",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.16666666666666666,
+          "f1_score": 0.2857142857142857,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 6,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_django_username_validator",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.030303030303030304,
+          "f1_score": 0.05882352941176471,
+          "mrr": 0.0625,
+          "required_file_recall": 1.0,
+          "result_file_count": 33,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_express_error_middleware",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.2,
+          "f1_score": 0.33333333333333337,
+          "mrr": 0.5,
+          "required_file_recall": 1.0,
+          "result_file_count": 5,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_mrr_floor",
+            "rank_below_first"
+          ]
+        },
+        {
+          "task_id": "loc_fastapi_jsonable_encoder",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.1111111111111111,
+          "f1_score": 0.19999999999999998,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 9,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_fastapi_solve_dependencies",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.5,
+          "f1_score": 0.6666666666666666,
+          "mrr": 0.5,
+          "required_file_recall": 1.0,
+          "result_file_count": 2,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_mrr_floor",
+            "rank_below_first"
+          ]
+        },
+        {
+          "task_id": "loc_flask_blueprint_register",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.08333333333333333,
+          "f1_score": 0.15384615384615385,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 12,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_flask_full_dispatch",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.1,
+          "f1_score": 0.18181818181818182,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 10,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_httpx_pool_transport",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.058823529411764705,
+          "f1_score": 0.1111111111111111,
+          "mrr": 0.2,
+          "required_file_recall": 1.0,
+          "result_file_count": 17,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_httpx_redirect_headers",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.1111111111111111,
+          "f1_score": 0.19999999999999998,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 9,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_mini_redis_command_from_frame",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.05555555555555555,
+          "f1_score": 0.10526315789473684,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 18,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_requests_adapter_send",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.125,
+          "f1_score": 0.2222222222222222,
+          "mrr": 0.14285714285714285,
+          "required_file_recall": 1.0,
+          "result_file_count": 8,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_requests_redirect_auth",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.05555555555555555,
+          "f1_score": 0.10526315789473684,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 18,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "loc_sqlalchemy_session_merge",
+          "family": "localization",
+          "recall": 1.0,
+          "precision": 0.1111111111111111,
+          "f1_score": 0.19999999999999998,
+          "mrr": 0.3333333333333333,
+          "required_file_recall": 1.0,
+          "result_file_count": 9,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "mini_redis_async",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.16666666666666666,
+          "f1_score": 0.2857142857142857,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 18,
+          "required_file_count": 3,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "react_hooks",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.2222222222222222,
+          "f1_score": 0.3636363636363636,
+          "mrr": 0.16666666666666666,
+          "required_file_recall": 1.0,
+          "result_file_count": 9,
+          "required_file_count": 2,
+          "failure_classes": [
+            "below_mrr_floor",
+            "rank_below_first"
+          ]
+        },
+        {
+          "task_id": "routing_mixed_cache",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.15384615384615385,
+          "f1_score": 0.2666666666666667,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 13,
+          "required_file_count": 2,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "routing_mixed_chunker",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.16666666666666666,
+          "f1_score": 0.2857142857142857,
+          "mrr": 0.5,
+          "required_file_recall": 1.0,
+          "result_file_count": 6,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "below_mrr_floor",
+            "rank_below_first",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "routing_pl_intent",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.017543859649122806,
+          "f1_score": 0.034482758620689655,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 57,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "routing_pl_large",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.017543859649122806,
+          "f1_score": 0.034482758620689655,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 57,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "routing_pl_path_symbol",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.020833333333333332,
+          "f1_score": 0.04081632653061225,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 48,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "routing_pl_scoring",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.07692307692307693,
+          "f1_score": 0.14285714285714288,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 26,
+          "required_file_count": 2,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "routing_pl_tight",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.14285714285714285,
+          "f1_score": 0.25,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 7,
+          "required_file_count": 1,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "routing_trace_api",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.03508771929824561,
+          "f1_score": 0.06779661016949151,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 57,
+          "required_file_count": 2,
+          "failure_classes": [
+            "below_precision_floor",
+            "below_f1_floor",
+            "broad_result_set"
+          ]
+        },
+        {
+          "task_id": "rust_tokio_runtime",
+          "family": "comprehension",
+          "recall": 1.0,
+          "precision": 0.17647058823529413,
+          "f1_score": 0.3,
+          "mrr": 1.0,
+          "required_file_recall": 1.0,
+          "result_file_count": 17,
+          "required_file_count": 3,
+          "failure_classes": [
+            "below_precision_floor",
+            "broad_result_set"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/archex/benchmark/ranking.py
+++ b/src/archex/benchmark/ranking.py
@@ -1,0 +1,121 @@
+"""Read file-ranking and result-set-noise evidence without consulting benchmark
+task oracles.
+
+Mirrors `archex.benchmark.coverage`: a report-only reader over fields that
+`archex benchmark run` already emits. It never loads benchmark tasks or
+expected-file definitions; it only classifies already-recorded gate metrics
+(recall, precision, F1, MRR) and file counts into a rank/noise failure
+taxonomy for M0.3 characterization.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from archex.benchmark.models import BenchmarkReport, Strategy, TaskFamily
+
+# "rank_below_first": every required file the task asks for is present
+# somewhere in the returned set (required_file_recall == 1.0), but the first
+# required file is not ranked first (mrr < 1.0). The result set is correct;
+# only its order is wrong.
+#
+# "broad_result_set": required-file recall clears the gate floor, but
+# precision does not -- the returned file set is dominated by files the task
+# never asked for. The order may or may not be correct; the set is too big.
+#
+# A task can carry both classes (recall is fine, first hit is not first, and
+# the set is also noisy) or neither (a pure coverage miss, out of M0.3 scope
+# and left to M0.2/M0.4).
+RANK_BELOW_FIRST = "rank_below_first"
+BROAD_RESULT_SET = "broad_result_set"
+BELOW_RECALL_FLOOR = "below_recall_floor"
+BELOW_PRECISION_FLOOR = "below_precision_floor"
+BELOW_F1_FLOOR = "below_f1_floor"
+BELOW_MRR_FLOOR = "below_mrr_floor"
+
+
+@dataclass(frozen=True)
+class RankNoiseObservation:
+    """Returned-file rank/noise evidence for one task and one benchmark strategy."""
+
+    task_id: str
+    strategy: Strategy
+    family: TaskFamily
+    required_file_recall: float
+    recall: float
+    precision: float
+    f1_score: float
+    mrr: float
+    result_file_count: int
+    required_file_count: int
+    failure_classes: tuple[str, ...]
+
+
+def read_rank_noise_observations(
+    reports: Iterable[BenchmarkReport],
+    strategy: Strategy,
+    *,
+    min_recall: float,
+    min_precision: float,
+    min_f1: float,
+    min_mrr: float,
+) -> list[RankNoiseObservation]:
+    """Return one rank/noise observation per report for *strategy*.
+
+    The reader uses only fields emitted in benchmark reports (recall,
+    precision, F1, MRR, required-file recall, and returned/required file
+    counts). It deliberately does not load benchmark tasks or expected-file
+    definitions.
+    """
+    rows: list[RankNoiseObservation] = []
+    seen_task_ids: set[str] = set()
+    for report in reports:
+        if report.task_id in seen_task_ids:
+            msg = f"Duplicate benchmark report task ID: {report.task_id}"
+            raise ValueError(msg)
+        seen_task_ids.add(report.task_id)
+        matches = [result for result in report.results if result.strategy is strategy]
+        if len(matches) != 1:
+            msg = (
+                f"Expected exactly one {strategy.value} result for {report.task_id}, "
+                f"found {len(matches)}"
+            )
+            raise ValueError(msg)
+        result = matches[0]
+        required_file_count = len(result.required_files_present) + len(
+            result.required_files_missing
+        )
+
+        classes: list[str] = []
+        if result.recall < min_recall:
+            classes.append(BELOW_RECALL_FLOOR)
+        if result.precision < min_precision:
+            classes.append(BELOW_PRECISION_FLOOR)
+        if result.f1_score < min_f1:
+            classes.append(BELOW_F1_FLOOR)
+        if result.mrr < min_mrr:
+            classes.append(BELOW_MRR_FLOOR)
+        if result.required_file_recall >= 1.0 and result.mrr < 1.0:
+            classes.append(RANK_BELOW_FIRST)
+        if result.required_file_recall >= min_recall and result.precision < min_precision:
+            classes.append(BROAD_RESULT_SET)
+
+        rows.append(
+            RankNoiseObservation(
+                task_id=report.task_id,
+                strategy=strategy,
+                family=result.family,
+                required_file_recall=result.required_file_recall,
+                recall=result.recall,
+                precision=result.precision,
+                f1_score=result.f1_score,
+                mrr=result.mrr,
+                result_file_count=len(result.result_files),
+                required_file_count=required_file_count,
+                failure_classes=tuple(classes),
+            )
+        )
+    return rows

--- a/tests/benchmark/test_ranking.py
+++ b/tests/benchmark/test_ranking.py
@@ -1,0 +1,242 @@
+"""Tests for benchmark file-ranking and result-set-noise evidence reading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from archex.benchmark.evidence import task_manifest_digest
+from archex.benchmark.models import BenchmarkReport, BenchmarkResult, Strategy, TaskFamily
+from archex.benchmark.ranking import (
+    BELOW_F1_FLOOR,
+    BELOW_MRR_FLOOR,
+    BELOW_PRECISION_FLOOR,
+    BELOW_RECALL_FLOOR,
+    BROAD_RESULT_SET,
+    RANK_BELOW_FIRST,
+    read_rank_noise_observations,
+)
+
+_GATE = {"min_recall": 0.60, "min_precision": 0.20, "min_f1": 0.30, "min_mrr": 0.55}
+
+
+def _result(
+    task_id: str,
+    strategy: Strategy,
+    *,
+    recall: float,
+    precision: float,
+    f1_score: float,
+    mrr: float,
+    required_file_recall: float,
+    result_files: list[str],
+    required_files_present: list[str],
+    required_files_missing: list[str],
+    family: TaskFamily = TaskFamily.COMPREHENSION,
+) -> BenchmarkResult:
+    return BenchmarkResult(
+        task_id=task_id,
+        strategy=strategy,
+        tokens_total=100,
+        tool_calls=1,
+        files_accessed=len(result_files),
+        recall=recall,
+        precision=precision,
+        f1_score=f1_score,
+        mrr=mrr,
+        savings_vs_raw=0.0,
+        wall_time_ms=10.0,
+        cached=True,
+        timestamp="2026-07-12T00:00:00+00:00",
+        result_files=result_files,
+        required_file_recall=required_file_recall,
+        required_files_present=required_files_present,
+        required_files_missing=required_files_missing,
+        family=family,
+    )
+
+
+def _report(task_id: str, result: BenchmarkResult) -> BenchmarkReport:
+    return BenchmarkReport(
+        task_id=task_id,
+        repo="owner/repo",
+        question="Where is the required file?",
+        results=[result],
+        baseline_tokens=100,
+    )
+
+
+def test_classifies_rank_below_first_when_required_file_present_but_not_first() -> None:
+    result = _result(
+        "rank_task",
+        Strategy.ARCHEX_QUERY,
+        recall=1.0,
+        precision=0.6,
+        f1_score=0.75,
+        mrr=0.5,
+        required_file_recall=1.0,
+        result_files=["a.py", "required.py", "c.py"],
+        required_files_present=["required.py"],
+        required_files_missing=[],
+    )
+
+    rows = read_rank_noise_observations(
+        [_report("rank_task", result)], Strategy.ARCHEX_QUERY, **_GATE
+    )
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert RANK_BELOW_FIRST in row.failure_classes
+    assert BROAD_RESULT_SET not in row.failure_classes
+    assert BELOW_MRR_FLOOR in row.failure_classes
+    assert BELOW_RECALL_FLOOR not in row.failure_classes
+    assert row.result_file_count == 3
+    assert row.required_file_count == 1
+
+
+def test_classifies_broad_result_set_when_precision_fails_despite_full_recall() -> None:
+    result = _result(
+        "noise_task",
+        Strategy.ARCHEX_QUERY,
+        recall=1.0,
+        precision=0.05,
+        f1_score=0.10,
+        mrr=1.0,
+        required_file_recall=1.0,
+        result_files=[f"n{i}.py" for i in range(20)] + ["required.py"],
+        required_files_present=["required.py"],
+        required_files_missing=[],
+    )
+
+    rows = read_rank_noise_observations(
+        [_report("noise_task", result)], Strategy.ARCHEX_QUERY, **_GATE
+    )
+
+    row = rows[0]
+    assert BROAD_RESULT_SET in row.failure_classes
+    assert RANK_BELOW_FIRST not in row.failure_classes
+    assert BELOW_PRECISION_FLOOR in row.failure_classes
+    assert BELOW_F1_FLOOR in row.failure_classes
+    assert row.result_file_count == 21
+    assert row.required_file_count == 1
+
+
+def test_classifies_neither_class_for_a_clean_pass() -> None:
+    result = _result(
+        "clean_task",
+        Strategy.ARCHEX_QUERY,
+        recall=1.0,
+        precision=1.0,
+        f1_score=1.0,
+        mrr=1.0,
+        required_file_recall=1.0,
+        result_files=["required.py"],
+        required_files_present=["required.py"],
+        required_files_missing=[],
+    )
+
+    rows = read_rank_noise_observations(
+        [_report("clean_task", result)], Strategy.ARCHEX_QUERY, **_GATE
+    )
+
+    assert rows[0].failure_classes == ()
+
+
+def test_classifies_neither_rank_class_for_a_pure_coverage_miss() -> None:
+    # required_file_recall below 1.0 -- this is a coverage problem (M0.2's
+    # scope), not a ranking/noise problem (M0.3's scope), and must not be
+    # mislabeled either way.
+    result = _result(
+        "coverage_miss_task",
+        Strategy.ARCHEX_QUERY,
+        recall=0.0,
+        precision=0.0,
+        f1_score=0.0,
+        mrr=0.0,
+        required_file_recall=0.0,
+        result_files=["unrelated.py"],
+        required_files_present=[],
+        required_files_missing=["required.py"],
+    )
+
+    rows = read_rank_noise_observations(
+        [_report("coverage_miss_task", result)], Strategy.ARCHEX_QUERY, **_GATE
+    )
+
+    row = rows[0]
+    assert RANK_BELOW_FIRST not in row.failure_classes
+    assert BROAD_RESULT_SET not in row.failure_classes
+    assert BELOW_RECALL_FLOOR in row.failure_classes
+
+
+def test_rejects_report_without_requested_strategy() -> None:
+    result = _result(
+        "task",
+        Strategy.RAW_FILES,
+        recall=1.0,
+        precision=1.0,
+        f1_score=1.0,
+        mrr=1.0,
+        required_file_recall=1.0,
+        result_files=["a.py"],
+        required_files_present=["a.py"],
+        required_files_missing=[],
+    )
+    with pytest.raises(ValueError, match="Expected exactly one archex_query result"):
+        read_rank_noise_observations([_report("task", result)], Strategy.ARCHEX_QUERY, **_GATE)
+
+
+def test_rejects_duplicate_report_task_ids() -> None:
+    result = _result(
+        "dup_task",
+        Strategy.ARCHEX_QUERY,
+        recall=1.0,
+        precision=1.0,
+        f1_score=1.0,
+        mrr=1.0,
+        required_file_recall=1.0,
+        result_files=["a.py"],
+        required_files_present=["a.py"],
+        required_files_missing=[],
+    )
+    reports = [_report("dup_task", result), _report("dup_task", result)]
+
+    with pytest.raises(ValueError, match="Duplicate benchmark report task ID"):
+        read_rank_noise_observations(reports, Strategy.ARCHEX_QUERY, **_GATE)
+
+
+def test_control_ranking_artifact_characterizes_seventeen_rank_noise_tasks() -> None:
+    root = Path(__file__).parents[2]
+    artifact = root / "benchmarks" / "evidence" / "m0.3-control-ranking.json"
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+
+    assert payload["task_manifest_digest"] == task_manifest_digest(root / "benchmarks" / "tasks")
+    assert payload["gate_thresholds"] == _GATE
+
+    by_strategy = {block["strategy"]: block for block in payload["strategies"]}
+    assert set(by_strategy) == {
+        Strategy.ARCHEX_QUERY.value,
+        Strategy.ARCHEX_QUERY_COVERAGE_CANDIDATE.value,
+    }
+
+    control = by_strategy[Strategy.ARCHEX_QUERY.value]
+    assert len(control["tasks"]) == 17
+    assert control["rank_below_first_count"] + control["broad_result_set_count"] >= 17
+    for observation in control["tasks"]:
+        classes = set(observation["failure_classes"])
+        assert classes & {RANK_BELOW_FIRST, BROAD_RESULT_SET}
+        if RANK_BELOW_FIRST in classes:
+            assert observation["required_file_recall"] >= 1.0
+        if BROAD_RESULT_SET in classes:
+            assert observation["required_file_recall"] >= _GATE["min_recall"]
+            assert observation["precision"] < _GATE["min_precision"]
+
+    # The M0.2 coverage candidate is M0.3's declared input: it recovers
+    # required-file coverage but, unmodified, makes rank/noise worse (more
+    # flagged tasks) by always admitting a flat 32-seed/24-neighbor budget
+    # regardless of whether the base query already found the file. This is
+    # exactly the defect M0.3 must repair without discarding M0.2's recall.
+    candidate = by_strategy[Strategy.ARCHEX_QUERY_COVERAGE_CANDIDATE.value]
+    assert len(candidate["tasks"]) > len(control["tasks"])


### PR DESCRIPTION
## Stack

Stack-Id: `m03-rank-noise-recovery-20260712`
Base: `main`
Position: 1/4

1. `m03-ranking-noise-characterization` → this PR
2. `m03-direct-evidence-rank` → #507
3. `m03-localization-presentation` → #508
4. `m03-corpus-mutation-proof` → #509

Depends on: none
Upstack: #507

## Summary

Adds `archex.benchmark.ranking`, a report-only reader over already-emitted
`BenchmarkResult` fields (recall/precision/F1/MRR, required-file recall,
returned/required file counts). It classifies each task into a rank/noise
failure taxonomy without loading benchmark tasks or expected-file
definitions:

- `rank_below_first`: every required file is present in the returned set
  (`required_file_recall == 1.0`) but the first required file is not ranked
  first (`mrr < 1.0`).
- `broad_result_set`: required-file recall clears the gate floor but
  precision does not — the returned set is dominated by files the task
  never asked for.

Records a fresh, real 64-task local run
(`benchmarks/evidence/m0.3-control-ranking.json`, source revision
`bb71b668fe89750d278f59171fa56dc4c1839dac`) characterizing both the
product default (`archex_query`: **17 rank/noise tasks**, matching the
milestone's declared target count exactly) and the M0.2 coverage candidate
that M0.3 takes as its input (`archex_query_coverage_candidate`: **43
rank/noise tasks**). The coverage candidate recovers required-file
coverage but, unmodified, makes rank/noise *worse* by always admitting a
flat 32-seed/24-neighbor budget regardless of whether the base query
already found the file — this is the defect the rest of this stack
repairs.

`archex_query` remains unchanged.

## Validation

- `uv run ruff check src/archex/benchmark/ranking.py tests/benchmark/test_ranking.py` — passed
- `uv run ruff format --check src/archex/benchmark/ranking.py tests/benchmark/test_ranking.py` — passed
- `uv run pyright src/archex/benchmark/ranking.py tests/benchmark/test_ranking.py` — 0 errors
- `uv run pytest --no-cov tests/benchmark/test_ranking.py` — 7 passed
- `uv run pytest --no-cov tests/benchmark/` — 743 passed, 5 deselected (full-suite regression check)

## Scope

Benchmark-only characterization and evidence reading. No candidate policy,
production-default, score-weight, task-oracle runtime, or gate change.
