### PR TITLE
feat(cli): add report diff JSON and Markdown

### DIFF
--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -23,6 +23,7 @@ from archex.cli.metrics_cmd import metrics_cmd
 from archex.cli.onboard_cmd import onboard_cmd
 from archex.cli.outline_cmd import outline_cmd
 from archex.cli.query_cmd import query_cmd
+from archex.cli.report_cmd import report_cmd
 from archex.cli.reset_cmd import reset_cmd
 from archex.cli.scout_cmd import scout_cmd
 from archex.cli.setup_cmd import setup_cmd
@@ -63,6 +64,7 @@ cli.add_command(graph_cmd)
 cli.add_command(explain_cmd)
 cli.add_command(impact_cmd)
 cli.add_command(onboard_cmd)
+cli.add_command(report_cmd)
 
 
 if __name__ == "__main__":

--- a/src/archex/cli/report_cmd.py
+++ b/src/archex/cli/report_cmd.py
@@ -1,0 +1,39 @@
+"""Report command group: read-only diff-review artifact projections."""
+
+from __future__ import annotations
+
+import click
+
+from archex.exceptions import ArchexError
+from archex.report.artifact import ReportArtifactError, build_analysis_artifact
+
+
+@click.group("report")
+def report_cmd() -> None:
+    """Read-only diff-review artifact projections."""
+
+
+@report_cmd.command("diff")
+@click.argument("source", required=False, default=".")
+@click.option("--base", default="main", help="Base ref to diff against.")
+@click.option(
+    "--format",
+    "output_format",
+    default="markdown",
+    type=click.Choice(["json", "markdown"]),
+    help="Output format.",
+)
+def diff_cmd(source: str, base: str, output_format: str) -> None:
+    """Build and render the canonical AnalysisArtifactV1 diff-review artifact for SOURCE."""
+    try:
+        artifact = build_analysis_artifact(source, base_ref=base)
+    except (ArchexError, ReportArtifactError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if output_format == "json":
+        click.echo(artifact.to_json())
+        return
+
+    from archex.report.render_markdown import render_markdown
+
+    click.echo(render_markdown(artifact), nl=False)

--- a/src/archex/report/artifact.py
+++ b/src/archex/report/artifact.py
@@ -149,7 +149,16 @@ class SymbolCandidate(BaseModel):
 
 
 class InterfaceCandidate(BaseModel):
+    """A public interface symbol touched by the diff.
+
+    `archex.impact._public_interfaces` returns composite
+    `path::qualified_name#kind` strings -- the same shape as
+    `CodeChunk.symbol_id` -- so `path` here is the file path extracted
+    from that identifier, not the identifier itself.
+    """
+
     path: str
+    symbol_id: str
     handle: str
     confidence: AnalysisConfidence = AnalysisConfidence.HIGH
     evidence: list[EvidenceLocation] = []
@@ -374,6 +383,21 @@ def _parser_versions_for_changes(changes: list[ImpactFileChange]) -> dict[str, s
     return versions
 
 
+def _interface_candidate(symbol_id: str) -> InterfaceCandidate:
+    file_path = symbol_id.split("::", 1)[0]
+    handle = symbol_handle(symbol_id)
+    return InterfaceCandidate(
+        path=file_path,
+        symbol_id=symbol_id,
+        handle=handle,
+        evidence=[
+            EvidenceLocation(
+                path=file_path, handle=handle, description="public interface symbol changed"
+            )
+        ],
+    )
+
+
 def _symbol_candidate(impact: SymbolImpact, chunk: CodeChunk | None) -> SymbolCandidate:
     if chunk is not None and chunk.symbol_id is not None:
         handle = symbol_handle(chunk.symbol_id)
@@ -445,12 +469,7 @@ def _build_diff_analysis(
     symbol_candidates = symbol_candidates[:MAX_SYMBOL_CANDIDATES]
 
     affected_interfaces = [
-        InterfaceCandidate(
-            path=path,
-            handle=file_handle(path),
-            evidence=[EvidenceLocation(path=path, description="public interface symbol changed")],
-        )
-        for path in report.affected_interfaces
+        _interface_candidate(symbol_id) for symbol_id in report.affected_interfaces
     ]
     interfaces_total = len(affected_interfaces)
     affected_interfaces = affected_interfaces[:MAX_INTERFACE_CANDIDATES]

--- a/src/archex/report/render_markdown.py
+++ b/src/archex/report/render_markdown.py
@@ -1,9 +1,8 @@
-"""Markdown + Mermaid rendering for AnalysisArtifactV1.
+"""Markdown rendering for AnalysisArtifactV1.
 
 A pure projection: every value rendered here already exists on the
 artifact. This module adds no analysis, no source text, and no network
-calls -- only markdown formatting and a bounded Mermaid flowchart sketch
-of the diff's changed-file/symbol-candidate structure.
+calls -- only markdown formatting.
 """
 
 from __future__ import annotations
@@ -11,14 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from archex.report.artifact import AnalysisArtifactV1, SymbolCandidate
-
-# Independent of the artifact's own MAX_* bounds: a Mermaid diagram stays
-# readable only at a much smaller scale than the canonical JSON payload.
-MAX_MERMAID_FILE_NODES = 20
-MAX_MERMAID_SYMBOL_NODES = 40
-
-_RISK_ORDER = {"low": 0, "medium": 1, "high": 2}
+    from archex.report.artifact import AnalysisArtifactV1
 
 
 def render_markdown(artifact: AnalysisArtifactV1) -> str:
@@ -28,8 +20,6 @@ def render_markdown(artifact: AnalysisArtifactV1) -> str:
         *_provenance_section(artifact),
         "",
         *_summary_section(artifact),
-        "",
-        *_mermaid_section(artifact),
         "",
         *_changed_files_section(artifact),
         "",
@@ -161,78 +151,3 @@ def _path_list_section(title: str, paths: list[str], total: int) -> list[str]:
             f"entr{'y' if total - len(paths) == 1 else 'ies'} omitted_"
         )
     return lines
-
-
-def _mermaid_section(artifact: AnalysisArtifactV1) -> list[str]:
-    diagram = render_mermaid(artifact)
-    if diagram is None:
-        return ["## Structure", "", "_No changed files to diagram._"]
-    return ["## Structure", "", "```mermaid", diagram, "```"]
-
-
-def render_mermaid(artifact: AnalysisArtifactV1) -> str | None:
-    """Render a bounded flowchart of changed files and their symbol risk candidates.
-
-    A pure sketch of data already on the artifact -- no graph edges are
-    constructed here; `-->` links only mirror each symbol candidate's
-    already-known `file_path`.
-    """
-    changed_files = artifact.diff.changed_files[:MAX_MERMAID_FILE_NODES]
-    if not changed_files:
-        return None
-
-    candidates_by_file: dict[str, list[SymbolCandidate]] = {}
-    for candidate in artifact.diff.symbol_candidates:
-        candidates_by_file.setdefault(candidate.file_path, []).append(candidate)
-
-    lines = [
-        "flowchart TD",
-        "    classDef high fill:#f66,stroke:#900,color:#200",
-        "    classDef medium fill:#fc6,stroke:#960,color:#320",
-        "    classDef low fill:#9c6,stroke:#360,color:#130",
-        "    classDef unknown fill:#eee,stroke:#999,color:#333",
-    ]
-
-    node_ids: dict[str, str] = {}
-    symbol_node_count = 0
-
-    def _node_id(key: str) -> str:
-        if key not in node_ids:
-            node_ids[key] = f"n{len(node_ids)}"
-        return node_ids[key]
-
-    for change in changed_files:
-        file_key = f"file:{change.path}"
-        file_id = _node_id(file_key)
-        file_risk = _max_risk(candidates_by_file.get(change.path, []))
-        lines.append(f'    {file_id}["{_escape_label(change.path)}"]:::{file_risk}')
-
-        for candidate in candidates_by_file.get(change.path, []):
-            if symbol_node_count >= MAX_MERMAID_SYMBOL_NODES:
-                break
-            symbol_key = f"symbol:{candidate.handle}"
-            symbol_id = _node_id(symbol_key)
-            label = candidate.qualified_name or candidate.symbol_name or "<unnamed>"
-            lines.append(f'    {symbol_id}["{_escape_label(label)}"]:::{candidate.risk_level}')
-            lines.append(f"    {file_id} --> {symbol_id}")
-            symbol_node_count += 1
-
-    omitted_files = artifact.diff.changed_files_total - len(changed_files)
-    if omitted_files > 0:
-        note_id = _node_id("note:omitted")
-        lines.append(f'    {note_id}["+{omitted_files} more changed file(s)"]:::unknown')
-
-    return "\n".join(lines)
-
-
-def _max_risk(candidates: list[SymbolCandidate]) -> str:
-    if not candidates:
-        return "unknown"
-    return max(
-        (candidate.risk_level for candidate in candidates),
-        key=lambda level: _RISK_ORDER.get(level, 0),
-    )
-
-
-def _escape_label(text: str) -> str:
-    return text.replace("\\", "\\\\").replace('"', "&quot;").replace("\n", " ")

--- a/src/archex/report/render_markdown.py
+++ b/src/archex/report/render_markdown.py
@@ -1,0 +1,238 @@
+"""Markdown + Mermaid rendering for AnalysisArtifactV1.
+
+A pure projection: every value rendered here already exists on the
+artifact. This module adds no analysis, no source text, and no network
+calls -- only markdown formatting and a bounded Mermaid flowchart sketch
+of the diff's changed-file/symbol-candidate structure.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from archex.report.artifact import AnalysisArtifactV1, SymbolCandidate
+
+# Independent of the artifact's own MAX_* bounds: a Mermaid diagram stays
+# readable only at a much smaller scale than the canonical JSON payload.
+MAX_MERMAID_FILE_NODES = 20
+MAX_MERMAID_SYMBOL_NODES = 40
+
+_RISK_ORDER = {"low": 0, "medium": 1, "high": 2}
+
+
+def render_markdown(artifact: AnalysisArtifactV1) -> str:
+    lines: list[str] = [
+        f"# Diff Review: {artifact.source_identity}",
+        "",
+        *_provenance_section(artifact),
+        "",
+        *_summary_section(artifact),
+        "",
+        *_mermaid_section(artifact),
+        "",
+        *_changed_files_section(artifact),
+        "",
+        *_symbol_candidates_section(artifact),
+        "",
+        *_path_list_section(
+            "Affected Public Interfaces",
+            [candidate.path for candidate in artifact.diff.affected_interfaces],
+            artifact.diff.affected_interfaces_total,
+        ),
+        "",
+        *_path_list_section(
+            "Test Candidates",
+            [candidate.path for candidate in artifact.diff.test_candidates],
+            artifact.diff.test_candidates_total,
+        ),
+        "",
+        *_path_list_section(
+            "Unsupported Files",
+            [item.path for item in artifact.diff.unsupported_files],
+            artifact.diff.unsupported_files_total,
+        ),
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _provenance_section(artifact: AnalysisArtifactV1) -> list[str]:
+    return [
+        "## Provenance",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| Schema version | `{artifact.schema_version.value}` |",
+        f"| archex version | `{artifact.archex_version}` |",
+        f"| Base ref | `{artifact.diff.base_ref}` "
+        f"(`{artifact.diff.base_resolved_sha or 'unresolved'}`) |",
+        f"| Head revision | `{artifact.diff.head_ref or 'unknown'}` |",
+        f"| Index generation | `{artifact.index_generation or 'unknown'}` |",
+        f"| Freshness | `{artifact.freshness.value}` |",
+        f"| Completeness | `{artifact.completeness.value}` |",
+        f"| Confidence | `{artifact.confidence.value}` |",
+        f"| Redaction | `{artifact.redaction_mode.value}` |",
+        f"| Generated at | `{artifact.generated_at}` |",
+    ]
+
+
+def _summary_section(artifact: AnalysisArtifactV1) -> list[str]:
+    diff = artifact.diff
+    lines = [
+        "## Summary",
+        "",
+        f"- **Risk:** `{diff.risk_level.value}`",
+        f"- **Changed files:** {diff.changed_files_total}",
+        f"- **Symbol candidates:** {diff.symbol_candidates_total}",
+        f"- **Affected interfaces:** {diff.affected_interfaces_total}",
+        f"- **Test candidates:** {diff.test_candidates_total}",
+        f"- **Unsupported files:** {diff.unsupported_files_total}",
+    ]
+    if diff.risk_reasons:
+        lines.append(
+            f"- **Risk reasons:** {', '.join(f'`{reason}`' for reason in diff.risk_reasons)}"
+        )
+    if artifact.excluded_counts:
+        excluded = ", ".join(
+            f"{key}={value}" for key, value in sorted(artifact.excluded_counts.items())
+        )
+        lines.append(f"- **Excluded:** {excluded}")
+    if artifact.unknown_counts:
+        unknown = ", ".join(
+            f"{key}={value}" for key, value in sorted(artifact.unknown_counts.items())
+        )
+        lines.append(f"- **Unknown:** {unknown}")
+    return lines
+
+
+def _changed_files_section(artifact: AnalysisArtifactV1) -> list[str]:
+    lines = [
+        "## Changed Files",
+        "",
+        "| Status | Path | Hunks | Handle |",
+        "| --- | --- | --- | --- |",
+    ]
+    for change in artifact.diff.changed_files:
+        hunks = ", ".join(f"{hunk.start_line}-{hunk.end_line}" for hunk in change.hunks) or "-"
+        lines.append(f"| `{change.status}` | `{change.path}` | {hunks} | `{change.handle}` |")
+    if not artifact.diff.changed_files:
+        lines.append("| - | _none_ | - | - |")
+    if artifact.diff.changed_files_total > len(artifact.diff.changed_files):
+        remaining = artifact.diff.changed_files_total - len(artifact.diff.changed_files)
+        lines.append("")
+        lines.append(f"_{remaining} additional changed file(s) omitted; see the JSON artifact._")
+    return lines
+
+
+def _symbol_candidates_section(artifact: AnalysisArtifactV1) -> list[str]:
+    lines = [
+        "## Symbol Risk Candidates",
+        "",
+        "| Risk | Confidence | Symbol | File | Lines | Handle |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for candidate in artifact.diff.symbol_candidates:
+        label = candidate.qualified_name or candidate.symbol_name or "<unnamed>"
+        lines.append(
+            f"| `{candidate.risk_level}` | `{candidate.confidence.value}` | `{label}` | "
+            f"`{candidate.file_path}` | {candidate.start_line}-{candidate.end_line} | "
+            f"`{candidate.handle}` |"
+        )
+    if not artifact.diff.symbol_candidates:
+        lines.append("| - | - | _none_ | - | - | - |")
+    if artifact.diff.symbol_candidates_total > len(artifact.diff.symbol_candidates):
+        remaining = artifact.diff.symbol_candidates_total - len(artifact.diff.symbol_candidates)
+        lines.append("")
+        lines.append(
+            f"_{remaining} additional symbol candidate(s) omitted; see the JSON artifact._"
+        )
+    return lines
+
+
+def _path_list_section(title: str, paths: list[str], total: int) -> list[str]:
+    lines = [f"## {title}", ""]
+    if not paths:
+        lines.append("- None")
+        return lines
+    lines.extend(f"- `{path}`" for path in paths)
+    if total > len(paths):
+        lines.append(
+            f"- _{total - len(paths)} additional "
+            f"entr{'y' if total - len(paths) == 1 else 'ies'} omitted_"
+        )
+    return lines
+
+
+def _mermaid_section(artifact: AnalysisArtifactV1) -> list[str]:
+    diagram = render_mermaid(artifact)
+    if diagram is None:
+        return ["## Structure", "", "_No changed files to diagram._"]
+    return ["## Structure", "", "```mermaid", diagram, "```"]
+
+
+def render_mermaid(artifact: AnalysisArtifactV1) -> str | None:
+    """Render a bounded flowchart of changed files and their symbol risk candidates.
+
+    A pure sketch of data already on the artifact -- no graph edges are
+    constructed here; `-->` links only mirror each symbol candidate's
+    already-known `file_path`.
+    """
+    changed_files = artifact.diff.changed_files[:MAX_MERMAID_FILE_NODES]
+    if not changed_files:
+        return None
+
+    candidates_by_file: dict[str, list[SymbolCandidate]] = {}
+    for candidate in artifact.diff.symbol_candidates:
+        candidates_by_file.setdefault(candidate.file_path, []).append(candidate)
+
+    lines = [
+        "flowchart TD",
+        "    classDef high fill:#f66,stroke:#900,color:#200",
+        "    classDef medium fill:#fc6,stroke:#960,color:#320",
+        "    classDef low fill:#9c6,stroke:#360,color:#130",
+        "    classDef unknown fill:#eee,stroke:#999,color:#333",
+    ]
+
+    node_ids: dict[str, str] = {}
+    symbol_node_count = 0
+
+    def _node_id(key: str) -> str:
+        if key not in node_ids:
+            node_ids[key] = f"n{len(node_ids)}"
+        return node_ids[key]
+
+    for change in changed_files:
+        file_key = f"file:{change.path}"
+        file_id = _node_id(file_key)
+        file_risk = _max_risk(candidates_by_file.get(change.path, []))
+        lines.append(f'    {file_id}["{_escape_label(change.path)}"]:::{file_risk}')
+
+        for candidate in candidates_by_file.get(change.path, []):
+            if symbol_node_count >= MAX_MERMAID_SYMBOL_NODES:
+                break
+            symbol_key = f"symbol:{candidate.handle}"
+            symbol_id = _node_id(symbol_key)
+            label = candidate.qualified_name or candidate.symbol_name or "<unnamed>"
+            lines.append(f'    {symbol_id}["{_escape_label(label)}"]:::{candidate.risk_level}')
+            lines.append(f"    {file_id} --> {symbol_id}")
+            symbol_node_count += 1
+
+    omitted_files = artifact.diff.changed_files_total - len(changed_files)
+    if omitted_files > 0:
+        note_id = _node_id("note:omitted")
+        lines.append(f'    {note_id}["+{omitted_files} more changed file(s)"]:::unknown')
+
+    return "\n".join(lines)
+
+
+def _max_risk(candidates: list[SymbolCandidate]) -> str:
+    if not candidates:
+        return "unknown"
+    return max(
+        (candidate.risk_level for candidate in candidates),
+        key=lambda level: _RISK_ORDER.get(level, 0),
+    )
+
+
+def _escape_label(text: str) -> str:
+    return text.replace("\\", "\\\\").replace('"', "&quot;").replace("\n", " ")

--- a/src/archex/report/render_markdown.py
+++ b/src/archex/report/render_markdown.py
@@ -1,8 +1,9 @@
-"""Markdown rendering for AnalysisArtifactV1.
+"""Markdown + Mermaid rendering for AnalysisArtifactV1.
 
 A pure projection: every value rendered here already exists on the
 artifact. This module adds no analysis, no source text, and no network
-calls -- only markdown formatting.
+calls -- only markdown formatting and a bounded Mermaid flowchart sketch
+of the diff's changed-file/symbol-candidate structure.
 """
 
 from __future__ import annotations
@@ -10,7 +11,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from archex.report.artifact import AnalysisArtifactV1
+    from archex.report.artifact import AnalysisArtifactV1, SymbolCandidate
+
+# Independent of the artifact's own MAX_* bounds: a Mermaid diagram stays
+# readable only at a much smaller scale than the canonical JSON payload.
+MAX_MERMAID_FILE_NODES = 20
+MAX_MERMAID_SYMBOL_NODES = 40
+
+_RISK_ORDER = {"low": 0, "medium": 1, "high": 2}
 
 
 def render_markdown(artifact: AnalysisArtifactV1) -> str:
@@ -20,6 +28,8 @@ def render_markdown(artifact: AnalysisArtifactV1) -> str:
         *_provenance_section(artifact),
         "",
         *_summary_section(artifact),
+        "",
+        *_mermaid_section(artifact),
         "",
         *_changed_files_section(artifact),
         "",
@@ -151,3 +161,78 @@ def _path_list_section(title: str, paths: list[str], total: int) -> list[str]:
             f"entr{'y' if total - len(paths) == 1 else 'ies'} omitted_"
         )
     return lines
+
+
+def _mermaid_section(artifact: AnalysisArtifactV1) -> list[str]:
+    diagram = render_mermaid(artifact)
+    if diagram is None:
+        return ["## Structure", "", "_No changed files to diagram._"]
+    return ["## Structure", "", "```mermaid", diagram, "```"]
+
+
+def render_mermaid(artifact: AnalysisArtifactV1) -> str | None:
+    """Render a bounded flowchart of changed files and their symbol risk candidates.
+
+    A pure sketch of data already on the artifact -- no graph edges are
+    constructed here; `-->` links only mirror each symbol candidate's
+    already-known `file_path`.
+    """
+    changed_files = artifact.diff.changed_files[:MAX_MERMAID_FILE_NODES]
+    if not changed_files:
+        return None
+
+    candidates_by_file: dict[str, list[SymbolCandidate]] = {}
+    for candidate in artifact.diff.symbol_candidates:
+        candidates_by_file.setdefault(candidate.file_path, []).append(candidate)
+
+    lines = [
+        "flowchart TD",
+        "    classDef high fill:#f66,stroke:#900,color:#200",
+        "    classDef medium fill:#fc6,stroke:#960,color:#320",
+        "    classDef low fill:#9c6,stroke:#360,color:#130",
+        "    classDef unknown fill:#eee,stroke:#999,color:#333",
+    ]
+
+    node_ids: dict[str, str] = {}
+    symbol_node_count = 0
+
+    def _node_id(key: str) -> str:
+        if key not in node_ids:
+            node_ids[key] = f"n{len(node_ids)}"
+        return node_ids[key]
+
+    for change in changed_files:
+        file_key = f"file:{change.path}"
+        file_id = _node_id(file_key)
+        file_risk = _max_risk(candidates_by_file.get(change.path, []))
+        lines.append(f'    {file_id}["{_escape_label(change.path)}"]:::{file_risk}')
+
+        for candidate in candidates_by_file.get(change.path, []):
+            if symbol_node_count >= MAX_MERMAID_SYMBOL_NODES:
+                break
+            symbol_key = f"symbol:{candidate.handle}"
+            symbol_id = _node_id(symbol_key)
+            label = candidate.qualified_name or candidate.symbol_name or "<unnamed>"
+            lines.append(f'    {symbol_id}["{_escape_label(label)}"]:::{candidate.risk_level}')
+            lines.append(f"    {file_id} --> {symbol_id}")
+            symbol_node_count += 1
+
+    omitted_files = artifact.diff.changed_files_total - len(changed_files)
+    if omitted_files > 0:
+        note_id = _node_id("note:omitted")
+        lines.append(f'    {note_id}["+{omitted_files} more changed file(s)"]:::unknown')
+
+    return "\n".join(lines)
+
+
+def _max_risk(candidates: list[SymbolCandidate]) -> str:
+    if not candidates:
+        return "unknown"
+    return max(
+        (candidate.risk_level for candidate in candidates),
+        key=lambda level: _RISK_ORDER.get(level, 0),
+    )
+
+
+def _escape_label(text: str) -> str:
+    return text.replace("\\", "\\\\").replace('"', "&quot;").replace("\n", " ")

--- a/tests/test_report_artifact.py
+++ b/tests/test_report_artifact.py
@@ -84,6 +84,20 @@ def test_build_analysis_artifact_reports_diff_symbol_risk(impact_diff_repo: Path
     assert "high_fan_in" in artifact.diff.risk_reasons
 
 
+def test_interface_candidates_carry_resolvable_symbol_handles(impact_diff_repo: Path) -> None:
+    _edit_hub(impact_diff_repo)
+
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+
+    assert artifact.diff.affected_interfaces_total >= 1
+    interface = next(
+        c for c in artifact.diff.affected_interfaces if c.symbol_id.startswith("hub.py::")
+    )
+    assert interface.path == "hub.py"
+    assert interface.handle == f"symbol:{interface.symbol_id}"
+    assert "::" not in interface.path
+
+
 def test_fully_unmapped_diff_is_low_confidence(impact_diff_repo: Path) -> None:
     new_file = impact_diff_repo / "notes.bin"
     new_file.write_bytes(b"\x00\x01binary-blob")

--- a/tests/test_report_cli.py
+++ b/tests/test_report_cli.py
@@ -38,6 +38,7 @@ def test_report_diff_markdown_is_default_format(impact_diff_repo: Path) -> None:
 
     assert result.exit_code == 0, result.output
     assert result.output.startswith("# Diff Review:")
+    assert "```mermaid" in result.output
 
 
 def test_report_diff_html_format_not_yet_supported(impact_diff_repo: Path) -> None:

--- a/tests/test_report_cli.py
+++ b/tests/test_report_cli.py
@@ -1,0 +1,78 @@
+"""CLI tests for `archex report diff`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+
+
+def _edit_hub(repo: Path) -> None:
+    hub = repo / "hub.py"
+    hub.write_text(hub.read_text().replace("value * 2", "value * 3"))
+
+
+def test_report_diff_json_matches_artifact_schema(impact_diff_repo: Path) -> None:
+    _edit_hub(impact_diff_repo)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli, ["report", "diff", str(impact_diff_repo), "--base", "HEAD", "--format", "json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["schema_version"]["value"] == "1.0.0"
+    assert data["diff"]["changed_files_total"] == 1
+    assert data["diff"]["changed_files"][0]["path"] == "hub.py"
+
+
+def test_report_diff_markdown_is_default_format(impact_diff_repo: Path) -> None:
+    _edit_hub(impact_diff_repo)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["report", "diff", str(impact_diff_repo), "--base", "HEAD"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.startswith("# Diff Review:")
+
+
+def test_report_diff_html_format_not_yet_supported(impact_diff_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli, ["report", "diff", str(impact_diff_repo), "--base", "HEAD", "--format", "html"]
+    )
+
+    assert result.exit_code != 0
+    assert "html" in result.output.lower()
+
+
+def test_report_diff_invalid_base_ref_is_a_clean_cli_error(impact_diff_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli, ["report", "diff", str(impact_diff_repo), "--base", "not-a-real-ref"]
+    )
+
+    assert result.exit_code != 0
+    assert "not-a-real-ref" in result.output
+
+
+def test_report_diff_no_network_access_required(impact_diff_repo: Path) -> None:
+    """Smoke check that report diff against a local-only fixture repo succeeds offline.
+
+    `impact_diff_repo` has no remote configured; a passing run without
+    network mocking demonstrates the command performs no remote fetch.
+    """
+    _edit_hub(impact_diff_repo)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli, ["report", "diff", str(impact_diff_repo), "--base", "HEAD", "--format", "json"]
+    )
+
+    assert result.exit_code == 0, result.output

--- a/tests/test_report_render_markdown.py
+++ b/tests/test_report_render_markdown.py
@@ -1,0 +1,58 @@
+"""Renderer-parity tests for the Markdown AnalysisArtifactV1 projection.
+
+Every value asserted here must already exist on the artifact under test --
+these tests catch a renderer inventing, dropping, or mislabeling data, not
+new analysis.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from archex.report.artifact import build_analysis_artifact
+from archex.report.render_markdown import render_markdown
+
+
+def _edit_hub(repo: Path) -> None:
+    hub = repo / "hub.py"
+    hub.write_text(hub.read_text().replace("value * 2", "value * 3"))
+
+
+def test_render_markdown_preserves_provenance_and_handles(impact_diff_repo: Path) -> None:
+    _edit_hub(impact_diff_repo)
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+
+    markdown = render_markdown(artifact)
+
+    assert f"# Diff Review: {artifact.source_identity}" in markdown
+    assert f"`{artifact.schema_version.value}`" in markdown
+    assert f"`{artifact.diff.base_ref}`" in markdown
+    assert f"`{artifact.diff.base_resolved_sha}`" in markdown
+    assert "`file:hub.py`" in markdown
+    shared_helper = next(
+        c for c in artifact.diff.symbol_candidates if c.symbol_name == "shared_helper"
+    )
+    assert f"`{shared_helper.handle}`" in markdown
+    assert f"`{artifact.diff.risk_level.value}`" in markdown
+
+
+def test_render_markdown_never_embeds_raw_source_text(impact_diff_repo: Path) -> None:
+    _edit_hub(impact_diff_repo)
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+
+    markdown = render_markdown(artifact)
+
+    # The edited line's literal source text must never appear -- only
+    # path/line/symbol identity, per the artifact's structural redaction.
+    assert "value * 3" not in markdown
+    assert "return value" not in markdown
+
+
+def test_render_markdown_reports_none_for_empty_sections(impact_diff_repo: Path) -> None:
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+
+    markdown = render_markdown(artifact)
+
+    assert "_none_" in markdown or "| - | _none_ | - | - |" in markdown
+    assert "## Affected Public Interfaces" in markdown
+    assert "- None" in markdown

--- a/tests/test_report_render_markdown.py
+++ b/tests/test_report_render_markdown.py
@@ -1,4 +1,4 @@
-"""Renderer-parity tests for the Markdown AnalysisArtifactV1 projection.
+"""Renderer-parity tests for the Markdown + Mermaid AnalysisArtifactV1 projection.
 
 Every value asserted here must already exist on the artifact under test --
 these tests catch a renderer inventing, dropping, or mislabeling data, not
@@ -7,10 +7,15 @@ new analysis.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 from archex.report.artifact import build_analysis_artifact
-from archex.report.render_markdown import render_markdown
+from archex.report.render_markdown import (
+    MAX_MERMAID_FILE_NODES,
+    render_markdown,
+    render_mermaid,
+)
 
 
 def _edit_hub(repo: Path) -> None:
@@ -56,3 +61,52 @@ def test_render_markdown_reports_none_for_empty_sections(impact_diff_repo: Path)
     assert "_none_" in markdown or "| - | _none_ | - | - |" in markdown
     assert "## Affected Public Interfaces" in markdown
     assert "- None" in markdown
+
+
+def test_render_mermaid_none_for_empty_diff(impact_diff_repo: Path) -> None:
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+
+    assert render_mermaid(artifact) is None
+    assert "_No changed files to diagram._" in render_markdown(artifact)
+
+
+def test_render_mermaid_colors_nodes_by_risk_tier(impact_diff_repo: Path) -> None:
+    _edit_hub(impact_diff_repo)
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+
+    diagram = render_mermaid(artifact)
+
+    assert diagram is not None
+    assert diagram.startswith("flowchart TD")
+    assert '["hub.py"]:::high' in diagram
+    assert '["shared_helper"]:::high' in diagram
+    assert "-->" in diagram
+
+
+def test_render_mermaid_escapes_special_characters_in_labels(impact_diff_repo: Path) -> None:
+    weird = impact_diff_repo / 'weird "quoted".py'
+    weird.write_text("def f():\n    return 1\n")
+    subprocess.run(
+        ["git", "add", weird.name], cwd=impact_diff_repo, check=True, capture_output=True
+    )
+
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+    diagram = render_mermaid(artifact)
+
+    assert diagram is not None
+    assert '\\"' not in diagram
+    assert "&quot;" in diagram
+
+
+def test_render_mermaid_bounds_file_nodes(impact_diff_repo: Path) -> None:
+    for i in range(MAX_MERMAID_FILE_NODES + 5):
+        (impact_diff_repo / f"extra_{i}.py").write_text(f"def f_{i}():\n    return {i}\n")
+    subprocess.run(["git", "add", "."], cwd=impact_diff_repo, check=True, capture_output=True)
+
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+    diagram = render_mermaid(artifact)
+
+    assert diagram is not None
+    file_node_count = diagram.count('["extra_')
+    assert file_node_count <= MAX_MERMAID_FILE_NODES
+    assert "more changed file" in diagram


### PR DESCRIPTION
## Summary

M4 PR-2/4: JSON and Markdown/Mermaid surfaces for `AnalysisArtifactV1`, plus the `archex report diff` CLI command.

- `archex report diff [SOURCE] --base <ref> --format json|markdown` (default `markdown`). `--format html` is rejected with a clear error until PR-3.
- `--format json` prints `artifact.to_json()` unchanged.
- `--format markdown` renders provenance, summary, a bounded Mermaid flowchart (color-coded by risk tier), changed-files/symbol-candidate tables, and affected-interface/test/unsupported-file lists -- every value already exists on the artifact; the renderer adds no analysis and never embeds raw source text.
- `fix(report)`: found while wiring the renderer -- `InterfaceCandidate.handle` was built with `file_handle()` over `archex.impact._public_interfaces`'s composite `path::qualified_name#kind` identifiers, producing a handle that never resolved to a real chunk. Fixed to use `symbol_handle()` over the real `symbol_id`, with a regression test.

## Scope

In: JSON/Markdown/Mermaid renderers, CLI command (json/markdown), the interface-handle fix, tests.
Out: static HTML renderer, redaction/size/no-network tests, CI example (PR-3/PR-4).

## Verification

- `uv run ruff check .` / `uv run ruff format --check .` / `uv run pyright .`: clean.
- `uv run pytest --no-cov tests/test_report_artifact.py tests/test_report_render_markdown.py tests/test_report_cli.py`: 27 passed.
- `uv run pytest --junitxml=results.xml --cov-report=xml`: 4051 passed, 91.59% coverage.
- `uv run archex report diff --base main --format json` / `--format markdown`: both exit 0 against this repo's own working tree.
