### PR TITLE
feat(setup): promote hooks and CLI over MCP registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ archex does not ask the downstream agent to trust ranking alone. Every query/sco
 | If you are evaluating... | Start here | Why |
 | --- | --- | --- |
 | Agent workflows | `archex doctor`, then `archex scout "question" --budget 1000 --format json` | Checks local trust first, then returns a compact map, a receipt summary, and exact fetch handles. |
-| Claude Code or MCP | [MCP and Claude Code](#mcp-and-claude-code) | Stdio MCP server, optional warm `--watch`, additive top-level receipts, and an in-repo skill that teaches doctor → scout → fetch. |
+| Already using an agent that calls Grep/Glob | `archex install-client <client> --hooks` | Zero added context cost — augments existing tool calls instead of registering a new MCP tool surface. |
+| Want the full tool surface (graph, impact, symbol lookup, etc.) | [MCP and Claude Code](#mcp-and-claude-code) | Stdio MCP server, optional warm `--watch`, additive top-level receipts. Registers 17 tool schemas that resend every turn regardless of use — heavier than hooks, richer than grep/glob augmentation. |
 | Python applications | [Python API](#python-api) | Deterministic `query()`, `analyze()`, `compare()`, and receipt-bearing bundles. |
 | Benchmark proof | [Measured results](#measured-results) and [archex vs. cocoindex-code](docs/ARCHEX_VS_COCOINDEX.md) | Same-task C1 report, raw-ripgrep/read baseline, bundle-only evaluator reports, required-file trust gates, and TurboQuant storage/recall evidence. |
 | Installation and clients | [Compatibility matrix](docs/CLIENT_COMPATIBILITY_MATRIX.md) | Client bootstrap paths for Claude Code, Codex, Pi, OpenCode, Cursor, and oh-my-pi (`omp`); global/user scope by default, `--dry-run` previews. |
@@ -166,6 +167,8 @@ archex symbol 'symbol:src/auth/middleware.py::authenticate#function'
 ```
 
 ### MCP and Claude Code
+
+Registers all 17 archex tools with a client; every tool's schema resends on every conversational turn regardless of use, since tool-calling APIs are stateless. That is real, measurable context cost — roughly 6,000 tokens for the full set, computed from the tool schemas in `src/archex/integrations/mcp.py`. If a client only needs grep/glob-shaped lookups, `archex install-client <client> --hooks` (documented further down this section) gets the same retrieval quality with zero added schema cost. Use MCP when the fuller surface — graph inspection, impact analysis, batch symbol lookup — is worth that fixed per-turn cost.
 
 Install the MCP extra and register the stdio server:
 

--- a/src/archex/cli/setup_cmd.py
+++ b/src/archex/cli/setup_cmd.py
@@ -382,9 +382,29 @@ def setup_cmd(
         click.echo("\nWarning: archex mcp runtime is not available.")
         click.echo("MCP clients cannot be used until the 'mcp' extra is installed.")
 
-    # Clients
+    # Hooks — offered first: zero context cost, augments existing Grep/Glob
+    # calls instead of registering a new tool surface. Default on when a
+    # supported client is discovered, since it has no downside worth an
+    # explicit opt-out.
+    do_hooks = hooks
+    if not do_hooks and preflight.discovered_clients:
+        click.echo(
+            "\nHooks quietly augment your client's existing Grep/Glob calls with archex "
+            "results — no new tool schema, no added context cost per turn."
+        )
+        do_hooks = click.confirm("Install optional shell/editor hooks?", default=True)
+
+    # Clients (MCP) — registers the full 17-tool surface (query, scout, graph
+    # inspection, impact analysis, etc.). Every tool's schema is resent on
+    # every turn regardless of use, so this is worth it when you want that
+    # full surface, not just grep/glob augmentation.
     do_clients = clients
     if do_clients is None and preflight.discovered_clients and preflight.mcp_runtime_available:
+        click.echo(
+            "\nMCP registers all 17 archex tools with your client (query, scout, graph "
+            "inspection, impact analysis, and more) — the richest surface, at the cost of "
+            "resending every tool's schema on every turn."
+        )
         do_clients = click.confirm(
             f"Configure {len(preflight.discovered_clients)} discovered MCP clients?",
             default=True,
@@ -398,11 +418,6 @@ def setup_cmd(
     if do_metrics is None:
         click.echo("\nUsage metrics are anonymous and local-only.")
         do_metrics = click.confirm("Enable local usage metrics?", default=False)
-
-    # Hooks
-    do_hooks = hooks
-    if not do_hooks and preflight.discovered_clients:
-        do_hooks = click.confirm("Install optional shell/editor hooks?", default=False)
 
     mh_results = apply_metrics_hooks(
         source, preflight, dry_run=False, metrics_flag=do_metrics, hooks_flag=do_hooks


### PR DESCRIPTION
## What

Reorders and better informs the `archex setup` wizard's hooks vs MCP client-registration choice, and updates README to match.

- `archex setup` now offers to install hooks *before* offering MCP client registration, and defaults hooks to on (was off) when a supported client is discovered. Both prompts get one line of inline copy explaining the tradeoff before the user answers.
- README's Fast Paths table gets a dedicated hooks row ("already using an agent that calls Grep/Glob"), and the "MCP and Claude Code" section leads with the same tradeoff before the registration steps.

## Why

MCP client registration adds all 17 archex tool schemas to a client's context on every conversational turn regardless of use — tool-calling APIs are stateless, so the full `tools` array resends with every request. Measured from `src/archex/integrations/mcp.py`: roughly 6,000 tokens for the full 17-tool set. Hooks give the same retrieval quality (they augment the client's existing Grep/Glob calls with archex results) at zero added schema cost, so they're the better default for anyone who doesn't specifically need the deeper graph/impact/symbol-lookup tools.

## Scope

No default MCP behavior is disabled or removed — MCP client registration still defaults to on for users who want the full 17-tool surface. This changes *ordering* and *messaging* only: hooks are offered first and default on, MCP is still offered and still defaults on, and both prompts now explain the tradeoff instead of asking blind.

## Verification

- `uv run pytest tests/cli/test_setup_cmd.py` — 9 passed (interactive `click.confirm` prompts aren't exercised by these tests; they run against non-TTY/`--yes`/`--dry-run` paths, so this is a low-risk default flip).
- Full suite: `uv run pytest` — 3,774 passed, 91% coverage.
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright src/archex/cli/setup_cmd.py` — clean.

No source/retrieval behavior changed — setup-wizard UX and docs only.
