### PR TITLE
fix(context): bound debugging result tails

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -994,28 +994,40 @@ def _file_path_boost(
     max_boost_chunks: int = 30,
     max_chunks_per_file: int = 3,
 ) -> list[tuple[CodeChunk, float]]:
-    """Find chunks whose file_path contains query terms as exact substrings.
+    """Find chunks whose file path matches query terms or explicit locations."""
+    import re
 
-    Terms are searched longest-first (from _extract_path_terms) so specific terms
-    like "validators" get priority over generic ones like "pydantic". Boost score
-    is max BM25 multiplied by _path_match_multiplier: 0.85 for stem/basename
-    matches, 0.70 for path segment matches, and 0.45 for substring matches.
-    Per-file caps prevent one matching directory from flooding file-level aggregation.
-    """
     terms = _extract_path_terms(question)
+    explicit_paths = {
+        path.lower()
+        for path in re.findall(
+            r"(?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.[A-Za-z0-9]+",
+            question,
+        )
+    }
     boosted: list[tuple[CodeChunk, float]] = []
     seen: set[str] = set(existing_ids)
     boosted_by_file: dict[str, int] = {}
+    for path in sorted(explicit_paths, key=len, reverse=True):
+        for chunk in store.search_chunks_by_path_keyword(path, limit=max_chunks_per_file):
+            if chunk.file_path.lower() != path:
+                continue
+            # An explicit source location is user-supplied direct evidence. Keep
+            # its score even when BM25 already returned the same chunk.
+            boosted.append((chunk, max_bm25_score * 5.0))
+            seen.add(chunk.id)
+            boosted_by_file[chunk.file_path] = boosted_by_file.get(chunk.file_path, 0) + 1
 
     for term in terms:
         for chunk in store.search_chunks_by_path_keyword(term, limit=20):
             if boosted_by_file.get(chunk.file_path, 0) >= max_chunks_per_file:
                 continue
-            if chunk.id not in seen:
-                seen.add(chunk.id)
-                boost_score = max_bm25_score * _path_match_multiplier(chunk.file_path, term)
-                boosted.append((chunk, boost_score))
-                boosted_by_file[chunk.file_path] = boosted_by_file.get(chunk.file_path, 0) + 1
+            if chunk.id in seen:
+                continue
+            seen.add(chunk.id)
+            boost_score = max_bm25_score * _path_match_multiplier(chunk.file_path, term)
+            boosted.append((chunk, boost_score))
+            boosted_by_file[chunk.file_path] = boosted_by_file.get(chunk.file_path, 0) + 1
             if len(boosted) >= max_boost_chunks:
                 return boosted
 
@@ -1036,10 +1048,10 @@ def _symbol_search_seeds(
 
     Differentiates between two confidence levels:
     - Exact symbol_name match (case-insensitive equality): high-confidence seed,
-      boosted at 0.60× max BM25.  Handles queries like "dependency injection"
+      boosted at 0.60× max BM25. Handles queries like "dependency injection"
       finding symbols literally named "depend" or "inject".
     - Partial / qualified-name match: low-confidence seed, boosted at 0.15×
-      max BM25.  Gets the file into seed_files for import expansion without
+      max BM25. Gets the file into seed_files for import expansion without
       competing directly for top file slots.
 
     File_path-only matches from FTS5 are discarded as noise.
@@ -1779,8 +1791,9 @@ def query(
     if index_config is None:
         index_config = load_index_config(source)
     _bootstrap_plugins()
-    from archex.serve.intent import token_budget_for_query
+    from archex.serve.intent import QueryIntent, classify_intent, token_budget_for_query
 
+    query_intent = classify_intent(question)
     intent_budget = None if explicit_token_budget else token_budget_for_query(question)
 
     t0 = time.perf_counter()
@@ -1848,8 +1861,12 @@ def query(
                     intent_budget,
                 )
 
-                # Passthrough: entire repo fits within budget
-                if effective_budget >= total_repo_tokens:
+                # A debugging question needs ranked evidence, not a whole-repository
+                # dump, even when that repository happens to fit the budget.
+                if (
+                    effective_budget >= total_repo_tokens
+                    and query_intent is not QueryIntent.DEBUGGING
+                ):
                     cached_chunks = store.get_chunks()
                     pt = passthrough_context(cached_chunks, question, effective_budget)
                     if timing is not None:

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -655,12 +655,9 @@ def _pack_ranked_chunks(
         for file_path, _score in sorted_files
         if file_path in top_files and file_path in best_by_file
     ]
-    ordered_files.sort(
-        key=lambda file_path: (
-            _is_test_file(file_path),
-            -best_by_file[file_path].final_score,
-        )
-    )
+    # Preserve aggregate relevance order while delaying test files. Python's
+    # stable sort retains the `sorted_files` order within each file class.
+    ordered_files.sort(key=_is_test_file)
     for file_path in ordered_files:
         total_tokens = _try_include_ranked_chunk(
             best_by_file[file_path],

--- a/src/archex/serve/context.py
+++ b/src/archex/serve/context.py
@@ -533,6 +533,9 @@ def _path_alignment_boost(file_path: str, query_terms: set[str]) -> float:
         part for token in stem.replace("-", "_").split("_") for part in _split_compound_token(token)
     )
     path_terms = {term.lower() for term in path_terms if len(term) >= 3}
+    normalized_stem_variants = {normalized_stem, *_singular_query_variants(normalized_stem)}
+    if normalized_stem_variants & query_terms:
+        return 3.0
     if stem.lower() in query_terms or normalized_stem in query_terms:
         return 3.0
     matched_terms = path_terms & query_terms
@@ -1097,7 +1100,9 @@ def assemble_context(
             cli_terms.add("api")
         alignment_terms = q_terms & cli_terms or q_terms
     else:
-        alignment_terms = {term for term in q_terms if term not in _ARCH_KEYWORDS} or q_terms
+        # Architectural vocabulary is still direct lexical/path evidence. Excluding
+        # it hides exact implementation files such as ``adapters.py``.
+        alignment_terms = q_terms
 
     # Determine whether this is an architecture query (enables 2-hop expansion)
     is_arch_query = _is_architecture_query(question)
@@ -1496,6 +1501,8 @@ def assemble_context(
     )
     top_files: set[str] = set()
     adaptive_max = _adaptive_max_files(sorted_files)
+    if intent == QueryIntent.DEBUGGING:
+        adaptive_max = min(adaptive_max, 5)
     if intent == QueryIntent.CLI or q_terms & {
         "graph",
         "dependency",

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -1472,6 +1472,12 @@ def test_path_alignment_matches_query_term_in_filename() -> None:
     )
 
 
+def test_path_alignment_matches_singular_query_to_plural_filename() -> None:
+    from archex.serve.context import _path_alignment_boost  # pyright: ignore[reportPrivateUsage]
+
+    assert _path_alignment_boost("src/requests/adapters.py", {"adapter"}) == 3.0
+
+
 def test_query_terms_expand_query_pipeline_to_bm25_context_signals() -> None:
     from archex.serve.context import _query_terms  # pyright: ignore[reportPrivateUsage]
 

--- a/tests/serve/test_context.py
+++ b/tests/serve/test_context.py
@@ -211,6 +211,25 @@ def test_packing_covers_selected_files_before_extra_chunks() -> None:
     assert bundle.token_count <= 460
 
 
+def test_packing_orders_files_by_aggregate_score() -> None:
+    graph = DependencyGraph()
+    graph.add_file_node("aggregate.py")
+    graph.add_file_node("peak.py")
+    aggregate_a = make_chunk("aggregate_a", "aggregate.py", token_count=50)
+    aggregate_b = make_chunk("aggregate_b", "aggregate.py", token_count=50)
+    peak = make_chunk("peak", "peak.py", token_count=50)
+
+    bundle = assemble_context(
+        [(peak, 10.0), (aggregate_a, 9.0), (aggregate_b, 8.0)],
+        graph,
+        [aggregate_a, aggregate_b, peak],
+        "query",
+        token_budget=500,
+    )
+
+    assert [rc.chunk.id for rc in bundle.chunks][:2] == ["aggregate_a", "peak"]
+
+
 def test_cli_packing_limits_extra_chunks_per_file() -> None:
     graph = DependencyGraph()
     chunks: list[CodeChunk] = []

--- a/tests/serve/test_query_normalization.py
+++ b/tests/serve/test_query_normalization.py
@@ -290,6 +290,27 @@ def test_file_path_boost_caps_chunks_per_file() -> None:
         store.close()
 
 
+def test_file_path_boost_promotes_explicit_source_location() -> None:
+    from archex.api import _file_path_boost
+
+    chunk = _chunk(
+        file_path="src/archex/cache.py",
+        name="cache_key",
+        qualified_name="cache_key",
+    )
+    store = _make_store([chunk])
+    try:
+        boosted = _file_path_boost(
+            store,
+            'Traceback: File "src/archex/cache.py", line 60',
+            existing_ids={chunk.id},
+            max_bm25_score=10.0,
+        )
+        assert boosted == [(chunk, 50.0)]
+    finally:
+        store.close()
+
+
 def test_exact_symbol_match_gets_high_boost() -> None:
     """Exact symbol_name equality → 0.60× max_bm25_score boost.
 

--- a/tests/test_query_pipeline.py
+++ b/tests/test_query_pipeline.py
@@ -115,6 +115,22 @@ class TestQueryPipelineEndToEnd:
         assert timing.search_ms is not None or timing.strategy == "passthrough"
         assert len(bundle.chunks) > 0
 
+    def test_debugging_query_does_not_passthrough_small_repository(
+        self, python_simple_repo: Path
+    ) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        timing = PipelineTiming()
+
+        bundle = query(
+            source,
+            "Bug report: authentication rejects a valid user. Where is validation performed?",
+            config=Config(cache=True),
+            timing=timing,
+        )
+
+        assert timing.strategy != "passthrough"
+        assert bundle.retrieval_metadata.strategy != "passthrough"
+
     def test_query_with_custom_weights(self, python_simple_repo: Path) -> None:
         source = RepoSource(local_path=str(python_simple_repo))
         config = Config(cache=False)


### PR DESCRIPTION
## Stack

Stack-Id: `benchmark-quality-20260711`
Base: `feat/benchmark-localization-candidate`
Position: 5/6

1. `fix/benchmark-workflow-execution` → #495
2. `refactor/benchmark-baseline-contract` → #496
3. `test/benchmark-failure-characterization` → #497
4. `feat/benchmark-localization-candidate` → #498
5. `fix/retrieval-quality-tail` → this PR
6. `ci/benchmark-quality-enforcement` → pending

Depends on: #498
Upstack: pending

## Summary

Repairs production retrieval ranking without changing task definitions, quality floors, or benchmark strategy selection.

- Cap debugging bundles at five files while retaining broader comprehension bundles.
- Treat singular query terms as exact matches for plural filename stems.
- Retain architectural vocabulary for direct path alignment.
- Treat explicit source paths in a question or traceback as protected direct evidence.
- Disable whole-repository passthrough for debugging queries, which require ranked evidence even when the repository fits the token budget.

The candidate reduces the absolute 64-task default quality gate from 43 to 12 violations. Remaining defects are rank-order failures. This PR remains draft until the recovery gate clears.

## Validation

- `uv run pytest tests/test_query_pipeline.py tests/serve/test_query_normalization.py tests/serve/test_context.py tests/serve/test_context_recall.py --no-cov` — 153 passed
- `uv run ruff check src/archex/api.py src/archex/serve/context.py tests/test_query_pipeline.py tests/serve/test_query_normalization.py tests/serve/test_context.py`
- `uv run archex benchmark run --tasks-dir benchmarks/tasks --output .archex/recovery-pr5-debug-retrieval-20260714 --strategy archex_query --warm-cache --no-progress`
- Absolute gate: 12 violations; no baseline was promoted.

## Known gate status

The full default quality gate remains red. This PR does not weaken its thresholds or alter benchmark oracles.