### PR TITLE
test(benchmark): characterize context-economy failures

### DIFF
--- a/src/archex/benchmark/region_metrics.py
+++ b/src/archex/benchmark/region_metrics.py
@@ -22,9 +22,10 @@ from archex.benchmark.models import ExpectedRegion, RegionGranularity
 class ReturnedRegion:
     """One returned context unit, in the order the bundle ranks it.
 
-    ``start_line``/``end_line`` are 1-indexed inclusive line bounds. Returned
-    context always carries a line range because it originates from concrete code
-    chunks; ``symbol`` is the chunk's symbol name when one applies.
+    ``start_line``/``end_line`` are 1-indexed inclusive line bounds. An
+    elision anchor retains source coordinates and consumes context tokens but
+    exposes no source evidence, so it is counted as noise without earning
+    region, line, or ranking credit.
     """
 
     path: str
@@ -32,6 +33,7 @@ class ReturnedRegion:
     end_line: int
     symbol: str | None
     tokens: int
+    source_evidence: bool = True
 
 
 @dataclass(frozen=True)
@@ -229,24 +231,25 @@ def compute_region_metrics(
     if not expected_regions:
         return None
 
+    evidence_regions = [region for region in returned_regions if region.source_evidence]
     covered_weight = 0.0
     total_weight = 0.0
     for expected in expected_regions:
         total_weight += expected.weight
-        if any(_overlaps(returned, expected) for returned in returned_regions):
+        if any(_overlaps(returned, expected) for returned in evidence_regions):
             covered_weight += expected.weight
     region_recall = (covered_weight / total_weight) if total_weight > 0 else 0.0
 
     overlapping_returned = sum(
         1
-        for returned in returned_regions
+        for returned in evidence_regions
         if any(_overlaps(returned, expected) for expected in expected_regions)
     )
-    region_precision = (overlapping_returned / len(returned_regions)) if returned_regions else 0.0
+    region_precision = (overlapping_returned / len(evidence_regions)) if evidence_regions else 0.0
     region_f1 = _f1(region_precision, region_recall)
 
-    line_recall, line_precision = _line_metrics(returned_regions, expected_regions)
-    mrr, ndcg = _ranking_metrics(returned_regions, expected_regions)
+    line_recall, line_precision = _line_metrics(evidence_regions, expected_regions)
+    mrr, ndcg = _ranking_metrics(evidence_regions, expected_regions)
 
     by_path: dict[str, list[ExpectedRegion]] = {}
     for expected in expected_regions:
@@ -259,6 +262,8 @@ def compute_region_metrics(
     useful_tokens = 0
     for returned in returned_regions:
         total_tokens += returned.tokens
+        if not returned.source_evidence:
+            continue
         same_path = by_path.get(returned.path)
         if not same_path:
             continue

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -1104,17 +1104,39 @@ def measure_archex_freshness(task: BenchmarkTask, repo_path: Path) -> tuple[floa
 
 
 def _bundle_returned_regions(bundle: ContextBundle) -> list[ReturnedRegion]:
-    """Build ranked returned regions from a context bundle, preserving order."""
-    return [
-        ReturnedRegion(
-            path=ranked.chunk.file_path,
-            start_line=ranked.chunk.start_line,
-            end_line=ranked.chunk.end_line,
-            symbol=ranked.chunk.symbol_name,
-            tokens=count_tokens(ranked.chunk.content),
+    """Build ranked content-bearing regions from a context bundle.
+
+    A structural-elision anchor retains a handle for later fetches but no longer
+    exposes its source lines. It must not receive region or line-recall credit;
+    doing so would turn an elision regression into a false pass.
+    """
+    from archex.scout import chunk_handle
+
+    receipt_items = (
+        {item.handle: item for item in bundle.receipt.returned_context}
+        if bundle.receipt is not None
+        else {}
+    )
+    returned: list[ReturnedRegion] = []
+    for ranked in bundle.chunks:
+        chunk = ranked.chunk
+        item = receipt_items.get(chunk_handle(chunk.id))
+        is_elided = (
+            item is not None
+            and item.compression is not None
+            and item.compression.compression_mode is CompressionMode.STRUCTURAL_CODE_ELISION
         )
-        for ranked in bundle.chunks
-    ]
+        returned.append(
+            ReturnedRegion(
+                path=chunk.file_path,
+                start_line=chunk.start_line,
+                end_line=chunk.end_line,
+                symbol=chunk.symbol_name,
+                tokens=count_tokens(chunk.content),
+                source_evidence=not is_elided,
+            )
+        )
+    return returned
 
 
 def _region_result_fields(

--- a/tests/benchmark/test_region_fixtures.py
+++ b/tests/benchmark/test_region_fixtures.py
@@ -12,8 +12,25 @@ from pathlib import Path
 import pytest
 
 from archex.benchmark.loader import load_task, load_tasks, validate_task
-from archex.benchmark.models import RegionGranularity, TaskFamily
-from archex.benchmark.strategies import run_archex_query
+from archex.benchmark.models import ExpectedRegion, RegionGranularity, TaskFamily
+from archex.benchmark.region_metrics import compute_region_metrics
+from archex.benchmark.strategies import (
+    _bundle_returned_regions,  # pyright: ignore[reportPrivateUsage]
+    run_archex_query,
+)
+from archex.models import (
+    CodeChunk,
+    CompressionLossRisk,
+    CompressionMetadata,
+    CompressionMode,
+    ContextBundle,
+    ContextReceipt,
+    ContextReceiptItem,
+    ContextReceiptTokenBudget,
+    RankedChunk,
+    RetrievalMetadata,
+)
+from archex.scout import chunk_handle
 
 REGION_TASKS_DIR = Path(__file__).resolve().parent.parent / "fixtures" / "region_tasks"
 REAL_TASKS_DIR = Path(__file__).resolve().parents[2] / "benchmarks" / "tasks"
@@ -79,6 +96,68 @@ def test_region_fixture_task_computes_region_metrics(python_simple_repo: Path) -
     assert result.useful_tokens is not None
     assert result.wasted_tokens is not None
     assert result.relevance_per_1k_tokens is not None
+
+
+def test_elided_anchor_does_not_count_as_returned_region_evidence() -> None:
+    """An anchor preserves fetch provenance, but not region/line evidence."""
+    chunk = CodeChunk(
+        id="elided",
+        content="... [archex packed: 50-token region elided; fetch original: handle] ...",
+        file_path="src/service.py",
+        start_line=10,
+        end_line=20,
+        language="python",
+        symbol_name="process",
+    )
+    handle = chunk_handle(chunk.id)
+    bundle = ContextBundle(
+        query="where is process implemented?",
+        chunks=[RankedChunk(chunk=chunk, final_score=1.0)],
+        token_count=12,
+        token_budget=128,
+        retrieval_metadata=RetrievalMetadata(),
+        receipt=ContextReceipt(
+            query="where is process implemented?",
+            token_budget=ContextReceiptTokenBudget(requested=128, consumed=12),
+            index_revision="test",
+            returned_context=[
+                ContextReceiptItem(
+                    handle=handle,
+                    file_path=chunk.file_path,
+                    start_line=chunk.start_line,
+                    end_line=chunk.end_line,
+                    content_hash="test",
+                    compression=CompressionMetadata(
+                        compression_mode=CompressionMode.STRUCTURAL_CODE_ELISION,
+                        original_tokens=50,
+                        compressed_tokens=12,
+                        compression_ratio=0.24,
+                        original_content_hash="original",
+                        compressed_content_hash="elided",
+                        fetch_original_handle=handle,
+                        compression_loss_risk=CompressionLossRisk.MEDIUM,
+                    ),
+                )
+            ],
+        ),
+    )
+    expected = [
+        ExpectedRegion(
+            path=chunk.file_path,
+            granularity=RegionGranularity.LINE_RANGE,
+            start_line=10,
+            end_line=20,
+        )
+    ]
+
+    metrics = compute_region_metrics(_bundle_returned_regions(bundle), expected)
+
+    assert metrics is not None
+    assert metrics.region_recall == 0.0
+    assert metrics.line_recall == 0.0
+    assert metrics.useful_tokens == 0
+    assert metrics.wasted_tokens > 0
+    assert metrics.context_noise_ratio == 1.0
 
 
 def test_external_localization_tasks_declare_valid_region_labels() -> None:


### PR DESCRIPTION
## Stack

Stack-Id: `m04-context-economy-7f3a91`
Base: `main`
Position: 1/5

1. `m04-region-evidence` -> this PR
2. `m04-region-packing` -> pending
3. `m04-composed-frontier` -> pending
4. `m04-default-promotion` -> blocked on two passing local runs
5. `m04-final-gate` -> blocked on promotion

Depends on: none
Upstack: pending

## Change

Make region and line metrics fail closed for structural-elision anchors. An anchor retains a fetch receipt but exposes no source lines, so it cannot receive region or line-recall credit.

## Validation

- `uv run ruff check src/archex/benchmark/strategies.py tests/benchmark/test_region_fixtures.py`
- `uv run ruff format --check src/archex/benchmark/strategies.py tests/benchmark/test_region_fixtures.py`
- `uv run pyright src/archex/benchmark/strategies.py tests/benchmark/test_region_fixtures.py`
- `uv run pytest tests/benchmark/test_region_fixtures.py --no-cov`
- Mutation proof: removing the structural-elision exclusion makes `test_elided_anchor_does_not_count_as_returned_region_evidence` fail with false `region_recall == 1.0`.
