### PR TITLE
fix(benchmark): enforce promotion candidate gate

### DIFF
--- a/docs/LOCAL_BENCHMARK_EVIDENCE.md
+++ b/docs/LOCAL_BENCHMARK_EVIDENCE.md
@@ -34,3 +34,15 @@ uv run archex benchmark gate --input <evidence-dir> --min-recall 0.60 --min-f1 0
 A non-zero gate result is evidence. Preserve the manifest and all 64 reports with the failing result. Do not promote or overwrite a baseline until the declared promotion milestone verifies a passing full-corpus result.
 
 Evidence is invalid when its source revision, task digest, report hashes, task coverage, strategy coverage, or retrieval configuration differs from the manifest.
+
+## Promotion candidate procedure
+
+Promotion evidence uses one named candidate and the retained `archex_query` control from the same manifest. The operator must request a warm-cache run; the runner discards one cache-populating execution for each indexed strategy before it records the result. A promotion gate rejects a candidate row unless it reports `cached: true`, `cache_state: "warm"`, and a nonzero `warm_latency_ms`.
+
+```text
+uv run archex benchmark run --tasks-dir benchmarks/tasks --output <evidence-dir> --strategy <candidate-strategy> --warm-cache
+uv run archex benchmark validate --kind evidence --tasks-dir benchmarks/tasks --input <evidence-dir>
+uv run archex benchmark gate --input <evidence-dir> --promotion-strategy <candidate-strategy> --control-strategy archex_query --min-recall 0.60 --min-precision 0.20 --min-f1 0.30 --min-mrr 0.55 --min-token-efficiency-with-completion 0.08 --max-p95-warm-latency-ms 3000
+```
+
+The promotion gate hard-fails every absolute row for the named candidate, including the product token-efficiency floor. It separately rejects required-file, region, or line-recall regressions against the control. The control remains an informational comparator for absolute quality, so its existing failures neither block a candidate nor become a promoted baseline.

--- a/src/archex/benchmark/gate.py
+++ b/src/archex/benchmark/gate.py
@@ -13,6 +13,7 @@ from archex.benchmark.baseline import (
 from archex.benchmark.models import (  # noqa: TCH001 — Pydantic needs at runtime
     BenchmarkReport,
     DeltaBenchmarkResult,
+    Strategy,
 )
 
 # Tier 2.5 product-default `archex_query` minimum higher-is-better token
@@ -279,6 +280,108 @@ def check_recall_regressions(
                         actual=result.token_efficiency_with_completion,
                     )
                 )
+    return violations
+
+
+def check_strategy_non_regressions(
+    reports: list[BenchmarkReport],
+    *,
+    candidate_strategy: Strategy,
+    control_strategy: Strategy,
+) -> list[BaselineGateViolation]:
+    """Compare one candidate against its same-run control on protected evidence."""
+    violations: list[BaselineGateViolation] = []
+    for report in reports:
+        results_by_strategy = {result.strategy: result for result in report.results}
+        control = results_by_strategy.get(control_strategy)
+        candidate = results_by_strategy.get(candidate_strategy)
+        if control is None:
+            violations.append(
+                BaselineGateViolation(
+                    task_id=report.task_id,
+                    strategy=candidate_strategy.value,
+                    metric="control_missing",
+                    baseline=1.0,
+                    actual=0.0,
+                )
+            )
+            continue
+        if candidate is None:
+            violations.append(
+                BaselineGateViolation(
+                    task_id=report.task_id,
+                    strategy=candidate_strategy.value,
+                    metric="candidate_missing",
+                    baseline=1.0,
+                    actual=0.0,
+                )
+            )
+            continue
+        for metric in ("required_file_recall", "region_recall", "line_recall"):
+            control_value = getattr(control, metric)
+            candidate_value = getattr(candidate, metric)
+            if control_value is None:
+                continue
+            actual = 0.0 if candidate_value is None else candidate_value
+            if actual < control_value:
+                violations.append(
+                    BaselineGateViolation(
+                        task_id=report.task_id,
+                        strategy=candidate_strategy.value,
+                        metric=metric,
+                        baseline=control_value,
+                        actual=actual,
+                    )
+                )
+    return violations
+
+
+def check_warm_p95_latency(
+    reports: list[BenchmarkReport],
+    *,
+    strategy: Strategy,
+    max_p95_warm_latency_ms: float | None,
+) -> list[GateViolation]:
+    """Require measured warm samples and enforce their aggregate p95 when configured."""
+    violations: list[GateViolation] = []
+    warm_samples: list[float] = []
+    for report in reports:
+        result = next((item for item in report.results if item.strategy is strategy), None)
+        if result is None:
+            violations.append(
+                GateViolation(
+                    task_id=report.task_id,
+                    strategy=strategy.value,
+                    metric="candidate_missing",
+                    threshold=1.0,
+                    actual=0.0,
+                )
+            )
+            continue
+        if not result.cached or result.cache_state != "warm" or result.warm_latency_ms <= 0.0:
+            violations.append(
+                GateViolation(
+                    task_id=report.task_id,
+                    strategy=strategy.value,
+                    metric="warm_latency_unmeasured",
+                    threshold=1.0,
+                    actual=0.0,
+                )
+            )
+            continue
+        warm_samples.append(result.warm_latency_ms)
+    if max_p95_warm_latency_ms is not None and warm_samples:
+        p95 = float(np.percentile(warm_samples, 95))
+        if p95 > max_p95_warm_latency_ms:
+            violations.append(
+                GateViolation(
+                    task_id="aggregate",
+                    strategy=strategy.value,
+                    metric="warm_p95_latency_ms",
+                    threshold=max_p95_warm_latency_ms,
+                    actual=p95,
+                )
+            )
     return violations
 
 

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -293,6 +293,9 @@ class BenchmarkRetrievalOptions(BaseModel):
     rerank_model: str | None = None
     allow_remote_code: bool = False
     freshness: bool = False
+    # Discard one cache-populating execution per indexed strategy before timing.
+    # This is an explicit local-operator measurement mode, not product behavior.
+    warm_cache: bool = False
     chunker: ChunkerName = "default"
     bm25_chunker: ChunkerName | None = None
     vector_chunker: ChunkerName | None = None

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -74,6 +74,13 @@ _VECTOR_STRATEGIES: frozenset[Strategy] = frozenset(
     }
 )
 
+_CACHE_WARMABLE_STRATEGIES: frozenset[Strategy] = frozenset(Strategy) - {
+    Strategy.RAW_FILES,
+    Strategy.RAW_GREPPED,
+    Strategy.RAW_RIPGREP,
+    Strategy.EXTERNAL_MCP,
+}
+
 
 def _check_vector_available() -> bool:
     """Check if vector embedding dependencies are available (fastembed or sentence-transformers)."""
@@ -260,6 +267,17 @@ def run_benchmark(
                 )
         if progress is not None:
             progress.finish_warmup(strategies)
+        if retrieval_options.warm_cache:
+            for strategy in strategies:
+                if strategy not in _CACHE_WARMABLE_STRATEGIES:
+                    continue
+                runner = default_strategy_registry.get(strategy)
+                if runner is None:
+                    continue
+                try:
+                    runner(task, repo_path)
+                except (NotImplementedError, ArchexIndexError) as exc:
+                    logger.info("Skipping warmup for %s: %s", strategy.value, exc)
 
         results: list[BenchmarkResult] = []
         for strategy in strategies:

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -1008,7 +1008,7 @@ def benchmark_index_config(
 
 def benchmark_cache_enabled(default: bool) -> bool:
     options = current_benchmark_retrieval_options()
-    return default or options.splade or options.module_prefilter
+    return default or options.warm_cache or options.splade or options.module_prefilter
 
 
 def benchmark_repo_source(
@@ -1233,6 +1233,7 @@ def _assemble_query_result(
         "map_score": compute_map(ranked_files, task.expected_files),
         "savings_vs_raw": 0.0,
         "wall_time_ms": wall_ms,
+        "warm_latency_ms": wall_ms if timing.cached else 0.0,
         "cached": timing.cached,
         "timing": timing,
         "timestamp": now_iso(),

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -45,6 +45,8 @@ from archex.benchmark.gate import (
     check_latency_violations,
     check_latency_warnings,
     check_recall_regressions,
+    check_strategy_non_regressions,
+    check_warm_p95_latency,
     non_token_quality_warnings,
     token_efficiency_violations,
 )
@@ -101,6 +103,22 @@ if TYPE_CHECKING:
 
 DEFAULT_BENCHMARK_RESULTS_DIR = ".archex/benchmark-results"
 DEFAULT_DELTA_RESULTS_DIR = ".archex/delta-results"
+
+
+def _select_strategy_reports(
+    reports: list[BenchmarkReport],
+    strategy: Strategy,
+) -> list[BenchmarkReport]:
+    """Return one result per report for a gate's named subject strategy."""
+    selected_reports: list[BenchmarkReport] = []
+    for report in reports:
+        selected = [result for result in report.results if result.strategy is strategy]
+        if len(selected) != 1:
+            raise click.ClickException(
+                f"Expected exactly one {strategy.value} result for task {report.task_id!r}"
+            )
+        selected_reports.append(report.model_copy(update={"results": selected}))
+    return selected_reports
 
 
 @click.group("benchmark")
@@ -209,6 +227,12 @@ def benchmark_cmd() -> None:
     help="Cap candidates scored by the cross-encoder reranker.",
 )
 @click.option(
+    "--warm-cache",
+    is_flag=True,
+    default=False,
+    help="Discard a cache-populating run per indexed strategy before timing results.",
+)
+@click.option(
     "--self-only",
     is_flag=True,
     default=False,
@@ -238,6 +262,7 @@ def run_cmd(
     vector_chunker: ChunkerName | None,
     rerank_model: str | None,
     rerank_candidate_limit: int | None,
+    warm_cache: bool,
     self_only: bool,
     no_progress: bool,
 ) -> None:
@@ -269,6 +294,7 @@ def run_cmd(
         bm25_chunker=bm25_chunker,
         vector_chunker=vector_chunker,
         rerank_candidate_limit=rerank_candidate_limit,
+        warm_cache=warm_cache,
     )
     try:
         warmed_models = warm_benchmark_models(strategies, retrieval_options)
@@ -905,6 +931,30 @@ def baseline_compare_cmd(input_dir: str, baseline_path: str) -> None:
         "Distinct from --warn-latency-ms, which only prints a warning. Disabled by default."
     ),
 )
+@click.option(
+    "--promotion-strategy",
+    default=None,
+    type=click.Choice([strategy.value for strategy in Strategy]),
+    help="Candidate strategy subject to strict all-row promotion checks.",
+)
+@click.option(
+    "--control-strategy",
+    default=None,
+    type=click.Choice([strategy.value for strategy in Strategy]),
+    help="Same-run control strategy for required-file, region, and line non-regression.",
+)
+@click.option(
+    "--min-token-efficiency-with-completion",
+    default=None,
+    type=float,
+    help="Required completion-adjusted token-efficiency floor for a promotion gate.",
+)
+@click.option(
+    "--max-p95-warm-latency-ms",
+    default=None,
+    type=float,
+    help="Hard maximum aggregate p95 for measured warm candidate latency in ms.",
+)
 def gate_cmd(
     input_dir: str,
     tasks_dir: str,
@@ -915,6 +965,10 @@ def gate_cmd(
     baseline_dir: str | None,
     warn_latency_ms: float,
     max_latency_ms: float | None,
+    promotion_strategy: str | None,
+    control_strategy: str | None,
+    min_token_efficiency_with_completion: float | None,
+    max_p95_warm_latency_ms: float | None,
 ) -> None:
     """Check benchmark results against quality thresholds."""
     try:
@@ -930,9 +984,69 @@ def gate_cmd(
         min_precision=min_precision,
         min_f1=min_f1,
         min_mrr=min_mrr,
+        min_token_efficiency_with_completion=(
+            0.0
+            if min_token_efficiency_with_completion is None
+            else min_token_efficiency_with_completion
+        ),
+        product_default_strategy=(
+            promotion_strategy
+            if promotion_strategy is not None
+            else QualityThresholds().product_default_strategy
+        ),
         warn_latency_ms=warn_latency_ms,
         max_latency_ms=max_latency_ms,
     )
+    if promotion_strategy is not None:
+        if control_strategy is None:
+            raise click.ClickException("--promotion-strategy requires --control-strategy")
+        if baseline_dir is not None:
+            raise click.ClickException("--promotion-strategy cannot be combined with --baseline")
+        if min_token_efficiency_with_completion is None:
+            raise click.ClickException(
+                "--promotion-strategy requires --min-token-efficiency-with-completion"
+            )
+        if max_p95_warm_latency_ms is None:
+            raise click.ClickException("--promotion-strategy requires --max-p95-warm-latency-ms")
+        promotion = Strategy(promotion_strategy)
+        if promotion.value in thresholds.gate_exempt_strategies:
+            raise click.ClickException(
+                f"--promotion-strategy {promotion.value!r} is gate-exempt and cannot be promoted"
+            )
+        control = Strategy(control_strategy)
+        if promotion is control:
+            raise click.ClickException("--promotion-strategy and --control-strategy must differ")
+        candidate_reports = _select_strategy_reports(reports, promotion)
+        absolute_violations = check_gate(candidate_reports, thresholds)
+        warm_latency_violations = check_warm_p95_latency(
+            reports,
+            strategy=promotion,
+            max_p95_warm_latency_ms=max_p95_warm_latency_ms,
+        )
+        protected_evidence_regressions = check_strategy_non_regressions(
+            reports,
+            candidate_strategy=promotion,
+            control_strategy=control,
+        )
+        violations = [*absolute_violations, *warm_latency_violations]
+        if violations or protected_evidence_regressions:
+            click.echo(
+                "PROMOTION GATE FAILED: "
+                f"{len(violations) + len(protected_evidence_regressions)} violation(s)"
+            )
+            for violation in violations:
+                click.echo(
+                    f"  {violation.task_id}/{violation.strategy} {violation.metric}: "
+                    f"{violation.actual:.3f} < {violation.threshold:.3f}"
+                )
+            for regression in protected_evidence_regressions:
+                click.echo(
+                    f"  {regression.task_id}/{regression.strategy} {regression.metric}: "
+                    f"{regression.actual:.3f} < control {regression.baseline:.3f}"
+                )
+            raise SystemExit(1)
+        click.echo("Quality gate passed.")
+        return
 
     latency_warnings: list[LatencyWarning] = check_latency_warnings(reports, thresholds)
     if latency_warnings:

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -484,6 +484,165 @@ class TestGateCommand:
         assert result.exit_code == 0
         assert "Quality gate passed." in result.output
 
+    def test_promotion_gate_hard_checks_only_candidate_and_protects_evidence(
+        self,
+        runner: CliRunner,
+        results_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        control = BenchmarkResult(
+            task_id="test",
+            strategy=Strategy.ARCHEX_QUERY,
+            tokens_total=1000,
+            tool_calls=1,
+            files_accessed=3,
+            recall=1.0,
+            precision=0.1,
+            f1_score=0.18,
+            mrr=0.1,
+            savings_vs_raw=0.0,
+            token_efficiency=0.01,
+            token_efficiency_with_completion=0.01,
+            required_file_recall=1.0,
+            region_recall=1.0,
+            line_recall=1.0,
+            wall_time_ms=100.0,
+            cached=True,
+            cache_state="warm",
+            timestamp="2025-01-01T00:00:00Z",
+        )
+        candidate = control.model_copy(
+            update={
+                "strategy": Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+                "precision": 1.0,
+                "f1_score": 1.0,
+                "mrr": 1.0,
+                "token_efficiency": 0.5,
+                "token_efficiency_with_completion": 0.5,
+                "warm_latency_ms": 100.0,
+            }
+        )
+        report = BenchmarkReport(
+            task_id="test",
+            repo="owner/repo",
+            question="How?",
+            results=[control, candidate],
+            baseline_tokens=1000,
+        )
+        _patch_gate_evidence(monkeypatch, [report])
+
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "gate",
+                "--input",
+                str(results_dir),
+                "--promotion-strategy",
+                Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE.value,
+                "--control-strategy",
+                Strategy.ARCHEX_QUERY.value,
+                "--min-token-efficiency-with-completion",
+                "0.08",
+                "--max-p95-warm-latency-ms",
+                "3000",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Quality gate passed." in result.output
+
+    def test_promotion_gate_fails_protected_region_regression(
+        self,
+        runner: CliRunner,
+        results_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        control = BenchmarkResult(
+            task_id="test",
+            strategy=Strategy.ARCHEX_QUERY,
+            tokens_total=1000,
+            tool_calls=1,
+            files_accessed=1,
+            recall=1.0,
+            precision=1.0,
+            f1_score=1.0,
+            mrr=1.0,
+            savings_vs_raw=0.0,
+            token_efficiency=0.5,
+            token_efficiency_with_completion=0.5,
+            required_file_recall=1.0,
+            region_recall=1.0,
+            line_recall=1.0,
+            wall_time_ms=100.0,
+            cached=True,
+            cache_state="warm",
+            timestamp="2025-01-01T00:00:00Z",
+        )
+        candidate = control.model_copy(
+            update={
+                "strategy": Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+                "region_recall": 0.5,
+                "warm_latency_ms": 100.0,
+            }
+        )
+        report = BenchmarkReport(
+            task_id="test",
+            repo="owner/repo",
+            question="How?",
+            results=[control, candidate],
+            baseline_tokens=1000,
+        )
+        _patch_gate_evidence(monkeypatch, [report])
+
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "gate",
+                "--input",
+                str(results_dir),
+                "--promotion-strategy",
+                Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE.value,
+                "--control-strategy",
+                Strategy.ARCHEX_QUERY.value,
+                "--min-token-efficiency-with-completion",
+                "0.08",
+                "--max-p95-warm-latency-ms",
+                "3000",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "region_recall" in result.output
+
+    def test_promotion_gate_rejects_gate_exempt_candidate(
+        self,
+        runner: CliRunner,
+        results_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        report = BenchmarkReport.model_validate_json((results_dir / "test.json").read_bytes())
+        _patch_gate_evidence(monkeypatch, [report])
+
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "gate",
+                "--input",
+                str(results_dir),
+                "--promotion-strategy",
+                Strategy.RAW_FILES.value,
+                "--control-strategy",
+                Strategy.ARCHEX_QUERY.value,
+                "--min-token-efficiency-with-completion",
+                "0.08",
+                "--max-p95-warm-latency-ms",
+                "3000",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "gate-exempt" in result.output
+
     def test_max_latency_ms_hard_fails_on_breach(
         self,
         runner: CliRunner,

--- a/tests/benchmark/test_gate.py
+++ b/tests/benchmark/test_gate.py
@@ -10,6 +10,8 @@ from archex.benchmark.gate import (
     check_gate,
     check_ranking_stability,
     check_recall_regressions,
+    check_strategy_non_regressions,
+    check_warm_p95_latency,
     non_token_quality_warnings,
     token_efficiency_violations,
 )
@@ -203,6 +205,84 @@ def test_baseline_gate_reports_missing_baseline_result() -> None:
     violations = check_recall_regressions(current, baseline)
 
     assert [(v.strategy, v.metric) for v in violations] == [("archex_query", "baseline_missing")]
+
+
+def test_strategy_non_regressions_flag_required_file_region_and_line_declines() -> None:
+    control = _make_report()
+    control_result = control.results[0].model_copy(
+        update={
+            "strategy": Strategy.ARCHEX_QUERY,
+            "required_file_recall": 1.0,
+            "region_recall": 1.0,
+            "line_recall": 1.0,
+        }
+    )
+    candidate_result = control_result.model_copy(
+        update={
+            "strategy": Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+            "required_file_recall": 0.5,
+            "region_recall": 0.5,
+            "line_recall": 0.5,
+        }
+    )
+    reports = [control.model_copy(update={"results": [control_result, candidate_result]})]
+
+    violations = check_strategy_non_regressions(
+        reports,
+        candidate_strategy=Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+        control_strategy=Strategy.ARCHEX_QUERY,
+    )
+
+    assert [(violation.strategy, violation.metric) for violation in violations] == [
+        ("archex_query_context_candidate", "required_file_recall"),
+        ("archex_query_context_candidate", "region_recall"),
+        ("archex_query_context_candidate", "line_recall"),
+    ]
+
+
+def test_warm_p95_gate_rejects_unmeasured_candidate_rows() -> None:
+    report = _make_report()
+    candidate = report.results[0].model_copy(
+        update={
+            "strategy": Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+            "cached": False,
+            "cache_state": "cold",
+            "warm_latency_ms": 0.0,
+        }
+    )
+
+    violations = check_warm_p95_latency(
+        [report.model_copy(update={"results": [candidate]})],
+        strategy=Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+        max_p95_warm_latency_ms=3000.0,
+    )
+
+    assert [(violation.strategy, violation.metric) for violation in violations] == [
+        ("archex_query_context_candidate", "warm_latency_unmeasured")
+    ]
+
+
+def test_warm_p95_gate_rejects_numeric_p95_breach() -> None:
+    report = _make_report()
+    candidate = report.results[0].model_copy(
+        update={
+            "strategy": Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+            "cached": True,
+            "cache_state": "warm",
+            "warm_latency_ms": 3500.0,
+        }
+    )
+
+    violations = check_warm_p95_latency(
+        [report.model_copy(update={"results": [candidate]})],
+        strategy=Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+        max_p95_warm_latency_ms=3000.0,
+    )
+
+    assert [
+        (violation.task_id, violation.metric, violation.threshold, violation.actual)
+        for violation in violations
+    ] == [("aggregate", "warm_p95_latency_ms", 3000.0, 3500.0)]
 
 
 def test_absolute_gate_separates_token_failures_from_quality_warnings() -> None:

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -8,7 +8,12 @@ from unittest.mock import patch
 
 import pytest
 
-from archex.benchmark.models import BenchmarkRetrievalOptions, BenchmarkTask, Strategy
+from archex.benchmark.models import (
+    BenchmarkResult,
+    BenchmarkRetrievalOptions,
+    BenchmarkTask,
+    Strategy,
+)
 from archex.benchmark.runner import AVAILABLE_STRATEGIES, DEFAULT_STRATEGIES, run_benchmark
 
 if TYPE_CHECKING:
@@ -174,6 +179,70 @@ class TestRunBenchmark:
         )
         assert len(report.results) == 1
         assert report.results[0].strategy == Strategy.RAW_FILES
+
+    def test_warm_cache_primes_indexed_strategies_before_measurement(
+        self,
+        fixture_task: tuple[BenchmarkTask, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        task, repo_path = fixture_task
+        from archex.benchmark.strategies import default_strategy_registry
+
+        calls: list[Strategy] = []
+
+        def run_candidate(_task: BenchmarkTask, _repo_path: Path) -> BenchmarkResult:
+            calls.append(Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE)
+            return BenchmarkResult(
+                task_id=task.task_id,
+                strategy=Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+                tokens_total=100,
+                tool_calls=1,
+                files_accessed=1,
+                recall=1.0,
+                precision=1.0,
+                savings_vs_raw=0.0,
+                wall_time_ms=10.0,
+                cached=True,
+                cache_state="warm",
+                timestamp="2026-01-01T00:00:00Z",
+            )
+
+        monkeypatch.setitem(
+            default_strategy_registry._runners,  # pyright: ignore[reportPrivateUsage]
+            Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE.value,
+            run_candidate,
+        )
+
+        run_benchmark(
+            task,
+            strategies=[Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE],
+            repo_path=repo_path,
+            retrieval_options=BenchmarkRetrievalOptions(warm_cache=True),
+        )
+
+        assert calls == [
+            Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+            Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+        ]
+
+    @REQUIRES_RG
+    def test_warm_cache_records_measured_warm_candidate_latency(
+        self,
+        fixture_task: tuple[BenchmarkTask, Path],
+    ) -> None:
+        task, repo_path = fixture_task
+
+        report = run_benchmark(
+            task,
+            strategies=[Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE],
+            repo_path=repo_path,
+            retrieval_options=BenchmarkRetrievalOptions(warm_cache=True),
+        )
+
+        candidate = report.results[0]
+        assert candidate.cached is True
+        assert candidate.cache_state == "warm"
+        assert candidate.warm_latency_ms > 0.0
 
     def test_warms_vector_index_when_vector_strategy_present(
         self,


### PR DESCRIPTION
## Stack

Stack-Id: `m04r-promotion-recovery-3c9e7a`

Position: 1/3

Base: `m04r-cache-identity` ([#514](https://github.com/Mathews-Tom/archex/pull/514))

## Change

Add an explicit promotion-gate mode for a named candidate strategy. It applies every absolute quality floor to the candidate only, requires measured warm samples and an aggregate warm p95 bound, and rejects required-file, region, and line regressions against the same-run `archex_query` control.

`--warm-cache` discards one cache-populating execution per indexed strategy before it records benchmark results. The evidence manifest records the mode. The local-operator procedure now documents the exact promotion invocation.

## Verification

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright .`
- `uv run pytest` — 3769 passed, 7 deselected
- Focused mutation proof: removing the warm-measurement guard makes `test_warm_p95_gate_rejects_unmeasured_candidate_rows` fail with the expected assertion.

## Non-goals

No `archex_query` default change, baseline promotion, canonical evidence change, M1 draft change, benchmark-quality draft change, threshold reduction, expected-label runtime access, or retrieval-policy promotion.