### PR TITLE
feat(context): define primary context facade

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -56,6 +56,12 @@ from archex.analyze.modules import detect_modules
 from archex.analyze.patterns import detect_patterns
 from archex.cache import CacheManager
 from archex.config import load_config, load_index_config
+from archex.context_facade import (
+    ContextRequest,
+    ContextResult,
+    apply_context_filters,
+    resolve_context_route,
+)
 from archex.exceptions import ArchexIndexError, DeltaIndexError
 from archex.index.bm25 import BM25Index
 from archex.index.graph import DependencyGraph
@@ -2519,6 +2525,52 @@ def query(
         )
     finally:
         cleanup()
+
+
+def context(
+    source: RepoSource,
+    request: ContextRequest,
+    *,
+    config: Config | None = None,
+    index_config: IndexConfig | None = None,
+    timing: PipelineTiming | None = None,
+    trace: PipelineTrace | None = None,
+    refresh: bool = True,
+    runtime: QueryRuntime | None = None,
+) -> ContextResult:
+    """Retrieve the primary agent-facing context result for `request`.
+
+    Thin wrapper over `query()`: resolves `request.intent`/`request.profile`/
+    `request.budgets`/`request.handles` into `query()` call parameters via
+    `archex.context_facade.resolve_context_route`, runs the canonical
+    retrieval pipeline unchanged, then applies `request.filters` as a
+    deterministic post-retrieval exclusion. The returned `ContextResult`
+    exposes a compact candidate map, exact fetch handles, selected code,
+    relation paths, the route decision, the single `ContextBundle` receipt,
+    and a recommended next action — every field either newly resolved
+    routing metadata or a read-only view over the one `ContextBundle`
+    `query()` produced. Existing specialized entry points (`query`, `scout`,
+    `get_symbol`, ...) are unaffected and remain fully supported.
+    """
+    resolution = resolve_context_route(request)
+    bundle = query(
+        source,
+        request.query,
+        token_budget=resolution.token_budget,
+        config=config,
+        index_config=index_config,
+        scoring_weights=resolution.scoring_weights,
+        timing=timing,
+        trace=trace,
+        explicit_token_budget=resolution.explicit_token_budget,
+        refresh=refresh,
+        handles=request.handles or None,
+        runtime=runtime,
+        profile=request.profile,
+    )
+    if not request.filters.is_empty():
+        bundle = apply_context_filters(bundle, request.filters)
+    return ContextResult(bundle=bundle, route=resolution.route)
 
 
 _RERANK_MAX_CANDIDATES = 50

--- a/src/archex/context_facade.py
+++ b/src/archex/context_facade.py
@@ -1,0 +1,424 @@
+"""Primary agent-facing context facade: `query, intent, profile, filters, budgets, handles`.
+
+`archex.api.context()` is the single documented primary path for an agent to
+retrieve code context. It is a thin wrapper over the canonical `query()`
+retrieval pipeline (`archex.api.query`) — it never reranks, never talks to a
+provider, and never invents a second receipt or handle authority. Every
+field it adds is either:
+
+- a **route decision** (`ContextRouteDecision`): how this module interpreted
+  `intent`/`profile`/`budgets`/`handles` before calling `query()`, built once
+  from the same canonical classifiers `query()` and `scout()` already use
+  (`archex.serve.intent.classify_intent`, `archex.serve.modality`), or
+- a **read-only view** onto the `ContextBundle` `query()` already produced
+  (`ContextResult`'s `candidate_map`, `fetch_handles`, `selected_code`,
+  `relation_paths`, `receipt`, `next_action` are all computed properties over
+  `ContextResult.bundle`, never a second copy of that data).
+
+The only genuinely new behavior this module performs is `ContextFilters`: a
+deterministic, post-retrieval include/exclude/language predicate over the
+chunks `query()` already ranked. It never adds candidates, never reorders
+survivors, and moves every excluded chunk into the existing
+`ContextReceipt.skipped_candidates` ledger with reason
+`ContextSkippedReason.FILTER_EXCLUDED` so the receipt still accounts for
+every candidate `query()` considered.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+from typing import Literal
+
+from pydantic import BaseModel, computed_field, model_validator
+
+from archex.models import (
+    CodeChunk,
+    ContextBundle,
+    ContextReceipt,
+    ContextReceiptItem,
+    ContextRecommendedAction,
+    ContextSkippedCandidate,
+    ContextSkippedReason,
+    RankedChunk,
+    RetrievalProfile,
+    ScoringWeights,
+    StructuralContext,
+)
+from archex.scout import chunk_handle
+from archex.serve.context import estimate_tokens
+from archex.serve.intent import (
+    DEFAULT_TOKEN_BUDGET,
+    INTENT_TOKEN_BUDGETS,
+    INTENT_WEIGHTS,
+    QueryIntent,
+    classify_intent,
+)
+from archex.serve.modality import BudgetTier, QueryModality, budget_tier, classify_modality
+
+# ---------------------------------------------------------------------------
+# Input models
+# ---------------------------------------------------------------------------
+
+
+class ContextFilters(BaseModel):
+    """Deterministic post-retrieval candidate filters.
+
+    Filters only exclude candidates `query()` already ranked; they never
+    change ranking, add candidates, or trigger a reindex. `languages`
+    matches `CodeChunk.language` exactly. `include_paths`/`exclude_paths`
+    are `fnmatch`-style glob patterns matched case-sensitively against a
+    chunk's `file_path` (e.g. `"src/auth/**"`, `"*.py"`).
+    """
+
+    include_paths: list[str] = []
+    exclude_paths: list[str] = []
+    languages: list[str] = []
+
+    @model_validator(mode="after")
+    def _validate_non_blank(self) -> ContextFilters:
+        for value in (*self.include_paths, *self.exclude_paths, *self.languages):
+            if not value.strip():
+                raise ValueError("filter values must not be blank")
+        return self
+
+    def is_empty(self) -> bool:
+        return not (self.include_paths or self.exclude_paths or self.languages)
+
+    def matches(self, chunk: CodeChunk) -> bool:
+        """Return True when `chunk` survives every active filter clause."""
+        if self.languages and chunk.language not in self.languages:
+            return False
+        if self.include_paths and not any(
+            fnmatch.fnmatchcase(chunk.file_path, pattern) for pattern in self.include_paths
+        ):
+            return False
+        return not (
+            self.exclude_paths
+            and any(fnmatch.fnmatchcase(chunk.file_path, pattern) for pattern in self.exclude_paths)
+        )
+
+
+class ContextBudgets(BaseModel):
+    """Token-budget input for `context()`.
+
+    `token_budget` is an explicit override. Omitted, `context()` resolves a
+    budget from the pinned `intent` (`ContextRequest.intent`) when one was
+    given, or falls back to `query()`'s own intent-routed auto-scaling —
+    identical to `archex query`'s undecorated default. Either way the
+    resolved value is receipt-explained via `ContextRouteDecision` and
+    `ContextReceipt.token_budget`.
+    """
+
+    token_budget: int | None = None
+
+    @model_validator(mode="after")
+    def _validate_budget(self) -> ContextBudgets:
+        if self.token_budget is not None and self.token_budget <= 0:
+            raise ValueError(f"token_budget must be positive, got {self.token_budget}")
+        return self
+
+
+class ContextRequest(BaseModel):
+    """The shared `context()` request contract.
+
+    `query, intent, profile, filters, budgets, handles` — the six inputs
+    `archex.api.context()` documents as the primary agent path.
+    """
+
+    query: str
+    intent: QueryIntent | None = None
+    profile: RetrievalProfile | None = None
+    filters: ContextFilters = ContextFilters()
+    budgets: ContextBudgets = ContextBudgets()
+    handles: list[str] = []
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> ContextRequest:
+        if not self.query.strip():
+            raise ValueError("query must not be blank")
+        for handle in self.handles:
+            if not handle.strip():
+                raise ValueError("handles must not contain blank entries")
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Output models
+# ---------------------------------------------------------------------------
+
+
+class ContextRouteDecision(BaseModel):
+    """How `context()` interpreted a request before calling `query()`.
+
+    Every field here is resolved once, deterministically, from the same
+    canonical classifiers `query()`/`scout()` already use — this is a
+    read-only explanation of routing, not a second retrieval authority.
+    """
+
+    resolved_intent: QueryIntent
+    intent_source: Literal["explicit", "auto"]
+    resolved_modality: QueryModality
+    resolved_profile: RetrievalProfile | None
+    profile_source: Literal["explicit", "none"]
+    resolved_budget_tier: BudgetTier
+    token_budget_requested: int
+    budget_source: Literal["explicit", "intent_default"]
+    handles_mode: bool
+    filters_active: bool
+    reasons: list[str] = []
+
+
+class ContextResult(BaseModel):
+    """The primary agent-facing `context()` result.
+
+    `bundle` and `route` are the only stored fields; every other attribute
+    is a computed, read-only view over `bundle` so there is exactly one
+    receipt and one handle authority (`bundle.receipt`, chunk handles on
+    `bundle.chunks`).
+    """
+
+    bundle: ContextBundle
+    route: ContextRouteDecision
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def candidate_map(self) -> list[ContextReceiptItem]:
+        """Compact map of every returned candidate: handle, location, score."""
+        return list(self.bundle.receipt.returned_context) if self.bundle.receipt else []
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def fetch_handles(self) -> list[str]:
+        """Exact fetch handles for every returned candidate (`query(handles=...)`-ready)."""
+        return [item.handle for item in self.candidate_map]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def selected_code(self) -> list[RankedChunk]:
+        """The ranked, budget-fit code chunks `query()` selected."""
+        return list(self.bundle.chunks)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def relation_paths(self) -> StructuralContext:
+        """Dependency/module relation paths for the selected code."""
+        return self.bundle.structural_context
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def receipt(self) -> ContextReceipt | None:
+        """The single receipt authority for this result (`bundle.receipt`)."""
+        return self.bundle.receipt
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def next_action(self) -> ContextRecommendedAction | None:
+        """The receipt's recommended next action, when a receipt is present."""
+        return self.bundle.receipt.recommended_next_action if self.bundle.receipt else None
+
+
+@dataclass(frozen=True)
+class ContextRouteResolution:
+    """Internal: resolved `query()` call parameters plus the route decision to report."""
+
+    scoring_weights: ScoringWeights | None
+    token_budget: int
+    explicit_token_budget: bool
+    route: ContextRouteDecision
+
+
+# ---------------------------------------------------------------------------
+# Route resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_context_route(request: ContextRequest) -> ContextRouteResolution:
+    """Resolve `request` into `query()` call parameters plus a `ContextRouteDecision`.
+
+    Reuses the existing intent/modality/budget-tier classifiers and preset
+    tables verbatim (`classify_intent`, `classify_modality`, `budget_tier`,
+    `INTENT_WEIGHTS`, `INTENT_TOKEN_BUDGETS`) — no new ranking or budget
+    logic is introduced here, only explicit selection into what already
+    exists.
+    """
+    handles_mode = bool(request.handles)
+    reasons: list[str] = []
+
+    intent_source: Literal["explicit", "auto"]
+    scoring_weights: ScoringWeights | None
+    if request.intent is not None:
+        resolved_intent = request.intent
+        intent_source = "explicit"
+        scoring_weights = INTENT_WEIGHTS[resolved_intent]
+        reasons.append(f"intent pinned explicitly to '{resolved_intent.value}'")
+    else:
+        resolved_intent = classify_intent(request.query)
+        intent_source = "auto"
+        scoring_weights = None
+        reasons.append(f"intent auto-classified as '{resolved_intent.value}' from the query text")
+
+    budget_source: Literal["explicit", "intent_default"]
+    if request.budgets.token_budget is not None:
+        token_budget = request.budgets.token_budget
+        explicit_token_budget = True
+        budget_source = "explicit"
+        reasons.append(f"token budget pinned explicitly to {token_budget}")
+    elif request.intent is not None:
+        token_budget = INTENT_TOKEN_BUDGETS[resolved_intent]
+        explicit_token_budget = True
+        budget_source = "intent_default"
+        reasons.append(
+            f"token budget resolved from pinned intent '{resolved_intent.value}': {token_budget}"
+        )
+    else:
+        token_budget = DEFAULT_TOKEN_BUDGET
+        explicit_token_budget = False
+        budget_source = "intent_default"
+        reasons.append("token budget left to query()'s own intent-routed auto-scaling")
+
+    if handles_mode:
+        reasons.append(
+            f"{len(request.handles)} exact fetch handle(s) supplied — routed to direct "
+            "handle fetch instead of broad search"
+        )
+    if not request.filters.is_empty():
+        reasons.append("deterministic post-retrieval filters active")
+
+    route = ContextRouteDecision(
+        resolved_intent=resolved_intent,
+        intent_source=intent_source,
+        resolved_modality=classify_modality(request.query),
+        resolved_profile=request.profile,
+        profile_source="explicit" if request.profile is not None else "none",
+        resolved_budget_tier=budget_tier(token_budget),
+        token_budget_requested=token_budget,
+        budget_source=budget_source,
+        handles_mode=handles_mode,
+        filters_active=not request.filters.is_empty(),
+        reasons=reasons,
+    )
+    return ContextRouteResolution(
+        scoring_weights=scoring_weights,
+        token_budget=token_budget,
+        explicit_token_budget=explicit_token_budget,
+        route=route,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+
+def apply_context_filters(bundle: ContextBundle, filters: ContextFilters) -> ContextBundle:
+    """Apply `filters` to an already-retrieved `bundle`, in place, and return it.
+
+    Excluded chunks are removed from `bundle.chunks` and moved from
+    `bundle.receipt.returned_context` into `bundle.receipt.skipped_candidates`
+    with `ContextSkippedReason.FILTER_EXCLUDED` — every candidate `query()`
+    considered stays accounted for in the one receipt. `token_count` and
+    `receipt.token_budget.consumed` are resummed via the same per-chunk
+    `estimate_tokens` helper `query()` already uses for the surviving
+    chunks; no new token-estimation logic is introduced.
+    """
+    kept: list[RankedChunk] = []
+    filtered_out_ids: set[str] = set()
+    for ranked in bundle.chunks:
+        if filters.matches(ranked.chunk):
+            kept.append(ranked)
+        else:
+            filtered_out_ids.add(ranked.chunk.id)
+    if not filtered_out_ids:
+        return bundle
+
+    bundle.chunks = kept
+    bundle.token_count = sum(estimate_tokens(ranked.chunk) for ranked in kept)
+
+    receipt = bundle.receipt
+    if receipt is None:
+        return bundle
+    receipt.token_budget.consumed = bundle.token_count
+
+    filtered_handles = {chunk_handle(chunk_id) for chunk_id in filtered_out_ids}
+    survivors: list[ContextReceiptItem] = []
+    newly_skipped: list[ContextReceiptItem] = []
+    for item in receipt.returned_context:
+        (newly_skipped if item.handle in filtered_handles else survivors).append(item)
+
+    receipt.returned_context = survivors
+    receipt.skipped_candidates = [
+        *receipt.skipped_candidates,
+        *(
+            ContextSkippedCandidate(
+                file_path=item.file_path,
+                reason=ContextSkippedReason.FILTER_EXCLUDED,
+                handle=item.handle,
+                symbol=item.symbols[0] if item.symbols else None,
+                score=item.score,
+                detail="excluded by context() filters",
+            )
+            for item in newly_skipped
+        ),
+    ]
+    receipt.returned_total = len(receipt.returned_context)
+    receipt.skipped_total = len(receipt.skipped_candidates)
+    return bundle
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render_context_markdown(result: ContextResult) -> str:
+    """Render a `ContextResult` as Markdown: route, receipt summary, candidate map, code."""
+    from archex.serve.renderers.markdown import render_markdown
+
+    route = result.route
+    receipt = result.receipt
+    lines = [f"# Context: {result.bundle.query}", "", "## Route"]
+    profile_label = route.resolved_profile.value if route.resolved_profile is not None else "none"
+    lines.append(f"- intent: `{route.resolved_intent.value}` ({route.intent_source})")
+    lines.append(f"- modality: `{route.resolved_modality.value}`")
+    lines.append(f"- profile: `{profile_label}` ({route.profile_source})")
+    lines.append(
+        f"- budget tier: `{route.resolved_budget_tier.value}` — requested "
+        f"{route.token_budget_requested} tokens ({route.budget_source})"
+    )
+    lines.append(f"- handles mode: `{route.handles_mode}`")
+    lines.append(f"- filters active: `{route.filters_active}`")
+    for reason in route.reasons:
+        lines.append(f"  - {reason}")
+    lines.append("")
+
+    if receipt is not None:
+        lines.append("## Receipt")
+        lines.append(f"- index revision: `{receipt.index_revision}`")
+        lines.append(f"- freshness: `{receipt.freshness.value}`")
+        lines.append(
+            f"- token budget: {receipt.token_budget.consumed}/"
+            f"{receipt.token_budget.requested} consumed"
+        )
+        lines.append(f"- returned: {receipt.returned_total}, skipped: {receipt.skipped_total}")
+        lines.append(
+            f"- complete: `{receipt.context_complete.value}` "
+            f"({receipt.context_complete_reason.value})"
+        )
+        lines.append(f"- next action: `{receipt.recommended_next_action.value}`")
+        lines.append("")
+
+    lines.append("## Candidate map")
+    if result.candidate_map:
+        for item in result.candidate_map:
+            lines.append(
+                f"- `{item.handle}` {item.file_path}:{item.start_line}-{item.end_line} "
+                f"(score {item.score:.3f})"
+            )
+    else:
+        lines.append("_(no candidates returned)_")
+    lines.append("")
+
+    lines.append("## Selected code")
+    lines.append(render_markdown(result.bundle))
+    return "\n".join(lines)

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -140,6 +140,7 @@ class ContextSkippedReason(StrEnum):
     BELOW_THRESHOLD = "below_threshold"
     DEPENDENCY_FRONTIER_CUT = "dependency_frontier_cut"
     DUPLICATE = "duplicate"
+    FILTER_EXCLUDED = "filter_excluded"
     OVER_BUDGET = "over_budget"
     STALE_INDEX = "stale_index"
     TEST_DEPRIORITIZED = "test_deprioritized"

--- a/tests/test_context_facade.py
+++ b/tests/test_context_facade.py
@@ -1,0 +1,428 @@
+"""Contract tests for the primary agent-facing context() facade.
+
+Covers ContextRequest/ContextFilters/ContextBudgets validation, deterministic
+route resolution, post-retrieval filtering, ContextResult's computed views,
+and an end-to-end context() call against the python_simple fixture.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import ValidationError
+
+from archex.api import context
+from archex.context_facade import (
+    ContextBudgets,
+    ContextFilters,
+    ContextRequest,
+    ContextResult,
+    ContextRouteDecision,
+    apply_context_filters,
+    render_context_markdown,
+    resolve_context_route,
+)
+from archex.models import (
+    Config,
+    ContextBundle,
+    ContextCompletenessReason,
+    ContextCompletenessStatus,
+    ContextFreshness,
+    ContextReceipt,
+    ContextReceiptTokenBudget,
+    ContextRecommendedAction,
+    ContextSkippedReason,
+    RankedChunk,
+    RepoSource,
+    RetrievalProfile,
+    StructuralContext,
+)
+from archex.receipt import build_context_receipt
+from archex.scout import chunk_handle
+from archex.serve.intent import (
+    DEFAULT_TOKEN_BUDGET,
+    INTENT_TOKEN_BUDGETS,
+    INTENT_WEIGHTS,
+    QueryIntent,
+    classify_intent,
+)
+from archex.serve.modality import BudgetTier, QueryModality, classify_modality
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from tests.serve.test_context import make_chunk
+
+# ---------------------------------------------------------------------------
+# ContextRequest / ContextFilters / ContextBudgets validation
+# ---------------------------------------------------------------------------
+
+
+class TestContextRequestValidation:
+    def test_blank_query_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ContextRequest(query="   ")
+
+    def test_blank_handle_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ContextRequest(query="how does auth work?", handles=["chunk:x", "  "])
+
+    def test_minimal_request_defaults(self) -> None:
+        request = ContextRequest(query="how does auth work?")
+        assert request.intent is None
+        assert request.profile is None
+        assert request.filters.is_empty()
+        assert request.budgets.token_budget is None
+        assert request.handles == []
+
+
+class TestContextBudgetsValidation:
+    def test_non_positive_budget_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ContextBudgets(token_budget=0)
+        with pytest.raises(ValidationError):
+            ContextBudgets(token_budget=-1)
+
+    def test_positive_budget_accepted(self) -> None:
+        assert ContextBudgets(token_budget=1024).token_budget == 1024
+
+
+class TestContextFiltersValidation:
+    def test_blank_filter_value_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ContextFilters(include_paths=["  "])
+        with pytest.raises(ValidationError):
+            ContextFilters(exclude_paths=[""])
+        with pytest.raises(ValidationError):
+            ContextFilters(languages=["  "])
+
+    def test_is_empty(self) -> None:
+        assert ContextFilters().is_empty()
+        assert not ContextFilters(languages=["python"]).is_empty()
+
+    def test_matches_language_filter(self) -> None:
+        filters = ContextFilters(languages=["python"])
+        py_chunk = make_chunk("c1", "a.py")
+        assert filters.matches(py_chunk)
+        js_chunk = py_chunk.model_copy(update={"language": "javascript"})
+        assert not filters.matches(js_chunk)
+
+    def test_matches_include_glob(self) -> None:
+        filters = ContextFilters(include_paths=["src/auth/**"])
+        assert filters.matches(make_chunk("c1", "src/auth/login.py"))
+        assert not filters.matches(make_chunk("c2", "src/models/user.py"))
+
+    def test_matches_exclude_glob(self) -> None:
+        filters = ContextFilters(exclude_paths=["*/tests/*"])
+        assert filters.matches(make_chunk("c1", "src/auth/login.py"))
+        assert not filters.matches(make_chunk("c2", "src/tests/test_login.py"))
+
+    def test_matches_combines_all_clauses(self) -> None:
+        filters = ContextFilters(
+            include_paths=["src/**"], exclude_paths=["src/tests/**"], languages=["python"]
+        )
+        assert filters.matches(make_chunk("c1", "src/auth/login.py"))
+        assert not filters.matches(make_chunk("c2", "src/tests/test_login.py"))
+        assert not filters.matches(make_chunk("c3", "other/login.py"))
+
+
+# ---------------------------------------------------------------------------
+# Route resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveContextRoute:
+    def test_auto_intent_matches_classifier(self) -> None:
+        question = "how does authentication work?"
+        resolution = resolve_context_route(ContextRequest(query=question))
+        assert resolution.route.resolved_intent == classify_intent(question)
+        assert resolution.route.intent_source == "auto"
+        assert resolution.scoring_weights is None
+        assert resolution.explicit_token_budget is False
+        assert resolution.token_budget == DEFAULT_TOKEN_BUDGET
+
+    def test_explicit_intent_pins_weights_and_budget(self) -> None:
+        request = ContextRequest(query="anything", intent=QueryIntent.DEBUGGING)
+        resolution = resolve_context_route(request)
+        assert resolution.route.resolved_intent == QueryIntent.DEBUGGING
+        assert resolution.route.intent_source == "explicit"
+        assert resolution.scoring_weights == INTENT_WEIGHTS[QueryIntent.DEBUGGING]
+        assert resolution.token_budget == INTENT_TOKEN_BUDGETS[QueryIntent.DEBUGGING]
+        assert resolution.explicit_token_budget is True
+        assert resolution.route.budget_source == "intent_default"
+
+    def test_explicit_budget_wins_over_intent_default(self) -> None:
+        request = ContextRequest(
+            query="anything",
+            intent=QueryIntent.DEBUGGING,
+            budgets=ContextBudgets(token_budget=512),
+        )
+        resolution = resolve_context_route(request)
+        assert resolution.token_budget == 512
+        assert resolution.route.budget_source == "explicit"
+
+    def test_resolved_modality_matches_classifier(self) -> None:
+        question = "how does authentication work?"
+        resolution = resolve_context_route(ContextRequest(query=question))
+        assert resolution.route.resolved_modality == classify_modality(question)
+
+    def test_handles_mode_flag(self) -> None:
+        resolution = resolve_context_route(ContextRequest(query="x", handles=["chunk:a.py:1"]))
+        assert resolution.route.handles_mode is True
+        no_handles = resolve_context_route(ContextRequest(query="x"))
+        assert no_handles.route.handles_mode is False
+
+    def test_filters_active_flag(self) -> None:
+        resolution = resolve_context_route(
+            ContextRequest(query="x", filters=ContextFilters(languages=["python"]))
+        )
+        assert resolution.route.filters_active is True
+        no_filters = resolve_context_route(ContextRequest(query="x"))
+        assert no_filters.route.filters_active is False
+
+    def test_profile_source_reported(self) -> None:
+        with_profile = resolve_context_route(
+            ContextRequest(query="x", profile=RetrievalProfile.FAST)
+        )
+        assert with_profile.route.profile_source == "explicit"
+        assert with_profile.route.resolved_profile == RetrievalProfile.FAST
+        without_profile = resolve_context_route(ContextRequest(query="x"))
+        assert without_profile.route.profile_source == "none"
+        assert without_profile.route.resolved_profile is None
+
+    def test_reasons_are_non_empty(self) -> None:
+        resolution = resolve_context_route(ContextRequest(query="x"))
+        assert resolution.route.reasons
+
+
+# ---------------------------------------------------------------------------
+# apply_context_filters
+# ---------------------------------------------------------------------------
+
+
+def _bundle_with_chunks(paths: list[str]) -> ContextBundle:
+    chunks = [make_chunk(f"c{i}", path) for i, path in enumerate(paths)]
+    ranked = [RankedChunk(chunk=chunk, relevance_score=1.0, final_score=1.0) for chunk in chunks]
+    bundle = ContextBundle(
+        query="q",
+        chunks=ranked,
+        token_count=sum(c.token_count for c in chunks),
+        token_budget=8192,
+    )
+    bundle.receipt = build_context_receipt(
+        bundle,
+        index_revision="rev",
+        freshness=ContextFreshness.CLEAN,
+    )
+    return bundle
+
+
+class TestApplyContextFilters:
+    def test_removes_non_matching_chunks(self) -> None:
+        bundle = _bundle_with_chunks(["src/auth/login.py", "src/tests/test_login.py"])
+        filtered = apply_context_filters(bundle, ContextFilters(exclude_paths=["src/tests/**"]))
+        assert [rc.chunk.file_path for rc in filtered.chunks] == ["src/auth/login.py"]
+
+    def test_no_op_when_nothing_filtered(self) -> None:
+        bundle = _bundle_with_chunks(["src/auth/login.py"])
+        original_chunks = list(bundle.chunks)
+        filtered = apply_context_filters(bundle, ContextFilters(languages=["python"]))
+        assert filtered.chunks == original_chunks
+
+    def test_moves_filtered_items_to_skipped_with_reason(self) -> None:
+        bundle = _bundle_with_chunks(["src/auth/login.py", "src/tests/test_login.py"])
+        assert bundle.receipt is not None
+        assert len(bundle.receipt.returned_context) == 2
+        filtered = apply_context_filters(bundle, ContextFilters(exclude_paths=["src/tests/**"]))
+        assert filtered.receipt is not None
+        assert len(filtered.receipt.returned_context) == 1
+        skipped = [
+            item
+            for item in filtered.receipt.skipped_candidates
+            if item.reason == ContextSkippedReason.FILTER_EXCLUDED
+        ]
+        assert len(skipped) == 1
+        assert skipped[0].handle == chunk_handle("c1")
+
+    def test_recomputes_totals_and_token_count(self) -> None:
+        bundle = _bundle_with_chunks(["src/auth/login.py", "src/tests/test_login.py"])
+        assert bundle.receipt is not None
+        original_skipped_total = bundle.receipt.skipped_total
+        filtered = apply_context_filters(bundle, ContextFilters(exclude_paths=["src/tests/**"]))
+        assert filtered.receipt is not None
+        assert filtered.receipt.returned_total == 1
+        assert filtered.receipt.skipped_total == original_skipped_total + 1
+        assert filtered.token_count == make_chunk("c0", "src/auth/login.py").token_count
+
+    def test_resums_receipt_consumed_budget(self) -> None:
+        bundle = _bundle_with_chunks(["src/auth/login.py", "src/tests/test_login.py"])
+        assert bundle.receipt is not None
+        original_consumed = bundle.receipt.token_budget.consumed
+        filtered = apply_context_filters(bundle, ContextFilters(exclude_paths=["src/tests/**"]))
+        assert filtered.receipt is not None
+        assert filtered.receipt.token_budget.consumed == filtered.token_count
+        assert filtered.receipt.token_budget.consumed < original_consumed
+
+
+# ---------------------------------------------------------------------------
+# ContextResult computed views
+# ---------------------------------------------------------------------------
+
+
+class TestContextResultComputedViews:
+    def _make_result(self) -> ContextResult:
+        question = "how does auth work?"
+        chunk = make_chunk("c1", "src/auth/login.py")
+        ranked = RankedChunk(chunk=chunk, relevance_score=0.9, final_score=0.9)
+        bundle = ContextBundle(
+            query=question,
+            chunks=[ranked],
+            structural_context=StructuralContext(relevant_modules=["auth"]),
+            token_count=chunk.token_count,
+            token_budget=8192,
+            receipt=ContextReceipt(
+                query=question,
+                token_budget=ContextReceiptTokenBudget(requested=8192, consumed=chunk.token_count),
+                index_revision="rev",
+                freshness=ContextFreshness.CLEAN,
+                returned_context=[],
+                returned_total=1,
+                context_complete=ContextCompletenessStatus.COMPLETE,
+                context_complete_reason=ContextCompletenessReason.COMPLETE,
+                recommended_next_action=ContextRecommendedAction.USE_BUNDLE,
+            ),
+        )
+        bundle.receipt = build_context_receipt(
+            bundle, index_revision="rev", freshness=ContextFreshness.CLEAN
+        )
+        route = ContextRouteDecision(
+            resolved_intent=QueryIntent.GENERAL,
+            intent_source="auto",
+            resolved_modality=QueryModality.NL_TO_PL,
+            resolved_profile=None,
+            profile_source="none",
+            resolved_budget_tier=BudgetTier.STANDARD,
+            token_budget_requested=8192,
+            budget_source="intent_default",
+            handles_mode=False,
+            filters_active=False,
+        )
+        return ContextResult(bundle=bundle, route=route)
+
+    def test_candidate_map_matches_receipt(self) -> None:
+        result = self._make_result()
+        assert result.candidate_map == result.bundle.receipt.returned_context  # type: ignore[union-attr]
+
+    def test_fetch_handles_match_candidate_map(self) -> None:
+        result = self._make_result()
+        assert result.fetch_handles == [item.handle for item in result.candidate_map]
+        assert result.fetch_handles == [chunk_handle("c1")]
+
+    def test_selected_code_matches_bundle_chunks(self) -> None:
+        result = self._make_result()
+        assert result.selected_code == result.bundle.chunks
+
+    def test_relation_paths_matches_structural_context(self) -> None:
+        result = self._make_result()
+        assert result.relation_paths == result.bundle.structural_context
+        assert result.relation_paths.relevant_modules == ["auth"]
+
+    def test_receipt_matches_bundle_receipt(self) -> None:
+        result = self._make_result()
+        assert result.receipt is result.bundle.receipt
+
+    def test_next_action_matches_receipt(self) -> None:
+        result = self._make_result()
+        assert result.next_action == result.bundle.receipt.recommended_next_action  # type: ignore[union-attr]
+
+    def test_next_action_none_without_receipt(self) -> None:
+        result = self._make_result()
+        result.bundle.receipt = None
+        assert result.next_action is None
+        assert result.candidate_map == []
+        assert result.fetch_handles == []
+
+    def test_markdown_render_includes_route_and_candidates(self) -> None:
+        result = self._make_result()
+        rendered = render_context_markdown(result)
+        assert "## Route" in rendered
+        assert "## Candidate map" in rendered
+        assert chunk_handle("c1") in rendered
+        assert "## Selected code" in rendered
+
+
+# ---------------------------------------------------------------------------
+# End-to-end context() against a real fixture repo
+# ---------------------------------------------------------------------------
+_QUESTION = "How does authentication work?"
+
+
+class TestContextEndToEnd:
+    def test_context_returns_candidate_map_and_handles(self, python_simple_repo: Path) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        result = context(source, ContextRequest(query=_QUESTION), config=Config(cache=False))
+
+        assert isinstance(result, ContextResult)
+        assert len(result.selected_code) > 0
+        assert len(result.candidate_map) > 0
+        assert result.fetch_handles
+        assert result.receipt is not None
+        assert result.next_action is not None
+        assert result.route.resolved_intent is not None
+
+    def test_context_explicit_intent_sets_route_and_budget(self, python_simple_repo: Path) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        request = ContextRequest(query=_QUESTION, intent=QueryIntent.DEBUGGING)
+        result = context(source, request, config=Config(cache=False))
+
+        assert result.route.resolved_intent == QueryIntent.DEBUGGING
+        assert result.route.intent_source == "explicit"
+        assert result.route.token_budget_requested == INTENT_TOKEN_BUDGETS[QueryIntent.DEBUGGING]
+
+    def test_context_profile_propagates_to_metadata(self, python_simple_repo: Path) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        request = ContextRequest(query=_QUESTION, profile=RetrievalProfile.FAST)
+        result = context(source, request, config=Config(cache=False))
+
+        assert result.bundle.retrieval_metadata.retrieval_profile == "fast"
+        assert result.route.resolved_profile == RetrievalProfile.FAST
+
+    def test_context_filters_exclude_matching_files(self, python_simple_repo: Path) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(cache=False)
+        baseline = context(source, ContextRequest(query=_QUESTION), config=config)
+        excluded_path = baseline.bundle.chunks[0].chunk.file_path
+
+        filtered_request = ContextRequest(
+            query=_QUESTION,
+            filters=ContextFilters(exclude_paths=[excluded_path]),
+        )
+        filtered = context(source, filtered_request, config=config)
+
+        assert all(rc.chunk.file_path != excluded_path for rc in filtered.selected_code)
+        assert filtered.route.filters_active is True
+        assert any(
+            item.reason == ContextSkippedReason.FILTER_EXCLUDED
+            for item in filtered.receipt.skipped_candidates  # type: ignore[union-attr]
+        )
+
+    def test_context_handles_mode_fetches_exact_chunk(self, python_simple_repo: Path) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(cache=False)
+        baseline = context(source, ContextRequest(query=_QUESTION), config=config)
+        handle = baseline.fetch_handles[0]
+        expected_chunk = next(
+            rc.chunk for rc in baseline.selected_code if chunk_handle(rc.chunk.id) == handle
+        )
+
+        fetched = context(source, ContextRequest(query="ignored", handles=[handle]), config=config)
+
+        assert fetched.route.handles_mode is True
+        assert len(fetched.selected_code) == 1
+        assert fetched.selected_code[0].chunk.id == expected_chunk.id
+        assert fetched.selected_code[0].chunk.content == expected_chunk.content
+
+    def test_context_invalid_request_fails_loud(self) -> None:
+        with pytest.raises(ValidationError):
+            ContextRequest(query="")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -135,6 +135,7 @@ def test_context_receipt_enum_members() -> None:
         "BELOW_THRESHOLD": "below_threshold",
         "DEPENDENCY_FRONTIER_CUT": "dependency_frontier_cut",
         "DUPLICATE": "duplicate",
+        "FILTER_EXCLUDED": "filter_excluded",
         "OVER_BUDGET": "over_budget",
         "STALE_INDEX": "stale_index",
         "TEST_DEPRIORITIZED": "test_deprioritized",


### PR DESCRIPTION
## Stack

Stack-Id: `m10-context-facade`
Base: `main`
Position: 1/3

1. `m10-1-facade-contract` -> this PR
2. `m10-2-surfaces-handles` -> (next)
3. `m10-3-adoption-smoke` -> (next)

Depends on: (none — root)
Upstack: PR-2 (surface integration)

## Summary

M10 (Simplify the Agent-Facing Context Interface): defines the shared
`context(query, intent, profile, filters, budgets, handles)` contract as a
thin facade over the canonical `query()` runtime.

- `archex.context_facade`: `ContextRequest`/`ContextFilters`/`ContextBudgets`
  input models; `ContextRouteDecision`/`ContextResult` output models;
  `resolve_context_route()`, `apply_context_filters()`,
  `render_context_markdown()`.
- `archex.api.context(source, request) -> ContextResult`: resolves
  intent/profile/budget routing by reusing the existing
  `classify_intent`/`INTENT_WEIGHTS`/`INTENT_TOKEN_BUDGETS` tables, passes
  `handles` through to `query()`'s existing exact-fetch path unchanged, then
  applies deterministic post-retrieval filters that move excluded
  candidates into the existing receipt's `skipped_candidates` under a new
  `ContextSkippedReason.FILTER_EXCLUDED`.
- `ContextResult` exposes `candidate_map`, `fetch_handles`, `selected_code`,
  `relation_paths`, `receipt`, `next_action` as computed properties over one
  stored `ContextBundle` — no second receipt/handle authority.

No CLI/MCP surface yet (PR-2), no README/CI smoke docs yet (PR-3). Existing
`query`/`scout`/precision tools are untouched.

## Validation

```
uv run ruff check .            # All checks passed!
uv run ruff format --check .   # 400 files already formatted
uv run pyright .               # 0 errors, 0 warnings, 0 informations
uv run pytest tests/test_context_facade.py tests/test_query_pipeline.py \
  tests/serve/test_context.py tests/test_scout.py tests/cli/test_query_cmd.py \
  tests/integrations/test_mcp.py --no-cov -q
# 249 passed
```