### PR TITLE
feat(report): show runtime evidence sources

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -130,6 +130,7 @@ if TYPE_CHECKING:
 
     from archex.index.embeddings.base import Embedder
     from archex.index.rerank import CrossEncoderReranker
+    from archex.integrations.runtime.models import RuntimeProviderReceipt
     from archex.integrations.semantic.models import SemanticProviderReceipt
     from archex.models import ComparisonResult
     from archex.serve.runtime import QueryRuntime
@@ -163,7 +164,10 @@ def _index_config_metadata_matches(store: IndexStore, index_config: IndexConfig)
     ):
         return False
     stored_semantic_providers = store.get_metadata("semantic_evidence_providers") or ""
-    return stored_semantic_providers == ",".join(index_config.semantic_evidence_providers)
+    if stored_semantic_providers != ",".join(index_config.semantic_evidence_providers):
+        return False
+    stored_runtime_providers = store.get_metadata("runtime_evidence_providers") or ""
+    return stored_runtime_providers == ",".join(index_config.runtime_evidence_providers)
 
 
 def _set_index_config_metadata(store: IndexStore, index_config: IndexConfig) -> None:
@@ -173,6 +177,9 @@ def _set_index_config_metadata(store: IndexStore, index_config: IndexConfig) -> 
     store.set_metadata("quantize_bits", str(index_config.quantize_bits))
     store.set_metadata(
         "semantic_evidence_providers", ",".join(index_config.semantic_evidence_providers)
+    )
+    store.set_metadata(
+        "runtime_evidence_providers", ",".join(index_config.runtime_evidence_providers)
     )
 
 
@@ -259,6 +266,20 @@ def _full_index(
                 )
                 graph.add_semantic_edges(semantic_edges)
                 store.set_semantic_provider_receipts(semantic_receipts)
+            if effective_index_config.runtime_evidence_providers:
+                from archex.index.runtime_evidence import collect_runtime_evidence
+
+                runtime_revision = (
+                    cloned_head or cache.git_head(source.local_path) or source.commit or ""
+                )
+                coverage_evidence, profile_evidence, runtime_receipts = collect_runtime_evidence(
+                    repo_path,
+                    effective_index_config.runtime_evidence_providers,
+                    expected_revision=runtime_revision,
+                )
+                store.set_runtime_coverage_evidence(coverage_evidence)
+                store.set_runtime_profile_evidence(profile_evidence)
+                store.set_runtime_provider_receipts(runtime_receipts)
             edges = graph.file_edges()
             store.replace_file_states(compute_file_states(repo_path, files))
             store.insert_edges(edges)
@@ -1527,6 +1548,7 @@ def _refresh_receipt(
     freshness: ContextFreshness,
     metadata_timing: PipelineTiming | None,
     semantic_providers: list[SemanticProviderReceipt] | None = None,
+    runtime_providers: list[RuntimeProviderReceipt] | None = None,
 ) -> None:
     skipped = list(bundle.receipt.skipped_candidates) if bundle.receipt is not None else []
     if freshness != ContextFreshness.CLEAN:
@@ -1540,6 +1562,11 @@ def _refresh_receipt(
         if semantic_providers is not None
         else (bundle.receipt.semantic_providers if bundle.receipt is not None else [])
     )
+    resolved_runtime_providers = (
+        runtime_providers
+        if runtime_providers is not None
+        else (bundle.receipt.runtime_providers if bundle.receipt is not None else [])
+    )
     bundle.receipt = build_context_receipt(
         bundle,
         index_revision=index_revision,
@@ -1548,6 +1575,7 @@ def _refresh_receipt(
         omitted_edges=omitted_edges,
         skipped_candidates=skipped,
         semantic_providers=resolved_semantic_providers,
+        runtime_providers=resolved_runtime_providers,
     )
 
 
@@ -1566,6 +1594,7 @@ def _finalize_context_bundle(
     freshness: ContextFreshness,
     post_search_at: float | None = None,
     semantic_providers: list[SemanticProviderReceipt] | None = None,
+    runtime_providers: list[RuntimeProviderReceipt] | None = None,
 ) -> ContextBundle:
     _attach_vector_metadata(bundle, index_config)
     _attach_index_metadata(
@@ -1602,6 +1631,7 @@ def _finalize_context_bundle(
         freshness=freshness,
         metadata_timing=metadata_timing,
         semantic_providers=semantic_providers,
+        runtime_providers=runtime_providers,
     )
     return bundle
 
@@ -2150,6 +2180,7 @@ def query(
                     freshness=_freshness_for_query(refresh),
                     post_search_at=t_post_search,
                     semantic_providers=search_store.get_semantic_provider_receipts(),
+                    runtime_providers=search_store.get_runtime_provider_receipts(),
                 )
             finally:
                 store.close()
@@ -2270,6 +2301,21 @@ def query(
                 )
                 graph.add_semantic_edges(semantic_edges)
                 store.set_semantic_provider_receipts(semantic_receipts)
+            runtime_receipts: list[RuntimeProviderReceipt] = []
+            if index_config.runtime_evidence_providers:
+                from archex.index.runtime_evidence import collect_runtime_evidence
+
+                runtime_revision = (
+                    cloned_head or cache.git_head(source.local_path) or source.commit or ""
+                )
+                coverage_evidence, profile_evidence, runtime_receipts = collect_runtime_evidence(
+                    repo_path,
+                    index_config.runtime_evidence_providers,
+                    expected_revision=runtime_revision,
+                )
+                store.set_runtime_coverage_evidence(coverage_evidence)
+                store.set_runtime_profile_evidence(profile_evidence)
+                store.set_runtime_provider_receipts(runtime_receipts)
             edges = graph.file_edges()
             from archex.index.delta import compute_file_states
 
@@ -2409,6 +2455,7 @@ def query(
                     freshness=_freshness_for_query(refresh),
                     metadata_timing=metadata_timing,
                     semantic_providers=semantic_receipts,
+                    runtime_providers=runtime_receipts,
                 )
                 return pt
 
@@ -2558,6 +2605,7 @@ def query(
             freshness=_freshness_for_query(refresh),
             post_search_at=t_post_search_miss,
             semantic_providers=semantic_receipts,
+            runtime_providers=runtime_receipts,
         )
     finally:
         cleanup()

--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -9,6 +9,11 @@ import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+from archex.integrations.runtime.models import (
+    CoverageFileEvidence,
+    RuntimeProfileEvidence,
+    RuntimeProviderReceipt,
+)
 from archex.integrations.semantic.models import SemanticProviderReceipt
 from archex.models import (
     ChunkSurrogate,
@@ -25,6 +30,9 @@ if TYPE_CHECKING:
     from types import TracebackType
 
 _SEMANTIC_PROVIDER_RECEIPTS_KEY = "semantic_provider_receipts"
+_RUNTIME_PROVIDER_RECEIPTS_KEY = "runtime_provider_receipts"
+_RUNTIME_COVERAGE_EVIDENCE_KEY = "runtime_coverage_evidence"
+_RUNTIME_PROFILE_EVIDENCE_KEY = "runtime_profile_evidence"
 
 logger = logging.getLogger(__name__)
 
@@ -842,6 +850,62 @@ class IndexStore:
         if not raw:
             return []
         return [SemanticProviderReceipt.model_validate(item) for item in json.loads(raw)]
+
+    def set_runtime_provider_receipts(self, receipts: list[RuntimeProviderReceipt]) -> None:
+        """Persist the M7 conditional runtime/coverage-evidence provider receipts for this build."""
+        self.set_metadata(
+            _RUNTIME_PROVIDER_RECEIPTS_KEY,
+            json.dumps([r.model_dump(mode="json") for r in receipts], sort_keys=True),
+        )
+
+    def get_runtime_provider_receipts(self) -> list[RuntimeProviderReceipt]:
+        """Return the persisted M7 runtime/coverage-evidence provider receipts, if any.
+
+        Empty when no runtime/coverage provider was configured for this
+        build — a store built before M7 or with ``runtime_evidence_providers``
+        unset has no receipts, which is a fully expected, honest empty
+        result, not an error.
+        """
+        raw = self.get_metadata(_RUNTIME_PROVIDER_RECEIPTS_KEY)
+        if not raw:
+            return []
+        return [RuntimeProviderReceipt.model_validate(item) for item in json.loads(raw)]
+
+    def set_runtime_coverage_evidence(self, evidence: list[CoverageFileEvidence]) -> None:
+        """Persist the M7 revision-bound coverage evidence collected for this build."""
+        self.set_metadata(
+            _RUNTIME_COVERAGE_EVIDENCE_KEY,
+            json.dumps([e.model_dump(mode="json") for e in evidence], sort_keys=True),
+        )
+
+    def get_runtime_coverage_evidence(self) -> list[CoverageFileEvidence]:
+        """Return the persisted M7 coverage evidence, if any.
+
+        Empty when the coverage provider was not configured or produced no
+        available evidence for this build.
+        """
+        raw = self.get_metadata(_RUNTIME_COVERAGE_EVIDENCE_KEY)
+        if not raw:
+            return []
+        return [CoverageFileEvidence.model_validate(item) for item in json.loads(raw)]
+
+    def set_runtime_profile_evidence(self, evidence: list[RuntimeProfileEvidence]) -> None:
+        """Persist the M7 revision-bound folded-stack runtime evidence collected for this build."""
+        self.set_metadata(
+            _RUNTIME_PROFILE_EVIDENCE_KEY,
+            json.dumps([e.model_dump(mode="json") for e in evidence], sort_keys=True),
+        )
+
+    def get_runtime_profile_evidence(self) -> list[RuntimeProfileEvidence]:
+        """Return the persisted M7 folded-stack runtime evidence, if any.
+
+        Empty when the runtime-profile provider was not configured or
+        produced no available evidence for this build.
+        """
+        raw = self.get_metadata(_RUNTIME_PROFILE_EVIDENCE_KEY)
+        if not raw:
+            return []
+        return [RuntimeProfileEvidence.model_validate(item) for item in json.loads(raw)]
 
     def needs_reindex(self) -> bool:
         """Return True if the store contains chunks without symbol_ids (pre-stable-ID data)."""

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, model_validator
 
 from archex.index.quantize import SUPPORTED_BITS
 from archex.integrations.lsap_models import LSAPEnrichment  # noqa: TCH001
+from archex.integrations.runtime.models import RuntimeProviderReceipt  # noqa: TCH001
 from archex.integrations.semantic.models import SemanticProviderReceipt  # noqa: TCH001
 
 # ---------------------------------------------------------------------------
@@ -280,6 +281,13 @@ class IndexConfig(BaseModel):
     #: graph change, matching the plan's "no automatic provider promotion"
     #: requirement. Accepted values: "scip", "lsp".
     semantic_evidence_providers: list[str] = []
+    #: Conditional coverage/folded-stack runtime-evidence providers to run
+    #: at index time (M7). Empty by default: no provider runs, no bytes of
+    #: the syntax graph or the retrieval path change. Accepted values:
+    #: "coverage", "runtime_profile". Kept independent from
+    #: semantic_evidence_providers -- the two conditional evidence channels
+    #: are separately disableable and separately rollback-able.
+    runtime_evidence_providers: list[str] = []
 
     @model_validator(mode="after")
     def _validate_index_config(self) -> IndexConfig:
@@ -299,10 +307,20 @@ class IndexConfig(BaseModel):
             raise ValueError("rerank_candidate_limit must be at least 1")
         if self.quantize_bits not in SUPPORTED_BITS:
             raise ValueError(f"quantize_bits must be one of {SUPPORTED_BITS}")
-        unknown_providers = set(self.semantic_evidence_providers) - {"scip", "lsp"}
-        if unknown_providers:
+        unknown_semantic_providers = set(self.semantic_evidence_providers) - {"scip", "lsp"}
+        if unknown_semantic_providers:
             raise ValueError(
-                f"semantic_evidence_providers has unknown entries: {sorted(unknown_providers)}"
+                "semantic_evidence_providers has unknown entries: "
+                f"{sorted(unknown_semantic_providers)}"
+            )
+        unknown_runtime_providers = set(self.runtime_evidence_providers) - {
+            "coverage",
+            "runtime_profile",
+        }
+        if unknown_runtime_providers:
+            raise ValueError(
+                "runtime_evidence_providers has unknown entries: "
+                f"{sorted(unknown_runtime_providers)}"
             )
         return self
 
@@ -892,6 +910,7 @@ class ContextReceipt(BaseModel):
     omitted_edges: list[ContextReceiptEdge] = []
     skipped_candidates: list[ContextSkippedCandidate] = []
     semantic_providers: list[SemanticProviderReceipt] = []
+    runtime_providers: list[RuntimeProviderReceipt] = []
     returned_total: int = 0
     skipped_total: int = 0
     included_edges_total: int = 0

--- a/src/archex/receipt.py
+++ b/src/archex/receipt.py
@@ -28,6 +28,7 @@ from archex.scout import ScoutResult, chunk_handle, file_handle, parse_scout_han
 if TYPE_CHECKING:
     from archex.index.graph import DependencyGraph
     from archex.index.store import IndexStore
+    from archex.integrations.runtime.models import RuntimeProviderReceipt
     from archex.integrations.semantic.models import SemanticProviderReceipt
     from archex.models import ContextBundle
 
@@ -80,6 +81,7 @@ def build_context_receipt(
     omitted_edges: Iterable[ContextReceiptEdge] = (),
     skipped_candidates: Iterable[ContextSkippedCandidate] = (),
     semantic_providers: Iterable[SemanticProviderReceipt] = (),
+    runtime_providers: Iterable[RuntimeProviderReceipt] = (),
 ) -> ContextReceipt:
     returned = _returned_context(bundle)
     skipped_all = list(skipped_candidates)
@@ -117,6 +119,7 @@ def build_context_receipt(
         omitted_edges=omitted,
         skipped_candidates=skipped,
         semantic_providers=list(semantic_providers),
+        runtime_providers=list(runtime_providers),
         returned_total=len(returned),
         skipped_total=len(skipped_all),
         included_edges_total=len(included_all),

--- a/src/archex/report/artifact.py
+++ b/src/archex/report/artifact.py
@@ -48,6 +48,7 @@ from archex.serve.generation import read_generation_id
 
 if TYPE_CHECKING:
     from archex.impact import ImpactReport, SymbolImpact
+    from archex.integrations.runtime.models import CoverageFileEvidence, RuntimeProfileEvidence
     from archex.models import CodeChunk
 
 REPORT_SCHEMA_VERSION = "1.0.0"
@@ -146,6 +147,19 @@ class SymbolCandidate(BaseModel):
     confidence: AnalysisConfidence
     signals: list[str] = []
     evidence: list[EvidenceLocation] = []
+    #: M7: total folded-stack sample count observed for this symbol's file
+    #: (and, when available, its qualified name) in the most recently
+    #: collected runtime-profile evidence. ``None`` when the runtime_profile
+    #: provider was not enabled or produced no matching evidence -- never a
+    #: fabricated zero.
+    runtime_sample_count: int | None = None
+    #: Git revision the runtime-profile evidence above was collected
+    #: against; ``None`` alongside ``runtime_sample_count is None``.
+    runtime_revision: str | None = None
+    #: True when ``runtime_revision`` does not match this artifact's own
+    #: ``source_revision`` -- the evidence is displayed but flagged unusable
+    #: for any downstream decision rather than silently applied.
+    runtime_stale: bool = False
 
 
 class InterfaceCandidate(BaseModel):
@@ -170,6 +184,17 @@ class TestCandidate(BaseModel):
     reason: str
     confidence: AnalysisConfidence = AnalysisConfidence.HIGH
     evidence: list[EvidenceLocation] = []
+    #: M7: line-coverage rate (0.0-1.0) observed for this test file in the
+    #: most recently collected coverage evidence. ``None`` when the
+    #: coverage provider was not enabled or produced no matching evidence.
+    coverage_line_rate: float | None = None
+    #: Git revision the coverage evidence above was collected against;
+    #: ``None`` alongside ``coverage_line_rate is None``.
+    coverage_revision: str | None = None
+    #: True when ``coverage_revision`` does not match this artifact's own
+    #: ``source_revision`` -- the evidence is displayed but flagged unusable
+    #: for any downstream decision rather than silently applied.
+    coverage_stale: bool = False
 
 
 class UnsupportedFile(BaseModel):
@@ -302,6 +327,8 @@ def build_analysis_artifact(source: str | Path, *, base_ref: str) -> AnalysisArt
         source_revision = (
             store.get_metadata("commit_hash") or CacheManager.git_head(str(repo_root)) or ""
         )
+        coverage_evidence = store.get_runtime_coverage_evidence()
+        profile_evidence = store.get_runtime_profile_evidence()
     finally:
         store.close()
 
@@ -313,6 +340,9 @@ def build_analysis_artifact(source: str | Path, *, base_ref: str) -> AnalysisArt
         report=report,
         touched_chunks=touched_chunks,
         hunks=hunks,
+        coverage_evidence=coverage_evidence,
+        profile_evidence=profile_evidence,
+        source_revision=source_revision,
     )
     parser_versions = _parser_versions_for_changes(changes)
     excluded_counts = {"unmapped_changed_files": diff.unsupported_files_total}
@@ -404,7 +434,55 @@ def _interface_candidate(symbol_id: str) -> InterfaceCandidate:
     )
 
 
-def _symbol_candidate(impact: SymbolImpact, chunk: CodeChunk | None) -> SymbolCandidate:
+def _runtime_sample_count_for_symbol(
+    file_path: str,
+    qualified_name: str | None,
+    profile_evidence: list[RuntimeProfileEvidence],
+    source_revision: str,
+) -> tuple[int | None, str | None, bool]:
+    """Sum folded-stack sample counts observed for *file_path* (and, when
+    given, *qualified_name*) across the most recently collected runtime
+    profile evidence. Returns ``(None, None, False)`` when no sample ever
+    touched this file -- never a fabricated zero.
+    """
+    for record in profile_evidence:
+        total = 0
+        matched = False
+        for sample in record.samples:
+            for frame in sample.frames:
+                frame_path, _, frame_symbol = frame.partition(":")
+                if frame_path != file_path:
+                    continue
+                if qualified_name is not None and frame_symbol != qualified_name:
+                    continue
+                total += sample.sample_count
+                matched = True
+                break
+        if matched:
+            return total, record.revision, record.revision != source_revision
+    return None, None, False
+
+
+def _coverage_for_path(
+    path: str, coverage_evidence: list[CoverageFileEvidence], source_revision: str
+) -> tuple[float | None, str | None, bool]:
+    """Return ``(line_rate, revision, stale)`` for *path* from the most
+    recently collected coverage evidence. Returns ``(None, None, False)``
+    when no coverage record was collected for this file.
+    """
+    for record in coverage_evidence:
+        if record.file_path == path:
+            return record.line_rate, record.revision, record.revision != source_revision
+    return None, None, False
+
+
+def _symbol_candidate(
+    impact: SymbolImpact,
+    chunk: CodeChunk | None,
+    *,
+    profile_evidence: list[RuntimeProfileEvidence],
+    source_revision: str,
+) -> SymbolCandidate:
     if chunk is not None and chunk.symbol_id is not None:
         handle = symbol_handle(chunk.symbol_id)
     elif chunk is not None:
@@ -427,6 +505,9 @@ def _symbol_candidate(impact: SymbolImpact, chunk: CodeChunk | None) -> SymbolCa
         )
         for signal in impact.signals
     ]
+    runtime_sample_count, runtime_revision, runtime_stale = _runtime_sample_count_for_symbol(
+        impact.file_path, impact.qualified_name, profile_evidence, source_revision
+    )
     return SymbolCandidate(
         handle=handle,
         file_path=impact.file_path,
@@ -439,6 +520,9 @@ def _symbol_candidate(impact: SymbolImpact, chunk: CodeChunk | None) -> SymbolCa
         confidence=confidence,
         signals=[f"{signal.name}: {signal.detail}" for signal in impact.signals],
         evidence=evidence,
+        runtime_sample_count=runtime_sample_count,
+        runtime_revision=runtime_revision,
+        runtime_stale=runtime_stale,
     )
 
 
@@ -450,6 +534,9 @@ def _build_diff_analysis(
     report: ImpactReport,
     touched_chunks: list[CodeChunk],
     hunks: dict[str, list[tuple[int, int]]],
+    coverage_evidence: list[CoverageFileEvidence],
+    profile_evidence: list[RuntimeProfileEvidence],
+    source_revision: str,
 ) -> DiffAnalysis:
     changed_files = [
         DiffFileChange(
@@ -468,7 +555,12 @@ def _build_diff_analysis(
     changed_files = changed_files[:MAX_CHANGED_FILES]
 
     symbol_candidates = [
-        _symbol_candidate(impact, chunk)
+        _symbol_candidate(
+            impact,
+            chunk,
+            profile_evidence=profile_evidence,
+            source_revision=source_revision,
+        )
         for impact, chunk in _zip_symbols(report.affected_symbols, touched_chunks)
     ]
     symbols_total = len(symbol_candidates)
@@ -480,17 +572,26 @@ def _build_diff_analysis(
     interfaces_total = len(affected_interfaces)
     affected_interfaces = affected_interfaces[:MAX_INTERFACE_CANDIDATES]
 
-    test_candidates = [
-        TestCandidate(
-            path=path,
-            handle=file_handle(path),
-            reason="affected_test_surface",
-            evidence=[
-                EvidenceLocation(path=path, description="test file reachable from changed files")
-            ],
+    test_candidates: list[TestCandidate] = []
+    for path in report.affected_tests:
+        coverage_line_rate, coverage_revision, coverage_stale = _coverage_for_path(
+            path, coverage_evidence, source_revision
         )
-        for path in report.affected_tests
-    ]
+        test_candidates.append(
+            TestCandidate(
+                path=path,
+                handle=file_handle(path),
+                reason="affected_test_surface",
+                evidence=[
+                    EvidenceLocation(
+                        path=path, description="test file reachable from changed files"
+                    )
+                ],
+                coverage_line_rate=coverage_line_rate,
+                coverage_revision=coverage_revision,
+                coverage_stale=coverage_stale,
+            )
+        )
     tests_total = len(test_candidates)
     test_candidates = test_candidates[:MAX_TEST_CANDIDATES]
 

--- a/src/archex/report/render_html.py
+++ b/src/archex/report/render_html.py
@@ -26,7 +26,12 @@ from urllib.parse import quote
 from archex.report.render_markdown import render_mermaid
 
 if TYPE_CHECKING:
-    from archex.report.artifact import AnalysisArtifactV1, DiffFileChange, SymbolCandidate
+    from archex.report.artifact import (
+        AnalysisArtifactV1,
+        DiffFileChange,
+        SymbolCandidate,
+        TestCandidate,
+    )
 
 MAX_HTML_ROWS = 50
 
@@ -66,12 +71,7 @@ def render_html(artifact: AnalysisArtifactV1) -> str:
             artifact.diff.affected_interfaces_total,
             artifact.source_root,
         ),
-        _path_list(
-            "Test Candidates",
-            [c.path for c in artifact.diff.test_candidates],
-            artifact.diff.test_candidates_total,
-            artifact.source_root,
-        ),
+        _test_candidates_table(artifact),
         _path_list(
             "Unsupported Files",
             [item.path for item in artifact.diff.unsupported_files],
@@ -173,14 +173,22 @@ def _symbol_candidates_table(artifact: AnalysisArtifactV1) -> str:
     candidates = artifact.diff.symbol_candidates[:MAX_HTML_ROWS]
     header = (
         "<tr><th>Risk</th><th>Confidence</th><th>Symbol</th>"
-        "<th>File</th><th>Lines</th><th>Handle</th></tr>"
+        "<th>File</th><th>Lines</th><th>Handle</th><th>Runtime evidence</th></tr>"
     )
     rows = (
         "".join(_symbol_candidate_row(candidate, artifact.source_root) for candidate in candidates)
-        or "<tr><td colspan='6'><em>None</em></td></tr>"
+        or "<tr><td colspan='7'><em>None</em></td></tr>"
     )
     note = _truncation_note(artifact.diff.symbol_candidates_total, len(candidates))
     return f"<h2>Symbol Risk Candidates</h2>\n<table>{header}{rows}</table>{note}"
+
+
+def _runtime_evidence_cell(candidate: SymbolCandidate) -> str:
+    if candidate.runtime_sample_count is None:
+        return "-"
+    revision = escape((candidate.runtime_revision or "unknown")[:8])
+    stale = " <strong>STALE</strong>" if candidate.runtime_stale else ""
+    return f"{candidate.runtime_sample_count} samples @ <code>{revision}</code>{stale}"
 
 
 def _symbol_candidate_row(candidate: SymbolCandidate, source_root: str) -> str:
@@ -195,7 +203,39 @@ def _symbol_candidate_row(candidate: SymbolCandidate, source_root: str) -> str:
         f"<td><code>{escape(label)}</code></td>"
         f"<td><code>{file_link}</code></td>"
         f"<td>{candidate.start_line}-{candidate.end_line}</td>"
-        f"<td><code>{escape(candidate.handle)}</code></td></tr>"
+        f"<td><code>{escape(candidate.handle)}</code></td>"
+        f"<td>{_runtime_evidence_cell(candidate)}</td></tr>"
+    )
+
+
+def _test_candidates_table(artifact: AnalysisArtifactV1) -> str:
+    candidates = artifact.diff.test_candidates[:MAX_HTML_ROWS]
+    header = "<tr><th>Path</th><th>Handle</th><th>Coverage</th><th>Revision</th><th>Stale</th></tr>"
+    rows = (
+        "".join(_test_candidate_row(candidate, artifact.source_root) for candidate in candidates)
+        or "<tr><td colspan='5'><em>None</em></td></tr>"
+    )
+    note = _truncation_note(artifact.diff.test_candidates_total, len(candidates))
+    return f"<h2>Test Candidates</h2>\n<table>{header}{rows}</table>{note}"
+
+
+def _test_candidate_row(candidate: TestCandidate, source_root: str) -> str:
+    path_link = _editor_link(source_root, candidate.path, None, escape(candidate.path))
+    coverage = (
+        f"{candidate.coverage_line_rate:.2f}" if candidate.coverage_line_rate is not None else "-"
+    )
+    revision = (
+        f"<code>{escape(candidate.coverage_revision[:8])}</code>"
+        if candidate.coverage_revision
+        else "-"
+    )
+    stale = "yes" if candidate.coverage_stale else "no"
+    return (
+        f"<tr><td><code>{path_link}</code></td>"
+        f"<td><code>{escape(candidate.handle)}</code></td>"
+        f"<td>{coverage}</td>"
+        f"<td>{revision}</td>"
+        f"<td>{stale}</td></tr>"
     )
 
 

--- a/src/archex/report/render_markdown.py
+++ b/src/archex/report/render_markdown.py
@@ -41,11 +41,7 @@ def render_markdown(artifact: AnalysisArtifactV1) -> str:
             artifact.diff.affected_interfaces_total,
         ),
         "",
-        *_path_list_section(
-            "Test Candidates",
-            [candidate.path for candidate in artifact.diff.test_candidates],
-            artifact.diff.test_candidates_total,
-        ),
+        *_test_candidates_section(artifact),
         "",
         *_path_list_section(
             "Unsupported Files",
@@ -128,24 +124,57 @@ def _symbol_candidates_section(artifact: AnalysisArtifactV1) -> list[str]:
     lines = [
         "## Symbol Risk Candidates",
         "",
-        "| Risk | Confidence | Symbol | File | Lines | Handle |",
-        "| --- | --- | --- | --- | --- | --- |",
+        "| Risk | Confidence | Symbol | File | Lines | Handle | Runtime evidence |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
     ]
     for candidate in artifact.diff.symbol_candidates:
         label = candidate.qualified_name or candidate.symbol_name or "<unnamed>"
         lines.append(
             f"| `{candidate.risk_level}` | `{candidate.confidence.value}` | `{label}` | "
             f"`{candidate.file_path}` | {candidate.start_line}-{candidate.end_line} | "
-            f"`{candidate.handle}` |"
+            f"`{candidate.handle}` | {_runtime_evidence_label(candidate)} |"
         )
     if not artifact.diff.symbol_candidates:
-        lines.append("| - | - | _none_ | - | - | - |")
+        lines.append("| - | - | _none_ | - | - | - | - |")
     if artifact.diff.symbol_candidates_total > len(artifact.diff.symbol_candidates):
         remaining = artifact.diff.symbol_candidates_total - len(artifact.diff.symbol_candidates)
         lines.append("")
         lines.append(
             f"_{remaining} additional symbol candidate(s) omitted; see the JSON artifact._"
         )
+    return lines
+
+
+def _runtime_evidence_label(candidate: SymbolCandidate) -> str:
+    if candidate.runtime_sample_count is None:
+        return "-"
+    revision = (candidate.runtime_revision or "unknown")[:8]
+    stale = " **STALE**" if candidate.runtime_stale else ""
+    return f"{candidate.runtime_sample_count} samples @ `{revision}`{stale}"
+
+
+def _test_candidates_section(artifact: AnalysisArtifactV1) -> list[str]:
+    lines = [
+        "## Test Candidates",
+        "",
+        "| Path | Handle | Coverage | Revision | Stale |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for candidate in artifact.diff.test_candidates:
+        coverage = "-"
+        if candidate.coverage_line_rate is not None:
+            coverage = f"{candidate.coverage_line_rate:.2f}"
+        revision = f"`{candidate.coverage_revision[:8]}`" if candidate.coverage_revision else "-"
+        stale = "yes" if candidate.coverage_stale else "no"
+        lines.append(
+            f"| `{candidate.path}` | `{candidate.handle}` | {coverage} | {revision} | {stale} |"
+        )
+    if not artifact.diff.test_candidates:
+        lines.append("| _none_ | - | - | - | - |")
+    if artifact.diff.test_candidates_total > len(artifact.diff.test_candidates):
+        remaining = artifact.diff.test_candidates_total - len(artifact.diff.test_candidates)
+        lines.append("")
+        lines.append(f"_{remaining} additional test candidate(s) omitted; see the JSON artifact._")
     return lines
 
 

--- a/src/archex/serve/generation.py
+++ b/src/archex/serve/generation.py
@@ -55,6 +55,7 @@ def _index_config_fingerprint(index_config: IndexConfig) -> str:
         index_config.quantize_bits,
         index_config.identifier_fragment_tokenization,
         ",".join(index_config.semantic_evidence_providers),
+        ",".join(index_config.runtime_evidence_providers),
     )
     return "|".join(str(field) for field in fields)
 

--- a/tests/index/test_runtime_evidence_wiring.py
+++ b/tests/index/test_runtime_evidence_wiring.py
@@ -1,0 +1,109 @@
+"""Tests for M7's index_repository() wiring: cache metadata, generation
+fingerprint invalidation, and end-to-end runtime/coverage evidence
+persistence through a real index build.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from archex.api import index_repository
+from archex.index.store import IndexStore
+from archex.integrations.runtime.models import ProviderAvailability
+from archex.models import Config, IndexConfig, RepoSource
+
+
+def _git_head(repo: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+class TestIndexRepositoryRuntimeEvidenceWiring:
+    def test_default_config_produces_no_runtime_evidence(self, python_simple_repo: Path) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        store = index_repository(source, config=Config(cache=False), index_config=IndexConfig())
+        try:
+            assert store.get_runtime_provider_receipts() == []
+            assert store.get_runtime_coverage_evidence() == []
+        finally:
+            store.close()
+
+    def test_enabled_provider_without_evidence_reports_unavailable(
+        self, python_simple_repo: Path
+    ) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        store = index_repository(
+            source,
+            config=Config(cache=False),
+            index_config=IndexConfig(runtime_evidence_providers=["coverage"]),
+        )
+        try:
+            receipts = store.get_runtime_provider_receipts()
+            assert len(receipts) == 1
+            assert receipts[0].availability == ProviderAvailability.UNAVAILABLE
+            assert store.get_runtime_coverage_evidence() == []
+        finally:
+            store.close()
+
+    def test_enabled_provider_with_real_evidence_persists_coverage(
+        self, python_simple_repo: Path
+    ) -> None:
+        head = _git_head(python_simple_repo)
+        evidence_dir = python_simple_repo / ".archex" / "runtime-evidence" / "coverage"
+        evidence_dir.mkdir(parents=True)
+        (evidence_dir / "manifest.json").write_text(
+            json.dumps({"revision": head, "tool": "coverage.py", "tool_version": "7.6.0"})
+        )
+        (evidence_dir / "coverage.xml").write_text(
+            '<?xml version="1.0" ?>\n'
+            '<coverage line-rate="1.0">\n'
+            "<packages><package><classes>\n"
+            '<class filename="main.py" line-rate="1.0">\n'
+            '<lines><line number="1" hits="2"/></lines>\n'
+            "</class>\n"
+            "</classes></package></packages>\n"
+            "</coverage>\n"
+        )
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        store = index_repository(
+            source,
+            config=Config(cache=False),
+            index_config=IndexConfig(runtime_evidence_providers=["coverage"]),
+        )
+        try:
+            receipts = store.get_runtime_provider_receipts()
+            assert len(receipts) == 1
+            assert receipts[0].availability == ProviderAvailability.AVAILABLE
+            coverage_evidence = store.get_runtime_coverage_evidence()
+            assert len(coverage_evidence) == 1
+            assert coverage_evidence[0].file_path == "main.py"
+            assert coverage_evidence[0].revision == head
+        finally:
+            store.close()
+
+
+class TestIndexConfigMetadataCacheValidity:
+    def test_runtime_evidence_providers_change_invalidates_cache(self, tmp_path: Path) -> None:
+        from archex.api import (
+            _index_config_metadata_matches,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        db_path = tmp_path / "index.db"
+        store = IndexStore(db_path)
+        try:
+            from archex.api import (
+                _set_index_config_metadata,  # pyright: ignore[reportPrivateUsage]
+            )
+
+            _set_index_config_metadata(store, IndexConfig(runtime_evidence_providers=[]))
+            assert _index_config_metadata_matches(store, IndexConfig(runtime_evidence_providers=[]))
+            assert not _index_config_metadata_matches(
+                store, IndexConfig(runtime_evidence_providers=["coverage"])
+            )
+        finally:
+            store.close()

--- a/tests/index/test_store.py
+++ b/tests/index/test_store.py
@@ -1170,3 +1170,91 @@ class TestSemanticProviderReceipts:
         )
         store.set_semantic_provider_receipts([])
         assert store.get_semantic_provider_receipts() == []
+
+
+class TestRuntimeProviderReceipts:
+    def test_empty_when_unset(self, store: IndexStore) -> None:
+        assert store.get_runtime_provider_receipts() == []
+        assert store.get_runtime_coverage_evidence() == []
+        assert store.get_runtime_profile_evidence() == []
+
+    def test_round_trips_receipts(self, store: IndexStore) -> None:
+        from archex.integrations.runtime.models import (
+            ProviderAvailability,
+            RuntimeEvidenceProviderName,
+            RuntimeProviderReceipt,
+        )
+
+        receipts = [
+            RuntimeProviderReceipt(
+                provider=RuntimeEvidenceProviderName.COVERAGE,
+                availability=ProviderAvailability.AVAILABLE,
+                tool_name="coverage.py",
+                tool_version="7.6.0",
+                expected_revision="abc123",
+                observed_revision="abc123",
+                records_collected=2,
+                collected_at="2026-01-01T00:00:00+00:00",
+            ),
+            RuntimeProviderReceipt(
+                provider=RuntimeEvidenceProviderName.RUNTIME_PROFILE,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason="no runtime-profile evidence found",
+                expected_revision="abc123",
+                collected_at="2026-01-01T00:00:00+00:00",
+            ),
+        ]
+        store.set_runtime_provider_receipts(receipts)
+        assert store.get_runtime_provider_receipts() == receipts
+
+    def test_round_trips_coverage_evidence(self, store: IndexStore) -> None:
+        from archex.integrations.runtime.models import CoverageFileEvidence, CoverageLineRecord
+
+        evidence = [
+            CoverageFileEvidence(
+                file_path="a.py",
+                lines=[CoverageLineRecord(line=1, hits=3), CoverageLineRecord(line=2, hits=0)],
+                line_rate=0.5,
+                revision="abc123",
+            )
+        ]
+        store.set_runtime_coverage_evidence(evidence)
+        assert store.get_runtime_coverage_evidence() == evidence
+
+    def test_round_trips_profile_evidence(self, store: IndexStore) -> None:
+        from archex.integrations.runtime.models import RuntimeProfileEvidence, RuntimeStackSample
+
+        evidence = [
+            RuntimeProfileEvidence(
+                samples=[RuntimeStackSample(frames=("a.py:f",), sample_count=4)],
+                total_samples=4,
+                revision="abc123",
+            )
+        ]
+        store.set_runtime_profile_evidence(evidence)
+        assert store.get_runtime_profile_evidence() == evidence
+
+    def test_overwrites_prior_receipts_and_evidence(self, store: IndexStore) -> None:
+        from archex.integrations.runtime.models import (
+            CoverageFileEvidence,
+            ProviderAvailability,
+            RuntimeEvidenceProviderName,
+            RuntimeProviderReceipt,
+        )
+
+        store.set_runtime_provider_receipts(
+            [
+                RuntimeProviderReceipt(
+                    provider=RuntimeEvidenceProviderName.COVERAGE,
+                    availability=ProviderAvailability.UNAVAILABLE,
+                    reason="no evidence",
+                )
+            ]
+        )
+        store.set_runtime_coverage_evidence(
+            [CoverageFileEvidence(file_path="a.py", line_rate=1.0, revision="abc123")]
+        )
+        store.set_runtime_provider_receipts([])
+        store.set_runtime_coverage_evidence([])
+        assert store.get_runtime_provider_receipts() == []
+        assert store.get_runtime_coverage_evidence() == []

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -202,6 +202,25 @@ class TestComputeGenerationId:
         )
         assert a != b
 
+    def test_runtime_evidence_providers_change_changes_id(self) -> None:
+        a = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(runtime_evidence_providers=[]),
+        )
+        b = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(runtime_evidence_providers=["coverage"]),
+        )
+        assert a != b
+
     def test_vector_mode_changes_id(self) -> None:
         raw = compute_generation_id(
             schema_version="5",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -779,6 +779,17 @@ class TestIndexConfigValidation:
         with pytest.raises(ValueError, match="unknown entries"):
             IndexConfig(semantic_evidence_providers=["scip", "bogus"])
 
+    def test_runtime_evidence_providers_defaults_empty(self) -> None:
+        assert IndexConfig().runtime_evidence_providers == []
+
+    def test_runtime_evidence_providers_accepts_known_names(self) -> None:
+        config = IndexConfig(runtime_evidence_providers=["coverage", "runtime_profile"])
+        assert config.runtime_evidence_providers == ["coverage", "runtime_profile"]
+
+    def test_runtime_evidence_providers_rejects_unknown_name(self) -> None:
+        with pytest.raises(ValueError, match="unknown entries"):
+            IndexConfig(runtime_evidence_providers=["coverage", "bogus"])
+
     def test_quantize_bits_must_be_supported(self) -> None:
         with pytest.raises(ValueError, match="quantize_bits must be one of"):
             IndexConfig(quantize_bits=8)

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+from archex.integrations.runtime.models import (
+    ProviderAvailability as RuntimeProviderAvailability,
+)
+from archex.integrations.runtime.models import (
+    RuntimeEvidenceProviderName,
+    RuntimeProviderReceipt,
+)
 from archex.integrations.semantic.models import (
     ProviderAvailability,
     SemanticProviderName,
@@ -246,6 +253,32 @@ def test_build_context_receipt_defaults_semantic_providers_empty() -> None:
     bundle = ContextBundle(query="q", token_count=10, token_budget=100)
     receipt = build_context_receipt(bundle, index_revision="rev", freshness=ContextFreshness.CLEAN)
     assert receipt.semantic_providers == []
+
+
+def test_build_context_receipt_carries_runtime_providers() -> None:
+    bundle = ContextBundle(query="q", token_count=10, token_budget=100)
+    receipts = [
+        RuntimeProviderReceipt(
+            provider=RuntimeEvidenceProviderName.COVERAGE,
+            availability=RuntimeProviderAvailability.AVAILABLE,
+            records_collected=3,
+        )
+    ]
+
+    receipt = build_context_receipt(
+        bundle,
+        index_revision="rev",
+        freshness=ContextFreshness.CLEAN,
+        runtime_providers=receipts,
+    )
+
+    assert receipt.runtime_providers == receipts
+
+
+def test_build_context_receipt_defaults_runtime_providers_empty() -> None:
+    bundle = ContextBundle(query="q", token_count=10, token_budget=100)
+    receipt = build_context_receipt(bundle, index_revision="rev", freshness=ContextFreshness.CLEAN)
+    assert receipt.runtime_providers == []
 
 
 def test_receipt_edge_from_edge_helper_propagates_provider() -> None:

--- a/tests/test_report_artifact.py
+++ b/tests/test_report_artifact.py
@@ -226,3 +226,95 @@ def test_source_revision_matches_git_head(impact_diff_repo: Path) -> None:
 
     assert artifact.source_revision == head
     assert artifact.diff.base_resolved_sha == head
+
+
+def test_symbol_candidate_carries_runtime_evidence_when_available(
+    impact_diff_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """M7: a symbol candidate reports runtime-profile provenance when the
+    runtime_profile provider is enabled and its evidence covers the
+    symbol's file and qualified name.
+    """
+    import json
+
+    _edit_hub(impact_diff_repo)
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=impact_diff_repo,
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.strip()
+
+    # First build discovers shared_helper's exact qualified_name without guessing.
+    baseline = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+    shared_helper = next(
+        c for c in baseline.diff.symbol_candidates if c.symbol_name == "shared_helper"
+    )
+    assert shared_helper.runtime_sample_count is None
+
+    evidence_dir = impact_diff_repo / ".archex" / "runtime-evidence" / "profile"
+    evidence_dir.mkdir(parents=True)
+    (evidence_dir / "manifest.json").write_text(json.dumps({"revision": head, "tool": "cProfile"}))
+    label = shared_helper.qualified_name or shared_helper.symbol_name
+    frame = f"{shared_helper.file_path}:{label}"
+    (evidence_dir / "profile.folded").write_text(f"{frame} 7\n")
+
+    from archex.config import load_index_config as original_load_index_config
+    from archex.models import IndexConfig, RepoSource
+
+    def _patched_load_index_config(source: RepoSource) -> IndexConfig:
+        config = original_load_index_config(source)
+        return config.model_copy(update={"runtime_evidence_providers": ["runtime_profile"]})
+
+    monkeypatch.setattr("archex.report.artifact.load_index_config", _patched_load_index_config)
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+
+    enriched = next(c for c in artifact.diff.symbol_candidates if c.symbol_name == "shared_helper")
+    assert enriched.runtime_sample_count == 7
+    assert enriched.runtime_revision == head
+    assert enriched.runtime_stale is False
+
+
+def test_coverage_for_path_reports_match_and_staleness() -> None:
+    from archex.integrations.runtime.models import CoverageFileEvidence
+    from archex.report.artifact import _coverage_for_path  # pyright: ignore[reportPrivateUsage]
+
+    records = [CoverageFileEvidence(file_path="a.py", line_rate=0.5, revision="rev-a")]
+
+    rate, revision, stale = _coverage_for_path("a.py", records, "rev-a")
+    assert (rate, revision, stale) == (0.5, "rev-a", False)
+
+    rate, revision, stale = _coverage_for_path("a.py", records, "rev-b")
+    assert (rate, revision, stale) == (0.5, "rev-a", True)
+
+    rate, revision, stale = _coverage_for_path("missing.py", records, "rev-a")
+    assert (rate, revision, stale) == (None, None, False)
+
+
+def test_runtime_sample_count_for_symbol_matches_file_and_qualified_name() -> None:
+    from archex.integrations.runtime.models import RuntimeProfileEvidence, RuntimeStackSample
+    from archex.report.artifact import (
+        _runtime_sample_count_for_symbol,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    records = [
+        RuntimeProfileEvidence(
+            samples=[
+                RuntimeStackSample(frames=("a.py:outer", "a.py:inner"), sample_count=3),
+                RuntimeStackSample(frames=("a.py:inner",), sample_count=2),
+                RuntimeStackSample(frames=("b.py:other",), sample_count=9),
+            ],
+            total_samples=14,
+            revision="rev-a",
+        )
+    ]
+
+    count, revision, stale = _runtime_sample_count_for_symbol("a.py", "inner", records, "rev-a")
+    assert (count, revision, stale) == (5, "rev-a", False)
+
+    count, revision, stale = _runtime_sample_count_for_symbol("a.py", "inner", records, "rev-b")
+    assert (count, revision, stale) == (5, "rev-a", True)
+
+    count, revision, stale = _runtime_sample_count_for_symbol("c.py", None, records, "rev-a")
+    assert (count, revision, stale) == (None, None, False)


### PR DESCRIPTION
## Stack

Stack-Id: `m7-runtime-evidence-6ae0cd`
Base: `m7-1-runtime-coverage-contracts` (#554)
Position: 2/3

1. `m7-1-runtime-coverage-contracts` -> #554
2. `m7-2-artifact-and-receipt-integration` -> this PR
3. `m7-3-gated-performance-evaluation` -> next

Depends on: #554
Upstack: (next PR in stack)

## Summary

M7 (Add Runtime and Coverage Evidence Conditionally), PR 2/3: wires PR-1's contracts into the index build pipeline, cache validity, query receipts, and the read-only diff-review artifact/reports, gated entirely by the new `IndexConfig.runtime_evidence_providers` flag (default empty — fully disabled).

- `models.py`: `IndexConfig.runtime_evidence_providers`, `ContextReceipt.runtime_providers`.
- `index/store.py`: `IndexStore` persistence for provider receipts, coverage evidence, and profile evidence.
- `api.py`: wires `collect_runtime_evidence()` into every full-index-build path; adds `runtime_evidence_providers` to cache-metadata match/set; threads runtime receipts through every `query()` return path.
- `serve/generation.py`: `runtime_evidence_providers` is part of the generation fingerprint.
- `report/artifact.py`: `SymbolCandidate`/`TestCandidate` gain revision-bound runtime/coverage provenance + staleness fields, populated from the store's persisted M7 evidence inside `build_analysis_artifact()`'s existing scope.
- `report/render_html.py` / `report/render_markdown.py`: symbol table gains a "Runtime evidence" column; Test Candidates becomes a table showing coverage rate/revision/staleness.
- `receipt.py`: `build_context_receipt()` gains `runtime_providers`, threaded to `ContextReceipt.runtime_providers`.

## Verification

- `uv run ruff check .` / `uv run ruff format --check .`: clean (whole repo).
- `uv run pyright .`: 0 errors (whole repo).
- `uv run pytest --junitxml=results.xml --cov-report=xml`: **4266 passed**, 91.38% coverage (repo gate: 85%).
- Targeted new-test run: `uv run pytest tests/index/test_runtime_evidence_wiring.py tests/index/test_store.py tests/test_generation.py tests/test_models.py tests/test_receipt.py tests/test_report_artifact.py -q` — 220 passed.
