### PR TITLE
feat(explorer): add bounded review views

### DIFF
--- a/src/archex/explorer/render.py
+++ b/src/archex/explorer/render.py
@@ -18,11 +18,21 @@ from html import escape
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from archex.explorer.viewmodel import DiffView, ManifestView
+    from archex.explorer.viewmodel import (
+        DiffView,
+        HealthView,
+        ManifestView,
+        ModuleMapView,
+        NeighborhoodView,
+        ReceiptView,
+    )
 
-# PR-2 extends this with Module Map, Receipt Inspector, and Index Health.
 NAV_ITEMS: list[tuple[str, str]] = [
+    ("Module Map", "/view/modules"),
     ("Diff Review", "/view/diff"),
+    ("Target Neighborhood", "/view/neighborhood"),
+    ("Receipt Inspector", "/view/receipt"),
+    ("Index Health", "/view/health"),
 ]
 
 _STYLE = """
@@ -228,3 +238,183 @@ def render_error_page(status: int, title: str, message: str) -> str:
         f"<main><h2>{status} {escape(title)}</h2><p>{escape(message)}</p></main>\n"
         "</body>\n</html>\n"
     )
+
+
+def render_module_map_page(manifest: ManifestView, view: ModuleMapView) -> str:
+    if not view.available:
+        body = (
+            "<h2>Module Map</h2>"
+            '<p class="empty">No graph artifact provided. '
+            "Pass <code>--graph</code> (an <code>archex graph export</code> output) "
+            "to <code>archex explore</code> to enable this view.</p>"
+        )
+        return render_page("Module Map", manifest, body)
+
+    if not view.modules:
+        body = '<h2>Module Map</h2><p class="empty">The graph has no nodes.</p>'
+        return render_page("Module Map", manifest, body)
+
+    rows = "".join(
+        "<tr>"
+        f"<td>{escape(row.module)}</td><td>{row.node_count}</td><td>{row.file_count}</td>"
+        f"<td>{row.symbol_count}</td><td>{row.interface_count}</td>"
+        "</tr>"
+        for row in view.modules
+    )
+    note = _truncation_note(view.modules_total, len(view.modules))
+    body = (
+        "<h2>Module Map</h2>"
+        '<p class="note">Module-aggregated node counts (not a per-node graph). '
+        "Look up a module's file or symbol under Target Neighborhood.</p>"
+        "<table><tr><th>Module</th><th>Nodes</th><th>Files</th>"
+        "<th>Symbols</th><th>Interfaces</th></tr>" + rows + "</table>" + note
+    )
+    return render_page("Module Map", manifest, body)
+
+
+def render_receipt_page(manifest: ManifestView, view: ReceiptView) -> str:
+    evidence_rows_html = "".join(
+        "<tr>"
+        f"<td>{escape(item.path)}</td>"
+        f"<td>{item.start_line if item.start_line is not None else '-'}</td>"
+        f"<td>{item.end_line if item.end_line is not None else '-'}</td>"
+        f"<td>{escape(item.handle or '-')}</td>"
+        f"<td>{escape(item.description)}</td>"
+        "</tr>"
+        for item in view.evidence_locations
+    )
+    evidence_note = _truncation_note(view.evidence_locations_total, len(view.evidence_locations))
+    excluded_rows = (
+        "".join(
+            f"<li>{escape(key)}: {value}</li>"
+            for key, value in sorted(view.excluded_counts.items())
+        )
+        or '<li class="empty">none</li>'
+    )
+    unknown_rows = (
+        "".join(
+            f"<li>{escape(key)}: {value}</li>" for key, value in sorted(view.unknown_counts.items())
+        )
+        or '<li class="empty">none</li>'
+    )
+    body = (
+        "<h2>Receipt</h2>"
+        "<ul>"
+        f"<li>Freshness: {escape(view.freshness)}</li>"
+        f"<li>Completeness: {escape(view.completeness)}</li>"
+        f"<li>Confidence: {escape(view.confidence)}</li>"
+        f"<li>Redaction mode: {escape(view.redaction_mode)}</li>"
+        f"<li>Generated at: {escape(view.generated_at)}</li>"
+        "</ul>"
+        "<h2>Excluded counts</h2><ul>" + excluded_rows + "</ul>"
+        "<h2>Unknown counts</h2><ul>" + unknown_rows + "</ul>"
+        "<h2>Evidence locations</h2>"
+        + (
+            "<table><tr><th>Path</th><th>Start</th><th>End</th>"
+            "<th>Handle</th><th>Description</th></tr>"
+            + evidence_rows_html
+            + "</table>"
+            + evidence_note
+            if view.evidence_locations
+            else '<p class="empty">none</p>'
+        )
+    )
+    return render_page("Receipt Inspector", manifest, body)
+
+
+def render_health_page(manifest: ManifestView, view: HealthView) -> str:
+    parser_rows = (
+        "".join(
+            f"<li>{escape(language)}: {escape(version)}</li>"
+            for language, version in sorted(view.parser_versions.items())
+        )
+        or '<li class="empty">none recorded</li>'
+    )
+    body = (
+        "<h2>Index Health</h2>"
+        "<ul>"
+        f"<li>archex version: {escape(view.archex_version)}</li>"
+        f"<li>Artifact schema version: {escape(view.schema_version)}</li>"
+        f"<li>Index generation: {escape(view.index_generation)}</li>"
+        f"<li>Index schema version: {escape(view.index_schema_version)}</li>"
+        f"<li>Chunker revision: {escape(view.chunker_revision)}</li>"
+        f"<li>Retrieval profile: {escape(view.retrieval_profile or 'default')}</li>"
+        f"<li>Config fingerprint: {escape(view.config_fingerprint)}</li>"
+        f"<li>Working tree fingerprint: {escape(view.working_tree_fingerprint)}</li>"
+        f"<li>Producer: {escape(view.producer)} {escape(view.producer_version)}</li>"
+        "</ul>"
+        "<h2>Parser versions</h2><ul>" + parser_rows + "</ul>"
+    )
+    return render_page("Index Health", manifest, body)
+
+
+def render_neighborhood_page(manifest: ManifestView, view: NeighborhoodView) -> str:
+    form = (
+        '<form method="get" action="/view/neighborhood">'
+        f'<input type="text" name="node" placeholder="file or symbol id" '
+        f'value="{escape(view.query or "")}">'
+        '<select name="direction">'
+        + "".join(
+            f'<option value="{d}"{" selected" if d == view.direction else ""}>{d}</option>'
+            for d in ("both", "out", "in")
+        )
+        + "</select>"
+        f'<input type="number" name="depth" min="1" value="{view.depth}">'
+        f'<input type="number" name="limit" min="1" value="{view.limit}">'
+        '<button type="submit">Find neighbors</button>'
+        "</form>"
+    )
+    if not view.available:
+        body = (
+            "<h2>Target Neighborhood</h2>" + form + '<p class="empty">No graph artifact provided. '
+            "Pass <code>--graph</code> to <code>archex explore</code> to enable this view.</p>"
+        )
+        return render_page("Target Neighborhood", manifest, body)
+
+    if view.error is not None:
+        body = "<h2>Target Neighborhood</h2>" + form + f'<p class="empty">{escape(view.error)}</p>'
+        return render_page("Target Neighborhood", manifest, body)
+
+    if view.seed is None:
+        body = (
+            "<h2>Target Neighborhood</h2>"
+            + form
+            + '<p class="empty">Enter a file path or symbol id to see its bounded '
+            "neighborhood.</p>"
+        )
+        return render_page("Target Neighborhood", manifest, body)
+
+    node_rows = "".join(
+        f"<tr><td>{escape(node.id)}</td><td>{escape(node.type)}</td>"
+        f"<td>{escape(node.label)}</td><td>{node.degree}</td></tr>"
+        for node in view.nodes
+    )
+    edge_rows = "".join(
+        f"<tr><td>{escape(edge.source_id)}</td><td>{escape(edge.type)}</td>"
+        f"<td>{escape(edge.target_id)}</td><td>{escape(edge.confidence)}</td></tr>"
+        for edge in view.edges
+    )
+    hub_rows = "".join(f"<li>{escape(hub.id)}</li>" for hub in view.hubs) or (
+        '<li class="empty">none</li>'
+    )
+    truncation = (
+        f'<p class="note">Truncated: {view.omitted_edges} edges omitted at limit {view.limit}.</p>'
+        if view.truncated
+        else ""
+    )
+    body = (
+        "<h2>Target Neighborhood</h2>" + form + f"<p>Seed: <code>{escape(view.seed.id)}</code> "
+        f"({escape(view.seed.type)}, degree {view.seed.degree}) &middot; "
+        f"direction: {escape(view.direction)} &middot; depth: {view.depth}</p>"
+        + truncation
+        + "<h3>Nodes</h3>"
+        "<table><tr><th>ID</th><th>Type</th><th>Label</th><th>Degree</th></tr>"
+        + node_rows
+        + "</table>"
+        "<h3>Edges</h3>"
+        "<table><tr><th>Source</th><th>Type</th><th>Target</th><th>Confidence</th></tr>"
+        + edge_rows
+        + "</table>"
+        "<h3>Hubs skipped (high fan-out)</h3><ul>" + hub_rows + "</ul>"
+    )
+    return render_page("Target Neighborhood", manifest, body)

--- a/src/archex/explorer/security.py
+++ b/src/archex/explorer/security.py
@@ -1,11 +1,12 @@
-"""Session-token authorization for the local explorer.
+"""Session, `Host`, and response-header security controls for the local explorer.
 
 The explorer requires a per-process session token on every request (query
-string `?token=` or the `archex_session` cookie the server sets once a valid
-token is presented). Loopback binding, CSP, and `Host` header validation are
-layered on in `archex.explorer.server`; this module owns only credential
-generation and constant-time comparison so neither concern leaks timing
-information about the token.
+string `?token=` or the `archex_session` cookie the server sets once a
+valid token is presented, hardened with `HttpOnly`/`SameSite=Strict`).
+Every response also carries a restrictive Content-Security-Policy and
+related hardening headers, and every request's `Host` header is validated
+against the server's own bind address/port to defend against DNS
+rebinding -- see `archex.explorer.server` for where these are enforced.
 """
 
 from __future__ import annotations
@@ -50,3 +51,45 @@ def is_authorized(*, query_string: str, cookie_header: str | None, expected_toke
     return token_matches(token_from_query(query_string), expected_token) or token_matches(
         token_from_cookie_header(cookie_header), expected_token
     )
+
+
+CSP_HEADER_VALUE = (
+    "default-src 'none'; "
+    "style-src 'unsafe-inline'; "
+    "img-src 'self'; "
+    "base-uri 'none'; "
+    "form-action 'self'; "
+    "frame-ancestors 'none'"
+)
+
+SECURITY_RESPONSE_HEADERS: dict[str, str] = {
+    "Content-Security-Policy": CSP_HEADER_VALUE,
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "no-referrer",
+    "Cache-Control": "no-store",
+}
+
+
+def session_cookie_header(token: str) -> str:
+    """A hardened `Set-Cookie` value: HttpOnly, SameSite=Strict, path-scoped."""
+    return f"{SESSION_COOKIE_NAME}={token}; Path=/; HttpOnly; SameSite=Strict"
+
+
+def allowed_host_headers(bind_host: str, port: int) -> frozenset[str]:
+    """The exact `Host` header values this server accepts for BIND_HOST:PORT.
+
+    A browser may send either the literal bind address or the `localhost`
+    alias; anything else -- including a bind address with a different port,
+    or an attacker-controlled DNS name that happens to resolve to this
+    loopback address -- is a DNS-rebinding attempt and must be rejected.
+    """
+    if bind_host == "127.0.0.1":
+        return frozenset({f"127.0.0.1:{port}", f"localhost:{port}"})
+    if bind_host == "::1":
+        return frozenset({f"[::1]:{port}", f"localhost:{port}"})
+    raise ValueError(f"unsupported bind host {bind_host!r}")
+
+
+def is_valid_host_header(host_header: str | None, allowed: frozenset[str]) -> bool:
+    return host_header is not None and host_header in allowed

--- a/src/archex/explorer/server.py
+++ b/src/archex/explorer/server.py
@@ -1,6 +1,6 @@
 """Loopback-only HTTP server rendering the local explorer.
 
-PR-1 binds hardcoded to `127.0.0.1`/`::1` and requires a per-process session
+Binds hardcoded to `127.0.0.1`/`::1` and requires a per-process session
 token on every request (see `archex.explorer.security`). CSP response
 headers and `Host` header validation are added by a follow-up hardening
 change; until then this server is loopback-reachable-only, GET-only, and
@@ -13,9 +13,18 @@ import logging
 import socket
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import TYPE_CHECKING
-from urllib.parse import urlsplit
+from urllib.parse import parse_qs, urlsplit
 
-from archex.explorer.render import render_diff_page, render_error_page, render_page
+from archex.explorer.render import (
+    NAV_ITEMS,
+    render_diff_page,
+    render_error_page,
+    render_health_page,
+    render_module_map_page,
+    render_neighborhood_page,
+    render_page,
+    render_receipt_page,
+)
 from archex.explorer.security import (
     SESSION_COOKIE_NAME,
     TOKEN_QUERY_PARAM,
@@ -24,10 +33,21 @@ from archex.explorer.security import (
     token_from_query,
     token_matches,
 )
-from archex.explorer.viewmodel import build_diff_view, build_manifest_view
+from archex.explorer.viewmodel import (
+    DEFAULT_NEIGHBORHOOD_DEPTH,
+    DEFAULT_NEIGHBORHOOD_LIMIT,
+    build_diff_view,
+    build_health_view,
+    build_manifest_view,
+    build_module_map_view,
+    build_neighborhood_view,
+    build_receipt_view,
+)
 
 if TYPE_CHECKING:
     from archex.explorer.loader import ExplorerData
+    from archex.explorer.viewmodel import ManifestView, NeighborhoodView
+    from archex.graph_query import GraphDirection
 
 LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1"})
 
@@ -114,16 +134,51 @@ class _ExplorerRequestHandler(BaseHTTPRequestHandler):
             return
 
         route = split.path
+        params = parse_qs(split.query)
         manifest = build_manifest_view(server.data)
-        if route in ("/", ""):
-            body = render_page("archex explorer", manifest, self._index_body())
-        elif route == "/view/diff":
-            body = render_diff_page(manifest, build_diff_view(server.data))
-        else:
+        body = self._render_route(route, params, server, manifest)
+        if body is None:
             self._reject(404, "Not Found", f"No view at {route!r}.")
             return
 
         self._respond(200, body, presented_token=token_from_query(split.query), server=server)
+
+    def _render_route(
+        self,
+        route: str,
+        params: dict[str, list[str]],
+        server: ExplorerServer,
+        manifest: ManifestView,
+    ) -> str | None:
+        if route in ("/", ""):
+            return render_page("archex explorer", manifest, self._index_body())
+        if route == "/view/diff":
+            return render_diff_page(manifest, build_diff_view(server.data))
+        if route == "/view/modules":
+            return render_module_map_page(manifest, build_module_map_view(server.data))
+        if route == "/view/receipt":
+            return render_receipt_page(manifest, build_receipt_view(server.data))
+        if route == "/view/health":
+            return render_health_page(manifest, build_health_view(server.data))
+        if route == "/view/neighborhood":
+            return render_neighborhood_page(manifest, self._neighborhood_view(params, server))
+        return None
+
+    def _neighborhood_view(
+        self, params: dict[str, list[str]], server: ExplorerServer
+    ) -> NeighborhoodView:
+        query = params.get("node", [None])[0]
+        direction_value = params.get("direction", ["both"])[0]
+        direction: GraphDirection = (
+            direction_value  # type: ignore[assignment]
+            if direction_value in ("both", "out", "in")
+            else "both"
+        )
+        depth = _parse_positive_int(params.get("depth", [None])[0], DEFAULT_NEIGHBORHOOD_DEPTH)
+        limit = _parse_positive_int(params.get("limit", [None])[0], DEFAULT_NEIGHBORHOOD_LIMIT)
+        return build_neighborhood_view(
+            server.data, query, direction=direction, depth=depth, limit=limit
+        )
 
     def _explorer_server(self) -> ExplorerServer:
         server = self.server
@@ -131,7 +186,8 @@ class _ExplorerRequestHandler(BaseHTTPRequestHandler):
         return server
 
     def _index_body(self) -> str:
-        return '<h2>Views</h2>\n<ul><li><a href="/view/diff">Diff Review</a></li></ul>'
+        items = "".join(f'<li><a href="{path}">{label}</a></li>' for label, path in NAV_ITEMS)
+        return f"<h2>Views</h2>\n<ul>{items}</ul>"
 
     def _respond(
         self,
@@ -157,3 +213,13 @@ class _ExplorerRequestHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(payload)))
         self.end_headers()
         self.wfile.write(payload)
+
+
+def _parse_positive_int(raw: str | None, default: int) -> int:
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value >= 1 else default

--- a/src/archex/explorer/server.py
+++ b/src/archex/explorer/server.py
@@ -1,10 +1,15 @@
 """Loopback-only HTTP server rendering the local explorer.
 
-Binds hardcoded to `127.0.0.1`/`::1` and requires a per-process session
-token on every request (see `archex.explorer.security`). CSP response
-headers and `Host` header validation are added by a follow-up hardening
-change; until then this server is loopback-reachable-only, GET-only, and
-serves nothing without a valid token.
+Every request must pass three independent checks before any artifact data
+is rendered: the bind address itself is hardcoded to loopback
+(`127.0.0.1`/`::1`, never configurable to a wider address), the `Host`
+header must match the server's own bind address/port (defends against DNS
+rebinding), and a valid per-process session token must be present (query
+string or session cookie) -- see `archex.explorer.security`. Every response
+carries a restrictive Content-Security-Policy and related hardening
+headers. The server is GET-only (405 on any other method) and serves
+nothing beyond the read-only view HTML this module renders: no source
+upload, no state mutation, no remote fetch.
 """
 
 from __future__ import annotations
@@ -26,10 +31,13 @@ from archex.explorer.render import (
     render_receipt_page,
 )
 from archex.explorer.security import (
-    SESSION_COOKIE_NAME,
+    SECURITY_RESPONSE_HEADERS,
     TOKEN_QUERY_PARAM,
+    allowed_host_headers,
     generate_token,
     is_authorized,
+    is_valid_host_header,
+    session_cookie_header,
     token_from_query,
     token_matches,
 )
@@ -65,6 +73,7 @@ class ExplorerServer(ThreadingHTTPServer):
     allow_reuse_address = True
     data: ExplorerData
     token: str
+    allowed_host_headers: frozenset[str]
 
     def __init__(
         self,
@@ -83,6 +92,7 @@ class ExplorerServer(ThreadingHTTPServer):
         self.token = token or generate_token()
         self.address_family = socket.AF_INET6 if host == "::1" else socket.AF_INET
         super().__init__((host, port), _ExplorerRequestHandler)
+        self.allowed_host_headers = allowed_host_headers(host, self.server_address[1])
 
     @property
     def url(self) -> str:
@@ -124,6 +134,11 @@ class _ExplorerRequestHandler(BaseHTTPRequestHandler):
 
     def _handle_get(self) -> None:
         server = self._explorer_server()
+
+        if not is_valid_host_header(self.headers.get("Host"), server.allowed_host_headers):
+            self._reject(400, "Bad Request", "Invalid Host header.")
+            return
+
         split = urlsplit(self.path)
         if not is_authorized(
             query_string=split.query,
@@ -136,7 +151,7 @@ class _ExplorerRequestHandler(BaseHTTPRequestHandler):
         route = split.path
         params = parse_qs(split.query)
         manifest = build_manifest_view(server.data)
-        body = self._render_route(route, params, server, manifest)
+        body: str | None = self._render_route(route, params, server, manifest)
         if body is None:
             self._reject(404, "Not Found", f"No view at {route!r}.")
             return
@@ -201,8 +216,10 @@ class _ExplorerRequestHandler(BaseHTTPRequestHandler):
         self.send_response(status)
         self.send_header("Content-Type", "text/html; charset=utf-8")
         self.send_header("Content-Length", str(len(payload)))
+        for name, value in SECURITY_RESPONSE_HEADERS.items():
+            self.send_header(name, value)
         if presented_token is not None and token_matches(presented_token, server.token):
-            self.send_header("Set-Cookie", f"{SESSION_COOKIE_NAME}={presented_token}; Path=/")
+            self.send_header("Set-Cookie", session_cookie_header(presented_token))
         self.end_headers()
         self.wfile.write(payload)
 
@@ -211,6 +228,8 @@ class _ExplorerRequestHandler(BaseHTTPRequestHandler):
         self.send_response(status)
         self.send_header("Content-Type", "text/html; charset=utf-8")
         self.send_header("Content-Length", str(len(payload)))
+        for name, value in SECURITY_RESPONSE_HEADERS.items():
+            self.send_header(name, value)
         self.end_headers()
         self.wfile.write(payload)
 

--- a/src/archex/explorer/viewmodel.py
+++ b/src/archex/explorer/viewmodel.py
@@ -10,11 +10,15 @@ than silently truncating.
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from archex.graph_query import DEFAULT_GRAPH_LIMIT, GraphQuery, GraphQueryError
+
 if TYPE_CHECKING:
     from archex.explorer.loader import ExplorerData
+    from archex.graph_query import GraphDirection, GraphEdgeSummary, GraphNodeSummary
     from archex.report.artifact import EvidenceLocation
 
 MAX_DIFF_FILE_ROWS = 100
@@ -205,3 +209,262 @@ def build_diff_view(data: ExplorerData) -> DiffView:
 def evidence_rows(evidence: list[EvidenceLocation], *, limit: int) -> list[EvidenceLocation]:
     """Shared bounded-slice helper so every view truncates evidence identically."""
     return evidence[:limit]
+
+
+@dataclass(frozen=True)
+class ReceiptView:
+    """Is the artifact fresh, complete, and evidenced? (DEVELOPMENT_PLAN M5)."""
+
+    freshness: str
+    completeness: str
+    confidence: str
+    redaction_mode: str
+    generated_at: str
+    evidence_locations: list[EvidenceLocation]
+    evidence_locations_total: int
+    excluded_counts: dict[str, int]
+    unknown_counts: dict[str, int]
+
+
+MAX_EVIDENCE_ROWS = 100
+
+
+def build_receipt_view(data: ExplorerData) -> ReceiptView:
+    artifact = data.artifact
+    return ReceiptView(
+        freshness=artifact.freshness.value,
+        completeness=artifact.completeness.value,
+        confidence=artifact.confidence.value,
+        redaction_mode=artifact.redaction_mode.value,
+        generated_at=artifact.generated_at,
+        evidence_locations=evidence_rows(artifact.evidence_locations, limit=MAX_EVIDENCE_ROWS),
+        evidence_locations_total=len(artifact.evidence_locations),
+        excluded_counts=dict(artifact.excluded_counts),
+        unknown_counts=dict(artifact.unknown_counts),
+    )
+
+
+@dataclass(frozen=True)
+class HealthView:
+    """Is this evidence trustworthy? Index/parser/config identity (DEVELOPMENT_PLAN M5)."""
+
+    archex_version: str
+    schema_version: str
+    index_generation: str
+    index_schema_version: str
+    chunker_revision: str
+    parser_versions: dict[str, str]
+    retrieval_profile: str | None
+    config_fingerprint: str
+    working_tree_fingerprint: str
+    producer: str
+    producer_version: str
+
+
+def build_health_view(data: ExplorerData) -> HealthView:
+    artifact = data.artifact
+    return HealthView(
+        archex_version=artifact.archex_version,
+        schema_version=artifact.schema_version.value,
+        index_generation=artifact.index_generation,
+        index_schema_version=artifact.index_schema_version,
+        chunker_revision=artifact.chunker_revision,
+        parser_versions=dict(artifact.parser_versions),
+        retrieval_profile=artifact.retrieval_profile,
+        config_fingerprint=artifact.config_fingerprint,
+        working_tree_fingerprint=artifact.working_tree_fingerprint,
+        producer=artifact.producer,
+        producer_version=artifact.producer_version,
+    )
+
+
+MAX_MODULE_ROWS = 200
+_UNASSIGNED_MODULE = "(unassigned)"
+
+
+@dataclass(frozen=True)
+class ModuleRow:
+    module: str
+    node_count: int
+    file_count: int
+    symbol_count: int
+    interface_count: int
+
+
+@dataclass(frozen=True)
+class ModuleMapView:
+    """Where should I start? Module-aggregated node counts, not a force graph.
+
+    Default graph presentation is aggregation, never the raw per-node/edge
+    graph -- `build_neighborhood_view` is the only view that projects
+    individual nodes/edges, and only a bounded neighborhood of them.
+    """
+
+    available: bool
+    modules: list[ModuleRow]
+    modules_total: int
+
+
+def build_module_map_view(data: ExplorerData, *, limit: int = MAX_MODULE_ROWS) -> ModuleMapView:
+    if data.graph is None:
+        return ModuleMapView(available=False, modules=[], modules_total=0)
+
+    counts: dict[str, dict[str, int]] = defaultdict(
+        lambda: {"node": 0, "file": 0, "symbol": 0, "interface": 0}
+    )
+    for node in data.graph.nodes:
+        module = node.module or _UNASSIGNED_MODULE
+        counts[module]["node"] += 1
+        if node.type.value == "file":
+            counts[module]["file"] += 1
+        elif node.type.value == "symbol":
+            counts[module]["symbol"] += 1
+        elif node.type.value == "interface":
+            counts[module]["interface"] += 1
+
+    rows = sorted(
+        (
+            ModuleRow(
+                module=module,
+                node_count=stats["node"],
+                file_count=stats["file"],
+                symbol_count=stats["symbol"],
+                interface_count=stats["interface"],
+            )
+            for module, stats in counts.items()
+        ),
+        key=lambda row: (-row.node_count, row.module),
+    )
+    return ModuleMapView(available=True, modules=rows[:limit], modules_total=len(rows))
+
+
+DEFAULT_NEIGHBORHOOD_DEPTH = 1
+DEFAULT_NEIGHBORHOOD_LIMIT = DEFAULT_GRAPH_LIMIT
+
+
+@dataclass(frozen=True)
+class NeighborNodeRow:
+    id: str
+    type: str
+    label: str
+    path: str | None
+    degree: int
+
+
+@dataclass(frozen=True)
+class NeighborEdgeRow:
+    source_id: str
+    target_id: str
+    type: str
+    confidence: str
+
+
+@dataclass(frozen=True)
+class NeighborhoodView:
+    """What directly depends on this? A bounded traversal, never the full graph."""
+
+    available: bool
+    query: str | None
+    error: str | None
+    seed: NeighborNodeRow | None
+    direction: str
+    depth: int
+    limit: int
+    nodes: list[NeighborNodeRow]
+    edges: list[NeighborEdgeRow]
+    hubs: list[NeighborNodeRow]
+    truncated: bool
+    omitted_edges: int
+
+
+def build_neighborhood_view(
+    data: ExplorerData,
+    query: str | None,
+    *,
+    direction: GraphDirection = "both",
+    depth: int = DEFAULT_NEIGHBORHOOD_DEPTH,
+    limit: int = DEFAULT_NEIGHBORHOOD_LIMIT,
+) -> NeighborhoodView:
+    if data.graph is None:
+        return NeighborhoodView(
+            available=False,
+            query=query,
+            error="no graph artifact provided",
+            seed=None,
+            direction=direction,
+            depth=depth,
+            limit=limit,
+            nodes=[],
+            edges=[],
+            hubs=[],
+            truncated=False,
+            omitted_edges=0,
+        )
+    if not query:
+        return NeighborhoodView(
+            available=True,
+            query=query,
+            error=None,
+            seed=None,
+            direction=direction,
+            depth=depth,
+            limit=limit,
+            nodes=[],
+            edges=[],
+            hubs=[],
+            truncated=False,
+            omitted_edges=0,
+        )
+
+    graph_query = GraphQuery(data.graph)
+    try:
+        result = graph_query.neighbors(query, direction=direction, depth=depth, limit=limit)
+    except GraphQueryError as exc:
+        return NeighborhoodView(
+            available=True,
+            query=query,
+            error=str(exc),
+            seed=None,
+            direction=direction,
+            depth=depth,
+            limit=limit,
+            nodes=[],
+            edges=[],
+            hubs=[],
+            truncated=False,
+            omitted_edges=0,
+        )
+
+    return NeighborhoodView(
+        available=True,
+        query=query,
+        error=None,
+        seed=_node_row(result.seed),
+        direction=result.direction,
+        depth=result.depth,
+        limit=limit,
+        nodes=[_node_row(node) for node in result.traversed_nodes],
+        edges=[_edge_row(edge) for edge in result.edges],
+        hubs=[_node_row(node) for node in result.hubs],
+        truncated=result.truncated,
+        omitted_edges=result.omitted_edges,
+    )
+
+
+def _node_row(node: GraphNodeSummary) -> NeighborNodeRow:
+    return NeighborNodeRow(
+        id=node.id,
+        type=node.type,
+        label=node.label,
+        path=node.path,
+        degree=node.degree,
+    )
+
+
+def _edge_row(edge: GraphEdgeSummary) -> NeighborEdgeRow:
+    return NeighborEdgeRow(
+        source_id=edge.source.id,
+        target_id=edge.target.id,
+        type=edge.type,
+        confidence=edge.confidence,
+    )

--- a/tests/explorer/test_render.py
+++ b/tests/explorer/test_render.py
@@ -2,8 +2,27 @@
 
 from __future__ import annotations
 
-from archex.explorer.render import render_diff_page, render_error_page, render_page
-from archex.explorer.viewmodel import DiffFileRow, DiffView, ManifestView
+from archex.explorer.render import (
+    render_diff_page,
+    render_error_page,
+    render_health_page,
+    render_module_map_page,
+    render_neighborhood_page,
+    render_page,
+    render_receipt_page,
+)
+from archex.explorer.viewmodel import (
+    DiffFileRow,
+    DiffView,
+    HealthView,
+    ManifestView,
+    ModuleMapView,
+    ModuleRow,
+    NeighborEdgeRow,
+    NeighborhoodView,
+    NeighborNodeRow,
+    ReceiptView,
+)
 
 
 def _manifest(source_identity: str = "acme/widget") -> ManifestView:
@@ -87,3 +106,146 @@ def test_render_error_page_never_echoes_artifact_content() -> None:
     assert "403 Forbidden" in html
     assert "session token" in html
     assert "<script" not in html.lower()
+
+
+def _receipt_view() -> ReceiptView:
+    return ReceiptView(
+        freshness="clean",
+        completeness="complete",
+        confidence="high",
+        redaction_mode="redacted",
+        generated_at="2026-07-24T00:00:00Z",
+        evidence_locations=[],
+        evidence_locations_total=0,
+        excluded_counts={"unmapped": 2},
+        unknown_counts={},
+    )
+
+
+def _health_view() -> HealthView:
+    return HealthView(
+        archex_version="0.22.0",
+        schema_version="1.0.0",
+        index_generation="gen1",
+        index_schema_version="1",
+        chunker_revision="c1",
+        parser_versions={"python": "tree-sitter-python"},
+        retrieval_profile=None,
+        config_fingerprint="cfg1",
+        working_tree_fingerprint="fp",
+        producer="archex-cli",
+        producer_version="0.22.0",
+    )
+
+
+def test_render_module_map_page_reports_unavailable_without_graph() -> None:
+    view = ModuleMapView(available=False, modules=[], modules_total=0)
+
+    html = render_module_map_page(_manifest(), view)
+
+    assert "No graph artifact provided" in html
+    assert "<table" not in html
+
+
+def test_render_module_map_page_renders_aggregated_rows() -> None:
+    view = ModuleMapView(
+        available=True,
+        modules=[
+            ModuleRow(module="pkg", node_count=3, file_count=2, symbol_count=1, interface_count=0)
+        ],
+        modules_total=1,
+    )
+
+    html = render_module_map_page(_manifest(), view)
+
+    assert "pkg" in html
+    assert "<table" in html
+
+
+def test_render_neighborhood_page_reports_unavailable_without_graph() -> None:
+    view = NeighborhoodView(
+        available=False,
+        query=None,
+        error="no graph artifact provided",
+        seed=None,
+        direction="both",
+        depth=1,
+        limit=25,
+        nodes=[],
+        edges=[],
+        hubs=[],
+        truncated=False,
+        omitted_edges=0,
+    )
+
+    html = render_neighborhood_page(_manifest(), view)
+
+    assert "No graph artifact provided" in html
+    assert "<form" in html  # the search form still renders
+
+
+def test_render_neighborhood_page_escapes_node_and_edge_ids() -> None:
+    seed = NeighborNodeRow(
+        id="<script>x</script>", type="file", label="a.py", path="a.py", degree=1
+    )
+    view = NeighborhoodView(
+        available=True,
+        query="a.py",
+        error=None,
+        seed=seed,
+        direction="both",
+        depth=1,
+        limit=25,
+        nodes=[seed],
+        edges=[
+            NeighborEdgeRow(
+                source_id="<script>x</script>",
+                target_id="file:b.py",
+                type="imports",
+                confidence="extracted",
+            )
+        ],
+        hubs=[],
+        truncated=False,
+        omitted_edges=0,
+    )
+
+    html = render_neighborhood_page(_manifest(), view)
+
+    assert "<script>x</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_render_neighborhood_page_reports_unresolved_query_error() -> None:
+    view = NeighborhoodView(
+        available=True,
+        query="does-not-exist",
+        error="no node matched 'does-not-exist'",
+        seed=None,
+        direction="both",
+        depth=1,
+        limit=25,
+        nodes=[],
+        edges=[],
+        hubs=[],
+        truncated=False,
+        omitted_edges=0,
+    )
+
+    html = render_neighborhood_page(_manifest(), view)
+
+    assert "no node matched" in html
+
+
+def test_render_receipt_page_shows_excluded_counts() -> None:
+    html = render_receipt_page(_manifest(), _receipt_view())
+
+    assert "unmapped: 2" in html
+    assert "Freshness: clean" in html
+
+
+def test_render_health_page_shows_identity_fields() -> None:
+    html = render_health_page(_manifest(), _health_view())
+
+    assert "gen1" in html
+    assert "tree-sitter-python" in html

--- a/tests/explorer/test_server.py
+++ b/tests/explorer/test_server.py
@@ -1,7 +1,9 @@
 """Browser-level HTTP tests: real requests against a real loopback server.
 
-Exercises the explorer purely through HTTP, the way a browser would --
-these are the "artifact-only browser tests" M5 PR-1 requires.
+Exercises the explorer purely through HTTP, the way a browser would -- these
+are the "artifact-only browser tests" and "security tests" M5's stack
+requires (loopback binding, session token, CSP, `Host` validation, offline
+rendering).
 """
 
 from __future__ import annotations
@@ -18,6 +20,13 @@ import pytest
 
 from archex.explorer.loader import ExplorerData, load_explorer_data
 from archex.explorer.server import ExplorerSecurityError, ExplorerServer, create_server
+from archex.graph_artifact import (
+    ArchGraph,
+    GraphExportMetadata,
+    GraphNode,
+    GraphNodeType,
+    GraphProject,
+)
 
 
 def _artifact_json(path: Path, source_revision: str = "deadbeef") -> Path:
@@ -146,3 +155,81 @@ def test_forbidden_response_does_not_leak_artifact_content(
     body = exc_info.value.read().decode("utf-8")
     assert "acme/widget" not in body
     assert "a.py" not in body
+
+
+def _graph() -> ArchGraph:
+    return ArchGraph(
+        project=GraphProject(name="widget", total_files=1),
+        metadata=GraphExportMetadata(archex_version="0.22.0"),
+        nodes=[GraphNode(id="file:a.py", type=GraphNodeType.FILE, label="a.py", module="pkg")],
+    )
+
+
+@pytest.fixture
+def explorer_data_with_graph(tmp_path: Path) -> ExplorerData:
+    return ExplorerData(
+        artifact=load_explorer_data(_artifact_json(tmp_path)).artifact, graph=_graph()
+    )
+
+
+@pytest.fixture
+def running_server_with_graph(explorer_data_with_graph: ExplorerData) -> Iterator[ExplorerServer]:
+    server = create_server(explorer_data_with_graph, port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_module_map_view_is_reachable(running_server: ExplorerServer) -> None:
+    port = running_server.server_address[1]
+
+    response = _get(f"http://127.0.0.1:{port}/view/modules?token={running_server.token}")
+
+    assert response.status == 200
+    assert "No graph artifact provided" in response.read().decode("utf-8")
+
+
+def test_receipt_view_is_reachable(running_server: ExplorerServer) -> None:
+    port = running_server.server_address[1]
+
+    response = _get(f"http://127.0.0.1:{port}/view/receipt?token={running_server.token}")
+
+    assert response.status == 200
+    assert "Receipt" in response.read().decode("utf-8")
+
+
+def test_health_view_is_reachable(running_server: ExplorerServer) -> None:
+    port = running_server.server_address[1]
+
+    response = _get(f"http://127.0.0.1:{port}/view/health?token={running_server.token}")
+
+    assert response.status == 200
+    assert "Index Health" in response.read().decode("utf-8")
+
+
+def test_module_map_view_renders_with_graph(running_server_with_graph: ExplorerServer) -> None:
+    port = running_server_with_graph.server_address[1]
+
+    response = _get(f"http://127.0.0.1:{port}/view/modules?token={running_server_with_graph.token}")
+
+    assert response.status == 200
+    assert "pkg" in response.read().decode("utf-8")
+
+
+def test_neighborhood_view_finds_seed_with_graph(
+    running_server_with_graph: ExplorerServer,
+) -> None:
+    port = running_server_with_graph.server_address[1]
+
+    response = _get(
+        f"http://127.0.0.1:{port}/view/neighborhood"
+        f"?node=file:a.py&token={running_server_with_graph.token}"
+    )
+
+    assert response.status == 200
+    assert "file:a.py" in response.read().decode("utf-8")

--- a/tests/explorer/test_server.py
+++ b/tests/explorer/test_server.py
@@ -185,6 +185,52 @@ def running_server_with_graph(explorer_data_with_graph: ExplorerData) -> Iterato
         thread.join(timeout=5)
 
 
+def test_valid_response_carries_csp_and_hardening_headers(running_server: ExplorerServer) -> None:
+    response = _get(running_server.url)
+
+    csp = response.headers.get("Content-Security-Policy", "")
+    assert "default-src 'none'" in csp
+    assert "frame-ancestors 'none'" in csp
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("X-Frame-Options") == "DENY"
+    assert response.headers.get("Referrer-Policy") == "no-referrer"
+    assert response.headers.get("Cache-Control") == "no-store"
+
+
+def test_session_cookie_is_hardened(running_server: ExplorerServer) -> None:
+    response = _get(running_server.url)
+
+    cookie = response.headers.get("Set-Cookie", "")
+    assert "HttpOnly" in cookie
+    assert "SameSite=Strict" in cookie
+    assert "Path=/" in cookie
+
+
+def test_wrong_host_header_is_rejected(running_server: ExplorerServer) -> None:
+    port = running_server.server_address[1]
+    request = urllib.request.Request(  # noqa: S310
+        f"http://127.0.0.1:{port}/?token={running_server.token}",
+        headers={"Host": "evil.example.com"},
+    )
+
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        urllib.request.urlopen(request, timeout=5)  # noqa: S310
+
+    assert exc_info.value.code == 400
+
+
+def test_localhost_alias_host_header_is_accepted(running_server: ExplorerServer) -> None:
+    port = running_server.server_address[1]
+    request = urllib.request.Request(  # noqa: S310
+        f"http://127.0.0.1:{port}/?token={running_server.token}",
+        headers={"Host": f"localhost:{port}"},
+    )
+
+    response = urllib.request.urlopen(request, timeout=5)  # noqa: S310
+
+    assert response.status == 200
+
+
 def test_module_map_view_is_reachable(running_server: ExplorerServer) -> None:
     port = running_server.server_address[1]
 

--- a/tests/explorer/test_viewmodel.py
+++ b/tests/explorer/test_viewmodel.py
@@ -5,7 +5,24 @@ from __future__ import annotations
 from pathlib import Path
 
 from archex.explorer.loader import ExplorerData
-from archex.explorer.viewmodel import MAX_DIFF_FILE_ROWS, build_diff_view, build_manifest_view
+from archex.explorer.viewmodel import (
+    MAX_DIFF_FILE_ROWS,
+    build_diff_view,
+    build_health_view,
+    build_manifest_view,
+    build_module_map_view,
+    build_neighborhood_view,
+    build_receipt_view,
+)
+from archex.graph_artifact import (
+    ArchGraph,
+    GraphEdge,
+    GraphEdgeType,
+    GraphExportMetadata,
+    GraphNode,
+    GraphNodeType,
+    GraphProject,
+)
 from archex.report.artifact import (
     AnalysisArtifactV1,
     DiffAnalysis,
@@ -86,3 +103,136 @@ def test_build_diff_view_bounds_changed_files_and_reports_total() -> None:
 
     assert len(view.changed_files) == MAX_DIFF_FILE_ROWS
     assert view.changed_files_total == len(changed)
+
+
+def _minimal_artifact() -> AnalysisArtifactV1:
+    return AnalysisArtifactV1(
+        schema_version=ReportSchemaVersion(),
+        generated_at="2026-07-24T00:00:00Z",
+        source_identity="acme/widget",
+        source_root="/repo",
+        source_revision="deadbeef",
+        working_tree_fingerprint="fp",
+        index_generation="gen1",
+        index_schema_version="1",
+        chunker_revision="c1",
+        config_fingerprint="cfg1",
+        parser_versions={"python": "tree-sitter-python"},
+        excluded_counts={"unmapped": 2},
+        unknown_counts={"symbol_kind": 1},
+        diff=DiffAnalysis(base_ref="main"),
+    )
+
+
+def _small_graph() -> ArchGraph:
+    return ArchGraph(
+        project=GraphProject(name="widget", total_files=2),
+        metadata=GraphExportMetadata(archex_version="0.22.0"),
+        nodes=[
+            GraphNode(id="file:a.py", type=GraphNodeType.FILE, label="a.py", module="pkg"),
+            GraphNode(id="file:b.py", type=GraphNodeType.FILE, label="b.py", module="pkg"),
+            GraphNode(
+                id="symbol:a.py::f#function",
+                type=GraphNodeType.SYMBOL,
+                label="f",
+                module="pkg",
+            ),
+        ],
+        edges=[
+            GraphEdge(source="file:a.py", target="file:b.py", type=GraphEdgeType.IMPORTS),
+        ],
+    )
+
+
+def test_build_module_map_view_without_graph_is_unavailable() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=None)
+
+    view = build_module_map_view(data)
+
+    assert view.available is False
+    assert view.modules == []
+
+
+def test_build_module_map_view_aggregates_nodes_by_module() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=_small_graph())
+
+    view = build_module_map_view(data)
+
+    assert view.available is True
+    assert view.modules_total == 1
+    row = view.modules[0]
+    assert row.module == "pkg"
+    assert row.node_count == 3
+    assert row.file_count == 2
+    assert row.symbol_count == 1
+
+
+def test_build_neighborhood_view_without_graph_is_unavailable() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=None)
+
+    view = build_neighborhood_view(data, "file:a.py")
+
+    assert view.available is False
+    assert view.error is not None
+
+
+def test_build_neighborhood_view_without_query_is_empty_but_available() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=_small_graph())
+
+    view = build_neighborhood_view(data, None)
+
+    assert view.available is True
+    assert view.seed is None
+    assert view.error is None
+
+
+def test_build_neighborhood_view_finds_bounded_neighbors() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=_small_graph())
+
+    view = build_neighborhood_view(data, "file:a.py", depth=1, limit=25)
+
+    assert view.error is None
+    assert view.seed is not None
+    assert view.seed.id == "file:a.py"
+    assert {node.id for node in view.nodes} == {"file:a.py", "file:b.py"}
+
+
+def test_build_neighborhood_view_reports_unresolvable_query_as_error() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=_small_graph())
+
+    view = build_neighborhood_view(data, "does-not-exist")
+
+    assert view.available is True
+    assert view.error is not None
+    assert view.seed is None
+
+
+def test_build_neighborhood_view_never_constructs_new_edges() -> None:
+    """The view must only ever project `GraphQuery.neighbors`'s own bounded result."""
+    graph = _small_graph()
+    original_edge_count = len(graph.edges)
+    data = ExplorerData(artifact=_minimal_artifact(), graph=graph)
+
+    build_neighborhood_view(data, "file:a.py")
+
+    assert len(graph.edges) == original_edge_count
+
+
+def test_build_receipt_view_projects_evidence_and_counts() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=None)
+
+    view = build_receipt_view(data)
+
+    assert view.freshness == data.artifact.freshness.value
+    assert view.excluded_counts == {"unmapped": 2}
+    assert view.unknown_counts == {"symbol_kind": 1}
+
+
+def test_build_health_view_projects_identity_fields() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=None)
+
+    view = build_health_view(data)
+
+    assert view.index_generation == "gen1"
+    assert view.chunker_revision == "c1"
+    assert view.parser_versions == {"python": "tree-sitter-python"}


### PR DESCRIPTION
## Summary

M5 PR-2/3: the remaining four explorer views plus the security hardening M5's acceptance requires.

- **Module Map**: node counts aggregated by `GraphNode.module` (module aggregation, never a per-node force graph) -- "not available" when no `--graph` artifact was supplied.
- **Target Neighborhood**: a bounded traversal via the existing `archex.graph_query.GraphQuery.neighbors` (the same bounded query `archex graph neighbors` already uses). The explorer constructs no new edges, only projects that call's own bounded result. A plain `<form method="get">` (no client-side JavaScript) lets a user search by file path or symbol id.
- **Receipt Inspector**: the artifact's freshness/completeness/confidence/evidence-locations/excluded/unknown fields in full.
- **Index Health**: identity fields -- index generation, schema versions, parser versions, chunker revision, config fingerprint, producer.
- **Security hardening** (`fix` commit): `Host` header validation against the server's own bind address/port (DNS-rebinding defense, 400 before any auth check or render), a restrictive Content-Security-Policy (`default-src 'none'`) plus `X-Content-Type-Options`/`X-Frame-Options`/`Referrer-Policy`/`Cache-Control` on every response, and a hardened session cookie (`HttpOnly`, `SameSite=Strict`, path-scoped).

## Scope

In: `ModuleMapView`/`NeighborhoodView`/`ReceiptView`/`HealthView` + builders, matching server-rendered pages, nav bar linking to all five views, `Host`/CSP/cookie hardening, tests.

Out (PR-3): 10k/100k projection benchmarks, usability protocol/results.

## Review note on topology

This PR is based on `m5-1-artifact-only-explorer-shell` (#547), not yet merged; diff/commit list will shrink to just this PR's two commits once #547 merges and this PR's base updates automatically.

## Verification

- `uv run ruff check <changed files>` / `uv run ruff format --check <changed files>` / `uv run pyright <changed files>`: clean.
- `uv run pytest tests/explorer tests/cli/test_explore_cmd.py --no-cov`: 56 passed.
- `uv run pytest --junitxml=results.xml --cov-report=xml`: 4133 passed, 91.66% coverage.
- Manual smoke: real `archex graph export` + `archex report diff` fixtures against `archex explore artifact.json --graph graph.json`; confirmed a bad `Host` header gets 400, the `localhost` alias is accepted, CSP/hardening headers and a hardened `Set-Cookie` are present on every 200, and Module Map/Receipt/Health/Neighborhood all render real data (neighborhood correctly resolves a seed node and its bounded neighbors).
