### PR TITLE
feat(evidence): add coverage runtime contracts

### DIFF
--- a/src/archex/index/runtime_evidence.py
+++ b/src/archex/index/runtime_evidence.py
@@ -1,0 +1,136 @@
+"""Conditional runtime/coverage evidence collection (M7): dispatch configured providers.
+
+Zero-cost when no provider names are requested (the default): no provider
+module import happens beyond this module's own top-level imports, and no
+provider runs. Enabling a provider by name runs it against the given
+repository root and revision, and folds every non-``AVAILABLE`` outcome
+(unavailable, partial, or revision-stale) into an explicit receipt rather
+than a silent gap or a mismatched-revision record being silently applied.
+
+Kept structurally separate from ``archex.index.semantic_evidence`` (M6): the
+two conditional evidence channels are independently disableable and
+independently rollback-able, so neither imports or depends on the other.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+from typing import TYPE_CHECKING
+
+from archex.integrations.runtime.coverage_provider import CoverageXmlProvider
+from archex.integrations.runtime.models import (
+    ProviderAvailability,
+    RuntimeEvidenceProviderName,
+    RuntimeProviderReceipt,
+)
+from archex.integrations.runtime.profile_provider import RuntimeProfileProvider
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from archex.integrations.runtime.models import CoverageFileEvidence, RuntimeProfileEvidence
+    from archex.integrations.runtime.provider import (
+        CoverageEvidenceProvider,
+        RuntimeProfileEvidenceProvider,
+    )
+
+logger = logging.getLogger(__name__)
+
+#: Provider names accepted by ``IndexConfig.runtime_evidence_providers``.
+KNOWN_RUNTIME_EVIDENCE_PROVIDERS = frozenset({"coverage", "runtime_profile"})
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(tz=_dt.UTC).isoformat()
+
+
+def _collect_coverage(
+    provider: CoverageEvidenceProvider, repo_root: Path, expected_revision: str
+) -> tuple[list[CoverageFileEvidence], RuntimeProviderReceipt]:
+    try:
+        return provider.collect(repo_root, expected_revision=expected_revision)
+    except Exception as exc:
+        logger.warning(
+            "runtime evidence provider 'coverage' raised during collect()", exc_info=True
+        )
+        return [], RuntimeProviderReceipt(
+            provider=RuntimeEvidenceProviderName.COVERAGE,
+            availability=ProviderAvailability.UNAVAILABLE,
+            reason=f"provider raised {type(exc).__name__}: {exc}",
+            expected_revision=expected_revision,
+            collected_at=_now_iso(),
+        )
+
+
+def _collect_profile(
+    provider: RuntimeProfileEvidenceProvider, repo_root: Path, expected_revision: str
+) -> tuple[list[RuntimeProfileEvidence], RuntimeProviderReceipt]:
+    try:
+        return provider.collect(repo_root, expected_revision=expected_revision)
+    except Exception as exc:
+        logger.warning(
+            "runtime evidence provider 'runtime_profile' raised during collect()", exc_info=True
+        )
+        return [], RuntimeProviderReceipt(
+            provider=RuntimeEvidenceProviderName.RUNTIME_PROFILE,
+            availability=ProviderAvailability.UNAVAILABLE,
+            reason=f"provider raised {type(exc).__name__}: {exc}",
+            expected_revision=expected_revision,
+            collected_at=_now_iso(),
+        )
+
+
+def collect_runtime_evidence(
+    repo_root: Path,
+    provider_names: list[str],
+    *,
+    expected_revision: str,
+    coverage_provider: CoverageEvidenceProvider | None = None,
+    profile_provider: RuntimeProfileEvidenceProvider | None = None,
+) -> tuple[
+    list[CoverageFileEvidence],
+    list[RuntimeProfileEvidence],
+    list[RuntimeProviderReceipt],
+]:
+    """Run every provider named in *provider_names* against *repo_root*.
+
+    Returns ``([], [], [])`` immediately when *provider_names* is empty --
+    the default path adds no cost. *expected_revision* is the current index
+    build's resolved git revision; each provider validates its own
+    evidence's declared revision against it and reports ``STALE`` rather
+    than applying mismatched evidence. *coverage_provider*/*profile_provider*
+    let a caller inject an already-configured provider (for example one
+    pointed at a non-default evidence directory); the corresponding stock
+    provider is used when omitted.
+
+    A provider must never raise for ordinary unavailability, but this is an
+    external-tool boundary (a built-in provider's own bug, or a caller-
+    injected custom provider), so every ``collect()`` call is defended here:
+    an unexpected exception degrades that one provider to an explicit
+    ``UNAVAILABLE`` receipt rather than aborting the entire index build.
+    """
+    if not provider_names:
+        return [], [], []
+    unknown = set(provider_names) - KNOWN_RUNTIME_EVIDENCE_PROVIDERS
+    if unknown:
+        raise ValueError(f"unknown runtime evidence providers: {sorted(unknown)}")
+
+    coverage_evidence: list[CoverageFileEvidence] = []
+    profile_evidence: list[RuntimeProfileEvidence] = []
+    receipts: list[RuntimeProviderReceipt] = []
+
+    if "coverage" in provider_names:
+        resolved_coverage = coverage_provider or CoverageXmlProvider()
+        coverage_evidence, coverage_receipt = _collect_coverage(
+            resolved_coverage, repo_root, expected_revision
+        )
+        receipts.append(coverage_receipt)
+    if "runtime_profile" in provider_names:
+        resolved_profile = profile_provider or RuntimeProfileProvider()
+        profile_evidence, profile_receipt = _collect_profile(
+            resolved_profile, repo_root, expected_revision
+        )
+        receipts.append(profile_receipt)
+
+    return coverage_evidence, profile_evidence, receipts

--- a/src/archex/integrations/runtime/coverage_provider.py
+++ b/src/archex/integrations/runtime/coverage_provider.py
@@ -1,0 +1,189 @@
+"""Coverage evidence provider: reads a Cobertura-format ``coverage.xml`` report.
+
+Reads line-coverage evidence from a previously generated coverage report --
+the same Cobertura XML shape ``coverage xml`` / ``pytest --cov-report=xml``
+already produces -- plus a manifest recording the git revision the report
+was collected against. Coverage collection itself never runs automatically:
+an operator (or a CI job) runs the test suite with coverage enabled and
+writes the evidence directory; this provider only reads it.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import subprocess
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from archex.integrations.runtime.models import (
+    CoverageFileEvidence,
+    CoverageLineRecord,
+    ProviderAvailability,
+    RuntimeEvidenceProviderName,
+    RuntimeProviderReceipt,
+)
+
+#: Evidence directory layout, relative to the repository root: a manifest
+#: recording provenance plus the Cobertura report itself. Mirrors the
+#: existing ``.archex/`` local-workspace-state convention already used for
+#: benchmark baselines.
+_MANIFEST_FILENAME = "manifest.json"
+_REPORT_FILENAME = "coverage.xml"
+_DEFAULT_EVIDENCE_DIRNAME = ".archex/runtime-evidence/coverage"
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(tz=_dt.UTC).isoformat()
+
+
+class CoverageXmlProvider:
+    """Reads pre-collected Cobertura ``coverage.xml`` line-coverage evidence."""
+
+    def __init__(self, evidence_dir: Path | str | None = None) -> None:
+        self._evidence_dir = Path(evidence_dir) if evidence_dir is not None else None
+
+    @property
+    def name(self) -> RuntimeEvidenceProviderName:
+        return RuntimeEvidenceProviderName.COVERAGE
+
+    def _resolve_evidence_dir(self, repo_root: Path) -> Path:
+        if self._evidence_dir is not None:
+            return self._evidence_dir
+        return repo_root / _DEFAULT_EVIDENCE_DIRNAME
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> RuntimeProviderReceipt:
+        evidence_dir = self._resolve_evidence_dir(repo_root)
+        manifest_path = evidence_dir / _MANIFEST_FILENAME
+        report_path = evidence_dir / _REPORT_FILENAME
+        if not manifest_path.is_file() or not report_path.is_file():
+            return RuntimeProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason=f"no coverage evidence found at {evidence_dir}",
+                expected_revision=expected_revision,
+                collected_at=_now_iso(),
+            )
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            return RuntimeProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason=f"could not read coverage manifest at {manifest_path}: {exc}",
+                expected_revision=expected_revision,
+                collected_at=_now_iso(),
+            )
+        observed_revision = str(manifest.get("revision") or "") or None
+        if not observed_revision:
+            return RuntimeProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason=f"coverage manifest at {manifest_path} has no revision",
+                expected_revision=expected_revision,
+                collected_at=_now_iso(),
+            )
+        if observed_revision != expected_revision:
+            return RuntimeProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.STALE,
+                reason=(
+                    f"coverage evidence was collected at revision {observed_revision[:12]}, "
+                    f"current revision is {expected_revision[:12]}"
+                ),
+                expected_revision=expected_revision,
+                observed_revision=observed_revision,
+                collected_at=_now_iso(),
+            )
+        tool_version_raw = manifest.get("tool_version")
+        return RuntimeProviderReceipt(
+            provider=self.name,
+            availability=ProviderAvailability.AVAILABLE,
+            tool_name=str(manifest.get("tool") or "coverage.py"),
+            tool_version=str(tool_version_raw) if tool_version_raw else None,
+            expected_revision=expected_revision,
+            observed_revision=observed_revision,
+            collected_at=_now_iso(),
+        )
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[CoverageFileEvidence], RuntimeProviderReceipt]:
+        probe_receipt = self.probe(repo_root, expected_revision=expected_revision)
+        if probe_receipt.availability != ProviderAvailability.AVAILABLE:
+            return [], probe_receipt
+
+        evidence_dir = self._resolve_evidence_dir(repo_root)
+        report_path = evidence_dir / _REPORT_FILENAME
+        try:
+            # noqa comment kept short: local, operator-collected evidence, never untrusted network XML.
+            tree = ET.parse(report_path)  # noqa: S314
+        except ET.ParseError as exc:
+            return [], RuntimeProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.STALE,
+                reason=f"could not parse coverage report at {report_path}: {exc}",
+                expected_revision=expected_revision,
+                observed_revision=probe_receipt.observed_revision,
+                collected_at=_now_iso(),
+            )
+
+        repo_root_resolved = repo_root.resolve()
+        records: list[CoverageFileEvidence] = []
+        for class_elem in tree.getroot().iter("class"):
+            filename = class_elem.get("filename")
+            if not filename:
+                continue
+            normalized = filename.replace("\\", "/").strip().lstrip("/")
+            resolved = (repo_root / normalized).resolve()
+            try:
+                resolved.relative_to(repo_root_resolved)
+            except ValueError:
+                continue  # never attach evidence for a path outside the repository root
+            lines: list[CoverageLineRecord] = []
+            lines_elem = class_elem.find("lines")
+            if lines_elem is not None:
+                for line_elem in lines_elem.findall("line"):
+                    number = line_elem.get("number")
+                    hits = line_elem.get("hits")
+                    if number is None or hits is None:
+                        continue
+                    lines.append(CoverageLineRecord(line=int(number), hits=int(hits)))
+            line_rate_raw = class_elem.get("line-rate")
+            line_rate = (
+                min(1.0, max(0.0, float(line_rate_raw))) if line_rate_raw is not None else 0.0
+            )
+            records.append(
+                CoverageFileEvidence(
+                    file_path=normalized,
+                    lines=lines,
+                    line_rate=line_rate,
+                    revision=expected_revision,
+                )
+            )
+
+        receipt = RuntimeProviderReceipt(
+            provider=self.name,
+            availability=ProviderAvailability.AVAILABLE,
+            tool_name=probe_receipt.tool_name,
+            tool_version=probe_receipt.tool_version,
+            expected_revision=expected_revision,
+            observed_revision=probe_receipt.observed_revision,
+            records_collected=len(records),
+            collected_at=_now_iso(),
+        )
+        return records, receipt
+
+
+def current_repo_revision(repo_root: Path) -> str | None:
+    """Resolve the current git HEAD of *repo_root*, or ``None`` if it cannot be resolved."""
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()

--- a/src/archex/integrations/runtime/models.py
+++ b/src/archex/integrations/runtime/models.py
@@ -1,0 +1,167 @@
+"""Runtime and coverage evidence models (M7) — pure Pydantic, zero external dependencies.
+
+These types describe conditional, provider-sourced runtime evidence (line
+coverage collected by ``coverage.py`` and folded-stack sampling profiles)
+that is kept structurally distinct from Tree-sitter syntax evidence and from
+M6's compiler-grade semantic evidence: it is never added to
+``DependencyGraph`` as an edge. Every record is revision-bound -- it carries
+the exact git revision it was collected against -- so a consumer can always
+tell whether the evidence still applies to the checkout it is being read
+against. Every provider run yields a receipt describing whether it was
+available, partially available, unavailable, or stale (collected against a
+different revision than the one currently being analyzed), with a
+human-readable reason; providers never silently apply stale or mismatched
+evidence instead.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, model_validator
+
+
+class RuntimeEvidenceProviderName(StrEnum):
+    """Identifies which conditional runtime/coverage evidence provider produced a record."""
+
+    COVERAGE = "coverage"
+    RUNTIME_PROFILE = "runtime_profile"
+
+
+class ProviderAvailability(StrEnum):
+    """Explicit availability state for a runtime/coverage evidence provider run.
+
+    Mirrors ``archex.integrations.semantic.models.ProviderAvailability`` (M6)
+    in shape but is kept independent: M7's runtime/coverage channel and M6's
+    semantic channel are separately disableable and separately
+    rollback-able, so their availability vocabularies must not be coupled by
+    a shared import. ``UNAVAILABLE``, ``PARTIAL``, and ``STALE`` are
+    first-class outcomes, not error paths papered over with an empty
+    result -- an unusable or revision-mismatched provider must produce one
+    of these states with a reason rather than silently contributing zero
+    records or applying evidence collected against a different revision.
+    """
+
+    AVAILABLE = "available"
+    PARTIAL = "partial"
+    UNAVAILABLE = "unavailable"
+    STALE = "stale"
+    UNKNOWN = "unknown"
+
+
+class CoverageLineRecord(BaseModel):
+    """One executed-line observation for a single source line."""
+
+    line: int
+    hits: int
+
+    @model_validator(mode="after")
+    def _validate_line_record(self) -> CoverageLineRecord:
+        if self.line < 1:
+            raise ValueError("line must be >= 1")
+        if self.hits < 0:
+            raise ValueError("hits must be non-negative")
+        return self
+
+
+class CoverageFileEvidence(BaseModel):
+    """Revision-bound line-coverage evidence for one source file.
+
+    Read from a previously generated Cobertura-format coverage report (the
+    same shape ``coverage xml`` / ``pytest --cov-report=xml`` already
+    produces). ``revision`` is the git commit the report was collected
+    against, always equal to the caller's ``expected_revision`` by the time
+    a record reaches this model -- a provider that cannot confirm the
+    revision matches must return an explicit ``STALE`` receipt with no
+    records instead of constructing one.
+    """
+
+    file_path: str
+    lines: list[CoverageLineRecord] = []
+    line_rate: float
+    revision: str
+
+    @model_validator(mode="after")
+    def _validate_coverage_evidence(self) -> CoverageFileEvidence:
+        if not self.file_path.strip():
+            raise ValueError("file_path must not be empty")
+        if not 0.0 <= self.line_rate <= 1.0:
+            raise ValueError("line_rate must be between 0.0 and 1.0")
+        if not self.revision.strip():
+            raise ValueError("revision must not be empty")
+        return self
+
+
+class RuntimeStackSample(BaseModel):
+    """One folded call-stack sample.
+
+    ``frames`` is root-first: each entry is ``<repo-relative file
+    path>:<qualified symbol name>``, the same addressable shape used
+    throughout archex's own evidence/receipt surfaces, so a sample can
+    always be attributed to an indexed file and symbol without guessing at
+    an external profiler's own naming convention.
+    """
+
+    frames: tuple[str, ...]
+    sample_count: int
+
+    @model_validator(mode="after")
+    def _validate_stack_sample(self) -> RuntimeStackSample:
+        if not self.frames:
+            raise ValueError("frames must not be empty")
+        for frame in self.frames:
+            if ":" not in frame:
+                raise ValueError(f"frame {frame!r} must be '<file_path>:<qualified_name>'")
+        if self.sample_count < 1:
+            raise ValueError("sample_count must be >= 1")
+        return self
+
+
+class RuntimeProfileEvidence(BaseModel):
+    """Revision-bound folded-stack runtime evidence for one collection run.
+
+    ``revision`` is the git commit the profile was collected against, always
+    equal to the caller's ``expected_revision`` by the time a record reaches
+    this model -- mirrors ``CoverageFileEvidence.revision``.
+    """
+
+    samples: list[RuntimeStackSample] = []
+    total_samples: int
+    revision: str
+
+    @model_validator(mode="after")
+    def _validate_profile_evidence(self) -> RuntimeProfileEvidence:
+        if self.total_samples < 0:
+            raise ValueError("total_samples must be non-negative")
+        if not self.revision.strip():
+            raise ValueError("revision must not be empty")
+        return self
+
+
+class RuntimeProviderReceipt(BaseModel):
+    """Availability, revision-validity, and completeness receipt for one provider run.
+
+    Always produced, whether or not the provider was usable. ``reason`` is
+    required whenever ``availability`` is not ``AVAILABLE`` so an unusable or
+    stale provider is always explained rather than silently absent.
+    ``expected_revision``/``observed_revision`` record the exact revision
+    comparison a ``STALE`` outcome was based on.
+    """
+
+    provider: RuntimeEvidenceProviderName
+    availability: ProviderAvailability
+    reason: str = ""
+    tool_name: str | None = None
+    tool_version: str | None = None
+    expected_revision: str = ""
+    observed_revision: str | None = None
+    records_collected: int = 0
+    collected_at: str = ""
+
+    @model_validator(mode="after")
+    def _validate_receipt(self) -> RuntimeProviderReceipt:
+        if self.availability != ProviderAvailability.AVAILABLE and not self.reason.strip():
+            raise ValueError(f"reason is required when availability is {self.availability!r}")
+        if self.records_collected < 0:
+            raise ValueError("records_collected must be non-negative")
+        return self

--- a/src/archex/integrations/runtime/profile_provider.py
+++ b/src/archex/integrations/runtime/profile_provider.py
@@ -1,0 +1,195 @@
+"""Runtime-profile evidence provider: reads a folded-stack sample file.
+
+Reads revision-bound "folded stack" runtime samples -- the widely used
+flamegraph input format (``frame;frame;...;frame count`` per line, root
+frame first) -- from a previously collected profiling run plus a manifest
+recording the git revision it was collected against. Profiling itself never
+runs automatically: an operator runs a profiler (for example
+``python -m cProfile``, folded into this format by a companion script) and
+writes the evidence directory; this provider only reads it.
+
+Each frame must be ``<repo-relative file path>:<qualified symbol name>`` so
+a frame can always be attributed to an indexed file/symbol without guessing
+at an external tool's own naming convention. A malformed frame drops the
+whole sample rather than being partially applied.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from pathlib import Path
+
+from archex.integrations.runtime.models import (
+    ProviderAvailability,
+    RuntimeEvidenceProviderName,
+    RuntimeProfileEvidence,
+    RuntimeProviderReceipt,
+    RuntimeStackSample,
+)
+
+_MANIFEST_FILENAME = "manifest.json"
+_REPORT_FILENAME = "profile.folded"
+_DEFAULT_EVIDENCE_DIRNAME = ".archex/runtime-evidence/profile"
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(tz=_dt.UTC).isoformat()
+
+
+def _normalize_frame(frame: str, repo_root_resolved: Path, repo_root: Path) -> str | None:
+    file_part, sep, symbol = frame.partition(":")
+    if not sep or not file_part.strip() or not symbol.strip():
+        return None
+    normalized = file_part.replace("\\", "/").strip().lstrip("/")
+    resolved = (repo_root / normalized).resolve()
+    try:
+        resolved.relative_to(repo_root_resolved)
+    except ValueError:
+        return None  # never attach evidence for a path outside the repository root
+    return f"{normalized}:{symbol.strip()}"
+
+
+def _parse_folded_line(line: str, repo_root: Path) -> RuntimeStackSample | None:
+    stripped = line.strip()
+    if not stripped:
+        return None
+    stack_part, _, count_part = stripped.rpartition(" ")
+    if not stack_part or not count_part.isdigit():
+        return None
+    sample_count = int(count_part)
+    if sample_count < 1:
+        return None
+    repo_root_resolved = repo_root.resolve()
+    frames: list[str] = []
+    for raw_frame in stack_part.split(";"):
+        normalized = _normalize_frame(raw_frame, repo_root_resolved, repo_root)
+        if normalized is None:
+            return None
+        frames.append(normalized)
+    if not frames:
+        return None
+    return RuntimeStackSample(frames=tuple(frames), sample_count=sample_count)
+
+
+class RuntimeProfileProvider:
+    """Reads pre-collected folded-stack runtime-profile evidence."""
+
+    def __init__(self, evidence_dir: Path | str | None = None) -> None:
+        self._evidence_dir = Path(evidence_dir) if evidence_dir is not None else None
+
+    @property
+    def name(self) -> RuntimeEvidenceProviderName:
+        return RuntimeEvidenceProviderName.RUNTIME_PROFILE
+
+    def _resolve_evidence_dir(self, repo_root: Path) -> Path:
+        if self._evidence_dir is not None:
+            return self._evidence_dir
+        return repo_root / _DEFAULT_EVIDENCE_DIRNAME
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> RuntimeProviderReceipt:
+        evidence_dir = self._resolve_evidence_dir(repo_root)
+        manifest_path = evidence_dir / _MANIFEST_FILENAME
+        report_path = evidence_dir / _REPORT_FILENAME
+        if not manifest_path.is_file() or not report_path.is_file():
+            return RuntimeProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason=f"no runtime-profile evidence found at {evidence_dir}",
+                expected_revision=expected_revision,
+                collected_at=_now_iso(),
+            )
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            return RuntimeProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason=f"could not read runtime-profile manifest at {manifest_path}: {exc}",
+                expected_revision=expected_revision,
+                collected_at=_now_iso(),
+            )
+        observed_revision = str(manifest.get("revision") or "") or None
+        if not observed_revision:
+            return RuntimeProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason=f"runtime-profile manifest at {manifest_path} has no revision",
+                expected_revision=expected_revision,
+                collected_at=_now_iso(),
+            )
+        if observed_revision != expected_revision:
+            return RuntimeProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.STALE,
+                reason=(
+                    f"runtime-profile evidence was collected at revision "
+                    f"{observed_revision[:12]}, current revision is {expected_revision[:12]}"
+                ),
+                expected_revision=expected_revision,
+                observed_revision=observed_revision,
+                collected_at=_now_iso(),
+            )
+        tool_version_raw = manifest.get("tool_version")
+        return RuntimeProviderReceipt(
+            provider=self.name,
+            availability=ProviderAvailability.AVAILABLE,
+            tool_name=str(manifest.get("tool") or "cProfile"),
+            tool_version=str(tool_version_raw) if tool_version_raw else None,
+            expected_revision=expected_revision,
+            observed_revision=observed_revision,
+            collected_at=_now_iso(),
+        )
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[RuntimeProfileEvidence], RuntimeProviderReceipt]:
+        probe_receipt = self.probe(repo_root, expected_revision=expected_revision)
+        if probe_receipt.availability != ProviderAvailability.AVAILABLE:
+            return [], probe_receipt
+
+        evidence_dir = self._resolve_evidence_dir(repo_root)
+        report_path = evidence_dir / _REPORT_FILENAME
+        try:
+            raw_lines = report_path.read_text().splitlines()
+        except OSError as exc:
+            return [], RuntimeProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.STALE,
+                reason=f"could not read runtime-profile report at {report_path}: {exc}",
+                expected_revision=expected_revision,
+                observed_revision=probe_receipt.observed_revision,
+                collected_at=_now_iso(),
+            )
+
+        samples: list[RuntimeStackSample] = []
+        dropped = 0
+        for raw_line in raw_lines:
+            sample = _parse_folded_line(raw_line, repo_root)
+            if sample is None:
+                if raw_line.strip():
+                    dropped += 1
+                continue
+            samples.append(sample)
+
+        total_samples = sum(sample.sample_count for sample in samples)
+        evidence = [
+            RuntimeProfileEvidence(
+                samples=samples,
+                total_samples=total_samples,
+                revision=expected_revision,
+            )
+        ]
+        reason = f"{dropped} malformed frame line(s) dropped" if dropped else ""
+        receipt = RuntimeProviderReceipt(
+            provider=self.name,
+            availability=ProviderAvailability.AVAILABLE,
+            reason=reason,
+            tool_name=probe_receipt.tool_name,
+            tool_version=probe_receipt.tool_version,
+            expected_revision=expected_revision,
+            observed_revision=probe_receipt.observed_revision,
+            records_collected=len(samples),
+            collected_at=_now_iso(),
+        )
+        return evidence, receipt

--- a/src/archex/integrations/runtime/provider.py
+++ b/src/archex/integrations/runtime/provider.py
@@ -1,0 +1,86 @@
+"""Runtime/coverage evidence provider contracts (M7).
+
+A provider turns previously collected, revision-stamped local evidence (a
+Cobertura coverage report, a folded-stack profiling run) into typed evidence
+records plus a ``RuntimeProviderReceipt`` describing whether the run actually
+produced usable evidence. Providers must never raise for ordinary
+unavailability (missing evidence directory, missing manifest, mismatched
+revision) -- that is an expected outcome represented by an
+``UNAVAILABLE``/``PARTIAL``/``STALE`` receipt, never a fallback record and
+never an exception that would abort indexing. Providers never collect data by
+running a profiler or a coverage-instrumented test suite themselves; they
+only read evidence an operator collected out of band.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from archex.integrations.runtime.models import (
+        CoverageFileEvidence,
+        RuntimeProfileEvidence,
+        RuntimeProviderReceipt,
+    )
+
+
+class CoverageEvidenceProvider(Protocol):
+    """A conditional line-coverage evidence source (a Cobertura coverage report)."""
+
+    @property
+    def name(self) -> str:
+        """The provider identity recorded on every receipt it produces."""
+        ...
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> RuntimeProviderReceipt:
+        """Cheaply check availability and revision validity without collecting evidence.
+
+        Must not raise for ordinary unavailability; returns a receipt whose
+        ``availability`` reflects what was found (missing evidence, an
+        unreadable manifest, a revision mismatch, or ``AVAILABLE`` when a
+        full collect is expected to produce evidence).
+        """
+        ...
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[CoverageFileEvidence], RuntimeProviderReceipt]:
+        """Collect coverage evidence bound to *expected_revision*.
+
+        Returns ``([], receipt)`` with an explanatory non-``AVAILABLE``
+        receipt when the provider cannot run or the collected evidence was
+        collected against a different revision, rather than raising or
+        applying stale evidence.
+        """
+        ...
+
+
+class RuntimeProfileEvidenceProvider(Protocol):
+    """A conditional folded-stack runtime-profile evidence source."""
+
+    @property
+    def name(self) -> str:
+        """The provider identity recorded on every receipt it produces."""
+        ...
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> RuntimeProviderReceipt:
+        """Cheaply check availability and revision validity without collecting evidence.
+
+        Must not raise for ordinary unavailability; see
+        ``CoverageEvidenceProvider.probe``.
+        """
+        ...
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[RuntimeProfileEvidence], RuntimeProviderReceipt]:
+        """Collect runtime-profile evidence bound to *expected_revision*.
+
+        Returns ``([], receipt)`` with an explanatory non-``AVAILABLE``
+        receipt when the provider cannot run or the collected evidence was
+        collected against a different revision, rather than raising or
+        applying stale evidence.
+        """
+        ...

--- a/tests/index/test_runtime_evidence.py
+++ b/tests/index/test_runtime_evidence.py
@@ -1,0 +1,149 @@
+"""Tests for the runtime/coverage evidence ingestion dispatcher (M7)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from archex.index.runtime_evidence import collect_runtime_evidence
+from archex.integrations.runtime.models import (
+    CoverageFileEvidence,
+    ProviderAvailability,
+    RuntimeEvidenceProviderName,
+    RuntimeProfileEvidence,
+    RuntimeProviderReceipt,
+)
+
+_REVISION = "a" * 40
+
+
+class _StubCoverageProvider:
+    def __init__(self, *, raise_error: bool = False) -> None:
+        self._raise_error = raise_error
+
+    @property
+    def name(self) -> str:
+        return "coverage"
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> RuntimeProviderReceipt:
+        del repo_root, expected_revision
+        return RuntimeProviderReceipt(
+            provider=RuntimeEvidenceProviderName.COVERAGE,
+            availability=ProviderAvailability.AVAILABLE,
+        )
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[CoverageFileEvidence], RuntimeProviderReceipt]:
+        del repo_root
+        if self._raise_error:
+            raise RuntimeError("boom")
+        return (
+            [CoverageFileEvidence(file_path="a.py", line_rate=1.0, revision=expected_revision)],
+            RuntimeProviderReceipt(
+                provider=RuntimeEvidenceProviderName.COVERAGE,
+                availability=ProviderAvailability.AVAILABLE,
+                records_collected=1,
+            ),
+        )
+
+
+class _StubProfileProvider:
+    @property
+    def name(self) -> str:
+        return "runtime_profile"
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> RuntimeProviderReceipt:
+        del repo_root, expected_revision
+        return RuntimeProviderReceipt(
+            provider=RuntimeEvidenceProviderName.RUNTIME_PROFILE,
+            availability=ProviderAvailability.AVAILABLE,
+        )
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[RuntimeProfileEvidence], RuntimeProviderReceipt]:
+        del repo_root
+        return (
+            [RuntimeProfileEvidence(total_samples=0, revision=expected_revision)],
+            RuntimeProviderReceipt(
+                provider=RuntimeEvidenceProviderName.RUNTIME_PROFILE,
+                availability=ProviderAvailability.AVAILABLE,
+                records_collected=1,
+            ),
+        )
+
+
+class TestCollectRuntimeEvidence:
+    def test_returns_empty_when_no_providers_requested(self, tmp_path: Path) -> None:
+        coverage, profile, receipts = collect_runtime_evidence(
+            tmp_path, [], expected_revision=_REVISION
+        )
+        assert coverage == []
+        assert profile == []
+        assert receipts == []
+
+    def test_rejects_unknown_provider_name(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="unknown runtime evidence providers"):
+            collect_runtime_evidence(tmp_path, ["bogus"], expected_revision=_REVISION)
+
+    def test_uses_injected_coverage_provider(self, tmp_path: Path) -> None:
+        coverage, profile, receipts = collect_runtime_evidence(
+            tmp_path,
+            ["coverage"],
+            expected_revision=_REVISION,
+            coverage_provider=_StubCoverageProvider(),
+        )
+        assert len(coverage) == 1
+        assert profile == []
+        assert len(receipts) == 1
+        assert receipts[0].provider == RuntimeEvidenceProviderName.COVERAGE
+
+    def test_uses_injected_profile_provider(self, tmp_path: Path) -> None:
+        coverage, profile, receipts = collect_runtime_evidence(
+            tmp_path,
+            ["runtime_profile"],
+            expected_revision=_REVISION,
+            profile_provider=_StubProfileProvider(),
+        )
+        assert coverage == []
+        assert len(profile) == 1
+        assert len(receipts) == 1
+        assert receipts[0].provider == RuntimeEvidenceProviderName.RUNTIME_PROFILE
+
+    def test_runs_both_providers_when_both_requested(self, tmp_path: Path) -> None:
+        coverage, profile, receipts = collect_runtime_evidence(
+            tmp_path,
+            ["coverage", "runtime_profile"],
+            expected_revision=_REVISION,
+            coverage_provider=_StubCoverageProvider(),
+            profile_provider=_StubProfileProvider(),
+        )
+        assert len(coverage) == 1
+        assert len(profile) == 1
+        assert len(receipts) == 2
+
+    def test_provider_exception_degrades_to_unavailable_receipt(self, tmp_path: Path) -> None:
+        coverage, _profile, receipts = collect_runtime_evidence(
+            tmp_path,
+            ["coverage"],
+            expected_revision=_REVISION,
+            coverage_provider=_StubCoverageProvider(raise_error=True),
+        )
+        assert coverage == []
+        assert len(receipts) == 1
+        assert receipts[0].availability == ProviderAvailability.UNAVAILABLE
+        assert "boom" in receipts[0].reason
+
+    def test_default_providers_report_unavailable_without_evidence(self, tmp_path: Path) -> None:
+        coverage, profile, receipts = collect_runtime_evidence(
+            tmp_path, ["coverage", "runtime_profile"], expected_revision=_REVISION
+        )
+        assert coverage == []
+        assert profile == []
+        assert {r.provider for r in receipts} == {
+            RuntimeEvidenceProviderName.COVERAGE,
+            RuntimeEvidenceProviderName.RUNTIME_PROFILE,
+        }
+        assert all(r.availability == ProviderAvailability.UNAVAILABLE for r in receipts)

--- a/tests/integrations/runtime/__init__.py
+++ b/tests/integrations/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime and coverage evidence tests (M7)."""

--- a/tests/integrations/runtime/test_coverage_provider.py
+++ b/tests/integrations/runtime/test_coverage_provider.py
@@ -1,0 +1,164 @@
+"""Tests for the coverage evidence provider."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from archex.integrations.runtime.coverage_provider import (
+    CoverageXmlProvider,
+    current_repo_revision,
+)
+from archex.integrations.runtime.models import ProviderAvailability
+
+_REVISION = "a" * 40
+_OTHER_REVISION = "b" * 40
+
+_COBERTURA_XML = """<?xml version="1.0" ?>
+<coverage line-rate="0.75">
+  <packages>
+    <package name="pkg">
+      <classes>
+        <class filename="src/pkg/module.py" line-rate="0.75">
+          <lines>
+            <line number="1" hits="3"/>
+            <line number="2" hits="0"/>
+          </lines>
+        </class>
+        <class filename="../outside/escape.py" line-rate="1.0">
+          <lines><line number="1" hits="1"/></lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+"""
+
+
+def _write_evidence(
+    tmp_path: Path,
+    *,
+    revision: str = _REVISION,
+    tool: str = "coverage.py",
+    tool_version: str | None = "7.6.0",
+) -> Path:
+    evidence_dir = tmp_path / ".archex" / "runtime-evidence" / "coverage"
+    evidence_dir.mkdir(parents=True)
+    manifest = {"revision": revision, "tool": tool}
+    if tool_version is not None:
+        manifest["tool_version"] = tool_version
+    (evidence_dir / "manifest.json").write_text(json.dumps(manifest))
+    (evidence_dir / "coverage.xml").write_text(_COBERTURA_XML)
+    return tmp_path
+
+
+class TestCoverageXmlProviderProbe:
+    def test_unavailable_when_no_evidence(self, tmp_path: Path) -> None:
+        provider = CoverageXmlProvider()
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.UNAVAILABLE
+        assert "no coverage evidence" in receipt.reason
+
+    def test_unavailable_when_manifest_has_no_revision(self, tmp_path: Path) -> None:
+        evidence_dir = tmp_path / ".archex" / "runtime-evidence" / "coverage"
+        evidence_dir.mkdir(parents=True)
+        (evidence_dir / "manifest.json").write_text(json.dumps({"tool": "coverage.py"}))
+        (evidence_dir / "coverage.xml").write_text(_COBERTURA_XML)
+        provider = CoverageXmlProvider()
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.UNAVAILABLE
+        assert "no revision" in receipt.reason
+
+    def test_unavailable_when_manifest_is_malformed_json(self, tmp_path: Path) -> None:
+        evidence_dir = tmp_path / ".archex" / "runtime-evidence" / "coverage"
+        evidence_dir.mkdir(parents=True)
+        (evidence_dir / "manifest.json").write_text("{not json")
+        (evidence_dir / "coverage.xml").write_text(_COBERTURA_XML)
+        provider = CoverageXmlProvider()
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.UNAVAILABLE
+        assert "could not read coverage manifest" in receipt.reason
+
+    def test_stale_on_revision_mismatch(self, tmp_path: Path) -> None:
+        _write_evidence(tmp_path, revision=_OTHER_REVISION)
+        provider = CoverageXmlProvider()
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.STALE
+        assert receipt.observed_revision == _OTHER_REVISION
+        assert receipt.expected_revision == _REVISION
+
+    def test_available_on_revision_match(self, tmp_path: Path) -> None:
+        _write_evidence(tmp_path)
+        provider = CoverageXmlProvider()
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.AVAILABLE
+        assert receipt.tool_name == "coverage.py"
+        assert receipt.tool_version == "7.6.0"
+
+    def test_uses_injected_evidence_dir(self, tmp_path: Path) -> None:
+        custom_dir = tmp_path / "custom-evidence"
+        custom_dir.mkdir()
+        manifest = {"revision": _REVISION, "tool": "coverage.py"}
+        (custom_dir / "manifest.json").write_text(json.dumps(manifest))
+        (custom_dir / "coverage.xml").write_text(_COBERTURA_XML)
+        provider = CoverageXmlProvider(evidence_dir=custom_dir)
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.AVAILABLE
+
+
+class TestCoverageXmlProviderCollect:
+    def test_collect_returns_unavailable_receipt_and_empty_when_missing(
+        self, tmp_path: Path
+    ) -> None:
+        provider = CoverageXmlProvider()
+        evidence, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert evidence == []
+        assert receipt.availability == ProviderAvailability.UNAVAILABLE
+
+    def test_collect_returns_stale_receipt_and_empty_on_mismatch(self, tmp_path: Path) -> None:
+        _write_evidence(tmp_path, revision=_OTHER_REVISION)
+        provider = CoverageXmlProvider()
+        evidence, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert evidence == []
+        assert receipt.availability == ProviderAvailability.STALE
+
+    def test_collect_parses_lines_and_line_rate(self, tmp_path: Path) -> None:
+        _write_evidence(tmp_path)
+        provider = CoverageXmlProvider()
+        evidence, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.AVAILABLE
+        assert receipt.records_collected == 1
+        assert len(evidence) == 1
+        record = evidence[0]
+        assert record.file_path == "src/pkg/module.py"
+        assert record.revision == _REVISION
+        assert record.line_rate == 0.75
+        assert {(line.line, line.hits) for line in record.lines} == {(1, 3), (2, 0)}
+
+    def test_collect_drops_files_outside_repo_root(self, tmp_path: Path) -> None:
+        _write_evidence(tmp_path)
+        provider = CoverageXmlProvider()
+        evidence, _receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert all("outside" not in record.file_path for record in evidence)
+
+    def test_collect_reports_stale_on_unparseable_xml(self, tmp_path: Path) -> None:
+        evidence_dir = tmp_path / ".archex" / "runtime-evidence" / "coverage"
+        evidence_dir.mkdir(parents=True)
+        manifest = {"revision": _REVISION, "tool": "coverage.py"}
+        (evidence_dir / "manifest.json").write_text(json.dumps(manifest))
+        (evidence_dir / "coverage.xml").write_text("<not-xml")
+        provider = CoverageXmlProvider()
+        evidence, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert evidence == []
+        assert receipt.availability == ProviderAvailability.STALE
+        assert "could not parse" in receipt.reason
+
+
+class TestCurrentRepoRevision:
+    def test_returns_none_for_non_git_dir(self, tmp_path: Path) -> None:
+        assert current_repo_revision(tmp_path) is None
+
+    def test_resolves_head_for_this_repo(self) -> None:
+        revision = current_repo_revision(Path(__file__).resolve().parents[3])
+        assert revision is not None
+        assert len(revision) == 40

--- a/tests/integrations/runtime/test_models.py
+++ b/tests/integrations/runtime/test_models.py
@@ -1,0 +1,117 @@
+"""Tests for runtime/coverage evidence models (M7)."""
+
+from __future__ import annotations
+
+import pytest
+
+from archex.integrations.runtime.models import (
+    CoverageFileEvidence,
+    CoverageLineRecord,
+    ProviderAvailability,
+    RuntimeEvidenceProviderName,
+    RuntimeProfileEvidence,
+    RuntimeProviderReceipt,
+    RuntimeStackSample,
+)
+
+
+class TestCoverageLineRecord:
+    def test_rejects_line_below_one(self) -> None:
+        with pytest.raises(ValueError, match="line"):
+            CoverageLineRecord(line=0, hits=1)
+
+    def test_rejects_negative_hits(self) -> None:
+        with pytest.raises(ValueError, match="hits"):
+            CoverageLineRecord(line=1, hits=-1)
+
+    def test_accepts_zero_hits(self) -> None:
+        record = CoverageLineRecord(line=1, hits=0)
+        assert record.hits == 0
+
+
+class TestCoverageFileEvidence:
+    def test_rejects_empty_file_path(self) -> None:
+        with pytest.raises(ValueError, match="file_path"):
+            CoverageFileEvidence(file_path=" ", line_rate=0.5, revision="abc123")
+
+    def test_rejects_out_of_range_line_rate(self) -> None:
+        with pytest.raises(ValueError, match="line_rate"):
+            CoverageFileEvidence(file_path="a.py", line_rate=1.5, revision="abc123")
+
+    def test_rejects_empty_revision(self) -> None:
+        with pytest.raises(ValueError, match="revision"):
+            CoverageFileEvidence(file_path="a.py", line_rate=0.5, revision=" ")
+
+    def test_accepts_valid_evidence(self) -> None:
+        evidence = CoverageFileEvidence(
+            file_path="a.py",
+            lines=[CoverageLineRecord(line=1, hits=3)],
+            line_rate=1.0,
+            revision="abc123",
+        )
+        assert evidence.line_rate == 1.0
+        assert evidence.lines[0].hits == 3
+
+
+class TestRuntimeStackSample:
+    def test_rejects_empty_frames(self) -> None:
+        with pytest.raises(ValueError, match="frames"):
+            RuntimeStackSample(frames=(), sample_count=1)
+
+    def test_rejects_frame_without_colon(self) -> None:
+        with pytest.raises(ValueError, match="file_path.*qualified_name"):
+            RuntimeStackSample(frames=("no_colon_here",), sample_count=1)
+
+    def test_rejects_zero_sample_count(self) -> None:
+        with pytest.raises(ValueError, match="sample_count"):
+            RuntimeStackSample(frames=("a.py:func",), sample_count=0)
+
+    def test_accepts_valid_sample(self) -> None:
+        sample = RuntimeStackSample(frames=("a.py:outer", "b.py:inner"), sample_count=5)
+        assert sample.sample_count == 5
+        assert sample.frames == ("a.py:outer", "b.py:inner")
+
+
+class TestRuntimeProfileEvidence:
+    def test_rejects_negative_total_samples(self) -> None:
+        with pytest.raises(ValueError, match="total_samples"):
+            RuntimeProfileEvidence(total_samples=-1, revision="abc123")
+
+    def test_rejects_empty_revision(self) -> None:
+        with pytest.raises(ValueError, match="revision"):
+            RuntimeProfileEvidence(total_samples=0, revision=" ")
+
+    def test_accepts_empty_samples(self) -> None:
+        evidence = RuntimeProfileEvidence(total_samples=0, revision="abc123")
+        assert evidence.samples == []
+
+
+class TestRuntimeProviderReceipt:
+    def test_reason_required_when_unavailable(self) -> None:
+        with pytest.raises(ValueError, match="reason"):
+            RuntimeProviderReceipt(
+                provider=RuntimeEvidenceProviderName.COVERAGE,
+                availability=ProviderAvailability.UNAVAILABLE,
+            )
+
+    def test_reason_required_when_stale(self) -> None:
+        with pytest.raises(ValueError, match="reason"):
+            RuntimeProviderReceipt(
+                provider=RuntimeEvidenceProviderName.COVERAGE,
+                availability=ProviderAvailability.STALE,
+            )
+
+    def test_reason_optional_when_available(self) -> None:
+        receipt = RuntimeProviderReceipt(
+            provider=RuntimeEvidenceProviderName.COVERAGE,
+            availability=ProviderAvailability.AVAILABLE,
+        )
+        assert receipt.reason == ""
+
+    def test_rejects_negative_records_collected(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            RuntimeProviderReceipt(
+                provider=RuntimeEvidenceProviderName.RUNTIME_PROFILE,
+                availability=ProviderAvailability.AVAILABLE,
+                records_collected=-1,
+            )

--- a/tests/integrations/runtime/test_profile_provider.py
+++ b/tests/integrations/runtime/test_profile_provider.py
@@ -1,0 +1,101 @@
+"""Tests for the runtime-profile evidence provider."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from archex.integrations.runtime.models import ProviderAvailability
+from archex.integrations.runtime.profile_provider import RuntimeProfileProvider
+
+_REVISION = "a" * 40
+_OTHER_REVISION = "b" * 40
+
+_FOLDED_STACK = (
+    "src/a.py:outer;src/b.py:inner 3\n"
+    "src/a.py:outer 5\n"
+    "\n"
+    "not a valid frame line\n"
+    "src/a.py:outer;../outside.py:escape 1\n"
+)
+
+
+def _write_evidence(
+    tmp_path: Path,
+    *,
+    revision: str = _REVISION,
+    tool: str = "cProfile",
+    stack: str = _FOLDED_STACK,
+) -> Path:
+    evidence_dir = tmp_path / ".archex" / "runtime-evidence" / "profile"
+    evidence_dir.mkdir(parents=True)
+    manifest = {"revision": revision, "tool": tool, "tool_version": "3.12"}
+    (evidence_dir / "manifest.json").write_text(json.dumps(manifest))
+    (evidence_dir / "profile.folded").write_text(stack)
+    return tmp_path
+
+
+class TestRuntimeProfileProviderProbe:
+    def test_unavailable_when_no_evidence(self, tmp_path: Path) -> None:
+        provider = RuntimeProfileProvider()
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.UNAVAILABLE
+        assert "no runtime-profile evidence" in receipt.reason
+
+    def test_stale_on_revision_mismatch(self, tmp_path: Path) -> None:
+        _write_evidence(tmp_path, revision=_OTHER_REVISION)
+        provider = RuntimeProfileProvider()
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.STALE
+        assert receipt.observed_revision == _OTHER_REVISION
+
+    def test_available_on_revision_match(self, tmp_path: Path) -> None:
+        _write_evidence(tmp_path)
+        provider = RuntimeProfileProvider()
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.AVAILABLE
+        assert receipt.tool_name == "cProfile"
+        assert receipt.tool_version == "3.12"
+
+
+class TestRuntimeProfileProviderCollect:
+    def test_collect_returns_unavailable_and_empty_when_missing(self, tmp_path: Path) -> None:
+        provider = RuntimeProfileProvider()
+        evidence, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert evidence == []
+        assert receipt.availability == ProviderAvailability.UNAVAILABLE
+
+    def test_collect_returns_stale_and_empty_on_mismatch(self, tmp_path: Path) -> None:
+        _write_evidence(tmp_path, revision=_OTHER_REVISION)
+        provider = RuntimeProfileProvider()
+        evidence, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert evidence == []
+        assert receipt.availability == ProviderAvailability.STALE
+
+    def test_collect_parses_valid_samples_and_drops_malformed_lines(self, tmp_path: Path) -> None:
+        _write_evidence(tmp_path)
+        provider = RuntimeProfileProvider()
+        evidence, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.AVAILABLE
+        assert len(evidence) == 1
+        profile = evidence[0]
+        # 2 valid samples parsed; "not a valid frame line" and the
+        # outside-repo-path sample are dropped rather than guessed at.
+        assert len(profile.samples) == 2
+        assert profile.total_samples == 8
+        assert profile.revision == _REVISION
+        assert "2 malformed frame line(s) dropped" in receipt.reason
+        assert receipt.records_collected == 2
+
+    def test_collect_normalizes_frame_paths(self, tmp_path: Path) -> None:
+        _write_evidence(tmp_path, stack="src/a.py:outer;src/b.py:inner 1\n")
+        provider = RuntimeProfileProvider()
+        evidence, _receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert evidence[0].samples[0].frames == ("src/a.py:outer", "src/b.py:inner")
+
+    def test_collect_drops_sample_with_zero_count(self, tmp_path: Path) -> None:
+        _write_evidence(tmp_path, stack="src/a.py:outer 0\n")
+        provider = RuntimeProfileProvider()
+        evidence, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert evidence[0].samples == []
+        assert receipt.records_collected == 0


### PR DESCRIPTION
## Stack

Stack-Id: `m7-runtime-evidence-6ae0cd`
Base: `main`
Position: 1/3

1. `m7-1-runtime-coverage-contracts` -> this PR
2. `m7-2-artifact-and-receipt-integration` -> next
3. `m7-3-gated-performance-evaluation` -> next

Depends on: (none — root)

## Summary

M7 (Add Runtime and Coverage Evidence Conditionally), PR 1/3: pure contracts for revision-bound coverage and folded-stack runtime evidence, independent of `IndexConfig`/index-build wiring (that lands in PR-2).

- `archex.integrations.runtime.models`: `RuntimeEvidenceProviderName`, `ProviderAvailability`, `CoverageLineRecord`, `CoverageFileEvidence`, `RuntimeStackSample`, `RuntimeProfileEvidence`, `RuntimeProviderReceipt` — structurally independent of M6's `archex.integrations.semantic.models` (separately disableable/rollback-able channels).
- `archex.integrations.runtime.provider`: `CoverageEvidenceProvider`/`RuntimeProfileEvidenceProvider` protocols (`probe()`/`collect()`).
- `CoverageXmlProvider`: reads a previously generated Cobertura `coverage.xml` (the same shape `pytest --cov-report=xml` already produces) plus a `manifest.json` recording the collection revision, from `.archex/runtime-evidence/coverage/`. Never runs coverage itself.
- `RuntimeProfileProvider`: reads a previously collected folded-stack profile (`frame;frame;...;frame count`, frames shaped `<repo-relative path>:<qualified name>`) from `.archex/runtime-evidence/profile/`. Never runs a profiler itself.
- `archex.index.runtime_evidence.collect_runtime_evidence()`: dispatches the two providers by name against a caller-supplied expected revision; zero cost/imports when no provider is requested; an unexpected provider exception degrades to an explicit `UNAVAILABLE` receipt rather than aborting.

Every evidence record carries the revision it was collected against; a provider that cannot confirm the revision matches the caller's `expected_revision` reports `STALE` with no records rather than applying mismatched evidence.

## Verification

- `uv run ruff check src/archex/integrations/runtime/ src/archex/index/runtime_evidence.py tests/integrations/runtime/ tests/index/test_runtime_evidence.py`: clean.
- `uv run ruff format --check` on the same paths: clean.
- `uv run pyright` on the same paths: 0 errors.
- `uv run pytest tests/integrations/runtime/ tests/index/test_runtime_evidence.py -q`: 46 passed (the reported "Required test coverage of 85%" failure is expected for a partial-suite run — the full suite runs at PR-3/stack-merge time).
