### PR TITLE
feat(benchmark): constrain candidate graph admission

### DIFF
--- a/src/archex/benchmark/coverage_candidate.py
+++ b/src/archex/benchmark/coverage_candidate.py
@@ -139,8 +139,9 @@ def coverage_neighbor_decisions(
     existing_files: set[str],
     direct_decisions: list[CoverageSeedDecision],
     limit: int,
+    require_direct_evidence: bool = False,
 ) -> list[CoverageSeedDecision]:
-    """Rank bounded direct graph neighbors using extracted edges and seed evidence."""
+    """Rank bounded graph neighbors, optionally requiring direct query evidence."""
     if limit < 1:
         return []
 
@@ -158,6 +159,8 @@ def coverage_neighbor_decisions(
             if file_path in seed_files or file_path in existing_files or _is_test_path(file_path):
                 continue
             direct = direct_by_file.get(file_path)
+            if require_direct_evidence and direct is None:
+                continue
             direct_evidence = direct.evidence if direct is not None else ()
             decision = CoverageSeedDecision(
                 file=file_path,

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -3319,8 +3319,13 @@ def _rank_candidate_bundle(
     repo_path: Path,
     *,
     strategy: Strategy,
+    restrict_neighbor_admission: bool = False,
 ) -> tuple[ContextBundle, IndexConfig, PipelineTiming, dict[str, str]]:
-    """Compose M0.2 admission and M0.3 tail ranking without packing."""
+    """Compose M0.2 admission and M0.3 tail ranking without packing.
+
+    The M0.4 context candidate restricts graph expansion to files that also
+    carry direct query evidence; M0.2/M0.3 retain their broad graph policy.
+    """
     from archex.api import index_repository
     from archex.index.graph import DependencyGraph
     from archex.models import Config
@@ -3364,6 +3369,7 @@ def _rank_candidate_bundle(
             existing_files={ranked.chunk.file_path for ranked in seed_admission.bundle.chunks},
             direct_decisions=direct_decisions,
             limit=neighbor_cap,
+            require_direct_evidence=restrict_neighbor_admission,
         )
         neighbor_admission = _apply_coverage_seed_admission(
             seed_admission.bundle,
@@ -3386,6 +3392,7 @@ def _rank_candidate_bundle(
         or "none",
         "candidate_neighbor_cap": str(neighbor_cap),
         "candidate_neighbor_cap_bounded": str(neighbor_cap < _COVERAGE_NEIGHBOR_CAP),
+        "candidate_neighbor_requires_direct_evidence": str(restrict_neighbor_admission),
         "candidate_neighbor_admitted": ",".join(
             decision.file for decision in neighbor_admission.admitted
         )
@@ -3448,6 +3455,7 @@ def run_archex_query_context_candidate(
         task,
         repo_path,
         strategy=strategy,
+        restrict_neighbor_admission=True,
     )
     packing = _pack_context_candidate_bundle(bundle, question=task.question)
     result = _assemble_query_result(

--- a/tests/benchmark/test_coverage_graph.py
+++ b/tests/benchmark/test_coverage_graph.py
@@ -52,6 +52,28 @@ def test_neighbor_admission_requires_confident_graph_evidence() -> None:
     assert "symbol:validateinvoice" in decision.evidence
 
 
+def test_neighbor_admission_can_require_direct_query_evidence() -> None:
+    decisions = coverage_neighbor_decisions(
+        [
+            GraphEdge("entry.py", "validation.py", 0.9),
+            GraphEdge("entry.py", "boundary.py", 0.9),
+        ],
+        seed_files={"entry.py"},
+        existing_files=set(),
+        direct_decisions=[
+            CoverageSeedDecision(
+                file="validation.py",
+                score=8,
+                evidence=("symbol:validateinvoice",),
+            )
+        ],
+        limit=3,
+        require_direct_evidence=True,
+    )
+
+    assert [decision.file for decision in decisions] == ["validation.py"]
+
+
 def test_neighbor_admission_is_bounded_and_deterministic() -> None:
     edges = [
         GraphEdge("entry.py", "b.py", 0.9),


### PR DESCRIPTION
## Stack

Stack-Id: `m04r-context-economy-7f3a91`

Base: `m04r-cache-identity` → this PR #2/3

Depends on: #514

## Change

Make the M0.4 `archex_query_context_candidate` admit graph-neighbor files only when those files also carry direct query evidence. M0.2 coverage and M0.3 ranking candidates retain their existing broad graph policy. The candidate receipt records whether this restriction was active.

## Focused evidence

- New deterministic regression proves strict mode removes graph-only neighbors while preserving direct-evidence neighbors.
- Focused coverage, ranking, and packing tests pass.
- Ruff lint/format and Pyright pass.

## Full-corpus disposition

The immutable run at `cfe5c2f` validated 64 tasks and four strategies, then failed the M0.4 absolute gate with 133 violations. Relative to the cache-identity candidate run, strict graph admission reduced mean returned files from 18.234 to 16.797 and raised aggregate precision from 0.228829 to 0.234788, but left 38 precision failures, 35 F1 failures, 16 MRR failures, and two zero-efficiency paths. It also regressed required-file recall for `archex_project_config_resolution` by dropping `src/archex/models.py`, and worsened wall p95 from 3958 ms to 4293 ms.

This candidate is NO-GO. Do not promote the default, canonical baseline, or M1 unblock record from this PR.

No production retrieval default, benchmark baseline, canonical evidence, M1 draft, or benchmark-quality draft changes.