### PR TITLE
feat(benchmark): enforce promotion rule

### DIFF
--- a/docs/RETRIEVAL_DEFAULT_DECISIONS.md
+++ b/docs/RETRIEVAL_DEFAULT_DECISIONS.md
@@ -135,6 +135,16 @@ Disposition: **ships disabled by default.** A nine-task self-repo identifier-fra
 
 No recall/MRR improvement is claimed for the general corpus. Any future promotion to enabled-by-default must come from a checked-in benchmark artifact showing the fragment-collision root cause is resolved (e.g. a more targeted expansion that excludes colliding PascalCase siblings) without regressing the general corpus.
 
+## External quality frontier (M3)
+
+DEVELOPMENT_PLAN.md §4 M3 builds reproducible, task-family-specific external evidence comparing the product default (`archex_query`) against candidate lanes — cAST chunking (`--chunker cast`), the `fast`/`balanced` retrieval profiles (`archex_query_profile_fast`/`archex_query_profile_balanced`), and an only-if-defined symbolic-rerank lane — plus a pinned-external-corpus and sealed-chronological-holdout policy, a four-dimension scorecard (language/repository-size/query-intent/task-family), and a promotion gate extended with zero-recall, language-family, and fixed-agent non-regression checks.
+
+Decision rule: no candidate is eligible for automatic product-default promotion. Promotion requires every mandatory dimension to hold on a clean run — no index-invariant regression, no increase in zero-recall tasks, no required-file/region/line regression, no hidden per-language regression, a predeclared efficiency/ranking improvement within profile p95/RSS budgets, and preserved or improved fixed-agent downstream success — evaluated via `archex benchmark gate --promotion-strategy`/`--control-strategy` for same-strategy-family candidates (fast/balanced/symbolic-rerank) and via the absolute-threshold gate plus scorecard comparison for cAST (see the raw report for why a cross-chunker `--baseline` regression gate is not currently reachable).
+
+Disposition (local evaluation, 2026-07-23, self-repo scope): see `docs/m3-external-quality-frontier.md` for the full reproducible run (commands, thresholds, and every gate's exact output). On the 24-task self-repo scope, `fast`/`balanced` matched `archex_query` bit-for-bit on recall/F1/MRR/downstream-success with a marginally lower cold p50, but the promotion gate could not clear because warm-latency evidence was not measured in this run (a `--warm-cache` interaction with the `balanced` profile's `module_prefilter`, a pre-existing runner behavior, not root-caused here). cAST measurably regressed recall, F1, and downstream success on this scope and failed its absolute-threshold gate outright. The full pinned-external (48 tasks) and sealed-holdout (2 tasks) corpus runs, and the `--warm-cache` root cause, remain open local-operator follow-on work.
+
+No numeric external/sealed-corpus results are claimed here beyond the self-repo scope in `docs/m3-external-quality-frontier.md`. `archex_query` (default chunker) remains the product default; any future promotion claim must come from a checked-in benchmark artifact produced by `scripts/m3_frontier_pipeline.sh` against the full corpus that satisfies every mandatory M3 dimension above.
+
 ## Decision rationale
 
 ### Why this gate exists

--- a/docs/m3-external-quality-frontier.md
+++ b/docs/m3-external-quality-frontier.md
@@ -1,0 +1,79 @@
+# M3 — External Quality Frontier: Reproducible Comparison
+
+Status: candidate evidence, self-repo scope. No default-promotion decision is made by this document — see [Verdict](#verdict).
+
+## What this measures
+
+DEVELOPMENT_PLAN.md §4 M3 requires reproducible, task-family-specific evidence comparing archex's default retrieval path against candidate lanes (cAST chunking, the `fast`/`balanced` retrieval profiles, and an only-if-defined symbolic-rerank lane), reported by language, repository size, query intent, and task family rather than collapsed into one cross-family winner.
+
+The M3 stack (`#533`–`#536`) built:
+
+- a pinned-external-corpus policy plus a sealed chronological holdout corpus (`benchmarks/sealed_tasks/`), isolated from CI and from production vocabulary;
+- the four-dimension scorecard and raw provenance artifact (`archex benchmark scorecard`);
+- the candidate lane matrix (`archex_query_profile_fast`/`_balanced`, cAST via `--chunker`) and a deterministic fixed-agent trajectory signal (`post_bundle_search_turns`);
+- the multidimensional promotion gate (`archex benchmark gate --promotion-strategy`), extended with zero-recall, language-family, and fixed-agent non-regression checks;
+- `scripts/m3_frontier_pipeline.sh`, the local-operator orchestration script that runs the lane matrix and every gate in one invocation.
+
+## How to reproduce
+
+```bash
+# Self-repo scope (no network, ~8 minutes on this machine):
+ARCHEX_M3_SELF_ONLY=1 bash scripts/m3_frontier_pipeline.sh
+
+# Full public corpus (64 tasks, network clones for pinned external repos,
+# significantly longer -- local-operator only, never run in CI):
+bash scripts/m3_frontier_pipeline.sh
+
+# Sealed chronological holdout (2 tasks, network clones, local-operator only):
+ARCHEX_M3_TASKS_DIR=benchmarks/sealed_tasks ARCHEX_M3_ALLOW_SEALED_CORPUS=1 \
+  bash scripts/m3_frontier_pipeline.sh
+```
+
+Every stage's exact command, thresholds, and pass/fail output are logged to `logs/m3_frontier_pipeline.log` (or `$ARCHEX_M3_LOG_FILE`). Evidence directories under `$ARCHEX_M3_OUTPUT_ROOT` (default `.archex/m3-frontier`) are immutable, manifest-backed (`archex.benchmark.evidence`), and pinned to the exact source revision and task-manifest digest that produced them.
+
+## Results: self-repo scope demonstration (24 tasks, 2026-07-23)
+
+This run is **not** the full external quality frontier. It exercises every lane and every gate end to end against this repository's own 24 self-scoped tasks (no network access), as the delivery's functional proof. The full pinned-external (48 tasks) and sealed-holdout (2 tasks) runs require network clones of nine external repositories and take substantially longer; they are documented above as a separate local-operator activity, not executed as part of this PR to keep the delivery reviewable and reproducible without waiting on external-network variance.
+
+Command: `ARCHEX_M3_SELF_ONLY=1 bash scripts/m3_frontier_pipeline.sh`. Source revision `2692a0b`, task-manifest digest `c9b6eb5390…`.
+
+### Scorecard (single slice on this scope: language=python, size=large, intent=self, family=comprehension)
+
+| Lane | Recall | F1 | MRR | Zero-Recall | Dup. Rate | Tok. Eff. | Cold p50 (ms) | Downstream Success |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| default (`archex_query`) | 0.892 | 0.618 | 0.979 | 0 | 0.677 | 0.771 | 4282 | 0.625 |
+| fast (`archex_query_profile_fast`) | 0.892 | 0.618 | 0.979 | 0 | 0.677 | 0.771 | 4163 | 0.625 |
+| balanced (`archex_query_profile_balanced`) | 0.892 | 0.618 | 0.979 | 0 | 0.677 | 0.772 | 4186 | 0.625 |
+| cAST (`archex_query`, `--chunker cast`) | 0.823 | 0.574 | 0.979 | 0 | 0.635 | 0.729 | 5281 | 0.458 |
+
+Every retrieval-quality metric (recall/F1/MRR) is bit-identical between default and both profiles on this scope: `fast`/`balanced` only change vector/rerank/module-prefilter usage, and this repository's self-tasks never exercise those paths under the default configuration either, so the profiles produce the same BM25 ranking with a marginally lower cold p50 (safe to run, no measured downstream success or recall cost here). cAST recall/F1/downstream-success are all measurably lower on this scope, consistent with the source analysis's caveat that "a controlled 2026 study found function-only chunks off the cost-quality frontier" — a real, non-cherry-picked signal against promoting cAST as a default, at least at this scope.
+
+### Promotion gate: fast/balanced vs. default (same-run control)
+
+```
+uv run archex benchmark gate --input .archex/m3-frontier/frontier --tasks-dir benchmarks/tasks \
+  --promotion-strategy archex_query_profile_fast --control-strategy archex_query \
+  --min-token-efficiency-with-completion 0.08 --max-p95-warm-latency-ms 5000
+```
+
+**NO-GO** for both `fast` and `balanced` (27 violations each): 3 absolute-threshold misses shared by both profiles (`routing_pl_scoring` recall/F1, `routing_mixed_chunker` MRR — pre-existing on this scope, not introduced by the profile) plus 24 `warm_latency_unmeasured` violations. The warm-latency violation is a **methodology gap in this specific run**, not a quality finding: `--max-p95-warm-latency-ms` requires a `cache_state == "warm"` sample per task, which needs a `--warm-cache` pre-pass. In this environment, `--warm-cache` combined with the `balanced` profile's `module_prefilter` produced an incomplete per-task strategy set for one task on repeated attempts (see `scripts/m3_frontier_pipeline.sh`'s comment above the frontier-run command) — a pre-existing `archex benchmark run --warm-cache` interaction, not something this stack introduced, and out of scope to root-cause here. Until it is fixed, a genuine warm-latency-gated promotion attempt needs either a fixed `--warm-cache` pass or a relaxed `--max-p95-warm-latency-ms` invocation scoped to cold-only evidence.
+
+### cAST absolute-threshold gate
+
+```
+uv run archex benchmark gate --input .archex/m3-frontier/cast --tasks-dir benchmarks/tasks \
+  --min-recall 0.60 --min-f1 0.30 --min-mrr 0.55
+```
+
+**FAILED** (6 violations: `archex_graph_expansion`/`archex_pattern_detection`/`routing_pl_scoring`/`routing_mixed_chunker` recall/F1/MRR below floor). A true default-vs-cAST *regression* gate via `archex benchmark gate --baseline` is not currently reachable: `validate_baseline_coverage` requires the two evidence directories' `retrieval_options` to match exactly, and `chunker` is part of that object, so two directories that differ only by `--chunker` always fail baseline-coverage validation before the (already-implemented) `format_chunker_frontier_table` render is ever reached. This is a pre-existing `evidence.py`/`gate.py` constraint predating this stack; comparing the two scorecards above (or the `Scorecard: default` / `Scorecard: cast` markdown tables) is the reproducible substitute used here.
+
+## Verdict
+
+**NO-GO for automatic default promotion of any candidate**, on the evidence produced so far:
+
+- `fast`/`balanced`: no measured recall/F1/MRR/downstream-success regression, but no genuine warm-latency evidence exists yet (methodology gap above) and the M3 promotion rule requires staying inside profile p95 budgets with *evidence*, not by default.
+- cAST: measurable recall/F1/downstream-success regression on this scope; already excluded by the absolute-threshold gate.
+- symbolic-rerank: not run (only-if-defined; not exercised in this delivery).
+- Full pinned-external and sealed-holdout corpus scope: not yet executed (see reproduction commands above).
+
+This is consistent with the M3 constraints: no automatic product-default promotion, no cross-family winner claim, and no result cherry-picking — the retrieval harness's default (`archex_query`, default chunker) remains the shipped product default. The mechanism to reach a GO decision — lane matrix, scorecards, and the extended promotion gate — is complete, tested, and reproducible; reaching a promotion verdict on the full external/sealed corpus, and fixing the `--warm-cache`/`balanced`-profile interaction, are follow-on local-operator activities this stack unblocks but does not itself complete.

--- a/scripts/m3_frontier_pipeline.sh
+++ b/scripts/m3_frontier_pipeline.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# Local-operator M3 external quality frontier pipeline: runs the default,
+# fast, balanced, and (optionally) symbolic-rerank candidate lanes in one
+# "frontier" evidence run, the cAST lane in a second run (cAST needs its own
+# --chunker cast invocation of the archex_query strategy, which cannot share
+# a report with the default archex_query result -- see
+# src/archex/benchmark/external_frontier.py), then emits M3
+# scorecards, runs the multidimensional same-run promotion gate for the
+# fast/balanced/symbolic-rerank candidates against their archex_query
+# control, and runs an absolute-threshold gate on the cAST directory.
+#
+# This is local-operator only: it executes the full task corpus (network
+# clones for every pinned external task) and is never invoked from CI.
+set -Euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+
+resolve_repo_path() {
+    local path="$1"
+
+    case "$path" in
+        /*) printf '%s\n' "$path" ;;
+        *) printf '%s/%s\n' "$repo_root" "$path" ;;
+    esac
+}
+
+is_enabled() {
+    case "$1" in
+        1 | true | TRUE | yes | YES | on | ON) return 0 ;;
+        0 | false | FALSE | no | NO | off | OFF) return 1 ;;
+        *)
+            echo "Invalid boolean value: $1" >&2
+            exit 2
+            ;;
+    esac
+}
+
+append_option_if_set() {
+    local array_name="$1"
+    local option="$2"
+    local value="${3:-}"
+    local option_q value_q
+
+    if [[ -n "$value" ]]; then
+        printf -v option_q '%q' "$option"
+        printf -v value_q '%q' "$value"
+        eval "$array_name+=($option_q $value_q)"
+    fi
+}
+
+format_duration() {
+    local duration="$1"
+
+    printf '%02dh:%02dm:%02ds' \
+        "$((duration / 3600))" \
+        "$(((duration % 3600) / 60))" \
+        "$((duration % 60))"
+}
+
+run_step() {
+    local label="$1"
+    shift
+
+    local cmd="$*"
+    local start end duration status
+
+    echo
+    printf -- '=+%.0s' {1..25}
+    echo
+    echo "===== $(date '+%Y-%m-%d %H:%M:%S') : Starting \"$label\" ====="
+    echo "Command: $cmd"
+
+    start=$(date +%s)
+    if "$@"; then
+        status=0
+    else
+        status=$?
+    fi
+    end=$(date +%s)
+    duration=$((end - start))
+
+    if [[ "$status" -eq 0 ]]; then
+        echo "===== $(date '+%Y-%m-%d %H:%M:%S') : Completed \"$label\" ====="
+    else
+        echo "===== $(date '+%Y-%m-%d %H:%M:%S') : FAILED \"$label\" (exit $status) ====="
+    fi
+    echo "===== Time taken: $(format_duration "$duration") ====="
+    printf -- '=+%.0s' {1..25}
+    echo
+    echo
+    return "$status"
+}
+
+# Corpus and output settings. Point ARCHEX_M3_TASKS_DIR at
+# benchmarks/sealed_tasks plus ARCHEX_M3_ALLOW_SEALED_CORPUS=1 to run the
+# sealed holdout instead of the public bounded corpus.
+tasks_dir_rel="${ARCHEX_M3_TASKS_DIR:-benchmarks/tasks}"
+output_root_rel="${ARCHEX_M3_OUTPUT_ROOT:-.archex/m3-frontier}"
+allow_sealed_corpus="${ARCHEX_M3_ALLOW_SEALED_CORPUS:-0}"
+include_symbolic_rerank="${ARCHEX_M3_INCLUDE_SYMBOLIC_RERANK:-0}"
+self_only="${ARCHEX_M3_SELF_ONLY:-0}"
+
+# Promotion-gate thresholds for the same-run candidates (fast/balanced/
+# symbolic-rerank vs the archex_query control).
+min_token_efficiency_with_completion="${ARCHEX_M3_MIN_TOKEN_EFFICIENCY_WITH_COMPLETION:-0.08}"
+max_p95_warm_latency_ms="${ARCHEX_M3_MAX_P95_WARM_LATENCY_MS:-5000}"
+
+# Absolute-threshold gate for the cAST directory (see run_pipeline's
+# run_cast_gate note on why a --baseline regression gate isn't reachable
+# here today).
+cast_min_recall="${ARCHEX_M3_CAST_MIN_RECALL:-0.60}"
+cast_min_f1="${ARCHEX_M3_CAST_MIN_F1:-0.30}"
+cast_min_mrr="${ARCHEX_M3_CAST_MIN_MRR:-0.55}"
+
+log_file_rel="${ARCHEX_M3_LOG_FILE:-logs/m3_frontier_pipeline.log}"
+
+run_frontier="${ARCHEX_M3_RUN_FRONTIER:-1}"
+run_cast="${ARCHEX_M3_RUN_CAST:-1}"
+run_scorecards="${ARCHEX_M3_RUN_SCORECARDS:-1}"
+run_promotion_gates="${ARCHEX_M3_RUN_PROMOTION_GATES:-1}"
+run_cast_gate="${ARCHEX_M3_RUN_CAST_GATE:-1}"
+
+output_root="$(resolve_repo_path "$output_root_rel")"
+frontier_dir="$output_root/frontier"
+cast_dir="$output_root/cast"
+scorecards_dir="$output_root/scorecards"
+log_file="$(resolve_repo_path "$log_file_rel")"
+
+frontier_strategies=(archex_query archex_query_profile_fast archex_query_profile_balanced)
+if is_enabled "$include_symbolic_rerank"; then
+    frontier_strategies+=(archex_query_symbolic_rerank)
+fi
+
+prepare_run_artifacts() {
+    mkdir -p "$(dirname -- "$log_file")"
+    rm -f "$log_file"
+    if is_enabled "$run_frontier"; then
+        rm -rf "$frontier_dir"
+    fi
+    if is_enabled "$run_cast"; then
+        rm -rf "$cast_dir"
+    fi
+    if is_enabled "$run_scorecards"; then
+        rm -rf "$scorecards_dir"
+        mkdir -p "$scorecards_dir"
+    fi
+}
+
+run_scorecard() {
+    local input_dir="$1"
+    local strategy="$2"
+    local label="$3"
+    local -a cmd=(
+        uv run archex benchmark scorecard
+        --input "$input_dir"
+        --tasks-dir "$tasks_dir_rel"
+        --strategy "$strategy"
+        --format markdown
+        --output "$scorecards_dir/scorecard-$label.json"
+    )
+    if is_enabled "$allow_sealed_corpus"; then
+        cmd+=(--allow-sealed-corpus)
+    fi
+    run_step "Scorecard: $label" "${cmd[@]}"
+}
+
+run_promotion_gate() {
+    local candidate="$1"
+    local -a cmd=(
+        uv run archex benchmark gate
+        --input "$frontier_dir"
+        --tasks-dir "$tasks_dir_rel"
+        --promotion-strategy "$candidate"
+        --control-strategy archex_query
+        --min-token-efficiency-with-completion "$min_token_efficiency_with_completion"
+        --max-p95-warm-latency-ms "$max_p95_warm_latency_ms"
+    )
+    run_step "Promotion Gate: $candidate vs archex_query" "${cmd[@]}"
+}
+
+run_pipeline() {
+    local status=0
+    local -a frontier_run_cmd cast_run_cmd cast_gate_cmd
+    local -a run_flags=()
+    local symbolic_label=""
+
+    run_flags+=(--tasks-dir "$tasks_dir_rel")
+    if is_enabled "$self_only"; then
+        run_flags+=(--self-only)
+    fi
+    if is_enabled "$allow_sealed_corpus"; then
+        run_flags+=(--allow-sealed-corpus)
+    fi
+    if is_enabled "$include_symbolic_rerank"; then
+        symbolic_label=", symbolic-rerank"
+    fi
+
+    if is_enabled "$run_frontier"; then
+        frontier_run_cmd=(
+            uv run archex benchmark run "${run_flags[@]}"
+            --output "$frontier_dir" --chunker default --no-progress
+            # NOTE: --warm-cache was tried here to satisfy
+            # --max-p95-warm-latency-ms's cache_state=="warm" requirement,
+            # but it produced an incomplete per-task strategy set for the
+            # balanced (module_prefilter) profile on at least one task in
+            # this corpus/environment (a pre-existing runner interaction,
+            # not introduced by M3). Until that is root-caused, expect
+            # promotion-gate warm_latency_unmeasured violations here; treat
+            # them as a real, documented NO-GO reason rather than suppress
+            # them by re-adding --warm-cache blindly.
+        )
+        for strategy in "${frontier_strategies[@]}"; do
+            frontier_run_cmd+=(--strategy "$strategy")
+        done
+        run_step "Frontier Run (default, fast, balanced${symbolic_label})" \
+            "${frontier_run_cmd[@]}" || status=$?
+    fi
+
+    if is_enabled "$run_cast"; then
+        cast_run_cmd=(
+            uv run archex benchmark run "${run_flags[@]}"
+            --output "$cast_dir" --chunker cast --strategy archex_query --no-progress
+        )
+        run_step "cAST Run" "${cast_run_cmd[@]}" || status=$?
+    fi
+
+    if is_enabled "$run_scorecards"; then
+        run_scorecard "$frontier_dir" archex_query default || status=$?
+        run_scorecard "$frontier_dir" archex_query_profile_fast fast || status=$?
+        run_scorecard "$frontier_dir" archex_query_profile_balanced balanced || status=$?
+        if is_enabled "$include_symbolic_rerank"; then
+            run_scorecard "$frontier_dir" archex_query_symbolic_rerank symbolic-rerank || status=$?
+        fi
+        run_scorecard "$cast_dir" archex_query cast || status=$?
+    fi
+
+    if is_enabled "$run_promotion_gates"; then
+        run_promotion_gate archex_query_profile_fast || status=$?
+        run_promotion_gate archex_query_profile_balanced || status=$?
+        if is_enabled "$include_symbolic_rerank"; then
+            run_promotion_gate archex_query_symbolic_rerank || status=$?
+        fi
+    fi
+
+    if is_enabled "$run_cast_gate"; then
+        # `archex benchmark gate --baseline` requires the two evidence
+        # directories' retrieval_options to match exactly
+        # (validate_baseline_coverage), and `chunker` is part of that
+        # options object -- so a true default-vs-cast regression gate via
+        # --baseline is not currently reachable for two different-chunker
+        # directories (a pre-existing evidence.py constraint, not
+        # introduced by M3). This runs the absolute-threshold gate on the
+        # cAST directory instead: it proves cAST clears the same floors
+        # independently. Compare scorecards/scorecard-default.json against
+        # scorecards/scorecard-cast.json for the actual recall/F1/MRR delta
+        # -- both already carry per-task_id, per-strategy aggregates.
+        cast_gate_cmd=(
+            uv run archex benchmark gate
+            --input "$cast_dir" --tasks-dir "$tasks_dir_rel"
+            --min-recall "$cast_min_recall" --min-f1 "$cast_min_f1" --min-mrr "$cast_min_mrr"
+        )
+        run_step "cAST Absolute-Threshold Gate" "${cast_gate_cmd[@]}" || status=$?
+    fi
+
+    return "$status"
+}
+
+run_foreground() {
+    prepare_run_artifacts
+    cd "$repo_root"
+
+    (
+        local pipeline_start pipeline_end pipeline_status total_duration
+
+        pipeline_start=$(date +%s)
+        pipeline_status=0
+
+        echo "=================================================="
+        echo "M3 frontier pipeline started at $(date '+%Y-%m-%d %H:%M:%S')"
+        echo "Repository root: $repo_root"
+        echo "Tasks directory: $tasks_dir_rel"
+        echo "Output root: $output_root_rel"
+        echo "Symbolic-rerank lane included: $include_symbolic_rerank"
+        echo "Log file: $log_file_rel"
+        echo "=================================================="
+
+        run_pipeline || pipeline_status=$?
+
+        pipeline_end=$(date +%s)
+        total_duration=$((pipeline_end - pipeline_start))
+
+        echo
+        echo "=================================================="
+        echo "M3 frontier pipeline completed at $(date '+%Y-%m-%d %H:%M:%S')"
+        echo "Total time taken: $(format_duration "$total_duration")"
+        echo "Pipeline exit status: $pipeline_status"
+        echo "=================================================="
+        exit "$pipeline_status"
+    ) 2>&1 | tee "$log_file"
+}
+
+main() {
+    if (($# > 0)); then
+        echo "m3_frontier_pipeline.sh does not accept arguments; configure it via ARCHEX_M3_* environment variables (see the script header)." >&2
+        return 2
+    fi
+
+    run_foreground
+}
+
+main "$@"

--- a/src/archex/benchmark/gate.py
+++ b/src/archex/benchmark/gate.py
@@ -12,8 +12,11 @@ from archex.benchmark.baseline import (
 )
 from archex.benchmark.models import (  # noqa: TCH001 — Pydantic needs at runtime
     BenchmarkReport,
+    BenchmarkResult,
+    BenchmarkTask,
     DeltaBenchmarkResult,
     Strategy,
+    TaskCompletionResult,
 )
 
 # Tier 2.5 product-default `archex_query` minimum higher-is-better token
@@ -333,6 +336,144 @@ def check_strategy_non_regressions(
                         actual=actual,
                     )
                 )
+    return violations
+
+
+def check_zero_recall_non_regression(
+    reports: list[BenchmarkReport],
+    *,
+    candidate_strategy: Strategy,
+    control_strategy: Strategy,
+) -> list[BaselineGateViolation]:
+    """Flag any task where the candidate goes zero-recall but the control did not.
+
+    An absolute-threshold check already fails a zero-recall task outright
+    once its recall drops below ``min_recall``, but that says nothing about
+    whether the candidate *introduced* a zero-recall failure the control
+    did not have. This is the comparative half of the M3 promotion rule
+    "must not increase zero-recall tasks."
+    """
+    violations: list[BaselineGateViolation] = []
+    for report in reports:
+        results_by_strategy = {result.strategy: result for result in report.results}
+        control = results_by_strategy.get(control_strategy)
+        candidate = results_by_strategy.get(candidate_strategy)
+        if control is None or candidate is None:
+            continue  # already reported by check_strategy_non_regressions
+        if control.recall > 0.0 and candidate.recall <= 0.0:
+            violations.append(
+                BaselineGateViolation(
+                    task_id=report.task_id,
+                    strategy=candidate_strategy.value,
+                    metric="zero_recall_regression",
+                    baseline=control.recall,
+                    actual=candidate.recall,
+                )
+            )
+    return violations
+
+
+def check_language_family_non_regression(
+    reports: list[BenchmarkReport],
+    tasks_by_id: dict[str, BenchmarkTask],
+    *,
+    candidate_strategy: Strategy,
+    control_strategy: Strategy,
+    tolerance: float = 0.0,
+) -> list[BaselineGateViolation]:
+    """Flag any language whose candidate mean recall regresses behind its control mean.
+
+    One cross-family recall mean can hide a regression in a single language
+    behind gains in the others. Groups by ``BenchmarkTask.languages`` (a
+    multi-language task counts toward every language it declares) and
+    compares per-language means, so an improved aggregate can never mask a
+    hidden per-language loss -- the M3 "no hidden language-family
+    regression" promotion rule.
+    """
+    control_by_language: dict[str, list[float]] = {}
+    candidate_by_language: dict[str, list[float]] = {}
+    for report in reports:
+        task = tasks_by_id.get(report.task_id)
+        if task is None or not task.languages:
+            continue
+        results_by_strategy = {result.strategy: result for result in report.results}
+        control = results_by_strategy.get(control_strategy)
+        candidate = results_by_strategy.get(candidate_strategy)
+        if control is None or candidate is None:
+            continue
+        for language in task.languages:
+            control_by_language.setdefault(language, []).append(control.recall)
+            candidate_by_language.setdefault(language, []).append(candidate.recall)
+
+    violations: list[BaselineGateViolation] = []
+    for language in sorted(control_by_language):
+        control_values = control_by_language[language]
+        control_mean = sum(control_values) / len(control_values)
+        candidate_values = candidate_by_language.get(language, [])
+        candidate_mean = sum(candidate_values) / len(candidate_values) if candidate_values else 0.0
+        if candidate_mean < control_mean - tolerance:
+            violations.append(
+                BaselineGateViolation(
+                    task_id=f"language:{language}",
+                    strategy=candidate_strategy.value,
+                    metric="language_family_recall",
+                    baseline=control_mean,
+                    actual=candidate_mean,
+                )
+            )
+    return violations
+
+
+def _completion_outcome_score(result: BenchmarkResult) -> float | None:
+    outcome = (
+        result.bundle_only_success
+        if result.bundle_only_success is not None
+        else result.task_completion_result
+    )
+    if outcome is TaskCompletionResult.PASS:
+        return 1.0
+    if outcome is TaskCompletionResult.FAIL:
+        return 0.0
+    return None
+
+
+def check_fixed_agent_non_regression(
+    reports: list[BenchmarkReport],
+    *,
+    candidate_strategy: Strategy,
+    control_strategy: Strategy,
+) -> list[BaselineGateViolation]:
+    """Flag any task where the fixed-agent downstream outcome regresses.
+
+    Compares each task's completion outcome (``bundle_only_success``, or
+    ``task_completion_result`` when no external evaluator ran) between
+    candidate and control. A control PASS that becomes a candidate FAIL is a
+    fixed-agent success regression: the retrieval change broke a previously
+    solvable downstream task even if upstream recall/F1 look unchanged.
+    Tasks where either side's outcome is UNKNOWN are skipped -- there is no
+    outcome to regress from or to.
+    """
+    violations: list[BaselineGateViolation] = []
+    for report in reports:
+        results_by_strategy = {result.strategy: result for result in report.results}
+        control = results_by_strategy.get(control_strategy)
+        candidate = results_by_strategy.get(candidate_strategy)
+        if control is None or candidate is None:
+            continue
+        control_score = _completion_outcome_score(control)
+        candidate_score = _completion_outcome_score(candidate)
+        if control_score is None or candidate_score is None:
+            continue
+        if candidate_score < control_score:
+            violations.append(
+                BaselineGateViolation(
+                    task_id=report.task_id,
+                    strategy=candidate_strategy.value,
+                    metric="fixed_agent_success_regression",
+                    baseline=control_score,
+                    actual=candidate_score,
+                )
+            )
     return violations
 
 

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -45,12 +45,15 @@ from archex.benchmark.gate import (
     LatencyWarning,
     QualityThresholds,
     check_delta_gate,
+    check_fixed_agent_non_regression,
     check_gate,
+    check_language_family_non_regression,
     check_latency_violations,
     check_latency_warnings,
     check_recall_regressions,
     check_strategy_non_regressions,
     check_warm_p95_latency,
+    check_zero_recall_non_regression,
     non_token_quality_warnings,
     token_efficiency_violations,
 )
@@ -1143,6 +1146,28 @@ def gate_cmd(
             candidate_strategy=promotion,
             control_strategy=control,
         )
+        zero_recall_regressions = check_zero_recall_non_regression(
+            reports,
+            candidate_strategy=promotion,
+            control_strategy=control,
+        )
+        language_family_regressions = check_language_family_non_regression(
+            reports,
+            load_benchmark_tasks(Path(tasks_dir)),
+            candidate_strategy=promotion,
+            control_strategy=control,
+        )
+        fixed_agent_regressions = check_fixed_agent_non_regression(
+            reports,
+            candidate_strategy=promotion,
+            control_strategy=control,
+        )
+        protected_evidence_regressions = [
+            *protected_evidence_regressions,
+            *zero_recall_regressions,
+            *language_family_regressions,
+            *fixed_agent_regressions,
+        ]
         violations = [*absolute_violations, *warm_latency_violations]
         if violations or protected_evidence_regressions:
             click.echo(

--- a/tests/benchmark/test_cli.py
+++ b/tests/benchmark/test_cli.py
@@ -18,6 +18,7 @@ from archex.benchmark.models import (
     BenchmarkTask,
     BundleOnlyEvaluatorCommand,
     Strategy,
+    TaskCompletionResult,
 )
 from archex.cli.benchmark_cmd import benchmark_cmd
 
@@ -613,6 +614,201 @@ class TestGateCommand:
 
         assert result.exit_code != 0
         assert "region_recall" in result.output
+
+    def test_promotion_gate_fails_zero_recall_regression(
+        self,
+        runner: CliRunner,
+        results_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        control = BenchmarkResult(
+            task_id="test",
+            strategy=Strategy.ARCHEX_QUERY,
+            tokens_total=1000,
+            tool_calls=1,
+            files_accessed=1,
+            recall=1.0,
+            precision=1.0,
+            f1_score=1.0,
+            mrr=1.0,
+            savings_vs_raw=0.0,
+            token_efficiency=0.5,
+            token_efficiency_with_completion=0.5,
+            required_file_recall=1.0,
+            wall_time_ms=100.0,
+            cached=True,
+            cache_state="warm",
+            timestamp="2025-01-01T00:00:00Z",
+        )
+        candidate = control.model_copy(
+            update={
+                "strategy": Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+                "recall": 0.0,
+                "required_file_recall": 0.0,
+                "warm_latency_ms": 100.0,
+            }
+        )
+        report = BenchmarkReport(
+            task_id="test",
+            repo="owner/repo",
+            question="How?",
+            results=[control, candidate],
+            baseline_tokens=1000,
+        )
+        _patch_gate_evidence(monkeypatch, [report])
+
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "gate",
+                "--input",
+                str(results_dir),
+                "--promotion-strategy",
+                Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE.value,
+                "--control-strategy",
+                Strategy.ARCHEX_QUERY.value,
+                "--min-token-efficiency-with-completion",
+                "0.08",
+                "--max-p95-warm-latency-ms",
+                "3000",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "zero_recall_regression" in result.output
+
+    def test_promotion_gate_fails_fixed_agent_success_regression(
+        self,
+        runner: CliRunner,
+        results_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        control = BenchmarkResult(
+            task_id="test",
+            strategy=Strategy.ARCHEX_QUERY,
+            tokens_total=1000,
+            tool_calls=1,
+            files_accessed=1,
+            recall=1.0,
+            precision=1.0,
+            f1_score=1.0,
+            mrr=1.0,
+            savings_vs_raw=0.0,
+            token_efficiency=0.5,
+            token_efficiency_with_completion=0.5,
+            required_file_recall=1.0,
+            task_completion_result=TaskCompletionResult.PASS,
+            wall_time_ms=100.0,
+            cached=True,
+            cache_state="warm",
+            timestamp="2025-01-01T00:00:00Z",
+        )
+        candidate = control.model_copy(
+            update={
+                "strategy": Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+                "task_completion_result": TaskCompletionResult.FAIL,
+                "warm_latency_ms": 100.0,
+            }
+        )
+        report = BenchmarkReport(
+            task_id="test",
+            repo="owner/repo",
+            question="How?",
+            results=[control, candidate],
+            baseline_tokens=1000,
+        )
+        _patch_gate_evidence(monkeypatch, [report])
+
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "gate",
+                "--input",
+                str(results_dir),
+                "--promotion-strategy",
+                Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE.value,
+                "--control-strategy",
+                Strategy.ARCHEX_QUERY.value,
+                "--min-token-efficiency-with-completion",
+                "0.08",
+                "--max-p95-warm-latency-ms",
+                "3000",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "fixed_agent_success_regression" in result.output
+
+    def test_promotion_gate_fails_language_family_regression(
+        self,
+        runner: CliRunner,
+        results_dir: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        (tasks_dir / "test.yaml").write_text(
+            "task_id: test\nrepo: owner/repo\ncommit: v1.0.0\nquestion: How?\n"
+            "expected_files: [a.py]\nlanguages: [python]\n"
+        )
+        control = BenchmarkResult(
+            task_id="test",
+            strategy=Strategy.ARCHEX_QUERY,
+            tokens_total=1000,
+            tool_calls=1,
+            files_accessed=1,
+            recall=0.9,
+            precision=1.0,
+            f1_score=1.0,
+            mrr=1.0,
+            savings_vs_raw=0.0,
+            token_efficiency=0.5,
+            token_efficiency_with_completion=0.5,
+            required_file_recall=1.0,
+            wall_time_ms=100.0,
+            cached=True,
+            cache_state="warm",
+            timestamp="2025-01-01T00:00:00Z",
+        )
+        candidate = control.model_copy(
+            update={
+                "strategy": Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE,
+                "recall": 0.4,
+                "warm_latency_ms": 100.0,
+            }
+        )
+        report = BenchmarkReport(
+            task_id="test",
+            repo="owner/repo",
+            question="How?",
+            results=[control, candidate],
+            baseline_tokens=1000,
+        )
+        _patch_gate_evidence(monkeypatch, [report])
+
+        result = runner.invoke(
+            benchmark_cmd,
+            [
+                "gate",
+                "--input",
+                str(results_dir),
+                "--tasks-dir",
+                str(tasks_dir),
+                "--promotion-strategy",
+                Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE.value,
+                "--control-strategy",
+                Strategy.ARCHEX_QUERY.value,
+                "--min-token-efficiency-with-completion",
+                "0.08",
+                "--max-p95-warm-latency-ms",
+                "3000",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "language_family_recall" in result.output
+        assert "language:python" in result.output
 
     def test_promotion_gate_rejects_gate_exempt_candidate(
         self,

--- a/tests/benchmark/test_gate_m3_promotion.py
+++ b/tests/benchmark/test_gate_m3_promotion.py
@@ -1,0 +1,213 @@
+"""Tests for the M3 promotion-gate dimensions: zero-recall, language-family, fixed-agent."""
+
+from __future__ import annotations
+
+from archex.benchmark.gate import (
+    check_fixed_agent_non_regression,
+    check_language_family_non_regression,
+    check_zero_recall_non_regression,
+)
+from archex.benchmark.models import (
+    BenchmarkReport,
+    BenchmarkResult,
+    BenchmarkTask,
+    Strategy,
+    TaskCompletionResult,
+)
+
+_CANDIDATE = Strategy.ARCHEX_QUERY_CONTEXT_CANDIDATE
+_CONTROL = Strategy.ARCHEX_QUERY
+
+
+def _base_result(**overrides: object) -> BenchmarkResult:
+    defaults: dict[str, object] = {
+        "task_id": "t",
+        "strategy": _CONTROL,
+        "tokens_total": 1000,
+        "tool_calls": 1,
+        "files_accessed": 3,
+        "recall": 0.8,
+        "precision": 0.5,
+        "savings_vs_raw": 50.0,
+        "timestamp": "2026-01-01T00:00:00Z",
+    }
+    defaults.update(overrides)
+    return BenchmarkResult.model_validate(defaults)
+
+
+def _paired_report(
+    task_id: str,
+    control_overrides: dict[str, object],
+    candidate_overrides: dict[str, object],
+) -> BenchmarkReport:
+    control = _base_result(task_id=task_id, strategy=_CONTROL, **control_overrides)
+    candidate = _base_result(task_id=task_id, strategy=_CANDIDATE, **candidate_overrides)
+    return BenchmarkReport(
+        task_id=task_id,
+        repo="test/repo",
+        question="q",
+        results=[control, candidate],
+        baseline_tokens=2000,
+    )
+
+
+class TestCheckZeroRecallNonRegression:
+    def test_flags_candidate_going_zero_when_control_was_not(self) -> None:
+        report = _paired_report("t1", {"recall": 0.8}, {"recall": 0.0})
+        violations = check_zero_recall_non_regression(
+            [report], candidate_strategy=_CANDIDATE, control_strategy=_CONTROL
+        )
+        assert [(v.task_id, v.metric) for v in violations] == [("t1", "zero_recall_regression")]
+
+    def test_allows_both_zero_recall(self) -> None:
+        report = _paired_report("t1", {"recall": 0.0}, {"recall": 0.0})
+        violations = check_zero_recall_non_regression(
+            [report], candidate_strategy=_CANDIDATE, control_strategy=_CONTROL
+        )
+        assert violations == []
+
+    def test_allows_candidate_recovering_from_control_zero_recall(self) -> None:
+        report = _paired_report("t1", {"recall": 0.0}, {"recall": 0.6})
+        violations = check_zero_recall_non_regression(
+            [report], candidate_strategy=_CANDIDATE, control_strategy=_CONTROL
+        )
+        assert violations == []
+
+    def test_ignores_reports_missing_either_strategy(self) -> None:
+        result = _base_result(task_id="t1", strategy=_CONTROL, recall=0.8)
+        report = BenchmarkReport(
+            task_id="t1", repo="test/repo", question="q", results=[result], baseline_tokens=2000
+        )
+        violations = check_zero_recall_non_regression(
+            [report], candidate_strategy=_CANDIDATE, control_strategy=_CONTROL
+        )
+        assert violations == []
+
+
+def _task(task_id: str, languages: list[str] | None) -> BenchmarkTask:
+    return BenchmarkTask.model_validate(
+        {
+            "task_id": task_id,
+            "repo": "owner/repo",
+            "commit": "v1.0.0",
+            "question": "q",
+            "expected_files": ["a.py"],
+            "languages": languages,
+        }
+    )
+
+
+class TestCheckLanguageFamilyNonRegression:
+    def test_flags_a_single_regressed_language_behind_a_flat_aggregate(self) -> None:
+        # python regresses (0.9 -> 0.4) while go improves (0.5 -> 1.0), so the
+        # cross-family mean stays flat at 0.7 -- a naive aggregate check
+        # would see no regression, but the python-only loss must still fire.
+        tasks_by_id = {
+            "py_task": _task("py_task", ["python"]),
+            "go_task": _task("go_task", ["go"]),
+        }
+        reports = [
+            _paired_report("py_task", {"recall": 0.9}, {"recall": 0.4}),
+            _paired_report("go_task", {"recall": 0.5}, {"recall": 1.0}),
+        ]
+        violations = check_language_family_non_regression(
+            reports, tasks_by_id, candidate_strategy=_CANDIDATE, control_strategy=_CONTROL
+        )
+        assert [(v.task_id, v.metric) for v in violations] == [
+            ("language:python", "language_family_recall")
+        ]
+
+    def test_no_violation_when_every_language_holds_or_improves(self) -> None:
+        tasks_by_id = {
+            "py_task": _task("py_task", ["python"]),
+            "go_task": _task("go_task", ["go"]),
+        }
+        reports = [
+            _paired_report("py_task", {"recall": 0.5}, {"recall": 0.6}),
+            _paired_report("go_task", {"recall": 0.5}, {"recall": 1.0}),
+        ]
+        violations = check_language_family_non_regression(
+            reports, tasks_by_id, candidate_strategy=_CANDIDATE, control_strategy=_CONTROL
+        )
+        assert violations == []
+
+    def test_multi_language_task_contributes_to_every_language(self) -> None:
+        tasks_by_id = {"t1": _task("t1", ["python", "go"])}
+        reports = [_paired_report("t1", {"recall": 0.8}, {"recall": 0.2})]
+        violations = check_language_family_non_regression(
+            reports, tasks_by_id, candidate_strategy=_CANDIDATE, control_strategy=_CONTROL
+        )
+        assert {v.task_id for v in violations} == {"language:python", "language:go"}
+
+    def test_tasks_without_languages_are_excluded(self) -> None:
+        tasks_by_id = {"t1": _task("t1", None)}
+        reports = [_paired_report("t1", {"recall": 0.8}, {"recall": 0.0})]
+        violations = check_language_family_non_regression(
+            reports, tasks_by_id, candidate_strategy=_CANDIDATE, control_strategy=_CONTROL
+        )
+        assert violations == []
+
+    def test_tolerance_permits_small_regressions(self) -> None:
+        tasks_by_id = {"t1": _task("t1", ["python"])}
+        reports = [_paired_report("t1", {"recall": 0.80}, {"recall": 0.78})]
+        violations = check_language_family_non_regression(
+            reports,
+            tasks_by_id,
+            candidate_strategy=_CANDIDATE,
+            control_strategy=_CONTROL,
+            tolerance=0.05,
+        )
+        assert violations == []
+
+
+class TestCheckFixedAgentNonRegression:
+    def test_flags_control_pass_becoming_candidate_fail(self) -> None:
+        report = _paired_report(
+            "t1",
+            {"task_completion_result": TaskCompletionResult.PASS},
+            {"task_completion_result": TaskCompletionResult.FAIL},
+        )
+        violations = check_fixed_agent_non_regression(
+            [report], candidate_strategy=_CANDIDATE, control_strategy=_CONTROL
+        )
+        assert [(v.task_id, v.metric) for v in violations] == [
+            ("t1", "fixed_agent_success_regression")
+        ]
+
+    def test_allows_candidate_improving_on_control_fail(self) -> None:
+        report = _paired_report(
+            "t1",
+            {"task_completion_result": TaskCompletionResult.FAIL},
+            {"task_completion_result": TaskCompletionResult.PASS},
+        )
+        violations = check_fixed_agent_non_regression(
+            [report], candidate_strategy=_CANDIDATE, control_strategy=_CONTROL
+        )
+        assert violations == []
+
+    def test_prefers_bundle_only_success_over_task_completion_result(self) -> None:
+        report = _paired_report(
+            "t1",
+            {"task_completion_result": TaskCompletionResult.PASS},
+            {
+                "task_completion_result": TaskCompletionResult.PASS,
+                "bundle_only_success": TaskCompletionResult.FAIL,
+            },
+        )
+        violations = check_fixed_agent_non_regression(
+            [report], candidate_strategy=_CANDIDATE, control_strategy=_CONTROL
+        )
+        assert [(v.task_id, v.metric) for v in violations] == [
+            ("t1", "fixed_agent_success_regression")
+        ]
+
+    def test_skips_tasks_with_unknown_outcome(self) -> None:
+        report = _paired_report(
+            "t1",
+            {"task_completion_result": TaskCompletionResult.UNKNOWN},
+            {"task_completion_result": TaskCompletionResult.FAIL},
+        )
+        violations = check_fixed_agent_non_regression(
+            [report], candidate_strategy=_CANDIDATE, control_strategy=_CONTROL
+        )
+        assert violations == []


### PR DESCRIPTION
## Stack

Stack-Id: `m3-external-quality-frontier`
Base: `m3-3-candidate-fixed-agent-lanes`
Position: 4/4 (leaf)

1. `m3-1-corpus-boundary` -> #533
2. `m3-2-scorecard-artifacts` -> #534
3. `m3-3-candidate-fixed-agent-lanes` -> #535
4. `m3-4-promotion-gate-publication` -> this PR

Depends on: #535

## Summary

Part 4/4 (leaf) of M3. Closes the multidimensional promotion gate and publishes a reproducible external comparison.

**Promotion gate** (`src/archex/benchmark/gate.py`, `benchmark_cmd.py`):
- `check_zero_recall_non_regression`: flags a task where the candidate drops to zero recall but the control did not (the comparative half of "must not increase zero-recall tasks" -- an absolute floor alone only catches the candidate's own zero-recall tasks, not newly introduced ones).
- `check_language_family_non_regression`: groups by `BenchmarkTask.languages` and compares per-language mean recall, so an improved cross-family aggregate can never mask a hidden single-language regression.
- `check_fixed_agent_non_regression`: compares each task's completion outcome (`bundle_only_success`, or `task_completion_result`) between candidate and control; a control PASS becoming a candidate FAIL is a fixed-agent regression even when upstream recall/F1 look unchanged.
- All three fold into the same `PROMOTION GATE FAILED` output as the existing required-file/region/line checks: one verdict, every mandatory M3 dimension.

**Publication** (`scripts/m3_frontier_pipeline.sh`, `docs/m3-external-quality-frontier.md`, `docs/RETRIEVAL_DEFAULT_DECISIONS.md`):
- `scripts/m3_frontier_pipeline.sh`: local-operator orchestration running the candidate lane matrix (default/fast/balanced/[symbolic-rerank] in one "frontier" evidence run sharing a same-run control; cAST in a second run, since it shares the `archex_query` strategy value with default and cannot share a report) plus every scorecard and gate in one invocation.
- A **real, executed** self-repo-scope (24 tasks) demonstration run is published with its exact commands, thresholds, and full gate output -- not fabricated numbers. Two genuine mechanism gaps surfaced while producing this evidence are documented rather than papered over: (1) `--warm-cache` combined with the `balanced` profile's `module_prefilter` produced an incomplete per-task strategy set in this environment (a pre-existing runner interaction, out of scope to root-cause here); (2) `archex benchmark gate --baseline` cannot compare two different-chunker evidence directories because `validate_baseline_coverage` requires exact `retrieval_options` equality, which includes `chunker` -- so the cAST absolute-threshold gate plus scorecard comparison is used instead of a `--baseline` regression gate.
- **Verdict: NO-GO for automatic default promotion of any candidate.** `fast`/`balanced` matched `archex_query` bit-for-bit on recall/F1/MRR/downstream-success but the promotion gate could not clear (unmeasured warm latency, see above). cAST measurably regressed recall/F1/downstream-success and failed its absolute-threshold gate outright. `archex_query` (default chunker) remains the product default. The full pinned-external (48 tasks) and sealed-holdout (2 tasks) corpus runs are documented, reproducible follow-on local-operator work, not executed in this PR to keep the delivery's own verification bounded.

## Verification

- `uv run ruff check .` / `uv run ruff format --check .` -- pass
- `uv run pyright .` -- 0 errors
- `uv run pytest tests/benchmark -q --no-cov` -- 914 passed, 5 deselected
- New tests: `tests/benchmark/test_gate_m3_promotion.py` (13), plus 3 new CLI-level promotion tests in `tests/benchmark/test_cli.py` covering zero-recall, fixed-agent, and language-family CLI wiring
- `bash -n scripts/m3_frontier_pipeline.sh` -- syntax OK
- **Real end-to-end execution**: `ARCHEX_M3_SELF_ONLY=1 bash scripts/m3_frontier_pipeline.sh` run to completion four times while developing the script (fixing two real bugs it surfaced along the way: scorecard artifacts polluting the evidence directory's exact-file-set contract, and the cross-chunker baseline-gate limitation above); the final run's real output is what's published in `docs/m3-external-quality-frontier.md`
