### PR TITLE
docs(readme): distinguish archex from multimodal knowledge-graph tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Need another language? Register an adapter via Python entry points. See [System 
 - **Not a vector database** — vector search is optional; BM25 and structural signals are first-class.
 - **Not an LSP replacement** — use LSAP/LSP where compiler-backed type resolution matters; archex packages repository-scale context for agents.
 - **Not a prompt template library** — output is structured retrieval evidence, not prompt prose.
+- **Not a multimodal knowledge-graph builder** — no LLM-driven concept extraction over PDFs, images, or notes, and no persistent cross-session graph artifact; archex indexes source code deterministically to assemble token-budgeted retrieval context, not a browsable knowledge base.
 
 ## Development
 


### PR DESCRIPTION
## What
Adds one bullet to the "What archex is not" section clarifying archex is not a multimodal knowledge-graph builder (no LLM-driven extraction over PDFs/images/notes, no persistent cross-session graph artifact).

## Why
Came up while comparing archex to a third-party tool (graphify) that markets similar token-reduction claims and shares tree-sitter usage, creating plausible category confusion despite solving a different problem (multimodal knowledge graphing vs. deterministic code-context retrieval).

## Scope
Docs only, no code changes.