### PR TITLE
test(explorer): benchmark large projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **M5: local explorer for the canonical diff-review artifact.** Added `archex explore ARTIFACT [--graph GRAPH] [--port N]`: a loopback-only, session-token-gated local HTTP server rendering a previously exported `AnalysisArtifactV1` (`archex report diff --format json`) and an optional `ArchGraph` (`archex graph export`). Five read-only views project the artifact without any new source parsing or graph-edge construction: Module Map (node counts aggregated by module, not a force graph), Target Neighborhood (a bounded traversal via the existing `GraphQuery.neighbors`, reached through a plain HTML search form), Diff Review, Receipt Inspector (freshness/completeness/confidence/evidence/exclusions/unknowns), and Index Health (schema/parser/config identity). Every response carries a restrictive Content-Security-Policy plus `X-Content-Type-Options`/`X-Frame-Options`/`Referrer-Policy`/`Cache-Control` headers; every request is validated against the server's own `Host` header (DNS-rebinding defense) and a per-process session token (hardened cookie: `HttpOnly`, `SameSite=Strict`); the bind address is hardcoded to loopback (`127.0.0.1`/`::1`) with no wider-bind option; and the server is GET-only with no client-side JavaScript at all. Declared 10k/100k-node projection budgets and a new-contributor orientation usability proxy (real HTTP navigation timing against an objectively correct answer, not self-reported satisfaction) are documented in `docs/EXPLORER_USABILITY_EVIDENCE.md` and reproducible via `scripts/m5_explorer_projection_benchmark.py` / `scripts/m5_explorer_usability_evidence.py`.
+
 ## [0.22.0] - 2026-07-24
 
 This release combines three deferred release trains that were never individually tagged or published — `v0.20.0` (M2), `v0.21.0` (M3, M10), and `v0.22.0` (M4) — into a single cut, per `.docs/DEVELOPMENT_PLAN.md` §2.1's release-preparation policy. Each entry below is labeled with the version it was originally planned for.

--- a/docs/EXPLORER_USABILITY_EVIDENCE.md
+++ b/docs/EXPLORER_USABILITY_EVIDENCE.md
@@ -1,0 +1,75 @@
+# Explorer orientation usability evidence
+
+M5 (`.docs/DEVELOPMENT_PLAN.md` §4) requires "usability evidence measures time to first correct
+file/symbol rather than self-reported satisfaction" for the local explorer's new-contributor
+orientation use case (`.docs/2026-07-10-codeflow-archex-enhancement-analysis.md`, "Adoption
+wedge": *New contributor -- Where do I start? -- Bounded repository projection -- Time to first
+correct file/symbol*).
+
+## What this evidence is, and is not
+
+This is an **automated, deterministic proxy**, not a live human trial. No human subjects were
+recruited or observed to produce these numbers, and this evidence does not claim otherwise. What
+it measures honestly: real wall-clock elapsed time, over real HTTP requests, against a real
+running `ExplorerServer` (`archex.explorer.server`), to reach a page whose rendered content
+contains an objectively correct answer -- defined by the fixture's own documented graph shape,
+not by the script that measures it.
+
+A live new-contributor study (recruit unfamiliar developers, time their real navigation, compare
+against a self-reported-satisfaction control) remains valuable follow-on work but is out of scope
+for an autonomous delivery with no access to human subjects. Reporting this proxy honestly is
+preferable to fabricating a satisfaction score or skipping the acceptance row.
+
+## Protocol
+
+Run:
+
+```text
+uv run python scripts/m5_explorer_usability_evidence.py
+```
+
+The script:
+
+1. Copies `tests/fixtures/impact_diff` into a scratch directory and initializes a git repository
+   (mirrors `tests/conftest.py`'s `_init_fixture_repo` and `tests/test_report_artifact.py`'s
+   `_edit_hub` helper).
+2. Edits `hub.py` (`value * 2` -> `value * 3`), producing one changed file against `HEAD`.
+3. Builds a real `AnalysisArtifactV1` (`archex report diff`'s underlying builder) and a real
+   `ArchGraph` (`archex graph export`'s underlying builder) from the edited repository.
+4. Starts a real `ExplorerServer` loaded with both artifacts.
+5. Times two navigation paths over real HTTP requests against the running server:
+   - **Diff Review** (`GET /view/diff`): does the rendered page name `hub.py` as the changed
+     file?
+   - **Target Neighborhood** (`GET /view/neighborhood?node=file:hub.py`): does searching for
+     `hub.py` surface all four of its real importers?
+
+## Scenario ground truth
+
+`tests/fixtures/impact_diff`'s own documented graph shape (`tests/conftest.py`): `hub.py` is
+imported by four files (`leaf.py`, `consumer_a.py`, `consumer_b.py`, `consumer_c.py`) and is
+transitively reachable from the entry point `main.py` -- a deliberate hub for diff-scoped risk
+classification tests. A contributor who just cloned this repository and asks "what changed, and
+what does it affect?" should be able to answer "`hub.py`, and its four importers" from the
+explorer alone, without reading source.
+
+## Measured evidence (2026-07-24, reference dev machine)
+
+| Navigation path | Elapsed | Correct |
+| --- | ---: | :---: |
+| Diff Review (`/view/diff`) | 0.005s-0.009s (3 runs) | yes |
+| Target Neighborhood (`/view/neighborhood`) | 0.001s | yes |
+
+Both navigation paths reached the objectively correct file/symbol on every run. Elapsed time is
+dominated by Python HTTP request/response overhead, not by any per-request graph-index
+reconstruction: `archex.explorer.server.ExplorerServer` builds its `GraphQuery` once at startup
+(see `scripts/m5_explorer_projection_benchmark.py` and
+`tests/explorer/test_projection_benchmark.py` for the corresponding 10k/100k-node scale evidence),
+so every subsequent neighborhood lookup during one explorer session is a bounded, already-indexed
+traversal.
+
+## Reproducing this evidence
+
+Re-run the script above; correctness is asserted by the script itself (nonzero exit on a wrong
+answer), so a passing run is self-verifying. Wall-clock numbers will vary with hardware but should
+remain well under any budget a human would perceive as slow (sub-second), since the scenario's
+`ArchGraph`/`AnalysisArtifactV1` are small (six files).

--- a/scripts/m5_explorer_projection_benchmark.py
+++ b/scripts/m5_explorer_projection_benchmark.py
@@ -1,0 +1,173 @@
+"""Evidence script: measure explorer projection latency at 10k/100k graph nodes.
+
+M5's DEVELOPMENT_PLAN.md acceptance row requires "10k/100k projection tests
+meet declared rendering budgets". Run:
+
+    uv run python scripts/m5_explorer_projection_benchmark.py
+
+Builds a deterministic ring-connected synthetic `ArchGraph` at each node
+count (never real repository source -- this is a scale test of the
+explorer's own view-model/render/GraphQuery layers, not of parsing or
+indexing), then times:
+
+- server startup, including the one-time `GraphQuery` adjacency-index build
+  `archex.explorer.server.ExplorerServer` performs so per-request
+  neighborhood lookups never re-pay it;
+- Module Map view-model construction plus HTML render;
+- a post-startup Target Neighborhood lookup (view-model construction plus
+  HTML render), which should be dominated by the bounded depth/limit
+  traversal, not by graph size.
+
+Exits 1 (after printing every measurement) if any declared budget is
+exceeded. Budgets mirror `tests/explorer/test_projection_benchmark.py`
+(kept in sync by hand -- both are small, deliberately duplicated rather
+than cross-imported so this script stays a self-contained, type-checkable
+CLI evidence tool independent of the test tree).
+"""
+
+from __future__ import annotations
+
+import time
+
+from archex.explorer.loader import ExplorerData
+from archex.explorer.render import render_module_map_page, render_neighborhood_page
+from archex.explorer.server import create_server
+from archex.explorer.viewmodel import (
+    build_manifest_view,
+    build_module_map_view,
+    build_neighborhood_view,
+)
+from archex.graph_artifact import (
+    ArchGraph,
+    GraphEdge,
+    GraphEdgeType,
+    GraphExportMetadata,
+    GraphNode,
+    GraphNodeType,
+    GraphProject,
+)
+from archex.report.artifact import AnalysisArtifactV1, DiffAnalysis, ReportSchemaVersion
+
+NODE_COUNTS = (10_000, 100_000)
+
+# Measured baseline (this repo's reference dev machine, 2026-07-24):
+#   10,000 nodes:  server startup ~0.07s, module map view+render ~0.002s,
+#                   post-startup neighborhood lookup <0.001s.
+#   100,000 nodes: server startup ~1.12s, module map view+render ~0.024s,
+#                   post-startup neighborhood lookup <0.001s.
+# Budgets carry >2x headroom over the measured baseline. Kept identical to
+# `tests/explorer/test_projection_benchmark.py`'s budgets by hand.
+STARTUP_BUDGET_SECONDS = {10_000: 0.5, 100_000: 3.0}
+MODULE_MAP_BUDGET_SECONDS = {10_000: 0.1, 100_000: 0.5}
+NEIGHBORHOOD_LOOKUP_BUDGET_SECONDS = {10_000: 0.05, 100_000: 0.2}
+
+
+def _artifact() -> AnalysisArtifactV1:
+    return AnalysisArtifactV1(
+        schema_version=ReportSchemaVersion(),
+        generated_at="2026-07-24T00:00:00Z",
+        source_identity="acme/widget",
+        source_root="/repo",
+        source_revision="deadbeef",
+        working_tree_fingerprint="fp",
+        index_generation="gen1",
+        index_schema_version="1",
+        chunker_revision="c1",
+        config_fingerprint="cfg1",
+        diff=DiffAnalysis(base_ref="main"),
+    )
+
+
+def _synthetic_graph(node_count: int, *, module_count: int = 50) -> ArchGraph:
+    """A deterministic ring-connected synthetic graph with NODE_COUNT file nodes."""
+    nodes = [
+        GraphNode(
+            id=f"file:f{i}.py",
+            type=GraphNodeType.FILE,
+            label=f"f{i}.py",
+            module=f"pkg{i % module_count}",
+        )
+        for i in range(node_count)
+    ]
+    edges = [
+        GraphEdge(
+            source=f"file:f{i}.py",
+            target=f"file:f{(i + 1) % node_count}.py",
+            type=GraphEdgeType.IMPORTS,
+        )
+        for i in range(node_count)
+    ]
+    return ArchGraph(
+        project=GraphProject(name="widget", total_files=node_count),
+        metadata=GraphExportMetadata(archex_version="0.22.0"),
+        nodes=nodes,
+        edges=edges,
+    )
+
+
+def _measure(node_count: int) -> tuple[bool, dict[str, float]]:
+    graph = _synthetic_graph(node_count)
+    data = ExplorerData(artifact=_artifact(), graph=graph)
+
+    start = time.perf_counter()
+    server = create_server(data, port=0)
+    startup_elapsed = time.perf_counter() - start
+    try:
+        manifest = build_manifest_view(data)
+
+        start = time.perf_counter()
+        module_map = build_module_map_view(data)
+        render_module_map_page(manifest, module_map)
+        module_map_elapsed = time.perf_counter() - start
+
+        seed_id = graph.nodes[0].id
+        start = time.perf_counter()
+        neighborhood = build_neighborhood_view(
+            data, seed_id, depth=1, limit=25, graph_query=server.graph_query
+        )
+        render_neighborhood_page(manifest, neighborhood)
+        neighborhood_elapsed = time.perf_counter() - start
+    finally:
+        server.server_close()
+
+    measurements = {
+        "startup_seconds": startup_elapsed,
+        "module_map_seconds": module_map_elapsed,
+        "neighborhood_seconds": neighborhood_elapsed,
+    }
+    within_budget = (
+        startup_elapsed <= STARTUP_BUDGET_SECONDS[node_count]
+        and module_map_elapsed <= MODULE_MAP_BUDGET_SECONDS[node_count]
+        and neighborhood_elapsed <= NEIGHBORHOOD_LOOKUP_BUDGET_SECONDS[node_count]
+    )
+    return within_budget, measurements
+
+
+def main() -> int:
+    print(f"{'nodes':>8}  {'startup':>10}  {'module_map':>12}  {'neighborhood':>14}  budget")
+    all_within_budget = True
+    for node_count in NODE_COUNTS:
+        within_budget, measurements = _measure(node_count)
+        all_within_budget = all_within_budget and within_budget
+        status = "PASS" if within_budget else "FAIL"
+        print(
+            f"{node_count:>8,}  "
+            f"{measurements['startup_seconds']:>9.3f}s  "
+            f"{measurements['module_map_seconds']:>11.3f}s  "
+            f"{measurements['neighborhood_seconds']:>13.4f}s  {status}"
+        )
+        print(
+            f"           budgets: startup<={STARTUP_BUDGET_SECONDS[node_count]}s "
+            f"module_map<={MODULE_MAP_BUDGET_SECONDS[node_count]}s "
+            f"neighborhood<={NEIGHBORHOOD_LOOKUP_BUDGET_SECONDS[node_count]}s"
+        )
+
+    if not all_within_budget:
+        print("\nFAILED: one or more measurements exceeded its declared budget.")
+        return 1
+    print("\nPASSED: every measurement is within its declared budget.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/m5_explorer_usability_evidence.py
+++ b/scripts/m5_explorer_usability_evidence.py
@@ -1,0 +1,140 @@
+"""Evidence script: measure time to the correct file/symbol via a real explorer server.
+
+M5's DEVELOPMENT_PLAN.md acceptance row requires "usability evidence
+measures time to first correct file/symbol rather than self-reported
+satisfaction." Run:
+
+    uv run python scripts/m5_explorer_usability_evidence.py
+
+This is an automated, deterministic proxy for a new-contributor
+orientation task, not a live human trial -- no human subjects were
+involved in producing this evidence, and this script does not substitute
+for one. What it *does* measure honestly: real wall-clock elapsed time,
+over real HTTP requests, against a real running `ExplorerServer`, to reach
+a page whose rendered content contains an objectively correct answer
+(defined by `tests/fixtures/impact_diff`'s own documented graph shape, not
+by this script).
+
+Scenario (`tests/fixtures/impact_diff`, also used by
+`tests/test_report_artifact.py` and friends): `hub.py` is imported by four
+files (`leaf.py`, `consumer_a.py`, `consumer_b.py`, `consumer_c.py`) and is
+transitively reachable from the entry point `main.py` -- a deliberate hub.
+Editing `hub.py` makes it the diff's own single changed file and its
+riskiest symbol candidate (public-interface change, high fan-in). A
+contributor who just cloned this repository and asks "what changed, and
+what does it affect?" should be able to answer "hub.py, and its four
+importers" from the explorer alone.
+
+Two navigation paths are timed:
+
+1. Diff Review: does the rendered `/view/diff` page name `hub.py` as the
+   changed file and (if the risk classifier flagged one) surfaces it as a
+   symbol risk candidate?
+2. Target Neighborhood: does searching `/view/neighborhood?node=file:hub.py`
+   surface all four real importers?
+
+Both are graded pass/fail against the fixture's documented ground truth to
+keep "correct" objective, not just fast.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.request
+from pathlib import Path
+
+from archex.explorer.loader import ExplorerData
+from archex.explorer.server import create_server
+from archex.graph_artifact import build_arch_graph_from_store
+from archex.report.artifact import build_analysis_artifact
+
+FIXTURE_DIR = Path(__file__).resolve().parent.parent / "tests" / "fixtures" / "impact_diff"
+EXPECTED_IMPORTERS = frozenset({"leaf.py", "consumer_a.py", "consumer_b.py", "consumer_c.py"})
+
+
+def _init_fixture_repo(dest: Path) -> None:
+    shutil.copytree(FIXTURE_DIR, dest)
+    for command in (
+        ["git", "init"],
+        ["git", "config", "user.email", "usability@archex.test"],
+        ["git", "config", "user.name", "archex-usability"],
+        ["git", "add", "."],
+        ["git", "commit", "-m", "initial"],
+    ):
+        subprocess.run(command, cwd=dest, check=True, capture_output=True)
+    hub = dest / "hub.py"
+    hub.write_text(hub.read_text().replace("value * 2", "value * 3"))
+
+
+def _get(url: str) -> str:
+    with urllib.request.urlopen(url, timeout=5) as response:  # noqa: S310
+        return response.read().decode("utf-8")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="archex-explorer-usability-") as tmp:
+        repo_path = Path(tmp) / "impact_diff"
+        _init_fixture_repo(repo_path)
+
+        from archex.api import index_repository
+        from archex.config import load_config, load_index_config
+        from archex.models import RepoSource
+
+        repo_source = RepoSource(local_path=str(repo_path))
+        config = load_config(repo_source)
+        index_config = load_index_config(repo_source)
+        store = index_repository(repo_source, config=config, index_config=index_config)
+        try:
+            graph = build_arch_graph_from_store(store, repo_root=repo_path)
+        finally:
+            store.close()
+        artifact = build_analysis_artifact(repo_path, base_ref="HEAD")
+
+        data = ExplorerData(artifact=artifact, graph=graph)
+        server = create_server(data, port=0)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            port = server.server_address[1]
+
+            start = time.perf_counter()
+            diff_html = _get(f"http://127.0.0.1:{port}/view/diff?token={server.token}")
+            diff_elapsed = time.perf_counter() - start
+            diff_correct = "hub.py" in diff_html
+
+            start = time.perf_counter()
+            neighborhood_html = _get(
+                f"http://127.0.0.1:{port}/view/neighborhood?node=file:hub.py&token={server.token}"
+            )
+            neighborhood_elapsed = time.perf_counter() - start
+            neighborhood_correct = all(
+                importer in neighborhood_html for importer in EXPECTED_IMPORTERS
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+    print("Scenario: tests/fixtures/impact_diff, hub.py edited (deliberate hub, 4 importers)\n")
+    print(f"{'path':<28} {'elapsed':>10}  {'correct':>8}")
+    print(f"{'Diff Review (/view/diff)':<28} {diff_elapsed:>9.3f}s  {diff_correct!s:>8}")
+    print(f"{'Target Neighborhood':<28} {neighborhood_elapsed:>9.3f}s  {neighborhood_correct!s:>8}")
+
+    if not (diff_correct and neighborhood_correct):
+        print("\nFAILED: the explorer did not surface the objectively correct answer.")
+        return 1
+    print("\nPASSED: both navigation paths reached the correct file/symbol.")
+    print(
+        "\nNote: this is an automated, deterministic proxy measuring real HTTP wall-clock "
+        "time against a real server -- not a live human trial. No self-reported satisfaction "
+        "score was collected or is claimed here."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/archex/explorer/server.py
+++ b/src/archex/explorer/server.py
@@ -51,6 +51,7 @@ from archex.explorer.viewmodel import (
     build_neighborhood_view,
     build_receipt_view,
 )
+from archex.graph_query import GraphQuery
 
 if TYPE_CHECKING:
     from archex.explorer.loader import ExplorerData
@@ -74,6 +75,7 @@ class ExplorerServer(ThreadingHTTPServer):
     data: ExplorerData
     token: str
     allowed_host_headers: frozenset[str]
+    graph_query: GraphQuery | None
 
     def __init__(
         self,
@@ -90,6 +92,10 @@ class ExplorerServer(ThreadingHTTPServer):
             )
         self.data = data
         self.token = token or generate_token()
+        # Built once, reused for the server's lifetime: `data.graph` is loaded once
+        # and never mutated, so every neighborhood lookup shares one set of adjacency
+        # indices instead of rebuilding them (see the M5 projection benchmark).
+        self.graph_query = GraphQuery(data.graph) if data.graph is not None else None
         self.address_family = socket.AF_INET6 if host == "::1" else socket.AF_INET
         super().__init__((host, port), _ExplorerRequestHandler)
         self.allowed_host_headers = allowed_host_headers(host, self.server_address[1])
@@ -192,7 +198,12 @@ class _ExplorerRequestHandler(BaseHTTPRequestHandler):
         depth = _parse_positive_int(params.get("depth", [None])[0], DEFAULT_NEIGHBORHOOD_DEPTH)
         limit = _parse_positive_int(params.get("limit", [None])[0], DEFAULT_NEIGHBORHOOD_LIMIT)
         return build_neighborhood_view(
-            server.data, query, direction=direction, depth=depth, limit=limit
+            server.data,
+            query,
+            direction=direction,
+            depth=depth,
+            limit=limit,
+            graph_query=server.graph_query,
         )
 
     def _explorer_server(self) -> ExplorerServer:

--- a/src/archex/explorer/viewmodel.py
+++ b/src/archex/explorer/viewmodel.py
@@ -384,6 +384,7 @@ def build_neighborhood_view(
     direction: GraphDirection = "both",
     depth: int = DEFAULT_NEIGHBORHOOD_DEPTH,
     limit: int = DEFAULT_NEIGHBORHOOD_LIMIT,
+    graph_query: GraphQuery | None = None,
 ) -> NeighborhoodView:
     if data.graph is None:
         return NeighborhoodView(
@@ -416,9 +417,9 @@ def build_neighborhood_view(
             omitted_edges=0,
         )
 
-    graph_query = GraphQuery(data.graph)
+    engine = graph_query if graph_query is not None else GraphQuery(data.graph)
     try:
-        result = graph_query.neighbors(query, direction=direction, depth=depth, limit=limit)
+        result = engine.neighbors(query, direction=direction, depth=depth, limit=limit)
     except GraphQueryError as exc:
         return NeighborhoodView(
             available=True,

--- a/tests/explorer/test_projection_benchmark.py
+++ b/tests/explorer/test_projection_benchmark.py
@@ -1,0 +1,136 @@
+"""M5 scale evidence: 10k/100k-node projection tests against declared budgets.
+
+Marked slow (excluded from the default `-m 'not slow'` run) since building a
+100k-node synthetic graph and its `GraphQuery` adjacency indices takes real
+wall time. Run explicitly with `-m slow`, or via
+`scripts/m5_explorer_projection_benchmark.py` for printed evidence.
+
+Budgets are declared against a measured baseline (see the script's module
+docstring for the exact numbers) with headroom for CI variance, not
+invented thresholds.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from archex.explorer.loader import ExplorerData
+from archex.explorer.render import render_module_map_page, render_neighborhood_page
+from archex.explorer.server import create_server
+from archex.explorer.viewmodel import (
+    build_manifest_view,
+    build_module_map_view,
+    build_neighborhood_view,
+)
+from archex.graph_artifact import (
+    ArchGraph,
+    GraphEdge,
+    GraphEdgeType,
+    GraphExportMetadata,
+    GraphNode,
+    GraphNodeType,
+    GraphProject,
+)
+from archex.report.artifact import AnalysisArtifactV1, DiffAnalysis, ReportSchemaVersion
+
+# Measured baseline (this repo's reference dev machine, 2026-07-24):
+#   10,000 nodes:  server startup ~0.07s, module map view+render ~0.002s,
+#                   post-startup neighborhood lookup <0.001s.
+#   100,000 nodes: server startup ~1.12s, module map view+render ~0.024s,
+#                   post-startup neighborhood lookup <0.001s.
+# Budgets carry >2x headroom over the measured baseline.
+STARTUP_BUDGET_SECONDS = {10_000: 0.5, 100_000: 3.0}
+MODULE_MAP_BUDGET_SECONDS = {10_000: 0.1, 100_000: 0.5}
+NEIGHBORHOOD_LOOKUP_BUDGET_SECONDS = {10_000: 0.05, 100_000: 0.2}
+
+
+def _artifact() -> AnalysisArtifactV1:
+    return AnalysisArtifactV1(
+        schema_version=ReportSchemaVersion(),
+        generated_at="2026-07-24T00:00:00Z",
+        source_identity="acme/widget",
+        source_root="/repo",
+        source_revision="deadbeef",
+        working_tree_fingerprint="fp",
+        index_generation="gen1",
+        index_schema_version="1",
+        chunker_revision="c1",
+        config_fingerprint="cfg1",
+        diff=DiffAnalysis(base_ref="main"),
+    )
+
+
+def synthetic_graph(node_count: int, *, module_count: int = 50) -> ArchGraph:
+    """A deterministic ring-connected synthetic graph with NODE_COUNT file nodes."""
+    nodes = [
+        GraphNode(
+            id=f"file:f{i}.py",
+            type=GraphNodeType.FILE,
+            label=f"f{i}.py",
+            module=f"pkg{i % module_count}",
+        )
+        for i in range(node_count)
+    ]
+    edges = [
+        GraphEdge(
+            source=f"file:f{i}.py",
+            target=f"file:f{(i + 1) % node_count}.py",
+            type=GraphEdgeType.IMPORTS,
+        )
+        for i in range(node_count)
+    ]
+    return ArchGraph(
+        project=GraphProject(name="widget", total_files=node_count),
+        metadata=GraphExportMetadata(archex_version="0.22.0"),
+        nodes=nodes,
+        edges=edges,
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("node_count", [10_000, 100_000])
+def test_explorer_projection_meets_declared_budgets(node_count: int) -> None:
+    graph = synthetic_graph(node_count)
+    data = ExplorerData(artifact=_artifact(), graph=graph)
+
+    start = time.perf_counter()
+    server = create_server(data, port=0)
+    startup_elapsed = time.perf_counter() - start
+    try:
+        budget = STARTUP_BUDGET_SECONDS[node_count]
+        assert startup_elapsed <= budget, (
+            f"server startup at {node_count} nodes took {startup_elapsed:.3f}s, budget is {budget}s"
+        )
+
+        manifest = build_manifest_view(data)
+
+        start = time.perf_counter()
+        module_map = build_module_map_view(data)
+        render_module_map_page(manifest, module_map)
+        module_map_elapsed = time.perf_counter() - start
+        module_map_budget = MODULE_MAP_BUDGET_SECONDS[node_count]
+        assert module_map_elapsed <= module_map_budget, (
+            f"module map at {node_count} nodes took {module_map_elapsed:.3f}s, "
+            f"budget is {module_map_budget}s"
+        )
+        assert module_map.available is True
+        assert module_map.modules_total > 0
+
+        seed_id = graph.nodes[0].id
+        start = time.perf_counter()
+        neighborhood = build_neighborhood_view(
+            data, seed_id, depth=1, limit=25, graph_query=server.graph_query
+        )
+        render_neighborhood_page(manifest, neighborhood)
+        neighborhood_elapsed = time.perf_counter() - start
+        neighborhood_budget = NEIGHBORHOOD_LOOKUP_BUDGET_SECONDS[node_count]
+        assert neighborhood_elapsed <= neighborhood_budget, (
+            f"neighborhood lookup at {node_count} nodes took {neighborhood_elapsed:.3f}s, "
+            f"budget is {neighborhood_budget}s"
+        )
+        assert neighborhood.error is None
+        assert neighborhood.seed is not None
+    finally:
+        server.server_close()

--- a/tests/explorer/test_usability_evidence.py
+++ b/tests/explorer/test_usability_evidence.py
@@ -1,0 +1,86 @@
+"""M5 usability evidence regression test.
+
+Mirrors `scripts/m5_explorer_usability_evidence.py` as a standing regression
+test: proves the explorer's Diff Review and Target Neighborhood views
+surface the objectively correct file/importers for
+`tests/fixtures/impact_diff`'s documented `hub.py` scenario (see
+`docs/EXPLORER_USABILITY_EVIDENCE.md` for the full protocol and measured
+evidence).
+"""
+
+from __future__ import annotations
+
+import threading
+import urllib.request
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from archex.api import index_repository
+from archex.config import load_config, load_index_config
+from archex.explorer.loader import ExplorerData
+from archex.explorer.server import ExplorerServer, create_server
+from archex.graph_artifact import build_arch_graph_from_store
+from archex.models import RepoSource
+from archex.report.artifact import build_analysis_artifact
+
+EXPECTED_IMPORTERS = frozenset({"leaf.py", "consumer_a.py", "consumer_b.py", "consumer_c.py"})
+
+
+def _edit_hub(repo: Path) -> None:
+    hub = repo / "hub.py"
+    hub.write_text(hub.read_text().replace("value * 2", "value * 3"))
+
+
+@pytest.fixture
+def running_explorer_for_impact_diff(impact_diff_repo: Path) -> Iterator[ExplorerServer]:
+    _edit_hub(impact_diff_repo)
+    repo_source = RepoSource(local_path=str(impact_diff_repo))
+    config = load_config(repo_source)
+    index_config = load_index_config(repo_source)
+    store = index_repository(repo_source, config=config, index_config=index_config)
+    try:
+        graph = build_arch_graph_from_store(store, repo_root=impact_diff_repo)
+    finally:
+        store.close()
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+    data = ExplorerData(artifact=artifact, graph=graph)
+
+    server = create_server(data, port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _get(url: str) -> str:
+    with urllib.request.urlopen(url, timeout=5) as response:  # noqa: S310
+        return response.read().decode("utf-8")
+
+
+def test_diff_review_surfaces_the_correct_changed_file(
+    running_explorer_for_impact_diff: ExplorerServer,
+) -> None:
+    server = running_explorer_for_impact_diff
+    port = server.server_address[1]
+
+    html = _get(f"http://127.0.0.1:{port}/view/diff?token={server.token}")
+
+    assert "hub.py" in html
+
+
+def test_target_neighborhood_surfaces_all_real_importers(
+    running_explorer_for_impact_diff: ExplorerServer,
+) -> None:
+    server = running_explorer_for_impact_diff
+    port = server.server_address[1]
+
+    html = _get(f"http://127.0.0.1:{port}/view/neighborhood?node=file:hub.py&token={server.token}")
+
+    for importer in EXPECTED_IMPORTERS:
+        assert importer in html


### PR DESCRIPTION
## Summary

M5 PR-3/3 (final): scale and usability evidence, plus the CHANGELOG entry required before this milestone's final PR (`DEVELOPMENT_PLAN.md` §2.1).

- **Projection benchmarks**: `tests/explorer/test_projection_benchmark.py` (`@pytest.mark.slow`) and `scripts/m5_explorer_projection_benchmark.py` build deterministic 10k/100k-node synthetic `ArchGraph` fixtures and assert server startup, Module Map view+render, and a post-startup Target Neighborhood lookup against declared budgets (>2x headroom over the measured baseline).
- **Perf fix found while benchmarking**: `build_neighborhood_view` was rebuilding `GraphQuery`'s adjacency indices on every call (~1.4s per lookup at 100k nodes). `ExplorerServer` now builds one `GraphQuery` at startup and passes it through; every neighborhood lookup after startup is sub-millisecond regardless of graph size.
- **Usability evidence**: `docs/EXPLORER_USABILITY_EVIDENCE.md`, `scripts/m5_explorer_usability_evidence.py`, and `tests/explorer/test_usability_evidence.py` measure real HTTP wall-clock time to the objectively correct file/importers for `tests/fixtures/impact_diff`'s documented `hub.py` scenario -- explicitly labeled as an automated, deterministic proxy, not a live human trial, with no self-reported satisfaction claimed.
- **CHANGELOG**: `M5` entry added under `## [Unreleased]`.

## Scope

In: 10k/100k projection benchmark test+script, the GraphQuery caching fix, usability evidence doc+script+test, CHANGELOG entry.

## Review note on topology

Based on `m5-2-views-and-security-controls` (#548), itself based on `m5-1-artifact-only-explorer-shell` (#547) -- neither merged yet. Diff/commit list will shrink to just this PR's five commits as the earlier two merge and this PR's base updates automatically.

## Verification

- `uv run ruff check <changed files>` / `uv run ruff format --check <changed files>` / `uv run pyright <changed files>`: clean.
- `uv run pytest tests/explorer tests/cli/test_explore_cmd.py -m "slow or not slow" --no-cov`: 60 passed.
- `uv run pytest --junitxml=results.xml --cov-report=xml`: 4135 passed, 91.69% coverage.
- `uv run python scripts/m5_explorer_projection_benchmark.py`: PASSED -- 10k nodes: startup 0.081s/module_map 0.003s/neighborhood 0.0001s; 100k nodes: startup 1.554s/module_map 0.023s/neighborhood 0.0001s. All within declared budgets.
- `uv run python scripts/m5_explorer_usability_evidence.py`: PASSED -- Diff Review 0.005s-0.009s (correct: hub.py named), Target Neighborhood 0.001s (correct: all 4 real importers surfaced).
