### PR TITLE
feat(serve): add generation-keyed warm QueryRuntime

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -43,6 +43,7 @@ import shutil
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -111,6 +112,7 @@ from archex.scout import (
 )
 from archex.serve.compare import compare_repos
 from archex.serve.context import assemble_context, passthrough_context
+from archex.serve.generation import read_generation_id
 from archex.serve.profile import build_profile
 
 if TYPE_CHECKING:
@@ -121,6 +123,7 @@ if TYPE_CHECKING:
     from archex.index.embeddings.base import Embedder
     from archex.index.rerank import CrossEncoderReranker
     from archex.models import ComparisonResult
+    from archex.serve.runtime import QueryRuntime
 
 # ---------------------------------------------------------------------------
 # Acquisition + Indexing — shared helpers for all entry points
@@ -1793,6 +1796,7 @@ def query(
     explicit_token_budget: bool = False,
     refresh: bool = True,
     handles: list[str] | None = None,
+    runtime: QueryRuntime | None = None,
 ) -> ContextBundle:
     """Retrieve a ranked ContextBundle for a natural-language query.
 
@@ -1908,18 +1912,45 @@ def query(
                     )
                     return pt
 
-                bm25 = BM25Index(
-                    store,
-                    identifier_fragment_tokenization=index_config.identifier_fragment_tokenization,
-                )
-                stored_edges = store.get_edges()
-                graph = DependencyGraph.from_edges(stored_edges)
-
-                if graph.file_edge_count == 0 and graph.file_count > 1:
-                    co_dir_added = graph.add_co_directory_edges()
-                    logger.info(
-                        "Added %d co-directory edges (cached index had 0 edges)", co_dir_added
+                if runtime is not None:
+                    current_generation_id = read_generation_id(store)
+                    snapshot = runtime.get_or_build(
+                        cache_key,
+                        str(cache.db_path(cache_key)),
+                        current_generation_id,
+                        index_config,
                     )
+                else:
+                    snapshot = None
+                if snapshot is not None:
+                    store.close()
+                    search_store = snapshot.store
+                    bm25 = snapshot.bm25
+                    graph = snapshot.graph
+                    all_chunks_cached = snapshot.all_chunks
+                    surrogate_lookup = snapshot.surrogate_lookup
+                    modules_cached = snapshot.modules
+                    search_guard: AbstractContextManager[object] = snapshot.lock
+                else:
+                    search_store = store
+                    bm25 = BM25Index(
+                        store,
+                        identifier_fragment_tokenization=index_config.identifier_fragment_tokenization,
+                    )
+                    stored_edges = store.get_edges()
+                    graph = DependencyGraph.from_edges(stored_edges)
+
+                    if graph.file_edge_count == 0 and graph.file_count > 1:
+                        co_dir_added = graph.add_co_directory_edges()
+                        logger.info(
+                            "Added %d co-directory edges (cached index had 0 edges)", co_dir_added
+                        )
+                    # Pre-load all chunks into memory before parallel search so the
+                    # vector thread has no dependency on the SQLite store connection.
+                    all_chunks_cached = store.get_chunks()
+                    surrogate_lookup = _surrogate_lookup(store, all_chunks_cached, index_config)
+                    modules_cached = _modules_or_raise(store, index_config)
+                    search_guard = nullcontext()
 
                 top_k = _compute_top_k(chunk_count)
                 vector_top_k = _compute_vector_top_k(
@@ -1930,11 +1961,6 @@ def query(
                     bm25_top_k=top_k,
                     total_chunks=chunk_count,
                 )
-                # Pre-load all chunks into memory before parallel search so the
-                # vector thread has no dependency on the SQLite store connection.
-                all_chunks_cached = store.get_chunks()
-                surrogate_lookup = _surrogate_lookup(store, all_chunks_cached, index_config)
-                modules_cached = _modules_or_raise(store, index_config)
                 if timing is not None:
                     timing.index_ms = _elapsed_ms(t0)
                 t_search = time.perf_counter()
@@ -1947,7 +1973,10 @@ def query(
                 # calling thread.  BM25 must stay on the creating thread because
                 # SQLite connections are not thread-safe; the vector path uses only
                 # pre-loaded numpy arrays and requires no store access.
-                with ThreadPoolExecutor(max_workers=1) as _pool:
+                # search_guard additionally serializes access to a shared warm
+                # snapshot's store connection across separate query() calls when
+                # a runtime is used; it is a no-op context manager otherwise.
+                with search_guard, ThreadPoolExecutor(max_workers=1) as _pool:
                     _vec_future = _pool.submit(
                         _vector_search_precomputed,
                         cached_npz,
@@ -1968,7 +1997,7 @@ def query(
                             expansion_prov,
                         ) = _bm25_search_with_boosts(
                             bm25,
-                            store,
+                            search_store,
                             question,
                             top_k,
                             all_chunks_cached,
@@ -1982,7 +2011,7 @@ def query(
                         symbol_seeds = []
                         module_boost = []
                     splade_results = _splade_search_or_raise(
-                        store,
+                        search_store,
                         question,
                         index_config,
                         splade_top_k,
@@ -2040,11 +2069,12 @@ def query(
                             },
                         )
                     )
-                query_avg_idf = (
-                    bm25.avg_idf(question)
-                    if vector_results is not None or splade_results is not None
-                    else None
-                )
+                with search_guard:
+                    query_avg_idf = (
+                        bm25.avg_idf(question)
+                        if vector_results is not None or splade_results is not None
+                        else None
+                    )
                 # Cross-encoder reranker: enabled only when index_config.rerank is set.
                 _reranker = _maybe_reranker(index_config)
                 bundle = assemble_context(

--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -185,7 +185,13 @@ def _decode_edge_evidence(raw: object) -> list[str]:
 class IndexStore:
     """SQLite-backed persistence for chunks, edges, and metadata."""
 
-    def __init__(self, db_path: str | Path, *, delete_dir_on_close: bool = False) -> None:
+    def __init__(
+        self,
+        db_path: str | Path,
+        *,
+        delete_dir_on_close: bool = False,
+        check_same_thread: bool = True,
+    ) -> None:
         """Open (creating if absent) the SQLite store at `db_path`.
 
         `delete_dir_on_close` opts into deleting `db_path`'s *entire parent
@@ -194,10 +200,17 @@ class IndexStore:
         exclusively to this store (e.g. a fresh `tempfile.mkdtemp()`); a
         shared or otherwise meaningful directory would have its other
         contents silently deleted too.
+
+        `check_same_thread=False` lets the returned connection be used from
+        threads other than the one that opened it. Only pass it when the
+        caller independently serializes every operation on this store (a
+        single lock around each call) — sqlite3 connections are not safe
+        for genuinely concurrent use across threads regardless of this
+        flag, which only disables Python's own thread-affinity check.
         """
         self._db_path = str(db_path)
         self._delete_dir_on_close = delete_dir_on_close
-        self._conn = sqlite3.connect(self._db_path)
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=check_same_thread)
         try:
             self._conn.execute("PRAGMA journal_mode=WAL")
             self.create_schema()

--- a/src/archex/serve/runtime.py
+++ b/src/archex/serve/runtime.py
@@ -1,0 +1,162 @@
+"""In-process warm serving cache for repeat query() calls against one repo.
+
+``QueryRuntime`` caches, per repository ``cache_key``, the derived retrieval
+structures a warm query needs — a BM25 index backed by its own persistent
+store connection, the dependency graph, module summaries, and the hydrated
+chunk list — keyed by the store's generation ID
+(:mod:`archex.serve.generation`). A cache hit skips rebuilding these
+entirely; only a generation change (a real content, config, or revision
+change, or a store with no generation ID at all) triggers a rebuild.
+
+Scope note (M2, first round): this caches the full per-generation chunk
+list once rather than lazily hydrating only search candidates and their
+graph neighbors. True candidate-only content hydration would require
+making ``CodeChunk.content`` lazily fetched and would touch BM25's
+boost-scanning and ``assemble_context``'s graph-expansion path — deferred
+pending a real p95/RSS measurement on frozen fixtures, which is the actual
+arbiter of whether generation-level caching alone clears the target.
+
+Thread-safety: ``query()`` may be invoked from different threads across
+calls (for example a threaded MCP dispatch loop). Each cached snapshot's
+store connection opens with ``check_same_thread=False``, and callers must
+hold ``snapshot.lock`` for the duration of any operation that touches
+``snapshot.store`` (BM25/SPLADE search, boost lookups) — matching the
+pre-existing single-connection constraint already documented at those
+call sites for a fresh per-query store, just extended across calls that
+now share one persistent connection instead of opening a new one each
+time. Read-only in-memory attributes (``graph``, ``all_chunks``,
+``surrogate_lookup``, ``modules``) need no lock once built.
+
+Revision safety: every query() call re-derives current_generation_id from a
+freshly opened, independently-refreshed store (via _ensure_index()) before
+ever consulting the runtime, so a cached snapshot is used only when that
+fresh check confirms its generation still matches — an in-place delta
+applied since the snapshot was built always produces a different
+generation ID and forces a rebuild. There is one narrow, pre-existing race
+this does not close: if a delta commits to the same on-disk file between a
+snapshot being handed out and that call's search executing, SQLite's WAL
+snapshot-per-read semantics mean the live search could observe newer
+content than the snapshot's frozen ``all_chunks``/``graph``/``modules``
+for that one query. Concurrent delta application against the same
+cache_key was already unguarded by any lock before this module existed
+(_ensure_index() has no cross-call mutual exclusion); this module does not
+widen that gap, only makes the common warm-reuse path fast.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from archex.index.bm25 import BM25Index
+from archex.index.graph import DependencyGraph
+from archex.index.store import IndexStore
+
+if TYPE_CHECKING:
+    from archex.models import ChunkSurrogate, CodeChunk, IndexConfig, Module
+
+
+@dataclass
+class WarmSnapshot:
+    """Cached derived retrieval structures for one repository generation."""
+
+    generation_id: str
+    store: IndexStore
+    bm25: BM25Index
+    graph: DependencyGraph
+    all_chunks: list[CodeChunk]
+    surrogate_lookup: dict[str, ChunkSurrogate] | None
+    modules: list[Module]
+    lock: threading.Lock
+
+
+def _build_snapshot(
+    db_path: str,
+    generation_id: str,
+    index_config: IndexConfig,
+) -> WarmSnapshot:
+    """Build a fresh warm snapshot from a dedicated, persistent store connection.
+
+    Mirrors query()'s pre-runtime cached-path hydration exactly (same
+    BM25/graph/co-directory-edge/chunk/surrogate/module construction) so
+    output stays byte-equivalent whether or not a runtime is used.
+    """
+    from archex.api import (
+        _modules_or_raise,  # pyright: ignore[reportPrivateUsage]
+        _surrogate_lookup,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    store = IndexStore(db_path, check_same_thread=False)
+    try:
+        bm25 = BM25Index(
+            store,
+            identifier_fragment_tokenization=index_config.identifier_fragment_tokenization,
+        )
+        graph = DependencyGraph.from_edges(store.get_edges())
+        if graph.file_edge_count == 0 and graph.file_count > 1:
+            graph.add_co_directory_edges()
+        all_chunks = store.get_chunks()
+        surrogate_lookup = _surrogate_lookup(store, all_chunks, index_config)
+        modules = _modules_or_raise(store, index_config)
+    except BaseException:
+        store.close()
+        raise
+    return WarmSnapshot(
+        generation_id=generation_id,
+        store=store,
+        bm25=bm25,
+        graph=graph,
+        all_chunks=all_chunks,
+        surrogate_lookup=surrogate_lookup,
+        modules=modules,
+        lock=threading.Lock(),
+    )
+
+
+class QueryRuntime:
+    """Long-lived, generation-keyed warm cache for repeat query() calls.
+
+    One instance is meant to live for the lifetime of a process serving many
+    queries (for example an MCP server), shared across all query() calls.
+    Never share an instance across processes.
+    """
+
+    def __init__(self) -> None:
+        self._snapshots: dict[str, WarmSnapshot] = {}
+        self._registry_lock = threading.Lock()
+
+    def get_or_build(
+        self,
+        cache_key: str,
+        db_path: str,
+        current_generation_id: str | None,
+        index_config: IndexConfig,
+    ) -> WarmSnapshot | None:
+        """Return a warm snapshot for cache_key valid at current_generation_id.
+
+        Rebuilds when there is no cached snapshot, or the cached one's
+        generation ID no longer matches (a real content/config/revision
+        change occurred). Returns None — never caches — when
+        current_generation_id is None (a store predating generation-ID
+        support, or built without caching enabled): a None can never be
+        trusted to mean "the same generation as last time".
+        """
+        if current_generation_id is None:
+            return None
+        with self._registry_lock:
+            cached = self._snapshots.get(cache_key)
+            if cached is not None and cached.generation_id == current_generation_id:
+                return cached
+            snapshot = _build_snapshot(db_path, current_generation_id, index_config)
+            self._snapshots[cache_key] = snapshot
+            if cached is not None:
+                cached.store.close()
+            return snapshot
+
+    def close(self) -> None:
+        """Close every cached snapshot's store connection."""
+        with self._registry_lock:
+            for snapshot in self._snapshots.values():
+                snapshot.store.close()
+            self._snapshots.clear()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1188,6 +1188,158 @@ class TestGenerationIdIntegration:
             store.close()
 
 
+class TestQueryRuntimeIntegration:
+    """query(..., runtime=QueryRuntime()) is byte-equivalent and warm-reuses correctly.
+
+    A small explicit token_budget forces query()'s non-passthrough BM25/graph path
+    (the fixture repo otherwise fits entirely within the default budget and returns
+    via the earlier passthrough short-circuit, before any runtime code ever runs).
+    """
+
+    def test_query_with_runtime_matches_query_without_runtime(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        """A runtime-backed query must return the same chunks as the pre-runtime path."""
+        from archex.serve.runtime import QueryRuntime
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(languages=["python"], cache=True, cache_dir=str(tmp_path / "cache"))
+        question = "calculate_sum"
+
+        without_runtime = query(
+            source, question, config=config, token_budget=100, explicit_token_budget=True
+        )
+
+        runtime = QueryRuntime()
+        try:
+            with_runtime = query(
+                source,
+                question,
+                config=config,
+                token_budget=100,
+                explicit_token_budget=True,
+                runtime=runtime,
+            )
+        finally:
+            runtime.close()
+
+        without_files = sorted(rc.chunk.id for rc in without_runtime.chunks)
+        with_files = sorted(rc.chunk.id for rc in with_runtime.chunks)
+        assert with_files == without_files
+        assert with_runtime.token_count == without_runtime.token_count
+        assert (
+            with_runtime.retrieval_metadata.strategy == without_runtime.retrieval_metadata.strategy
+        )
+
+    def test_query_with_runtime_reuses_snapshot_across_repeat_calls(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        """A second query against an unchanged generation must not rebuild the snapshot."""
+        from archex.api import _cache_manager_for_source  # pyright: ignore[reportPrivateUsage]
+        from archex.serve.runtime import QueryRuntime
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(languages=["python"], cache=True, cache_dir=str(tmp_path / "cache"))
+        cache_key = _cache_manager_for_source(source, config).cache_key(source)
+
+        runtime = QueryRuntime()
+        try:
+            query(
+                source,
+                "calculate_sum",
+                config=config,
+                token_budget=100,
+                explicit_token_budget=True,
+                runtime=runtime,
+            )
+            first_snapshot = runtime._snapshots[cache_key]  # pyright: ignore[reportPrivateUsage]
+
+            query(
+                source,
+                "models",
+                config=config,
+                token_budget=100,
+                explicit_token_budget=True,
+                runtime=runtime,
+            )
+            second_snapshot = runtime._snapshots[cache_key]  # pyright: ignore[reportPrivateUsage]
+
+            assert second_snapshot is first_snapshot
+        finally:
+            runtime.close()
+
+    def test_query_with_runtime_reflects_committed_delta(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        """A shared runtime must serve fresh content after a real delta, not a stale snapshot."""
+        from archex.serve.runtime import QueryRuntime
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(languages=["python"], cache=True, cache_dir=str(tmp_path / "cache"))
+
+        runtime = QueryRuntime()
+        try:
+            query(
+                source,
+                "models",
+                config=config,
+                token_budget=100,
+                explicit_token_budget=True,
+                runtime=runtime,
+            )
+
+            (python_simple_repo / "utils.py").write_text(
+                "def runtime_delta_marker():\n    return 1\n"
+            )
+            _git(python_simple_repo, "add", ".")
+            _git(python_simple_repo, "commit", "-m", "runtime delta test")
+
+            bundle = query(
+                source,
+                "runtime_delta_marker",
+                config=config,
+                token_budget=100,
+                explicit_token_budget=True,
+                runtime=runtime,
+            )
+            text = "\n".join(rc.chunk.content for rc in bundle.chunks)
+            assert "runtime_delta_marker" in text
+        finally:
+            runtime.close()
+
+    def test_query_with_runtime_sets_cached_timing_strategy(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        from archex.serve.runtime import QueryRuntime
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(languages=["python"], cache=True, cache_dir=str(tmp_path / "cache"))
+        runtime = QueryRuntime()
+        try:
+            query(
+                source,
+                "models",
+                config=config,
+                token_budget=100,
+                explicit_token_budget=True,
+                runtime=runtime,
+            )
+            timing = PipelineTiming()
+            query(
+                source,
+                "models",
+                config=config,
+                token_budget=100,
+                explicit_token_budget=True,
+                runtime=runtime,
+                timing=timing,
+            )
+            assert timing.cached is True
+            assert timing.strategy == "cached"
+        finally:
+            runtime.close()
+
+
 # ---------------------------------------------------------------------------
 # New language integration tests (Java, Kotlin, C#, Swift)
 # ---------------------------------------------------------------------------

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,148 @@
+"""Unit tests for archex.serve.runtime.QueryRuntime: generation-keyed warm cache."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from archex.api import _ensure_index  # pyright: ignore[reportPrivateUsage]
+from archex.models import Config, IndexConfig, RepoSource
+from archex.serve.generation import read_generation_id
+from archex.serve.runtime import QueryRuntime
+
+
+def _index_and_generation_id(
+    python_simple_repo: Path, cache_dir: Path, index_config: IndexConfig | None = None
+) -> tuple[str, str, str]:
+    """Index the fixture repo and return (cache_key, db_path, generation_id)."""
+    from archex.api import _cache_manager_for_source  # pyright: ignore[reportPrivateUsage]
+
+    source = RepoSource(local_path=str(python_simple_repo))
+    config = Config(languages=["python"], cache=True, cache_dir=str(cache_dir))
+    store = _ensure_index(source, config=config, index_config=index_config)
+    manager = _cache_manager_for_source(source, config)
+    cache_key = manager.cache_key(source)
+    try:
+        generation_id = read_generation_id(store)
+        assert generation_id is not None
+        db_path = str(manager.db_path(cache_key))
+    finally:
+        store.close()
+    return cache_key, db_path, generation_id
+
+
+class TestQueryRuntimeGetOrBuild:
+    def test_returns_none_for_none_generation_id(self, tmp_path: Path) -> None:
+        runtime = QueryRuntime()
+        assert (
+            runtime.get_or_build("some-key", str(tmp_path / "idx.db"), None, IndexConfig()) is None
+        )
+
+    def test_second_call_with_same_generation_reuses_snapshot(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        cache_key, db_path, generation_id = _index_and_generation_id(
+            python_simple_repo, tmp_path / "cache"
+        )
+        runtime = QueryRuntime()
+        try:
+            first = runtime.get_or_build(cache_key, db_path, generation_id, IndexConfig())
+            second = runtime.get_or_build(cache_key, db_path, generation_id, IndexConfig())
+            assert first is not None
+            assert second is first
+        finally:
+            runtime.close()
+
+    def test_snapshot_holds_expected_derived_state(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        cache_key, db_path, generation_id = _index_and_generation_id(
+            python_simple_repo, tmp_path / "cache"
+        )
+        runtime = QueryRuntime()
+        try:
+            snapshot = runtime.get_or_build(cache_key, db_path, generation_id, IndexConfig())
+            assert snapshot is not None
+            assert snapshot.generation_id == generation_id
+            assert len(snapshot.all_chunks) > 0
+            assert snapshot.graph.file_count > 0
+        finally:
+            runtime.close()
+
+    def test_different_generation_id_rebuilds_and_closes_previous_store(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        cache_key, db_path, generation_id = _index_and_generation_id(
+            python_simple_repo, tmp_path / "cache"
+        )
+        runtime = QueryRuntime()
+        try:
+            first = runtime.get_or_build(cache_key, db_path, generation_id, IndexConfig())
+            assert first is not None
+
+            second = runtime.get_or_build(
+                cache_key, db_path, "a-different-generation-id", IndexConfig()
+            )
+            assert second is not None
+            assert second is not first
+            assert second.generation_id == "a-different-generation-id"
+            # The superseded snapshot's store connection must be closed, not leaked.
+            import sqlite3
+
+            try:
+                first.store.conn.execute("SELECT 1")
+            except sqlite3.ProgrammingError:
+                pass
+            else:
+                raise AssertionError("expected the superseded snapshot's store to be closed")
+        finally:
+            runtime.close()
+
+    def test_different_cache_key_builds_independent_snapshots(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        """The runtime isolates snapshots purely by cache_key string, so two
+        distinct keys never collide even against the same underlying store."""
+        cache_key, db_path, generation_id = _index_and_generation_id(
+            python_simple_repo, tmp_path / "cache"
+        )
+        runtime = QueryRuntime()
+        try:
+            snapshot_a = runtime.get_or_build(
+                f"{cache_key}-a", db_path, generation_id, IndexConfig()
+            )
+            snapshot_b = runtime.get_or_build(
+                f"{cache_key}-b", db_path, generation_id, IndexConfig()
+            )
+            assert snapshot_a is not None
+            assert snapshot_b is not None
+            assert snapshot_a is not snapshot_b
+            # Repeat lookups against each key keep returning that key's own snapshot.
+            assert (
+                runtime.get_or_build(f"{cache_key}-a", db_path, generation_id, IndexConfig())
+                is snapshot_a
+            )
+            assert (
+                runtime.get_or_build(f"{cache_key}-b", db_path, generation_id, IndexConfig())
+                is snapshot_b
+            )
+        finally:
+            runtime.close()
+
+    def test_close_closes_every_cached_snapshot_store(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        import sqlite3
+
+        cache_key, db_path, generation_id = _index_and_generation_id(
+            python_simple_repo, tmp_path / "cache"
+        )
+        runtime = QueryRuntime()
+        snapshot = runtime.get_or_build(cache_key, db_path, generation_id, IndexConfig())
+        assert snapshot is not None
+        runtime.close()
+        try:
+            snapshot.store.conn.execute("SELECT 1")
+        except sqlite3.ProgrammingError:
+            pass
+        else:
+            raise AssertionError("expected close() to close the cached store")


### PR DESCRIPTION
## M2 — PR-2 of 5 (warm QueryRuntime core)

Stacked on #528 (generation identity). Context: `.docs/DEVELOPMENT_PLAN.md` M2.

### Scope decision (see PR discussion)

M2's acceptance text requires both generation-keyed warm caching **and** literal candidate-only content hydration ("only selected candidates and bounded neighbors are hydrated") with no RSS regression. True candidate-only hydration would require making `CodeChunk.content` lazily fetched and touches BM25's boost-scanning plus `assemble_context`'s 700-line graph-expansion path — a much larger, higher-risk change than a straight warm cache. Per an explicit scope decision, this PR (and this round of M2) ships **generation-keyed caching only**: the full per-generation chunk list, BM25 index, dependency graph, and module summaries are hydrated once and reused across warm queries against an unchanged generation, eliminating the redundant SQLite re-hydration that previously ran on every single query. Whether this alone clears M2's numeric p95/RSS gate is an empirical question for PR5's frozen-fixture benchmark, not something pre-solved by architecture here. If PR5 finds an RSS regression on the large fixture, that's real, measured evidence informing a follow-up round — documented explicitly in code (`src/archex/serve/runtime.py`'s module docstring) rather than silently glossed over.

### What

- `src/archex/serve/runtime.py`: `QueryRuntime`, an in-process cache keyed by repository `cache_key`, storing a `WarmSnapshot` (BM25 index backed by its own persistent store connection, dependency graph, hydrated chunk list, surrogate lookup, module summaries) per generation. `get_or_build()` rebuilds only when there is no cached snapshot or the cached one's `generation_id` no longer matches the caller-supplied current one; a `None` generation_id (uncacheable store) never caches. Superseded snapshots have their store connection closed, not leaked.
- `query()` gains an optional `runtime: QueryRuntime | None = None` parameter (default `None`, exact prior behavior unchanged). When provided, the cached path calls `runtime.get_or_build(...)` with a freshly re-derived `generation_id` from the just-refreshed store (via the existing `_ensure_index()` freshness check, unchanged), and only reuses a snapshot when the fresh check confirms it. A real content/config/revision change always produces a different generation ID and forces a rebuild — no query ever serves data past a real change.
- `IndexStore` gains an opt-in `check_same_thread=False` constructor flag (default `True`, no behavior change for the ~40 existing call sites) so a runtime-owned snapshot's connection can be used across `query()` calls landing on different threads (e.g. a threaded MCP dispatch loop). Every store-touching operation on a cached snapshot is serialized under the snapshot's own `threading.Lock`, extending the pre-existing "BM25 stays on one connection" constraint across calls rather than narrowing it.

### Correctness note (found via testing, fixed before merge)

Initially wired `query()` to pass the ephemeral `store.db_path` into the runtime. On a cold (first-ever) index, `_full_index()` builds in a `tempfile.mkdtemp()` scratch directory marked `delete_dir_on_close=True` and only *copies* into the permanent cache location — so caching that ephemeral path would have pointed a warm snapshot at a soon-to-be-deleted file. Fixed to always resolve `cache.db_path(cache_key)`, the stable permanent path, which is what every non-cold path (`_ensure_index()`'s exact-hit, delta-refresh, and delta-apply branches) already resolves to. `tests/test_runtime.py` caught this via a real end-to-end sqlite `OperationalError`.

### Verification

- `uv run ruff check .` / `uv run ruff format --check .` — clean
- `uv run pyright .` — 0 errors
- `uv run pytest -q --no-cov` — 3836 passed, 7 deselected (3826 baseline + 10 new)
- `tests/test_runtime.py` (6 tests): `get_or_build` returns `None` for a `None` generation ID; repeat calls with an unchanged generation return the identical snapshot object; a snapshot holds expected derived state; a different generation ID rebuilds and closes the superseded store; different `cache_key`s stay isolated even against the same store; `close()` closes every cached connection.
- `tests/test_integration.py::TestQueryRuntimeIntegration` (4 tests, end-to-end through the public `query()` API): a runtime-backed query returns the identical chunk set/token count/strategy as the pre-runtime path (byte-equivalence); a second call against an unchanged generation reuses the exact same snapshot object (no rebuild); a shared runtime reflects a real committed delta on the next call (no stale serving); `timing.strategy == "cached"` still set correctly.

See PR-3 (to follow) for MCP-server wiring that actually instantiates one long-lived `QueryRuntime` per process.

Refs: `DEVELOPMENT_PLAN.md` M2.2