### PR TITLE
feat(explorer): render canonical artifact locally

### DIFF
--- a/src/archex/cli/explore_cmd.py
+++ b/src/archex/cli/explore_cmd.py
@@ -1,0 +1,52 @@
+"""Local, loopback-only explorer over a previously exported `AnalysisArtifactV1`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from archex.explorer.loader import ExplorerDataError, load_explorer_data
+from archex.explorer.server import ExplorerSecurityError, create_server
+
+
+@click.command("explore")
+@click.argument("artifact", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option(
+    "--graph",
+    "graph_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Optional `archex graph export` artifact for module map and neighborhood views.",
+)
+@click.option(
+    "--port",
+    default=0,
+    type=int,
+    show_default=True,
+    help="Loopback port to bind (0 selects an OS-assigned ephemeral port).",
+)
+def explore_cmd(artifact: Path, graph_path: Path | None, port: int) -> None:
+    """Render ARTIFACT (an `archex report diff --format json` output) locally.
+
+    Starts a loopback-only, session-token-gated HTTP server; nothing is
+    reachable outside this machine and no repository indexing runs.
+    """
+    try:
+        data = load_explorer_data(artifact, graph_path)
+    except ExplorerDataError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    try:
+        server = create_server(data, port=port)
+    except ExplorerSecurityError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo(f"archex explorer listening at {server.url}")
+    click.echo("Press Ctrl+C to stop.")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()

--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -13,6 +13,7 @@ from archex.cli.context_cmd import context_cmd
 from archex.cli.doctor_cmd import doctor_cmd
 from archex.cli.dogfood_cmd import dogfood_cmd
 from archex.cli.explain_cmd import explain_cmd
+from archex.cli.explore_cmd import explore_cmd
 from archex.cli.graph_cmd import graph_cmd
 from archex.cli.impact_cmd import impact_cmd
 from archex.cli.index_cmd import index_cmd
@@ -65,6 +66,7 @@ cli.add_command(explain_cmd)
 cli.add_command(impact_cmd)
 cli.add_command(onboard_cmd)
 cli.add_command(report_cmd)
+cli.add_command(explore_cmd)
 
 
 if __name__ == "__main__":

--- a/src/archex/explorer/__init__.py
+++ b/src/archex/explorer/__init__.py
@@ -1,0 +1,12 @@
+"""Local, loopback-only explorer that renders `AnalysisArtifactV1`.
+
+The explorer is a read-only projection over artifacts other commands already
+produced (`archex report diff`'s `AnalysisArtifactV1`, `archex graph
+export`'s `ArchGraph`). It never parses repository source, never constructs
+graph edges of its own, and never mutates project state -- see
+`archex.explorer.loader` for the artifact-only data boundary and
+`archex.explorer.server` for the loopback/session/CSP/Host security controls
+enforced on every request.
+"""
+
+from __future__ import annotations

--- a/src/archex/explorer/loader.py
+++ b/src/archex/explorer/loader.py
@@ -1,0 +1,55 @@
+"""Artifact-only data loading for the local explorer.
+
+Loads a previously generated `AnalysisArtifactV1` (and, optionally, a
+previously generated `ArchGraph`) from disk. This module performs no
+repository indexing, source parsing, or graph construction of its own -- it
+only validates and deserializes artifacts that `archex report diff` and
+`archex graph export` already produced. Neither loaded artifact ever carries
+raw source text (see `RedactionMode` and `ArchGraph`'s node/edge shapes), so
+the explorer has no source content to redact or leak.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from archex.graph_artifact import ArchGraph, GraphArtifactError, load_arch_graph
+from archex.report.artifact import AnalysisArtifactV1, ReportArtifactError, load_analysis_artifact
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class ExplorerDataError(ValueError):
+    """Raised when the explorer's input artifacts cannot be loaded."""
+
+
+@dataclass(frozen=True)
+class ExplorerData:
+    """The explorer's entire read-only input: one diff artifact, one optional graph."""
+
+    artifact: AnalysisArtifactV1
+    graph: ArchGraph | None
+
+
+def load_explorer_data(artifact_path: Path, graph_path: Path | None = None) -> ExplorerData:
+    """Load ARTIFACT_PATH (required) and GRAPH_PATH (optional) for the explorer.
+
+    Raises `ExplorerDataError` for a missing, unreadable, or schema-invalid
+    artifact -- the explorer never falls back to a partially loaded or
+    synthesized state.
+    """
+    try:
+        artifact = load_analysis_artifact(artifact_path)
+    except ReportArtifactError as exc:
+        raise ExplorerDataError(str(exc)) from exc
+
+    graph: ArchGraph | None = None
+    if graph_path is not None:
+        try:
+            graph = load_arch_graph(graph_path)
+        except GraphArtifactError as exc:
+            raise ExplorerDataError(str(exc)) from exc
+
+    return ExplorerData(artifact=artifact, graph=graph)

--- a/src/archex/explorer/render.py
+++ b/src/archex/explorer/render.py
@@ -1,0 +1,230 @@
+"""Server-rendered HTML for the local explorer.
+
+Every page is a single self-contained HTML document with an inline
+`<style>` block -- no external stylesheet, script, font, or CDN request, and
+no client-side JavaScript at all (navigation and the neighborhood search use
+plain `<a href>` links and `<form method="get">` submissions). This keeps
+every response fully offline and lets the Content-Security-Policy the server
+attaches (see `archex.explorer.security`) block `script-src` entirely.
+
+Every value written into a page is escaped with `html.escape`; nothing here
+ever emits raw source text (`AnalysisArtifactV1` and `ArchGraph` never carry
+any).
+"""
+
+from __future__ import annotations
+
+from html import escape
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from archex.explorer.viewmodel import DiffView, ManifestView
+
+# PR-2 extends this with Module Map, Receipt Inspector, and Index Health.
+NAV_ITEMS: list[tuple[str, str]] = [
+    ("Diff Review", "/view/diff"),
+]
+
+_STYLE = """
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+       margin: 0; padding: 0; color: #1a1a1a; background: #fafafa; }
+header.banner { background: #1a1a2e; color: #eee; padding: 0.75rem 1.25rem; }
+header.banner h1 { margin: 0 0 0.25rem 0; font-size: 1.1rem; }
+header.banner .meta { font-size: 0.8rem; color: #b8b8d0; }
+nav { background: #16213e; padding: 0.5rem 1.25rem; }
+nav a { color: #e0e0f0; text-decoration: none; margin-right: 1.25rem; font-size: 0.85rem; }
+nav a:hover { text-decoration: underline; }
+main { padding: 1.25rem; max-width: 960px; margin: 0 auto; }
+h2 { font-size: 1.05rem; border-bottom: 1px solid #ddd; padding-bottom: 0.25rem; }
+table { border-collapse: collapse; width: 100%; margin-bottom: 1rem; font-size: 0.85rem; }
+th, td { text-align: left; padding: 0.35rem 0.5rem; border-bottom: 1px solid #e5e5e5; }
+th { background: #f0f0f5; }
+.badge { display: inline-block; padding: 0.1rem 0.4rem; border-radius: 3px;
+         font-size: 0.75rem; background: #e0e0e0; }
+.badge-high, .badge-critical { background: #f8d7da; color: #842029; }
+.badge-medium { background: #fff3cd; color: #664d03; }
+.badge-low { background: #d1e7dd; color: #0f5132; }
+.note { color: #666; font-size: 0.8rem; font-style: italic; }
+.empty { color: #666; font-style: italic; }
+""".strip()
+
+
+def render_page(
+    title: str,
+    manifest: ManifestView,
+    body: str,
+    *,
+    nav: list[tuple[str, str]] | None = None,
+) -> str:
+    nav_items = NAV_ITEMS if nav is None else nav
+    nav_html = " ".join(
+        f'<a href="{escape(path)}">{escape(label)}</a>' for label, path in nav_items
+    )
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n<head>\n'
+        f'<meta charset="utf-8">\n<title>{escape(title)}</title>\n'
+        f"<style>{_STYLE}</style>\n</head>\n<body>\n"
+        f"{_manifest_banner(manifest)}\n"
+        f"<nav>{nav_html}</nav>\n"
+        f"<main>\n{body}\n</main>\n"
+        "</body>\n</html>\n"
+    )
+
+
+def _manifest_banner(manifest: ManifestView) -> str:
+    return (
+        '<header class="banner">'
+        f"<h1>{escape(manifest.source_identity)} @ {escape(manifest.source_revision)}</h1>"
+        '<div class="meta">'
+        f"generated {escape(manifest.generated_at)} by archex {escape(manifest.archex_version)} "
+        f"(schema {escape(manifest.schema_version)}) &middot; "
+        f"freshness: {escape(manifest.freshness)} &middot; "
+        f"completeness: {escape(manifest.completeness)} &middot; "
+        f"confidence: {escape(manifest.confidence)} &middot; "
+        f"redaction: {escape(manifest.redaction_mode)} &middot; "
+        f"evidence: {manifest.evidence_count} &middot; "
+        f"excluded: {manifest.excluded_total} &middot; "
+        f"unknown: {manifest.unknown_total} &middot; "
+        f"graph: {'attached' if manifest.has_graph else 'not provided'}"
+        "</div></header>"
+    )
+
+
+def render_diff_page(manifest: ManifestView, view: DiffView) -> str:
+    body = "".join(
+        [
+            _diff_summary(view),
+            _changed_files_table(view),
+            _symbol_candidates_table(view),
+            _interface_candidates_table(view),
+            _test_candidates_table(view),
+            _unsupported_files_list(view),
+        ]
+    )
+    return render_page(f"Diff Review: {view.base_ref}", manifest, body)
+
+
+def _risk_badge(level: str) -> str:
+    return f'<span class="badge badge-{escape(level.lower())}">{escape(level)}</span>'
+
+
+def _diff_summary(view: DiffView) -> str:
+    reasons = (
+        "".join(f"<li>{escape(reason)}</li>" for reason in view.risk_reasons)
+        or '<li class="empty">no risk reasons recorded</li>'
+    )
+    return (
+        "<h2>Summary</h2>"
+        "<ul>"
+        f"<li>Base: <code>{escape(view.base_ref)}</code>"
+        f" ({escape(view.base_resolved_sha) or 'unresolved'})</li>"
+        f"<li>Head: <code>{escape(view.head_ref) or 'working tree'}</code></li>"
+        f"<li>Risk level: {_risk_badge(view.risk_level)}</li>"
+        f"<li>Changed files: {view.changed_files_total}</li>"
+        f"<li>Symbol candidates: {view.symbol_candidates_total}</li>"
+        f"<li>Affected interfaces: {view.affected_interfaces_total}</li>"
+        f"<li>Test candidates: {view.test_candidates_total}</li>"
+        f"<li>Unsupported files: {view.unsupported_files_total}</li>"
+        "</ul>"
+        f"<h2>Risk reasons</h2><ul>{reasons}</ul>"
+    )
+
+
+def _changed_files_table(view: DiffView) -> str:
+    if not view.changed_files:
+        return '<h2>Changed files</h2><p class="empty">none</p>'
+    rows = "".join(
+        "<tr>"
+        f"<td>{escape(row.path)}</td><td>{escape(row.status)}</td>"
+        f"<td>{escape(row.old_path or '-')}</td>"
+        f"<td>{', '.join(f'{h.start_line}-{h.end_line}' for h in row.hunks) or '-'}</td>"
+        f"<td><code>{escape(row.handle)}</code></td>"
+        "</tr>"
+        for row in view.changed_files
+    )
+    note = _truncation_note(view.changed_files_total, len(view.changed_files))
+    return (
+        "<h2>Changed files</h2>"
+        "<table><tr><th>Path</th><th>Status</th><th>Old path</th>"
+        "<th>Hunks</th><th>Handle</th></tr>" + rows + "</table>" + note
+    )
+
+
+def _symbol_candidates_table(view: DiffView) -> str:
+    if not view.symbol_candidates:
+        return '<h2>Symbol risk candidates</h2><p class="empty">none</p>'
+    rows = "".join(
+        "<tr>"
+        f"<td>{escape(row.label)}</td><td>{escape(row.file_path)}:{row.start_line}-{row.end_line}</td>"
+        f"<td>{_risk_badge(row.risk_level)}</td><td>{escape(row.confidence)}</td>"
+        f"<td>{', '.join(escape(s) for s in row.signals) or '-'}</td>"
+        f"<td><code>{escape(row.handle)}</code></td>"
+        "</tr>"
+        for row in view.symbol_candidates
+    )
+    note = _truncation_note(view.symbol_candidates_total, len(view.symbol_candidates))
+    return (
+        "<h2>Symbol risk candidates</h2>"
+        "<table><tr><th>Symbol</th><th>Location</th><th>Risk</th>"
+        "<th>Confidence</th><th>Signals</th><th>Handle</th></tr>" + rows + "</table>" + note
+    )
+
+
+def _interface_candidates_table(view: DiffView) -> str:
+    if not view.affected_interfaces:
+        return '<h2>Affected interfaces</h2><p class="empty">none</p>'
+    rows = "".join(
+        f"<tr><td>{escape(row.path)}</td><td>{escape(row.symbol_id)}</td>"
+        f"<td>{escape(row.confidence)}</td><td><code>{escape(row.handle)}</code></td></tr>"
+        for row in view.affected_interfaces
+    )
+    note = _truncation_note(view.affected_interfaces_total, len(view.affected_interfaces))
+    return (
+        "<h2>Affected interfaces</h2>"
+        "<table><tr><th>Path</th><th>Symbol</th><th>Confidence</th>"
+        "<th>Handle</th></tr>" + rows + "</table>" + note
+    )
+
+
+def _test_candidates_table(view: DiffView) -> str:
+    if not view.test_candidates:
+        return '<h2>Test candidates</h2><p class="empty">none</p>'
+    rows = "".join(
+        f"<tr><td>{escape(row.path)}</td><td>{escape(row.reason)}</td>"
+        f"<td>{escape(row.confidence)}</td><td><code>{escape(row.handle)}</code></td></tr>"
+        for row in view.test_candidates
+    )
+    note = _truncation_note(view.test_candidates_total, len(view.test_candidates))
+    return (
+        "<h2>Test candidates</h2>"
+        "<table><tr><th>Path</th><th>Reason</th><th>Confidence</th>"
+        "<th>Handle</th></tr>" + rows + "</table>" + note
+    )
+
+
+def _unsupported_files_list(view: DiffView) -> str:
+    if not view.unsupported_files:
+        return '<h2>Unsupported files</h2><p class="empty">none</p>'
+    items = "".join(
+        f"<li>{escape(row.path)} ({escape(row.reason)})</li>" for row in view.unsupported_files
+    )
+    note = _truncation_note(view.unsupported_files_total, len(view.unsupported_files))
+    return f"<h2>Unsupported files</h2><ul>{items}</ul>{note}"
+
+
+def _truncation_note(total: int, shown: int) -> str:
+    if total <= shown:
+        return ""
+    return f'<p class="note">Showing {shown} of {total}.</p>'
+
+
+def render_error_page(status: int, title: str, message: str) -> str:
+    """A minimal, data-free error page for 400/403/404/405 responses."""
+    return (
+        '<!DOCTYPE html>\n<html lang="en">\n<head>\n'
+        f'<meta charset="utf-8">\n<title>{status} {escape(title)}</title>\n'
+        f"<style>{_STYLE}</style>\n</head>\n<body>\n"
+        f"<main><h2>{status} {escape(title)}</h2><p>{escape(message)}</p></main>\n"
+        "</body>\n</html>\n"
+    )

--- a/src/archex/explorer/security.py
+++ b/src/archex/explorer/security.py
@@ -1,0 +1,52 @@
+"""Session-token authorization for the local explorer.
+
+The explorer requires a per-process session token on every request (query
+string `?token=` or the `archex_session` cookie the server sets once a valid
+token is presented). Loopback binding, CSP, and `Host` header validation are
+layered on in `archex.explorer.server`; this module owns only credential
+generation and constant-time comparison so neither concern leaks timing
+information about the token.
+"""
+
+from __future__ import annotations
+
+import hmac
+import secrets
+from http.cookies import SimpleCookie
+from urllib.parse import parse_qs
+
+SESSION_COOKIE_NAME = "archex_session"
+TOKEN_QUERY_PARAM = "token"
+
+
+def generate_token() -> str:
+    """Generate a fresh, unguessable per-process session token."""
+    return secrets.token_urlsafe(32)
+
+
+def token_matches(candidate: str | None, expected: str) -> bool:
+    """Constant-time comparison; `candidate` is untrusted client input."""
+    if not candidate:
+        return False
+    return hmac.compare_digest(candidate, expected)
+
+
+def token_from_query(query_string: str) -> str | None:
+    values = parse_qs(query_string).get(TOKEN_QUERY_PARAM)
+    return values[0] if values else None
+
+
+def token_from_cookie_header(cookie_header: str | None) -> str | None:
+    if not cookie_header:
+        return None
+    jar = SimpleCookie()
+    jar.load(cookie_header)
+    morsel = jar.get(SESSION_COOKIE_NAME)
+    return morsel.value if morsel is not None else None
+
+
+def is_authorized(*, query_string: str, cookie_header: str | None, expected_token: str) -> bool:
+    """True when either the query token or the session cookie matches."""
+    return token_matches(token_from_query(query_string), expected_token) or token_matches(
+        token_from_cookie_header(cookie_header), expected_token
+    )

--- a/src/archex/explorer/server.py
+++ b/src/archex/explorer/server.py
@@ -1,0 +1,159 @@
+"""Loopback-only HTTP server rendering the local explorer.
+
+PR-1 binds hardcoded to `127.0.0.1`/`::1` and requires a per-process session
+token on every request (see `archex.explorer.security`). CSP response
+headers and `Host` header validation are added by a follow-up hardening
+change; until then this server is loopback-reachable-only, GET-only, and
+serves nothing without a valid token.
+"""
+
+from __future__ import annotations
+
+import logging
+import socket
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit
+
+from archex.explorer.render import render_diff_page, render_error_page, render_page
+from archex.explorer.security import (
+    SESSION_COOKIE_NAME,
+    TOKEN_QUERY_PARAM,
+    generate_token,
+    is_authorized,
+    token_from_query,
+    token_matches,
+)
+from archex.explorer.viewmodel import build_diff_view, build_manifest_view
+
+if TYPE_CHECKING:
+    from archex.explorer.loader import ExplorerData
+
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1"})
+
+logger = logging.getLogger(__name__)
+
+
+class ExplorerSecurityError(ValueError):
+    """Raised when the explorer server is asked to bind an unsafe address."""
+
+
+class ExplorerServer(ThreadingHTTPServer):
+    """A loopback-only, GET-only, session-token-gated `AnalysisArtifactV1` viewer."""
+
+    daemon_threads = True
+    allow_reuse_address = True
+    data: ExplorerData
+    token: str
+
+    def __init__(
+        self,
+        data: ExplorerData,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        token: str | None = None,
+    ) -> None:
+        if host not in LOOPBACK_HOSTS:
+            raise ExplorerSecurityError(
+                f"refusing to bind non-loopback host {host!r}; "
+                f"only {sorted(LOOPBACK_HOSTS)} are allowed"
+            )
+        self.data = data
+        self.token = token or generate_token()
+        self.address_family = socket.AF_INET6 if host == "::1" else socket.AF_INET
+        super().__init__((host, port), _ExplorerRequestHandler)
+
+    @property
+    def url(self) -> str:
+        host, port = self.server_address[0], self.server_address[1]
+        display_host = f"[{host}]" if ":" in str(host) else str(host)
+        return f"http://{display_host}:{port}/?{TOKEN_QUERY_PARAM}={self.token}"
+
+
+def create_server(
+    data: ExplorerData,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 0,
+    token: str | None = None,
+) -> ExplorerServer:
+    return ExplorerServer(data, host=host, port=port, token=token)
+
+
+class _ExplorerRequestHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        logger.debug("%s - %s", self.address_string(), format % args)
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._handle_get()
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._reject(405, "Method Not Allowed", "This explorer serves read-only GET requests.")
+
+    def do_PUT(self) -> None:  # noqa: N802
+        self._reject(405, "Method Not Allowed", "This explorer serves read-only GET requests.")
+
+    def do_DELETE(self) -> None:  # noqa: N802
+        self._reject(405, "Method Not Allowed", "This explorer serves read-only GET requests.")
+
+    def do_PATCH(self) -> None:  # noqa: N802
+        self._reject(405, "Method Not Allowed", "This explorer serves read-only GET requests.")
+
+    def _handle_get(self) -> None:
+        server = self._explorer_server()
+        split = urlsplit(self.path)
+        if not is_authorized(
+            query_string=split.query,
+            cookie_header=self.headers.get("Cookie"),
+            expected_token=server.token,
+        ):
+            self._reject(403, "Forbidden", "A valid session token is required.")
+            return
+
+        route = split.path
+        manifest = build_manifest_view(server.data)
+        if route in ("/", ""):
+            body = render_page("archex explorer", manifest, self._index_body())
+        elif route == "/view/diff":
+            body = render_diff_page(manifest, build_diff_view(server.data))
+        else:
+            self._reject(404, "Not Found", f"No view at {route!r}.")
+            return
+
+        self._respond(200, body, presented_token=token_from_query(split.query), server=server)
+
+    def _explorer_server(self) -> ExplorerServer:
+        server = self.server
+        assert isinstance(server, ExplorerServer)
+        return server
+
+    def _index_body(self) -> str:
+        return '<h2>Views</h2>\n<ul><li><a href="/view/diff">Diff Review</a></li></ul>'
+
+    def _respond(
+        self,
+        status: int,
+        html_body: str,
+        *,
+        presented_token: str | None,
+        server: ExplorerServer,
+    ) -> None:
+        payload = html_body.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(payload)))
+        if presented_token is not None and token_matches(presented_token, server.token):
+            self.send_header("Set-Cookie", f"{SESSION_COOKIE_NAME}={presented_token}; Path=/")
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _reject(self, status: int, title: str, message: str) -> None:
+        payload = render_error_page(status, title, message).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)

--- a/src/archex/explorer/viewmodel.py
+++ b/src/archex/explorer/viewmodel.py
@@ -1,0 +1,207 @@
+"""Pure, deterministic view models projected from `ExplorerData`.
+
+Every builder in this module is a pure function over already-loaded
+artifacts (`archex.explorer.loader.ExplorerData`): no file I/O, no network
+access, no repository indexing, and no new graph-edge construction. Bounded
+list fields mirror the `*_total` convention `archex.report.artifact` and
+`archex.graph_query` already use, so every view can show "N of TOTAL" rather
+than silently truncating.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from archex.explorer.loader import ExplorerData
+    from archex.report.artifact import EvidenceLocation
+
+MAX_DIFF_FILE_ROWS = 100
+MAX_SYMBOL_CANDIDATE_ROWS = 100
+MAX_INTERFACE_CANDIDATE_ROWS = 100
+MAX_TEST_CANDIDATE_ROWS = 100
+MAX_UNSUPPORTED_FILE_ROWS = 100
+
+
+@dataclass(frozen=True)
+class ManifestView:
+    """The cross-cutting provenance banner every explorer page renders.
+
+    Satisfies M5's acceptance that "all views display artifact provenance,
+    freshness/completeness, exclusions, unknowns, and evidence paths" without
+    duplicating the full receipt (see `ReceiptView`).
+    """
+
+    source_identity: str
+    source_revision: str
+    archex_version: str
+    schema_version: str
+    generated_at: str
+    freshness: str
+    completeness: str
+    confidence: str
+    redaction_mode: str
+    has_graph: bool
+    excluded_total: int
+    unknown_total: int
+    evidence_count: int
+
+
+def build_manifest_view(data: ExplorerData) -> ManifestView:
+    artifact = data.artifact
+    return ManifestView(
+        source_identity=artifact.source_identity,
+        source_revision=artifact.source_revision,
+        archex_version=artifact.archex_version,
+        schema_version=artifact.schema_version.value,
+        generated_at=artifact.generated_at,
+        freshness=artifact.freshness.value,
+        completeness=artifact.completeness.value,
+        confidence=artifact.confidence.value,
+        redaction_mode=artifact.redaction_mode.value,
+        has_graph=data.graph is not None,
+        excluded_total=sum(artifact.excluded_counts.values()),
+        unknown_total=sum(artifact.unknown_counts.values()),
+        evidence_count=len(artifact.evidence_locations),
+    )
+
+
+@dataclass(frozen=True)
+class DiffHunkRow:
+    start_line: int
+    end_line: int
+
+
+@dataclass(frozen=True)
+class DiffFileRow:
+    path: str
+    status: str
+    handle: str
+    old_path: str | None
+    hunks: list[DiffHunkRow]
+
+
+@dataclass(frozen=True)
+class SymbolCandidateRow:
+    handle: str
+    file_path: str
+    label: str
+    symbol_kind: str | None
+    start_line: int
+    end_line: int
+    risk_level: str
+    confidence: str
+    signals: list[str]
+
+
+@dataclass(frozen=True)
+class InterfaceCandidateRow:
+    path: str
+    symbol_id: str
+    handle: str
+    confidence: str
+
+
+@dataclass(frozen=True)
+class TestCandidateRow:
+    path: str
+    handle: str
+    reason: str
+    confidence: str
+
+
+@dataclass(frozen=True)
+class UnsupportedFileRow:
+    path: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class DiffView:
+    base_ref: str
+    base_resolved_sha: str
+    head_ref: str
+    risk_level: str
+    risk_reasons: list[str]
+
+    changed_files: list[DiffFileRow]
+    changed_files_total: int
+    symbol_candidates: list[SymbolCandidateRow]
+    symbol_candidates_total: int
+    affected_interfaces: list[InterfaceCandidateRow]
+    affected_interfaces_total: int
+    test_candidates: list[TestCandidateRow]
+    test_candidates_total: int
+    unsupported_files: list[UnsupportedFileRow]
+    unsupported_files_total: int
+
+
+def build_diff_view(data: ExplorerData) -> DiffView:
+    diff = data.artifact.diff
+    return DiffView(
+        base_ref=diff.base_ref,
+        base_resolved_sha=diff.base_resolved_sha,
+        head_ref=diff.head_ref,
+        risk_level=diff.risk_level.value,
+        risk_reasons=list(diff.risk_reasons),
+        changed_files=[
+            DiffFileRow(
+                path=change.path,
+                status=change.status,
+                handle=change.handle,
+                old_path=change.old_path,
+                hunks=[
+                    DiffHunkRow(start_line=hunk.start_line, end_line=hunk.end_line)
+                    for hunk in change.hunks
+                ],
+            )
+            for change in diff.changed_files[:MAX_DIFF_FILE_ROWS]
+        ],
+        changed_files_total=diff.changed_files_total,
+        symbol_candidates=[
+            SymbolCandidateRow(
+                handle=candidate.handle,
+                file_path=candidate.file_path,
+                label=candidate.qualified_name or candidate.symbol_name or "<unnamed>",
+                symbol_kind=candidate.symbol_kind,
+                start_line=candidate.start_line,
+                end_line=candidate.end_line,
+                risk_level=candidate.risk_level,
+                confidence=candidate.confidence.value,
+                signals=list(candidate.signals),
+            )
+            for candidate in diff.symbol_candidates[:MAX_SYMBOL_CANDIDATE_ROWS]
+        ],
+        symbol_candidates_total=diff.symbol_candidates_total,
+        affected_interfaces=[
+            InterfaceCandidateRow(
+                path=interface.path,
+                symbol_id=interface.symbol_id,
+                handle=interface.handle,
+                confidence=interface.confidence.value,
+            )
+            for interface in diff.affected_interfaces[:MAX_INTERFACE_CANDIDATE_ROWS]
+        ],
+        affected_interfaces_total=diff.affected_interfaces_total,
+        test_candidates=[
+            TestCandidateRow(
+                path=test.path,
+                handle=test.handle,
+                reason=test.reason,
+                confidence=test.confidence.value,
+            )
+            for test in diff.test_candidates[:MAX_TEST_CANDIDATE_ROWS]
+        ],
+        test_candidates_total=diff.test_candidates_total,
+        unsupported_files=[
+            UnsupportedFileRow(path=unsupported.path, reason=unsupported.reason)
+            for unsupported in diff.unsupported_files[:MAX_UNSUPPORTED_FILE_ROWS]
+        ],
+        unsupported_files_total=diff.unsupported_files_total,
+    )
+
+
+def evidence_rows(evidence: list[EvidenceLocation], *, limit: int) -> list[EvidenceLocation]:
+    """Shared bounded-slice helper so every view truncates evidence identically."""
+    return evidence[:limit]

--- a/tests/cli/test_explore_cmd.py
+++ b/tests/cli/test_explore_cmd.py
@@ -1,0 +1,71 @@
+"""Tests for the `archex explore` CLI command."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+
+
+def _artifact_json(path: Path) -> Path:
+    payload = {
+        "schema_version": {"value": "1.0.0"},
+        "archex_version": "0.22.0",
+        "generated_at": "2026-07-24T00:00:00Z",
+        "source_identity": "acme/widget",
+        "source_root": "/repo",
+        "source_revision": "deadbeef",
+        "working_tree_fingerprint": "fp",
+        "index_generation": "gen1",
+        "index_schema_version": "1",
+        "chunker_revision": "c1",
+        "config_fingerprint": "cfg1",
+        "diff": {"base_ref": "main"},
+    }
+    artifact_path = path / "artifact.json"
+    artifact_path.write_text(json.dumps(payload))
+    return artifact_path
+
+
+def test_explore_reports_a_clean_error_for_malformed_artifact(tmp_path: Path) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text("{not valid json")
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["explore", str(artifact_path)])
+
+    assert result.exit_code != 0
+    assert "Malformed" in result.output or "malformed" in result.output.lower()
+
+
+def test_explore_reports_a_clean_error_for_missing_artifact() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["explore", "/does/not/exist.json"])
+
+    assert result.exit_code != 0
+
+
+def test_explore_prints_the_loopback_url_and_stops_on_interrupt(tmp_path: Path) -> None:
+    artifact_path = _artifact_json(tmp_path)
+    runner = CliRunner()
+    before = threading.active_count()
+
+    def _serve_forever_then_interrupt(_self: object) -> None:
+        raise KeyboardInterrupt
+
+    with patch(
+        "archex.explorer.server.ExplorerServer.serve_forever",
+        _serve_forever_then_interrupt,
+    ):
+        result = runner.invoke(cli, ["explore", str(artifact_path), "--port", "0"])
+
+    assert result.exit_code == 0, result.output
+    assert "archex explorer listening at http://127.0.0.1:" in result.output
+    assert "?token=" in result.output
+    assert threading.active_count() == before

--- a/tests/explorer/test_loader.py
+++ b/tests/explorer/test_loader.py
@@ -1,0 +1,95 @@
+"""Tests for artifact-only explorer data loading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from archex.explorer.loader import ExplorerDataError, load_explorer_data
+from archex.graph_artifact import ArchGraph, GraphExportMetadata, GraphProject
+
+
+def _artifact_json(source_revision: str = "deadbeef") -> dict[str, object]:
+    return {
+        "schema_version": {"value": "1.0.0"},
+        "archex_version": "0.22.0",
+        "generated_at": "2026-07-24T00:00:00Z",
+        "source_identity": "acme/widget",
+        "source_root": "/repo",
+        "source_revision": source_revision,
+        "working_tree_fingerprint": "fp",
+        "index_generation": "gen1",
+        "index_schema_version": "1",
+        "chunker_revision": "c1",
+        "config_fingerprint": "cfg1",
+        "diff": {"base_ref": "main"},
+    }
+
+
+def test_load_explorer_data_reads_artifact_only(tmp_path: Path) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(json.dumps(_artifact_json()))
+
+    data = load_explorer_data(artifact_path)
+
+    assert data.artifact.source_identity == "acme/widget"
+    assert data.graph is None
+
+
+def test_load_explorer_data_accepts_optional_graph(tmp_path: Path) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(json.dumps(_artifact_json()))
+    graph = ArchGraph(
+        project=GraphProject(name="widget", total_files=1),
+        metadata=GraphExportMetadata(archex_version="0.22.0"),
+    )
+    graph_path = tmp_path / "graph.json"
+    graph_path.write_text(graph.to_json())
+
+    data = load_explorer_data(artifact_path, graph_path)
+
+    assert data.graph is not None
+    assert data.graph.project.name == "widget"
+
+
+def test_load_explorer_data_rejects_missing_artifact(tmp_path: Path) -> None:
+    with pytest.raises(ExplorerDataError):
+        load_explorer_data(tmp_path / "missing.json")
+
+
+def test_load_explorer_data_rejects_malformed_artifact_json(tmp_path: Path) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text("{not valid json")
+
+    with pytest.raises(ExplorerDataError):
+        load_explorer_data(artifact_path)
+
+
+def test_load_explorer_data_rejects_artifact_missing_required_fields(tmp_path: Path) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(json.dumps({"schema_version": {"value": "1.0.0"}}))
+
+    with pytest.raises(ExplorerDataError):
+        load_explorer_data(artifact_path)
+
+
+def test_load_explorer_data_rejects_unsupported_schema_major(tmp_path: Path) -> None:
+    payload = _artifact_json()
+    payload["schema_version"] = {"value": "2.0.0"}
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(json.dumps(payload))
+
+    with pytest.raises(ExplorerDataError):
+        load_explorer_data(artifact_path)
+
+
+def test_load_explorer_data_rejects_malformed_graph(tmp_path: Path) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(json.dumps(_artifact_json()))
+    graph_path = tmp_path / "graph.json"
+    graph_path.write_text("{not valid json")
+
+    with pytest.raises(ExplorerDataError):
+        load_explorer_data(artifact_path, graph_path)

--- a/tests/explorer/test_reject_analyzer_behavior.py
+++ b/tests/explorer/test_reject_analyzer_behavior.py
@@ -1,0 +1,125 @@
+"""Proves the explorer is artifact-only: no parsing, indexing, or new graph edges.
+
+Two independent checks:
+1. A static import-graph check -- no `archex.explorer` module imports the
+   parsing/indexing/acquisition machinery at all, so there is no code path
+   through which the explorer *could* re-analyze source.
+2. A functional check -- the full load-render-serve pipeline succeeds
+   against a bare artifact file (no git repository present) while
+   `archex.api.index_repository` is patched to raise if called.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from archex import explorer
+from archex.explorer.loader import load_explorer_data
+from archex.explorer.render import render_diff_page, render_page
+from archex.explorer.viewmodel import build_diff_view, build_manifest_view
+
+_FORBIDDEN_IMPORT_PREFIXES = (
+    "archex.api",
+    "archex.pipeline",
+    "archex.parse",
+    "archex.acquire",
+    "archex.index",
+    "archex.serve",
+    "tree_sitter",
+)
+
+
+def _module_paths() -> list[Path]:
+    package_dir = Path(explorer.__file__).parent
+    return sorted(package_dir.glob("*.py"))
+
+
+def _imported_names(source: str) -> set[str]:
+    tree = ast.parse(source)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            names.add(node.module)
+    return names
+
+
+def _offenders(imported: set[str]) -> set[str]:
+    return {
+        name
+        for name in imported
+        if any(
+            name == prefix or name.startswith(prefix + ".") for prefix in _FORBIDDEN_IMPORT_PREFIXES
+        )
+    }
+
+
+def test_explorer_modules_never_import_analyzer_machinery() -> None:
+    for module_path in _module_paths():
+        imported = _imported_names(module_path.read_text())
+        offenders = _offenders(imported)
+        assert not offenders, f"{module_path.name} imports analyzer machinery: {offenders}"
+
+
+def _artifact_json(path: Path) -> Path:
+    payload = {
+        "schema_version": {"value": "1.0.0"},
+        "archex_version": "0.22.0",
+        "generated_at": "2026-07-24T00:00:00Z",
+        "source_identity": "acme/widget",
+        "source_root": "/repo",
+        "source_revision": "deadbeef",
+        "working_tree_fingerprint": "fp",
+        "index_generation": "gen1",
+        "index_schema_version": "1",
+        "chunker_revision": "c1",
+        "config_fingerprint": "cfg1",
+        "diff": {
+            "base_ref": "main",
+            "changed_files": [{"path": "a.py", "status": "M", "handle": "file:a.py"}],
+            "changed_files_total": 1,
+        },
+    }
+    artifact_path = path / "artifact.json"
+    artifact_path.write_text(json.dumps(payload))
+    return artifact_path
+
+
+def test_explorer_renders_without_touching_the_repository_indexer(tmp_path: Path) -> None:
+    """No git repository, no index -- only the artifact file exists on disk."""
+    artifact_path = _artifact_json(tmp_path)
+
+    def _fail_if_called(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("explorer must never call index_repository")
+
+    with patch("archex.api.index_repository", side_effect=_fail_if_called):
+        data = load_explorer_data(artifact_path)
+        manifest = build_manifest_view(data)
+        diff_view = build_diff_view(data)
+        html = render_diff_page(manifest, diff_view)
+
+    assert "acme/widget" in html
+    assert "a.py" in html
+
+
+def test_explorer_shell_page_renders_from_artifact_alone(tmp_path: Path) -> None:
+    artifact_path = _artifact_json(tmp_path)
+    data = load_explorer_data(artifact_path)
+
+    html = render_page("archex explorer", build_manifest_view(data), "<h2>Views</h2>")
+
+    assert html.startswith("<!DOCTYPE html>")
+    assert "acme/widget" in html
+
+
+@pytest.mark.parametrize("forbidden", ["import tree_sitter", "from archex.pipeline import x"])
+def test_forbidden_import_detector_actually_detects(forbidden: str) -> None:
+    """Meta-test: confirms the detector used above is not a silent no-op."""
+    imported = _imported_names(forbidden)
+    assert _offenders(imported)

--- a/tests/explorer/test_render.py
+++ b/tests/explorer/test_render.py
@@ -1,0 +1,89 @@
+"""Tests for server-rendered explorer HTML: escaping, offline, no client-side JS."""
+
+from __future__ import annotations
+
+from archex.explorer.render import render_diff_page, render_error_page, render_page
+from archex.explorer.viewmodel import DiffFileRow, DiffView, ManifestView
+
+
+def _manifest(source_identity: str = "acme/widget") -> ManifestView:
+    return ManifestView(
+        source_identity=source_identity,
+        source_revision="deadbeef",
+        archex_version="0.22.0",
+        schema_version="1.0.0",
+        generated_at="2026-07-24T00:00:00Z",
+        freshness="clean",
+        completeness="complete",
+        confidence="high",
+        redaction_mode="redacted",
+        has_graph=False,
+        excluded_total=0,
+        unknown_total=0,
+        evidence_count=1,
+    )
+
+
+def _diff_view(path: str = "hub.py") -> DiffView:
+    return DiffView(
+        base_ref="main",
+        base_resolved_sha="deadbeef",
+        head_ref="",
+        risk_level="high",
+        risk_reasons=["public_interface_changed"],
+        changed_files=[
+            DiffFileRow(path=path, status="M", handle=f"file:{path}", old_path=None, hunks=[])
+        ],
+        changed_files_total=1,
+        symbol_candidates=[],
+        symbol_candidates_total=0,
+        affected_interfaces=[],
+        affected_interfaces_total=0,
+        test_candidates=[],
+        test_candidates_total=0,
+        unsupported_files=[],
+        unsupported_files_total=0,
+    )
+
+
+def test_render_page_is_offline_and_script_free() -> None:
+    html = render_page("archex explorer", _manifest(), "<h2>Body</h2>")
+
+    assert html.startswith("<!DOCTYPE html>")
+    assert "<script" not in html.lower()
+    assert "https://" not in html
+    assert "http://" not in html
+    assert "cdn." not in html.lower()
+
+
+def test_render_page_escapes_manifest_fields() -> None:
+    manifest = _manifest(source_identity="<script>alert(1)</script>")
+
+    html = render_page("t", manifest, "")
+
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_render_diff_page_escapes_untrusted_path_values() -> None:
+    view = _diff_view(path="<img src=x onerror=alert(1)>.py")
+
+    html = render_diff_page(_manifest(), view)
+
+    assert "<img src=x" not in html
+    assert "&lt;img" in html
+
+
+def test_render_diff_page_shows_truncation_note_when_bounded() -> None:
+    view = _diff_view()
+    html = render_diff_page(_manifest(), view)
+
+    assert "Showing" not in html  # not truncated: 1 shown of 1 total
+
+
+def test_render_error_page_never_echoes_artifact_content() -> None:
+    html = render_error_page(403, "Forbidden", "A valid session token is required.")
+
+    assert "403 Forbidden" in html
+    assert "session token" in html
+    assert "<script" not in html.lower()

--- a/tests/explorer/test_server.py
+++ b/tests/explorer/test_server.py
@@ -1,0 +1,148 @@
+"""Browser-level HTTP tests: real requests against a real loopback server.
+
+Exercises the explorer purely through HTTP, the way a browser would --
+these are the "artifact-only browser tests" M5 PR-1 requires.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from http.client import HTTPResponse
+from pathlib import Path
+
+import pytest
+
+from archex.explorer.loader import ExplorerData, load_explorer_data
+from archex.explorer.server import ExplorerSecurityError, ExplorerServer, create_server
+
+
+def _artifact_json(path: Path, source_revision: str = "deadbeef") -> Path:
+    payload = {
+        "schema_version": {"value": "1.0.0"},
+        "archex_version": "0.22.0",
+        "generated_at": "2026-07-24T00:00:00Z",
+        "source_identity": "acme/widget",
+        "source_root": "/repo",
+        "source_revision": source_revision,
+        "working_tree_fingerprint": "fp",
+        "index_generation": "gen1",
+        "index_schema_version": "1",
+        "chunker_revision": "c1",
+        "config_fingerprint": "cfg1",
+        "diff": {
+            "base_ref": "main",
+            "changed_files": [{"path": "a.py", "status": "M", "handle": "file:a.py"}],
+            "changed_files_total": 1,
+        },
+    }
+    artifact_path = path / "artifact.json"
+    artifact_path.write_text(json.dumps(payload))
+    return artifact_path
+
+
+@pytest.fixture
+def explorer_data(tmp_path: Path) -> ExplorerData:
+    return load_explorer_data(_artifact_json(tmp_path))
+
+
+@pytest.fixture
+def running_server(explorer_data: ExplorerData) -> Iterator[ExplorerServer]:
+    server = create_server(explorer_data, port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _get(url: str) -> HTTPResponse:
+    return urllib.request.urlopen(url, timeout=5)  # noqa: S310
+
+
+def test_root_without_token_is_forbidden(running_server: ExplorerServer) -> None:
+    base = f"http://127.0.0.1:{running_server.server_address[1]}/"
+
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        _get(base)
+
+    assert exc_info.value.code == 403
+
+
+def test_root_with_valid_token_renders_and_sets_session_cookie(
+    running_server: ExplorerServer,
+) -> None:
+    response = _get(running_server.url)
+
+    assert response.status == 200
+    body = response.read().decode("utf-8")
+    assert "acme/widget" in body
+    assert response.headers.get("Set-Cookie", "").startswith("archex_session=")
+
+
+def test_session_cookie_authorizes_subsequent_requests_without_token(
+    running_server: ExplorerServer,
+) -> None:
+    first = _get(running_server.url)
+    cookie = first.headers["Set-Cookie"].split(";", 1)[0]
+    port = running_server.server_address[1]
+
+    request = urllib.request.Request(  # noqa: S310
+        f"http://127.0.0.1:{port}/view/diff", headers={"Cookie": cookie}
+    )
+    response = urllib.request.urlopen(request, timeout=5)  # noqa: S310
+
+    assert response.status == 200
+    assert "a.py" in response.read().decode("utf-8")
+
+
+def test_invalid_token_is_forbidden(running_server: ExplorerServer) -> None:
+    port = running_server.server_address[1]
+
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        _get(f"http://127.0.0.1:{port}/?token=wrong-token")
+
+    assert exc_info.value.code == 403
+
+
+def test_unknown_view_is_not_found(running_server: ExplorerServer) -> None:
+    port = running_server.server_address[1]
+
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        _get(f"http://127.0.0.1:{port}/view/does-not-exist?token={running_server.token}")
+
+    assert exc_info.value.code == 404
+
+
+def test_post_is_method_not_allowed(running_server: ExplorerServer) -> None:
+    port = running_server.server_address[1]
+    request = urllib.request.Request(  # noqa: S310
+        f"http://127.0.0.1:{port}/?token={running_server.token}", data=b"", method="POST"
+    )
+
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(request, timeout=5)  # noqa: S310
+
+    assert exc_info.value.code == 405
+
+
+def test_server_refuses_to_bind_non_loopback_host(explorer_data: ExplorerData) -> None:
+    with pytest.raises(ExplorerSecurityError):
+        create_server(explorer_data, host="0.0.0.0")  # noqa: S104
+
+
+def test_forbidden_response_does_not_leak_artifact_content(
+    running_server: ExplorerServer,
+) -> None:
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        _get(f"http://127.0.0.1:{running_server.server_address[1]}/")
+
+    body = exc_info.value.read().decode("utf-8")
+    assert "acme/widget" not in body
+    assert "a.py" not in body

--- a/tests/explorer/test_viewmodel.py
+++ b/tests/explorer/test_viewmodel.py
@@ -1,0 +1,88 @@
+"""Tests for pure explorer view-model builders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from archex.explorer.loader import ExplorerData
+from archex.explorer.viewmodel import MAX_DIFF_FILE_ROWS, build_diff_view, build_manifest_view
+from archex.report.artifact import (
+    AnalysisArtifactV1,
+    DiffAnalysis,
+    DiffFileChange,
+    ReportSchemaVersion,
+    build_analysis_artifact,
+)
+
+
+def _edit_hub(repo: Path) -> None:
+    hub = repo / "hub.py"
+    hub.write_text(hub.read_text().replace("value * 2", "value * 3"))
+
+
+def test_build_manifest_view_projects_provenance_and_receipt_fields(
+    impact_diff_repo: Path,
+) -> None:
+    _edit_hub(impact_diff_repo)
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+    data = ExplorerData(artifact=artifact, graph=None)
+
+    manifest = build_manifest_view(data)
+
+    assert manifest.source_identity == artifact.source_identity
+    assert manifest.freshness == artifact.freshness.value
+    assert manifest.completeness == artifact.completeness.value
+    assert manifest.confidence == artifact.confidence.value
+    assert manifest.redaction_mode == artifact.redaction_mode.value
+    assert manifest.has_graph is False
+    assert manifest.evidence_count == len(artifact.evidence_locations)
+
+
+def test_build_diff_view_projects_changed_files_and_symbol_candidates(
+    impact_diff_repo: Path,
+) -> None:
+    _edit_hub(impact_diff_repo)
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+    data = ExplorerData(artifact=artifact, graph=None)
+
+    view = build_diff_view(data)
+
+    assert view.base_ref == "HEAD"
+    assert view.changed_files_total == artifact.diff.changed_files_total
+    assert [row.path for row in view.changed_files] == [
+        change.path for change in artifact.diff.changed_files
+    ]
+    assert view.symbol_candidates_total == artifact.diff.symbol_candidates_total
+    assert view.risk_level == artifact.diff.risk_level.value
+
+
+def test_build_diff_view_bounds_changed_files_and_reports_total() -> None:
+
+    changed = [
+        DiffFileChange(path=f"file_{i}.py", status="M", handle=f"file:file_{i}.py")
+        for i in range(MAX_DIFF_FILE_ROWS + 5)
+    ]
+    diff = DiffAnalysis(
+        base_ref="main",
+        changed_files=changed,
+        changed_files_total=len(changed),
+    )
+    artifact = AnalysisArtifactV1(
+        schema_version=ReportSchemaVersion(),
+        generated_at="2026-07-24T00:00:00Z",
+        source_identity="acme/widget",
+        source_root="/repo",
+        source_revision="deadbeef",
+        working_tree_fingerprint="fp",
+        index_generation="gen1",
+        index_schema_version="1",
+        chunker_revision="c1",
+        config_fingerprint="cfg1",
+        diff=diff,
+    )
+    data = ExplorerData(artifact=artifact, graph=None)
+
+    view = build_diff_view(data)
+
+    assert len(view.changed_files) == MAX_DIFF_FILE_ROWS
+    assert view.changed_files_total == len(changed)


### PR DESCRIPTION
## Summary

M5 PR-1/3: the artifact-only explorer shell. Adds `archex explore ARTIFACT [--graph GRAPH] [--port N]`: a loopback-only, session-token-gated local HTTP server that renders a previously exported `AnalysisArtifactV1` (from `archex report diff --format json`) plus an optional `ArchGraph` (from `archex graph export`).

- `archex.explorer.loader`: artifact-only data loading (no repository indexing, source parsing, or graph construction -- only deserializes and schema-validates artifacts other commands already produced).
- `archex.explorer.viewmodel`: pure view-model builders (`ManifestView`, `DiffView`) projecting the artifact's provenance/freshness/completeness/confidence/evidence fields and its diff-review payload, bounded the same way `archex.report.artifact` already bounds its own lists.
- `archex.explorer.render`: server-rendered, offline, script-free HTML (every value escaped via `html.escape`; no CDN, no client-side JavaScript, no external requests -- CSS is inline).
- `archex.explorer.security`: per-process session token generation and constant-time verification (query param or session cookie).
- `archex.explorer.server`: `ExplorerServer`, a `ThreadingHTTPServer` hardcoded to bind `127.0.0.1`/`::1` only, GET-only (405 on other methods), 403 on any request without a valid token.

Two independent guards prove the explorer never touches the analyzer: a static import-graph check (no `archex.explorer` module imports `archex.api`/`pipeline`/`parse`/`acquire`/`index`/`serve`/`tree_sitter`) plus a functional check (the load-render pipeline succeeds against a bare artifact file with `archex.api.index_repository` patched to raise if called).

## Scope

In: artifact/graph loader, manifest + diff view models, offline HTML rendering, minimal token-gated loopback server, `archex explore` CLI command, artifact-only tests.

Out (PR-2): module map / target neighborhood / receipt inspector / index health views, CSP response headers, `Host` header validation, session-cookie hardening, offline-asset packaging. This server is loopback-reachable-only and token-gated today; CSP/Host hardening lands in PR-2 before the feature is considered complete.

## Verification

- `uv run ruff check <changed files>` / `uv run ruff format --check <changed files>` / `uv run pyright <changed files>`: clean.
- `uv run pytest tests/explorer tests/cli/test_explore_cmd.py --no-cov`: 31 passed.
- `uv run pytest --junitxml=results.xml --cov-report=xml`: 4108 passed, 91.65% coverage.
- Manual smoke: `archex report diff --format json` against a real fixture repo, then `archex explore artifact.json --port N`; confirmed 403 without a token, 200 + `Set-Cookie` with a valid token, and correct diff-review content rendered from the real artifact.
