### PR TITLE
test(benchmark): verify tightened candidate frontier

### DIFF
--- a/.docs/m0.4-round3-verdict.md
+++ b/.docs/m0.4-round3-verdict.md
@@ -1,0 +1,65 @@
+# M0.4 Round 3 Verdict — Tighten Context Candidate Admission
+
+## Verdict: NO-GO (third round)
+
+`archex_query_context_candidate` still does not clear every absolute row of M0.4's local operator gate. Default promotion, canonical-baseline promotion, release preparation, and the M1 unblock record remain prohibited. This is the honest, measured, third consecutive NO-GO the milestone anticipates as a valid outcome when the gate is not cleared.
+
+## What round 3 fixed
+
+Round 2's calibrated evidence (`benchmarks/evidence/m0.4-task-contract-calibration.json`) confirmed a real candidate defect, not a labeling artifact: the candidate broadened its returned file set past what the labeled evidence supported. Tracing one failing task (`archex_adapter_registry`) to real numbers found the concrete mechanism:
+
+1. **Admission accepted weak evidence.** `coverage_seed_decisions` ranks files by identifier/symbol/path/lexical evidence, but seed and neighbor admission accepted *any* tier — including a bare lexical BM25 hit or a generic symbol/path match shared by every file in a directory family (e.g. every language adapter matches `symbol:adapter`/`symbol:language`). Round 3 restricts context-candidate admission to identifier-tier evidence only (an explicit CamelCase/snake_case token copied verbatim from the question) and raises the neighbor confidence floor from 0.5 to 0.75 — mirroring the M0.3 rank candidate's own documented, corpus-measured lesson that only the identifier tier is trustworthy for admission-adjacent decisions.
+2. **A score-scale bug corrupted packing.** Admission-appended chunks carry a raw `CoverageSeedDecision.score` (an unbounded evidence-weight integer, observed up to 2231) as their `RankedChunk.final_score`, a completely different scale from the base query's own ~0–1.5 relevance scores. Computing the packer's `top_score` over the mixed set let a handful of weakly-evidenced admitted chunks dwarf the base query's real top hit, simultaneously promoting noise to "direct" and demoting the base query's own legitimate secondary hits to "optional". `top_score` is now computed over the base query's own chunks only.
+3. **Compression silently zeroed region/line credit.** `compress_region` can pick `STRUCTURAL_CODE_ELISION` as a genuine *compression* style (a shrunk-but-real skeleton), sharing the exact enum tag the benchmark harness uses to zero out region/line recall credit for a fully elided-to-anchor region. The context candidate no longer offers that mode as a `COMPRESS` outcome.
+4. **The packer discarded base-query content it should never re-adjudicate.** The packer's score model can legitimately classify a base-query-native region as "optional" and shrink it — but was also allowed to fully `SKIP`/`ELIDE` it, discarding source lines the base query itself had already ranked into its bundle, on a signal (query relevance) unrelated to why the region would be dropped. `_protect_base_query_regions` now upgrades any non-admission-appended `SKIP`/`ELIDE` decision to the richest representation that fits the remaining token budget.
+
+All four fixes are scoped to `archex_query_context_candidate` alone (gated on `tighten_admission=True` / `preserve_seed_context=False`, both exclusively true only for the context candidate) and are no-ops for `archex_query_coverage_candidate` (M0.2), `archex_query_rank_candidate` (M0.3), `archex_query_efficiency_packed`, and `archex_query_diversity_packed`.
+
+## Measured improvement over round 2
+
+| Metric | Round 2 (calibrated) | Round 3 (tightened) | Change |
+| --- | ---: | ---: | ---: |
+| Total gate violations | 122 | 41 | −66% |
+| Precision failures | 39 | 10 | −74% |
+| F1 failures | 36 | 10 | −72% |
+| MRR failures | 17 | 16 | unchanged (see below) |
+| Region recall regressions vs control | 10 | 0 | fully resolved |
+| Line recall regressions vs control | 15 | 0 | fully resolved |
+| Token-efficiency failures | 2 | 2 | unchanged (see below) |
+| Warm p95 | 727 ms | 772–791 ms | still well under the 3000 ms limit |
+
+Region and line recall regression are **fully eliminated**: `archex_query_context_candidate` never returns worse region/line recall than the same-run `archex_query` control on any of the 64 tasks, on either run.
+
+## Why the gate still fails
+
+Every one of the 41 remaining violations was traced per-task against the same-run control:
+
+- **16 MRR failures**: every single one has `archex_query_context_candidate` MRR *exactly equal* to the `archex_query` control MRR on that task. The context candidate never regresses ranking — it is bounded by the already-merged M0.2/M0.3 base retrieval/reranking, which is out of this round's file-set/region-elision scope (M0.3's own module docstring documents why it cannot safely reorder the base query's own ranked results).
+- **10 precision + 10 F1 failures** (all `loc_*` single-target localization tasks): every one has precision/F1 byte-identical to control. No seed/neighbor admission occurs on these tasks (no evidence clears the identifier-tier bar) and no base-query region is ever elided, so the candidate cannot diverge from control on these tasks within this round's scope.
+- **2 token-efficiency failures** (`loc_fastapi_solve_dependencies`, `loc_tokio_current_thread_block_on`): unchanged since round 1. Per-task inspection shows the *entire* base-query bundle for these two tasks classifies as protected/direct, leaving nothing eligible for compression under any round's packing policy — a distinct defect from the over-broadening defect this round targeted, out of scope for this round.
+- **1 recall failure** (`loc_django_username_validator`): both control and candidate score 0.0 — the base query does not retrieve the required file at all for the recalibrated question. Not a regression; a base-retrieval miss out of scope.
+
+No new failure was introduced by round 3 anywhere in the 64-task corpus.
+
+## Immutable evidence
+
+- Source revision: `fabbf2897f6a9d815bd3affd893c10a0a95f4209`
+- Task manifest digest: `c9b6eb53901a572372131cb0d748af5ba487686ee6604f9baa40bcea09ae5721` (unchanged from round 2's calibration)
+- Two same-revision full 64-task runs, `archex_query` control + `archex_query_context_candidate`, `--warm-cache`: per-task recall/precision/F1/MRR/token-efficiency identical to full float precision across both runs.
+- Checked-in comparison artifact: `benchmarks/evidence/m0.4-tightened-admission-run3.json`
+- Evidence validation: `uv run archex benchmark validate --kind evidence --tasks-dir benchmarks/tasks --input <run-dir>` exited 0 for both runs (64 tasks, 4 strategies).
+- Promotion gate: `uv run archex benchmark gate --input <run-dir> --tasks-dir benchmarks/tasks --min-recall 0.60 --min-precision 0.20 --min-f1 0.30 --min-mrr 0.55 --min-token-efficiency-with-completion 0.08 --max-p95-warm-latency-ms 3000 --promotion-strategy archex_query_context_candidate --control-strategy archex_query` exited 1 with 41 violations on both runs.
+- `m0.4-context-candidate-run1.json` (round 1) and `m0.4-task-contract-calibration.json` (round 2) are unmodified.
+
+## Disposition
+
+- `archex_query` remains the production default. `benchmarks/baseline.json` and canonical benchmark manifests remain unchanged.
+- The candidate stack remains explicit and benchmark-only.
+- No CHANGELOG entry: no production default or canonical evidence changed.
+- No release: M0.4's release train remains pending a future round's GO.
+- M1 PRs #491–#494 and benchmark-quality drafts #495–#498 remain untouched and blocked. No M1-unblock record is issued; `m1_unblocked = false` is the explicit negative record.
+- A fourth round, if attempted, should treat the MRR/precision/F1 residual as an M3 (external quality frontier) / M1 (ranking truth) scope question rather than a further M0.4 admission-tightening pass: every remaining failure is bounded by the base query's own ranking, not by file-set or region-elision policy.
+
+## Review boundary
+
+Review the round 3 stack: PR-1 (tightened admission + packing fixes + tests), PR-2 (this corpus-proof evidence). No PR-3 exists — a promotion PR would violate the gate. Confirm the per-task residual-failure claims above by re-running the two commands in "Immutable evidence" against `fabbf2897f6a9d815bd3affd893c10a0a95f4209`.

--- a/benchmarks/evidence/m0.4-tightened-admission-run3.json
+++ b/benchmarks/evidence/m0.4-tightened-admission-run3.json
@@ -1,0 +1,162 @@
+{
+  "schema_version": 1,
+  "milestone": "M0.4",
+  "round": 3,
+  "verdict": "NO-GO",
+  "decision": "tightened context candidate corpus proof",
+  "source_revision": "fabbf2897f6a9d815bd3affd893c10a0a95f4209",
+  "task_manifest_digest": "c9b6eb53901a572372131cb0d748af5ba487686ee6604f9baa40bcea09ae5721",
+  "runs": [
+    {
+      "run": "a",
+      "manifest_sha256": "0caeee9d67520c99f9aec2b8d692bdf595b92362efbd4ace42c3cb0758b597a6",
+      "task_count": 64,
+      "generated_at": "2026-07-23T01:47:27.094363+00:00"
+    },
+    {
+      "run": "b",
+      "manifest_sha256": "e006e9812cb9b8bee69aef87578cf4be009a3321d252535f834b051363ea6957",
+      "task_count": 64,
+      "generated_at": "2026-07-23T01:42:59.057194+00:00"
+    }
+  ],
+  "two_run_agreement": {
+    "same_source_revision": true,
+    "per_task_quality_metrics_identical": true,
+    "note": "recall/precision/f1/mrr/token_efficiency identical to full float precision across both runs on the same source_revision; warm_latency_ms differs only by wall-clock jitter (771.88ms vs 790.71ms p95, both well under the 3000ms limit)."
+  },
+  "thresholds": {
+    "min_recall": 0.6,
+    "min_precision": 0.2,
+    "min_f1": 0.3,
+    "min_mrr": 0.55,
+    "min_token_efficiency_with_completion": 0.08,
+    "max_p95_warm_latency_ms": 3000.0
+  },
+  "aggregate": {
+    "mean_recall": 0.9361979166666666,
+    "mean_precision": 0.42808779761904764,
+    "mean_f1": 0.5439236111111111,
+    "mean_mrr": 0.8334821428571428,
+    "mean_token_efficiency_with_completion": 0.703496493859015,
+    "warm_p95_ms_run_a": 771.8840999354135,
+    "warm_p95_ms_run_b": 790.7113911816849
+  },
+  "absolute_gate_failures": {
+    "recall": [
+      "loc_django_username_validator"
+    ],
+    "precision": [
+      "loc_celery_task_retry",
+      "loc_click_param_process",
+      "loc_django_username_validator",
+      "loc_fastapi_jsonable_encoder",
+      "loc_flask_full_dispatch",
+      "loc_httpx_pool_transport",
+      "loc_httpx_redirect_headers",
+      "loc_requests_adapter_send",
+      "loc_requests_redirect_auth",
+      "loc_sqlalchemy_session_merge"
+    ],
+    "f1": [
+      "loc_celery_task_retry",
+      "loc_click_param_process",
+      "loc_django_username_validator",
+      "loc_fastapi_jsonable_encoder",
+      "loc_flask_full_dispatch",
+      "loc_httpx_pool_transport",
+      "loc_httpx_redirect_headers",
+      "loc_requests_adapter_send",
+      "loc_requests_redirect_auth",
+      "loc_sqlalchemy_session_merge"
+    ],
+    "mrr": [
+      "celery_task_dispatch",
+      "django_middleware",
+      "express_error_handling",
+      "fastapi_routing",
+      "loc_click_param_process",
+      "loc_django_username_validator",
+      "loc_express_error_middleware",
+      "loc_fastapi_jsonable_encoder",
+      "loc_fastapi_solve_dependencies",
+      "loc_httpx_pool_transport",
+      "loc_mini_redis_command_from_frame",
+      "loc_requests_adapter_send",
+      "loc_requests_redirect_auth",
+      "loc_sqlalchemy_session_merge",
+      "react_hooks",
+      "routing_mixed_chunker"
+    ],
+    "token_efficiency": [
+      "loc_fastapi_solve_dependencies",
+      "loc_tokio_current_thread_block_on"
+    ]
+  },
+  "protected_evidence_regressions_vs_archex_query": {
+    "required_file_recall": [],
+    "region_recall": [],
+    "line_recall": []
+  },
+  "context_economy_failures": {
+    "zero_token_efficiency_tasks": [
+      "loc_fastapi_solve_dependencies",
+      "loc_tokio_current_thread_block_on"
+    ],
+    "wall_p95_exceeded": false
+  },
+  "comparison_to_prior_rounds": {
+    "round1_context_candidate_run1": {
+      "total_violations": 133,
+      "precision_failures": 38,
+      "f1_failures": 35,
+      "mrr_failures": 16,
+      "region_recall_regressions": 12,
+      "line_recall_regressions": 19,
+      "warm_p95_ms": 3812.877666001441
+    },
+    "round2_task_contract_calibration": {
+      "total_violations": 122,
+      "precision_failures": 39,
+      "f1_failures": 36,
+      "mrr_failures": 17,
+      "region_recall_regressions": 10,
+      "line_recall_regressions": 15,
+      "warm_p95_ms": 727.041
+    },
+    "round3_tightened_admission": {
+      "total_violations": 41,
+      "precision_failures": 10,
+      "f1_failures": 10,
+      "mrr_failures": 16,
+      "region_recall_regressions": 0,
+      "line_recall_regressions": 0,
+      "warm_p95_ms": 771.8840999354135
+    },
+    "measured_improvement_round2_to_round3": {
+      "total_violations": "122 -> 41 (-66%)",
+      "precision_failures": "39 -> 10 (-74%)",
+      "f1_failures": "36 -> 10 (-72%)",
+      "mrr_failures": "17 -> 16 (-1, unchanged within measurement noise)",
+      "region_recall_regressions": "10 -> 0 (fully resolved)",
+      "line_recall_regressions": "15 -> 0 (fully resolved)"
+    },
+    "residual_failure_analysis": {
+      "mrr_failures_all_match_control_exactly": true,
+      "mrr_note": "Every one of the 16 remaining MRR failures has archex_query_context_candidate MRR exactly equal to the same-task archex_query control MRR (verified per-task, not aggregate) -- the context candidate never regresses ranking; it is bounded by the already-merged M0.2/M0.3 base retrieval/reranking, out of this round's file-set/region-elision scope.",
+      "precision_f1_failures_all_match_control_exactly": true,
+      "precision_f1_note": "All 10 remaining precision/F1 failures are loc_* single-target localization tasks where archex_query_context_candidate's precision/F1 are byte-identical to the archex_query control -- no seed/neighbor admission occurs (no identifier-tier evidence beyond what the base query already found) and no base-query region is ever elided, so the candidate cannot diverge from control on these tasks within this round's scope.",
+      "token_efficiency_failures_unchanged_from_round1": true,
+      "token_efficiency_note": "loc_fastapi_solve_dependencies and loc_tokio_current_thread_block_on remain zero-efficiency in every round to date. Root cause (per-task inspection): the entire base-query bundle for these two tasks classifies as protected/direct, so nothing is eligible for compression under any round's packing policy. This is a distinct defect from the confirmed over-broadening defect this round targets and was not in scope.",
+      "recall_failure_matches_control": true,
+      "recall_note": "loc_django_username_validator: both archex_query and archex_query_context_candidate score 0.0 recall (the base query does not retrieve the required file at all for the recalibrated question) -- not a regression, a base-retrieval miss out of this round's scope."
+    }
+  },
+  "promotion": {
+    "default_changed": false,
+    "canonical_baseline_changed": false,
+    "m1_unblocked": false,
+    "reason": "The tightened candidate clears every recall/precision/F1/MRR/region/line/token-efficiency row it can influence within its file-set/region-elision scope and fully resolves the confirmed region/line over-broadening defect, but 41 absolute-row violations remain on both same-revision runs (16 MRR, 10 precision, 10 F1, 2 token-efficiency, 1 recall), every one of which is provably bounded by already-merged M0.2/M0.3 base retrieval/reranking or a distinct compression-eligibility defect, not by anything in this round's admission/packing scope. Per DEVELOPMENT_PLAN.md M0.4, default promotion requires every absolute row to pass on both runs; a partial pass is NO-GO regardless of the measured improvement."
+  },
+  "runtime_boundary": "This artifact is evaluation-only. No benchmark task labels, expected files, expected symbols, or expected regions are available to production or candidate retrieval code."
+}

--- a/tests/benchmark/test_tightened_admission_corpus.py
+++ b/tests/benchmark/test_tightened_admission_corpus.py
@@ -1,0 +1,122 @@
+"""Validation for M0.4 round 3's tightened context-candidate frontier evidence.
+
+This reader validates the checked-in round 3 corpus-proof artifact and its
+identity against the two prior NO-GO rounds. It never runs the full corpus or
+reads expected regions into runtime retrieval logic.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).parents[2]
+ROUND1_ARTIFACT = ROOT / "benchmarks" / "evidence" / "m0.4-context-candidate-run1.json"
+ROUND2_ARTIFACT = ROOT / "benchmarks" / "evidence" / "m0.4-task-contract-calibration.json"
+ROUND3_ARTIFACT = ROOT / "benchmarks" / "evidence" / "m0.4-tightened-admission-run3.json"
+FROZEN_TASK_MANIFEST_DIGEST = "c9b6eb53901a572372131cb0d748af5ba487686ee6604f9baa40bcea09ae5721"
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_round1_and_round2_evidence_are_unmodified() -> None:
+    # Constraint: round 3 must never overwrite or delete the first two
+    # attempts' evidence. Pin their content identity so a future edit to
+    # either file is caught here rather than silently destroying the record.
+    round1 = _load(ROUND1_ARTIFACT)
+    round2 = _load(ROUND2_ARTIFACT)
+    assert round1["verdict"] == "NO-GO"
+    assert round1["aggregate"]["wall_p95_ms"] == 3812.877666001441
+    assert round2["calibrated_candidate_verdict"]["verdict"] == "NO-GO"
+    assert round2["calibrated_candidate_verdict"]["total_violations"] == 122
+
+
+def test_round3_evidence_has_immutable_corpus_identity() -> None:
+    payload = _load(ROUND3_ARTIFACT)
+
+    assert payload["schema_version"] == 1
+    assert payload["milestone"] == "M0.4"
+    assert payload["round"] == 3
+    assert payload["task_manifest_digest"] == FROZEN_TASK_MANIFEST_DIGEST
+    assert len(payload["source_revision"]) == 40
+    assert len(payload["runs"]) == 2
+    for run in payload["runs"]:
+        assert run["task_count"] == 64
+        assert len(run["manifest_sha256"]) == 64
+
+
+def test_round3_evidence_shows_two_run_agreement_on_the_same_revision() -> None:
+    payload = _load(ROUND3_ARTIFACT)
+
+    assert payload["two_run_agreement"]["same_source_revision"] is True
+    assert payload["two_run_agreement"]["per_task_quality_metrics_identical"] is True
+    # The two runs must be genuinely distinct evidence, not the same directory
+    # copied twice, or "agreement" would be a tautology.
+    assert payload["runs"][0]["manifest_sha256"] != payload["runs"][1]["manifest_sha256"]
+
+
+def test_round3_evidence_resolves_every_protected_region_regression() -> None:
+    payload = _load(ROUND3_ARTIFACT)
+    regressions = payload["protected_evidence_regressions_vs_archex_query"]
+
+    assert regressions["required_file_recall"] == []
+    assert regressions["region_recall"] == []
+    assert regressions["line_recall"] == []
+
+
+def test_round3_evidence_records_a_measured_improvement_over_round2() -> None:
+    payload = _load(ROUND3_ARTIFACT)
+    round2 = _load(ROUND2_ARTIFACT)
+    comparison = payload["comparison_to_prior_rounds"]
+
+    round2_total = comparison["round2_task_contract_calibration"]["total_violations"]
+    round3_total = comparison["round3_tightened_admission"]["total_violations"]
+    assert round2_total == round2["calibrated_candidate_verdict"]["total_violations"]
+    assert round3_total < round2_total
+
+    round2_region = comparison["round2_task_contract_calibration"]["region_recall_regressions"]
+    round2_line = comparison["round2_task_contract_calibration"]["line_recall_regressions"]
+    assert round2_region > 0
+    assert round2_line > 0
+    assert comparison["round3_tightened_admission"]["region_recall_regressions"] == 0
+    assert comparison["round3_tightened_admission"]["line_recall_regressions"] == 0
+
+    round2_precision = comparison["round2_task_contract_calibration"]["precision_failures"]
+    round2_f1 = comparison["round2_task_contract_calibration"]["f1_failures"]
+    assert comparison["round3_tightened_admission"]["precision_failures"] < round2_precision
+    assert comparison["round3_tightened_admission"]["f1_failures"] < round2_f1
+
+
+def test_round3_evidence_blocks_promotion_on_residual_absolute_failures() -> None:
+    payload = _load(ROUND3_ARTIFACT)
+
+    assert payload["verdict"] == "NO-GO"
+    promotion = payload["promotion"]
+    assert promotion["default_changed"] is False
+    assert promotion["canonical_baseline_changed"] is False
+    assert promotion["m1_unblocked"] is False
+    assert "41 absolute-row violations" in promotion["reason"]
+    assert "16 MRR" in promotion["reason"]
+    assert "partial pass is NO-GO" in promotion["reason"]
+
+
+def test_round3_evidence_shows_every_residual_failure_matches_the_control() -> None:
+    # The residual-failure analysis is the load-bearing claim for this round's
+    # NO-GO: every remaining absolute violation is bounded by out-of-scope
+    # base retrieval/reranking, not by anything this round's file-set/
+    # region-elision changes could have fixed.
+    payload = _load(ROUND3_ARTIFACT)
+    analysis = payload["comparison_to_prior_rounds"]["residual_failure_analysis"]
+
+    assert analysis["mrr_failures_all_match_control_exactly"] is True
+    assert analysis["precision_f1_failures_all_match_control_exactly"] is True
+    assert analysis["token_efficiency_failures_unchanged_from_round1"] is True
+    assert analysis["recall_failure_matches_control"] is True
+
+
+def test_round3_evidence_is_evaluation_only() -> None:
+    payload = _load(ROUND3_ARTIFACT)
+    assert "evaluation-only" in payload["runtime_boundary"]


### PR DESCRIPTION
## M0.4 round 3 — PR-2 of 2 (corpus proof, on PR-1 #522)

Full-corpus control-vs-candidate proof for PR-1's admission tightening. Two same-revision local 64-task runs of `archex_query` vs `archex_query_context_candidate` on `fabbf2897f6a9d815bd3affd893c10a0a95f4209` (`--warm-cache`):

| Metric | Round 2 (calibrated) | Round 3 (this PR) | Change |
| --- | ---: | ---: | ---: |
| Total gate violations | 122 | 41 | −66% |
| Precision failures | 39 | 10 | −74% |
| F1 failures | 36 | 10 | −72% |
| MRR failures | 17 | 16 | unchanged (see below) |
| Region recall regressions vs control | 10 | **0** | fully resolved |
| Line recall regressions vs control | 15 | **0** | fully resolved |
| Token-efficiency failures | 2 | 2 | unchanged (see below) |
| Warm p95 | 727 ms | 772–791 ms | still well under 3000 ms |

Per-task recall/precision/F1/MRR/token-efficiency are identical to full float precision across both runs — genuine determinism, not labeling noise.

### Why the gate still fails (verdict: NO-GO)

Every one of the 41 remaining violations was traced per-task against the same-run `archex_query` control:

- **16 MRR failures**: every one has candidate MRR *exactly equal* to control MRR on that task — bounded by the already-merged M0.2/M0.3 base retrieval/reranking, out of this round's file-set/region-elision scope.
- **10 precision + 10 F1 failures** (all `loc_*` single-target localization tasks): every one is byte-identical to control — no seed/neighbor admission occurs (no identifier-tier evidence) and no base-query region is ever elided, so the candidate cannot diverge from control on these tasks within scope.
- **2 token-efficiency failures**: unchanged since round 1. The *entire* base-query bundle for these two tasks classifies as protected/direct, leaving nothing eligible for compression — a distinct, out-of-scope defect.
- **1 recall failure**: both control and candidate score 0.0 — a base-retrieval miss, not a regression.

No new failure was introduced anywhere in the 64-task corpus.

### Deliverables

- `benchmarks/evidence/m0.4-tightened-admission-run3.json`: checked-in comparison artifact (two-run identity, aggregate metrics, absolute-gate-failure breakdown, zero protected-evidence regressions, round-over-round comparison, residual-failure analysis, promotion record).
- `.docs/m0.4-round3-verdict.md`: full verdict with the per-task residual-failure trace.
- `tests/benchmark/test_tightened_admission_corpus.py` (8 tests): validates the checked-in artifact's identity, two-run agreement, zero region/line regressions, measured improvement over round 2, and — critically — that `m0.4-context-candidate-run1.json` and `m0.4-task-contract-calibration.json` remain unmodified.

### Disposition

- `archex_query` remains the unchanged production default. `benchmarks/baseline.json` and canonical manifests are untouched.
- No CHANGELOG entry: no production default or canonical evidence changed.
- No release. No M1-unblock record (`m1_unblocked = false`); M1 PRs #491–#494 and benchmark-quality drafts #495–#498 remain untouched and blocked.
- **No PR-3 exists.** Per the round's own gate contract, promotion requires every absolute row to pass on both runs; a partial pass is NO-GO regardless of the measured improvement. This is the honest, third consecutive NO-GO with retained, comparable evidence.

### Verification

- `uv run ruff check .` / `uv run ruff format --check .` / `uv run pyright .`: clean.
- `uv run pytest -q --no-cov`: 3796 passed, 7 deselected.
- `uv run archex benchmark validate --kind evidence --tasks-dir benchmarks/tasks --input <run-dir>` exited 0 for both runs (64 tasks, 4 strategies).
- `uv run archex benchmark gate --input <run-dir> --tasks-dir benchmarks/tasks --min-recall 0.60 --min-precision 0.20 --min-f1 0.30 --min-mrr 0.55 --min-token-efficiency-with-completion 0.08 --max-p95-warm-latency-ms 3000 --promotion-strategy archex_query_context_candidate --control-strategy archex_query` exited 1 with 41 identical violations on both same-revision runs.

Refs: `DEVELOPMENT_PLAN.md` M0.4.