### PR TITLE
fix(benchmark): resolve HEAD cache identity

### DIFF
--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -1016,7 +1016,14 @@ def benchmark_repo_source(
     repo_path: Path,
     strategy: Strategy | None = None,
 ) -> RepoSource:
-    commit = task.commit or CacheManager.git_head(str(repo_path))
+    # A task declares ``HEAD`` as a moving local ref. Resolve it before putting it
+    # in ``stable_identity``; treating the literal as a cache key reuses a prior
+    # revision's index after every self-repository commit.
+    commit = (
+        CacheManager.git_head(str(repo_path))
+        if task.commit == "HEAD"
+        else task.commit or CacheManager.git_head(str(repo_path))
+    )
     if not commit:
         raise ConfigError(
             f"Benchmark task {task.task_id!r} has no commit and {repo_path} has no git HEAD"

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -475,8 +475,10 @@ class TestRunBenchmark:
             f"+max_seq={JINA_V2_MAX_SEQ_LENGTH}"
         )
         source = benchmark_repo_source(task, repo_path)
+        assert source.stable_identity is not None
+        base_identity = source.stable_identity.split("#", maxsplit=1)[0]
         assert source.stable_identity == (
-            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=default"
+            f"{base_identity}#embedder={jina_identity}+chunker=default"
         )
 
         token = set_benchmark_retrieval_options(BenchmarkRetrievalOptions(splade=True))
@@ -486,7 +488,7 @@ class TestRunBenchmark:
             reset_benchmark_retrieval_options(token)
 
         assert splade_source.stable_identity == (
-            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=default+splade"
+            f"{base_identity}#embedder={jina_identity}+chunker=default+splade"
         )
 
         coderank_token = set_benchmark_retrieval_options(
@@ -511,14 +513,14 @@ class TestRunBenchmark:
             reset_benchmark_retrieval_options(scoped_token)
 
         assert scoped_source.stable_identity == (
-            f"test/python_simple@HEAD#scope=src|tests+embedder={jina_identity}+chunker=default"
+            f"{base_identity}#scope=src|tests+embedder={jina_identity}+chunker=default"
         )
         assert cast_source.stable_identity == (
-            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=cast"
+            f"{base_identity}#embedder={jina_identity}+chunker=cast"
         )
 
         assert coderank_source.stable_identity == (
-            "test/python_simple@HEAD#embedder=coderank+chunker=default"
+            f"{base_identity}#embedder=coderank+chunker=default"
         )
 
         split_token = set_benchmark_retrieval_options(
@@ -539,10 +541,10 @@ class TestRunBenchmark:
             reset_benchmark_retrieval_options(split_token)
 
         assert split_bm25_source.stable_identity == (
-            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=default"
+            f"{base_identity}#embedder={jina_identity}+chunker=default"
         )
         assert split_vector_source.stable_identity == (
-            f"test/python_simple@HEAD#embedder={jina_identity}+chunker=cast"
+            f"{base_identity}#embedder={jina_identity}+chunker=cast"
         )
 
     def test_benchmark_index_config_applies_module_prefilter_only_with_bm25(self) -> None:

--- a/tests/benchmark/test_strategies.py
+++ b/tests/benchmark/test_strategies.py
@@ -687,6 +687,25 @@ class TestRunArchexQuery:
             f"test/repo@resolved#embedder={JINA_V2_CACHE_IDENTITY}+chunker=default"
         )
 
+    def test_benchmark_source_resolves_literal_head_from_git_head(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        task = BenchmarkTask(
+            task_id="test",
+            repo="test/repo",
+            commit="HEAD",
+            question="How?",
+            expected_files=["main.py"],
+        )
+
+        with patch.object(CacheManager, "git_head", return_value="resolved"):
+            source = benchmark_repo_source(task, tmp_path)
+
+        assert source.stable_identity == (
+            f"test/repo@resolved#embedder={JINA_V2_CACHE_IDENTITY}+chunker=default"
+        )
+
     def test_benchmark_source_rejects_missing_commit_without_git_head(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Stack

Stack-Id: `m04r-context-economy-7f3a91`

Base: `m04-composed-frontier` → this PR #1/3

Depends on: #512

## Change

Resolve a literal benchmark task ref of `HEAD` to the repository's immutable git SHA before constructing `RepoSource.stable_identity`. This prevents 24 self-repository tasks from reusing an index built for a previous revision when a candidate enables warm caching.

## Evidence

- New regression test fails against the prior literal `.@HEAD` identity and passes with the resolved SHA.
- Focused pytest, Ruff lint/format, and Pyright pass.

No production retrieval default, benchmark baseline, canonical evidence, M1 draft, or benchmark-quality draft changes.