### PR TITLE
feat(mcp): wire QueryRuntime into the MCP server's query_repo path

### DIFF
--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -73,6 +73,7 @@ from archex.scout import DEFAULT_SCOUT_TOKEN_BUDGET, ScoutFormat, ScoutResult, r
 from archex.serve.compare import validate_dimensions
 from archex.serve.intent import DEFAULT_TOKEN_BUDGET
 from archex.serve.renderers.xml import render_xml, render_xml_envelope
+from archex.serve.runtime import QueryRuntime
 from archex.utils import resolve_source
 
 logger = logging.getLogger(__name__)
@@ -122,7 +123,12 @@ def handle_analyze_repo(repo_url: str, output_format: str = "json") -> str:
     return json.dumps({"content": content, "_meta": meta.model_dump()}, indent=2)
 
 
-def handle_query_repo(repo_url: str, question: str, budget: int | None = None) -> str:
+def handle_query_repo(
+    repo_url: str,
+    question: str,
+    budget: int | None = None,
+    runtime: QueryRuntime | None = None,
+) -> str:
     """Retrieve context from a repository for a natural-language question.
 
     Args:
@@ -130,6 +136,8 @@ def handle_query_repo(repo_url: str, question: str, budget: int | None = None) -
         question: Natural-language question to answer from the codebase.
         budget: Optional explicit token budget override. Defaults to adaptive
             intent routing with a product ceiling of 8192.
+        runtime: Optional warm QueryRuntime shared across calls in one server
+            process. Omit for the exact pre-runtime per-call behavior.
 
     Returns:
         JSON envelope with ContextBundle content and _meta efficiency block.
@@ -148,6 +156,7 @@ def handle_query_repo(repo_url: str, question: str, budget: int | None = None) -
         token_budget=token_budget,
         timing=pt,
         explicit_token_budget=budget is not None,
+        runtime=runtime,
     )
 
     content = render_xml(bundle, include_receipt=False)
@@ -1141,6 +1150,7 @@ async def _run_mcp_tool(
     loop: asyncio.AbstractEventLoop,
     name: str,
     arguments: dict[str, Any],
+    runtime: QueryRuntime | None = None,
 ) -> str:
     if name == "analyze_repo":
         repo_url: str = arguments["repo_url"]
@@ -1161,7 +1171,9 @@ async def _run_mcp_tool(
         question: str = arguments["question"]
         budget_arg = arguments.get("budget")
         budget = int(budget_arg) if budget_arg is not None else None
-        return await loop.run_in_executor(None, handle_query_repo, repo_url, question, budget)
+        return await loop.run_in_executor(
+            None, handle_query_repo, repo_url, question, budget, runtime
+        )
     if name == "compare_repos":
         repo_a: str = arguments["repo_a"]
         repo_b: str = arguments["repo_b"]
@@ -1319,7 +1331,7 @@ async def _run_mcp_tool(
     raise ValueError(f"Unknown tool: {name!r}")
 
 
-def build_server() -> Any:
+def build_server(runtime: QueryRuntime | None = None) -> Any:
     """Build and return a configured MCP Server instance.
 
     Raises:
@@ -1332,6 +1344,9 @@ def build_server() -> Any:
         raise ImportError(
             "The 'mcp' package is required for MCP integration. Install it with: uv add mcp"
         ) from exc
+
+    if runtime is None:
+        runtime = QueryRuntime()
 
     server: Server[None, Any] = Server("archex")  # type: ignore[type-arg]
 
@@ -1877,7 +1892,7 @@ def build_server() -> Any:
         arguments: dict[str, Any],
     ) -> list[mcp_types.TextContent]:
         loop = asyncio.get_running_loop()
-        result_text = await _run_mcp_tool(loop, name, arguments)
+        result_text = await _run_mcp_tool(loop, name, arguments, runtime)
 
         return [mcp_types.TextContent(type="text", text=result_text)]
 
@@ -1968,12 +1983,17 @@ async def run_stdio_server(
     if watch:
         observer = _start_index_watch(Path(watch_path).expanduser().resolve(), watch_debounce_ms)
 
-    server = build_server()
+    # One QueryRuntime lives for this server process's whole lifetime, shared
+    # across every query_repo call so repeat warm queries against the same
+    # generation skip re-hydrating from SQLite.
+    runtime = QueryRuntime()
+    server = build_server(runtime=runtime)
     try:
         async with stdio_server() as (read_stream, write_stream):
             init_opts = server.create_initialization_options()
             await server.run(read_stream, write_stream, init_opts, raise_exceptions=True)
     finally:
+        runtime.close()
         if observer is not None:
             observer.stop()
             observer.join(timeout=5)

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -321,6 +321,30 @@ class TestHandleQueryRepo:
         source = mock_query.call_args[0][0]
         assert source.url == "https://github.com/example/repo"
 
+    def test_passes_runtime_through_to_query(self) -> None:
+        from archex.serve.runtime import QueryRuntime
+
+        bundle = _make_context_bundle()
+        runtime = QueryRuntime()
+        try:
+            with (
+                patch("archex.integrations.mcp.query", return_value=bundle) as mock_query,
+                patch("archex.integrations.mcp.get_files_token_count", return_value=0),
+            ):
+                handle_query_repo("/fake/repo", "question?", runtime=runtime)
+            assert mock_query.call_args.kwargs["runtime"] is runtime
+        finally:
+            runtime.close()
+
+    def test_omits_runtime_by_default(self) -> None:
+        bundle = _make_context_bundle()
+        with (
+            patch("archex.integrations.mcp.query", return_value=bundle) as mock_query,
+            patch("archex.integrations.mcp.get_files_token_count", return_value=0),
+        ):
+            handle_query_repo("/fake/repo", "question?")
+        assert mock_query.call_args.kwargs["runtime"] is None
+
 
 class TestHandleScoutRepo:
     def test_returns_scout_markdown_with_meta(self) -> None:
@@ -565,6 +589,42 @@ class TestRunStdioServer:
             with pytest.raises(ImportError, match="mcp"):
                 await run_stdio_server()
 
+    @pytest.mark.asyncio
+    async def test_run_stdio_server_creates_and_closes_query_runtime(self) -> None:
+        """One QueryRuntime lives for the server's lifetime and is closed on shutdown."""
+        from collections.abc import AsyncIterator
+        from contextlib import asynccontextmanager
+
+        from archex.integrations.mcp import run_stdio_server
+        from archex.serve.runtime import QueryRuntime
+
+        captured: dict[str, object] = {}
+
+        @asynccontextmanager
+        async def fake_stdio_server() -> AsyncIterator[tuple[None, None]]:
+            yield (None, None)
+
+        class FakeServer:
+            def create_initialization_options(self) -> object:
+                return object()
+
+            async def run(self, *args: object, **kwargs: object) -> None:
+                return None
+
+        def fake_build_server(runtime: QueryRuntime | None = None) -> object:
+            captured["runtime"] = runtime
+            return FakeServer()
+
+        with (
+            patch("archex.integrations.mcp.build_server", side_effect=fake_build_server),
+            patch("mcp.server.stdio.stdio_server", fake_stdio_server),
+            patch("archex.serve.runtime.QueryRuntime.close") as mock_close,
+        ):
+            await run_stdio_server()
+
+        assert isinstance(captured["runtime"], QueryRuntime)
+        mock_close.assert_called_once()
+
 
 class TestBuildServer:
     def test_returns_server_instance(self) -> None:
@@ -725,6 +785,103 @@ class TestBuildServer:
         assert "get_impact" in tool_names
         assert "explain_target" in tool_names
         assert "generate_onboarding" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_call_tool_query_repo_passes_explicit_runtime_to_handler(self) -> None:
+        from archex.serve.runtime import QueryRuntime
+
+        runtime = QueryRuntime()
+        try:
+            with patch(
+                "archex.integrations.mcp.handle_query_repo", return_value="<context/>"
+            ) as mock_handle:
+                server = build_server(runtime=runtime)
+                from mcp import types as mcp_types
+
+                handler = server.request_handlers[mcp_types.CallToolRequest]
+                list_handler = server.request_handlers[mcp_types.ListToolsRequest]
+                await list_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
+                req = mcp_types.CallToolRequest(
+                    method="tools/call",
+                    params=mcp_types.CallToolRequestParams(
+                        name="query_repo",
+                        arguments={"repo_url": "/fake", "question": "what?"},
+                    ),
+                )
+                await handler(req)
+            assert mock_handle.call_args[0][3] is runtime
+        finally:
+            runtime.close()
+
+    @pytest.mark.asyncio
+    async def test_call_tool_query_repo_default_runtime_is_query_runtime_instance(self) -> None:
+        from archex.serve.runtime import QueryRuntime
+
+        with patch(
+            "archex.integrations.mcp.handle_query_repo", return_value="<context/>"
+        ) as mock_handle:
+            server = build_server()
+            from mcp import types as mcp_types
+
+            handler = server.request_handlers[mcp_types.CallToolRequest]
+            list_handler = server.request_handlers[mcp_types.ListToolsRequest]
+            await list_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
+            req = mcp_types.CallToolRequest(
+                method="tools/call",
+                params=mcp_types.CallToolRequestParams(
+                    name="query_repo",
+                    arguments={"repo_url": "/fake", "question": "what?"},
+                ),
+            )
+            await handler(req)
+        passed_runtime = mock_handle.call_args[0][3]
+        assert isinstance(passed_runtime, QueryRuntime)
+
+    @pytest.mark.asyncio
+    async def test_query_repo_reuses_warm_snapshot_across_calls(
+        self, python_simple_repo: Path
+    ) -> None:
+        """End-to-end (unmocked): a second query_repo call against the same repo
+        through one server-owned runtime reuses the exact same warm snapshot."""
+        from archex.api import _cache_manager_for_source  # pyright: ignore[reportPrivateUsage]
+        from archex.models import Config, RepoSource
+        from archex.serve.runtime import QueryRuntime
+
+        runtime = QueryRuntime()
+        try:
+            server = build_server(runtime=runtime)
+            from mcp import types as mcp_types
+
+            handler = server.request_handlers[mcp_types.CallToolRequest]
+            list_handler = server.request_handlers[mcp_types.ListToolsRequest]
+            await list_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
+
+            def _call(question: str) -> mcp_types.CallToolRequest:
+                return mcp_types.CallToolRequest(
+                    method="tools/call",
+                    params=mcp_types.CallToolRequestParams(
+                        name="query_repo",
+                        arguments={
+                            "repo_url": str(python_simple_repo),
+                            "question": question,
+                            "budget": 100,
+                        },
+                    ),
+                )
+
+            source = RepoSource(local_path=str(python_simple_repo))
+            cache_key = _cache_manager_for_source(source, Config()).cache_key(source)
+
+            await handler(_call("calculate_sum"))
+            first_snapshot = runtime._snapshots.get(cache_key)  # pyright: ignore[reportPrivateUsage]
+            assert first_snapshot is not None
+
+            await handler(_call("models"))
+            second_snapshot = runtime._snapshots.get(cache_key)  # pyright: ignore[reportPrivateUsage]
+
+            assert second_snapshot is first_snapshot
+        finally:
+            runtime.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## M2 — PR-3 of 5 (MCP server wiring)

Stacked on #529 (`QueryRuntime` core) → #528 (generation identity). Context: `.docs/DEVELOPMENT_PLAN.md` M2.

### What

- `run_stdio_server()` creates one `QueryRuntime` for the server process's whole lifetime and closes it in its `finally:` block alongside the existing watch-observer cleanup.
- `build_server(runtime: QueryRuntime | None = None)` threads that runtime into its `call_tool` closure. If no runtime is passed (e.g. a bare `build_server()` call from other code or tests), it constructs a default `QueryRuntime()` internally so existing callers keep working unchanged.
- `_run_mcp_tool(..., runtime: QueryRuntime | None = None)` threads the runtime through to the `query_repo` dispatch only — every other tool (`analyze_repo`, `scout_repo`, `compare_repos`, graph tools, etc.) is untouched.
- `handle_query_repo(..., runtime: QueryRuntime | None = None)` passes it straight to `query(..., runtime=runtime)` (PR #529's parameter).

Net effect: repeat `query_repo` tool calls against the same repository within one MCP server process now reuse the warm BM25/graph/chunk snapshot instead of re-hydrating from SQLite on every call. A real content/config/revision change still forces a rebuild via the existing generation-ID check (PR #528/#529) — no MCP-specific staleness risk introduced.

### Verification

- `uv run ruff check .` / `uv run ruff format --check .` — clean
- `uv run pyright .` — 0 errors
- `uv run pytest -q --no-cov` — 3842 passed, 7 deselected (3836 baseline + 6 new)
- `tests/integrations/test_mcp.py` additions:
  - `TestHandleQueryRepo`: runtime passed through to `query()` when supplied; omitted (`None`) by default.
  - `TestRunStdioServer`: `run_stdio_server` constructs exactly one `QueryRuntime`, passes it to `build_server`, and calls `.close()` on shutdown (verified via a patched `stdio_server`/`server.run` and a spy on `QueryRuntime.close`).
  - `TestBuildServer`: an explicit runtime passed to `build_server` reaches `handle_query_repo`'s positional args; the default (no runtime passed) still reaches `handle_query_repo` as a real `QueryRuntime` instance, not `None`; and an **unmocked end-to-end** test against the real `python_simple_repo` fixture proves two `query_repo` tool calls through one server-owned runtime share the exact same warm snapshot object (`runtime._snapshots[cache_key]` identity across calls).

See PR-4 (to follow) for named `fast`/`balanced`/`deep` profiles and background incremental publication.

Refs: `DEVELOPMENT_PLAN.md` M2.3