### PR TITLE
test(benchmark): verify ranking candidate frontier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **M0.3: deterministic ranking and result-set recovery candidate.** Adds a benchmark-only `archex_query_rank_candidate` lane, built on M0.2's coverage candidate, that reorders identifier-tier-evidenced files toward the front of the candidate-admitted tail (the base query's own ranking is never displaced) and bounds the seed/neighbor admission caps when direct evidence is concentrated. Two same-revision 64-task local runs show zero required-file-recall regressions, M0.2's five-target coverage fully preserved, and measured (if modest) precision/F1 gains with zero regressions on any task. `archex_query` remains unchanged; the candidate is retained as evidence for M0.4, not promoted.
+
+
 ## [0.19.2] - 2026-07-11
 
 ### Fixed

--- a/benchmarks/evidence/m0.3-corpus-comparison.json
+++ b/benchmarks/evidence/m0.3-corpus-comparison.json
@@ -1,0 +1,1360 @@
+{
+  "schema_version": 1,
+  "milestone": "M0.3",
+  "source_revision": "ddff2b88b70ce6bf1e0a75a4c045a864e9c2529d",
+  "task_manifest_digest": "0ae42fb18f96678b5e79591be8372d83fbeed646c4c08e7cc0f118eba4c2bd09",
+  "gate_thresholds": {
+    "min_recall": 0.6,
+    "min_precision": 0.2,
+    "min_f1": 0.3,
+    "min_mrr": 0.55
+  },
+  "runs": {
+    "candidate_run_21": {
+      "strategy": "archex_query_rank_candidate",
+      "generated_at": "2026-07-11T22:52:36.525469+00:00"
+    },
+    "candidate_run_22": {
+      "strategy": "archex_query_rank_candidate",
+      "generated_at": "2026-07-11T23:05:35.233966+00:00"
+    },
+    "control_run_21": {
+      "strategy": "archex_query_coverage_candidate",
+      "generated_at": "2026-07-11T22:52:36.525469+00:00"
+    },
+    "control_run_22": {
+      "strategy": "archex_query_coverage_candidate",
+      "generated_at": "2026-07-11T23:05:35.233966+00:00"
+    }
+  },
+  "repeat_stability": {
+    "candidate_result_differences_across_repeat": [],
+    "control_result_differences_across_repeat": []
+  },
+  "required_file_regressions": [],
+  "m02_target_task_recovery": [
+    {
+      "task_id": "archex_adapter_registry",
+      "run21_required_file_recall": 1.0,
+      "run22_required_file_recall": 1.0
+    },
+    {
+      "task_id": "archex_project_status",
+      "run21_required_file_recall": 1.0,
+      "run22_required_file_recall": 1.0
+    },
+    {
+      "task_id": "django_middleware",
+      "run21_required_file_recall": 1.0,
+      "run22_required_file_recall": 1.0
+    },
+    {
+      "task_id": "loc_django_username_validator",
+      "run21_required_file_recall": 1.0,
+      "run22_required_file_recall": 1.0
+    },
+    {
+      "task_id": "routing_pl_scoring",
+      "run21_required_file_recall": 1.0,
+      "run22_required_file_recall": 1.0
+    }
+  ],
+  "aggregate": {
+    "candidate": {
+      "n_tasks": 64,
+      "mean_precision": 0.2232,
+      "mean_mrr": 0.8319,
+      "mean_f1": 0.3292,
+      "mean_required_file_recall": 0.9906,
+      "rank_below_first_count": 16,
+      "broad_result_set_count": 38
+    },
+    "control": {
+      "n_tasks": 64,
+      "mean_precision": 0.22,
+      "mean_mrr": 0.8319,
+      "mean_f1": 0.3238,
+      "mean_required_file_recall": 0.9906,
+      "rank_below_first_count": 16,
+      "broad_result_set_count": 38
+    },
+    "archex_query_default": {
+      "n_tasks": 64,
+      "mean_precision": 0.4244,
+      "mean_mrr": 0.8309,
+      "mean_f1": 0.5372,
+      "mean_required_file_recall": 0.9141,
+      "rank_below_first_count": 14,
+      "broad_result_set_count": 9
+    }
+  },
+  "family_breakdown": {
+    "self_repo": {
+      "candidate": {
+        "n_tasks": 24,
+        "mean_precision": 0.1549,
+        "mean_mrr": 0.9792,
+        "mean_f1": 0.2311,
+        "mean_required_file_recall": 0.975,
+        "rank_below_first_count": 1,
+        "broad_result_set_count": 20
+      },
+      "control": {
+        "n_tasks": 24,
+        "mean_precision": 0.1484,
+        "mean_mrr": 0.9792,
+        "mean_f1": 0.2203,
+        "mean_required_file_recall": 0.975,
+        "rank_below_first_count": 1,
+        "broad_result_set_count": 20
+      }
+    },
+    "external_comprehension": {
+      "candidate": {
+        "n_tasks": 19,
+        "mean_precision": 0.3177,
+        "mean_mrr": 0.8246,
+        "mean_f1": 0.4677,
+        "mean_required_file_recall": 1.0,
+        "rank_below_first_count": 5,
+        "broad_result_set_count": 5
+      },
+      "control": {
+        "n_tasks": 19,
+        "mean_precision": 0.3166,
+        "mean_mrr": 0.8246,
+        "mean_f1": 0.4661,
+        "mean_required_file_recall": 1.0,
+        "rank_below_first_count": 5,
+        "broad_result_set_count": 5
+      }
+    },
+    "localization": {
+      "candidate": {
+        "n_tasks": 21,
+        "mean_precision": 0.2158,
+        "mean_mrr": 0.6701,
+        "mean_f1": 0.3159,
+        "mean_required_file_recall": 1.0,
+        "rank_below_first_count": 10,
+        "broad_result_set_count": 13
+      },
+      "control": {
+        "n_tasks": 21,
+        "mean_precision": 0.2143,
+        "mean_mrr": 0.6701,
+        "mean_f1": 0.3132,
+        "mean_required_file_recall": 1.0,
+        "rank_below_first_count": 10,
+        "broad_result_set_count": 13
+      }
+    }
+  },
+  "rows": [
+    {
+      "task_id": "archex_adapter_registry",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.05357142857142857,
+      "control_precision": 0.05357142857142857,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "archex_benchmark_gate_lifecycle",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.5,
+      "control_precision": 0.5,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 0.8,
+      "control_required_file_recall": 0.8,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "archex_delta_index_lifecycle",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.15789473684210525,
+      "control_precision": 0.15789473684210525,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "archex_delta_indexing",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.06060606060606061,
+      "control_precision": 0.06060606060606061,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "archex_graph_expansion",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.09090909090909091,
+      "control_precision": 0.09090909090909091,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "archex_mcp_query_lifecycle",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.8333333333333334,
+      "control_precision": 0.8333333333333334,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "archex_pattern_detection",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.034482758620689655,
+      "control_precision": 0.034482758620689655,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "archex_project_config_resolution",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.07017543859649122,
+      "control_precision": 0.07017543859649122,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "archex_project_index",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.08771929824561403,
+      "control_precision": 0.08771929824561403,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "archex_project_init",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.16,
+      "control_precision": 0.07017543859649122,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "archex_project_reset",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.12,
+      "control_precision": 0.05357142857142857,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "archex_project_status",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.07017543859649122,
+      "control_precision": 0.07017543859649122,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "archex_query_cache_lifecycle",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.20833333333333334,
+      "control_precision": 0.20833333333333334,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "archex_query_pipeline",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.058823529411764705,
+      "control_precision": 0.058823529411764705,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "archex_scoring",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.5,
+      "control_precision": 0.5,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "archex_vector_cache_lifecycle",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.06521739130434782,
+      "control_precision": 0.06521739130434782,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 0.6,
+      "control_required_file_recall": 0.6,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "celery_task_dispatch",
+      "family": "comprehension",
+      "category": "external-large",
+      "candidate_precision": 0.16666666666666666,
+      "control_precision": 0.16666666666666666,
+      "candidate_mrr": 0.5,
+      "control_mrr": 0.5,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "click_decorators",
+      "family": "comprehension",
+      "category": "external-framework",
+      "candidate_precision": 0.1875,
+      "control_precision": 0.1875,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "django_middleware",
+      "family": "comprehension",
+      "category": "architecture-broad",
+      "candidate_precision": 0.15,
+      "control_precision": 0.15,
+      "candidate_mrr": 0.3333333333333333,
+      "control_mrr": 0.3333333333333333,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "django_orm_queries",
+      "family": "comprehension",
+      "category": "external-large",
+      "candidate_precision": 0.3333333333333333,
+      "control_precision": 0.3333333333333333,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "express_error_handling",
+      "family": "comprehension",
+      "category": "architecture-broad",
+      "candidate_precision": 0.2727272727272727,
+      "control_precision": 0.2727272727272727,
+      "candidate_mrr": 0.3333333333333333,
+      "control_mrr": 0.3333333333333333,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_mrr_floor",
+        "rank_below_first"
+      ],
+      "control_failure_classes": [
+        "below_mrr_floor",
+        "rank_below_first"
+      ]
+    },
+    {
+      "task_id": "express_middleware",
+      "family": "comprehension",
+      "category": "framework-semantic",
+      "candidate_precision": 0.2727272727272727,
+      "control_precision": 0.2727272727272727,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "fastapi_dependency_injection",
+      "family": "comprehension",
+      "category": "framework-semantic",
+      "candidate_precision": 0.23076923076923078,
+      "control_precision": 0.23076923076923078,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "fastapi_routing",
+      "family": "comprehension",
+      "category": "external-framework",
+      "candidate_precision": 0.6,
+      "control_precision": 0.6,
+      "candidate_mrr": 0.3333333333333333,
+      "control_mrr": 0.3333333333333333,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_mrr_floor",
+        "rank_below_first"
+      ],
+      "control_failure_classes": [
+        "below_mrr_floor",
+        "rank_below_first"
+      ]
+    },
+    {
+      "task_id": "flask_blueprints",
+      "family": "comprehension",
+      "category": "external-framework",
+      "candidate_precision": 0.42857142857142855,
+      "control_precision": 0.42857142857142855,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "gin_routing",
+      "family": "comprehension",
+      "category": "external-framework",
+      "candidate_precision": 0.5,
+      "control_precision": 0.5,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "go_gin_middleware",
+      "family": "comprehension",
+      "category": "architecture-broad",
+      "candidate_precision": 0.42857142857142855,
+      "control_precision": 0.42857142857142855,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "httpx_pooling",
+      "family": "comprehension",
+      "category": "external-framework",
+      "candidate_precision": 0.5,
+      "control_precision": 0.5,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "loc_celery_task_retry",
+      "family": "localization",
+      "category": "external-large",
+      "candidate_precision": 0.16666666666666666,
+      "control_precision": 0.16666666666666666,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "loc_click_param_process",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.09090909090909091,
+      "control_precision": 0.09090909090909091,
+      "candidate_mrr": 0.3333333333333333,
+      "control_mrr": 0.3333333333333333,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "loc_django_queryset_filter",
+      "family": "localization",
+      "category": "external-large",
+      "candidate_precision": 0.16666666666666666,
+      "control_precision": 0.16666666666666666,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "loc_django_username_validator",
+      "family": "localization",
+      "category": "external-large",
+      "candidate_precision": 0.05555555555555555,
+      "control_precision": 0.030303030303030304,
+      "candidate_mrr": 0.0625,
+      "control_mrr": 0.0625,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "loc_express_error_middleware",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.2,
+      "control_precision": 0.2,
+      "candidate_mrr": 0.5,
+      "control_mrr": 0.5,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_mrr_floor",
+        "rank_below_first"
+      ],
+      "control_failure_classes": [
+        "below_mrr_floor",
+        "rank_below_first"
+      ]
+    },
+    {
+      "task_id": "loc_fastapi_jsonable_encoder",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.1111111111111111,
+      "control_precision": 0.1111111111111111,
+      "candidate_mrr": 0.3333333333333333,
+      "control_mrr": 0.3333333333333333,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "loc_fastapi_solve_dependencies",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.5,
+      "control_precision": 0.5,
+      "candidate_mrr": 0.5,
+      "control_mrr": 0.5,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_mrr_floor",
+        "rank_below_first"
+      ],
+      "control_failure_classes": [
+        "below_mrr_floor",
+        "rank_below_first"
+      ]
+    },
+    {
+      "task_id": "loc_flask_blueprint_register",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.08333333333333333,
+      "control_precision": 0.08333333333333333,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "loc_flask_full_dispatch",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.1,
+      "control_precision": 0.1,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "loc_gin_context_next",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.25,
+      "control_precision": 0.25,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "loc_gin_tree_route",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.25,
+      "control_precision": 0.25,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "loc_httpx_pool_transport",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.058823529411764705,
+      "control_precision": 0.058823529411764705,
+      "candidate_mrr": 0.2,
+      "control_mrr": 0.2,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "loc_httpx_redirect_headers",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.1111111111111111,
+      "control_precision": 0.1111111111111111,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "loc_mini_redis_command_from_frame",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.058823529411764705,
+      "control_precision": 0.05555555555555555,
+      "candidate_mrr": 0.3333333333333333,
+      "control_mrr": 0.3333333333333333,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "loc_pydantic_validate_call",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.2,
+      "control_precision": 0.2,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "loc_pytest_fixture_resolution",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.5,
+      "control_precision": 0.5,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "loc_react_dispatch_set_state",
+      "family": "localization",
+      "category": "external-large",
+      "candidate_precision": 0.3333333333333333,
+      "control_precision": 0.3333333333333333,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "loc_requests_adapter_send",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.125,
+      "control_precision": 0.125,
+      "candidate_mrr": 0.14285714285714285,
+      "control_mrr": 0.14285714285714285,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "loc_requests_redirect_auth",
+      "family": "localization",
+      "category": "external-framework",
+      "candidate_precision": 0.058823529411764705,
+      "control_precision": 0.05555555555555555,
+      "candidate_mrr": 0.3333333333333333,
+      "control_mrr": 0.3333333333333333,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "loc_sqlalchemy_session_merge",
+      "family": "localization",
+      "category": "external-large",
+      "candidate_precision": 0.1111111111111111,
+      "control_precision": 0.1111111111111111,
+      "candidate_mrr": 0.3333333333333333,
+      "control_mrr": 0.3333333333333333,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "loc_tokio_current_thread_block_on",
+      "family": "localization",
+      "category": "external-large",
+      "candidate_precision": 1.0,
+      "control_precision": 1.0,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "mini_redis_async",
+      "family": "comprehension",
+      "category": "external-framework",
+      "candidate_precision": 0.17647058823529413,
+      "control_precision": 0.16666666666666666,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "pydantic_validators",
+      "family": "comprehension",
+      "category": "external-framework",
+      "candidate_precision": 0.2727272727272727,
+      "control_precision": 0.2727272727272727,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "pytest_fixtures",
+      "family": "comprehension",
+      "category": "external-framework",
+      "candidate_precision": 0.25,
+      "control_precision": 0.25,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "react_hooks",
+      "family": "comprehension",
+      "category": "external-large",
+      "candidate_precision": 0.2222222222222222,
+      "control_precision": 0.2222222222222222,
+      "candidate_mrr": 0.16666666666666666,
+      "control_mrr": 0.16666666666666666,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_mrr_floor",
+        "rank_below_first"
+      ],
+      "control_failure_classes": [
+        "below_mrr_floor",
+        "rank_below_first"
+      ]
+    },
+    {
+      "task_id": "requests_sessions",
+      "family": "comprehension",
+      "category": "external-framework",
+      "candidate_precision": 0.42857142857142855,
+      "control_precision": 0.42857142857142855,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    },
+    {
+      "task_id": "routing_mixed_cache",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.15384615384615385,
+      "control_precision": 0.15384615384615385,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "routing_mixed_chunker",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.16666666666666666,
+      "control_precision": 0.16666666666666666,
+      "candidate_mrr": 0.5,
+      "control_mrr": 0.5,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "below_mrr_floor",
+        "rank_below_first",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "routing_pl_intent",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.017543859649122806,
+      "control_precision": 0.017543859649122806,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "routing_pl_large",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.017543859649122806,
+      "control_precision": 0.017543859649122806,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "routing_pl_path_symbol",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.02702702702702703,
+      "control_precision": 0.02702702702702703,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "routing_pl_scoring",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.0625,
+      "control_precision": 0.0625,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "routing_pl_tight",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.16666666666666666,
+      "control_precision": 0.16666666666666666,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "routing_trace_api",
+      "family": "comprehension",
+      "category": "self",
+      "candidate_precision": 0.03508771929824561,
+      "control_precision": 0.03508771929824561,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "below_f1_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "rust_tokio_runtime",
+      "family": "comprehension",
+      "category": "external-large",
+      "candidate_precision": 0.1875,
+      "control_precision": 0.17647058823529413,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [
+        "below_precision_floor",
+        "broad_result_set"
+      ],
+      "control_failure_classes": [
+        "below_precision_floor",
+        "broad_result_set"
+      ]
+    },
+    {
+      "task_id": "sqlalchemy_sessions",
+      "family": "comprehension",
+      "category": "external-large",
+      "candidate_precision": 0.42857142857142855,
+      "control_precision": 0.42857142857142855,
+      "candidate_mrr": 1.0,
+      "control_mrr": 1.0,
+      "candidate_required_file_recall": 1.0,
+      "control_required_file_recall": 1.0,
+      "candidate_failure_classes": [],
+      "control_failure_classes": []
+    }
+  ]
+}

--- a/tests/benchmark/test_rank_candidate_corpus.py
+++ b/tests/benchmark/test_rank_candidate_corpus.py
@@ -1,0 +1,101 @@
+"""Corpus-level verification for the M0.3 direct-evidence rank candidate.
+
+Validates the checked-in 64-task corpus comparison artifact
+(`benchmarks/evidence/m0.3-corpus-comparison.json`), produced from two
+same-revision local runs of `archex_query_rank_candidate` (candidate) and
+`archex_query_coverage_candidate` (M0.2's candidate, M0.3's declared
+control/input) against the full task corpus. This is a report-only reader
+over the checked-in artifact -- it never re-runs the corpus or reads
+benchmark task expected-file definitions.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from archex.benchmark.evidence import task_manifest_digest
+from archex.benchmark.models import Strategy
+
+_GATE = {"min_recall": 0.60, "min_precision": 0.20, "min_f1": 0.30, "min_mrr": 0.55}
+
+
+def _load_artifact() -> dict[str, Any]:
+    root = Path(__file__).parents[2]
+    artifact = root / "benchmarks" / "evidence" / "m0.3-corpus-comparison.json"
+    return json.loads(artifact.read_text(encoding="utf-8"))
+
+
+def test_corpus_artifact_identity_matches_current_task_corpus() -> None:
+    root = Path(__file__).parents[2]
+    payload = _load_artifact()
+
+    assert payload["task_manifest_digest"] == task_manifest_digest(root / "benchmarks" / "tasks")
+    assert payload["gate_thresholds"] == _GATE
+
+
+def test_corpus_artifact_covers_all_sixty_four_tasks() -> None:
+    payload = _load_artifact()
+
+    assert len(payload["rows"]) == 64
+    task_ids = {row["task_id"] for row in payload["rows"]}
+    assert len(task_ids) == 64
+
+
+def test_corpus_artifact_records_two_reproducible_repeats() -> None:
+    payload = _load_artifact()
+
+    assert payload["repeat_stability"]["candidate_result_differences_across_repeat"] == []
+    assert payload["repeat_stability"]["control_result_differences_across_repeat"] == []
+    for tid in ("candidate_run_21", "candidate_run_22", "control_run_21", "control_run_22"):
+        assert payload["runs"][tid]["strategy"] in (
+            Strategy.ARCHEX_QUERY_RANK_CANDIDATE.value,
+            Strategy.ARCHEX_QUERY_COVERAGE_CANDIDATE.value,
+        )
+
+
+def test_corpus_artifact_shows_zero_required_file_recall_regressions() -> None:
+    payload = _load_artifact()
+
+    assert payload["required_file_regressions"] == []
+    for row in payload["rows"]:
+        assert row["candidate_required_file_recall"] >= row["control_required_file_recall"] - 1e-9
+
+
+def test_corpus_artifact_preserves_m02_five_target_recovery() -> None:
+    payload = _load_artifact()
+
+    targets = {entry["task_id"] for entry in payload["m02_target_task_recovery"]}
+    assert targets == {
+        "archex_adapter_registry",
+        "archex_project_status",
+        "django_middleware",
+        "loc_django_username_validator",
+        "routing_pl_scoring",
+    }
+    for entry in payload["m02_target_task_recovery"]:
+        assert entry["run21_required_file_recall"] == 1.0
+        assert entry["run22_required_file_recall"] == 1.0
+
+
+def test_corpus_artifact_family_breakdown_never_regresses_required_recall() -> None:
+    payload = _load_artifact()
+
+    for name in ("self_repo", "external_comprehension", "localization"):
+        block = payload["family_breakdown"][name]
+        assert block["candidate"]["n_tasks"] == block["control"]["n_tasks"]
+        assert (
+            block["candidate"]["mean_required_file_recall"]
+            >= block["control"]["mean_required_file_recall"] - 1e-9
+        )
+
+
+def test_corpus_artifact_candidate_never_worsens_precision_or_f1_per_row() -> None:
+    # The candidate is order/admission-narrowing only; it can only match or
+    # improve precision and F1 relative to its declared control, never
+    # regress them, on any single task.
+    payload = _load_artifact()
+
+    for row in payload["rows"]:
+        assert row["candidate_precision"] >= row["control_precision"] - 1e-9


### PR DESCRIPTION
## Stack

Stack-Id: `m03-rank-noise-recovery-20260712`
Base: `m03-localization-presentation`
Position: 4/4

1. `m03-ranking-noise-characterization` → #506
2. `m03-direct-evidence-rank` → #507
3. `m03-localization-presentation` → #508
4. `m03-corpus-mutation-proof` → this PR

Depends on: #508
Upstack: none

## Summary

Records two same-revision 64-task local runs
(`benchmarks/evidence/m0.3-corpus-comparison.json`, source revision
`ddff2b88b70ce6bf1e0a75a4c045a864e9c2529d`) comparing
`archex_query_rank_candidate` against `archex_query_coverage_candidate`
(M0.2's candidate, M0.3's declared control/input). A report-only test
suite (`test_rank_candidate_corpus.py`) validates the checked-in
artifact's identity, repeat reproducibility, and every required
invariant. Adds a `[Unreleased]` CHANGELOG entry for M0.3 per
`DEVELOPMENT_PLAN.md` §2.1.

## Evidence

- **Zero required-file-recall regressions** on either repeat; mean
  required-file recall `0.9906` for both candidate and control.
- **M0.2's five original target tasks** (`archex_adapter_registry`,
  `archex_project_status`, `django_middleware`,
  `loc_django_username_validator`, `routing_pl_scoring`) all retain
  `required_file_recall == 1.0` on both repeats.
- **Precision improved on 7 of 64 tasks with 0 worsened** (mean `0.2200 →
  0.2232`); **F1 improved on 7 of 64 with 0 worsened** (mean `0.3238 →
  0.3292`). MRR unchanged on all 64 tasks (no eligible tail-promotion
  case fired in this corpus).
- **Family breakdown** (self-repo 24, external-comprehension 19,
  localization 21): required-file recall preserved and precision/F1
  improved-or-equal in every family; no family regresses.
- `rank_below_first` and `broad_result_set` gate-floor counts are
  **unchanged** in binary terms (16/64 and 38/64 respectively for both
  candidate and control): the measured precision/F1 gains are real but
  too small, on every affected task, to cross the `min_precision=0.20` /
  `min_f1=0.30` gate floors by themselves.

## Verdict: NO-GO (retained, not promoted)

Per the milestone's own governance ("GO only when complete
candidate/control evidence clears every M0.3 target… Otherwise NO-GO;
retain artifacts and do not promote"), the candidate is **safe** (zero
regressions, fully reproducible, M0.2 coverage preserved) but does
**not** clear every M0.3 target — it is retained as evidence for M0.4,
not promoted. Narrowing further than the measured-safe admission-cap
floor was explicitly tested in PR-3 and found to drop a required file for
two tasks (`django_middleware`, `loc_django_username_validator`, at seed
position 10-11); stopping at that measured-safe boundary rather than
crossing it to manufacture a passing count is the correct, honest outcome
given the milestone's explicit constraint against floor modification and
blind truncation. `archex_query` remains the unchanged product default.

Full reasoning, including the two rejected reordering designs measured
and discarded in PR-2, is in `.docs/m0.3-final-verdict.md` (local
operator artifact, not checked in per repo convention — see PR-1/PR-2/PR-3
descriptions for the inline equivalent).

## Validation

- `uv run ruff check .` — passed (374 files)
- `uv run ruff format --check .` — passed
- `uv run pyright` — 0 errors, full project
- `uv run pytest --no-cov` — **3756 passed, 7 deselected, full project**
- `uv run pytest --no-cov tests/benchmark/test_rank_candidate_corpus.py` — 7 passed

## Scope

Benchmark-only evidence and a CHANGELOG entry for this milestone. No
production-default, score, gate, task-oracle runtime, hosted-inference,
or M1 change.
