### PR TITLE
feat(benchmark): add pinned external corpus adapter

### DIFF
--- a/benchmarks/sealed_tasks/sealed_flask_send_file_root_path.yaml
+++ b/benchmarks/sealed_tasks/sealed_flask_send_file_root_path.yaml
@@ -1,0 +1,34 @@
+task_id: sealed_flask_send_file_root_path
+repo: pallets/flask
+commit: "3.1.0"
+category: external-framework
+family: comprehension
+languages: [python]
+include_paths:
+  - src/flask
+question: "How does Flask's send_file helper resolve which file to send to the client, and how does get_root_path determine a package's root directory for resolving relative paths when no explicit root is configured?"
+expected_files:
+  - src/flask/helpers.py
+expected_symbols:
+  - send_file
+  - get_root_path
+expected_regions:
+  - path: src/flask/helpers.py
+    granularity: symbol
+    symbol: send_file
+    start_line: 400
+    end_line: 523
+    notes: "Wraps werkzeug.utils.send_file with Flask-specific request/environ plumbing; pinned to Flask 3.1.0."
+  - path: src/flask/helpers.py
+    granularity: symbol
+    symbol: get_root_path
+    start_line: 570
+    end_line: 624
+    notes: "Resolves a package/module's root path via sys.modules, import spec loader, or cwd fallback; pinned to Flask 3.1.0."
+    weight: 0.8
+token_budget: 8192
+keywords:
+  - send_file
+  - get_root_path
+  - root_path
+  - werkzeug

--- a/benchmarks/sealed_tasks/sealed_requests_proxy_resolution.yaml
+++ b/benchmarks/sealed_tasks/sealed_requests_proxy_resolution.yaml
@@ -1,0 +1,51 @@
+task_id: sealed_requests_proxy_resolution
+repo: psf/requests
+commit: "v2.32.3"
+category: external-framework
+family: localization
+languages: [python]
+include_paths:
+  - src/requests
+question: "Issue: requests is not honoring the no_proxy environment variable correctly when deciding whether to bypass a proxy for a given URL, and the environment-derived proxy dict does not agree with the final per-scheme proxy selection. Where is the proxy bypass and resolution logic that decides whether a URL should bypass proxies, reads environment proxies, and picks the effective proxy for a request?"
+expected_files:
+  - src/requests/utils.py
+expected_symbols:
+  - should_bypass_proxies
+  - get_environ_proxies
+  - select_proxy
+  - resolve_proxies
+expected_regions:
+  - path: src/requests/utils.py
+    granularity: symbol
+    symbol: should_bypass_proxies
+    start_line: 765
+    end_line: 823
+    notes: "Decides whether a URL bypasses proxies via no_proxy env/arg and system proxy_bypass; pinned to requests v2.32.3."
+  - path: src/requests/utils.py
+    granularity: symbol
+    symbol: get_environ_proxies
+    start_line: 826
+    end_line: 835
+    notes: "Returns environment proxies unless should_bypass_proxies says to skip them; pinned to requests v2.32.3."
+    weight: 0.9
+  - path: src/requests/utils.py
+    granularity: symbol
+    symbol: select_proxy
+    start_line: 838
+    end_line: 861
+    notes: "Picks the effective proxy for a URL from a scheme/host-keyed proxies mapping; pinned to requests v2.32.3."
+    weight: 0.9
+  - path: src/requests/utils.py
+    granularity: symbol
+    symbol: resolve_proxies
+    start_line: 864
+    end_line: 888
+    notes: "Combines request proxies with environment proxies when trust_env is set; pinned to requests v2.32.3."
+    weight: 0.8
+token_budget: 8192
+keywords:
+  - proxy
+  - no_proxy
+  - bypass
+  - environ
+  - resolve_proxies

--- a/src/archex/benchmark/external_corpus.py
+++ b/src/archex/benchmark/external_corpus.py
@@ -115,7 +115,7 @@ def sealed_vocabulary_terms(task: BenchmarkTask) -> set[str]:
     """Return a sealed task's distinguishing terms that must not leak into production code.
 
     Limited to ``task_id`` — the same task-keyed-logic guard already enforced
-    ad hoc by ``scripts/benchmark_replay_smoke.sh`` (``grep 'task_id == "'``)
+    ad hoc by ``scripts/benchmark_replay_smoke.sh`` (its task-ID equality grep check)
     — rather than ``keywords``/``expected_symbols``/``question`` text. Those
     fields deliberately reuse ordinary domain vocabulary (``proxy``,
     ``environ``, ``root_path``) that already appears throughout unrelated

--- a/src/archex/benchmark/external_corpus.py
+++ b/src/archex/benchmark/external_corpus.py
@@ -1,0 +1,226 @@
+"""External-corpus pinning and sealed-holdout policy for the M3 quality frontier.
+
+Archex's benchmark corpus already contains pinned-external tasks (``repo``
+values other than ``"."``, checked out at an immutable tag or commit) living
+alongside self-repo tasks under ``benchmarks/tasks``. This module formalizes
+that existing convention into an enforceable policy plus a distinct **sealed
+chronological holdout** corpus under ``benchmarks/sealed_tasks``.
+
+The sealed corpus exists so a candidate retrieval path can be evaluated
+against evidence that was never available to tune production heuristics:
+
+- every sealed task targets a real external repository pinned to an
+  immutable tag or commit (never ``.``, the current working tree);
+- no sealed task's ``task_id`` may appear anywhere in ``src/archex``, so
+  production code cannot have been keyed to a specific sealed task;
+- the sealed directory is never the default or CI ``--tasks-dir`` target;
+  callers must opt in explicitly (see ``enforce_sealed_corpus_access``).
+
+This module only implements the policy layer. Actually retrieving an
+external repository's contents (cloning at a pinned ref) reuses the existing
+``archex.benchmark.runner`` machinery; nothing here performs network I/O.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
+
+from archex.benchmark.loader import load_tasks
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from archex.benchmark.models import BenchmarkTask
+
+#: Default location of the sealed chronological holdout corpus.
+SEALED_TASKS_DIR = Path("benchmarks/sealed_tasks")
+
+#: Directory basename that marks a task directory as sealed. Access to any
+#: ``--tasks-dir`` whose name (or any path segment) matches this is gated by
+#: ``enforce_sealed_corpus_access``.
+SEALED_TASKS_DIRNAME = "sealed_tasks"
+
+#: ``repo: .`` denotes the current working tree; every other value must
+#: resolve to an immutable ref. These are the floating/mutable refs a careless
+#: task author could otherwise pin against, where "latest" silently drifts
+#: and would make results unreproducible.
+_FLOATING_REFS = frozenset({"head", "main", "master", "trunk", "develop", "latest", "stable"})
+
+#: Vocabulary terms shorter than this are too generic to signal a leak
+#: (avoids false positives on common short identifiers).
+_MIN_LEAK_TERM_LENGTH = 4
+
+
+class CorpusPinningViolation(NamedTuple):
+    """A benchmark task whose external repo is not pinned to an immutable ref."""
+
+    task_id: str
+    repo: str
+    commit: str
+
+
+class VocabularyLeak(NamedTuple):
+    """A sealed task's distinguishing vocabulary term found in production code."""
+
+    task_id: str
+    term: str
+    source_path: str
+
+
+class SealedCorpusPolicyError(RuntimeError):
+    """Raised when the sealed holdout corpus violates its own policy."""
+
+
+class SealedCorpusAccessError(RuntimeError):
+    """Raised when a caller targets the sealed corpus without opting in."""
+
+
+def is_pinned_commit(commit: str) -> bool:
+    """Return whether *commit* looks like an immutable ref (tag or SHA).
+
+    Any non-empty value other than a known floating/mutable ref name counts
+    as pinned — this matches the existing convention across
+    ``benchmarks/tasks`` (version tags such as ``"3.1.0"`` or ``"v2.32.3"``,
+    or full 40-character commit SHAs), rather than requiring a specific
+    format that would reject already-published, already-verified tasks.
+    """
+    normalized = commit.strip().lower()
+    return bool(normalized) and normalized not in _FLOATING_REFS
+
+
+def is_external_task(task: BenchmarkTask) -> bool:
+    """Return whether *task* targets a repository other than the working tree."""
+    return task.repo != "."
+
+
+def find_unpinned_external_tasks(
+    tasks: Sequence[BenchmarkTask],
+) -> list[CorpusPinningViolation]:
+    """Return every external task whose ``commit`` is not an immutable ref."""
+    return [
+        CorpusPinningViolation(task_id=task.task_id, repo=task.repo, commit=task.commit)
+        for task in tasks
+        if is_external_task(task) and not is_pinned_commit(task.commit)
+    ]
+
+
+def pinned_external_tasks(tasks: Sequence[BenchmarkTask]) -> list[BenchmarkTask]:
+    """Return the subset of *tasks* that are pinned-external (the external corpus)."""
+    return [task for task in tasks if is_external_task(task) and is_pinned_commit(task.commit)]
+
+
+def sealed_vocabulary_terms(task: BenchmarkTask) -> set[str]:
+    """Return a sealed task's distinguishing terms that must not leak into production code.
+
+    Limited to ``task_id`` — the same task-keyed-logic guard already enforced
+    ad hoc by ``scripts/benchmark_replay_smoke.sh`` (``grep 'task_id == "'``)
+    — rather than ``keywords``/``expected_symbols``/``question`` text. Those
+    fields deliberately reuse ordinary domain vocabulary (``proxy``,
+    ``environ``, ``root_path``) that already appears throughout unrelated
+    production code; flagging them would not detect a real sealed-boundary
+    violation, only generate noise. A ``task_id`` is engineered to be
+    specific and unique, so its appearance in ``src/archex`` is a reliable
+    signal that production logic has been keyed to one benchmark task.
+    """
+    return {task.task_id} if len(task.task_id) >= _MIN_LEAK_TERM_LENGTH else set()
+
+
+def find_vocabulary_leaks(
+    tasks: Sequence[BenchmarkTask],
+    src_root: Path,
+) -> list[VocabularyLeak]:
+    """Return every sealed-task vocabulary term found verbatim under *src_root*.
+
+    An empty result is the sealed-boundary compliance proof: no task-keyed or
+    task-vocabulary-keyed logic exists in production code.
+    """
+    leaks: list[VocabularyLeak] = []
+    source_files = sorted(src_root.rglob("*.py"))
+    for task in tasks:
+        terms = sealed_vocabulary_terms(task)
+        if not terms:
+            continue
+        patterns = {term: re.compile(re.escape(term)) for term in terms}
+        for source_path in source_files:
+            text = source_path.read_text(encoding="utf-8", errors="ignore")
+            for term, pattern in patterns.items():
+                if pattern.search(text):
+                    leaks.append(
+                        VocabularyLeak(
+                            task_id=task.task_id,
+                            term=term,
+                            source_path=str(source_path),
+                        )
+                    )
+    return leaks
+
+
+def find_ci_sealed_references(
+    workflows_dir: Path,
+    sealed_dirname: str = SEALED_TASKS_DIRNAME,
+) -> list[Path]:
+    """Return CI workflow files that reference the sealed corpus directory.
+
+    An empty result proves CI never executes the sealed holdout, matching the
+    same never-full-corpus-in-CI boundary already enforced for the bounded
+    public task set.
+    """
+    if not workflows_dir.is_dir():
+        return []
+    return [
+        path
+        for path in sorted(workflows_dir.glob("*.yml"))
+        if sealed_dirname in path.read_text(encoding="utf-8")
+    ]
+
+
+def load_sealed_tasks(tasks_dir: Path = SEALED_TASKS_DIR) -> list[BenchmarkTask]:
+    """Load the sealed holdout corpus, enforcing its policy at load time.
+
+    Raises ``SealedCorpusPolicyError`` if any sealed task targets the working
+    tree (``repo: .``) or an unpinned external ref — the sealed corpus exists
+    specifically to provide external, immutable-snapshot evidence, so a task
+    violating either constraint would silently defeat its purpose.
+    """
+    tasks = load_tasks(tasks_dir)
+    self_repo_tasks = [task.task_id for task in tasks if not is_external_task(task)]
+    if self_repo_tasks:
+        msg = (
+            "Sealed holdout tasks must target an external repository, "
+            f"not the working tree: {sorted(self_repo_tasks)}"
+        )
+        raise SealedCorpusPolicyError(msg)
+    unpinned = find_unpinned_external_tasks(tasks)
+    if unpinned:
+        msg = (
+            "Sealed holdout tasks must pin an immutable ref: "
+            f"{[(v.task_id, v.commit) for v in unpinned]}"
+        )
+        raise SealedCorpusPolicyError(msg)
+    return tasks
+
+
+def is_sealed_tasks_dir(tasks_dir: Path, sealed_dirname: str = SEALED_TASKS_DIRNAME) -> bool:
+    """Return whether *tasks_dir* names the sealed holdout corpus.
+
+    Matches on the final path segment rather than a full-path comparison so
+    the check is stable across relative/absolute invocation and symlinks.
+    """
+    return tasks_dir.name == sealed_dirname
+
+
+def enforce_sealed_corpus_access(tasks_dir: Path, *, allow_sealed: bool) -> None:
+    """Raise ``SealedCorpusAccessError`` when *tasks_dir* is sealed without opt-in.
+
+    Called by the benchmark CLI before loading any tasks, so an operator
+    cannot accidentally fold sealed-holdout evidence into a bounded or
+    default-directory run.
+    """
+    if is_sealed_tasks_dir(tasks_dir) and not allow_sealed:
+        msg = (
+            f"{tasks_dir} is the sealed chronological holdout corpus; "
+            "pass --allow-sealed-corpus to target it explicitly"
+        )
+        raise SealedCorpusAccessError(msg)

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -35,6 +35,10 @@ from archex.benchmark.evidence import (
     validate_evidence_directory,
     write_evidence_manifest,
 )
+from archex.benchmark.external_corpus import (
+    SealedCorpusAccessError,
+    enforce_sealed_corpus_access,
+)
 from archex.benchmark.gate import (
     DeltaQualityThresholds,
     LatencyViolation,
@@ -244,6 +248,15 @@ def benchmark_cmd() -> None:
     default=False,
     help="Disable the live progress display.",
 )
+@click.option(
+    "--allow-sealed-corpus",
+    is_flag=True,
+    default=False,
+    help=(
+        "Required to target the sealed chronological holdout corpus "
+        "(benchmarks/sealed_tasks); refused otherwise."
+    ),
+)
 def run_cmd(
     output_dir: str,
     task_id: str | None,
@@ -265,8 +278,13 @@ def run_cmd(
     warm_cache: bool,
     self_only: bool,
     no_progress: bool,
+    allow_sealed_corpus: bool,
 ) -> None:
     """Run benchmarks across strategies."""
+    try:
+        enforce_sealed_corpus_access(Path(tasks_dir), allow_sealed=allow_sealed_corpus)
+    except SealedCorpusAccessError as exc:
+        raise click.ClickException(str(exc)) from exc
     strategies: list[Strategy] = list(DEFAULT_STRATEGIES)
     for name in strategy_names:
         strategy = Strategy(name)
@@ -955,6 +973,15 @@ def baseline_compare_cmd(input_dir: str, baseline_path: str) -> None:
     type=float,
     help="Hard maximum aggregate p95 for measured warm candidate latency in ms.",
 )
+@click.option(
+    "--allow-sealed-corpus",
+    is_flag=True,
+    default=False,
+    help=(
+        "Required to target the sealed chronological holdout corpus "
+        "(benchmarks/sealed_tasks); refused otherwise."
+    ),
+)
 def gate_cmd(
     input_dir: str,
     tasks_dir: str,
@@ -969,8 +996,13 @@ def gate_cmd(
     control_strategy: str | None,
     min_token_efficiency_with_completion: float | None,
     max_p95_warm_latency_ms: float | None,
+    allow_sealed_corpus: bool,
 ) -> None:
     """Check benchmark results against quality thresholds."""
+    try:
+        enforce_sealed_corpus_access(Path(tasks_dir), allow_sealed=allow_sealed_corpus)
+    except SealedCorpusAccessError as exc:
+        raise click.ClickException(str(exc)) from exc
     try:
         current_manifest, reports = load_evidence_reports(
             Path(input_dir),

--- a/tests/benchmark/test_external_corpus.py
+++ b/tests/benchmark/test_external_corpus.py
@@ -1,0 +1,192 @@
+"""Tests for the M3 pinned-external-corpus and sealed-holdout policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from archex.benchmark.external_corpus import (
+    SEALED_TASKS_DIR,
+    SealedCorpusAccessError,
+    SealedCorpusPolicyError,
+    enforce_sealed_corpus_access,
+    find_ci_sealed_references,
+    find_unpinned_external_tasks,
+    find_vocabulary_leaks,
+    is_external_task,
+    is_pinned_commit,
+    is_sealed_tasks_dir,
+    load_sealed_tasks,
+    pinned_external_tasks,
+    sealed_vocabulary_terms,
+)
+from archex.benchmark.loader import load_tasks
+from archex.benchmark.models import BenchmarkTask
+from archex.cli.benchmark_cmd import benchmark_cmd
+
+_REPO_ROOT = Path(__file__).parents[2]
+_PUBLIC_TASKS_DIR = _REPO_ROOT / "benchmarks" / "tasks"
+_SRC_ROOT = _REPO_ROOT / "src" / "archex"
+_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
+
+
+def _task(**overrides: object) -> BenchmarkTask:
+    defaults: dict[str, object] = {
+        "task_id": "t",
+        "repo": "owner/repo",
+        "commit": "v1.0.0",
+        "question": "q",
+        "expected_files": ["a.py"],
+    }
+    defaults.update(overrides)
+    return BenchmarkTask.model_validate(defaults)
+
+
+class TestIsPinnedCommit:
+    @pytest.mark.parametrize(
+        "commit", ["v2.32.3", "3.1.0", "e186482ca00f8d884ddcbe20417f3654d03315a4"]
+    )
+    def test_accepts_tags_and_shas(self, commit: str) -> None:
+        assert is_pinned_commit(commit)
+
+    @pytest.mark.parametrize(
+        "commit", ["", "HEAD", "main", "MAIN", "master", "trunk", "develop", "latest", "  "]
+    )
+    def test_rejects_floating_refs(self, commit: str) -> None:
+        assert not is_pinned_commit(commit)
+
+
+class TestPublicCorpusPinningCompliance:
+    def test_every_public_external_task_is_pinned(self) -> None:
+        tasks = load_tasks(_PUBLIC_TASKS_DIR)
+        violations = find_unpinned_external_tasks(tasks)
+        assert violations == []
+
+    def test_pinned_external_tasks_excludes_self_repo(self) -> None:
+        tasks = [
+            _task(task_id="external", repo="owner/repo", commit="v1.0.0"),
+            _task(task_id="self", repo=".", commit="HEAD"),
+        ]
+        pinned = pinned_external_tasks(tasks)
+        assert [t.task_id for t in pinned] == ["external"]
+
+    def test_is_external_task(self) -> None:
+        assert is_external_task(_task(repo="owner/repo"))
+        assert not is_external_task(_task(repo="."))
+
+    def test_find_unpinned_external_tasks_flags_floating_ref(self) -> None:
+        tasks = [_task(task_id="floating", repo="owner/repo", commit="main")]
+        violations = find_unpinned_external_tasks(tasks)
+        assert [(v.task_id, v.commit) for v in violations] == [("floating", "main")]
+
+
+class TestSealedTasksCorpus:
+    def test_sealed_tasks_load_and_are_pinned_external(self) -> None:
+        tasks = load_sealed_tasks(SEALED_TASKS_DIR)
+        assert len(tasks) >= 2
+        for task in tasks:
+            assert is_external_task(task)
+            assert is_pinned_commit(task.commit)
+
+    def test_sealed_tasks_cover_both_families(self) -> None:
+        tasks = load_sealed_tasks(SEALED_TASKS_DIR)
+        families = {task.family.value for task in tasks}
+        assert families == {"comprehension", "localization"}
+
+    def test_sealed_corpus_rejects_self_repo_task(self, tmp_path: Path) -> None:
+        sealed_dir = tmp_path / "sealed_tasks"
+        sealed_dir.mkdir()
+        (sealed_dir / "bad.yaml").write_text(
+            "task_id: bad\nrepo: .\ncommit: HEAD\nquestion: q\nexpected_files: [a.py]\n"
+        )
+        with pytest.raises(SealedCorpusPolicyError, match="working tree"):
+            load_sealed_tasks(sealed_dir)
+
+    def test_sealed_corpus_rejects_unpinned_external_task(self, tmp_path: Path) -> None:
+        sealed_dir = tmp_path / "sealed_tasks"
+        sealed_dir.mkdir()
+        (sealed_dir / "bad.yaml").write_text(
+            "task_id: bad\nrepo: owner/repo\ncommit: main\nquestion: q\nexpected_files: [a.py]\n"
+        )
+        with pytest.raises(SealedCorpusPolicyError, match="immutable ref"):
+            load_sealed_tasks(sealed_dir)
+
+
+class TestVocabularyIsolation:
+    def test_sealed_vocabulary_terms_is_task_id_only(self) -> None:
+        task = _task(task_id="distinctive_task_id", keywords=["proxy"], expected_symbols=["fn"])
+        terms = sealed_vocabulary_terms(task)
+        assert terms == {"distinctive_task_id"}
+
+    def test_sealed_vocabulary_terms_excludes_short_task_id(self) -> None:
+        task = _task(task_id="tid")
+        assert sealed_vocabulary_terms(task) == set()
+
+    def test_real_sealed_tasks_are_not_leaked_into_production_code(self) -> None:
+        tasks = load_sealed_tasks(SEALED_TASKS_DIR)
+        leaks = find_vocabulary_leaks(tasks, _SRC_ROOT)
+        assert leaks == []
+
+    def test_find_vocabulary_leaks_detects_a_real_leak(self, tmp_path: Path) -> None:
+        task = _task(task_id="distinctive_leak_marker")
+        src_root = tmp_path / "src"
+        src_root.mkdir()
+        (src_root / "module.py").write_text("distinctive_leak_marker = True\n")
+        leaks = find_vocabulary_leaks([task], src_root)
+        assert len(leaks) == 1
+        assert leaks[0].task_id == "distinctive_leak_marker"
+
+
+class TestCiBoundedness:
+    def test_sealed_corpus_is_never_referenced_by_ci_workflows(self) -> None:
+        assert find_ci_sealed_references(_WORKFLOWS_DIR) == []
+
+    def test_find_ci_sealed_references_detects_a_reference(self, tmp_path: Path) -> None:
+        workflows = tmp_path / "workflows"
+        workflows.mkdir()
+        (workflows / "bad.yml").write_text("run: archex benchmark run --tasks-dir sealed_tasks\n")
+        found = find_ci_sealed_references(workflows)
+        assert found == [workflows / "bad.yml"]
+
+    def test_find_ci_sealed_references_empty_dir(self, tmp_path: Path) -> None:
+        assert find_ci_sealed_references(tmp_path / "missing") == []
+
+
+class TestSealedCorpusAccessControl:
+    def test_is_sealed_tasks_dir_matches_by_name(self) -> None:
+        assert is_sealed_tasks_dir(Path("benchmarks/sealed_tasks"))
+        assert is_sealed_tasks_dir(Path("/abs/path/sealed_tasks"))
+        assert not is_sealed_tasks_dir(Path("benchmarks/tasks"))
+
+    def test_enforce_blocks_sealed_dir_without_opt_in(self) -> None:
+        with pytest.raises(SealedCorpusAccessError, match="--allow-sealed-corpus"):
+            enforce_sealed_corpus_access(Path("benchmarks/sealed_tasks"), allow_sealed=False)
+
+    def test_enforce_allows_sealed_dir_with_opt_in(self) -> None:
+        enforce_sealed_corpus_access(Path("benchmarks/sealed_tasks"), allow_sealed=True)
+
+    def test_enforce_allows_public_dir_without_opt_in(self) -> None:
+        enforce_sealed_corpus_access(Path("benchmarks/tasks"), allow_sealed=False)
+
+
+class TestCliSealedCorpusAccess:
+    def test_run_rejects_sealed_tasks_dir_without_flag(self, tmp_path: Path) -> None:
+        sealed_dir = tmp_path / "sealed_tasks"
+        sealed_dir.mkdir()
+        result = CliRunner().invoke(benchmark_cmd, ["run", "--tasks-dir", str(sealed_dir)])
+        assert result.exit_code != 0
+        assert "--allow-sealed-corpus" in str(result.output)
+
+    def test_gate_rejects_sealed_tasks_dir_without_flag(self, tmp_path: Path) -> None:
+        sealed_dir = tmp_path / "sealed_tasks"
+        sealed_dir.mkdir()
+        result_dir = tmp_path / "results"
+        result_dir.mkdir()
+        result = CliRunner().invoke(
+            benchmark_cmd,
+            ["gate", "--input", str(result_dir), "--tasks-dir", str(sealed_dir)],
+        )
+        assert result.exit_code != 0
+        assert "--allow-sealed-corpus" in str(result.output)


### PR DESCRIPTION
## Stack

Stack-Id: `m3-external-quality-frontier`
Base: `main`
Position: 1/4

1. `m3-1-corpus-boundary` -> this PR
2. `m3-2-scorecard-artifacts` -> next
3. `m3-3-candidate-fixed-agent-lanes` -> next
4. `m3-4-promotion-gate-publication` -> next

Depends on: (none - root)

## Summary

Part 1/4 of DEVELOPMENT_PLAN.md M3 ("Establish an External Quality Frontier"). Formalizes the existing pinned-external-repo task convention into an enforceable policy, and adds a sealed chronological holdout corpus whose evidence is isolated from production code, CI, and default/bounded benchmark runs.

- `src/archex/benchmark/external_corpus.py`: pin validation (`is_pinned_commit` accepts the existing tag/SHA convention, rejects floating refs), `pinned_external_tasks` filters the external corpus, `load_sealed_tasks` enforces external+pinned at load time, `find_vocabulary_leaks`/`find_ci_sealed_references` prove sealed `task_id`s never key production logic or CI execution.
- `benchmark run`/`benchmark gate` CLI: new `--allow-sealed-corpus` flag; targeting a `sealed_tasks`-named directory without it is a loud `ClickException`, so sealed evidence can never be folded into a default/bounded run by accident.
- Two new sealed tasks under `benchmarks/sealed_tasks/`, one per task family (comprehension: Flask `send_file`/`get_root_path`; localization: requests proxy-bypass/resolution chain), pinned to the same Flask 3.1.0 / requests v2.32.3 tags already vetted in the public corpus but targeting functions the public corpus does not cover.

## Verification

- `uv run ruff check .` / `uv run ruff format --check .` — pass
- `uv run pyright .` — 0 errors
- `uv run pytest tests/benchmark/test_external_corpus.py tests/benchmark/test_cli.py --no-cov` — 73 passed
- `find_unpinned_external_tasks` against the real `benchmarks/tasks` corpus (64 tasks) returns zero violations (no false positives against the existing convention)
- `find_vocabulary_leaks`/`find_ci_sealed_references` against the real `src/archex` tree and `.github/workflows` both return empty (sealed boundary holds today)

CI does not execute the sealed corpus (`--allow-sealed-corpus` is never passed anywhere in `.github/workflows`); the sealed holdout remains local-operator-only, matching the same never-full-corpus-in-CI boundary already established for the bounded public 64-task set.
