### PR TITLE
feat(report): render static offline diff HTML

### DIFF
--- a/src/archex/cli/report_cmd.py
+++ b/src/archex/cli/report_cmd.py
@@ -20,7 +20,7 @@ def report_cmd() -> None:
     "--format",
     "output_format",
     default="markdown",
-    type=click.Choice(["json", "markdown"]),
+    type=click.Choice(["json", "markdown", "html"]),
     help="Output format.",
 )
 def diff_cmd(source: str, base: str, output_format: str) -> None:
@@ -32,6 +32,12 @@ def diff_cmd(source: str, base: str, output_format: str) -> None:
 
     if output_format == "json":
         click.echo(artifact.to_json())
+        return
+
+    if output_format == "html":
+        from archex.report.render_html import render_html
+
+        click.echo(render_html(artifact), nl=False)
         return
 
     from archex.report.render_markdown import render_markdown

--- a/src/archex/report/render_html.py
+++ b/src/archex/report/render_html.py
@@ -1,0 +1,205 @@
+"""Static, offline HTML rendering for AnalysisArtifactV1.
+
+A pure projection, like the Markdown renderer: every value rendered here
+already exists on the artifact. No source parsing, no analysis, no network
+calls -- and, unlike Markdown, no client-side script either. The Mermaid
+diagram is embedded as its plain-text source inside a `<pre>` block rather
+than rendered as an interactive diagram: rendering it client-side would
+require vendoring or fetching the Mermaid JS library, which conflicts with
+staying offline and script-free. The page is a single self-contained HTML
+document: inline CSS only, zero `<script>` tags, zero remote references
+(no CDN stylesheets, fonts, or images), so it opens correctly from a local
+file:// URL with no network access.
+
+Rows are capped independently of (and tighter than) the artifact's own
+MAX_* bounds and the Markdown renderer's full-list display: a static page
+meant to be opened directly needs a much smaller size budget than the
+canonical JSON payload.
+"""
+
+from __future__ import annotations
+
+from html import escape
+from typing import TYPE_CHECKING
+
+from archex.report.render_markdown import render_mermaid
+
+if TYPE_CHECKING:
+    from archex.report.artifact import AnalysisArtifactV1, DiffFileChange, SymbolCandidate
+
+MAX_HTML_ROWS = 50
+
+_STYLE = """
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+           margin: 2rem; color: #1a1a1a; background: #fff; }
+    h1 { font-size: 1.4rem; }
+    h2 { font-size: 1.1rem; margin-top: 2rem; border-bottom: 1px solid #ddd;
+         padding-bottom: .25rem; }
+    table { border-collapse: collapse; width: 100%; margin: .5rem 0; font-size: .85rem; }
+    th, td { border: 1px solid #ddd; padding: .35rem .5rem; text-align: left; }
+    th { background: #f4f4f4; }
+    code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    code { background: #f4f4f4; padding: .1rem .3rem; border-radius: 3px; }
+    pre { background: #f7f7f7; padding: .75rem; overflow-x: auto; border-radius: 4px; }
+    .risk-high { color: #900; font-weight: 600; }
+    .risk-medium, .risk-moderate { color: #960; font-weight: 600; }
+    .risk-low { color: #360; }
+    .note { color: #666; font-style: italic; font-size: .85rem; }
+""".strip()
+
+
+def render_html(artifact: AnalysisArtifactV1) -> str:
+    title = f"Diff Review: {escape(artifact.source_identity)}"
+    body = [
+        f"<h1>{title}</h1>",
+        _provenance_table(artifact),
+        _summary_list(artifact),
+        _structure_block(artifact),
+        _changed_files_table(artifact),
+        _symbol_candidates_table(artifact),
+        _path_list(
+            "Affected Public Interfaces",
+            [c.path for c in artifact.diff.affected_interfaces],
+            artifact.diff.affected_interfaces_total,
+        ),
+        _path_list(
+            "Test Candidates",
+            [c.path for c in artifact.diff.test_candidates],
+            artifact.diff.test_candidates_total,
+        ),
+        _path_list(
+            "Unsupported Files",
+            [item.path for item in artifact.diff.unsupported_files],
+            artifact.diff.unsupported_files_total,
+        ),
+    ]
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '<meta charset="utf-8">\n'
+        f"<title>{title}</title>\n"
+        f"<style>{_STYLE}</style>\n"
+        "</head>\n"
+        "<body>\n" + "\n".join(body) + "\n</body>\n</html>\n"
+    )
+
+
+def _provenance_table(artifact: AnalysisArtifactV1) -> str:
+    rows = [
+        ("Schema version", artifact.schema_version.value),
+        ("archex version", artifact.archex_version),
+        (
+            "Base ref",
+            f"{artifact.diff.base_ref} ({artifact.diff.base_resolved_sha or 'unresolved'})",
+        ),
+        ("Head revision", artifact.diff.head_ref or "unknown"),
+        ("Index generation", artifact.index_generation or "unknown"),
+        ("Freshness", artifact.freshness.value),
+        ("Completeness", artifact.completeness.value),
+        ("Confidence", artifact.confidence.value),
+        ("Redaction", artifact.redaction_mode.value),
+        ("Generated at", artifact.generated_at),
+    ]
+    body_rows = "".join(
+        f"<tr><td>{escape(k)}</td><td><code>{escape(v)}</code></td></tr>" for k, v in rows
+    )
+    return f"<h2>Provenance</h2>\n<table>{body_rows}</table>"
+
+
+def _summary_list(artifact: AnalysisArtifactV1) -> str:
+    diff = artifact.diff
+    items = [
+        f"Risk: <span class='risk-{escape(diff.risk_level.value)}'>"
+        f"{escape(diff.risk_level.value)}</span>",
+        f"Changed files: {diff.changed_files_total}",
+        f"Symbol candidates: {diff.symbol_candidates_total}",
+        f"Affected interfaces: {diff.affected_interfaces_total}",
+        f"Test candidates: {diff.test_candidates_total}",
+        f"Unsupported files: {diff.unsupported_files_total}",
+    ]
+    if diff.risk_reasons:
+        reasons = ", ".join(f"<code>{escape(r)}</code>" for r in diff.risk_reasons)
+        items.append(f"Risk reasons: {reasons}")
+    if artifact.excluded_counts:
+        excluded = ", ".join(
+            f"{escape(k)}={v}" for k, v in sorted(artifact.excluded_counts.items())
+        )
+        items.append(f"Excluded: {excluded}")
+    if artifact.unknown_counts:
+        unknown = ", ".join(f"{escape(k)}={v}" for k, v in sorted(artifact.unknown_counts.items()))
+        items.append(f"Unknown: {unknown}")
+    list_items = "".join(f"<li>{item}</li>" for item in items)
+    return f"<h2>Summary</h2>\n<ul>{list_items}</ul>"
+
+
+def _structure_block(artifact: AnalysisArtifactV1) -> str:
+    diagram = render_mermaid(artifact)
+    if diagram is None:
+        return "<h2>Structure</h2>\n<p class='note'>No changed files to diagram.</p>"
+    return f"<h2>Structure</h2>\n<pre>{escape(diagram)}</pre>"
+
+
+def _changed_files_table(artifact: AnalysisArtifactV1) -> str:
+    changes = artifact.diff.changed_files[:MAX_HTML_ROWS]
+    header = "<tr><th>Status</th><th>Path</th><th>Hunks</th><th>Handle</th></tr>"
+    rows = "".join(_changed_file_row(change) for change in changes) or (
+        "<tr><td colspan='4'><em>None</em></td></tr>"
+    )
+    note = _truncation_note(artifact.diff.changed_files_total, len(changes))
+    return f"<h2>Changed Files</h2>\n<table>{header}{rows}</table>{note}"
+
+
+def _changed_file_row(change: DiffFileChange) -> str:
+    hunks = ", ".join(f"{h.start_line}-{h.end_line}" for h in change.hunks) or "-"
+    return (
+        f"<tr><td><code>{escape(change.status)}</code></td>"
+        f"<td><code>{escape(change.path)}</code></td>"
+        f"<td>{escape(hunks)}</td>"
+        f"<td><code>{escape(change.handle)}</code></td></tr>"
+    )
+
+
+def _symbol_candidates_table(artifact: AnalysisArtifactV1) -> str:
+    candidates = artifact.diff.symbol_candidates[:MAX_HTML_ROWS]
+    header = (
+        "<tr><th>Risk</th><th>Confidence</th><th>Symbol</th>"
+        "<th>File</th><th>Lines</th><th>Handle</th></tr>"
+    )
+    rows = "".join(_symbol_candidate_row(candidate) for candidate in candidates) or (
+        "<tr><td colspan='6'><em>None</em></td></tr>"
+    )
+    note = _truncation_note(artifact.diff.symbol_candidates_total, len(candidates))
+    return f"<h2>Symbol Risk Candidates</h2>\n<table>{header}{rows}</table>{note}"
+
+
+def _symbol_candidate_row(candidate: SymbolCandidate) -> str:
+    label = candidate.qualified_name or candidate.symbol_name or "<unnamed>"
+    risk = escape(candidate.risk_level)
+    return (
+        f"<tr><td class='risk-{risk}'>{risk}</td>"
+        f"<td>{escape(candidate.confidence.value)}</td>"
+        f"<td><code>{escape(label)}</code></td>"
+        f"<td><code>{escape(candidate.file_path)}</code></td>"
+        f"<td>{candidate.start_line}-{candidate.end_line}</td>"
+        f"<td><code>{escape(candidate.handle)}</code></td></tr>"
+    )
+
+
+def _path_list(title: str, paths: list[str], total: int) -> str:
+    shown = paths[:MAX_HTML_ROWS]
+    if not shown:
+        return f"<h2>{escape(title)}</h2>\n<p class='note'>None</p>"
+    items = "".join(f"<li><code>{escape(path)}</code></li>" for path in shown)
+    note = _truncation_note(total, len(shown))
+    return f"<h2>{escape(title)}</h2>\n<ul>{items}</ul>{note}"
+
+
+def _truncation_note(total: int, shown: int) -> str:
+    if total <= shown:
+        return ""
+    remaining = total - shown
+    return (
+        f"<p class='note'>{remaining} additional "
+        f"entr{'y' if remaining == 1 else 'ies'} omitted; see the JSON artifact.</p>"
+    )

--- a/tests/test_report_cli.py
+++ b/tests/test_report_cli.py
@@ -41,15 +41,29 @@ def test_report_diff_markdown_is_default_format(impact_diff_repo: Path) -> None:
     assert "```mermaid" in result.output
 
 
-def test_report_diff_html_format_not_yet_supported(impact_diff_repo: Path) -> None:
+def test_report_diff_html_format_is_offline_self_contained(impact_diff_repo: Path) -> None:
+    _edit_hub(impact_diff_repo)
     runner = CliRunner()
 
     result = runner.invoke(
         cli, ["report", "diff", str(impact_diff_repo), "--base", "HEAD", "--format", "html"]
     )
 
+    assert result.exit_code == 0, result.output
+    assert result.output.startswith("<!DOCTYPE html>")
+    assert "<script" not in result.output.lower()
+    assert "https://" not in result.output
+
+
+def test_report_diff_rejects_unknown_format(impact_diff_repo: Path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli, ["report", "diff", str(impact_diff_repo), "--base", "HEAD", "--format", "yaml"]
+    )
+
     assert result.exit_code != 0
-    assert "html" in result.output.lower()
+    assert "yaml" in result.output.lower()
 
 
 def test_report_diff_invalid_base_ref_is_a_clean_cli_error(impact_diff_repo: Path) -> None:

--- a/tests/test_report_render_html.py
+++ b/tests/test_report_render_html.py
@@ -1,0 +1,105 @@
+"""Security and size tests for the static, offline HTML AnalysisArtifactV1 renderer."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from archex.report.artifact import build_analysis_artifact
+from archex.report.render_html import MAX_HTML_ROWS, render_html
+
+
+def _edit_hub(repo: Path) -> None:
+    hub = repo / "hub.py"
+    hub.write_text(hub.read_text().replace("value * 2", "value * 3"))
+
+
+def test_render_html_has_no_script_tags(impact_diff_repo: Path) -> None:
+    _edit_hub(impact_diff_repo)
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+
+    html = render_html(artifact)
+
+    assert "<script" not in html.lower()
+
+
+def test_render_html_has_no_remote_references(impact_diff_repo: Path) -> None:
+    _edit_hub(impact_diff_repo)
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+
+    html = render_html(artifact)
+
+    assert "http://" not in html
+    assert "https://" not in html
+    assert "<link" not in html.lower()
+    assert "cdn" not in html.lower()
+
+
+def test_render_html_is_a_single_self_contained_document(impact_diff_repo: Path) -> None:
+    _edit_hub(impact_diff_repo)
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+
+    html = render_html(artifact)
+
+    assert html.startswith("<!DOCTYPE html>")
+    assert "<style>" in html
+    assert html.count("<html") == 1
+    assert html.rstrip().endswith("</html>")
+
+
+def test_render_html_never_embeds_raw_source_text(impact_diff_repo: Path) -> None:
+    _edit_hub(impact_diff_repo)
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+
+    html = render_html(artifact)
+
+    assert "value * 3" not in html
+    assert "return value" not in html
+
+
+def test_render_html_escapes_path_and_symbol_text(impact_diff_repo: Path) -> None:
+    weird = impact_diff_repo / 'weird "quoted"<tag>.py'
+    weird.write_text("def f():\n    return 1\n")
+    subprocess.run(
+        ["git", "add", weird.name], cwd=impact_diff_repo, check=True, capture_output=True
+    )
+
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+    html = render_html(artifact)
+
+    assert "<tag>" not in html
+    assert "&lt;tag&gt;" in html
+
+
+def test_render_html_bounds_table_rows(impact_diff_repo: Path) -> None:
+    for i in range(MAX_HTML_ROWS + 20):
+        (impact_diff_repo / f"extra_{i}.py").write_text(f"def f_{i}():\n    return {i}\n")
+    subprocess.run(["git", "add", "."], cwd=impact_diff_repo, check=True, capture_output=True)
+
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+    html = render_html(artifact)
+
+    assert html.count("<tr><td><code>A</code>") <= MAX_HTML_ROWS
+    assert "additional entries omitted" in html or "additional entry omitted" in html
+
+
+def test_render_html_stays_within_a_reasonable_size_budget(impact_diff_repo: Path) -> None:
+    for i in range(MAX_HTML_ROWS + 50):
+        (impact_diff_repo / f"extra_{i}.py").write_text(f"def f_{i}():\n    return {i}\n")
+    subprocess.run(["git", "add", "."], cwd=impact_diff_repo, check=True, capture_output=True)
+
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+    html = render_html(artifact)
+
+    # Even with far more changed files than the row cap, the static page
+    # stays well under a size a browser opens instantly from a local file.
+    assert len(html.encode("utf-8")) < 200_000
+
+
+def test_render_html_reports_none_for_empty_diff(impact_diff_repo: Path) -> None:
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+
+    html = render_html(artifact)
+
+    assert "No changed files to diagram." in html
+    assert "<em>None</em>" in html


### PR DESCRIPTION
## Summary

M4 PR-3/4: static, offline HTML rendering for `AnalysisArtifactV1`, completing `archex report diff --format json|markdown|html`.

- `render_html`: a single self-contained document (inline `<style>` only), zero `<script>` tags, zero remote references (no CDN stylesheets, fonts, images) -- opens correctly from a local `file://` URL with no network access.
- The Mermaid diagram is embedded as its plain-text source inside a `<pre>` block rather than rendered client-side: rendering it would require vendoring or fetching the Mermaid JS library, which conflicts with staying offline and script-free. Same diagram data as the Markdown renderer, different presentation.
- Every table/list is capped at `MAX_HTML_ROWS` (tighter than, and independent of, the artifact's own bounds and the Markdown renderer's full-list display), with a truncation note, so the static page stays a predictable size regardless of how large the underlying diff is.
- All interpolated text is HTML-escaped (`html.escape`); dedicated tests cover tag-injection-shaped filenames.
- `archex report diff --format html` is now live in the CLI.

## Scope

In: static HTML renderer, redaction/size/no-network tests, CLI `--format html`.
Out: bounded CI delta example, pinned CI workflow, docs (PR-4).

## Verification

- `uv run ruff check .` / `uv run ruff format --check .` / `uv run pyright .`: clean.
- `uv run pytest --no-cov tests/test_report_render_html.py tests/test_report_cli.py`: 14 passed.
- `uv run pytest --junitxml=results.xml --cov-report=xml`: 4060 passed, 91.61% coverage.
- `uv run archex report diff --base main --format html`: exit 0, single self-contained document, zero script tags, zero remote references (verified against this repo's own working tree).
