### PR TITLE
test(benchmark): evaluate semantic evidence lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **M6 (disabled by default — see `benchmarks/results/m6_semantic_evidence/DECISION.md`): conditional compiler-grade semantic evidence infrastructure.** Added `archex.integrations.semantic`: a `SemanticEvidenceProvider` contract (`probe()`/`collect()`) with `ScipEvidenceProvider` (reads a pre-built [SCIP](https://github.com/sourcegraph/scip) index, new `archex[scip]` extra) and `LspEvidenceProvider` (reuses the existing `archex[lsap]` LSP wrapper against a caller-supplied client) implementations. `DependencyGraph.add_semantic_edges()` folds evidence into the file graph as new `EdgeKind.SEMANTIC_DEFINITION`/`SEMANTIC_REFERENCE`/`SEMANTIC_IMPLEMENTATION` edges — structurally distinct from every syntax kind, provider/version/confidence-stamped, never overwriting existing evidence — gated entirely behind the new `IndexConfig.semantic_evidence_providers: list[str] = []` flag (empty by default: zero behavioral change). Unavailable/stale/partial providers produce an explicit `SemanticProviderReceipt` (surfaced via `IndexStore.get_semantic_provider_receipts()` and `ContextReceipt.semantic_providers`) rather than a fallback edge. The gated `archex_query_semantic` benchmark lane shows zero measured improvement over `archex_query` on the self-repo corpus (no pre-built SCIP index was available to activate the provider in the measured environment — an external-tool limitation, not an implementation gap; see the decision doc), so the provider stays disabled by default pending a future measurement with real SCIP/LSP evidence available.
+
 ## [0.23.0] - 2026-07-24
 
 ### Added

--- a/benchmarks/results/m6_semantic_evidence/DECISION.md
+++ b/benchmarks/results/m6_semantic_evidence/DECISION.md
@@ -1,0 +1,139 @@
+# M6 — Compiler-grade semantic evidence: measurement and promotion decision
+
+Milestone: conditionally enrich the syntax graph with SCIP and LSAP/LSP
+definition/reference/implementation evidence, promoted to the shipped default
+only if it improves M3's declared benchmark without regression. This records
+the `archex_query` vs `archex_query_semantic` comparison on the self-repo
+benchmark family and the resulting promotion decision.
+
+## What was implemented
+
+- `archex.integrations.semantic`: `SemanticEvidenceProvider` contract
+  (`probe()`/`collect()`), `ScipEvidenceProvider` (reads a pre-built SCIP
+  index off disk via a vendored, protoc-generated `scip_pb2`), and
+  `LspEvidenceProvider` (reuses the existing `archex.integrations.lsap`
+  wrapper against a caller-supplied `lsp_client.Client`). Every provider
+  returns an explicit `AVAILABLE`/`PARTIAL`/`UNAVAILABLE`/`STALE` receipt
+  instead of raising or inventing edges.
+- `DependencyGraph.add_semantic_edges()`: folds evidence into the file graph
+  as new `EdgeKind.SEMANTIC_*` edges, distinct from every syntax kind, only
+  connecting files already known to the graph and never overwriting an
+  existing edge.
+- `IndexConfig.semantic_evidence_providers: list[str] = []` — the gate flag.
+  Empty by default: no provider runs, zero bytes of the index change.
+- `IndexStore`: nullable `provider`/`provider_version` edge columns and
+  `get/set_semantic_provider_receipts()`; `ContextReceipt.semantic_providers`
+  surfaces the receipts on the query cold path.
+- `archex_query_semantic` benchmark strategy (`Strategy.ARCHEX_QUERY_SEMANTIC`):
+  `archex_query`'s exact configuration plus
+  `semantic_evidence_providers=["scip"]`.
+
+## Method
+
+Self-repo benchmark family (`benchmarks/tasks/*.yaml`, `repo: "."`,
+`category: self`, 24 tasks) — the only family where a SCIP index for the
+corpus under test can plausibly be generated locally without cloning and
+type-checking an external repository. Same token budget, same chunker, same
+cache policy (`cache=False`, fresh cold build per task) as the product
+default `archex_query` strategy; the only variable is
+`semantic_evidence_providers=["scip"]`.
+
+```
+uv run archex benchmark run --tasks-dir benchmarks/tasks --self-only \
+  --strategy archex_query_semantic --warm-cache --output <dir> --no-progress
+uv run archex benchmark gate --input <dir> --tasks-dir benchmarks/tasks \
+  --min-recall 0.50 --min-precision 0.10 --min-f1 0.25 --min-mrr 0.50 \
+  --min-token-efficiency-with-completion 0.20 --max-p95-warm-latency-ms 15000 \
+  --promotion-strategy archex_query_semantic --control-strategy archex_query
+```
+
+`--strategy` is additive to the runner's always-included baseline set
+(`raw_files`, `raw_ripgrep`, `archex_query`), so `archex_query` and
+`archex_query_semantic` are measured in the same run against the same cold
+index build per task — the same-run control the gate command consumes.
+
+### Why no SCIP index was present for the measured run
+
+The provider is designed to read a pre-built SCIP index at
+`<repo_root>/index.scip`. The only real-world SCIP producer readily
+available in this environment, `@sourcegraph/scip-python` (run via `npx`),
+was exercised directly: it completes without error and reports "Total
+Project Files 413" for this repository (and even a trivial hand-written
+2-file smoke-test project with zero dependencies), but in every invocation
+tried — default, `--target-only`, `--project-name`, an explicit
+`pyrightconfig.json`, and an explicit empty `--environment` JSON array —
+emits an `Index` message with **zero `documents`**. This reproduces
+identically on the minimal smoke project, so it is a defect or environment
+incompatibility in `scip-python` itself in this sandbox, not a defect in
+this milestone's provider or graph-integration code, which is independently
+verified correct against hand-constructed SCIP protobuf fixtures
+(`tests/integrations/semantic/test_scip_provider.py`,
+`tests/index/test_semantic_evidence.py::TestIndexRepositoryWiring`,
+`tests/benchmark/test_semantic_strategy.py`) and produces real
+`SEMANTIC_DEFINITION`/`SEMANTIC_REFERENCE`/`SEMANTIC_IMPLEMENTATION` edges,
+correct provider/version/confidence, and an `AVAILABLE` receipt end to end
+through the public `index_repository()` API.
+
+The self-repo benchmark below therefore measures the provider's **honest,
+common real-world case: no pre-built SCIP index present.**
+
+## Results
+
+No `index.scip` was present at the repository root for the measured run.
+`ScipEvidenceProvider.probe()` correctly reported `UNAVAILABLE` (reason:
+`no SCIP index found at index.scip`) for every task; zero semantic edges
+were added; the two strategies' `IndexConfig` differ only in the unused
+flag.
+
+| task | base recall | cand recall | base f1 | cand f1 | base mrr | cand mrr |
+|---|---:|---:|---:|---:|---:|---:|
+| archex_adapter_registry | 1.000 | 1.000 | 0.750 | 0.750 | 1.000 | 1.000 |
+| archex_benchmark_gate_lifecycle | 0.800 | 0.800 | 0.800 | 0.800 | 1.000 | 1.000 |
+| archex_delta_index_lifecycle | 0.667 | 0.667 | 0.500 | 0.500 | 0.500 | 0.500 |
+| archex_delta_indexing | 1.000 | 1.000 | 0.571 | 0.571 | 1.000 | 1.000 |
+| archex_graph_expansion | 1.000 | 1.000 | 0.667 | 0.667 | 1.000 | 1.000 |
+| archex_mcp_query_lifecycle | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 | 1.000 |
+| archex_pattern_detection | 1.000 | 1.000 | 0.571 | 0.571 | 1.000 | 1.000 |
+| archex_project_config_resolution | 0.750 | 0.750 | 0.750 | 0.750 | 1.000 | 1.000 |
+| archex_project_index | 0.800 | 0.800 | 0.800 | 0.800 | 1.000 | 1.000 |
+| archex_project_init | 0.750 | 0.750 | 0.750 | 0.750 | 1.000 | 1.000 |
+| archex_project_reset | 1.000 | 1.000 | 0.857 | 0.857 | 1.000 | 1.000 |
+| archex_project_status | 0.750 | 0.750 | 0.750 | 0.750 | 1.000 | 1.000 |
+| archex_query_cache_lifecycle | 0.800 | 0.800 | 0.800 | 0.800 | 1.000 | 1.000 |
+| archex_query_pipeline | 0.667 | 0.667 | 0.500 | 0.500 | 1.000 | 1.000 |
+| archex_scoring | 1.000 | 1.000 | 0.750 | 0.750 | 1.000 | 1.000 |
+| archex_vector_cache_lifecycle | 0.600 | 0.600 | 0.600 | 0.600 | 1.000 | 1.000 |
+| routing_mixed_cache | 1.000 | 1.000 | 0.571 | 0.571 | 1.000 | 1.000 |
+| routing_mixed_chunker | 1.000 | 1.000 | 0.333 | 0.333 | 0.500 | 0.500 |
+| routing_pl_intent | 1.000 | 1.000 | 0.333 | 0.333 | 1.000 | 1.000 |
+| routing_pl_large | 1.000 | 1.000 | 0.400 | 0.400 | 1.000 | 1.000 |
+| routing_pl_path_symbol | 1.000 | 1.000 | 0.333 | 0.333 | 1.000 | 1.000 |
+| routing_pl_scoring | 0.500 | 0.500 | 0.286 | 0.286 | 1.000 | 1.000 |
+| routing_pl_tight | 1.000 | 1.000 | 0.333 | 0.333 | 1.000 | 1.000 |
+| routing_trace_api | 0.500 | 0.500 | 0.286 | 0.286 | 0.500 | 0.500 |
+| **mean** | **0.858** | **0.858** | **0.596** | **0.596** | **0.938** | **0.938** |
+
+Every metric is identical to 3 decimal places on every one of the 24
+self-repo tasks — Δ = 0.000 everywhere. `archex benchmark gate` with
+`--promotion-strategy archex_query_semantic --control-strategy archex_query`
+reports **`Quality gate passed`**: the absolute floors and the same-run
+control non-regression checks all pass, because the candidate is byte-for-byte
+identical to the control.
+
+## Decision
+
+**Do not enable by default.** Non-regression is not the milestone's bar —
+M6's stated acceptance is "production promotion occurs only if M3's declared
+benchmark **improves**." The measured candidate shows zero improvement on
+any metric, because no pre-built SCIP index was available to activate the
+provider (an external-tool defect in `scip-python` documented above, not an
+implementation gap in this milestone — see the passing unit and integration
+tests proving the provider produces real, correct edges when given real SCIP
+data). `IndexConfig.semantic_evidence_providers` ships **defaulting to
+`[]`** (disabled): the provider contract, graph/receipt integration, and
+gated benchmark lane are real, tested, reusable infrastructure, but nothing
+in this stack changes a single byte of default retrieval behavior. Its
+`Unreleased` CHANGELOG entry stays staged for a future minor, per
+`DEVELOPMENT_PLAN.md`'s "no standalone release by default" for this section
+— to be revisited once a working real-world SCIP (or a connected LSP server)
+source is available to measure an actual improvement against.

--- a/benchmarks/results/m6_semantic_evidence/DECISION.md
+++ b/benchmarks/results/m6_semantic_evidence/DECISION.md
@@ -34,9 +34,11 @@ Self-repo benchmark family (`benchmarks/tasks/*.yaml`, `repo: "."`,
 `category: self`, 24 tasks) — the only family where a SCIP index for the
 corpus under test can plausibly be generated locally without cloning and
 type-checking an external repository. Same token budget, same chunker, same
-cache policy (`cache=False`, fresh cold build per task) as the product
-default `archex_query` strategy; the only variable is
-`semantic_evidence_providers=["scip"]`.
+cache policy as the product default `archex_query` strategy — both lanes
+run with `--warm-cache` (one discarded cache-populating run per strategy,
+then a warm-timed run), required by `archex benchmark gate`'s
+`--max-p95-warm-latency-ms` check; the only variable between the two
+strategies is `semantic_evidence_providers=["scip"]`.
 
 ```
 uv run archex benchmark run --tasks-dir benchmarks/tasks --self-only \

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -44,6 +44,7 @@ class Strategy(StrEnum):
     ARCHEX_QUERY_DIVERSITY_PACKED = "archex_query_diversity_packed"
     ARCHEX_QUERY_PROFILE_FAST = "archex_query_profile_fast"
     ARCHEX_QUERY_PROFILE_BALANCED = "archex_query_profile_balanced"
+    ARCHEX_QUERY_SEMANTIC = "archex_query_semantic"
     EXTERNAL_MCP = "external_mcp"
 
 

--- a/src/archex/benchmark/strategies.py
+++ b/src/archex/benchmark/strategies.py
@@ -1374,6 +1374,27 @@ def run_archex_query(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     )
 
 
+def run_archex_query_semantic(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
+    """archex query with the SCIP semantic-evidence provider enabled (M6 candidate lane).
+
+    Benchmark-only: enables ``IndexConfig.semantic_evidence_providers=["scip"]``
+    on top of the exact ``archex_query`` baseline configuration. Reads a SCIP
+    index from ``<repo_path>/index.scip`` when present; when absent (the
+    common case for most benchmark corpora, which have no pre-built SCIP
+    index), the provider reports UNAVAILABLE and this lane is byte-identical
+    to ``archex_query``. Never the product default.
+    """
+    return _run_query_strategy(
+        task,
+        repo_path,
+        strategy=Strategy.ARCHEX_QUERY_SEMANTIC,
+        index_config=IndexConfig(vector=False, semantic_evidence_providers=["scip"]),
+        cache=benchmark_cache_enabled(default=False),
+        include_completion=True,
+        measure_freshness=True,
+    )
+
+
 def run_archex_query_profile_fast(task: BenchmarkTask, repo_path: Path) -> BenchmarkResult:
     """archex query under the product's ``fast`` retrieval profile (M3 candidate lane).
 
@@ -4309,3 +4330,4 @@ default_strategy_registry.register(
 default_strategy_registry.register(
     Strategy.ARCHEX_QUERY_PROFILE_BALANCED.value, run_archex_query_profile_balanced
 )
+default_strategy_registry.register(Strategy.ARCHEX_QUERY_SEMANTIC.value, run_archex_query_semantic)

--- a/tests/benchmark/test_semantic_strategy.py
+++ b/tests/benchmark/test_semantic_strategy.py
@@ -1,0 +1,80 @@
+"""Tests for the M6 archex_query_semantic benchmark lane."""
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+# pyright: reportUnknownArgumentType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from archex.benchmark.models import BenchmarkTask, Strategy
+from archex.benchmark.strategies import run_archex_query, run_archex_query_semantic
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _task(**overrides: object) -> BenchmarkTask:
+    defaults: dict[str, object] = {
+        "task_id": "test",
+        "repo": "test/repo",
+        "commit": "abc",
+        "question": "How does the main module work?",
+        "expected_files": ["main.py"],
+        "token_budget": 4096,
+    }
+    defaults.update(overrides)
+    return BenchmarkTask.model_validate(defaults)
+
+
+class TestRunArchexQuerySemantic:
+    def test_strategy_and_metrics_shape(self, python_simple_repo: Path) -> None:
+        result = run_archex_query_semantic(_task(), python_simple_repo)
+        assert result.strategy == Strategy.ARCHEX_QUERY_SEMANTIC
+        assert result.tool_calls == 1
+        assert result.timing is not None
+        assert 0.0 <= result.recall <= 1.0
+        assert 0.0 <= result.precision <= 1.0
+
+    def test_matches_baseline_when_no_scip_index_present(self, python_simple_repo: Path) -> None:
+        # No index.scip at the repo root -> ScipEvidenceProvider reports
+        # UNAVAILABLE and zero edges are added; retrieval must be identical
+        # to the unmodified archex_query baseline.
+        task = _task()
+        baseline = run_archex_query(task, python_simple_repo)
+        candidate = run_archex_query_semantic(task, python_simple_repo)
+
+        assert candidate.recall == baseline.recall
+        assert candidate.precision == baseline.precision
+        assert candidate.mrr == baseline.mrr
+        assert candidate.tokens_output == baseline.tokens_output
+        assert candidate.required_file_recall == baseline.required_file_recall
+
+    def test_runs_successfully_with_a_real_scip_index_present(
+        self, python_simple_repo: Path
+    ) -> None:
+        from archex.integrations.semantic import scip_pb2
+
+        index = scip_pb2.Index()
+        index.metadata.tool_info.name = "scip-python"
+        index.metadata.tool_info.version = "0.5.0"
+
+        main_doc = index.documents.add()
+        main_doc.relative_path = "main.py"
+        main_doc.language = "python"
+        definition = main_doc.occurrences.add()
+        definition.symbol = "scip-python python . . main/entry()."
+        definition.symbol_roles = scip_pb2.SymbolRole.Definition
+        definition.single_line_range.line = 0
+
+        models_doc = index.documents.add()
+        models_doc.relative_path = "models.py"
+        models_doc.language = "python"
+        usage = models_doc.occurrences.add()
+        usage.symbol = "scip-python python . . main/entry()."
+        usage.range.extend([3, 0, 4])
+
+        (python_simple_repo / "index.scip").write_bytes(index.SerializeToString())
+
+        result = run_archex_query_semantic(_task(), python_simple_repo)
+        assert result.strategy == Strategy.ARCHEX_QUERY_SEMANTIC
+        assert 0.0 <= result.recall <= 1.0


### PR DESCRIPTION
## Stack

Stack-Id: `m6-semantic-evidence-71f3c4`
Base: `main`
Position: 3/3

1. `m6-1-provider-contract` -> #551
2. `m6-2-graph-and-receipts` -> #552
3. `m6-3-gated-evaluation` -> this PR

Depends on: #552
Upstack: (none - leaf)

## Milestone

M6 — Add Compiler-Grade Semantic Evidence Conditionally. This PR adds the gated benchmark lane and publishes the measured promotion decision, closing out the milestone.

## Summary

- New `Strategy.ARCHEX_QUERY_SEMANTIC` / `archex_query_semantic` benchmark lane: `archex_query`'s exact configuration plus `semantic_evidence_providers=["scip"]`. Reads `<repo_path>/index.scip` when present; reports the provider `UNAVAILABLE` (byte-identical to `archex_query`) when absent.
- Ran the M3-style gate: `archex_query` vs `archex_query_semantic` on the 24-task self-repo family (`benchmarks/tasks/*.yaml`, `repo: "."`), `archex benchmark gate --promotion-strategy archex_query_semantic --control-strategy archex_query`.
- **Result: `benchmarks/results/m6_semantic_evidence/DECISION.md`.** All 24 tasks are metric-identical (Δ = 0.000 on recall/precision/f1/mrr) because no SCIP index was available to activate the provider — `@sourcegraph/scip-python` (the only real-world SCIP producer readily testable here) reproducibly emits zero `documents` even on a trivial hand-written 2-file project with no dependencies, across every invocation tried (default, `--target-only`, `--project-name`, explicit `pyrightconfig.json`, explicit empty `--environment` JSON). This is documented as an external-tool defect/environment incompatibility, independent of this milestone's own code — which is separately proven correct against hand-constructed SCIP protobuf fixtures in PR-1/PR-2 (real `SEMANTIC_DEFINITION`/`REFERENCE`/`IMPLEMENTATION` edges, correct provider/version/confidence, `AVAILABLE` receipts, end to end through the public `index_repository()` API).
- `archex benchmark gate` with the promotion/control strategy pair reports `Quality gate passed` (no regression — expected, since the candidate is byte-identical to control), but **M6's bar is measured improvement**, which this run cannot demonstrate without real SCIP data. `IndexConfig.semantic_evidence_providers` stays at its shipped default (`[]`, disabled) — no config change from PR-2.
- `CHANGELOG.md`: `M6` entry added under `Unreleased`, explicitly marked disabled-by-default per the DECISION doc.

## Validation

- `uv run ruff check .` / `uv run ruff format --check .` — pass (whole repo)
- `uv run pyright .` — 0 errors (whole repo)
- `uv run pytest tests/benchmark/test_semantic_strategy.py -v --no-cov` — 3 passed, including a direct within-run parity assertion (`archex_query_semantic` vs `archex_query`) and a real-SCIP-fixture smoke run
- `uv run pytest -m "not slow"` (full suite) — 4192 passed, 91.45% coverage
- Real benchmark evidence: 24-task self-repo comparison, `archex benchmark run --warm-cache` + `archex benchmark gate` against a clean (committed) tree, recorded manifest provenance

## Notes for reviewers

- This is the leaf of the stack. The whole-stack verdict (GO/NO-GO) and release decision belong in the final summary once all three PRs are reviewed.
- The scip-python tool-defect writeup is reproducible: same zero-document result on a from-scratch 2-file project outside this repo, ruling out an archex-specific cause.
