### PR TITLE
feat(index): add canonical index generation identity

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -312,6 +312,9 @@ def _full_index(
                 store.set_metadata("source_identity", identity)
                 store.set_metadata("indexed_at", str(time.time()))
                 _set_working_tree_signature(store, repo_path, config)
+                from archex.serve.generation import finalize_generation_id
+
+                finalize_generation_id(store, effective_index_config)
                 store.conn.execute("PRAGMA wal_checkpoint(FULL)")
 
                 manifest = IndexGenerationManifest(
@@ -498,6 +501,9 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
                         "working_tree_signature", attempt.working_tree_signature
                     )
                 clean_store.set_metadata("indexed_at", str(time.time()))
+                from archex.serve.generation import finalize_generation_id
+
+                finalize_generation_id(clean_store, attempt.index_config or IndexConfig())
                 if attempt.timing is not None:
                     attempt.timing.cached = True
                     attempt.timing.strategy = "cached"
@@ -594,6 +600,9 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
             store.set_metadata("indexed_at", str(time.time()))
             if attempt.working_tree_signature is not None:
                 store.set_metadata("working_tree_signature", attempt.working_tree_signature)
+            from archex.serve.generation import finalize_generation_id
+
+            finalize_generation_id(store, index_config)
             store.conn.execute("PRAGMA wal_checkpoint(FULL)")
             attempt.cache.put(
                 attempt.cache_key,

--- a/src/archex/serve/generation.py
+++ b/src/archex/serve/generation.py
@@ -1,0 +1,115 @@
+"""Immutable generation identity for warm-serving snapshot validation.
+
+M2's ``QueryRuntime`` (a long-lived, in-process cache of the BM25 index,
+dependency graph, and hydrated chunks for one repository) must know, cheaply
+and correctly, whether an already-built in-memory snapshot still matches the
+on-disk index it was built from. ``compute_generation_id`` derives a single
+canonical hash from every value that would make a warm snapshot unsafe to
+reuse without re-reading storage: the resolved commit/working-tree state,
+the store's schema version, the store's *actual* current content (chunk and
+file counts, read live rather than trusted from a metadata field that a
+buggy writer could forget to update), and every retrieval-affecting field of
+``IndexConfig``.
+
+Two builds with the same generation ID are guaranteed to produce
+byte-identical retrieval output for the same query and token budget: same
+source revision/working-tree state, same store schema, same completed
+content, and the same retrieval configuration. A generation ID is persisted
+as index-store metadata by every code path that finishes publishing a
+verified index (full index, and both delta-indexing branches), and is
+undefined (``None``) for any store built before this module existed or left
+mid-write — callers must never treat a missing generation ID as a match.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from archex.index.store import IndexStore
+    from archex.models import IndexConfig
+
+_METADATA_KEY = "generation_id"
+
+
+def _index_config_fingerprint(index_config: IndexConfig) -> str:
+    """Deterministic fingerprint of every ``IndexConfig`` field affecting retrieval output."""
+    fields = (
+        index_config.bm25,
+        index_config.vector,
+        index_config.splade,
+        index_config.module_prefilter,
+        index_config.embedder or "",
+        index_config.vector_mode.value,
+        index_config.surrogate_version,
+        index_config.retrieval_policy.value,
+        index_config.rerank,
+        index_config.rerank_model or "",
+        index_config.rerank_candidate_limit,
+        index_config.chunker,
+        index_config.chunk_max_tokens,
+        index_config.chunk_min_tokens,
+        index_config.token_encoding,
+        index_config.quantize_vectors,
+        index_config.quantize_bits,
+        index_config.identifier_fragment_tokenization,
+    )
+    return "|".join(str(field) for field in fields)
+
+
+def compute_generation_id(
+    *,
+    schema_version: str,
+    commit_hash: str | None,
+    working_tree_signature: str | None,
+    file_count: int,
+    chunk_count: int,
+    index_config: IndexConfig,
+) -> str:
+    """Canonical identity for one verified, complete index generation."""
+    payload = "\n".join(
+        [
+            f"schema_version={schema_version}",
+            f"commit_hash={commit_hash or ''}",
+            f"working_tree_signature={working_tree_signature or ''}",
+            f"file_count={file_count}",
+            f"chunk_count={chunk_count}",
+            f"index_config={_index_config_fingerprint(index_config)}",
+        ]
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def finalize_generation_id(store: IndexStore, index_config: IndexConfig) -> str:
+    """Compute this store's current generation ID from live state and persist it.
+
+    Must be called after every metadata field the identity depends on
+    (``commit_hash``, ``working_tree_signature``, ``schema_version``) has
+    already been written for this build or delta, and before the store is
+    published, so a fresh reader observes a complete, self-consistent
+    identity or none at all. Chunk and file counts are read live from the
+    ``chunks`` table rather than trusted from a separately-maintained
+    metadata field, so a caller that forgets to update a count field
+    elsewhere still gets a correct identity here.
+    """
+    generation_id = compute_generation_id(
+        schema_version=store.get_metadata("schema_version") or "",
+        commit_hash=store.get_metadata("commit_hash"),
+        working_tree_signature=store.get_metadata("working_tree_signature"),
+        file_count=store.get_file_count(),
+        chunk_count=store.get_chunk_count(),
+        index_config=index_config,
+    )
+    store.set_metadata(_METADATA_KEY, generation_id)
+    return generation_id
+
+
+def read_generation_id(store: IndexStore) -> str | None:
+    """Read the persisted generation ID for the store's current on-disk state.
+
+    ``None`` means the store predates this module or is mid-write; callers
+    must treat that as "no valid identity" and never match it against
+    another ``None`` to decide a cached snapshot is still safe to reuse.
+    """
+    return store.get_metadata(_METADATA_KEY)

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,0 +1,289 @@
+"""Unit tests for archex.serve.generation: canonical index generation identity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from archex.index.store import IndexStore
+from archex.models import IndexConfig, RetrievalPolicy, VectorMode
+from archex.serve.generation import (
+    compute_generation_id,
+    finalize_generation_id,
+    read_generation_id,
+)
+
+
+def _make_store(tmp_path: Path, name: str = "gen.db") -> IndexStore:
+    return IndexStore(tmp_path / name)
+
+
+class TestComputeGenerationId:
+    def test_same_inputs_produce_same_id(self) -> None:
+        config = IndexConfig()
+        first = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=config,
+        )
+        second = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=config,
+        )
+        assert first == second
+
+    def test_is_sha256_hex_digest(self) -> None:
+        generation_id = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature=None,
+            file_count=1,
+            chunk_count=1,
+            index_config=IndexConfig(),
+        )
+        assert len(generation_id) == 64
+        assert all(c in "0123456789abcdef" for c in generation_id)
+
+    def test_commit_hash_change_changes_id(self) -> None:
+        a = compute_generation_id(
+            schema_version="5",
+            commit_hash="commit-a",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(),
+        )
+        b = compute_generation_id(
+            schema_version="5",
+            commit_hash="commit-b",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(),
+        )
+        assert a != b
+
+    def test_working_tree_signature_change_changes_id(self) -> None:
+        a = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="sig-a",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(),
+        )
+        b = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="sig-b",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(),
+        )
+        assert a != b
+
+    def test_chunk_count_change_changes_id(self) -> None:
+        a = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(),
+        )
+        b = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=11,
+            index_config=IndexConfig(),
+        )
+        assert a != b
+
+    def test_file_count_change_changes_id(self) -> None:
+        a = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(),
+        )
+        b = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=4,
+            chunk_count=10,
+            index_config=IndexConfig(),
+        )
+        assert a != b
+
+    def test_schema_version_change_changes_id(self) -> None:
+        a = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(),
+        )
+        b = compute_generation_id(
+            schema_version="6",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(),
+        )
+        assert a != b
+
+    def test_retrieval_affecting_config_field_changes_id(self) -> None:
+        bm25_only = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(retrieval_policy=RetrievalPolicy.BM25_ONLY),
+        )
+        vector_only = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(retrieval_policy=RetrievalPolicy.VECTOR_ONLY),
+        )
+        assert bm25_only != vector_only
+
+    def test_chunker_setting_changes_id(self) -> None:
+        a = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(chunk_max_tokens=256),
+        )
+        b = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(chunk_max_tokens=512),
+        )
+        assert a != b
+
+    def test_vector_mode_changes_id(self) -> None:
+        raw = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(vector_mode=VectorMode.RAW),
+        )
+        surrogate = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(vector_mode=VectorMode.SURROGATE),
+        )
+        assert raw != surrogate
+
+    def test_none_commit_and_signature_do_not_crash(self) -> None:
+        generation_id = compute_generation_id(
+            schema_version="5",
+            commit_hash=None,
+            working_tree_signature=None,
+            file_count=0,
+            chunk_count=0,
+            index_config=IndexConfig(),
+        )
+        assert isinstance(generation_id, str) and generation_id
+
+
+class TestFinalizeAndReadGenerationId:
+    def test_read_generation_id_before_finalize_is_none(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        try:
+            assert read_generation_id(store) is None
+        finally:
+            store.close()
+
+    def test_finalize_persists_a_readable_generation_id(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        try:
+            store.set_metadata("schema_version", "5")
+            store.set_metadata("commit_hash", "abc123")
+            generation_id = finalize_generation_id(store, IndexConfig())
+            assert read_generation_id(store) == generation_id
+        finally:
+            store.close()
+
+    def test_finalize_reflects_live_chunk_count_not_a_stale_metadata_field(
+        self, tmp_path: Path
+    ) -> None:
+        """A caller that forgets to update a chunk_count metadata field elsewhere
+        still gets a correct identity, because finalize reads counts live from
+        the chunks table rather than trusting a separately maintained field."""
+        from archex.models import CodeChunk
+
+        store = _make_store(tmp_path)
+        try:
+            store.set_metadata("schema_version", "5")
+            store.set_metadata("commit_hash", "abc123")
+            # Deliberately wrong/stale metadata field — must not affect the result.
+            store.set_metadata("chunk_count", "999")
+            before = finalize_generation_id(store, IndexConfig())
+
+            store.insert_chunks(
+                [
+                    CodeChunk(
+                        id="c1",
+                        file_path="a.py",
+                        content="def f(): pass",
+                        start_line=1,
+                        end_line=1,
+                        language="python",
+                        token_count=3,
+                    )
+                ]
+            )
+            after = finalize_generation_id(store, IndexConfig())
+            assert before != after
+        finally:
+            store.close()
+
+    def test_finalize_is_stable_when_nothing_changes(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        try:
+            store.set_metadata("schema_version", "5")
+            store.set_metadata("commit_hash", "abc123")
+            first = finalize_generation_id(store, IndexConfig())
+            second = finalize_generation_id(store, IndexConfig())
+            assert first == second
+        finally:
+            store.close()
+
+    def test_finalize_changes_when_index_config_changes(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        try:
+            store.set_metadata("schema_version", "5")
+            store.set_metadata("commit_hash", "abc123")
+            default_id = finalize_generation_id(store, IndexConfig())
+            reranked_id = finalize_generation_id(store, IndexConfig(rerank=True))
+            assert default_id != reranked_id
+        finally:
+            store.close()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1038,6 +1038,156 @@ class TestDeltaIndexIntegration:
             store.close()
 
 
+class TestGenerationIdIntegration:
+    """Index generation identity is stable across warm reuse and changes across real pipelines."""
+
+    def test_generation_id_stable_across_repeated_cache_hits(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        """Repeated cache-hit queries against an unchanged commit must not mutate identity."""
+        from archex.api import _ensure_index  # pyright: ignore[reportPrivateUsage]
+        from archex.serve.generation import read_generation_id
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(languages=["python"], cache=True, cache_dir=str(tmp_path / "cache"))
+
+        store1 = _ensure_index(source, config=config)
+        try:
+            first_id = read_generation_id(store1)
+        finally:
+            store1.close()
+        assert first_id is not None
+
+        store2 = _ensure_index(source, config=config)
+        try:
+            second_id = read_generation_id(store2)
+        finally:
+            store2.close()
+
+        assert second_id == first_id
+
+    def test_generation_id_changes_after_committed_delta(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        """A real content change via the delta path must change the generation id."""
+        from archex.api import _ensure_index  # pyright: ignore[reportPrivateUsage]
+        from archex.serve.generation import read_generation_id
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(languages=["python"], cache=True, cache_dir=str(tmp_path / "cache"))
+
+        store1 = _ensure_index(source, config=config)
+        try:
+            before_id = read_generation_id(store1)
+        finally:
+            store1.close()
+
+        (python_simple_repo / "utils.py").write_text(
+            "def generation_id_delta_marker():\n    return 1\n"
+        )
+        _git(python_simple_repo, "add", ".")
+        _git(python_simple_repo, "commit", "-m", "generation id delta test")
+
+        timing = PipelineTiming()
+        store2 = _ensure_index(source, config=config, timing=timing)
+        try:
+            after_id = read_generation_id(store2)
+        finally:
+            store2.close()
+
+        assert timing.strategy == "delta"
+        assert after_id is not None
+        assert after_id != before_id
+
+    def test_generation_id_changes_after_uncommitted_working_tree_edit(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        """An uncommitted edit refreshed through the delta path changes identity too,
+        even though HEAD is unchanged — a warm snapshot keyed only on commit hash
+        would wrongly treat this as still current."""
+        import time as _time
+
+        from archex.api import _ensure_index  # pyright: ignore[reportPrivateUsage]
+        from archex.serve.generation import read_generation_id
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(languages=["python"], cache=True, cache_dir=str(tmp_path / "cache"))
+
+        store1 = _ensure_index(source, config=config)
+        try:
+            before_id = read_generation_id(store1)
+        finally:
+            store1.close()
+
+        _time.sleep(0.01)
+        (python_simple_repo / "utils.py").write_text(
+            "def uncommitted_generation_id_marker():\n    return 1\n",
+            encoding="utf-8",
+        )
+
+        store2 = _ensure_index(source, config=config)
+        try:
+            after_id = read_generation_id(store2)
+        finally:
+            store2.close()
+
+        assert after_id is not None
+        assert after_id != before_id
+
+    def test_generation_id_changes_when_index_config_changes(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        """The same commit indexed under two different IndexConfigs must not
+        collide on generation id, since retrieval output differs between them."""
+        from archex.api import _ensure_index  # pyright: ignore[reportPrivateUsage]
+        from archex.serve.generation import read_generation_id
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        default_config = Config(
+            languages=["python"], cache=True, cache_dir=str(tmp_path / "cache_default")
+        )
+        chunked_config = Config(
+            languages=["python"], cache=True, cache_dir=str(tmp_path / "cache_chunked")
+        )
+
+        store_default = _ensure_index(source, config=default_config)
+        try:
+            default_id = read_generation_id(store_default)
+        finally:
+            store_default.close()
+
+        store_chunked = _ensure_index(
+            source,
+            config=chunked_config,
+            index_config=IndexConfig(chunk_max_tokens=256, chunk_min_tokens=32),
+        )
+        try:
+            chunked_id = read_generation_id(store_chunked)
+        finally:
+            store_chunked.close()
+
+        assert default_id is not None
+        assert chunked_id is not None
+        assert default_id != chunked_id
+
+    def test_generation_id_present_after_full_index_without_cache(
+        self, python_simple_repo: Path
+    ) -> None:
+        """A no-cache full index still publishes a generation id for callers that
+        want to validate a store's identity even without disk caching enabled."""
+        from archex.api import _ensure_index  # pyright: ignore[reportPrivateUsage]
+        from archex.serve.generation import read_generation_id
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(languages=["python"], cache=False)
+
+        store = _ensure_index(source, config=config)
+        try:
+            assert read_generation_id(store) is None
+        finally:
+            store.close()
+
+
 # ---------------------------------------------------------------------------
 # New language integration tests (Java, Kotlin, C#, Swift)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## M2 — PR-1 of 5 (generation identity foundation)

Context: `.docs/DEVELOPMENT_PLAN.md` M2 ("Add Warm QueryRuntime and Retrieval Profiles"). Depends only on M1 (merged, PRs #524-#527). M0.4 round 3 concluded a retained NO-GO; per the replanned dependency gate, M2 does not require M0.4 to have promoted a default and builds runtime/caching infrastructure that applies to whichever retrieval logic is currently in production (`archex_query`, unchanged).

### What

Adds `archex.serve.generation`, a single canonical SHA256 identity (`compute_generation_id`) derived from:
- store schema version
- resolved commit hash / working-tree signature
- **live** chunk and file counts (read from the `chunks` table at finalization time, not trusted from a separately-maintained metadata field a caller could forget to update)
- every retrieval-affecting `IndexConfig` field (bm25/vector/splade/module_prefilter, embedder, vector_mode, surrogate_version, retrieval_policy, rerank + model + candidate_limit, chunker, chunk_max/min_tokens, token_encoding, quantize_vectors/bits, identifier_fragment_tokenization)

`finalize_generation_id(store, index_config)` computes and persists this as index-store metadata (`generation_id`) at every point a generation is published:
1. `_full_index`'s cache-publish block (only when `config.cache` — an ephemeral no-cache store has nothing to key a warm cache against)
2. `_try_delta_index`'s "no working-tree changes, same commit" refresh branch
3. `_try_delta_index`'s real delta-apply branch

`read_generation_id(store)` reads it back. Returns `None` for stores built before this PR (backward compatible) — callers must treat `None` as "no valid identity" and never match two `None`s as equal (documented in the module docstring; this is the exact hazard PR-2's warm-snapshot cache must guard against).

### Why

This is the foundation for M2's `QueryRuntime`: an in-process warm cache of the BM25 index, dependency graph, and hydrated chunks, keyed by generation. Two generation IDs matching guarantees byte-identical retrieval output for the same query and budget, so a cached snapshot can be validated with one cheap metadata read instead of re-hydrating everything from SQLite on every query — the core inefficiency this milestone targets.

### Verification

- `uv run ruff check .` / `uv run ruff format --check .` — clean
- `uv run pyright .` — 0 errors
- `uv run pytest -q --no-cov` — 3826 passed, 7 deselected (3805 baseline + 21 new)
- New tests: `tests/test_generation.py` (16 unit tests covering hash stability/sensitivity to every input field, live-vs-stale count reflection) and 5 new integration tests in `tests/test_integration.py::TestGenerationIdIntegration` exercising the real `_ensure_index` pipeline — stability across repeated cache hits, invalidation on committed delta, invalidation on uncommitted working-tree edits, invalidation across differing `IndexConfig`, and the no-cache boundary.

No behavior change to production retrieval output; this PR only adds new metadata and a new module.

See PR-2 (stacked on this branch) for the `QueryRuntime` cache that consumes this.

Refs: `DEVELOPMENT_PLAN.md` M2.1