### PR TITLE
feat(cli,mcp): expose context facade with stable exact-fetch handles

### DIFF
--- a/src/archex/cli/context_cmd.py
+++ b/src/archex/cli/context_cmd.py
@@ -1,0 +1,188 @@
+"""CLI context subcommand: the primary agent-facing context() facade."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+import click
+from pydantic import ValidationError
+
+from archex.api import context, get_files_token_count
+from archex.context_facade import (
+    ContextBudgets,
+    ContextFilters,
+    ContextRequest,
+    ContextResult,
+    render_context_markdown,
+)
+from archex.exceptions import ArchexError
+from archex.metrics.capture import record_query_usage
+from archex.metrics.health import note_metrics_recording_failure
+from archex.metrics.policy import resolve_metrics_policy
+from archex.models import RetrievalProfile
+from archex.serve.intent import QueryIntent
+from archex.utils import resolve_source
+
+if TYPE_CHECKING:
+    from archex.models import Config, RepoSource
+
+logger = logging.getLogger(__name__)
+
+_INTENT_CHOICES = [intent.value for intent in QueryIntent]
+_PROFILE_CHOICES = [profile.value for profile in RetrievalProfile]
+
+
+@click.command("context")
+@click.argument("args", nargs=-1, required=True)
+@click.option(
+    "--intent",
+    type=click.Choice(_INTENT_CHOICES),
+    default=None,
+    help="Pin the query intent instead of auto-classifying it from the query text.",
+)
+@click.option(
+    "--profile",
+    type=click.Choice(_PROFILE_CHOICES),
+    default=None,
+    help="Named retrieval profile: 'fast', 'balanced', or 'deep'. Omit for the repo default.",
+)
+@click.option(
+    "--include",
+    "include_paths",
+    multiple=True,
+    help="Glob pattern(s) a candidate's file path must match (fnmatch, e.g. 'src/auth/**').",
+)
+@click.option(
+    "--exclude",
+    "exclude_paths",
+    multiple=True,
+    help="Glob pattern(s) that exclude a candidate by file path.",
+)
+@click.option(
+    "-l",
+    "--language",
+    "languages",
+    multiple=True,
+    help="Restrict returned candidates to these languages (post-retrieval, exact match).",
+)
+@click.option(
+    "--budget",
+    type=int,
+    default=None,
+    help="Explicit token budget override. Omit to resolve from --intent or query()'s auto-scaling.",
+)
+@click.option(
+    "--handle",
+    "handles",
+    multiple=True,
+    help="Exact fetch handle(s) — bypasses broad search and returns exactly these candidates.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default="json",
+    type=click.Choice(["json", "markdown"]),
+    help="Output format.",
+)
+def context_cmd(
+    args: tuple[str, ...],
+    intent: str | None,
+    profile: str | None,
+    include_paths: tuple[str, ...],
+    exclude_paths: tuple[str, ...],
+    languages: tuple[str, ...],
+    budget: int | None,
+    handles: tuple[str, ...],
+    output_format: str,
+) -> None:
+    """Retrieve the primary agent-facing context result for a repository question.
+
+    Returns a compact candidate map, exact fetch handles, selected code,
+    relation paths, the route decision, the receipt, and a recommended next
+    action — a thin facade over `archex query`. Existing specialized
+    commands (`query`, `scout`, `symbol`, ...) remain fully supported.
+    """
+    from archex.config import load_config, load_index_config
+
+    source, question = _source_and_question(args)
+    repo_source = resolve_source(source)
+    config = load_config(repo_source)
+    index_config = load_index_config(repo_source)
+
+    try:
+        request = ContextRequest(
+            query=question,
+            intent=QueryIntent(intent) if intent is not None else None,
+            profile=RetrievalProfile(profile) if profile is not None else None,
+            filters=ContextFilters(
+                include_paths=list(include_paths),
+                exclude_paths=list(exclude_paths),
+                languages=list(languages),
+            ),
+            budgets=ContextBudgets(token_budget=budget),
+            handles=list(handles),
+        )
+    except ValidationError as exc:
+        raise click.ClickException(f"invalid context request: {exc}") from exc
+
+    try:
+        result = context(repo_source, request, config=config, index_config=index_config)
+    except ArchexError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo(_render(result, output_format))
+    _record_metrics(repo_source, result, config)
+
+
+def _render(result: ContextResult, output_format: str) -> str:
+    if output_format == "markdown":
+        return render_context_markdown(result)
+    envelope = {
+        "content": [chunk.model_dump(mode="json") for chunk in result.selected_code],
+        "candidate_map": [item.model_dump(mode="json") for item in result.candidate_map],
+        "fetch_handles": result.fetch_handles,
+        "relation_paths": result.relation_paths.model_dump(mode="json"),
+        "route": result.route.model_dump(mode="json"),
+        "receipt": result.receipt.model_dump(mode="json") if result.receipt else None,
+        "next_action": result.next_action.value if result.next_action else None,
+    }
+    return json.dumps(envelope, indent=2)
+
+
+def _record_metrics(repo_source: RepoSource, result: ContextResult, config: Config) -> None:
+    try:
+        policy = resolve_metrics_policy()
+        if not policy.metrics_enabled:
+            return
+        unique_files = list({c.chunk.file_path for c in result.bundle.chunks})
+        raw_tokens = get_files_token_count(repo_source, unique_files, config)
+        whole_repo_tokens = _repo_total_tokens(repo_source, config)
+        record_query_usage(
+            repo_source,
+            result.bundle,
+            surface="cli",
+            tool_name="context",
+            tokens_raw_equivalent=raw_tokens,
+            whole_repo_tokens=whole_repo_tokens,
+        )
+    except Exception as exc:
+        note_metrics_recording_failure(exc)
+
+
+def _repo_total_tokens(repo_source: RepoSource, config: Config) -> int | None:
+    try:
+        from archex.api import get_repo_total_tokens
+
+        return get_repo_total_tokens(repo_source, config=config)
+    except ArchexError:
+        return None
+
+
+def _source_and_question(args: tuple[str, ...]) -> tuple[str, str]:
+    if len(args) == 1:
+        return ".", args[0]
+    if len(args) >= 2:
+        return args[0], " ".join(args[1:])
+    raise click.UsageError("context requires a question")

--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -9,6 +9,7 @@ from archex.cli.analyze_cmd import analyze_cmd
 from archex.cli.benchmark_cmd import benchmark_cmd
 from archex.cli.cache_cmd import cache_cmd
 from archex.cli.compare_cmd import compare_cmd
+from archex.cli.context_cmd import context_cmd
 from archex.cli.doctor_cmd import doctor_cmd
 from archex.cli.dogfood_cmd import dogfood_cmd
 from archex.cli.explain_cmd import explain_cmd
@@ -40,6 +41,7 @@ def cli() -> None:
 cli.add_command(analyze_cmd)
 cli.add_command(benchmark_cmd)
 cli.add_command(query_cmd)
+cli.add_command(context_cmd)
 cli.add_command(compare_cmd)
 cli.add_command(cache_cmd)
 cli.add_command(init_cmd)

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -14,6 +14,7 @@ from typing import Any
 from archex.api import (
     analyze,
     compare,
+    context,
     file_outline,
     file_tree,
     get_file_token_count,
@@ -27,6 +28,12 @@ from archex.api import (
     search_symbols,
 )
 from archex.config import load_config, load_index_config
+from archex.context_facade import (
+    ContextBudgets,
+    ContextFilters,
+    ContextRequest,
+    render_context_markdown,
+)
 from archex.explain import (
     ExplainError,
     explain_file,
@@ -71,7 +78,7 @@ from archex.onboarding import OnboardingError, render_onboarding_markdown
 from archex.reporting import compute_meta, count_tokens
 from archex.scout import DEFAULT_SCOUT_TOKEN_BUDGET, ScoutFormat, ScoutResult, render_scout
 from archex.serve.compare import validate_dimensions
-from archex.serve.intent import DEFAULT_TOKEN_BUDGET
+from archex.serve.intent import DEFAULT_TOKEN_BUDGET, QueryIntent
 from archex.serve.renderers.xml import render_xml, render_xml_envelope
 from archex.serve.runtime import QueryRuntime
 from archex.utils import resolve_source
@@ -205,6 +212,93 @@ def handle_query_repo(
     )
 
 
+def handle_context(
+    repo_url: str,
+    query_text: str,
+    intent: str | None = None,
+    profile: str | None = None,
+    filters: dict[str, Any] | None = None,
+    budgets: dict[str, Any] | None = None,
+    handles: list[str] | None = None,
+    output_format: str = "json",
+) -> str:
+    """Retrieve the primary agent-facing context result for a repository question.
+
+    Args:
+        repo_url: Local path or HTTP(S) URL of the repository to query.
+        query_text: Natural-language question to answer from the codebase.
+        intent: Optional query-intent override — pins the scoring-weight
+            preset and default token budget instead of auto-classifying
+            from `query_text`.
+        profile: Optional named retrieval profile — 'fast', 'balanced', or
+            'deep'. Omit to use the repo's configured retrieval settings.
+        filters: Optional `{include_paths, exclude_paths, languages}`
+            deterministic post-retrieval candidate filter.
+        budgets: Optional `{token_budget}` explicit budget override.
+        handles: Optional exact fetch handles — bypasses broad search and
+            returns exactly these candidates.
+        output_format: 'json' or 'markdown'. Defaults to 'json'.
+
+    Returns:
+        JSON envelope with content, candidate_map, fetch_handles,
+        relation_paths, route, receipt, next_action, and the standard
+        _meta efficiency block.
+    """
+    if not query_text.strip():
+        raise ValueError("query must not be empty")
+    if output_format not in {"json", "markdown"}:
+        raise ValueError(f"format must be one of ['json', 'markdown'], got {output_format!r}")
+    try:
+        request = ContextRequest(
+            query=query_text,
+            intent=QueryIntent(intent) if intent is not None else None,
+            profile=RetrievalProfile(profile) if profile is not None else None,
+            filters=ContextFilters(**(filters or {})),
+            budgets=ContextBudgets(**(budgets or {})),
+            handles=list(handles or []),
+        )
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"invalid context request: {exc}") from exc
+
+    source = resolve_source(repo_url)
+    pt = PipelineTiming()
+    result = context(source, request, timing=pt)
+
+    content: Any
+    if output_format == "markdown":
+        content = render_context_markdown(result)
+    else:
+        content = [chunk.model_dump(mode="json") for chunk in result.selected_code]
+
+    raw_file_paths = sorted({c.chunk.file_path for c in result.bundle.chunks})
+    raw_tokens = get_files_token_count(source, raw_file_paths)
+    response_text = content if isinstance(content, str) else json.dumps(content)
+    meta = compute_meta(
+        tool_name="context",
+        response_text=response_text,
+        raw_file_tokens=raw_tokens or 0,
+        strategy="context_facade",
+        cached=pt.cached,
+        index_time_ms=pt.index_ms,
+        query_time_ms=pt.total_ms,
+        delta=pt.delta_meta,
+    )
+    _record_query_metrics(source, result.bundle, raw_tokens, tool_name="context")
+    return json.dumps(
+        {
+            "content": content,
+            "candidate_map": [item.model_dump(mode="json") for item in result.candidate_map],
+            "fetch_handles": result.fetch_handles,
+            "relation_paths": result.relation_paths.model_dump(mode="json"),
+            "route": result.route.model_dump(mode="json"),
+            "receipt": _receipt_payload(result.bundle.receipt),
+            "next_action": result.next_action.value if result.next_action else None,
+            "_meta": meta.model_dump(),
+        },
+        indent=2,
+    )
+
+
 def handle_scout_repo(
     repo_url: str,
     question: str,
@@ -251,6 +345,8 @@ def _record_query_metrics(
     source: RepoSource,
     bundle: ContextBundle,
     raw_tokens: int | None,
+    *,
+    tool_name: str = "query_repo",
 ) -> None:
     try:
         policy = resolve_metrics_policy()
@@ -261,7 +357,7 @@ def _record_query_metrics(
             source,
             bundle,
             surface="mcp",
-            tool_name="query_repo",
+            tool_name=tool_name,
             tokens_raw_equivalent=raw_tokens,
             whole_repo_tokens=whole_repo_tokens,
         )
@@ -1188,6 +1284,27 @@ async def _run_mcp_tool(
         return await loop.run_in_executor(
             None, handle_query_repo, repo_url, question, budget, runtime, profile_arg
         )
+    if name == "context":
+        context_repo_url: str = arguments["repo_url"]
+        context_query: str = arguments["query"]
+        context_intent: str | None = arguments.get("intent")
+        context_profile: str | None = arguments.get("profile")
+        context_filters: dict[str, Any] | None = arguments.get("filters")
+        context_budgets: dict[str, Any] | None = arguments.get("budgets")
+        context_handles: list[str] | None = arguments.get("handles")
+        context_format: str = arguments.get("format", "json")
+        return await loop.run_in_executor(
+            None,
+            handle_context,
+            context_repo_url,
+            context_query,
+            context_intent,
+            context_profile,
+            context_filters,
+            context_budgets,
+            context_handles,
+            context_format,
+        )
     if name == "compare_repos":
         repo_a: str = arguments["repo_a"]
         repo_b: str = arguments["repo_b"]
@@ -1468,6 +1585,108 @@ def build_server(runtime: QueryRuntime | None = None) -> Any:
                         },
                     },
                     "required": ["repo_url", "question"],
+                },
+            ),
+            mcp_types.Tool(
+                name="context",
+                description=(
+                    "Primary agent-facing context retrieval: query, intent, profile, "
+                    "filters, budgets, and handles as one contract. Returns a compact "
+                    "candidate map, exact fetch handles, selected code, relation paths, "
+                    "the route decision, a receipt, and a recommended next action. A "
+                    "thin facade over query_repo — query_repo and the other specialized "
+                    "tools remain fully supported."
+                ),
+                inputSchema={
+                    "type": "object",
+                    "properties": {
+                        "repo_url": {
+                            "type": "string",
+                            "description": (
+                                "Local filesystem path or HTTP(S) Git URL of the repository."
+                            ),
+                        },
+                        "query": {
+                            "type": "string",
+                            "description": (
+                                "Natural-language question to answer from the codebase."
+                            ),
+                        },
+                        "intent": {
+                            "type": "string",
+                            "enum": [intent.value for intent in QueryIntent],
+                            "description": (
+                                "Optional: pin the query intent instead of "
+                                "auto-classifying it from the query text. Determines "
+                                "the scoring-weight preset and default token budget."
+                            ),
+                        },
+                        "profile": {
+                            "type": "string",
+                            "enum": [profile.value for profile in RetrievalProfile],
+                            "description": (
+                                "Optional named retrieval profile. Omit to use the "
+                                "repo's configured retrieval settings unchanged."
+                            ),
+                        },
+                        "filters": {
+                            "type": "object",
+                            "description": (
+                                "Optional deterministic post-retrieval candidate "
+                                "filters — never changes ranking or adds candidates."
+                            ),
+                            "properties": {
+                                "include_paths": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "description": (
+                                        "fnmatch glob(s) a candidate's file path must match."
+                                    ),
+                                },
+                                "exclude_paths": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "description": (
+                                        "fnmatch glob(s) that exclude a candidate by file path."
+                                    ),
+                                },
+                                "languages": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                    "description": (
+                                        "Restrict returned candidates to these languages."
+                                    ),
+                                },
+                            },
+                        },
+                        "budgets": {
+                            "type": "object",
+                            "description": "Optional token-budget input.",
+                            "properties": {
+                                "token_budget": {
+                                    "type": "integer",
+                                    "description": (
+                                        "Explicit token budget override. Omit to resolve "
+                                        "from 'intent' or the query's own auto-scaling."
+                                    ),
+                                },
+                            },
+                        },
+                        "handles": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Optional exact fetch handle(s) — bypasses broad search "
+                                "and returns exactly these candidates."
+                            ),
+                        },
+                        "format": {
+                            "type": "string",
+                            "enum": ["json", "markdown"],
+                            "description": "Output format. Defaults to 'json'.",
+                        },
+                    },
+                    "required": ["repo_url", "query"],
                 },
             ),
             mcp_types.Tool(

--- a/src/archex/metrics/categories.py
+++ b/src/archex/metrics/categories.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 CONTEXT_RETRIEVAL = "context_retrieval"
 STRUCTURAL_TOOLS = "structural_tools"
 
-_CONTEXT_RETRIEVAL_TOOLS = frozenset({"query", "scout", "query_repo", "scout_repo"})
+_CONTEXT_RETRIEVAL_TOOLS = frozenset({"context", "query", "scout", "query_repo", "scout_repo"})
 _STRUCTURAL_TOOLS = frozenset(
     {
         "analyze",

--- a/tests/cli/test_context_cmd.py
+++ b/tests/cli/test_context_cmd.py
@@ -1,0 +1,152 @@
+"""Tests for the CLI `context` subcommand — the primary agent-facing facade."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+
+
+def test_context_json_default_returns_full_envelope(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["context", str(python_simple_repo), "how does authentication work?"]
+    )
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    for key in (
+        "content",
+        "candidate_map",
+        "fetch_handles",
+        "relation_paths",
+        "route",
+        "receipt",
+        "next_action",
+    ):
+        assert key in parsed
+    assert len(parsed["content"]) > 0
+    assert len(parsed["candidate_map"]) > 0
+    assert parsed["fetch_handles"]
+    assert parsed["route"]["intent_source"] == "auto"
+    assert parsed["receipt"]["index_revision"]
+
+
+def test_context_markdown_format(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "context",
+            str(python_simple_repo),
+            "how does authentication work?",
+            "--format",
+            "markdown",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "## Route" in result.output
+    assert "## Candidate map" in result.output
+    assert "## Selected code" in result.output
+
+
+def test_context_intent_pins_budget(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["context", str(python_simple_repo), "anything", "--intent", "debugging"],
+    )
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["route"]["resolved_intent"] == "debugging"
+    assert parsed["route"]["intent_source"] == "explicit"
+    assert parsed["route"]["budget_source"] == "intent_default"
+
+
+def test_context_invalid_intent_rejected(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["context", str(python_simple_repo), "anything", "--intent", "not_a_real_intent"],
+    )
+    assert result.exit_code != 0
+    assert "Invalid value for '--intent'" in result.output
+
+
+def test_context_invalid_profile_rejected(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["context", str(python_simple_repo), "anything", "--profile", "ultra"],
+    )
+    assert result.exit_code != 0
+    assert "Invalid value for '--profile'" in result.output
+
+
+def test_context_non_positive_budget_rejected(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["context", str(python_simple_repo), "anything", "--budget", "0"],
+    )
+    assert result.exit_code != 0
+    assert "invalid context request" in result.output
+
+
+def test_context_exclude_filter_removes_matching_files(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+    baseline = runner.invoke(
+        cli, ["context", str(python_simple_repo), "how does authentication work?"]
+    )
+    assert baseline.exit_code == 0, baseline.output
+    excluded_path = json.loads(baseline.output)["candidate_map"][0]["file_path"]
+
+    filtered = runner.invoke(
+        cli,
+        [
+            "context",
+            str(python_simple_repo),
+            "how does authentication work?",
+            "--exclude",
+            excluded_path,
+        ],
+    )
+    assert filtered.exit_code == 0, filtered.output
+    parsed = json.loads(filtered.output)
+    assert all(item["file_path"] != excluded_path for item in parsed["candidate_map"])
+    assert parsed["route"]["filters_active"] is True
+    assert any(
+        skipped["reason"] == "filter_excluded"
+        for skipped in parsed["receipt"]["skipped_candidates"]
+    )
+
+
+def test_context_handle_bypasses_broad_search(python_simple_repo: Path) -> None:
+    runner = CliRunner()
+    baseline = runner.invoke(
+        cli, ["context", str(python_simple_repo), "how does authentication work?"]
+    )
+    assert baseline.exit_code == 0, baseline.output
+    handle = json.loads(baseline.output)["fetch_handles"][0]
+
+    fetched = runner.invoke(
+        cli, ["context", str(python_simple_repo), "ignored", "--handle", handle]
+    )
+    assert fetched.exit_code == 0, fetched.output
+    parsed = json.loads(fetched.output)
+    assert parsed["route"]["handles_mode"] is True
+    assert parsed["fetch_handles"] == [handle]
+
+
+def test_context_no_model_first_use(python_simple_repo: Path) -> None:
+    """The primary agent path reaches a useful result on a plain, model-free invocation."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["context", str(python_simple_repo), "how does archex score and rank candidates"]
+    )
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert len(parsed["candidate_map"]) > 0
+    assert parsed["receipt"]["freshness"] in {"clean", "unknown"}

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -14,6 +14,7 @@ import pytest
 
 pytest.importorskip("mcp", reason="mcp not installed")
 
+from archex.context_facade import ContextResult, ContextRouteDecision
 from archex.explain import ExplainError
 from archex.graph_artifact import (
     ArchGraph,
@@ -31,6 +32,7 @@ from archex.integrations.mcp import (
     clear_graph_query_cache,
     handle_analyze_repo,
     handle_compare_repos,
+    handle_context,
     handle_explain_target,
     handle_generate_onboarding,
     handle_get_impact,
@@ -59,6 +61,8 @@ from archex.models import (
     TypeDefinition,
 )
 from archex.reporting import count_tokens
+from archex.serve.intent import QueryIntent
+from archex.serve.modality import BudgetTier, QueryModality
 from archex.serve.renderers.xml import render_xml, render_xml_envelope
 
 # ---------------------------------------------------------------------------
@@ -83,6 +87,24 @@ def _make_context_bundle(question: str = "how does auth work?") -> ContextBundle
             context_complete=ContextCompletenessStatus.COMPLETE,
             context_complete_reason=ContextCompletenessReason.COMPLETE,
             recommended_next_action=ContextRecommendedAction.USE_BUNDLE,
+        ),
+    )
+
+
+def _make_context_result(question: str = "how does auth work?") -> ContextResult:
+    return ContextResult(
+        bundle=_make_context_bundle(question),
+        route=ContextRouteDecision(
+            resolved_intent=QueryIntent.GENERAL,
+            intent_source="auto",
+            resolved_modality=QueryModality.NL_TO_PL,
+            resolved_profile=None,
+            profile_source="none",
+            resolved_budget_tier=BudgetTier.STANDARD,
+            token_budget_requested=8000,
+            budget_source="intent_default",
+            handles_mode=False,
+            filters_active=False,
         ),
     )
 
@@ -368,6 +390,100 @@ class TestHandleQueryRepo:
     def test_rejects_invalid_profile_string(self) -> None:
         with pytest.raises(ValueError, match="profile must be one of"):
             handle_query_repo("/fake/repo", "question?", profile="ultra")
+
+
+class TestHandleContext:
+    def test_returns_json_envelope_with_all_six_outputs(self) -> None:
+        result = _make_context_result()
+        with (
+            patch("archex.integrations.mcp.context", return_value=result) as mock_context,
+            patch("archex.integrations.mcp.get_files_token_count", return_value=0),
+        ):
+            output = handle_context("/fake/repo", "how does auth work?")
+        mock_context.assert_called_once()
+        parsed = json.loads(output)
+        for key in (
+            "content",
+            "candidate_map",
+            "fetch_handles",
+            "relation_paths",
+            "route",
+            "receipt",
+            "next_action",
+            "_meta",
+        ):
+            assert key in parsed
+        assert parsed["_meta"]["tool_name"] == "context"
+        assert parsed["_meta"]["strategy"] == "context_facade"
+        assert parsed["receipt"]["index_revision"] == "rev"
+        assert parsed["route"]["resolved_intent"] == "general"
+        assert parsed["next_action"] == "use_bundle"
+
+    def test_markdown_format_returns_rendered_string_content(self) -> None:
+        result = _make_context_result()
+        with (
+            patch("archex.integrations.mcp.context", return_value=result),
+            patch("archex.integrations.mcp.get_files_token_count", return_value=0),
+        ):
+            output = handle_context("/fake/repo", "how does auth work?", output_format="markdown")
+        parsed = json.loads(output)
+        assert isinstance(parsed["content"], str)
+        assert "## Route" in parsed["content"]
+
+    def test_rejects_blank_query(self) -> None:
+        with pytest.raises(ValueError, match="query must not be empty"):
+            handle_context("/fake/repo", "   ")
+
+    def test_rejects_invalid_format(self) -> None:
+        with pytest.raises(ValueError, match="format must be one of"):
+            handle_context("/fake/repo", "question?", output_format="xml")
+
+    def test_rejects_invalid_intent(self) -> None:
+        with pytest.raises(ValueError, match="invalid context request"):
+            handle_context("/fake/repo", "question?", intent="not_a_real_intent")
+
+    def test_rejects_invalid_profile(self) -> None:
+        with pytest.raises(ValueError, match="invalid context request"):
+            handle_context("/fake/repo", "question?", profile="ultra")
+
+    def test_rejects_non_positive_budget(self) -> None:
+        with pytest.raises(ValueError, match="invalid context request"):
+            handle_context("/fake/repo", "question?", budgets={"token_budget": 0})
+
+    def test_passes_request_fields_through_to_context(self) -> None:
+        result = _make_context_result()
+        with (
+            patch("archex.integrations.mcp.context", return_value=result) as mock_context,
+            patch("archex.integrations.mcp.get_files_token_count", return_value=0),
+        ):
+            handle_context(
+                "/fake/repo",
+                "question?",
+                intent="debugging",
+                profile="fast",
+                filters={"include_paths": ["src/**"], "languages": ["python"]},
+                budgets={"token_budget": 2048},
+                handles=["chunk:a.py:1"],
+            )
+        request = mock_context.call_args.args[1]
+        assert request.query == "question?"
+        assert request.intent == QueryIntent.DEBUGGING
+        assert request.filters.include_paths == ["src/**"]
+        assert request.filters.languages == ["python"]
+        assert request.budgets.token_budget == 2048
+        assert request.handles == ["chunk:a.py:1"]
+
+    def test_records_metrics_under_context_tool_name(self) -> None:
+        result = _make_context_result()
+        with (
+            patch("archex.integrations.mcp.context", return_value=result),
+            patch("archex.integrations.mcp.get_files_token_count", return_value=0),
+            patch("archex.integrations.mcp.record_query_usage") as mock_record,
+            patch("archex.integrations.mcp.resolve_metrics_policy") as mock_policy,
+        ):
+            mock_policy.return_value.metrics_enabled = True
+            handle_context("/fake/repo", "how does auth work?")
+        assert mock_record.call_args.kwargs["tool_name"] == "context"
 
 
 class TestHandleScoutRepo:
@@ -799,7 +915,7 @@ class TestBuildServer:
         server_result = await handler(req)
         result = server_result.root
         assert isinstance(result, mcp_types.ListToolsResult)
-        assert len(result.tools) == 17
+        assert len(result.tools) == 18
         tool_names = {t.name for t in result.tools}
         assert "scout_repo" in tool_names
         assert "get_file_tree" in tool_names
@@ -811,6 +927,7 @@ class TestBuildServer:
         assert "get_impact" in tool_names
         assert "explain_target" in tool_names
         assert "generate_onboarding" in tool_names
+        assert "context" in tool_names
 
     @pytest.mark.asyncio
     async def test_call_tool_query_repo_passes_explicit_runtime_to_handler(self) -> None:
@@ -1545,3 +1662,73 @@ class TestHandleGenerateOnboarding:
 
         with pytest.raises(OnboardingError, match="max-files must be greater than zero"):
             handle_generate_onboarding(str(python_simple_repo), max_files=0)
+
+
+class TestHandleContextEndToEnd:
+    """Unmocked context() facade exercised through the real MCP dispatch path."""
+
+    def test_matches_cli_output_for_json(self, python_simple_repo: Path) -> None:
+        from click.testing import CliRunner
+
+        from archex.cli.main import cli
+
+        runner = CliRunner()
+        cli_result = runner.invoke(
+            cli, ["context", str(python_simple_repo), "how does authentication work?"]
+        )
+        assert cli_result.exit_code == 0, cli_result.output
+        cli_data = json.loads(cli_result.output)
+
+        mcp_result = handle_context(str(python_simple_repo), "how does authentication work?")
+        envelope = json.loads(mcp_result)
+
+        assert envelope["fetch_handles"] == cli_data["fetch_handles"]
+        assert [item["handle"] for item in envelope["candidate_map"]] == [
+            item["handle"] for item in cli_data["candidate_map"]
+        ]
+        assert envelope["route"]["resolved_intent"] == cli_data["route"]["resolved_intent"]
+
+    @pytest.mark.asyncio
+    async def test_stable_handle_round_trip_through_call_tool_dispatch(
+        self, python_simple_repo: Path
+    ) -> None:
+        """A handle returned by one `context` MCP call fetches the exact same
+        chunk on a second `context` call routed through the real dispatch
+        path — no broad search re-run."""
+        server = build_server()
+        from mcp import types as mcp_types
+
+        handler = server.request_handlers[mcp_types.CallToolRequest]
+        list_handler = server.request_handlers[mcp_types.ListToolsRequest]
+        await list_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
+
+        def _call(query: str, handles: list[str] | None = None) -> mcp_types.CallToolRequest:
+            arguments: dict[str, object] = {
+                "repo_url": str(python_simple_repo),
+                "query": query,
+            }
+            if handles is not None:
+                arguments["handles"] = handles
+            return mcp_types.CallToolRequest(
+                method="tools/call",
+                params=mcp_types.CallToolRequestParams(name="context", arguments=arguments),
+            )
+
+        first = (await handler(_call("how does authentication work?"))).root
+        assert isinstance(first, mcp_types.CallToolResult)
+        first_envelope = json.loads(first.content[0].text)  # type: ignore[union-attr]
+        handle = first_envelope["fetch_handles"][0]
+        expected_chunk = next(
+            item for item in first_envelope["content"] if item["chunk"]["id"] in handle
+        )
+
+        second = (await handler(_call("ignored query text", handles=[handle]))).root
+        assert isinstance(second, mcp_types.CallToolResult)
+        second_envelope = json.loads(second.content[0].text)  # type: ignore[union-attr]
+
+        assert second_envelope["route"]["handles_mode"] is True
+        assert second_envelope["fetch_handles"] == [handle]
+        assert len(second_envelope["content"]) == 1
+        assert (
+            second_envelope["content"][0]["chunk"]["content"] == expected_chunk["chunk"]["content"]
+        )


### PR DESCRIPTION
## Stack

Stack-Id: `m10-context-facade`
Base: `m10-1-facade-contract` (#537)
Position: 2/3

1. `m10-1-facade-contract` -> #537
2. `m10-2-surfaces-handles` -> this PR
3. `m10-3-adoption-smoke` -> (next)

Depends on: #537
Upstack: PR-3 (adoption docs/smoke)

## Summary

M10: surfaces `context()` on the CLI and MCP, both built on PR-1's
`ContextRequest`/`ContextResult` contract, so both surfaces speak
identical field names.

- **CLI**: `archex context <source> <question>` — `--intent`/`--profile`/
  `--include`/`--exclude`/`--language`/`--budget`/`--handle` map directly
  onto `ContextRequest`. `--format json` (default) emits a flat envelope
  (`content`, `candidate_map`, `fetch_handles`, `relation_paths`, `route`,
  `receipt`, `next_action`); `--format markdown` renders
  `render_context_markdown()`.
- **MCP**: new `context` tool (18th tool, `repo_url`/`query`/`intent`/
  `profile`/`filters`/`budgets`/`handles`/`format`), envelope shape matches
  the CLI. `_record_query_metrics()` now takes an explicit `tool_name` so
  `context` records under its own metrics name instead of borrowing
  `query_repo`'s; `"context"` is registered in the metrics
  context-retrieval category.
- Existing `query`/`scout`/`symbol`/`compare` CLI commands and
  `query_repo`/`scout_repo`/`compare_repos`/... MCP tools are unchanged —
  verified by an unmocked CLI-vs-MCP output-parity test and the existing
  17-tool suite staying green (now 18).
- **Stable handles across surfaces**: an unmocked test drives the real MCP
  `call_tool` dispatch twice — first a broad `context` call, then a second
  `context` call passing back one of its `fetch_handles` — and asserts the
  second call returns the exact same chunk content with `handles_mode:
  true`, with no broad search re-run.

## Validation

```
uv run ruff check .            # All checks passed!
uv run ruff format --check .   # 402 files already formatted
uv run pyright .               # 0 errors, 0 warnings, 0 informations
uv run pytest tests/integrations/test_mcp.py tests/cli/ --no-cov -q
# 246 passed
```

Manual smoke:
```
archex context <repo> "how does authentication work?" --format markdown
archex context <repo> "..." --format json --exclude utils.py   # filter
archex context <repo> "..." --format json --handle chunk:...   # exact fetch
```