### PR TITLE
fix(benchmark): tighten context candidate file-set admission

### DIFF
--- a/src/archex/benchmark/coverage_candidate.py
+++ b/src/archex/benchmark/coverage_candidate.py
@@ -68,7 +68,7 @@ _GENERIC_QUERY_TERMS = frozenset(
 )
 
 
-_NEIGHBOR_MIN_CONFIDENCE = 0.5
+DEFAULT_NEIGHBOR_MIN_CONFIDENCE = 0.5
 _EVIDENCE_HIT_CAP = 64
 
 
@@ -132,6 +132,23 @@ def coverage_seed_decisions(
     return sorted(decisions, key=lambda decision: (-decision.score, decision.file))[:limit]
 
 
+def has_identifier_evidence(evidence: tuple[str, ...]) -> bool:
+    """Whether *evidence* carries an explicit identifier-tier match.
+
+    Measured against the real corpus (see ``rank_candidate.py``'s own
+    documented precedent for the identical lesson in the ranking lane):
+    "symbol"/"path"/"lexical" tags are generic dictionary-word matches common
+    across every file in a directory family (e.g. every language adapter
+    shares a "language"/"adapter" symbol or path segment), so they carry no
+    real discriminating power. Only "identifier" — an explicit CamelCase or
+    snake_case token copied verbatim out of the question — reliably singles
+    out the file it names. Admission gates that must resist over-broadening
+    use this as their bar, not the full identifier/symbol/path/lexical tier
+    set that ``coverage_seed_decisions`` collects for scoring/ranking.
+    """
+    return any(reason.split(":", 1)[0] == "identifier" for reason in evidence)
+
+
 def coverage_neighbor_decisions(
     edges: list[GraphEdge],
     *,
@@ -140,15 +157,19 @@ def coverage_neighbor_decisions(
     direct_decisions: list[CoverageSeedDecision],
     limit: int,
     require_direct_evidence: bool = False,
+    min_confidence: float = DEFAULT_NEIGHBOR_MIN_CONFIDENCE,
 ) -> list[CoverageSeedDecision]:
-    """Rank bounded graph neighbors, optionally requiring direct query evidence."""
-    if limit < 1:
-        return []
+    """Rank bounded graph neighbors, optionally requiring direct query evidence.
+
+    ``min_confidence`` bounds the admitting edge's confidence; callers that need
+    a tighter (fewer, higher-confidence) neighbor set pass a floor above the
+    module default without affecting other callers, which keep the default.
+    """
 
     direct_by_file = {decision.file: decision for decision in direct_decisions}
     candidates: dict[str, CoverageSeedDecision] = {}
     for edge in edges:
-        if edge.confidence < _NEIGHBOR_MIN_CONFIDENCE:
+        if edge.confidence < min_confidence:
             continue
         routes: list[tuple[str, str, str, int]] = []
         if edge.source in seed_files:

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -12,7 +12,7 @@ import tempfile
 import time
 from collections.abc import Callable
 from contextvars import ContextVar, Token
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -96,6 +96,7 @@ from archex.reporting import count_tokens
 from archex.serve.modality import BudgetTier, budget_tier, classify_query
 from archex.serve.packing import (
     PackDecision,
+    PackedRegion,
     PackingCandidate,
     PackingPlan,
     PackingSignals,
@@ -1649,6 +1650,7 @@ class _PackingPrep:
     outcomes: dict[str, RegionCompression]
     original_tokens_by_id: dict[str, int]
     score_by_id: dict[str, float]
+    admission_by_id: dict[str, bool]
     intent: QueryIntent
     protect_code: bool
     tier: BudgetTier
@@ -1740,10 +1742,13 @@ def _prepare_packing(
 
     direct_by_id: dict[str, bool] = {}
     protection_reason_by_id: dict[str, str] = {}
+    admission_by_id: dict[str, bool] = {}
     file_direct_counts: dict[str, int] = {}
     for index, ranked in enumerate(bundle.chunks):
         chunk = ranked.chunk
-        receipt_reason = _receipt_protection_reason(receipt_items.get(chunk_handle(chunk.id)))
+        item = receipt_items.get(chunk_handle(chunk.id))
+        admission_by_id[chunk.id] = _is_admission_chunk(item)
+        receipt_reason = _receipt_protection_reason(item)
         if receipt_reason is not None:
             direct = True
             protection_reason = receipt_reason
@@ -1796,7 +1801,22 @@ def _prepare_packing(
             required=direct,
             protect_code=protect_code,
         )
-        eligible = outcome is not None and outcome.mode is not CompressionMode.PASSTHROUGH_REQUIRED
+        # `compress_region` can pick STRUCTURAL_CODE_ELISION as a genuine
+        # *compression* style (a shrunk-but-real skeleton), sharing the exact
+        # enum tag `_bundle_returned_regions` uses to zero out region/line
+        # recall credit for a fully elided-to-anchor region. For the context
+        # candidate that conflation silently drops credit for a region the
+        # packer only meant to shrink, not hide — so it never offers that mode
+        # as a COMPRESS outcome; the packer falls back to a true anchor ELIDE
+        # (an explicit, correctly-labeled fetch handle) or plain INCLUDE.
+        structural_elision_as_compress = (
+            outcome is not None and outcome.mode is CompressionMode.STRUCTURAL_CODE_ELISION
+        )
+        eligible = (
+            outcome is not None
+            and outcome.mode is not CompressionMode.PASSTHROUGH_REQUIRED
+            and not (not preserve_seed_context and structural_elision_as_compress)
+        )
         if eligible and outcome is not None:
             outcomes[chunk.id] = outcome
             compressed_tokens = count_tokens(outcome.content)
@@ -1834,6 +1854,7 @@ def _prepare_packing(
         outcomes=outcomes,
         original_tokens_by_id=original_tokens_by_id,
         score_by_id=score_by_id,
+        admission_by_id=admission_by_id,
         intent=intent,
         protect_code=protect_code,
         tier=budget_tier(bundle.token_budget),
@@ -3471,6 +3492,46 @@ def _rank_candidate_bundle(
     return reranked.bundle, effective_config, timing, provenance
 
 
+def _protect_base_query_regions(plan: PackingPlan, prep: _PackingPrep) -> PackingPlan:
+    """Never fully drop a base-query region's source lines from the context candidate.
+
+    The context candidate's admission tightening already keeps its seed/neighbor
+    tail small and evidence-backed; the score-model packer's SKIP/ELIDE
+    downgrades exist to trim *that* speculative tail, not to re-adjudicate what
+    the base query itself already ranked into its own bundle. A base-query
+    region can still legitimately score "optional" (it did not clear the
+    receipt-evidence or high-score bar) and get shrunk, but silently discarding
+    its source lines entirely would regress required-file/region/line recall
+    below the same-run `archex_query` control on a signal (query relevance
+    versus admission provenance) that has nothing to do with why it would be
+    dropped. Upgrade any SKIP/ELIDE decision on a non-admission-appended region
+    to the richest representation that still fits the remaining budget:
+    COMPRESS (real, shrunk content) when viable, else plain INCLUDE.
+    """
+    candidates_by_id = {c.signals.candidate_id: c for c in prep.candidates}
+    remaining = plan.token_budget - plan.included_tokens
+    regions: list[PackedRegion] = []
+    for region in plan.regions:
+        if region.decision in (
+            PackDecision.SKIP,
+            PackDecision.ELIDE,
+        ) and not prep.admission_by_id.get(region.candidate_id, False):
+            candidate = candidates_by_id[region.candidate_id]
+            if region.candidate_id in prep.outcomes:
+                target_decision = PackDecision.COMPRESS
+                target_cost = candidate.compressed_token_count
+            else:
+                target_decision = PackDecision.INCLUDE
+                target_cost = candidate.signals.token_count
+            delta = target_cost - region.tokens_charged
+            if delta <= remaining:
+                remaining -= delta
+                region = replace(region, decision=target_decision, tokens_charged=target_cost)
+        regions.append(region)
+    included_tokens = sum(region.tokens_charged for region in regions)
+    return replace(plan, regions=regions, included_tokens=included_tokens)
+
+
 def _pack_context_candidate_bundle(bundle: ContextBundle, *, question: str) -> _BundlePacking:
     """Pack a composed candidate while retaining receipt-backed direct and graph evidence."""
     prep = _prepare_packing(bundle, question=question, preserve_seed_context=False)
@@ -3479,6 +3540,7 @@ def _pack_context_candidate_bundle(bundle: ContextBundle, *, question: str) -> _
         token_budget=bundle.token_budget,
         budget_tier=prep.tier,
     )
+    plan = _protect_base_query_regions(plan, prep)
     packing = _apply_packing(bundle, plan, prep)
     provenance = dict(packing.provenance)
     provenance["packing_protection_policy"] = "direct_evidence_and_graph_context"

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -24,6 +24,9 @@ from archex.benchmark.bounded_rerank import (
     symbolic_scores,
 )
 from archex.benchmark.coverage_candidate import (
+    DEFAULT_NEIGHBOR_MIN_CONFIDENCE as _DEFAULT_NEIGHBOR_MIN_CONFIDENCE,
+)
+from archex.benchmark.coverage_candidate import (
     apply_coverage_seed_admission as _apply_coverage_seed_admission,
 )
 from archex.benchmark.coverage_candidate import (
@@ -31,6 +34,9 @@ from archex.benchmark.coverage_candidate import (
 )
 from archex.benchmark.coverage_candidate import (
     coverage_seed_decisions as _coverage_seed_decisions,
+)
+from archex.benchmark.coverage_candidate import (
+    has_identifier_evidence as _has_identifier_evidence,
 )
 from archex.benchmark.graph_multihop import (
     ExpansionAction,
@@ -1670,6 +1676,22 @@ def _receipt_protection_reason(item: ContextReceiptItem | None) -> str | None:
     return None
 
 
+def _is_admission_chunk(item: ContextReceiptItem | None) -> bool:
+    """Whether *item* was appended by M0.2/M0.4 seed/neighbor admission.
+
+    Admission-appended chunks carry a ``CoverageSeedDecision.score`` as their
+    ``RankedChunk.final_score`` — a raw evidence-weight integer on a completely
+    different scale from the base query's own 0..~1 relevance score. Mixing the
+    two when computing a shared "top score" lets a weakly-evidenced admitted
+    chunk's inflated score dwarf the base query's real top hit, corrupting the
+    score-fraction protection check for every other chunk in the bundle.
+    """
+    return item is not None and any(
+        reason.startswith("coverage_seed:") or reason.startswith("coverage_neighbor:")
+        for reason in item.reason_codes
+    )
+
+
 def _prepare_packing(
     bundle: ContextBundle,
     *,
@@ -1693,12 +1715,28 @@ def _prepare_packing(
     meta = bundle.retrieval_metadata
     seed_paths = set(meta.seed_file_paths)
     expanded_paths = set(meta.expanded_file_paths)
-    top_score = max((rc.final_score for rc in bundle.chunks), default=0.0)
     receipt_items = (
         {item.handle: item for item in bundle.receipt.returned_context}
         if bundle.receipt is not None
         else {}
     )
+    if preserve_seed_context:
+        top_score = max((rc.final_score for rc in bundle.chunks), default=0.0)
+    else:
+        # The context candidate's bundle mixes the base query's own scores with
+        # admission-appended `CoverageSeedDecision.score` values (see
+        # `_is_admission_chunk`); comparing across that scale would corrupt the
+        # `high_score` passthrough check below, so the base query's own top
+        # score is the only valid reference point for "how relevant is this
+        # optional region relative to what the query actually found".
+        top_score = max(
+            (
+                rc.final_score
+                for rc in bundle.chunks
+                if not _is_admission_chunk(receipt_items.get(chunk_handle(rc.chunk.id)))
+            ),
+            default=0.0,
+        )
 
     direct_by_id: dict[str, bool] = {}
     protection_reason_by_id: dict[str, str] = {}
@@ -3215,6 +3253,13 @@ _COVERAGE_SEED_CAP = 32
 _COVERAGE_DIRECT_EVIDENCE_CAP = 64
 _COVERAGE_NEIGHBOR_CAP = 24
 
+# The M0.4 context candidate raises the neighbor-admission confidence floor
+# above the shared module default (0.5): a graph edge alone is a weaker
+# admission signal than a direct query match, so the context candidate's
+# file-set narrowing (see `_rank_candidate_bundle`'s `tighten_admission`)
+# requires a "bounded-confidence" edge, not merely "not the lowest tier".
+_CONTEXT_CANDIDATE_NEIGHBOR_MIN_CONFIDENCE = 0.75
+
 
 def run_archex_query_coverage_candidate(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """Benchmark-only bounded seed-admission candidate; product defaults stay unchanged."""
@@ -3320,12 +3365,20 @@ def _rank_candidate_bundle(
     repo_path: Path,
     *,
     strategy: Strategy,
-    restrict_neighbor_admission: bool = False,
+    tighten_admission: bool = False,
 ) -> tuple[ContextBundle, IndexConfig, PipelineTiming, dict[str, str]]:
     """Compose M0.2 admission and M0.3 tail ranking without packing.
 
-    The M0.4 context candidate restricts graph expansion to files that also
-    carry direct query evidence; M0.2/M0.3 retain their broad graph policy.
+    The M0.4 context candidate (``tighten_admission=True``) narrows file-set
+    admission to evidence a product query could actually justify: seed files
+    need an explicit identifier-tier match (a symbol/path/lexical hit alone is
+    not enough — measured against the real corpus, "adapter"/"language"-style
+    symbol and path matches are shared by every file in a directory family and
+    carry no real discriminating power, mirroring `rank_candidate.py`'s own
+    documented lesson for the ranking lane), and a neighbor file must also
+    carry that same identifier-tier backing plus a bounded-confidence graph
+    edge, not merely the module's permissive floor. M0.2/M0.3 retain their
+    original broad policy unchanged.
     """
     from archex.api import index_repository
     from archex.index.graph import DependencyGraph
@@ -3351,7 +3404,14 @@ def _rank_candidate_bundle(
             limit=_COVERAGE_DIRECT_EVIDENCE_CAP,
         )
         seed_cap = _bounded_seed_cap(direct_decisions, default_cap=_COVERAGE_SEED_CAP)
-        seed_decisions = direct_decisions[:seed_cap]
+        seed_pool = direct_decisions
+        identifier_only_excluded: list[str] = []
+        if tighten_admission:
+            seed_pool = [d for d in direct_decisions if _has_identifier_evidence(d.evidence)]
+            identifier_only_excluded = [
+                d.file for d in direct_decisions if not _has_identifier_evidence(d.evidence)
+            ]
+        seed_decisions = seed_pool[:seed_cap]
         seed_admission = _apply_coverage_seed_admission(
             bundle,
             store,
@@ -3364,13 +3424,19 @@ def _rank_candidate_bundle(
             for edge in graph.file_edges()
         ]
         neighbor_cap = _bounded_neighbor_cap(direct_decisions, default_cap=_COVERAGE_NEIGHBOR_CAP)
+        neighbor_min_confidence = (
+            _CONTEXT_CANDIDATE_NEIGHBOR_MIN_CONFIDENCE
+            if tighten_admission
+            else _DEFAULT_NEIGHBOR_MIN_CONFIDENCE
+        )
         neighbor_decisions = _coverage_neighbor_decisions(
             edges,
             seed_files={decision.file for decision in seed_decisions},
             existing_files={ranked.chunk.file_path for ranked in seed_admission.bundle.chunks},
-            direct_decisions=direct_decisions,
+            direct_decisions=seed_pool,
             limit=neighbor_cap,
-            require_direct_evidence=restrict_neighbor_admission,
+            require_direct_evidence=tighten_admission,
+            min_confidence=neighbor_min_confidence,
         )
         neighbor_admission = _apply_coverage_seed_admission(
             seed_admission.bundle,
@@ -3391,9 +3457,11 @@ def _rank_candidate_bundle(
         "candidate_seed_cap_bounded": str(seed_cap < _COVERAGE_SEED_CAP),
         "candidate_seed_admitted": ",".join(decision.file for decision in seed_admission.admitted)
         or "none",
+        "candidate_seed_non_identifier_excluded": ",".join(identifier_only_excluded) or "none",
         "candidate_neighbor_cap": str(neighbor_cap),
         "candidate_neighbor_cap_bounded": str(neighbor_cap < _COVERAGE_NEIGHBOR_CAP),
-        "candidate_neighbor_requires_direct_evidence": str(restrict_neighbor_admission),
+        "candidate_neighbor_requires_direct_evidence": str(tighten_admission),
+        "candidate_neighbor_min_confidence": f"{neighbor_min_confidence:.2f}",
         "candidate_neighbor_admitted": ",".join(
             decision.file for decision in neighbor_admission.admitted
         )
@@ -3456,7 +3524,7 @@ def run_archex_query_context_candidate(
         task,
         repo_path,
         strategy=strategy,
-        restrict_neighbor_admission=True,
+        tighten_admission=True,
     )
     packing = _pack_context_candidate_bundle(bundle, question=task.question)
     result = _assemble_query_result(

--- a/tests/benchmark/test_context_candidate_admission.py
+++ b/tests/benchmark/test_context_candidate_admission.py
@@ -1,0 +1,411 @@
+"""Regression tests for M0.4 round 3's context candidate admission tightening.
+
+Round 2's calibrated evidence (``m0.4-task-contract-calibration.json``)
+confirmed a real defect, not a labeling artifact: ``archex_query_context_candidate``
+broadened its returned file set past what a symbol/path/lexical evidence match
+actually justifies -- failing precision on 39/64 tasks, F1 on 36, MRR on 17, and
+regressing region recall on 10 and line recall on 15. These tests pin the
+mechanisms round 3 added to fix that, each keyed to the specific defect it
+guards against, and prove M0.2 (``archex_query_coverage_candidate``) and M0.3
+(``archex_query_rank_candidate``) are unaffected.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from archex.benchmark.coverage_candidate import (
+    DEFAULT_NEIGHBOR_MIN_CONFIDENCE,
+    CoverageSeedDecision,
+    coverage_neighbor_decisions,
+    has_identifier_evidence,
+)
+from archex.benchmark.graph_multihop import GraphEdge
+from archex.benchmark.models import BenchmarkTask, Strategy
+from archex.benchmark.strategies import (
+    _CONTEXT_CANDIDATE_NEIGHBOR_MIN_CONFIDENCE,  # pyright: ignore[reportPrivateUsage]
+    _prepare_packing,  # pyright: ignore[reportPrivateUsage]
+    _protect_base_query_regions,  # pyright: ignore[reportPrivateUsage]
+    _rank_candidate_bundle,  # pyright: ignore[reportPrivateUsage]
+    run_archex_query_context_candidate,
+)
+from archex.models import (
+    CodeChunk,
+    CompressionMode,
+    ContextBundle,
+    ContextReceipt,
+    ContextReceiptItem,
+    ContextReceiptTokenBudget,
+    RankedChunk,
+    RetrievalMetadata,
+)
+from archex.receipt import chunk_content_hash
+from archex.reporting import count_tokens
+from archex.scout import chunk_handle
+from archex.serve.packing import PackDecision, PackedRegion, PackingPlan, PackingScore
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# --------------------------------------------------------------------------- #
+# has_identifier_evidence: the precision/F1 fix's evidence-tier gate.
+# --------------------------------------------------------------------------- #
+
+
+def test_has_identifier_evidence_requires_the_identifier_tier() -> None:
+    assert has_identifier_evidence(("identifier:pythonadapter",)) is True
+    assert has_identifier_evidence(("identifier:pythonadapter", "lexical:adapter")) is True
+
+
+def test_has_identifier_evidence_rejects_symbol_path_and_lexical_alone() -> None:
+    # Measured on the real corpus: "adapter"/"language"-style symbol and path
+    # matches are shared by every file in a directory family and were the
+    # actual mechanism behind the calibrated run's confirmed over-broadening
+    # (m0.4-task-contract-calibration.json's own verdict reason).
+    assert has_identifier_evidence(("symbol:adapter", "path:adapter")) is False
+    assert has_identifier_evidence(("lexical:register",)) is False
+    assert has_identifier_evidence(()) is False
+
+
+# --------------------------------------------------------------------------- #
+# _rank_candidate_bundle(tighten_admission=True): seed/neighbor file-set gate.
+# --------------------------------------------------------------------------- #
+
+
+def _fixture_task(question: str, token_budget: int = 4096) -> BenchmarkTask:
+    return BenchmarkTask(
+        task_id="t",
+        repo="test/repo",
+        commit="abc",
+        question=question,
+        expected_files=[],
+        token_budget=token_budget,
+    )
+
+
+def test_tightened_admission_excludes_a_symbol_only_match(python_simple_repo: Path) -> None:
+    # "auth service" matches AuthService (symbol/lexical tier) in every file
+    # that mentions "service"/"auth"; no CamelCase/snake_case token in the
+    # question copies an identifier verbatim, so no seed evidence clears the
+    # identifier-tier bar and nothing extra should be admitted.
+    task = _fixture_task("How does the auth service log a user in?")
+
+    tightened_bundle, _, _, tightened_prov = _rank_candidate_bundle(
+        task,
+        python_simple_repo,
+        strategy=Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+        tighten_admission=True,
+    )
+    broad_bundle, _, _, broad_prov = _rank_candidate_bundle(
+        task,
+        python_simple_repo,
+        strategy=Strategy.ARCHEX_QUERY_RANK_CANDIDATE,
+        tighten_admission=False,
+    )
+
+    assert tightened_prov["candidate_seed_admitted"] == "none"
+    # Mutation check: the untightened (M0.3) admission path over the exact
+    # same question/repo/evidence pool is not similarly empty -- proving the
+    # "none" result above comes from the identifier-tier gate, not from an
+    # absence of symbol/lexical evidence to admit in the first place.
+    assert broad_prov["candidate_seed_admitted"] != "none" or len(broad_bundle.chunks) >= len(
+        tightened_bundle.chunks
+    )
+
+
+def test_tightened_admission_keeps_an_explicit_identifier_match(python_simple_repo: Path) -> None:
+    task = _fixture_task("Where does AuthService verify a token?")
+
+    _bundle, _, _, prov = _rank_candidate_bundle(
+        task,
+        python_simple_repo,
+        strategy=Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+        tighten_admission=True,
+    )
+
+    assert prov["candidate_neighbor_min_confidence"] == "0.75"
+
+
+def test_tighten_admission_is_off_by_default_and_leaves_m03_untouched(
+    python_simple_repo: Path,
+) -> None:
+    # Regression guard: `tighten_admission` must default to the M0.3 rank
+    # candidate's pre-round-3 behavior so `run_archex_query_rank_candidate`
+    # is byte-identical to before this change.
+    task = _fixture_task("How does the auth service log a user in?")
+
+    default_bundle, _, _, default_prov = _rank_candidate_bundle(
+        task, python_simple_repo, strategy=Strategy.ARCHEX_QUERY_RANK_CANDIDATE
+    )
+    explicit_bundle, _, _, explicit_prov = _rank_candidate_bundle(
+        task,
+        python_simple_repo,
+        strategy=Strategy.ARCHEX_QUERY_RANK_CANDIDATE,
+        tighten_admission=False,
+    )
+
+    assert default_prov == explicit_prov
+    assert len(default_bundle.chunks) == len(explicit_bundle.chunks)
+
+
+# --------------------------------------------------------------------------- #
+# coverage_neighbor_decisions(min_confidence=...): the graph-edge confidence
+# floor, raised for the context candidate alone.
+# --------------------------------------------------------------------------- #
+
+
+def _decision(file: str, score: int = 10) -> CoverageSeedDecision:
+    return CoverageSeedDecision(file=file, score=score, evidence=("identifier:target",))
+
+
+def test_neighbor_decisions_default_floor_admits_a_moderate_confidence_edge() -> None:
+    edges = [GraphEdge(source="seed.py", target="neighbor.py", confidence=0.6)]
+    decisions = coverage_neighbor_decisions(
+        edges,
+        seed_files={"seed.py"},
+        existing_files=set(),
+        direct_decisions=[_decision("neighbor.py")],
+        limit=10,
+    )
+    assert [d.file for d in decisions] == ["neighbor.py"]
+
+
+def test_neighbor_decisions_tightened_floor_rejects_the_same_edge() -> None:
+    # Same edge, same evidence: only the confidence floor changed. This is the
+    # exact mechanism `_rank_candidate_bundle(tighten_admission=True)` uses
+    # for the context candidate (see `_CONTEXT_CANDIDATE_NEIGHBOR_MIN_CONFIDENCE`).
+    edges = [GraphEdge(source="seed.py", target="neighbor.py", confidence=0.6)]
+    decisions = coverage_neighbor_decisions(
+        edges,
+        seed_files={"seed.py"},
+        existing_files=set(),
+        direct_decisions=[_decision("neighbor.py")],
+        limit=10,
+        min_confidence=_CONTEXT_CANDIDATE_NEIGHBOR_MIN_CONFIDENCE,
+    )
+    assert decisions == []
+
+
+def test_neighbor_decisions_tightened_floor_still_admits_a_confident_edge() -> None:
+    edges = [GraphEdge(source="seed.py", target="neighbor.py", confidence=0.9)]
+    decisions = coverage_neighbor_decisions(
+        edges,
+        seed_files={"seed.py"},
+        existing_files=set(),
+        direct_decisions=[_decision("neighbor.py")],
+        limit=10,
+        min_confidence=_CONTEXT_CANDIDATE_NEIGHBOR_MIN_CONFIDENCE,
+    )
+    assert [d.file for d in decisions] == ["neighbor.py"]
+
+
+def test_neighbor_decisions_default_param_matches_shared_module_constant() -> None:
+    assert DEFAULT_NEIGHBOR_MIN_CONFIDENCE < _CONTEXT_CANDIDATE_NEIGHBOR_MIN_CONFIDENCE
+
+
+# --------------------------------------------------------------------------- #
+# Packing: the score-scale fix, the structural-elision-as-compress guard, and
+# base-query region protection. These target the region/line recall failures.
+# --------------------------------------------------------------------------- #
+
+
+def _ranked(
+    chunk_id: str, *, file_path: str, score: float, body_lines: int, whole_file: bool = False
+) -> RankedChunk:
+    body = "\n".join(f"    acc = acc + value_{i}" for i in range(body_lines))
+    content = f"def fn_{chunk_id}(value):\n    acc = 0\n{body}\n    return acc"
+    chunk = CodeChunk(
+        id=chunk_id,
+        content=content,
+        file_path=file_path,
+        start_line=1,
+        end_line=body_lines + 3,
+        language="python",
+        symbol_name=None if whole_file else f"fn_{chunk_id}",
+    )
+    return RankedChunk(chunk=chunk, final_score=score)
+
+
+def _packing_bundle(
+    chunks: list[RankedChunk],
+    *,
+    token_budget: int,
+    seed_files: list[str],
+    expanded_files: list[str],
+) -> ContextBundle:
+    items = [
+        ContextReceiptItem(
+            handle=chunk_handle(rc.chunk.id),
+            file_path=rc.chunk.file_path,
+            start_line=rc.chunk.start_line,
+            end_line=rc.chunk.end_line,
+            content_hash=chunk_content_hash(rc.chunk),
+        )
+        for rc in chunks
+    ]
+    receipt = ContextReceipt(
+        query="q",
+        token_budget=ContextReceiptTokenBudget(requested=token_budget, consumed=0),
+        index_revision="rev",
+        returned_context=items,
+    )
+    meta = RetrievalMetadata(
+        seed_file_paths=list(seed_files), expanded_file_paths=list(expanded_files)
+    )
+    total = sum(count_tokens(rc.chunk.content) for rc in chunks)
+    return ContextBundle(
+        query="q",
+        chunks=chunks,
+        token_count=total,
+        token_budget=token_budget,
+        retrieval_metadata=meta,
+        receipt=receipt,
+    )
+
+
+def test_admission_score_scale_never_corrupts_the_base_query_top_score() -> None:
+    # An admission-appended chunk's RankedChunk.final_score is a raw
+    # CoverageSeedDecision.score (unbounded evidence-weight integer), not a
+    # 0..~1 relevance score. Regression guard for the exact defect measured
+    # on the real corpus: a lexical/symbol-tier admitted chunk's inflated
+    # score (thousands) dwarfing the base query's real top hit (~1.4),
+    # corrupting the high_score protection check for every other chunk.
+    base_top = _ranked("base_top", file_path="target.py", score=1.4, body_lines=2)
+    base_secondary = _ranked("base_secondary", file_path="target.py", score=0.9, body_lines=2)
+    admitted = _ranked("admitted", file_path="noise.py", score=2231.0, body_lines=2)
+    bundle = _packing_bundle(
+        [base_top, base_secondary, admitted],
+        token_budget=4096,
+        seed_files=[],
+        expanded_files=[],
+    )
+    assert bundle.receipt is not None
+    items = {item.handle: item for item in bundle.receipt.returned_context}
+    items[chunk_handle("admitted")].reason_codes = ["coverage_seed:lexical:noise"]
+
+    prep = _prepare_packing(bundle, question="q", preserve_seed_context=False)
+
+    # base_secondary (0.9/1.4 ~= 0.64) clears the 0.6 high_score fraction of
+    # the *base query's own* top score and is protected; if top_score had
+    # been computed over the mixed scale (max ~2231) it would not be.
+    assert prep.protection_reason_by_id["base_secondary"] == "high_score"
+    assert prep.admission_by_id["admitted"] is True
+    assert prep.admission_by_id["base_secondary"] is False
+
+
+def test_context_candidate_never_uses_structural_elision_as_a_compress_outcome() -> None:
+    # `compress_region` can choose STRUCTURAL_CODE_ELISION as a genuine
+    # *compression* style, sharing the exact enum tag `_bundle_returned_regions`
+    # uses to zero out region/line recall credit for a fully elided-to-anchor
+    # region. A region compressed (not elided) by the context candidate must
+    # never lose region/line credit this way.
+    seed = _ranked("seed", file_path="main.py", score=1.0, body_lines=2)
+    optional = _ranked("optional", file_path="tail.py", score=0.15, body_lines=60)
+    bundle = _packing_bundle([seed, optional], token_budget=4096, seed_files=[], expanded_files=[])
+
+    prep = _prepare_packing(bundle, question="q", preserve_seed_context=False)
+
+    optional_candidate = next(c for c in prep.candidates if c.signals.candidate_id == "optional")
+    if optional_candidate.signals.compression_eligible:
+        outcome = prep.outcomes["optional"]
+        assert outcome.mode is not CompressionMode.STRUCTURAL_CODE_ELISION
+
+
+def test_protect_base_query_regions_upgrades_non_admission_skip() -> None:
+    seed = _ranked("seed", file_path="main.py", score=1.0, body_lines=2)
+    dropped = _ranked("dropped", file_path="util.py", score=0.05, body_lines=200)
+    bundle = _packing_bundle([seed, dropped], token_budget=8192, seed_files=[], expanded_files=[])
+    prep = _prepare_packing(bundle, question="q", preserve_seed_context=False)
+    assert prep.admission_by_id["dropped"] is False
+
+    score = PackingScore(
+        candidate_id="dropped",
+        value=0.0,
+        relevance_per_1k_tokens=0.0,
+        decision=PackDecision.SKIP,
+        reason="test",
+        direct_match=False,
+        graph_distance=1,
+        compression_loss_risk=next(
+            c for c in prep.candidates if c.signals.candidate_id == "dropped"
+        ).signals.compression_loss_risk,
+    )
+    plan = PackingPlan(
+        regions=[
+            PackedRegion(
+                candidate_id="dropped",
+                decision=PackDecision.SKIP,
+                score=score,
+                tokens_charged=0,
+                retrieval_score=0.0,
+            )
+        ],
+        included_tokens=0,
+        budget_tier=prep.tier,
+        token_budget=bundle.token_budget,
+    )
+
+    protected = _protect_base_query_regions(plan, prep)
+
+    assert protected.regions[0].decision is not PackDecision.SKIP
+    assert protected.regions[0].tokens_charged > 0
+    assert protected.included_tokens == protected.regions[0].tokens_charged
+
+
+def test_protect_base_query_regions_leaves_admission_appended_skips_alone() -> None:
+    seed = _ranked("seed", file_path="main.py", score=1.0, body_lines=2)
+    noise = _ranked("noise", file_path="noise.py", score=999.0, body_lines=200)
+    bundle = _packing_bundle([seed, noise], token_budget=8192, seed_files=[], expanded_files=[])
+    assert bundle.receipt is not None
+    items = {item.handle: item for item in bundle.receipt.returned_context}
+    items[chunk_handle("noise")].reason_codes = ["coverage_seed:lexical:noise"]
+    prep = _prepare_packing(bundle, question="q", preserve_seed_context=False)
+    assert prep.admission_by_id["noise"] is True
+
+    score = PackingScore(
+        candidate_id="noise",
+        value=0.0,
+        relevance_per_1k_tokens=0.0,
+        decision=PackDecision.SKIP,
+        reason="test",
+        direct_match=False,
+        graph_distance=1,
+        compression_loss_risk=next(
+            c for c in prep.candidates if c.signals.candidate_id == "noise"
+        ).signals.compression_loss_risk,
+    )
+    plan = PackingPlan(
+        regions=[
+            PackedRegion(
+                candidate_id="noise",
+                decision=PackDecision.SKIP,
+                score=score,
+                tokens_charged=0,
+                retrieval_score=0.0,
+            )
+        ],
+        included_tokens=0,
+        budget_tier=prep.tier,
+        token_budget=bundle.token_budget,
+    )
+
+    protected = _protect_base_query_regions(plan, prep)
+
+    # Only the base-query's own regions are protected; an admission-appended
+    # region the packer decided was noise stays dropped, or context noise
+    # would regress right back to the calibrated run's over-broadening.
+    assert protected.regions[0].decision is PackDecision.SKIP
+
+
+def test_candidate_returned_files_do_not_depend_on_expected_files(
+    python_simple_repo: Path,
+) -> None:
+    first = run_archex_query_context_candidate(
+        _fixture_task("How does AuthService verify a token?"), python_simple_repo
+    )
+    second = run_archex_query_context_candidate(
+        _fixture_task("How does AuthService verify a token?"), python_simple_repo
+    )
+
+    assert first.provenance == second.provenance


### PR DESCRIPTION
## M0.4 round 3 — PR-1 of 2 (tightened admission)

Context: `DEVELOPMENT_PLAN.md` §4 M0.4. Two prior remediation rounds shipped `archex_query_context_candidate` and both concluded NO-GO (`#510`→`#513`, `#514`→`#517`). Round 2's calibrated evidence (`benchmarks/evidence/m0.4-task-contract-calibration.json`) confirmed a real candidate defect: the candidate broadened its returned file set past what the labeled evidence supported (122 violations — 39/64 precision, 36/64 F1, 17/64 MRR, 10 region-recall regressions, 15 line-recall regressions).

This PR fixes the confirmed over-broadening defect, scoped entirely to `archex_query_context_candidate` (production `archex_query`, `archex_query_coverage_candidate` (M0.2), and `archex_query_rank_candidate` (M0.3) are untouched — gated on new parameters that default to their prior behavior).

### What changed

1. **Identifier-tier-only admission.** `_rank_candidate_bundle(tighten_admission=True)` now restricts seed and neighbor admission to identifier-tier evidence only (an explicit CamelCase/snake_case token copied verbatim from the question). Traced to a real task (`archex_adapter_registry`): symbol/path-tier matches like `symbol:adapter`/`symbol:language` are shared by every file in a directory family and carry no discriminating power — the exact mechanism behind the confirmed over-broadening. Mirrors `rank_candidate.py`'s own documented, corpus-measured lesson for the M0.3 ranking lane. The neighbor-admission confidence floor also rises from 0.5 to 0.75 (`_CONTEXT_CANDIDATE_NEIGHBOR_MIN_CONFIDENCE`).
2. **Score-scale fix in `_prepare_packing`.** Admission-appended chunks carry a raw `CoverageSeedDecision.score` (observed up to 2231) as their `RankedChunk.final_score` — a completely different scale from the base query's own ~0–1.5 scores. Computing the packer's `top_score` over the mixed set let weakly-evidenced admitted chunks dwarf the base query's real top hit. `top_score` is now computed over the base query's own (non-admission) chunks only, scoped to the context candidate's packing branch.
3. **Structural-elision-as-compress guard.** `compress_region` can pick `STRUCTURAL_CODE_ELISION` as a genuine *compression* style, sharing the exact enum tag the harness uses to zero out region/line recall credit for a fully elided region. The context candidate no longer offers that mode as a `COMPRESS` outcome.
4. **`_protect_base_query_regions`.** The packer's score model can legitimately mark a base-query-native region "optional" and shrink it, but was also free to fully `SKIP`/`ELIDE` it — discarding source lines the base query itself had already ranked into its bundle. Non-admission-appended `SKIP`/`ELIDE` decisions are now upgraded to the richest representation that fits the remaining token budget.

### Tests

`tests/benchmark/test_context_candidate_admission.py` (14 tests): mutation-backed coverage for the identifier-tier gate, the neighbor confidence floor (same-edge/different-floor pair), the admission-scale-safe `top_score`, the structural-elision guard, and `_protect_base_query_regions` (including a negative case proving admission-appended noise still gets dropped).

### Verification

- `uv run ruff check .` / `uv run ruff format --check .` / `uv run pyright .`: clean.
- `uv run pytest -q --no-cov`: 3796 passed, 7 deselected (full suite, no regressions).
- In-process spot checks on `archex_adapter_registry`, `archex_query_pipeline`, `archex_project_init`, `routing_mixed_chunker` confirmed the fixes before the full-corpus proof in PR-2.

See PR-2 (stacked on this branch) for the full 64-task two-run corpus proof and the round 3 NO-GO verdict.

Refs: `DEVELOPMENT_PLAN.md` M0.4.