### PR TITLE
feat(graph): store typed semantic evidence

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -130,6 +130,7 @@ if TYPE_CHECKING:
 
     from archex.index.embeddings.base import Embedder
     from archex.index.rerank import CrossEncoderReranker
+    from archex.integrations.semantic.models import SemanticProviderReceipt
     from archex.models import ComparisonResult
     from archex.serve.runtime import QueryRuntime
 
@@ -244,6 +245,14 @@ def _full_index(
             )
             if chunk_surrogates:
                 store.insert_chunk_surrogates(chunk_surrogates)
+            if effective_index_config.semantic_evidence_providers:
+                from archex.index.semantic_evidence import collect_semantic_evidence
+
+                semantic_edges, semantic_receipts = collect_semantic_evidence(
+                    parsed_files, repo_path, effective_index_config
+                )
+                graph.add_semantic_edges(semantic_edges)
+                store.set_semantic_provider_receipts(semantic_receipts)
             edges = graph.file_edges()
             store.replace_file_states(compute_file_states(repo_path, files))
             store.insert_edges(edges)
@@ -1511,6 +1520,7 @@ def _refresh_receipt(
     index_revision: str,
     freshness: ContextFreshness,
     metadata_timing: PipelineTiming | None,
+    semantic_providers: list[SemanticProviderReceipt] | None = None,
 ) -> None:
     skipped = list(bundle.receipt.skipped_candidates) if bundle.receipt is not None else []
     if freshness != ContextFreshness.CLEAN:
@@ -1519,6 +1529,11 @@ def _refresh_receipt(
         skipped.append(unsupported_grammar_skipped_candidate(metadata_timing.parse_failure_count))
     included_edges = list(bundle.receipt.included_edges) if bundle.receipt is not None else []
     omitted_edges = list(bundle.receipt.omitted_edges) if bundle.receipt is not None else []
+    resolved_semantic_providers = (
+        semantic_providers
+        if semantic_providers is not None
+        else (bundle.receipt.semantic_providers if bundle.receipt is not None else [])
+    )
     bundle.receipt = build_context_receipt(
         bundle,
         index_revision=index_revision,
@@ -1526,6 +1541,7 @@ def _refresh_receipt(
         included_edges=included_edges,
         omitted_edges=omitted_edges,
         skipped_candidates=skipped,
+        semantic_providers=resolved_semantic_providers,
     )
 
 
@@ -1543,6 +1559,7 @@ def _finalize_context_bundle(
     index_revision: str,
     freshness: ContextFreshness,
     post_search_at: float | None = None,
+    semantic_providers: list[SemanticProviderReceipt] | None = None,
 ) -> ContextBundle:
     _attach_vector_metadata(bundle, index_config)
     _attach_index_metadata(
@@ -1578,6 +1595,7 @@ def _finalize_context_bundle(
         index_revision=index_revision,
         freshness=freshness,
         metadata_timing=metadata_timing,
+        semantic_providers=semantic_providers,
     )
     return bundle
 
@@ -2236,6 +2254,15 @@ def query(
             store.insert_chunks(all_chunks)
             if chunk_surrogates:
                 store.insert_chunk_surrogates(chunk_surrogates)
+            semantic_receipts: list[SemanticProviderReceipt] = []
+            if index_config.semantic_evidence_providers:
+                from archex.index.semantic_evidence import collect_semantic_evidence
+
+                semantic_edges, semantic_receipts = collect_semantic_evidence(
+                    parsed_files, repo_path, index_config
+                )
+                graph.add_semantic_edges(semantic_edges)
+                store.set_semantic_provider_receipts(semantic_receipts)
             edges = graph.file_edges()
             from archex.index.delta import compute_file_states
 
@@ -2522,6 +2549,7 @@ def query(
             index_revision=index_revision,
             freshness=_freshness_for_query(refresh),
             post_search_at=t_post_search_miss,
+            semantic_providers=semantic_receipts,
         )
     finally:
         cleanup()

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -158,9 +158,12 @@ def _index_config_metadata_matches(store: IndexStore, index_config: IndexConfig)
     stored_quantize_enabled = stored_quantize == "True" if stored_quantize is not None else False
     if stored_quantize_enabled != index_config.quantize_vectors:
         return False
-    if index_config.quantize_vectors:
-        return store.get_metadata("quantize_bits") == str(index_config.quantize_bits)
-    return True
+    if index_config.quantize_vectors and store.get_metadata("quantize_bits") != str(
+        index_config.quantize_bits
+    ):
+        return False
+    stored_semantic_providers = store.get_metadata("semantic_evidence_providers") or ""
+    return stored_semantic_providers == ",".join(index_config.semantic_evidence_providers)
 
 
 def _set_index_config_metadata(store: IndexStore, index_config: IndexConfig) -> None:
@@ -168,6 +171,9 @@ def _set_index_config_metadata(store: IndexStore, index_config: IndexConfig) -> 
     store.set_metadata("chunker_revision", chunker_revision(index_config.chunker))
     store.set_metadata("quantize_vectors", str(index_config.quantize_vectors))
     store.set_metadata("quantize_bits", str(index_config.quantize_bits))
+    store.set_metadata(
+        "semantic_evidence_providers", ",".join(index_config.semantic_evidence_providers)
+    )
 
 
 def _full_index(
@@ -2143,6 +2149,7 @@ def query(
                     index_revision=index_revision,
                     freshness=_freshness_for_query(refresh),
                     post_search_at=t_post_search,
+                    semantic_providers=search_store.get_semantic_provider_receipts(),
                 )
             finally:
                 store.close()
@@ -2401,6 +2408,7 @@ def query(
                     index_revision=index_revision,
                     freshness=_freshness_for_query(refresh),
                     metadata_timing=metadata_timing,
+                    semantic_providers=semantic_receipts,
                 )
                 return pt
 

--- a/src/archex/index/graph.py
+++ b/src/archex/index/graph.py
@@ -8,10 +8,13 @@ from typing import TYPE_CHECKING, Any
 
 import networkx as nx
 
+from archex.integrations.semantic.models import SemanticEdgeKind
 from archex.models import Edge, EdgeConfidence, EdgeKind, ImportStatement, ParsedFile
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from archex.integrations.semantic.models import SemanticEdgeEvidence
 
 _CO_DIRECTORY_CONFIDENCE_SCORE = 0.6
 _CO_DIRECTORY_EVIDENCE = [
@@ -27,6 +30,12 @@ _CO_DIRECTORY_EVIDENCE = [
 _CO_DIRECTORY_DENSE_THRESHOLD = 50
 _CO_DIRECTORY_WINDOW_SIZE = 20
 
+_SEMANTIC_EDGE_KIND: dict[SemanticEdgeKind, EdgeKind] = {
+    SemanticEdgeKind.DEFINITION: EdgeKind.SEMANTIC_DEFINITION,
+    SemanticEdgeKind.REFERENCE: EdgeKind.SEMANTIC_REFERENCE,
+    SemanticEdgeKind.IMPLEMENTATION: EdgeKind.SEMANTIC_IMPLEMENTATION,
+}
+
 
 def _resolved_import_evidence(file_path: str, imported_module: str, line: int) -> list[str]:
     return [f"resolved import {imported_module!r} at {file_path}:{line}"]
@@ -39,6 +48,8 @@ def _edge_attrs(
     confidence: EdgeConfidence = EdgeConfidence.EXTRACTED,
     confidence_score: float = 1.0,
     evidence: list[str] | None = None,
+    provider: str | None = None,
+    provider_version: str | None = None,
 ) -> dict[str, object]:
     return {
         "kind": kind,
@@ -46,6 +57,8 @@ def _edge_attrs(
         "confidence": confidence,
         "confidence_score": confidence_score,
         "evidence": list(evidence or []),
+        "provider": provider,
+        "provider_version": provider_version,
         "traversable": confidence != EdgeConfidence.AMBIGUOUS,
     }
 
@@ -59,6 +72,8 @@ def _edge_from_data(source: object, target: object, data: dict[str, Any]) -> Edg
         confidence=data.get("confidence", EdgeConfidence.EXTRACTED),
         confidence_score=float(data.get("confidence_score", 1.0)),
         evidence=list(data.get("evidence", [])),
+        provider=data.get("provider"),
+        provider_version=data.get("provider_version"),
     )
 
 
@@ -68,6 +83,8 @@ def _ensure_sqlite_edge_confidence_columns(conn: sqlite3.Connection) -> None:
         "confidence": "ALTER TABLE edges ADD COLUMN confidence TEXT DEFAULT 'extracted'",
         "confidence_score": "ALTER TABLE edges ADD COLUMN confidence_score REAL DEFAULT 1.0",
         "evidence": "ALTER TABLE edges ADD COLUMN evidence TEXT DEFAULT '[]'",
+        "provider": "ALTER TABLE edges ADD COLUMN provider TEXT",
+        "provider_version": "ALTER TABLE edges ADD COLUMN provider_version TEXT",
     }
     migrated = False
     for column, statement in edge_migrations.items():
@@ -205,6 +222,58 @@ class DependencyGraph:
 
         return added
 
+    def add_semantic_edges(self, evidence: list[SemanticEdgeEvidence]) -> int:
+        """Add conditional SCIP/LSP semantic edges (M6) to the file graph.
+
+        Only connects source/target file paths that already exist as file
+        nodes — semantic evidence enriches the syntax graph's existing
+        corpus, it never introduces a file the syntax pass didn't already
+        discover. Every added edge carries its provider, provider version,
+        and confidence, and is a distinct EdgeKind from every syntax edge.
+
+        The underlying graph allows at most one edge per (source, target)
+        file pair, so a pair that already has ANY edge — syntax or a prior
+        semantic edge from this same call — is left untouched rather than
+        overwritten; syntax evidence authority is never replaced, and a
+        second semantic relationship between the same two files with the
+        same direction is skipped rather than silently clobbering the
+        first. Returns the number of edges added.
+        """
+        added = 0
+        for item in evidence:
+            source_path = item.source.file_path
+            target_path = item.target.file_path
+            if not self._file_graph.has_node(source_path):  # type: ignore[misc]
+                continue
+            if not self._file_graph.has_node(target_path):  # type: ignore[misc]
+                continue
+            if self._file_graph.has_edge(source_path, target_path):  # type: ignore[misc]
+                continue
+            self._file_graph.add_edge(  # type: ignore[misc]
+                source_path,
+                target_path,
+                **_edge_attrs(
+                    kind=_SEMANTIC_EDGE_KIND[item.kind],
+                    location=(
+                        f"{source_path}:{item.source.line} -> {target_path}:{item.target.line}"
+                    ),
+                    confidence=EdgeConfidence.EXTRACTED,
+                    confidence_score=item.confidence,
+                    evidence=[
+                        f"{item.provider.value} v{item.provider_version} {item.kind.value}: "
+                        f"{source_path}:{item.source.line} -> {target_path}:{item.target.line}"
+                    ],
+                    provider=item.provider.value,
+                    provider_version=item.provider_version,
+                ),
+            )
+            added += 1
+
+        if added > 0:
+            self._invalidate_centrality_caches()
+
+        return added
+
     @classmethod
     def from_edges(cls, edges: list[Edge]) -> DependencyGraph:
         """Reconstruct a file-level DependencyGraph from Edge objects."""
@@ -219,6 +288,8 @@ class DependencyGraph:
                     confidence=edge.confidence,
                     confidence_score=edge.confidence_score,
                     evidence=edge.evidence,
+                    provider=edge.provider,
+                    provider_version=edge.provider_version,
                 ),
             )
         return graph
@@ -273,6 +344,8 @@ class DependencyGraph:
                     confidence=edge.confidence,
                     confidence_score=edge.confidence_score,
                     evidence=edge.evidence,
+                    provider=edge.provider,
+                    provider_version=edge.provider_version,
                 ),
             )
 
@@ -380,7 +453,8 @@ class DependencyGraph:
             cur.execute(
                 "CREATE TABLE IF NOT EXISTS edges "
                 "(source TEXT, target TEXT, kind TEXT, location TEXT, "
-                "confidence TEXT, confidence_score REAL, evidence TEXT)"
+                "confidence TEXT, confidence_score REAL, evidence TEXT, "
+                "provider TEXT, provider_version TEXT)"
             )
             _ensure_sqlite_edge_confidence_columns(conn)
             cur.execute("DELETE FROM files")
@@ -393,8 +467,9 @@ class DependencyGraph:
                 edge_data: dict[str, Any] = data  # type: ignore[assignment]
                 cur.execute(
                     "INSERT INTO edges "
-                    "(source, target, kind, location, confidence, confidence_score, evidence) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    "(source, target, kind, location, confidence, confidence_score, evidence, "
+                    "provider, provider_version) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (
                         str(src),
                         str(tgt),
@@ -403,6 +478,8 @@ class DependencyGraph:
                         edge_data.get("confidence", EdgeConfidence.EXTRACTED),
                         float(edge_data.get("confidence_score", 1.0)),
                         json.dumps(edge_data.get("evidence", []), sort_keys=True),
+                        edge_data.get("provider"),
+                        edge_data.get("provider_version"),
                     ),
                 )
 
@@ -420,9 +497,19 @@ class DependencyGraph:
             _ensure_sqlite_edge_confidence_columns(conn)
             for (path,) in cur.execute("SELECT path FROM files"):
                 graph._file_graph.add_node(str(path))  # type: ignore[misc]
-            for src, tgt, kind, location, confidence, confidence_score, evidence in cur.execute(
-                "SELECT source, target, kind, location, confidence, confidence_score, evidence "
-                "FROM edges"
+            for (
+                src,
+                tgt,
+                kind,
+                location,
+                confidence,
+                confidence_score,
+                evidence,
+                provider,
+                provider_version,
+            ) in cur.execute(
+                "SELECT source, target, kind, location, confidence, confidence_score, evidence, "
+                "provider, provider_version FROM edges"
             ):
                 graph._file_graph.add_edge(  # type: ignore[misc]
                     str(src),
@@ -433,6 +520,8 @@ class DependencyGraph:
                         confidence=EdgeConfidence(confidence),
                         confidence_score=float(confidence_score),
                         evidence=json.loads(str(evidence)),
+                        provider=provider,
+                        provider_version=provider_version,
                     ),
                 )
         finally:

--- a/src/archex/index/semantic_evidence.py
+++ b/src/archex/index/semantic_evidence.py
@@ -1,0 +1,64 @@
+"""Conditional semantic-evidence collection (M6): dispatch configured SCIP/LSP providers.
+
+Zero-cost when ``IndexConfig.semantic_evidence_providers`` is empty (the
+default): no provider module is imported, no provider runs, and the syntax
+graph is completely unaffected. Enabling a provider by name runs it and
+folds every non-``AVAILABLE`` outcome into an explicit receipt rather than a
+silent gap.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from archex.integrations.semantic.lsp_provider import LspEvidenceProvider
+from archex.integrations.semantic.scip_provider import ScipEvidenceProvider
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from archex.integrations.semantic.models import (
+        SemanticEdgeEvidence,
+        SemanticProviderReceipt,
+    )
+    from archex.integrations.semantic.provider import SemanticEvidenceProvider
+    from archex.models import IndexConfig, ParsedFile
+
+
+def _default_provider(name: str) -> SemanticEvidenceProvider:
+    if name == "scip":
+        return ScipEvidenceProvider()
+    if name == "lsp":
+        return LspEvidenceProvider()
+    # Unreachable via IndexConfig, whose validator restricts values to
+    # _KNOWN_PROVIDERS; guarded here for direct callers of this function.
+    raise ValueError(f"unknown semantic evidence provider: {name!r}")
+
+
+def collect_semantic_evidence(
+    parsed_files: list[ParsedFile],
+    repo_root: Path,
+    index_config: IndexConfig,
+    *,
+    providers: dict[str, SemanticEvidenceProvider] | None = None,
+) -> tuple[list[SemanticEdgeEvidence], list[SemanticProviderReceipt]]:
+    """Run every provider named in ``index_config.semantic_evidence_providers``.
+
+    Returns ``([], [])`` immediately when no provider is configured — the
+    default path adds no cost and touches no optional dependency. ``providers``
+    lets a caller inject an already-configured provider (for example an
+    ``LspEvidenceProvider`` bound to a live ``lsp_client.Client``); entries not
+    supplied fall back to a stock provider constructed with default settings.
+    """
+    if not index_config.semantic_evidence_providers:
+        return [], []
+
+    resolved = providers or {}
+    evidence: list[SemanticEdgeEvidence] = []
+    receipts: list[SemanticProviderReceipt] = []
+    for name in index_config.semantic_evidence_providers:
+        provider = resolved.get(name) or _default_provider(name)
+        item_evidence, receipt = provider.collect(parsed_files, repo_root)
+        evidence.extend(item_evidence)
+        receipts.append(receipt)
+    return evidence, receipts

--- a/src/archex/index/semantic_evidence.py
+++ b/src/archex/index/semantic_evidence.py
@@ -9,20 +9,22 @@ silent gap.
 
 from __future__ import annotations
 
+import datetime as _dt
+import logging
 from typing import TYPE_CHECKING
 
 from archex.integrations.semantic.lsp_provider import LspEvidenceProvider
+from archex.integrations.semantic.models import ProviderAvailability, SemanticProviderReceipt
 from archex.integrations.semantic.scip_provider import ScipEvidenceProvider
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from archex.integrations.semantic.models import (
-        SemanticEdgeEvidence,
-        SemanticProviderReceipt,
-    )
+    from archex.integrations.semantic.models import SemanticEdgeEvidence
     from archex.integrations.semantic.provider import SemanticEvidenceProvider
     from archex.models import IndexConfig, ParsedFile
+
+logger = logging.getLogger(__name__)
 
 
 def _default_provider(name: str) -> SemanticEvidenceProvider:
@@ -49,6 +51,12 @@ def collect_semantic_evidence(
     lets a caller inject an already-configured provider (for example an
     ``LspEvidenceProvider`` bound to a live ``lsp_client.Client``); entries not
     supplied fall back to a stock provider constructed with default settings.
+
+    A provider must never raise for ordinary unavailability, but this is an
+    external-tool boundary (a built-in provider's own bug, or a caller-
+    injected custom provider), so every ``collect()`` call is defended here:
+    an unexpected exception degrades that one provider to an explicit
+    ``UNAVAILABLE`` receipt rather than aborting the entire index build.
     """
     if not index_config.semantic_evidence_providers:
         return [], []
@@ -58,7 +66,21 @@ def collect_semantic_evidence(
     receipts: list[SemanticProviderReceipt] = []
     for name in index_config.semantic_evidence_providers:
         provider = resolved.get(name) or _default_provider(name)
-        item_evidence, receipt = provider.collect(parsed_files, repo_root)
+        try:
+            item_evidence, receipt = provider.collect(parsed_files, repo_root)
+        except Exception as exc:
+            logger.warning(
+                "semantic evidence provider %r raised during collect()", name, exc_info=True
+            )
+            receipts.append(
+                SemanticProviderReceipt(
+                    provider=provider.name,
+                    availability=ProviderAvailability.UNAVAILABLE,
+                    reason=f"provider raised {type(exc).__name__}: {exc}",
+                    collected_at=_dt.datetime.now(tz=_dt.UTC).isoformat(),
+                )
+            )
+            continue
         evidence.extend(item_evidence)
         receipts.append(receipt)
     return evidence, receipts

--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -9,6 +9,7 @@ import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+from archex.integrations.semantic.models import SemanticProviderReceipt
 from archex.models import (
     ChunkSurrogate,
     CodeChunk,
@@ -22,6 +23,8 @@ from archex.models import (
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from types import TracebackType
+
+_SEMANTIC_PROVIDER_RECEIPTS_KEY = "semantic_provider_receipts"
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +57,9 @@ CREATE TABLE IF NOT EXISTS edges (
     location TEXT,
     confidence TEXT NOT NULL DEFAULT 'extracted',
     confidence_score REAL NOT NULL DEFAULT 1.0,
-    evidence TEXT NOT NULL DEFAULT '[]'
+    evidence TEXT NOT NULL DEFAULT '[]',
+    provider TEXT,
+    provider_version TEXT
 );
 """
 
@@ -317,8 +322,9 @@ class IndexStore:
     def _insert_edges_no_commit(self, edges: list[Edge]) -> None:
         self._conn.executemany(
             "INSERT INTO edges "
-            "(source, target, kind, location, confidence, confidence_score, evidence) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "(source, target, kind, location, confidence, confidence_score, evidence, "
+            "provider, provider_version) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
             [
                 (
                     e.source,
@@ -328,6 +334,8 @@ class IndexStore:
                     str(e.confidence),
                     e.confidence_score,
                     json.dumps(e.evidence, sort_keys=True),
+                    e.provider,
+                    e.provider_version,
                 )
                 for e in edges
             ],
@@ -787,8 +795,8 @@ class IndexStore:
 
     def get_edges(self) -> list[Edge]:
         cur = self._conn.execute(
-            "SELECT source, target, kind, location, confidence, confidence_score, evidence "
-            "FROM edges"
+            "SELECT source, target, kind, location, confidence, confidence_score, evidence, "
+            "provider, provider_version FROM edges"
         )
         return [
             Edge(
@@ -799,6 +807,8 @@ class IndexStore:
                 confidence=EdgeConfidence(r[4]),
                 confidence_score=float(r[5]),
                 evidence=_decode_edge_evidence(r[6]),
+                provider=r[7],
+                provider_version=r[8],
             )
             for r in cur.fetchall()
         ]
@@ -813,6 +823,25 @@ class IndexStore:
         cur = self._conn.execute("SELECT value FROM metadata WHERE key = ?", (key,))
         row = cur.fetchone()
         return str(row[0]) if row else None
+
+    def set_semantic_provider_receipts(self, receipts: list[SemanticProviderReceipt]) -> None:
+        """Persist the M6 conditional semantic-evidence provider receipts for this build."""
+        self.set_metadata(
+            _SEMANTIC_PROVIDER_RECEIPTS_KEY,
+            json.dumps([r.model_dump(mode="json") for r in receipts], sort_keys=True),
+        )
+
+    def get_semantic_provider_receipts(self) -> list[SemanticProviderReceipt]:
+        """Return the persisted M6 semantic-evidence provider receipts, if any.
+
+        Empty when no semantic provider was configured for this build — a store
+        built before M6 or with ``semantic_evidence_providers`` unset has no
+        receipts, which is a fully expected, honest empty result, not an error.
+        """
+        raw = self.get_metadata(_SEMANTIC_PROVIDER_RECEIPTS_KEY)
+        if not raw:
+            return []
+        return [SemanticProviderReceipt.model_validate(item) for item in json.loads(raw)]
 
     def needs_reindex(self) -> bool:
         """Return True if the store contains chunks without symbol_ids (pre-stable-ID data)."""
@@ -853,12 +882,14 @@ class IndexStore:
                 "ALTER TABLE edges ADD COLUMN confidence_score REAL NOT NULL DEFAULT 1.0"
             ),
             "evidence": "ALTER TABLE edges ADD COLUMN evidence TEXT NOT NULL DEFAULT '[]'",
+            "provider": "ALTER TABLE edges ADD COLUMN provider TEXT",
+            "provider_version": "ALTER TABLE edges ADD COLUMN provider_version TEXT",
         }
         for column, statement in edge_migrations.items():
             if column not in edge_columns:
                 self._conn.execute(statement)
         edge_columns = {row[1] for row in self._conn.execute("PRAGMA table_info(edges)")}
-        if {"confidence", "confidence_score", "evidence"} - edge_columns:
+        if set(edge_migrations) - edge_columns:
             raise RuntimeError("edges table missing confidence columns after migration")
         file_state_columns = {
             row[1] for row in self._conn.execute("PRAGMA table_info(file_states)")

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, model_validator
 
 from archex.index.quantize import SUPPORTED_BITS
 from archex.integrations.lsap_models import LSAPEnrichment  # noqa: TCH001
+from archex.integrations.semantic.models import SemanticProviderReceipt  # noqa: TCH001
 
 # ---------------------------------------------------------------------------
 # Enumerations
@@ -42,6 +43,12 @@ class EdgeKind(StrEnum):
     USES_TYPE = "uses_type"
     EXPORTS = "exports"
     CO_DIRECTORY = "co_directory"
+    # Conditional, provider-sourced semantic evidence (M6) — kept distinct
+    # from the syntax kinds above. Only ever added when an explicitly
+    # enabled SCIP/LSP provider produced them; never a Tree-sitter output.
+    SEMANTIC_DEFINITION = "semantic_definition"
+    SEMANTIC_REFERENCE = "semantic_reference"
+    SEMANTIC_IMPLEMENTATION = "semantic_implementation"
 
 
 class EdgeConfidence(StrEnum):
@@ -268,6 +275,11 @@ class IndexConfig(BaseModel):
     #: outweighed the intended recall gain) — see
     #: benchmarks/results/m17_identifier_bm25/DECISION.md.
     identifier_fragment_tokenization: bool = False
+    #: Conditional SCIP/LSP semantic-evidence providers to run at index time
+    #: (M6). Empty by default: no provider runs, no bytes of the syntax
+    #: graph change, matching the plan's "no automatic provider promotion"
+    #: requirement. Accepted values: "scip", "lsp".
+    semantic_evidence_providers: list[str] = []
 
     @model_validator(mode="after")
     def _validate_index_config(self) -> IndexConfig:
@@ -287,6 +299,11 @@ class IndexConfig(BaseModel):
             raise ValueError("rerank_candidate_limit must be at least 1")
         if self.quantize_bits not in SUPPORTED_BITS:
             raise ValueError(f"quantize_bits must be one of {SUPPORTED_BITS}")
+        unknown_providers = set(self.semantic_evidence_providers) - {"scip", "lsp"}
+        if unknown_providers:
+            raise ValueError(
+                f"semantic_evidence_providers has unknown entries: {sorted(unknown_providers)}"
+            )
         return self
 
 
@@ -502,6 +519,11 @@ class Edge(BaseModel):
     confidence: EdgeConfidence = EdgeConfidence.EXTRACTED
     confidence_score: float = 1.0
     evidence: list[str] = []
+    #: Conditional semantic-evidence provenance (M6). None for every syntax
+    #: edge; set to "scip"/"lsp" only on edges a SemanticEvidenceProvider
+    #: produced, so semantic and syntax evidence are always distinguishable.
+    provider: str | None = None
+    provider_version: str | None = None
 
     @model_validator(mode="after")
     def _validate_confidence_score(self) -> Edge:
@@ -835,6 +857,8 @@ class ContextReceiptEdge(BaseModel):
     confidence: EdgeConfidence | None = None
     confidence_score: float | None = None
     evidence: list[str] = []
+    provider: str | None = None
+    provider_version: str | None = None
     reason: ContextOmittedEdgeReason | None = None
 
     @model_validator(mode="after")
@@ -867,6 +891,7 @@ class ContextReceipt(BaseModel):
     included_edges: list[ContextReceiptEdge] = []
     omitted_edges: list[ContextReceiptEdge] = []
     skipped_candidates: list[ContextSkippedCandidate] = []
+    semantic_providers: list[SemanticProviderReceipt] = []
     returned_total: int = 0
     skipped_total: int = 0
     included_edges_total: int = 0

--- a/src/archex/receipt.py
+++ b/src/archex/receipt.py
@@ -28,6 +28,7 @@ from archex.scout import ScoutResult, chunk_handle, file_handle, parse_scout_han
 if TYPE_CHECKING:
     from archex.index.graph import DependencyGraph
     from archex.index.store import IndexStore
+    from archex.integrations.semantic.models import SemanticProviderReceipt
     from archex.models import ContextBundle
 
 _MAX_RECEIPT_SKIPPED = 20
@@ -78,6 +79,7 @@ def build_context_receipt(
     included_edges: Iterable[ContextReceiptEdge] = (),
     omitted_edges: Iterable[ContextReceiptEdge] = (),
     skipped_candidates: Iterable[ContextSkippedCandidate] = (),
+    semantic_providers: Iterable[SemanticProviderReceipt] = (),
 ) -> ContextReceipt:
     returned = _returned_context(bundle)
     skipped_all = list(skipped_candidates)
@@ -114,6 +116,7 @@ def build_context_receipt(
         included_edges=included,
         omitted_edges=omitted,
         skipped_candidates=skipped,
+        semantic_providers=list(semantic_providers),
         returned_total=len(returned),
         skipped_total=len(skipped_all),
         included_edges_total=len(included_all),
@@ -332,6 +335,8 @@ def _receipt_edge(edge: Edge) -> ContextReceiptEdge:
         confidence=edge.confidence,
         confidence_score=edge.confidence_score,
         evidence=edge.evidence,
+        provider=edge.provider,
+        provider_version=edge.provider_version,
     )
 
 

--- a/src/archex/serve/generation.py
+++ b/src/archex/serve/generation.py
@@ -54,6 +54,7 @@ def _index_config_fingerprint(index_config: IndexConfig) -> str:
         index_config.quantize_vectors,
         index_config.quantize_bits,
         index_config.identifier_fragment_tokenization,
+        ",".join(index_config.semantic_evidence_providers),
     )
     return "|".join(str(field) for field in fields)
 

--- a/tests/index/test_graph.py
+++ b/tests/index/test_graph.py
@@ -4,6 +4,12 @@ from typing import TYPE_CHECKING
 
 from archex import languages
 from archex.index.graph import DependencyGraph
+from archex.integrations.semantic.models import (
+    SemanticEdgeEvidence,
+    SemanticEdgeKind,
+    SemanticEvidenceLocation,
+    SemanticProviderName,
+)
 from archex.languages import LanguageSupport, get_language_tier
 from archex.models import (
     Edge,
@@ -536,3 +542,101 @@ class TestCoDirectoryEdges:
         assert added > 0
         assert added <= max_windowed
         assert added < full_pairwise // 10
+
+
+class TestAddSemanticEdges:
+    def _base_graph(self) -> DependencyGraph:
+        return DependencyGraph.from_parsed_files(_make_parsed_files(), _make_import_map())
+
+    def _evidence(
+        self, *, source_path: str = "models.py", target_path: str = "utils.py"
+    ) -> list[SemanticEdgeEvidence]:
+        return [
+            SemanticEdgeEvidence(
+                provider=SemanticProviderName.SCIP,
+                provider_version="0.5.0",
+                kind=SemanticEdgeKind.DEFINITION,
+                source=SemanticEvidenceLocation(file_path=source_path, line=3, character=1),
+                target=SemanticEvidenceLocation(file_path=target_path, line=10, character=0),
+                confidence=0.92,
+            )
+        ]
+
+    def test_adds_edge_between_existing_files(self) -> None:
+        graph = self._base_graph()
+        added = graph.add_semantic_edges(self._evidence())
+        assert added == 1
+        assert graph.file_edge_count == 2  # 1 import edge + 1 semantic edge
+
+    def test_edge_kind_is_semantic_and_distinct_from_syntax(self) -> None:
+        graph = self._base_graph()
+        graph.add_semantic_edges(self._evidence())
+        semantic_edges = [e for e in graph.file_edges() if e.kind == EdgeKind.SEMANTIC_DEFINITION]
+        assert len(semantic_edges) == 1
+        assert semantic_edges[0].provider == "scip"
+        assert semantic_edges[0].provider_version == "0.5.0"
+        assert semantic_edges[0].confidence_score == 0.92
+        syntax_edges = [e for e in graph.file_edges() if e.kind == EdgeKind.IMPORTS]
+        assert all(e.provider is None for e in syntax_edges)
+
+    def test_skips_edge_when_source_node_missing(self) -> None:
+        graph = self._base_graph()
+        added = graph.add_semantic_edges(self._evidence(source_path="unknown.py"))
+        assert added == 0
+        assert graph.file_edge_count == 1  # unchanged: only the import edge
+
+    def test_skips_edge_when_target_node_missing(self) -> None:
+        graph = self._base_graph()
+        added = graph.add_semantic_edges(self._evidence(target_path="unknown.py"))
+        assert added == 0
+        assert graph.file_edge_count == 1
+
+    def test_does_not_overwrite_existing_syntax_edge(self) -> None:
+        graph = self._base_graph()
+        # main.py -> models.py already has an IMPORTS edge from _make_import_map().
+        added = graph.add_semantic_edges(
+            self._evidence(source_path="main.py", target_path="models.py")
+        )
+        assert added == 0
+        [existing] = [
+            e for e in graph.file_edges() if e.source == "main.py" and e.target == "models.py"
+        ]
+        assert existing.kind == EdgeKind.IMPORTS
+        assert existing.provider is None
+
+    def test_empty_evidence_adds_nothing(self) -> None:
+        graph = self._base_graph()
+        assert graph.add_semantic_edges([]) == 0
+        assert graph.file_edge_count == 1
+
+    def test_invalidates_centrality_cache(self) -> None:
+        graph = self._base_graph()
+        graph.structural_centrality()
+        assert graph._centrality_cache is not None  # pyright: ignore[reportPrivateUsage]
+        graph.add_semantic_edges(self._evidence())
+        assert graph._centrality_cache is None  # pyright: ignore[reportPrivateUsage]
+
+    def test_reference_and_implementation_kinds_map_distinctly(self) -> None:
+        graph = self._base_graph()
+        evidence = [
+            SemanticEdgeEvidence(
+                provider=SemanticProviderName.LSP,
+                provider_version="lsp-client",
+                kind=SemanticEdgeKind.REFERENCE,
+                source=SemanticEvidenceLocation(file_path="models.py", line=1, character=0),
+                target=SemanticEvidenceLocation(file_path="utils.py", line=2, character=0),
+                confidence=0.8,
+            ),
+            SemanticEdgeEvidence(
+                provider=SemanticProviderName.LSP,
+                provider_version="lsp-client",
+                kind=SemanticEdgeKind.IMPLEMENTATION,
+                source=SemanticEvidenceLocation(file_path="utils.py", line=1, character=0),
+                target=SemanticEvidenceLocation(file_path="models.py", line=2, character=0),
+                confidence=0.8,
+            ),
+        ]
+        graph.add_semantic_edges(evidence)
+        kinds = {e.kind for e in graph.file_edges()}
+        assert EdgeKind.SEMANTIC_REFERENCE in kinds
+        assert EdgeKind.SEMANTIC_IMPLEMENTATION in kinds

--- a/tests/index/test_quantize.py
+++ b/tests/index/test_quantize.py
@@ -514,6 +514,32 @@ def test_index_config_metadata_tracks_quantization(tmp_path: Path) -> None:
         store.close()
 
 
+def test_index_config_metadata_tracks_semantic_evidence_providers(tmp_path: Path) -> None:
+    from archex.api import (
+        _index_config_metadata_matches,  # pyright: ignore[reportPrivateUsage]
+        _set_index_config_metadata,  # pyright: ignore[reportPrivateUsage]
+    )
+    from archex.index.store import IndexStore
+
+    store = IndexStore(tmp_path / "index.db")
+    try:
+        _set_index_config_metadata(store, IndexConfig(semantic_evidence_providers=[]))
+        assert _index_config_metadata_matches(store, IndexConfig(semantic_evidence_providers=[]))
+        assert not _index_config_metadata_matches(
+            store, IndexConfig(semantic_evidence_providers=["scip"])
+        )
+
+        _set_index_config_metadata(store, IndexConfig(semantic_evidence_providers=["scip"]))
+        assert _index_config_metadata_matches(
+            store, IndexConfig(semantic_evidence_providers=["scip"])
+        )
+        assert not _index_config_metadata_matches(
+            store, IndexConfig(semantic_evidence_providers=[])
+        )
+    finally:
+        store.close()
+
+
 # ---------------------------------------------------------------------------
 # End-to-end quantization pipeline test
 # ---------------------------------------------------------------------------

--- a/tests/index/test_semantic_evidence.py
+++ b/tests/index/test_semantic_evidence.py
@@ -1,0 +1,187 @@
+"""Tests for M6 semantic-evidence pipeline wiring: collect_semantic_evidence() and
+the end-to-end index_repository() integration.
+"""
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+# pyright: reportUnknownArgumentType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from archex.index.semantic_evidence import (
+    _default_provider,  # pyright: ignore[reportPrivateUsage]
+    collect_semantic_evidence,
+)
+from archex.integrations.semantic.lsp_provider import LspEvidenceProvider
+from archex.integrations.semantic.models import (
+    ProviderAvailability,
+    SemanticEdgeEvidence,
+    SemanticEdgeKind,
+    SemanticEvidenceLocation,
+    SemanticProviderName,
+    SemanticProviderReceipt,
+)
+from archex.integrations.semantic.scip_provider import ScipEvidenceProvider
+from archex.models import EdgeKind, IndexConfig, ParsedFile
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _FakeProvider:
+    def __init__(self, name: SemanticProviderName, evidence: list[SemanticEdgeEvidence]) -> None:
+        self._name = name
+        self._evidence = evidence
+
+    @property
+    def name(self) -> SemanticProviderName:
+        return self._name
+
+    def probe(self, repo_root: Path) -> SemanticProviderReceipt:
+        del repo_root
+        return SemanticProviderReceipt(
+            provider=self._name, availability=ProviderAvailability.AVAILABLE
+        )
+
+    def collect(
+        self, parsed_files: list[ParsedFile], repo_root: Path
+    ) -> tuple[list[SemanticEdgeEvidence], SemanticProviderReceipt]:
+        del parsed_files, repo_root
+        return self._evidence, SemanticProviderReceipt(
+            provider=self._name,
+            availability=ProviderAvailability.AVAILABLE,
+            evidence_count=len(self._evidence),
+        )
+
+
+def _evidence_item(provider: SemanticProviderName) -> SemanticEdgeEvidence:
+    return SemanticEdgeEvidence(
+        provider=provider,
+        provider_version="1.0",
+        kind=SemanticEdgeKind.DEFINITION,
+        source=SemanticEvidenceLocation(file_path="a.py", line=1, character=0),
+        target=SemanticEvidenceLocation(file_path="b.py", line=2, character=0),
+        confidence=0.9,
+    )
+
+
+class TestCollectSemanticEvidence:
+    def test_empty_config_returns_nothing(self, tmp_path: Path) -> None:
+        evidence, receipts = collect_semantic_evidence(
+            [], tmp_path, IndexConfig(semantic_evidence_providers=[])
+        )
+        assert evidence == []
+        assert receipts == []
+
+    def test_injected_provider_is_used(self, tmp_path: Path) -> None:
+        fake = _FakeProvider(SemanticProviderName.SCIP, [_evidence_item(SemanticProviderName.SCIP)])
+        evidence, receipts = collect_semantic_evidence(
+            [],
+            tmp_path,
+            IndexConfig(semantic_evidence_providers=["scip"]),
+            providers={"scip": fake},
+        )
+        assert len(evidence) == 1
+        assert len(receipts) == 1
+        assert receipts[0].availability == ProviderAvailability.AVAILABLE
+
+    def test_unconfigured_provider_falls_back_to_default(self, tmp_path: Path) -> None:
+        # No SCIP index present at tmp_path -> default ScipEvidenceProvider reports
+        # UNAVAILABLE rather than raising or inventing edges.
+        evidence, receipts = collect_semantic_evidence(
+            [], tmp_path, IndexConfig(semantic_evidence_providers=["scip"])
+        )
+        assert evidence == []
+        [receipt] = receipts
+        assert receipt.availability == ProviderAvailability.UNAVAILABLE
+        assert receipt.provider == SemanticProviderName.SCIP
+
+    def test_multiple_providers_aggregate_in_order(self, tmp_path: Path) -> None:
+        scip_fake = _FakeProvider(
+            SemanticProviderName.SCIP, [_evidence_item(SemanticProviderName.SCIP)]
+        )
+        lsp_fake = _FakeProvider(
+            SemanticProviderName.LSP, [_evidence_item(SemanticProviderName.LSP)]
+        )
+        evidence, receipts = collect_semantic_evidence(
+            [],
+            tmp_path,
+            IndexConfig(semantic_evidence_providers=["scip", "lsp"]),
+            providers={"scip": scip_fake, "lsp": lsp_fake},
+        )
+        expected_order = [SemanticProviderName.SCIP, SemanticProviderName.LSP]
+        assert [e.provider for e in evidence] == expected_order
+        assert [r.provider for r in receipts] == expected_order
+
+    def test_default_provider_resolves_scip_and_lsp(self) -> None:
+        assert isinstance(_default_provider("scip"), ScipEvidenceProvider)
+        assert isinstance(_default_provider("lsp"), LspEvidenceProvider)
+
+    def test_default_provider_rejects_unknown_name(self) -> None:
+        with pytest.raises(ValueError, match="unknown semantic evidence provider"):
+            _default_provider("bogus")
+
+
+class TestIndexRepositoryWiring:
+    def test_default_config_produces_no_semantic_edges(self, python_simple_repo: Path) -> None:
+        from archex.api import index_repository
+        from archex.models import Config, RepoSource
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        store = index_repository(source, config=Config(cache=False), index_config=IndexConfig())
+        try:
+            edges = store.get_edges()
+            assert edges
+            assert all(edge.provider is None for edge in edges)
+            assert store.get_semantic_provider_receipts() == []
+        finally:
+            store.close()
+
+    def test_scip_index_produces_semantic_edges(self, python_simple_repo: Path) -> None:
+        from archex.api import index_repository
+        from archex.integrations.semantic import scip_pb2
+        from archex.models import Config, RepoSource
+
+        index = scip_pb2.Index()
+        index.metadata.tool_info.name = "scip-python"
+        index.metadata.tool_info.version = "0.5.0"
+
+        main_doc = index.documents.add()
+        main_doc.relative_path = "main.py"
+        main_doc.language = "python"
+        definition = main_doc.occurrences.add()
+        definition.symbol = "scip-python python . . main/entry()."
+        definition.symbol_roles = scip_pb2.SymbolRole.Definition
+        definition.single_line_range.line = 0
+        definition.single_line_range.start_character = 4
+
+        models_doc = index.documents.add()
+        models_doc.relative_path = "models.py"
+        models_doc.language = "python"
+        usage = models_doc.occurrences.add()
+        usage.symbol = "scip-python python . . main/entry()."
+        usage.range.extend([3, 0, 4])
+
+        (python_simple_repo / "index.scip").write_bytes(index.SerializeToString())
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        store = index_repository(
+            source,
+            config=Config(cache=False),
+            index_config=IndexConfig(semantic_evidence_providers=["scip"]),
+        )
+        try:
+            edges = store.get_edges()
+            semantic_edges = [e for e in edges if e.kind == EdgeKind.SEMANTIC_DEFINITION]
+            assert len(semantic_edges) == 1
+            assert semantic_edges[0].provider == "scip"
+            assert semantic_edges[0].provider_version == "0.5.0"
+
+            [receipt] = store.get_semantic_provider_receipts()
+            assert receipt.provider == SemanticProviderName.SCIP
+            assert receipt.availability == ProviderAvailability.AVAILABLE
+            assert receipt.evidence_count > 0
+        finally:
+            store.close()

--- a/tests/index/test_semantic_evidence.py
+++ b/tests/index/test_semantic_evidence.py
@@ -56,6 +56,26 @@ class _FakeProvider:
         )
 
 
+class _RaisingProvider:
+    """A misbehaving provider that violates the never-raise contract."""
+
+    @property
+    def name(self) -> SemanticProviderName:
+        return SemanticProviderName.SCIP
+
+    def probe(self, repo_root: Path) -> SemanticProviderReceipt:
+        del repo_root
+        return SemanticProviderReceipt(
+            provider=SemanticProviderName.SCIP, availability=ProviderAvailability.AVAILABLE
+        )
+
+    def collect(
+        self, parsed_files: list[ParsedFile], repo_root: Path
+    ) -> tuple[list[SemanticEdgeEvidence], SemanticProviderReceipt]:
+        del parsed_files, repo_root
+        raise RuntimeError("boom: unexpected provider bug")
+
+
 def _evidence_item(provider: SemanticProviderName) -> SemanticEdgeEvidence:
     return SemanticEdgeEvidence(
         provider=provider,
@@ -97,6 +117,39 @@ class TestCollectSemanticEvidence:
         [receipt] = receipts
         assert receipt.availability == ProviderAvailability.UNAVAILABLE
         assert receipt.provider == SemanticProviderName.SCIP
+
+    def test_provider_raising_degrades_to_unavailable_not_a_crash(self, tmp_path: Path) -> None:
+        # A provider that violates 'never raise' must not abort the whole
+        # index build -- it degrades to an explicit UNAVAILABLE receipt.
+        evidence, receipts = collect_semantic_evidence(
+            [],
+            tmp_path,
+            IndexConfig(semantic_evidence_providers=["scip"]),
+            providers={"scip": _RaisingProvider()},
+        )
+        assert evidence == []
+        [receipt] = receipts
+        assert receipt.availability == ProviderAvailability.UNAVAILABLE
+        assert receipt.provider == SemanticProviderName.SCIP
+        assert "RuntimeError" in receipt.reason
+        assert "boom" in receipt.reason
+
+    def test_one_provider_raising_does_not_block_the_others(self, tmp_path: Path) -> None:
+        lsp_fake = _FakeProvider(
+            SemanticProviderName.LSP, [_evidence_item(SemanticProviderName.LSP)]
+        )
+        evidence, receipts = collect_semantic_evidence(
+            [],
+            tmp_path,
+            IndexConfig(semantic_evidence_providers=["scip", "lsp"]),
+            providers={"scip": _RaisingProvider(), "lsp": lsp_fake},
+        )
+        assert len(evidence) == 1
+        assert evidence[0].provider == SemanticProviderName.LSP
+        assert [r.availability for r in receipts] == [
+            ProviderAvailability.UNAVAILABLE,
+            ProviderAvailability.AVAILABLE,
+        ]
 
     def test_multiple_providers_aggregate_in_order(self, tmp_path: Path) -> None:
         scip_fake = _FakeProvider(
@@ -185,3 +238,125 @@ class TestIndexRepositoryWiring:
             assert receipt.evidence_count > 0
         finally:
             store.close()
+
+
+def _write_scip_index(repo_path: Path) -> None:
+    from archex.integrations.semantic import scip_pb2
+
+    index = scip_pb2.Index()
+    index.metadata.tool_info.name = "scip-python"
+    index.metadata.tool_info.version = "0.5.0"
+
+    main_doc = index.documents.add()
+    main_doc.relative_path = "main.py"
+    main_doc.language = "python"
+    definition = main_doc.occurrences.add()
+    definition.symbol = "scip-python python . . main/entry()."
+    definition.symbol_roles = scip_pb2.SymbolRole.Definition
+    definition.single_line_range.line = 0
+    definition.single_line_range.start_character = 4
+
+    models_doc = index.documents.add()
+    models_doc.relative_path = "models.py"
+    models_doc.language = "python"
+    usage = models_doc.occurrences.add()
+    usage.symbol = "scip-python python . . main/entry()."
+    usage.range.extend([3, 0, 4])
+
+    (repo_path / "index.scip").write_bytes(index.SerializeToString())
+
+
+class TestQueryCacheHitReceipt:
+    def test_cached_query_still_reports_semantic_provider_receipts(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        """A warm cache-hit query must not silently drop the receipt.
+
+        Regression test: the cache-hit branch in query() previously called
+        _finalize_context_bundle without semantic_providers, so a cached
+        query returned a receipt with semantic_providers=[] while its
+        included_edges carried provider="scip" -- internally contradictory.
+        """
+        from archex.api import query
+        from archex.models import Config, PipelineTiming, RepoSource
+
+        _write_scip_index(python_simple_repo)
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(cache=True, cache_dir=str(tmp_path / "cache"))
+        index_config = IndexConfig(semantic_evidence_providers=["scip"])
+
+        first_timing = PipelineTiming()
+        _first = query(
+            source,
+            "how does entry work",
+            config=config,
+            index_config=index_config,
+            timing=first_timing,
+            token_budget=50,
+            explicit_token_budget=True,
+        )
+        assert first_timing.strategy == "full"
+
+        second_timing = PipelineTiming()
+        second = query(
+            source,
+            "how does entry work",
+            config=config,
+            index_config=index_config,
+            timing=second_timing,
+            token_budget=50,
+            explicit_token_budget=True,
+        )
+        assert second_timing.strategy == "cached"
+        assert second.receipt is not None
+        assert second.receipt.semantic_providers != []
+        assert any(
+            r.provider == SemanticProviderName.SCIP
+            and r.availability == ProviderAvailability.AVAILABLE
+            for r in second.receipt.semantic_providers
+        )
+
+    def test_warm_runtime_snapshot_query_reports_receipts_without_crashing(
+        self, python_simple_repo: Path, tmp_path: Path
+    ) -> None:
+        """A QueryRuntime-backed warm-snapshot query must not use a closed store.
+
+        Regression test: when a runtime snapshot is reused, the original
+        `store` handle is closed early (api.py) and retrieval switches to
+        `search_store` (the warm snapshot's own store). Reading semantic
+        provider receipts off the wrong (closed) handle raised
+        sqlite3.ProgrammingError instead of returning the receipt.
+        """
+        from archex.api import query
+        from archex.models import Config, RepoSource
+        from archex.serve.runtime import QueryRuntime
+
+        _write_scip_index(python_simple_repo)
+        source = RepoSource(local_path=str(python_simple_repo))
+        config = Config(cache=True, cache_dir=str(tmp_path / "cache"))
+        index_config = IndexConfig(semantic_evidence_providers=["scip"])
+
+        runtime = QueryRuntime()
+        try:
+            query(
+                source,
+                "how does entry work",
+                config=config,
+                index_config=index_config,
+                token_budget=50,
+                explicit_token_budget=True,
+                runtime=runtime,
+            )
+            second = query(
+                source,
+                "how does entry work",
+                config=config,
+                index_config=index_config,
+                token_budget=50,
+                explicit_token_budget=True,
+                runtime=runtime,
+            )
+            assert second.receipt is not None
+            assert second.receipt.semantic_providers != []
+        finally:
+            runtime.close()

--- a/tests/index/test_store.py
+++ b/tests/index/test_store.py
@@ -338,6 +338,32 @@ def test_edge_confidence_round_trip(store: IndexStore) -> None:
     assert stored.evidence == ["same symbol stem", "test path targets source path"]
 
 
+def test_edge_provider_round_trip(store: IndexStore) -> None:
+    edge = Edge(
+        source="a.py",
+        target="b.py",
+        kind=EdgeKind.SEMANTIC_DEFINITION,
+        confidence=EdgeConfidence.EXTRACTED,
+        confidence_score=0.95,
+        provider="scip",
+        provider_version="0.5.0",
+    )
+
+    store.insert_edges([edge])
+    [stored] = store.get_edges()
+
+    assert stored.kind == EdgeKind.SEMANTIC_DEFINITION
+    assert stored.provider == "scip"
+    assert stored.provider_version == "0.5.0"
+
+
+def test_syntax_edge_has_no_provider(store: IndexStore) -> None:
+    store.insert_edges([Edge(source="a.py", target="b.py", kind=EdgeKind.IMPORTS)])
+    [stored] = store.get_edges()
+    assert stored.provider is None
+    assert stored.provider_version is None
+
+
 def test_empty_store_returns_empty_lists(store: IndexStore) -> None:
     assert store.get_chunks() == []
     assert store.get_edges() == []
@@ -447,7 +473,7 @@ def test_fresh_store_has_schema_version(store: IndexStore) -> None:
 def test_fresh_store_has_edge_confidence_columns(store: IndexStore) -> None:
     columns = {row[1] for row in store.conn.execute("PRAGMA table_info(edges)")}
 
-    assert {"confidence", "confidence_score", "evidence"} <= columns
+    assert {"confidence", "confidence_score", "evidence", "provider", "provider_version"} <= columns
 
 
 def test_migrated_store_with_null_symbol_ids_needs_reindex(tmp_path: Path) -> None:
@@ -531,6 +557,8 @@ def test_old_edges_migrate_with_confidence_defaults(tmp_path: Path) -> None:
     assert edge.confidence == EdgeConfidence.EXTRACTED
     assert edge.confidence_score == 1.0
     assert edge.evidence == []
+    assert edge.provider is None
+    assert edge.provider_version is None
 
 
 def test_clear_reindex_flag(tmp_path: Path) -> None:
@@ -1089,3 +1117,56 @@ class TestCorruptedDatabase:
 
         with pytest.raises(sqlite3.DatabaseError):
             IndexStore(bad_db)
+
+
+class TestSemanticProviderReceipts:
+    def test_empty_when_unset(self, store: IndexStore) -> None:
+        assert store.get_semantic_provider_receipts() == []
+
+    def test_round_trips_receipts(self, store: IndexStore) -> None:
+        from archex.integrations.semantic.models import (
+            ProviderAvailability,
+            SemanticProviderName,
+            SemanticProviderReceipt,
+        )
+
+        receipts = [
+            SemanticProviderReceipt(
+                provider=SemanticProviderName.SCIP,
+                availability=ProviderAvailability.AVAILABLE,
+                tool_name="scip-python",
+                tool_version="0.5.0",
+                files_attempted=3,
+                files_succeeded=2,
+                evidence_count=5,
+                collected_at="2026-01-01T00:00:00+00:00",
+            ),
+            SemanticProviderReceipt(
+                provider=SemanticProviderName.LSP,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason="no LSP client configured",
+                collected_at="2026-01-01T00:00:00+00:00",
+            ),
+        ]
+        store.set_semantic_provider_receipts(receipts)
+        stored = store.get_semantic_provider_receipts()
+        assert stored == receipts
+
+    def test_overwrites_prior_receipts(self, store: IndexStore) -> None:
+        from archex.integrations.semantic.models import (
+            ProviderAvailability,
+            SemanticProviderName,
+            SemanticProviderReceipt,
+        )
+
+        store.set_semantic_provider_receipts(
+            [
+                SemanticProviderReceipt(
+                    provider=SemanticProviderName.SCIP,
+                    availability=ProviderAvailability.UNAVAILABLE,
+                    reason="no index",
+                )
+            ]
+        )
+        store.set_semantic_provider_receipts([])
+        assert store.get_semantic_provider_receipts() == []

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -183,6 +183,25 @@ class TestComputeGenerationId:
         )
         assert a != b
 
+    def test_semantic_evidence_providers_change_changes_id(self) -> None:
+        a = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(semantic_evidence_providers=[]),
+        )
+        b = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(semantic_evidence_providers=["scip"]),
+        )
+        assert a != b
+
     def test_vector_mode_changes_id(self) -> None:
         raw = compute_generation_id(
             schema_version="5",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -768,6 +768,17 @@ class TestIndexConfigValidation:
         assert config.quantize_vectors is True
         assert config.quantize_bits == 4
 
+    def test_semantic_evidence_providers_defaults_empty(self) -> None:
+        assert IndexConfig().semantic_evidence_providers == []
+
+    def test_semantic_evidence_providers_accepts_known_names(self) -> None:
+        config = IndexConfig(semantic_evidence_providers=["scip", "lsp"])
+        assert config.semantic_evidence_providers == ["scip", "lsp"]
+
+    def test_semantic_evidence_providers_rejects_unknown_name(self) -> None:
+        with pytest.raises(ValueError, match="unknown entries"):
+            IndexConfig(semantic_evidence_providers=["scip", "bogus"])
+
     def test_quantize_bits_must_be_supported(self) -> None:
         with pytest.raises(ValueError, match="quantize_bits must be one of"):
             IndexConfig(quantize_bits=8)

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from archex.integrations.semantic.models import (
+    ProviderAvailability,
+    SemanticProviderName,
+    SemanticProviderReceipt,
+)
 from archex.models import (
     CompressionLossRisk,
     CompressionMetadata,
@@ -15,6 +20,8 @@ from archex.models import (
     ContextRecommendedAction,
     ContextSkippedCandidate,
     ContextSkippedReason,
+    Edge,
+    EdgeConfidence,
     EdgeKind,
 )
 from archex.receipt import (
@@ -213,3 +220,58 @@ def test_receipt_round_trips_with_compressed_rows() -> None:
     assert restored == receipt
     # A compressed row never flips a complete receipt; completeness is preserved.
     assert restored.context_complete == ContextCompletenessStatus.COMPLETE
+
+
+def test_build_context_receipt_carries_semantic_providers() -> None:
+    bundle = ContextBundle(query="q", token_count=10, token_budget=100)
+    receipts = [
+        SemanticProviderReceipt(
+            provider=SemanticProviderName.SCIP,
+            availability=ProviderAvailability.AVAILABLE,
+            evidence_count=3,
+        )
+    ]
+
+    receipt = build_context_receipt(
+        bundle,
+        index_revision="rev",
+        freshness=ContextFreshness.CLEAN,
+        semantic_providers=receipts,
+    )
+
+    assert receipt.semantic_providers == receipts
+
+
+def test_build_context_receipt_defaults_semantic_providers_empty() -> None:
+    bundle = ContextBundle(query="q", token_count=10, token_budget=100)
+    receipt = build_context_receipt(bundle, index_revision="rev", freshness=ContextFreshness.CLEAN)
+    assert receipt.semantic_providers == []
+
+
+def test_receipt_edge_from_edge_helper_propagates_provider() -> None:
+    from archex.receipt import _receipt_edge  # pyright: ignore[reportPrivateUsage]
+
+    edge = Edge(
+        source="a.py",
+        target="b.py",
+        kind=EdgeKind.SEMANTIC_DEFINITION,
+        confidence=EdgeConfidence.EXTRACTED,
+        confidence_score=0.9,
+        provider="scip",
+        provider_version="0.5.0",
+    )
+
+    receipt_edge = _receipt_edge(edge)
+
+    assert receipt_edge.provider == "scip"
+    assert receipt_edge.provider_version == "0.5.0"
+
+
+def test_receipt_edge_from_edge_helper_syntax_edge_has_no_provider() -> None:
+    from archex.receipt import _receipt_edge  # pyright: ignore[reportPrivateUsage]
+
+    edge = Edge(source="a.py", target="b.py", kind=EdgeKind.IMPORTS)
+    receipt_edge = _receipt_edge(edge)
+
+    assert receipt_edge.provider is None
+    assert receipt_edge.provider_version is None


### PR DESCRIPTION
## Stack

Stack-Id: `m6-semantic-evidence-71f3c4`
Base: `main`
Position: 2/3

1. `m6-1-provider-contract` -> #551
2. `m6-2-graph-and-receipts` -> this PR
3. `m6-3-gated-evaluation` -> (next)

Depends on: #551
Upstack: PR-3 (gated evaluation)

## Milestone

M6 — Add Compiler-Grade Semantic Evidence Conditionally. This PR wires the PR-1 provider contract into the syntax graph, index pipeline, and receipts — entirely gated behind a new opt-in flag, default off. PR-3 adds the M3 benchmark lane and reports the promotion verdict.

## Summary

- `models.py`: three new `EdgeKind` members (`SEMANTIC_DEFINITION`, `SEMANTIC_REFERENCE`, `SEMANTIC_IMPLEMENTATION`), structurally distinct from every syntax kind. `Edge`/`ContextReceiptEdge` gain `provider`/`provider_version` (`None` on every syntax edge). `ContextReceipt` gains `semantic_providers: list[SemanticProviderReceipt]`. New `IndexConfig.semantic_evidence_providers: list[str] = []` — empty by default, matching the M17 `identifier_fragment_tokenization` precedent for a benchmark-gated, default-off flag.
- `index/graph.py`: `DependencyGraph.add_semantic_edges()` folds evidence into the file graph. Only connects file paths already present as nodes (never invents one), and never overwrites an existing edge — the digraph model allows one edge per node pair, so syntax evidence authority is preserved and a second semantic relationship in the same direction is skipped rather than silently clobbering the first (covered by a dedicated regression test after this exact collision surfaced during development). Edge/sqlite round-trip helpers and the confidence-column migration now carry provider/provider_version end to end.
- `index/store.py`: `edges` table gains nullable `provider`/`provider_version` columns (in-place migration, tested against a pre-M6 schema); `IndexStore.get/set_semantic_provider_receipts()` persist the per-build receipts.
- `index/semantic_evidence.py`: `collect_semantic_evidence()` dispatches configured providers, zero-cost (no import) when the list is empty.
- `api.py`: wired into both full-build paths (`index_repository()`'s cold build and `query()`'s cold path); receipts persisted to the store and threaded through to `ContextReceipt.semantic_providers` on the query cold path.
- `receipt.py`: `build_context_receipt()` gains `semantic_providers`; `_receipt_edge()` propagates provider fields; `build_scout_receipt()` inherits them for free via `model_copy()`.

## Validation

- `uv run ruff check .` / `uv run ruff format --check .` — pass
- `uv run pyright .` — 0 errors
- Full changed-file set (`src/archex/{models,api,receipt}.py`, `src/archex/index/{graph,store,semantic_evidence}.py`, plus tests) — 0 ruff/pyright issues
- `uv run pytest -m "not slow"` (full suite) — 4189 passed (up from 4161 pre-PR), 91.43% coverage
- End-to-end proof: `tests/index/test_semantic_evidence.py::TestIndexRepositoryWiring` indexes a real fixture repo through the public `index_repository()` API — once with the default config (asserts zero provider-tagged edges, byte-identical to pre-M6 behavior) and once with a real crafted SCIP index on disk (asserts a `SEMANTIC_DEFINITION` edge with correct provider/version and an `AVAILABLE` receipt land in the store)

## Notes for reviewers

- The "never overwrite an existing edge" rule is a direct consequence of `nx.DiGraph` allowing only one edge per `(source, target)` pair — worth double-checking against the acceptance criterion "syntax and semantic evidence remain distinguishable" holds even under this constraint (it does: syntax edges are never touched; competing semantic edges for the same file pair are deterministically first-wins, not corrupted).
- Default behavior is unchanged repo-wide: `semantic_evidence_providers` defaults to `[]`, so no existing store, edge, or receipt shape changes unless a caller explicitly opts in.
