### PR TITLE
feat(serve): add named fast/balanced/deep retrieval profiles

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -79,6 +79,7 @@ from archex.models import (
     RepoMetadata,
     RepoSource,
     RetrievalMetadata,
+    RetrievalProfile,
     ScoringWeights,
     SymbolMatch,
     SymbolSource,
@@ -114,6 +115,7 @@ from archex.serve.compare import compare_repos
 from archex.serve.context import assemble_context, passthrough_context
 from archex.serve.generation import read_generation_id
 from archex.serve.profile import build_profile
+from archex.serve.profiles import index_config_for_profile
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -1797,6 +1799,7 @@ def query(
     refresh: bool = True,
     handles: list[str] | None = None,
     runtime: QueryRuntime | None = None,
+    profile: RetrievalProfile | None = None,
 ) -> ContextBundle:
     """Retrieve a ranked ContextBundle for a natural-language query.
 
@@ -1808,8 +1811,11 @@ def query(
     """
     if config is None:
         config = load_config(source)
+    profile_applied = index_config is None and profile is not None
     if index_config is None:
         index_config = load_index_config(source)
+        if profile is not None:
+            index_config = index_config_for_profile(profile, index_config)
     _bootstrap_plugins()
     from archex.serve.intent import token_budget_for_query
 
@@ -1884,6 +1890,9 @@ def query(
                 if effective_budget >= total_repo_tokens:
                     cached_chunks = store.get_chunks()
                     pt = passthrough_context(cached_chunks, question, effective_budget)
+                    pt.retrieval_metadata.retrieval_profile = (
+                        profile.value if profile_applied and profile is not None else None
+                    )
                     if timing is not None:
                         timing.strategy = "passthrough"
                         timing.index_ms = 0.0
@@ -2091,6 +2100,9 @@ def query(
                     reranker=_reranker,
                     rerank_candidate_limit=index_config.rerank_candidate_limit,
                     apply_intent_budget=False,
+                )
+                bundle.retrieval_metadata.retrieval_profile = (
+                    profile.value if profile_applied and profile is not None else None
                 )
                 bundle.retrieval_metadata.expanded_query = expanded_query
                 bundle.retrieval_metadata.expansion_provenance = expansion_prov
@@ -2331,6 +2343,9 @@ def query(
             if effective_budget >= total_repo_tokens:
                 t_assemble = time.perf_counter()
                 pt = passthrough_context(all_chunks, question, effective_budget)
+                pt.retrieval_metadata.retrieval_profile = (
+                    profile.value if profile_applied and profile is not None else None
+                )
                 if timing is not None:
                     timing.strategy = "passthrough"
                     timing.assemble_ms = _elapsed_ms(t_assemble)
@@ -2478,6 +2493,9 @@ def query(
                 reranker=_reranker_miss,
                 rerank_candidate_limit=index_config.rerank_candidate_limit,
                 apply_intent_budget=False,
+            )
+            bundle.retrieval_metadata.retrieval_profile = (
+                profile.value if profile_applied and profile is not None else None
             )
             logger.info("Search + assemble in %.0fms", _elapsed_ms(t6))
         finally:

--- a/src/archex/cli/query_cmd.py
+++ b/src/archex/cli/query_cmd.py
@@ -67,6 +67,17 @@ logger = logging.getLogger(__name__)
     help="Allow explicitly selected pinned model paths that require Hugging Face remote code.",
 )
 @click.option(
+    "--profile",
+    type=click.Choice(["fast", "balanced", "deep"]),
+    default=None,
+    help=(
+        "Named retrieval profile: 'fast' (bm25 only, zero vector/model work), "
+        "'balanced' (adds module prefiltering), or 'deep' (adds vector search and "
+        "reranking). Applied before --strategy/--splade/--module-prefilter, which "
+        "still override individual fields on top of it."
+    ),
+)
+@click.option(
     "--no-refresh",
     is_flag=True,
     default=False,
@@ -90,6 +101,7 @@ def query_cmd(
     splade: bool,
     module_prefilter: bool,
     allow_remote_code: bool,
+    profile: str | None,
     no_refresh: bool,
     refresh_threshold: float | None,
 ) -> None:
@@ -105,6 +117,11 @@ def query_cmd(
     if language:
         config = config.model_copy(update={"languages": list(language)})
     index_config = load_index_config(repo_source)
+    if profile is not None:
+        from archex.models import RetrievalProfile
+        from archex.serve.profiles import index_config_for_profile
+
+        index_config = index_config_for_profile(RetrievalProfile(profile), index_config)
     if strategy is not None:
         index_config = index_config.model_copy(update={"vector": strategy == "hybrid"})
     if allow_remote_code:

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -66,7 +66,7 @@ from archex.impact import (
 from archex.metrics.capture import record_query_usage, record_scout_usage, record_structural_usage
 from archex.metrics.health import note_metrics_recording_failure
 from archex.metrics.policy import resolve_metrics_policy
-from archex.models import ContextBundle, PipelineTiming, RepoSource
+from archex.models import ContextBundle, PipelineTiming, RepoSource, RetrievalProfile
 from archex.onboarding import OnboardingError, render_onboarding_markdown
 from archex.reporting import compute_meta, count_tokens
 from archex.scout import DEFAULT_SCOUT_TOKEN_BUDGET, ScoutFormat, ScoutResult, render_scout
@@ -128,6 +128,7 @@ def handle_query_repo(
     question: str,
     budget: int | None = None,
     runtime: QueryRuntime | None = None,
+    profile: str | None = None,
 ) -> str:
     """Retrieve context from a repository for a natural-language question.
 
@@ -138,6 +139,10 @@ def handle_query_repo(
             intent routing with a product ceiling of 8192.
         runtime: Optional warm QueryRuntime shared across calls in one server
             process. Omit for the exact pre-runtime per-call behavior.
+        profile: Optional named retrieval profile — 'fast' (bm25 only, zero
+            vector/model work), 'balanced' (adds module prefiltering), or
+            'deep' (adds vector search and reranking). Omit to use the
+            repo's configured IndexConfig unchanged.
 
     Returns:
         JSON envelope with ContextBundle content and _meta efficiency block.
@@ -146,6 +151,13 @@ def handle_query_repo(
         raise ValueError("question must not be empty")
     if budget is not None and budget <= 0:
         raise ValueError(f"budget must be positive, got {budget}")
+    resolved_profile: RetrievalProfile | None = None
+    if profile is not None:
+        try:
+            resolved_profile = RetrievalProfile(profile)
+        except ValueError as exc:
+            valid = sorted(p.value for p in RetrievalProfile)
+            raise ValueError(f"profile must be one of {valid}, got {profile!r}") from exc
 
     source = resolve_source(repo_url)
     pt = PipelineTiming()
@@ -157,6 +169,7 @@ def handle_query_repo(
         timing=pt,
         explicit_token_budget=budget is not None,
         runtime=runtime,
+        profile=resolved_profile,
     )
 
     content = render_xml(bundle, include_receipt=False)
@@ -1171,8 +1184,9 @@ async def _run_mcp_tool(
         question: str = arguments["question"]
         budget_arg = arguments.get("budget")
         budget = int(budget_arg) if budget_arg is not None else None
+        profile_arg: str | None = arguments.get("profile")
         return await loop.run_in_executor(
-            None, handle_query_repo, repo_url, question, budget, runtime
+            None, handle_query_repo, repo_url, question, budget, runtime, profile_arg
         )
     if name == "compare_repos":
         repo_a: str = arguments["repo_a"]
@@ -1440,6 +1454,16 @@ def build_server(runtime: QueryRuntime | None = None) -> Any:
                             "description": (
                                 "Optional explicit token budget override. Omit to use "
                                 "adaptive intent routing with the 8192 product ceiling."
+                            ),
+                        },
+                        "profile": {
+                            "type": "string",
+                            "enum": ["fast", "balanced", "deep"],
+                            "description": (
+                                "Optional named retrieval profile: 'fast' (bm25 only, zero "
+                                "vector/model work), 'balanced' (adds module prefiltering), "
+                                "or 'deep' (adds vector search and reranking). Omit to use "
+                                "the repo's configured retrieval settings unchanged."
                             ),
                         },
                     },

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -77,6 +77,24 @@ class RetrievalPolicy(StrEnum):
     CROSS_LAYER = "cross_layer"
 
 
+class RetrievalProfile(StrEnum):
+    """Named retrieval-cost/quality tradeoff, mapped to IndexConfig feature flags.
+
+    FAST: bm25 only — zero vector/model thread work, the cheapest and always
+        available tier. Equivalent to IndexConfig()'s own defaults.
+    BALANCED: adds module-responsibility prefiltering, a pure structural
+        signal computed from the dependency graph — still no model calls.
+    DEEP: adds vector search and cross-encoder reranking for maximum quality
+        at the highest cost. Falls back to the bm25-only path per the
+        existing embedder/reranker-unavailable behavior if neither is
+        configured.
+    """
+
+    FAST = "fast"
+    BALANCED = "balanced"
+    DEEP = "deep"
+
+
 class LanguageTier(StrEnum):
     FULL = "full"
     STRUCTURED = "structured"
@@ -746,6 +764,10 @@ class RetrievalMetadata(BaseModel):
     chunker: ChunkerName = "default"
     index_chunk_count: int = 0
     mean_chunk_tokens: float = 0.0
+    #: Named profile (fast/balanced/deep) resolved for this query, when one was
+    #: used to construct the effective IndexConfig. None when the caller
+    #: supplied an explicit IndexConfig or the auto-loaded repo config as-is.
+    retrieval_profile: str | None = None
 
 
 class ContextReceiptTokenBudget(BaseModel):

--- a/src/archex/serve/profiles.py
+++ b/src/archex/serve/profiles.py
@@ -1,0 +1,53 @@
+"""Named retrieval profiles: fast/balanced/deep IndexConfig presets.
+
+A `RetrievalProfile` (`archex.models.RetrievalProfile`) is a convenience
+shorthand for a common retrieval-feature combination — a preset of
+`IndexConfig` boolean feature toggles selecting a cost/quality tradeoff,
+not a separate configuration system. `index_config_for_profile` layers a
+profile's toggles onto a caller-supplied base `IndexConfig`, preserving
+every other field (embedder, chunker, token encoding, quantization, and so
+on) from that base so a profile composes with repo-level and CLI-level
+configuration instead of discarding it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from archex.models import RetrievalProfile
+
+if TYPE_CHECKING:
+    from archex.models import IndexConfig
+
+#: Boolean feature toggles that define each profile's cost/quality tradeoff.
+#: Every other IndexConfig field (embedder, chunker, token budgets, etc.) is
+#: left untouched — profiles select *which* retrieval signals run, not how
+#: they're configured.
+_PROFILE_OVERRIDES: dict[RetrievalProfile, dict[str, bool]] = {
+    RetrievalProfile.FAST: {
+        "vector": False,
+        "module_prefilter": False,
+        "rerank": False,
+    },
+    RetrievalProfile.BALANCED: {
+        "vector": False,
+        "module_prefilter": True,
+        "rerank": False,
+    },
+    RetrievalProfile.DEEP: {
+        "vector": True,
+        "module_prefilter": True,
+        "rerank": True,
+    },
+}
+
+
+def index_config_for_profile(profile: RetrievalProfile, base: IndexConfig) -> IndexConfig:
+    """Return `base` with `profile`'s retrieval feature flags applied.
+
+    `FAST` performs zero vector/model thread work: both `vector` and
+    `rerank` are forced off, so no embedder or cross-encoder model ever
+    loads or runs for a fast-profile query, regardless of what `base`
+    specifies.
+    """
+    return base.model_copy(update=_PROFILE_OVERRIDES[profile])

--- a/tests/cli/test_query_cmd.py
+++ b/tests/cli/test_query_cmd.py
@@ -1,0 +1,121 @@
+"""Tests for the CLI query subcommand's --profile flag."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+from archex.models import (
+    ContextBundle,
+    ContextCompletenessReason,
+    ContextCompletenessStatus,
+    ContextFreshness,
+    ContextReceipt,
+    ContextReceiptTokenBudget,
+    ContextRecommendedAction,
+)
+
+
+def _make_bundle(question: str = "how does auth work?") -> ContextBundle:
+    return ContextBundle(
+        query=question,
+        token_count=10,
+        token_budget=8000,
+        receipt=ContextReceipt(
+            query=question,
+            token_budget=ContextReceiptTokenBudget(requested=8000, consumed=10),
+            index_revision="rev",
+            freshness=ContextFreshness.CLEAN,
+            context_complete=ContextCompletenessStatus.COMPLETE,
+            context_complete_reason=ContextCompletenessReason.COMPLETE,
+            recommended_next_action=ContextRecommendedAction.USE_BUNDLE,
+        ),
+    )
+
+
+def test_profile_fast_disables_vector_module_prefilter_and_rerank(
+    python_simple_repo: Path,
+) -> None:
+    runner = CliRunner()
+    with patch("archex.cli.query_cmd.query", return_value=_make_bundle()) as mock_query:
+        result = runner.invoke(
+            cli, ["query", str(python_simple_repo), "question", "--profile", "fast"]
+        )
+    assert result.exit_code == 0, result.output
+    index_config = mock_query.call_args.kwargs["index_config"]
+    assert index_config.vector is False
+    assert index_config.module_prefilter is False
+    assert index_config.rerank is False
+
+
+def test_profile_deep_enables_vector_module_prefilter_and_rerank(
+    python_simple_repo: Path,
+) -> None:
+    runner = CliRunner()
+    with patch("archex.cli.query_cmd.query", return_value=_make_bundle()) as mock_query:
+        result = runner.invoke(
+            cli, ["query", str(python_simple_repo), "question", "--profile", "deep"]
+        )
+    assert result.exit_code == 0, result.output
+    index_config = mock_query.call_args.kwargs["index_config"]
+    assert index_config.vector is True
+    assert index_config.module_prefilter is True
+    assert index_config.rerank is True
+
+
+def test_profile_balanced_enables_only_module_prefilter(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+    with patch("archex.cli.query_cmd.query", return_value=_make_bundle()) as mock_query:
+        result = runner.invoke(
+            cli, ["query", str(python_simple_repo), "question", "--profile", "balanced"]
+        )
+    assert result.exit_code == 0, result.output
+    index_config = mock_query.call_args.kwargs["index_config"]
+    assert index_config.vector is False
+    assert index_config.module_prefilter is True
+    assert index_config.rerank is False
+
+
+def test_no_profile_leaves_index_config_from_repo_settings(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+    with patch("archex.cli.query_cmd.query", return_value=_make_bundle()) as mock_query:
+        result = runner.invoke(cli, ["query", str(python_simple_repo), "question"])
+    assert result.exit_code == 0, result.output
+    index_config = mock_query.call_args.kwargs["index_config"]
+    assert index_config.vector is False
+    assert index_config.module_prefilter is False
+    assert index_config.rerank is False
+
+
+def test_module_prefilter_flag_overrides_profile_fast(python_simple_repo: Path) -> None:
+    """Individual flags still apply on top of a profile, per the documented order."""
+    runner = CliRunner()
+    with patch("archex.cli.query_cmd.query", return_value=_make_bundle()) as mock_query:
+        result = runner.invoke(
+            cli,
+            [
+                "query",
+                str(python_simple_repo),
+                "question",
+                "--profile",
+                "fast",
+                "--module-prefilter",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    index_config = mock_query.call_args.kwargs["index_config"]
+    assert index_config.vector is False
+    assert index_config.module_prefilter is True
+    assert index_config.rerank is False
+
+
+def test_invalid_profile_choice_rejected(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["query", str(python_simple_repo), "question", "--profile", "ultra"]
+    )
+    assert result.exit_code != 0
+    assert "Invalid value for '--profile'" in result.output

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -345,6 +345,30 @@ class TestHandleQueryRepo:
             handle_query_repo("/fake/repo", "question?")
         assert mock_query.call_args.kwargs["runtime"] is None
 
+    def test_passes_valid_profile_string_through_to_query(self) -> None:
+        from archex.models import RetrievalProfile
+
+        bundle = _make_context_bundle()
+        with (
+            patch("archex.integrations.mcp.query", return_value=bundle) as mock_query,
+            patch("archex.integrations.mcp.get_files_token_count", return_value=0),
+        ):
+            handle_query_repo("/fake/repo", "question?", profile="fast")
+        assert mock_query.call_args.kwargs["profile"] is RetrievalProfile.FAST
+
+    def test_omits_profile_by_default(self) -> None:
+        bundle = _make_context_bundle()
+        with (
+            patch("archex.integrations.mcp.query", return_value=bundle) as mock_query,
+            patch("archex.integrations.mcp.get_files_token_count", return_value=0),
+        ):
+            handle_query_repo("/fake/repo", "question?")
+        assert mock_query.call_args.kwargs["profile"] is None
+
+    def test_rejects_invalid_profile_string(self) -> None:
+        with pytest.raises(ValueError, match="profile must be one of"):
+            handle_query_repo("/fake/repo", "question?", profile="ultra")
+
 
 class TestHandleScoutRepo:
     def test_returns_scout_markdown_with_meta(self) -> None:
@@ -666,6 +690,8 @@ class TestBuildServer:
         budget_schema = query_repo.inputSchema["properties"]["budget"]
         assert "default" not in budget_schema
         assert "Omit to use adaptive intent routing" in budget_schema["description"]
+        profile_schema = query_repo.inputSchema["properties"]["profile"]
+        assert profile_schema["enum"] == ["fast", "balanced", "deep"]
 
     @pytest.mark.asyncio
     async def test_call_tool_analyze_repo(self) -> None:

--- a/tests/serve/test_profiles.py
+++ b/tests/serve/test_profiles.py
@@ -1,0 +1,56 @@
+"""Unit tests for archex.serve.profiles: named retrieval-profile IndexConfig presets."""
+
+from __future__ import annotations
+
+from archex.models import IndexConfig, RetrievalProfile
+from archex.serve.profiles import index_config_for_profile
+
+
+class TestIndexConfigForProfile:
+    def test_fast_disables_vector_module_prefilter_and_rerank(self) -> None:
+        result = index_config_for_profile(RetrievalProfile.FAST, IndexConfig())
+        assert result.vector is False
+        assert result.module_prefilter is False
+        assert result.rerank is False
+        assert result.bm25 is True
+
+    def test_fast_matches_index_config_defaults(self) -> None:
+        """FAST is documented as equivalent to IndexConfig()'s own defaults."""
+        result = index_config_for_profile(RetrievalProfile.FAST, IndexConfig())
+        assert result == IndexConfig()
+
+    def test_balanced_enables_module_prefilter_only(self) -> None:
+        result = index_config_for_profile(RetrievalProfile.BALANCED, IndexConfig())
+        assert result.vector is False
+        assert result.module_prefilter is True
+        assert result.rerank is False
+
+    def test_deep_enables_vector_module_prefilter_and_rerank(self) -> None:
+        result = index_config_for_profile(RetrievalProfile.DEEP, IndexConfig())
+        assert result.vector is True
+        assert result.module_prefilter is True
+        assert result.rerank is True
+
+    def test_preserves_base_fields_not_covered_by_profile(self) -> None:
+        base = IndexConfig(
+            embedder="jina-v2",
+            chunker="cast",
+            chunk_max_tokens=256,
+            token_encoding="o200k_base",
+            rerank_candidate_limit=8,
+        )
+        for profile in RetrievalProfile:
+            result = index_config_for_profile(profile, base)
+            assert result.embedder == "jina-v2"
+            assert result.chunker == "cast"
+            assert result.chunk_max_tokens == 256
+            assert result.token_encoding == "o200k_base"
+            assert result.rerank_candidate_limit == 8
+
+    def test_deep_from_fast_base_overrides_correctly(self) -> None:
+        """A profile fully replaces the prior profile's toggles rather than merging."""
+        fast_config = index_config_for_profile(RetrievalProfile.FAST, IndexConfig())
+        deep_from_fast = index_config_for_profile(RetrievalProfile.DEEP, fast_config)
+        assert deep_from_fast.vector is True
+        assert deep_from_fast.module_prefilter is True
+        assert deep_from_fast.rerank is True

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -234,6 +234,116 @@ class TestQueryVector:
         assert bundle.retrieval_metadata.strategy in ("bm25+graph", "passthrough")
 
 
+class TestQueryRetrievalProfile:
+    """Named profile (fast/balanced/deep) selection through the public query() API."""
+
+    def test_fast_profile_never_calls_get_embedder_or_constructs_reranker(
+        self, python_simple_repo: Path
+    ) -> None:
+        """FAST performs zero vector/model thread work: even when the repo's
+        loaded IndexConfig has vector+rerank enabled, FAST suppresses both —
+        neither an embedder nor a cross-encoder reranker is ever instantiated
+        (asserted by forcing both to raise if hit)."""
+        from unittest.mock import patch
+
+        from archex.models import RetrievalProfile
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        vector_and_rerank_config = IndexConfig(vector=True, rerank=True, embedder="jina-v2")
+        with (
+            patch("archex.api.load_index_config", return_value=vector_and_rerank_config),
+            patch("archex.api._get_embedder", side_effect=AssertionError("embedder touched")),
+            patch(
+                "archex.index.rerank.CrossEncoderReranker.__init__",
+                side_effect=AssertionError("reranker constructed"),
+            ),
+        ):
+            bundle = query(
+                source,
+                "models",
+                token_budget=100,
+                explicit_token_budget=True,
+                config=Config(languages=["python"], cache=False),
+                profile=RetrievalProfile.FAST,
+            )
+        assert isinstance(bundle, ContextBundle)
+        assert bundle.retrieval_metadata.retrieval_profile == "fast"
+
+    def test_deep_profile_reaches_get_embedder(self, python_simple_repo: Path) -> None:
+        """DEEP actually attempts vector search and reranking — _get_embedder and
+        _maybe_reranker are both invoked, even though neither model is actually
+        loaded here (both are mocked to avoid a real remote-code model load) and
+        the query still falls back to bm25-only output."""
+        from unittest.mock import patch
+
+        from archex.models import RetrievalProfile
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        with (
+            patch("archex.api._get_embedder", return_value=None) as mock_embedder,
+            patch("archex.api._maybe_reranker", return_value=None) as mock_reranker,
+        ):
+            bundle = query(
+                source,
+                "models",
+                token_budget=100,
+                explicit_token_budget=True,
+                config=Config(languages=["python"], cache=False),
+                profile=RetrievalProfile.DEEP,
+            )
+        mock_embedder.assert_called()
+        mock_reranker.assert_called()
+        assert isinstance(bundle, ContextBundle)
+        assert bundle.retrieval_metadata.retrieval_profile == "deep"
+
+    def test_balanced_profile_sets_retrieval_metadata(self, python_simple_repo: Path) -> None:
+        from archex.models import RetrievalProfile
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        bundle = query(
+            source,
+            "models",
+            token_budget=100,
+            explicit_token_budget=True,
+            config=Config(languages=["python"], cache=False),
+            profile=RetrievalProfile.BALANCED,
+        )
+        assert bundle.retrieval_metadata.retrieval_profile == "balanced"
+
+    def test_no_profile_leaves_retrieval_metadata_profile_none(
+        self, python_simple_repo: Path
+    ) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        bundle = query(
+            source,
+            "models",
+            token_budget=100,
+            explicit_token_budget=True,
+            config=Config(languages=["python"], cache=False),
+        )
+        assert bundle.retrieval_metadata.retrieval_profile is None
+
+    def test_explicit_index_config_ignores_profile_and_leaves_receipt_unset(
+        self, python_simple_repo: Path
+    ) -> None:
+        """An explicit index_config is never overwritten by a profile; since the
+        profile had no actual effect, the receipt must not claim one was applied."""
+        from archex.models import RetrievalProfile
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        explicit_config = IndexConfig(module_prefilter=False, rerank=False, vector=False)
+        bundle = query(
+            source,
+            "models",
+            token_budget=100,
+            explicit_token_budget=True,
+            config=Config(languages=["python"], cache=False),
+            index_config=explicit_config,
+            profile=RetrievalProfile.DEEP,
+        )
+        assert bundle.retrieval_metadata.retrieval_profile is None
+
+
 class TestCompareEndToEnd:
     """Compare two repos via api.compare()."""
 


### PR DESCRIPTION
## M2 — PR-4 of 5 (named retrieval profiles)

Stacked on #530 (MCP wiring) → #529 (QueryRuntime) → #528 (generation identity). Context: `.docs/DEVELOPMENT_PLAN.md` M2.

### Scope decision — deferred items (see commit body)

M2's deliverable list includes "phase-level progress and partial-ready lexical status" and "background incremental publication that retains the verified previous snapshot". Both require a genuinely different async-orchestration architecture — a background build racing against continued serving from the current `QueryRuntime` snapshot, with an observable partial-completion state exposed to callers. That's substantial, novel feature work distinct from the profile-selection work in this PR, and warrants its own scoped round with its own tests rather than folding in here. Documented explicitly rather than silently dropped, consistent with the candidate-only-hydration scope call in PR #529.

### What

- `RetrievalProfile` (`fast`/`balanced`/`deep`) in `src/archex/models.py`.
- `src/archex/serve/profiles.py`: `index_config_for_profile(profile, base)` — layers a profile's boolean feature toggles (`vector`, `module_prefilter`, `rerank`) onto a caller-supplied base `IndexConfig`, preserving every other field (embedder, chunker, token encoding, quantization, etc.).
  - `fast`: bm25 only — **equivalent to `IndexConfig()`'s own defaults**, zero vector/model thread work.
  - `balanced`: adds module-responsibility prefiltering — a pure structural/graph signal, still no model calls.
  - `deep`: adds vector search and cross-encoder reranking for maximum quality at the highest cost.
- `query()` gains an optional `profile` parameter. It only takes effect when the caller does **not** pass an explicit `index_config` (explicit `index_config` always wins — matches the existing config-file/CLI-flag layering pattern). `RetrievalMetadata.retrieval_profile` records which profile actually determined the effective config (the receipt "route decision"); it's left `None` both when no profile was requested and when one was requested but ignored because `index_config` was explicit — verified as two distinct test cases.
- MCP: `handle_query_repo` and the `query_repo` tool schema gain an optional `profile` string (`fast`/`balanced`/`deep` enum), validated and mapped to `RetrievalProfile`, with a clear `ValueError` for an invalid value.
- CLI: `archex query --profile fast|balanced|deep`, applied before the existing `--strategy`/`--splade`/`--module-prefilter`/`--allow-remote-code` flags, which still override individual fields on top of it (matches the existing flag-layering order).

### Verification

- `uv run ruff check .` / `uv run ruff format --check .` — clean
- `uv run pyright .` — 0 errors
- `uv run pytest -q --no-cov` — 3862 passed, 7 deselected (3842 baseline + 20 new)
- `tests/serve/test_profiles.py` (6 tests): each profile's exact toggle set; `fast` structurally equals `IndexConfig()` defaults; every profile preserves unrelated base fields; a profile fully replaces the prior profile's toggles when chained.
- `tests/test_integration.py::TestQueryRetrievalProfile` (5 tests, real end-to-end `query()` calls): **the core `fast` = zero vector/model work claim**, verified by forcing `_get_embedder` and `CrossEncoderReranker.__init__` to raise if touched — a `fast`-profile query still completes cleanly even against a base config with `vector=True, rerank=True` already set; `deep` genuinely reaches `_get_embedder`/`_maybe_reranker` (mocked to avoid a real remote-code model load in CI); `balanced` sets the receipt correctly; no profile leaves the receipt field `None`; an explicit `index_config` ignores the profile and leaves the receipt field `None` too (not misleadingly claiming an unused profile was applied).
- `tests/integrations/test_mcp.py` (4 tests): valid profile string reaches `query()` as the correct enum member; omitted profile passes `None`; invalid profile string raises `ValueError`; the `query_repo` tool schema's `profile` property has the expected 3-value enum.
- `tests/cli/test_query_cmd.py` (6 new tests, new file): each `--profile` value sets the expected `IndexConfig` toggles; no `--profile` leaves the repo's loaded config unchanged; `--module-prefilter` still overrides `--profile fast` on top; an invalid `--profile` choice is rejected by Click.

See PR-5 (to follow) for parser I/O reduction and the frozen-fixture p95/RSS/recall benchmark gate.

Refs: `DEVELOPMENT_PLAN.md` M2.4