### PR TITLE
fix(benchmark): record reproducible provenance

### DIFF
--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -632,6 +632,17 @@ class BenchmarkResult(BaseModel):
     diversity_deselected_regions: int | None = None
 
 
+class BenchmarkProvenance(BaseModel):
+    """Reproducible run provenance for benchmark reports."""
+
+    archex_version: str
+    commit: str | None = None
+    generation_time: str
+    config: dict[str, str | bool | int | float | list[str]] = {}
+    hardware: str | None = None
+    sample_count: int = 1
+
+
 class BenchmarkReport(BaseModel):
     task_id: str
     repo: str
@@ -640,6 +651,7 @@ class BenchmarkReport(BaseModel):
     baseline_tokens: int
     median_latency_ms: float = 0.0
     p95_latency_ms: float = 0.0
+    provenance: BenchmarkProvenance | None = None
 
 
 class CompressionLayerResult(BaseModel):

--- a/src/archex/benchmark/runner.py
+++ b/src/archex/benchmark/runner.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import logging
+import platform
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from archex import __version__
 from archex.benchmark.loader import load_tasks
 from archex.benchmark.models import (
+    BenchmarkProvenance,
     BenchmarkReport,
     BenchmarkResult,
     BenchmarkRetrievalOptions,
@@ -26,6 +30,7 @@ from archex.benchmark.strategies import (
     reset_benchmark_retrieval_options,
     set_benchmark_retrieval_options,
 )
+from archex.cache import CacheManager
 from archex.exceptions import ArchexIndexError, BenchmarkCloneError
 
 if TYPE_CHECKING:
@@ -328,6 +333,38 @@ def run_benchmark(
                         result.task_completion_result == baseline_completion
                     )
 
+        provenance_config: dict[str, str | bool | int | float | list[str]] = {
+            "splade": retrieval_options.splade,
+            "module_prefilter": retrieval_options.module_prefilter,
+            "embedder": retrieval_options.embedder,
+            "allow_remote_code": retrieval_options.allow_remote_code,
+            "freshness": retrieval_options.freshness,
+            "chunker": retrieval_options.chunker,
+            "symbolic_rerank_mode": retrieval_options.symbolic_rerank_mode,
+            "symbolic_rerank_alpha": retrieval_options.symbolic_rerank_alpha,
+            "summary_sidecar_enabled": retrieval_options.summary_sidecar_path is not None,
+            "token_budget": task.token_budget,
+            "languages": task.languages or "all",
+            "include_paths": sorted(task.include_paths),
+            "strategies": [strategy.value for strategy in strategies],
+        }
+        if retrieval_options.bm25_chunker is not None:
+            provenance_config["bm25_chunker"] = retrieval_options.bm25_chunker
+        if retrieval_options.vector_chunker is not None:
+            provenance_config["vector_chunker"] = retrieval_options.vector_chunker
+        if retrieval_options.rerank_model is not None:
+            provenance_config["rerank_model"] = retrieval_options.rerank_model
+        if retrieval_options.rerank_candidate_limit is not None:
+            provenance_config["rerank_candidate_limit"] = retrieval_options.rerank_candidate_limit
+
+        provenance = BenchmarkProvenance(
+            archex_version=__version__,
+            commit=CacheManager.git_head(str(repo_path)) or task.commit,
+            generation_time=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            config=provenance_config,
+            hardware=platform.platform(),
+        )
+
         return BenchmarkReport(
             task_id=task.task_id,
             repo=task.repo,
@@ -342,6 +379,7 @@ def run_benchmark(
                 [result.wall_time_ms for result in results if result.wall_time_ms is not None],
                 0.95,
             ),
+            provenance=provenance,
         )
     finally:
         reset_benchmark_retrieval_options(token)

--- a/tests/benchmark/test_policy.py
+++ b/tests/benchmark/test_policy.py
@@ -1,0 +1,64 @@
+import os
+from pathlib import Path
+
+from archex.benchmark.models import BenchmarkProvenance, BenchmarkReport
+
+
+def test_sealed_corpus_boundaries_no_benchmark_specialization() -> None:
+    """Ensure production code does not hardcode benchmark-specific vocabulary."""
+    # Production code must never specialize behavior to known benchmark tasks/repos.
+    banned_terms = [
+        "swe_bench",
+        "swebench",
+        "human_eval",
+        "humaneval",
+        "mbpp",
+        "bird",
+        "spider",
+        "defects4j",
+    ]
+
+    src_dir = Path("src/archex")
+    for root, _, files in os.walk(src_dir):
+        for file in files:
+            if not file.endswith(".py"):
+                continue
+            path = Path(root) / file
+
+            # The benchmark engine itself is allowed to know about benchmarks.
+            if "benchmark" in path.parts:
+                continue
+
+            content = path.read_text().lower()
+            for term in banned_terms:
+                assert term not in content, (
+                    f"Sealed corpus violation: benchmark-specific term '{term}' "
+                    f"found in production file {path}. Production behavior must "
+                    f"generalize heuristically, not specialize to benchmarks."
+                )
+
+
+def test_benchmark_report_provenance_populated() -> None:
+    """Ensure BenchmarkReport can record full reproducible provenance."""
+    prov = BenchmarkProvenance(
+        archex_version="1.0.0",
+        generation_time="2026-07-11T00:00:00Z",
+        hardware="darwin-arm64",
+        config={"feature_flag": True},
+        sample_count=5,
+        commit="a1b2c3d4",
+    )
+    report = BenchmarkReport(
+        task_id="t1",
+        repo="r1",
+        question="q1",
+        results=[],
+        baseline_tokens=100,
+        provenance=prov,
+    )
+
+    assert report.provenance is not None
+    assert report.provenance.archex_version == "1.0.0"
+    assert report.provenance.hardware == "darwin-arm64"
+    assert report.provenance.commit == "a1b2c3d4"
+    assert report.provenance.sample_count == 5

--- a/tests/benchmark/test_runner.py
+++ b/tests/benchmark/test_runner.py
@@ -15,6 +15,7 @@ from archex.benchmark.models import (
     Strategy,
 )
 from archex.benchmark.runner import AVAILABLE_STRATEGIES, DEFAULT_STRATEGIES, run_benchmark
+from archex.cache import CacheManager
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -133,6 +134,34 @@ class TestRunBenchmark:
         assert len(report.results) == 2
         assert report.median_latency_ms > 0
         assert report.p95_latency_ms >= report.median_latency_ms
+
+    def test_records_evaluated_revision_and_runtime_configuration(
+        self,
+        fixture_task: tuple[BenchmarkTask, Path],
+    ) -> None:
+        task, repo_path = fixture_task
+        options = BenchmarkRetrievalOptions(
+            module_prefilter=True,
+            freshness=True,
+            rerank_candidate_limit=32,
+        )
+
+        report = run_benchmark(
+            task,
+            strategies=[Strategy.RAW_FILES],
+            repo_path=repo_path,
+            retrieval_options=options,
+        )
+
+        assert report.provenance is not None
+        assert report.provenance.commit == CacheManager.git_head(str(repo_path))
+        assert report.provenance.config["token_budget"] == task.token_budget
+        assert report.provenance.config["languages"] == "all"
+        assert report.provenance.config["include_paths"] == []
+        assert report.provenance.config["strategies"] == [Strategy.RAW_FILES.value]
+        assert report.provenance.config["module_prefilter"] is True
+        assert report.provenance.config["freshness"] is True
+        assert report.provenance.config["rerank_candidate_limit"] == 32
 
     @REQUIRES_RG
     def test_baseline_tokens_from_raw_files(


### PR DESCRIPTION
## M1 — PR-3 of 4 (reproducible provenance + sealed-corpus guard, on PR-2 #525)

Every published benchmark record now carries Archex version, evaluated source commit, generation timestamp, hardware manifest, and the full retrieval/task/strategy configuration (`BenchmarkProvenance`, wired into `BenchmarkReport` by `run_benchmark`). Reused from closed PR `#493` as prior art — `models.py`'s additive `BenchmarkProvenance` class and the new `test_policy.py` file applied cleanly; `runner.py`'s provenance construction and `test_runner.py`'s regression test were re-authored against the current `run_benchmark()` body (the original draft's insertion points no longer existed after M0.2/M0.3/M0.4 changes).

### Sealed-corpus guard

Also adds `test_sealed_corpus_boundaries_no_benchmark_specialization`, asserting production code (everything outside `src/archex/benchmark/`) never hardcodes known external-benchmark vocabulary (`swe_bench`, `human_eval`, `mbpp`, `bird`, `spider`, `defects4j`) — production behavior must generalize heuristically, never specialize to a named benchmark's identity.

### Verification

- `uv run ruff check .` / `uv run ruff format --check .` / `uv run pyright .`: clean.
- `uv run pytest -q --no-cov`: 3804 passed, 7 deselected.
- Focused: `tests/benchmark/test_policy.py` + `tests/benchmark/test_runner.py::test_records_evaluated_revision_and_runtime_configuration` all pass.

See PR-4 (stacked on this branch) for expansion-provenance threading and the vocabulary-disjoint ablation guard.

Refs: `DEVELOPMENT_PLAN.md` M1.