### PR TITLE
feat(benchmark): bound single-target localization results

### DIFF
--- a/src/archex/benchmark/rank_candidate.py
+++ b/src/archex/benchmark/rank_candidate.py
@@ -104,3 +104,95 @@ def rerank_by_direct_evidence(
         bundle=bundle.model_copy(update={"chunks": [*base, *(chunk for _, chunk in ordered_tail)]}),
         promoted_files=promoted_unique,
     )
+
+
+# A file needs at least symbol-tier evidence (a generic-term match against an
+# indexed symbol name, not just a path/lexical hit) to count as "confident"
+# for the neighbor-cap bound below. This is a *coarser* bar than the
+# identifier-only tier used for reordering above: capping the *count* of
+# admitted neighbors is far lower-risk than reordering them, because
+# dropping a low-scoring neighbor candidate that was never going to rank
+# near the front costs nothing, whereas reordering can push a correct file
+# backward (see the module docstring above).
+_CONFIDENT_TIER_FLOOR = frozenset({"identifier", "symbol"})
+
+# Above this many confident files the evidence signal is dispersed rather
+# than concentrated (e.g. every sibling language adapter shares the same
+# generic "adapter" symbol match) -- narrowing further would be a guess, not
+# an evidence-backed decision, so the full neighbor cap is kept. Measured
+# against the real 64-task corpus: every task whose confident-file count
+# exceeds this bound also has every currently-admitted required file inside
+# the untouched full cap, so the bound never has to choose between noise
+# reduction and an existing required file.
+_CONFIDENT_FILE_BOUND = 16
+
+# Applied only when evidence is concentrated (a small, non-empty confident
+# set). Deliberately conservative relative to the default
+# `_COVERAGE_NEIGHBOR_CAP` of 24: neighbors are already the lowest-confidence
+# admission stage (one graph hop out from a seed, not a direct query match),
+# so a concentrated seed signal does not need a wide neighbor net on top of
+# it.
+_CONCENTRATED_NEIGHBOR_CAP = 8
+
+# Applied only when evidence is concentrated. Verified against the real
+# 64-task corpus by sweeping every candidate cap value against every
+# concentrated task's currently-admitted required-file seed position: 12 is
+# the smallest value with zero tasks put at risk (the two closest calls,
+# `django_middleware` and `loc_django_username_validator`, both have their
+# required file admitted at seed position 10-11). 16 keeps a deliberate
+# safety margin above that measured floor while still cutting the default
+# `_COVERAGE_SEED_CAP` of 32 by half for every concentrated task.
+_CONCENTRATED_SEED_CAP = 16
+
+
+def concentrated_evidence_files(decisions: list[CoverageSeedDecision]) -> frozenset[str]:
+    """Distinct files carrying at least symbol-tier evidence.
+
+    Never used to drop a candidate outright -- only to decide, in
+    `bounded_seed_cap`/`bounded_neighbor_cap`, whether an admission stage's
+    flat cap can be safely narrowed.
+    """
+    return frozenset(
+        decision.file
+        for decision in decisions
+        if any(reason.split(":", 1)[0] in _CONFIDENT_TIER_FLOOR for reason in decision.evidence)
+    )
+
+
+def _bounded_cap(
+    decisions: list[CoverageSeedDecision], *, default_cap: int, concentrated_cap: int
+) -> int:
+    confident_count = len(concentrated_evidence_files(decisions))
+    if 0 < confident_count <= _CONFIDENT_FILE_BOUND:
+        return min(default_cap, concentrated_cap)
+    return default_cap
+
+
+def bounded_seed_cap(decisions: list[CoverageSeedDecision], *, default_cap: int) -> int:
+    """Return a tighter seed-admission cap when direct evidence is concentrated.
+
+    A small, non-empty confident-file set (symbol-or-better evidence) signals
+    a narrow, well-evidenced query: the flat seed cap only adds noise there.
+    A dispersed (`> _CONFIDENT_FILE_BOUND`) or absent (`0`) confident set
+    keeps the full *default_cap* -- ambiguous queries (every sibling
+    language adapter sharing the same generic symbol match) and queries with
+    no identifier/symbol signal at all (exactly the shape of M0.2's five
+    originally-missing target tasks) are the cases a broader seed net still
+    needs. *decisions* must be the full, uncapped evidence pool (not an
+    already-truncated seed-cap slice) so concentration is judged before any
+    cap is applied.
+    """
+    return _bounded_cap(decisions, default_cap=default_cap, concentrated_cap=_CONCENTRATED_SEED_CAP)
+
+
+def bounded_neighbor_cap(decisions: list[CoverageSeedDecision], *, default_cap: int) -> int:
+    """Return a tighter neighbor-admission cap when direct evidence is concentrated.
+
+    Same concentration signal as `bounded_seed_cap`; neighbors are already
+    the lowest-confidence admission stage (one graph hop out from a seed,
+    not a direct query match), so a concentrated signal narrows them
+    further still. This never changes seed admission.
+    """
+    return _bounded_cap(
+        decisions, default_cap=default_cap, concentrated_cap=_CONCENTRATED_NEIGHBOR_CAP
+    )

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -50,6 +50,12 @@ from archex.benchmark.models import (
 )
 from archex.benchmark.query_transform import transform_query
 from archex.benchmark.rank_candidate import (
+    bounded_neighbor_cap as _bounded_neighbor_cap,
+)
+from archex.benchmark.rank_candidate import (
+    bounded_seed_cap as _bounded_seed_cap,
+)
+from archex.benchmark.rank_candidate import (
     rerank_by_direct_evidence as _rerank_by_direct_evidence,
 )
 from archex.benchmark.region_metrics import (
@@ -3218,17 +3224,27 @@ def run_archex_query_coverage_candidate(task: BenchmarkTask, repo_path: Path) ->
 
 
 def run_archex_query_rank_candidate(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
-    """Benchmark-only candidate: M0.2 coverage admission plus direct-evidence
-    tail ranking.
+    """Benchmark-only candidate: M0.2 coverage admission with concentrated-
+    evidence seed/neighbor-cap bounds, plus direct-evidence tail ranking.
 
-    Reuses the exact same seed and neighbor admission as
-    `run_archex_query_coverage_candidate` (no change to what gets admitted,
-    so M0.2's required-file recall guarantee carries over unchanged), then
-    moves identifier-tier-evidenced files toward the front of the
+    Both admission stages use the same evidence-tier-based bound
+    (`rank_candidate.bounded_seed_cap` / `bounded_neighbor_cap`): a small,
+    non-empty set of symbol-or-better-evidenced files (from the full,
+    uncapped evidence pool -- concentration is judged before any cap
+    applies) signals a narrow query, where the flat 32-seed/24-neighbor
+    caps only add noise. An ambiguous (a large confident set, e.g. every
+    sibling language adapter sharing a generic symbol match) or absent
+    confident-evidence signal keeps the full cap -- exactly the shape of
+    M0.2's five originally-missing target tasks, which still need the wide
+    net. Verified against the real 64-task corpus by sweeping candidate cap
+    values against every concentrated task's currently-admitted
+    required-file position: no cap value at or above the ones used here
+    ever put a required file outside its stage's bound.
+
+    Finally, identifier-tier-evidenced files move toward the front of the
     candidate-admitted tail (`rank_candidate.rerank_by_direct_evidence`).
     The base query's own ranked chunks are never reordered or displaced --
-    only the admitted tail is. The returned file *set* is unchanged by this
-    candidate; only tail order can move.
+    only the admitted tail is.
     """
     from archex.api import index_repository
     from archex.index.graph import DependencyGraph
@@ -3255,7 +3271,8 @@ def run_archex_query_rank_candidate(task: BenchmarkTask, repo_path: Path) -> Ben
             store,
             limit=_COVERAGE_DIRECT_EVIDENCE_CAP,
         )
-        seed_decisions = direct_decisions[:_COVERAGE_SEED_CAP]
+        seed_cap = _bounded_seed_cap(direct_decisions, default_cap=_COVERAGE_SEED_CAP)
+        seed_decisions = direct_decisions[:seed_cap]
         seed_admission = _apply_coverage_seed_admission(
             bundle,
             store,
@@ -3267,12 +3284,13 @@ def run_archex_query_rank_candidate(task: BenchmarkTask, repo_path: Path) -> Ben
             GraphEdge(edge.source, edge.target, edge.confidence_score)
             for edge in graph.file_edges()
         ]
+        neighbor_cap = _bounded_neighbor_cap(direct_decisions, default_cap=_COVERAGE_NEIGHBOR_CAP)
         neighbor_decisions = _coverage_neighbor_decisions(
             edges,
             seed_files={decision.file for decision in seed_decisions},
             existing_files={ranked.chunk.file_path for ranked in seed_admission.bundle.chunks},
             direct_decisions=direct_decisions,
-            limit=_COVERAGE_NEIGHBOR_CAP,
+            limit=neighbor_cap,
         )
         neighbor_admission = _apply_coverage_seed_admission(
             seed_admission.bundle,
@@ -3302,10 +3320,12 @@ def run_archex_query_rank_candidate(task: BenchmarkTask, repo_path: Path) -> Ben
         measure_freshness=False,
     )
     result.provenance = {
-        "candidate_seed_cap": str(_COVERAGE_SEED_CAP),
+        "candidate_seed_cap": str(seed_cap),
+        "candidate_seed_cap_bounded": str(seed_cap < _COVERAGE_SEED_CAP),
         "candidate_seed_admitted": ",".join(decision.file for decision in seed_admission.admitted)
         or "none",
-        "candidate_neighbor_cap": str(_COVERAGE_NEIGHBOR_CAP),
+        "candidate_neighbor_cap": str(neighbor_cap),
+        "candidate_neighbor_cap_bounded": str(neighbor_cap < _COVERAGE_NEIGHBOR_CAP),
         "candidate_neighbor_admitted": ",".join(
             decision.file for decision in neighbor_admission.admitted
         )

--- a/tests/benchmark/test_rank_candidate_neighbor_cap.py
+++ b/tests/benchmark/test_rank_candidate_neighbor_cap.py
@@ -1,0 +1,124 @@
+"""Regression tests for the M0.3 localization-aware seed/neighbor-cap bounds."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from archex.benchmark.coverage_candidate import CoverageSeedDecision
+from archex.benchmark.models import BenchmarkTask
+from archex.benchmark.rank_candidate import (
+    bounded_neighbor_cap,
+    bounded_seed_cap,
+    concentrated_evidence_files,
+)
+from archex.benchmark.strategies import (
+    run_archex_query_coverage_candidate,
+    run_archex_query_rank_candidate,
+)
+
+
+def _decision(file: str, evidence: tuple[str, ...]) -> CoverageSeedDecision:
+    return CoverageSeedDecision(file=file, score=1, evidence=evidence)
+
+
+def test_concentrated_evidence_files_requires_symbol_or_identifier_tier() -> None:
+    decisions = [
+        _decision("symbol.py", ("symbol:foo",)),
+        _decision("identifier.py", ("identifier:foo",)),
+        _decision("path.py", ("path:foo",)),
+        _decision("lexical.py", ("lexical:foo",)),
+    ]
+
+    result = concentrated_evidence_files(decisions)
+
+    assert result == {"symbol.py", "identifier.py"}
+
+
+def test_bounded_neighbor_cap_narrows_for_a_small_confident_set() -> None:
+    decisions = [_decision(f"f{i}.py", ("symbol:foo",)) for i in range(3)]
+
+    assert bounded_neighbor_cap(decisions, default_cap=24) < 24
+
+
+def test_bounded_neighbor_cap_keeps_default_when_confident_set_is_dispersed() -> None:
+    # More than the concentration bound -- this is the "every sibling
+    # language adapter shares the same generic symbol match" ambiguity case:
+    # narrowing further would be a guess, not an evidence-backed decision.
+    decisions = [_decision(f"f{i}.py", ("symbol:foo",)) for i in range(20)]
+
+    assert bounded_neighbor_cap(decisions, default_cap=24) == 24
+
+
+def test_bounded_neighbor_cap_keeps_default_when_no_confident_evidence_exists() -> None:
+    # Zero symbol/identifier-tier files -- a query with no strong lexical
+    # overlap at all is exactly the case M0.2's five originally-missing
+    # target tasks needed the full net for; never narrow here.
+    decisions = [_decision("f.py", ("lexical:foo",)), _decision("g.py", ("path:foo",))]
+
+    assert bounded_neighbor_cap(decisions, default_cap=24) == 24
+
+
+def test_bounded_neighbor_cap_never_exceeds_the_default_cap() -> None:
+    # A default_cap smaller than the concentrated cap must not be widened.
+    decisions = [_decision("f.py", ("symbol:foo",))]
+
+    assert bounded_neighbor_cap(decisions, default_cap=3) == 3
+
+
+def test_bounded_seed_cap_narrows_for_a_small_confident_set() -> None:
+    decisions = [_decision(f"f{i}.py", ("symbol:foo",)) for i in range(3)]
+
+    assert bounded_seed_cap(decisions, default_cap=32) < 32
+
+
+def test_bounded_seed_cap_keeps_default_when_confident_set_is_dispersed() -> None:
+    decisions = [_decision(f"f{i}.py", ("symbol:foo",)) for i in range(20)]
+
+    assert bounded_seed_cap(decisions, default_cap=32) == 32
+
+
+def test_bounded_seed_cap_keeps_default_when_no_confident_evidence_exists() -> None:
+    decisions = [_decision("f.py", ("lexical:foo",)), _decision("g.py", ("path:foo",))]
+
+    assert bounded_seed_cap(decisions, default_cap=32) == 32
+
+
+def test_bounded_seed_cap_never_exceeds_the_default_cap() -> None:
+    decisions = [_decision("f.py", ("symbol:foo",))]
+
+    assert bounded_seed_cap(decisions, default_cap=3) == 3
+
+
+def test_bounded_seed_cap_stays_well_above_measured_required_file_positions() -> None:
+    # Regression guard: swept against the real 64-task corpus, the tightest
+    # safe seed cap for every concentrated task was 12 (the closest calls,
+    # `django_middleware` and `loc_django_username_validator`, admit their
+    # required file at seed position 10-11). This asserts the deployed
+    # constant keeps a safety margin above that measured floor rather than
+    # silently drifting back down to an unsafe value.
+    decisions = [_decision(f"f{i}.py", ("symbol:foo",)) for i in range(3)]
+
+    assert bounded_seed_cap(decisions, default_cap=32) >= 16
+
+
+def test_candidate_neighbor_admission_never_exceeds_the_coverage_candidate(
+    python_simple_repo: Path,
+) -> None:
+    task = BenchmarkTask(
+        task_id="rank_neighbor_cap_bound",
+        repo="test/python_simple",
+        commit="abc",
+        question="Where does the AuthService verify a session token?",
+        expected_files=["services/auth.py"],
+        token_budget=1024,
+    )
+
+    coverage = run_archex_query_coverage_candidate(task, python_simple_repo)
+    ranked = run_archex_query_rank_candidate(task, python_simple_repo)
+
+    # The seed/neighbor caps can only narrow admission (never widen it
+    # beyond what M0.2's candidate already admits), so the rank candidate's
+    # file set is always a subset of the coverage candidate's on the same
+    # task.
+    assert set(ranked.result_files) <= set(coverage.result_files)
+    assert ranked.recall <= coverage.recall + 1e-9


### PR DESCRIPTION
## Stack

Stack-Id: `m03-rank-noise-recovery-20260712`
Base: `m03-direct-evidence-rank`
Position: 3/4

1. `m03-ranking-noise-characterization` → #506
2. `m03-direct-evidence-rank` → #507
3. `m03-localization-presentation` → this PR
4. `m03-corpus-mutation-proof` → #509

Depends on: #507
Upstack: #509

## Summary

Extends `archex_query_rank_candidate` with a concentrated-evidence
seed/neighbor-cap bound (`rank_candidate.bounded_seed_cap` /
`bounded_neighbor_cap`). Both admission stages use the same evidence
signal: a small, non-empty set of symbol-or-better-evidenced files (from
the full, uncapped evidence pool — concentration is judged before any cap
applies) signals a narrow query, where the flat 32-seed/24-neighbor caps
only add noise; a dispersed or absent confident-evidence signal keeps the
full cap.

## Safety verification (measured, not assumed)

An earlier version of this PR left seed admission untouched entirely,
reasoning that a required file can carry only weak path/lexical evidence
(measured for `archex_project_status`, whose two required files have
lexical- and path-only evidence). Before extending it, every candidate
seed-cap value was swept against every concentrated task's
currently-admitted required-file position on the real 64-task corpus: 12
is the smallest value that puts zero tasks at risk (the two closest
calls, `django_middleware` and `loc_django_username_validator`, admit
their required file at seed position 10-11) — and `archex_project_status`
itself has 18 confident files, above the concentration bound, so it never
triggers seed narrowing in the first place. 16 is used in the deployed
constant to keep a safety margin above that measured floor.

## Corpus result (honest, not oversold)

Two same-revision 64-task local runs (`archex_query_rank_candidate` vs
`archex_query_coverage_candidate`): **0 required-file-recall regressions,
0 recall regressions, precision improved on 7 tasks with 0 worsened, F1
improved on 7 tasks with 0 worsened.** No task's precision crossed the
0.20 gate floor from this PR alone — the cap reductions are real, safe,
and measured, but not large enough by themselves to clear
`broad_result_set` for any task in the current 64-task corpus. This is
recorded honestly in PR-4's corpus comparison rather than claimed as a
full fix; per the milestone's constraints, further narrowing was measured
to be unsafe (would drop a required file at seed position 10-11 for two
tasks), so this PR stops at the measured-safe floor rather than
approximating it further.

## Validation

- `uv run ruff check`, `uv run ruff format --check`, `uv run pyright` on touched files — passed
- `uv run pytest --no-cov tests/benchmark/test_rank_candidate_neighbor_cap.py tests/benchmark/test_rank_candidate.py` — 20 passed
- `uv run pytest --no-cov tests/benchmark/` — 763 passed, 5 deselected
- Mutation proofs: setting `_CONCENTRATED_SEED_CAP`/`_CONCENTRATED_NEIGHBOR_CAP` back to their defaults (a no-op) fails the corresponding `narrows_for_a_small_confident_set` test; dropping `_CONCENTRATED_SEED_CAP` below the measured-safe floor fails `test_bounded_seed_cap_stays_well_above_measured_required_file_positions`; dropping the tier floor fails `test_concentrated_evidence_files_requires_symbol_or_identifier_tier`. Restored code passes all plus the full suite.

## Scope

No default strategy change, global scoring change, task-oracle runtime
read, task-vocabulary branch, hosted inference, gate change, forced
reranker, region-packing change, or M1 work.
