### PR TITLE
test(benchmark): calibrate ambiguous task evidence

### DIFF
--- a/benchmarks/evidence/m0.4-task-contract-calibration.json
+++ b/benchmarks/evidence/m0.4-task-contract-calibration.json
@@ -36,5 +36,30 @@
       "rationale": "The prior issue statement evaluated validator classes without using the identifying validator concept."
     }
   ],
+  "calibrated_candidate_run": {
+    "source_revision": "56bf07a97aea07a5ee6980e5cf6a8416475f748d",
+    "manifest_sha256": "39c886239d20116449fab68745a8ce5e06d9b4585f6619bdc89cdcbc69161877",
+    "strategy": "archex_query_context_candidate",
+    "task_count": 64,
+    "warm_samples": 64,
+    "warm_p95_ms": 727.041
+  },
+  "calibrated_candidate_verdict": {
+    "verdict": "NO-GO",
+    "total_violations": 122,
+    "absolute_failures": {
+      "recall": 1,
+      "precision": 39,
+      "f1_score": 36,
+      "mrr": 17,
+      "token_efficiency": 2,
+      "token_efficiency_with_completion": 2
+    },
+    "protected_evidence_regressions": {
+      "region_recall": 10,
+      "line_recall": 15
+    },
+    "reason": "The calibrated task wording restored query-to-label specificity but the existing context candidate still broadens file sets and regresses labeled evidence."
+  },
   "runtime_boundary": "This artifact is evaluation-only. No benchmark task labels, expected files, expected symbols, or expected regions are available to production or candidate retrieval code."
 }

--- a/benchmarks/evidence/m0.4-task-contract-calibration.json
+++ b/benchmarks/evidence/m0.4-task-contract-calibration.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 1,
+  "milestone": "M0.4",
+  "decision": "evaluation-only task contract calibration",
+  "authorization": "User-approved 2026-07-12 after intrinsic query-to-label ambiguity review; labels remain inaccessible to runtime retrieval.",
+  "source_revision": "68310cb857de5387471b2b2cfbc0aefea57ceefc",
+  "prior_task_manifest_digest": "0ae42fb18f96678b5e79591be8372d83fbeed646c4c08e7cc0f118eba4c2bd09",
+  "task_manifest_digest": "c9b6eb53901a572372131cb0d748af5ba487686ee6604f9baa40bcea09ae5721",
+  "changes": [
+    {
+      "task_id": "archex_adapter_registry",
+      "field": "question",
+      "before": "How does archex register language adapters?",
+      "after": "How does archex register language adapters, including the default PythonAdapter implementation?",
+      "rationale": "The expected PythonAdapter region was not distinguishable from the peer language adapters in the prior question."
+    },
+    {
+      "task_id": "archex_project_status",
+      "field": "question",
+      "before": "How does archex inspect whether a repo-local index is fresh, stale, dirty, or corrupt?",
+      "after": "How does archex inspect repo-local index state, compute its working-tree signature, and render the status command for fresh, stale, dirty, or corrupt results?",
+      "rationale": "The prior question did not name the status command or working-tree signature despite evaluating their symbols."
+    },
+    {
+      "task_id": "django_middleware",
+      "field": "question",
+      "before": "How does Django implement the middleware chain for request/response processing?",
+      "after": "How do Django's BaseHandler, WSGI entrypoint, and CommonMiddleware implement the request/response middleware chain?",
+      "rationale": "The expected WSGI and CommonMiddleware files were not distinguished from the broader middleware family."
+    },
+    {
+      "task_id": "loc_django_username_validator",
+      "field": "question",
+      "before": "Issue: the set of characters accepted in account usernames during authentication needs to change (the allowed-character pattern is too permissive and accepts inputs it should reject). Which classes define the username validation pattern that must be edited?",
+      "after": "Issue: account username validator classes accept an allowed-character pattern that is too permissive. Which username validator classes define the pattern that must be edited?",
+      "rationale": "The prior issue statement evaluated validator classes without using the identifying validator concept."
+    }
+  ],
+  "runtime_boundary": "This artifact is evaluation-only. No benchmark task labels, expected files, expected symbols, or expected regions are available to production or candidate retrieval code."
+}

--- a/benchmarks/tasks/archex_adapter_registry.yaml
+++ b/benchmarks/tasks/archex_adapter_registry.yaml
@@ -3,7 +3,7 @@ repo: "."
 commit: "HEAD"
 category: self
 languages: [python]
-question: "How does archex register language adapters?"
+question: "How does archex register language adapters, including the default PythonAdapter implementation?"
 expected_files:
   - src/archex/parse/adapters/__init__.py
   - src/archex/parse/adapters/python.py

--- a/benchmarks/tasks/archex_project_status.yaml
+++ b/benchmarks/tasks/archex_project_status.yaml
@@ -3,7 +3,7 @@ repo: "."
 commit: "HEAD"
 category: self
 languages: [python]
-question: "How does archex inspect whether a repo-local index is fresh, stale, dirty, or corrupt?"
+question: "How does archex inspect repo-local index state, compute its working-tree signature, and render the status command for fresh, stale, dirty, or corrupt results?"
 # Expected files cover CLI rendering, status-state inspection, project path resolution,
 # and working-tree signature calculation.
 expected_files:

--- a/benchmarks/tasks/django_middleware.yaml
+++ b/benchmarks/tasks/django_middleware.yaml
@@ -14,7 +14,7 @@ include_paths:
   - django/utils/deprecation.py
   - django/utils/log.py
   - django/utils/module_loading.py
-question: "How does Django implement the middleware chain for request/response processing?"
+question: "How do Django's BaseHandler, WSGI entrypoint, and CommonMiddleware implement the request/response middleware chain?"
 expected_files:
   - django/core/handlers/base.py
   - django/core/handlers/wsgi.py

--- a/benchmarks/tasks/loc_django_username_validator.yaml
+++ b/benchmarks/tasks/loc_django_username_validator.yaml
@@ -6,7 +6,7 @@ family: localization
 languages: [python]
 include_paths:
   - django/contrib/auth
-question: "Issue: the set of characters accepted in account usernames during authentication needs to change (the allowed-character pattern is too permissive and accepts inputs it should reject). Which classes define the username validation pattern that must be edited?"
+question: "Issue: account username validator classes accept an allowed-character pattern that is too permissive. Which username validator classes define the pattern that must be edited?"
 expected_files:
   - django/contrib/auth/validators.py
 expected_symbols:

--- a/tests/benchmark/test_context_candidate_corpus.py
+++ b/tests/benchmark/test_context_candidate_corpus.py
@@ -11,22 +11,56 @@ from pathlib import Path
 from typing import Any
 
 from archex.benchmark.evidence import task_manifest_digest
+from archex.benchmark.loader import load_tasks
 from archex.benchmark.models import Strategy
+from archex.serve.context import generic_query_terms
 
 ROOT = Path(__file__).parents[2]
 ARTIFACT = ROOT / "benchmarks" / "evidence" / "m0.4-context-candidate-run1.json"
+CALIBRATION_ARTIFACT = ROOT / "benchmarks" / "evidence" / "m0.4-task-contract-calibration.json"
+FROZEN_TASK_MANIFEST_DIGEST = "0ae42fb18f96678b5e79591be8372d83fbeed646c4c08e7cc0f118eba4c2bd09"
 
 
 def _load_artifact() -> dict[str, Any]:
     return json.loads(ARTIFACT.read_text(encoding="utf-8"))
 
 
-def test_context_candidate_evidence_has_current_corpus_identity() -> None:
+def test_task_contract_calibration_binds_the_reviewed_current_corpus() -> None:
+    payload = json.loads(CALIBRATION_ARTIFACT.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == 1
+    assert payload["milestone"] == "M0.4"
+    assert payload["decision"] == "evaluation-only task contract calibration"
+    assert payload["prior_task_manifest_digest"] == FROZEN_TASK_MANIFEST_DIGEST
+    assert payload["task_manifest_digest"] == task_manifest_digest(ROOT / "benchmarks" / "tasks")
+    assert {change["task_id"] for change in payload["changes"]} == {
+        "archex_adapter_registry",
+        "archex_project_status",
+        "django_middleware",
+        "loc_django_username_validator",
+    }
+    assert "evaluation-only" in payload["runtime_boundary"]
+
+
+def test_calibrated_tasks_name_their_distinguishing_runtime_evidence() -> None:
+    tasks = {task.task_id: task for task in load_tasks(ROOT / "benchmarks" / "tasks")}
+    required_terms = {
+        "archex_adapter_registry": {"pythonadapter"},
+        "archex_project_status": {"status", "command", "signature"},
+        "django_middleware": {"basehandler", "wsgi", "commonmiddleware"},
+        "loc_django_username_validator": {"validator"},
+    }
+
+    for task_id, expected_terms in required_terms.items():
+        assert expected_terms <= set(generic_query_terms(tasks[task_id].question))
+
+
+def test_context_candidate_evidence_has_immutable_corpus_identity() -> None:
     payload = _load_artifact()
 
     assert payload["schema_version"] == 1
     assert payload["milestone"] == "M0.4"
-    assert payload["task_manifest_digest"] == task_manifest_digest(ROOT / "benchmarks" / "tasks")
+    assert payload["task_manifest_digest"] == FROZEN_TASK_MANIFEST_DIGEST
     assert payload["candidate_run"]["strategy"] == Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE.value
     assert payload["candidate_run"]["task_count"] == 64
     assert len(payload["candidate_run"]["manifest_sha256"]) == 64

--- a/tests/benchmark/test_context_candidate_corpus.py
+++ b/tests/benchmark/test_context_candidate_corpus.py
@@ -40,6 +40,16 @@ def test_task_contract_calibration_binds_the_reviewed_current_corpus() -> None:
         "loc_django_username_validator",
     }
     assert "evaluation-only" in payload["runtime_boundary"]
+    assert payload["calibrated_candidate_run"] == {
+        "source_revision": "56bf07a97aea07a5ee6980e5cf6a8416475f748d",
+        "manifest_sha256": "39c886239d20116449fab68745a8ce5e06d9b4585f6619bdc89cdcbc69161877",
+        "strategy": Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE.value,
+        "task_count": 64,
+        "warm_samples": 64,
+        "warm_p95_ms": 727.041,
+    }
+    assert payload["calibrated_candidate_verdict"]["verdict"] == "NO-GO"
+    assert payload["calibrated_candidate_verdict"]["total_violations"] == 122
 
 
 def test_calibrated_tasks_name_their_distinguishing_runtime_evidence() -> None:

--- a/tests/benchmark/test_coverage.py
+++ b/tests/benchmark/test_coverage.py
@@ -8,8 +8,9 @@ from pathlib import Path
 import pytest
 
 from archex.benchmark.coverage import read_required_file_coverage
-from archex.benchmark.evidence import task_manifest_digest
 from archex.benchmark.models import BenchmarkReport, BenchmarkResult, Strategy
+
+_M02_TASK_MANIFEST_DIGEST = "0ae42fb18f96678b5e79591be8372d83fbeed646c4c08e7cc0f118eba4c2bd09"
 
 
 def _result(task_id: str, strategy: Strategy) -> BenchmarkResult:
@@ -87,7 +88,7 @@ def test_control_coverage_artifact_characterizes_five_reproducible_misses() -> N
     payload = json.loads(artifact.read_text(encoding="utf-8"))
 
     assert payload["strategy"] == Strategy.ARCHEX_QUERY.value
-    assert payload["task_manifest_digest"] == task_manifest_digest(root / "benchmarks" / "tasks")
+    assert payload["task_manifest_digest"] == _M02_TASK_MANIFEST_DIGEST
     observations = {entry["task_id"]: entry for entry in payload["tasks"]}
     assert set(observations) == {
         "archex_adapter_registry",

--- a/tests/benchmark/test_rank_candidate_corpus.py
+++ b/tests/benchmark/test_rank_candidate_corpus.py
@@ -15,8 +15,10 @@ import json
 from pathlib import Path
 from typing import Any
 
-from archex.benchmark.evidence import task_manifest_digest
 from archex.benchmark.models import Strategy
+
+_M03_TASK_MANIFEST_DIGEST = "0ae42fb18f96678b5e79591be8372d83fbeed646c4c08e7cc0f118eba4c2bd09"
+
 
 _GATE = {"min_recall": 0.60, "min_precision": 0.20, "min_f1": 0.30, "min_mrr": 0.55}
 
@@ -27,11 +29,10 @@ def _load_artifact() -> dict[str, Any]:
     return json.loads(artifact.read_text(encoding="utf-8"))
 
 
-def test_corpus_artifact_identity_matches_current_task_corpus() -> None:
-    root = Path(__file__).parents[2]
+def test_corpus_artifact_identity_matches_its_historical_task_corpus() -> None:
     payload = _load_artifact()
 
-    assert payload["task_manifest_digest"] == task_manifest_digest(root / "benchmarks" / "tasks")
+    assert payload["task_manifest_digest"] == _M03_TASK_MANIFEST_DIGEST
     assert payload["gate_thresholds"] == _GATE
 
 

--- a/tests/benchmark/test_ranking.py
+++ b/tests/benchmark/test_ranking.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import pytest
 
-from archex.benchmark.evidence import task_manifest_digest
 from archex.benchmark.models import BenchmarkReport, BenchmarkResult, Strategy, TaskFamily
 from archex.benchmark.ranking import (
     BELOW_F1_FLOOR,
@@ -18,6 +17,9 @@ from archex.benchmark.ranking import (
     RANK_BELOW_FIRST,
     read_rank_noise_observations,
 )
+
+_M03_TASK_MANIFEST_DIGEST = "0ae42fb18f96678b5e79591be8372d83fbeed646c4c08e7cc0f118eba4c2bd09"
+
 
 _GATE = {"min_recall": 0.60, "min_precision": 0.20, "min_f1": 0.30, "min_mrr": 0.55}
 
@@ -212,7 +214,7 @@ def test_control_ranking_artifact_characterizes_seventeen_rank_noise_tasks() -> 
     artifact = root / "benchmarks" / "evidence" / "m0.3-control-ranking.json"
     payload = json.loads(artifact.read_text(encoding="utf-8"))
 
-    assert payload["task_manifest_digest"] == task_manifest_digest(root / "benchmarks" / "tasks")
+    assert payload["task_manifest_digest"] == _M03_TASK_MANIFEST_DIGEST
     assert payload["gate_thresholds"] == _GATE
 
     by_strategy = {block["strategy"]: block for block in payload["strategies"]}


### PR DESCRIPTION
## Stack

Stack-Id: `m04r-promotion-recovery-3c9e7a`

Position: 2/3

Base: `m04r-promotion-gate` ([#516](https://github.com/Mathews-Tom/archex/pull/516))

## Change

Recalibrate four M0.4 benchmark questions whose expected symbols and files were not distinguishable from their prior query text. The expected files, symbols, and regions remain unchanged; each revised question now names the evaluated product concept:

- `PythonAdapter` for `archex_adapter_registry`
- status command and working-tree signature for `archex_project_status`
- `BaseHandler`, WSGI, and `CommonMiddleware` for `django_middleware`
- username validator classes for `loc_django_username_validator`

`benchmarks/evidence/m0.4-task-contract-calibration.json` preserves the prior immutable task digest, records the user-authorized evaluation-only scope, binds the recalibrated digest, and states that labels remain unavailable to runtime retrieval. Historical M0.2/M0.3 evidence readers now bind to their own frozen task-manifest digest rather than mutating historical provenance whenever a later benchmark task is clarified.

## Calibrated frontier result

A new immutable, warm-cache 64-task candidate/control run completed and validated:

- Source revision: `56bf07a97aea07a5ee6980e5cf6a8416475f748d`
- Manifest SHA-256: `39c886239d20116449fab68745a8ce5e06d9b4585f6619bdc89cdcbc69161877`
- Candidate warm samples: 64/64; warm p95: 727.041 ms
- Promotion gate: **NO-GO**, 122 violations: 1 recall, 39 precision, 36 F1, 17 MRR, 2 token-efficiency, 2 completion-adjusted-efficiency, 10 region, and 15 line regressions.

The recalibration restored task/query specificity and the warm measurement is valid. It did not repair the candidate’s broad file-set policy. A second promotion run is prohibited.

## Verification

- `uv run archex benchmark validate --kind tasks --tasks-dir benchmarks/tasks` — 64 tasks valid
- `uv run archex benchmark validate --kind evidence --tasks-dir benchmarks/tasks --input .archex/m04r-calibration-run1` — 64 tasks, 4 strategies valid
- `uv run pytest tests/benchmark/test_coverage.py tests/benchmark/test_rank_candidate_corpus.py tests/benchmark/test_ranking.py tests/benchmark/test_context_candidate_corpus.py --no-cov` — 22 passed
- `uv run ruff check tests/benchmark/test_coverage.py tests/benchmark/test_rank_candidate_corpus.py tests/benchmark/test_ranking.py tests/benchmark/test_context_candidate_corpus.py`
- `uv run ruff format --check tests/benchmark/test_coverage.py tests/benchmark/test_rank_candidate_corpus.py tests/benchmark/test_ranking.py tests/benchmark/test_context_candidate_corpus.py`
- `uv run pyright tests/benchmark/test_coverage.py tests/benchmark/test_rank_candidate_corpus.py tests/benchmark/test_ranking.py tests/benchmark/test_context_candidate_corpus.py`
- `uv run pytest --no-cov` — 3773 passed, 7 deselected

## Non-goals

No production retrieval change, task-label access at runtime, floor reduction, default promotion, canonical baseline promotion, M1 change, or benchmark-quality draft change.