### PR TITLE
feat(history): gate conditional history route

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -130,6 +130,11 @@ if TYPE_CHECKING:
 
     from archex.index.embeddings.base import Embedder
     from archex.index.rerank import CrossEncoderReranker
+    from archex.integrations.history.models import (
+        ChangeCard,
+        HistoryProviderReceipt,
+        TemporalCouplingObservation,
+    )
     from archex.integrations.runtime.models import RuntimeProviderReceipt
     from archex.integrations.semantic.models import SemanticProviderReceipt
     from archex.models import ComparisonResult
@@ -167,7 +172,10 @@ def _index_config_metadata_matches(store: IndexStore, index_config: IndexConfig)
     if stored_semantic_providers != ",".join(index_config.semantic_evidence_providers):
         return False
     stored_runtime_providers = store.get_metadata("runtime_evidence_providers") or ""
-    return stored_runtime_providers == ",".join(index_config.runtime_evidence_providers)
+    if stored_runtime_providers != ",".join(index_config.runtime_evidence_providers):
+        return False
+    stored_history_providers = store.get_metadata("history_evidence_providers") or ""
+    return stored_history_providers == ",".join(index_config.history_evidence_providers)
 
 
 def _set_index_config_metadata(store: IndexStore, index_config: IndexConfig) -> None:
@@ -180,6 +188,9 @@ def _set_index_config_metadata(store: IndexStore, index_config: IndexConfig) -> 
     )
     store.set_metadata(
         "runtime_evidence_providers", ",".join(index_config.runtime_evidence_providers)
+    )
+    store.set_metadata(
+        "history_evidence_providers", ",".join(index_config.history_evidence_providers)
     )
 
 
@@ -280,6 +291,26 @@ def _full_index(
                 store.set_runtime_coverage_evidence(coverage_evidence)
                 store.set_runtime_profile_evidence(profile_evidence)
                 store.set_runtime_provider_receipts(runtime_receipts)
+            if effective_index_config.history_evidence_providers:
+                from archex.index.history_evidence import collect_history_evidence
+
+                history_revision = (
+                    cloned_head or cache.git_head(source.local_path) or source.commit or ""
+                )
+                (
+                    history_change_cards,
+                    history_coupling_observations,
+                    history_rationale,
+                    history_receipts,
+                ) = collect_history_evidence(
+                    repo_path,
+                    effective_index_config.history_evidence_providers,
+                    expected_revision=history_revision,
+                )
+                store.set_history_change_cards(history_change_cards)
+                store.set_history_coupling_observations(history_coupling_observations)
+                store.set_history_operator_rationale(history_rationale)
+                store.set_history_provider_receipts(history_receipts)
             edges = graph.file_edges()
             store.replace_file_states(compute_file_states(repo_path, files))
             store.insert_edges(edges)
@@ -1549,6 +1580,9 @@ def _refresh_receipt(
     metadata_timing: PipelineTiming | None,
     semantic_providers: list[SemanticProviderReceipt] | None = None,
     runtime_providers: list[RuntimeProviderReceipt] | None = None,
+    history_providers: list[HistoryProviderReceipt] | None = None,
+    history_change_cards: list[ChangeCard] | None = None,
+    history_coupling_observations: list[TemporalCouplingObservation] | None = None,
 ) -> None:
     skipped = list(bundle.receipt.skipped_candidates) if bundle.receipt is not None else []
     if freshness != ContextFreshness.CLEAN:
@@ -1567,6 +1601,11 @@ def _refresh_receipt(
         if runtime_providers is not None
         else (bundle.receipt.runtime_providers if bundle.receipt is not None else [])
     )
+    resolved_history_providers = (
+        history_providers
+        if history_providers is not None
+        else (bundle.receipt.history_providers if bundle.receipt is not None else [])
+    )
     bundle.receipt = build_context_receipt(
         bundle,
         index_revision=index_revision,
@@ -1576,6 +1615,9 @@ def _refresh_receipt(
         skipped_candidates=skipped,
         semantic_providers=resolved_semantic_providers,
         runtime_providers=resolved_runtime_providers,
+        history_providers=resolved_history_providers,
+        history_change_cards=history_change_cards or [],
+        history_coupling_observations=history_coupling_observations or [],
     )
 
 
@@ -1595,6 +1637,9 @@ def _finalize_context_bundle(
     post_search_at: float | None = None,
     semantic_providers: list[SemanticProviderReceipt] | None = None,
     runtime_providers: list[RuntimeProviderReceipt] | None = None,
+    history_providers: list[HistoryProviderReceipt] | None = None,
+    history_change_cards: list[ChangeCard] | None = None,
+    history_coupling_observations: list[TemporalCouplingObservation] | None = None,
 ) -> ContextBundle:
     _attach_vector_metadata(bundle, index_config)
     _attach_index_metadata(
@@ -1632,6 +1677,9 @@ def _finalize_context_bundle(
         metadata_timing=metadata_timing,
         semantic_providers=semantic_providers,
         runtime_providers=runtime_providers,
+        history_providers=history_providers,
+        history_change_cards=history_change_cards,
+        history_coupling_observations=history_coupling_observations,
     )
     return bundle
 
@@ -2181,6 +2229,9 @@ def query(
                     post_search_at=t_post_search,
                     semantic_providers=search_store.get_semantic_provider_receipts(),
                     runtime_providers=search_store.get_runtime_provider_receipts(),
+                    history_providers=search_store.get_history_provider_receipts(),
+                    history_change_cards=search_store.get_history_change_cards(),
+                    history_coupling_observations=search_store.get_history_coupling_observations(),
                 )
             finally:
                 store.close()
@@ -2316,6 +2367,29 @@ def query(
                 store.set_runtime_coverage_evidence(coverage_evidence)
                 store.set_runtime_profile_evidence(profile_evidence)
                 store.set_runtime_provider_receipts(runtime_receipts)
+            history_change_cards: list[ChangeCard] = []
+            history_coupling_observations: list[TemporalCouplingObservation] = []
+            history_receipts: list[HistoryProviderReceipt] = []
+            if index_config.history_evidence_providers:
+                from archex.index.history_evidence import collect_history_evidence
+
+                history_revision = (
+                    cloned_head or cache.git_head(source.local_path) or source.commit or ""
+                )
+                (
+                    history_change_cards,
+                    history_coupling_observations,
+                    history_rationale,
+                    history_receipts,
+                ) = collect_history_evidence(
+                    repo_path,
+                    index_config.history_evidence_providers,
+                    expected_revision=history_revision,
+                )
+                store.set_history_change_cards(history_change_cards)
+                store.set_history_coupling_observations(history_coupling_observations)
+                store.set_history_operator_rationale(history_rationale)
+                store.set_history_provider_receipts(history_receipts)
             edges = graph.file_edges()
             from archex.index.delta import compute_file_states
 
@@ -2456,6 +2530,9 @@ def query(
                     metadata_timing=metadata_timing,
                     semantic_providers=semantic_receipts,
                     runtime_providers=runtime_receipts,
+                    history_providers=history_receipts,
+                    history_change_cards=history_change_cards,
+                    history_coupling_observations=history_coupling_observations,
                 )
                 return pt
 
@@ -2606,6 +2683,9 @@ def query(
             post_search_at=t_post_search_miss,
             semantic_providers=semantic_receipts,
             runtime_providers=runtime_receipts,
+            history_providers=history_receipts,
+            history_change_cards=history_change_cards,
+            history_coupling_observations=history_coupling_observations,
         )
     finally:
         cleanup()

--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -9,6 +9,12 @@ import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+from archex.integrations.history.models import (
+    ChangeCard,
+    HistoryProviderReceipt,
+    OperatorRationale,
+    TemporalCouplingObservation,
+)
 from archex.integrations.runtime.models import (
     CoverageFileEvidence,
     RuntimeProfileEvidence,
@@ -33,6 +39,10 @@ _SEMANTIC_PROVIDER_RECEIPTS_KEY = "semantic_provider_receipts"
 _RUNTIME_PROVIDER_RECEIPTS_KEY = "runtime_provider_receipts"
 _RUNTIME_COVERAGE_EVIDENCE_KEY = "runtime_coverage_evidence"
 _RUNTIME_PROFILE_EVIDENCE_KEY = "runtime_profile_evidence"
+_HISTORY_PROVIDER_RECEIPTS_KEY = "history_provider_receipts"
+_HISTORY_CHANGE_CARDS_KEY = "history_change_cards"
+_HISTORY_COUPLING_OBSERVATIONS_KEY = "history_coupling_observations"
+_HISTORY_OPERATOR_RATIONALE_KEY = "history_operator_rationale"
 
 logger = logging.getLogger(__name__)
 
@@ -906,6 +916,82 @@ class IndexStore:
         if not raw:
             return []
         return [RuntimeProfileEvidence.model_validate(item) for item in json.loads(raw)]
+
+    def set_history_provider_receipts(self, receipts: list[HistoryProviderReceipt]) -> None:
+        """Persist the M8 conditional repository-memory provider receipts for this build."""
+        self.set_metadata(
+            _HISTORY_PROVIDER_RECEIPTS_KEY,
+            json.dumps([r.model_dump(mode="json") for r in receipts], sort_keys=True),
+        )
+
+    def get_history_provider_receipts(self) -> list[HistoryProviderReceipt]:
+        """Return the persisted M8 repository-memory provider receipts, if any.
+
+        Empty when no history provider was configured for this build — a
+        store built before M8 or with ``history_evidence_providers`` unset
+        has no receipts, which is a fully expected, honest empty result,
+        not an error.
+        """
+        raw = self.get_metadata(_HISTORY_PROVIDER_RECEIPTS_KEY)
+        if not raw:
+            return []
+        return [HistoryProviderReceipt.model_validate(item) for item in json.loads(raw)]
+
+    def set_history_change_cards(self, cards: list[ChangeCard]) -> None:
+        """Persist the M8 revision-bound local-history change cards for this build."""
+        self.set_metadata(
+            _HISTORY_CHANGE_CARDS_KEY,
+            json.dumps([c.model_dump(mode="json") for c in cards], sort_keys=True),
+        )
+
+    def get_history_change_cards(self) -> list[ChangeCard]:
+        """Return the persisted M8 change cards, if any.
+
+        Empty when the git_log provider was not configured or produced no
+        available evidence for this build.
+        """
+        raw = self.get_metadata(_HISTORY_CHANGE_CARDS_KEY)
+        if not raw:
+            return []
+        return [ChangeCard.model_validate(item) for item in json.loads(raw)]
+
+    def set_history_coupling_observations(
+        self, observations: list[TemporalCouplingObservation]
+    ) -> None:
+        """Persist the M8 non-causal temporal-coupling observations for this build."""
+        self.set_metadata(
+            _HISTORY_COUPLING_OBSERVATIONS_KEY,
+            json.dumps([o.model_dump(mode="json") for o in observations], sort_keys=True),
+        )
+
+    def get_history_coupling_observations(self) -> list[TemporalCouplingObservation]:
+        """Return the persisted M8 temporal-coupling observations, if any.
+
+        Empty when the git_log provider was not configured or produced no
+        available evidence for this build.
+        """
+        raw = self.get_metadata(_HISTORY_COUPLING_OBSERVATIONS_KEY)
+        if not raw:
+            return []
+        return [TemporalCouplingObservation.model_validate(item) for item in json.loads(raw)]
+
+    def set_history_operator_rationale(self, entries: list[OperatorRationale]) -> None:
+        """Persist the M8 revision-bound operator-authored rationale for this build."""
+        self.set_metadata(
+            _HISTORY_OPERATOR_RATIONALE_KEY,
+            json.dumps([e.model_dump(mode="json") for e in entries], sort_keys=True),
+        )
+
+    def get_history_operator_rationale(self) -> list[OperatorRationale]:
+        """Return the persisted M8 operator rationale, if any.
+
+        Empty when the operator_rationale provider was not configured or
+        produced no available evidence for this build.
+        """
+        raw = self.get_metadata(_HISTORY_OPERATOR_RATIONALE_KEY)
+        if not raw:
+            return []
+        return [OperatorRationale.model_validate(item) for item in json.loads(raw)]
 
     def needs_reindex(self) -> bool:
         """Return True if the store contains chunks without symbol_ids (pre-stable-ID data)."""

--- a/src/archex/integrations/history/eligibility.py
+++ b/src/archex/integrations/history/eligibility.py
@@ -1,0 +1,160 @@
+"""Repository-memory eligibility policy (M8): density, linkage, and relevance gates.
+
+History evidence is collected unconditionally once ``git_log`` is enabled
+(cheap: a single bounded ``git log`` walk), but it must never be *surfaced*
+to a report or receipt unless it clears three predeclared thresholds:
+
+- **density** -- is there enough real commit activity in the collected
+  window to say anything meaningful (a nearly-empty window is not
+  history-rich)?
+- **linkage** -- do the collected commits actually relate to each other
+  (temporal coupling), or is this a pile of isolated, unrelated changes?
+- **relevance** -- does the collected history actually cover the files this
+  specific operation (query or diff) cares about?
+
+Any threshold miss disables the channel for that operation with an explicit
+reason -- never a partial, silently-degraded surface. This mirrors the
+milestone's acceptance: "History is disabled when density, linkage quality,
+or query relevance is below its declared threshold."
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, model_validator
+
+from archex.integrations.history.models import (
+    ChangeCard,
+    HistoryProviderReceipt,
+    ProviderAvailability,
+    TemporalCouplingObservation,
+)
+
+#: Predeclared thresholds (see module docstring). Not user-configurable:
+#: DEVELOPMENT_PLAN.md's M8 row calls these "declared thresholds", matching
+#: the plan's broader "no automatic provider promotion" posture for every
+#: conditional evidence channel -- a caller cannot loosen the gate to force
+#: history onto a sparse repository.
+MIN_DENSITY = 0.30
+MIN_LINKAGE = 0.10
+MIN_RELEVANCE = 0.20
+
+
+class HistoryEligibilityDecision(BaseModel):
+    """Explains whether repository-memory evidence is surfaced for one operation.
+
+    Always produced when the ``git_log`` provider was configured, whether or
+    not history ends up enabled -- a disabled decision still reports its
+    three scores and a human-readable reason.
+    """
+
+    enabled: bool
+    density_score: float
+    linkage_score: float
+    relevance_score: float
+    reason: str = ""
+
+    @model_validator(mode="after")
+    def _validate_decision(self) -> HistoryEligibilityDecision:
+        for name, value in (
+            ("density_score", self.density_score),
+            ("linkage_score", self.linkage_score),
+            ("relevance_score", self.relevance_score),
+        ):
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be between 0.0 and 1.0")
+        if not self.enabled and not self.reason.strip():
+            raise ValueError("reason is required when history is disabled")
+        return self
+
+
+def _density_score(change_cards: list[ChangeCard], window_commit_count: int) -> float:
+    if window_commit_count <= 0:
+        return 0.0
+    return min(1.0, len(change_cards) / window_commit_count)
+
+
+def _linkage_score(
+    change_cards: list[ChangeCard], coupling_observations: list[TemporalCouplingObservation]
+) -> float:
+    changed_files = {path for card in change_cards for path in card.changed_files}
+    if not changed_files:
+        return 0.0
+    linked_files = {
+        path
+        for observation in coupling_observations
+        for path in (observation.file_a, observation.file_b)
+    }
+    return len(linked_files & changed_files) / len(changed_files)
+
+
+def _relevance_score(
+    change_cards: list[ChangeCard],
+    coupling_observations: list[TemporalCouplingObservation],
+    candidate_file_paths: set[str],
+) -> float:
+    if not candidate_file_paths:
+        return 0.0
+    history_files = {path for card in change_cards for path in card.changed_files}
+    history_files.update(
+        path
+        for observation in coupling_observations
+        for path in (observation.file_a, observation.file_b)
+    )
+    return len(candidate_file_paths & history_files) / len(candidate_file_paths)
+
+
+def evaluate_history_eligibility(
+    change_cards: list[ChangeCard],
+    coupling_observations: list[TemporalCouplingObservation],
+    candidate_file_paths: set[str],
+    *,
+    git_log_receipt: HistoryProviderReceipt | None,
+    window_commit_count: int,
+    min_density: float = MIN_DENSITY,
+    min_linkage: float = MIN_LINKAGE,
+    min_relevance: float = MIN_RELEVANCE,
+) -> HistoryEligibilityDecision:
+    """Decide whether to surface history evidence for one query or diff.
+
+    ``candidate_file_paths`` is the operation's own relevant file set (a
+    query's returned/candidate files, or a diff's changed files) -- the
+    basis for the relevance score. Disabled whenever the ``git_log``
+    provider itself was not ``AVAILABLE``, or when any of the three scores
+    falls below its threshold.
+    """
+    if git_log_receipt is None or git_log_receipt.availability != ProviderAvailability.AVAILABLE:
+        reason_detail = git_log_receipt.reason if git_log_receipt is not None else "not collected"
+        return HistoryEligibilityDecision(
+            enabled=False,
+            density_score=0.0,
+            linkage_score=0.0,
+            relevance_score=0.0,
+            reason=f"git_log evidence unavailable: {reason_detail or 'unknown reason'}",
+        )
+
+    density = _density_score(change_cards, window_commit_count)
+    linkage = _linkage_score(change_cards, coupling_observations)
+    relevance = _relevance_score(change_cards, coupling_observations, candidate_file_paths)
+
+    failures: list[str] = []
+    if density < min_density:
+        failures.append(f"density {density:.2f} < {min_density:.2f}")
+    if linkage < min_linkage:
+        failures.append(f"linkage {linkage:.2f} < {min_linkage:.2f}")
+    if relevance < min_relevance:
+        failures.append(f"relevance {relevance:.2f} < {min_relevance:.2f}")
+
+    if failures:
+        return HistoryEligibilityDecision(
+            enabled=False,
+            density_score=density,
+            linkage_score=linkage,
+            relevance_score=relevance,
+            reason="below threshold: " + "; ".join(failures),
+        )
+    return HistoryEligibilityDecision(
+        enabled=True,
+        density_score=density,
+        linkage_score=linkage,
+        relevance_score=relevance,
+    )

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -9,6 +9,8 @@ from typing import Any, Literal
 from pydantic import BaseModel, model_validator
 
 from archex.index.quantize import SUPPORTED_BITS
+from archex.integrations.history.eligibility import HistoryEligibilityDecision  # noqa: TCH001
+from archex.integrations.history.models import HistoryProviderReceipt  # noqa: TCH001
 from archex.integrations.lsap_models import LSAPEnrichment  # noqa: TCH001
 from archex.integrations.runtime.models import RuntimeProviderReceipt  # noqa: TCH001
 from archex.integrations.semantic.models import SemanticProviderReceipt  # noqa: TCH001
@@ -288,6 +290,15 @@ class IndexConfig(BaseModel):
     #: semantic_evidence_providers -- the two conditional evidence channels
     #: are separately disableable and separately rollback-able.
     runtime_evidence_providers: list[str] = []
+    #: Conditional local-git-history/operator-rationale evidence providers
+    #: to run at index time (M8). Empty by default: no provider runs.
+    #: Accepted values: "git_log", "operator_rationale". Kept independent
+    #: from semantic_evidence_providers/runtime_evidence_providers -- every
+    #: conditional evidence channel is separately disableable and
+    #: separately rollback-able. Collected evidence is further gated by a
+    #: predeclared density/linkage/relevance eligibility policy
+    #: (archex.integrations.history.eligibility) before it is ever surfaced.
+    history_evidence_providers: list[str] = []
 
     @model_validator(mode="after")
     def _validate_index_config(self) -> IndexConfig:
@@ -321,6 +332,15 @@ class IndexConfig(BaseModel):
             raise ValueError(
                 "runtime_evidence_providers has unknown entries: "
                 f"{sorted(unknown_runtime_providers)}"
+            )
+        unknown_history_providers = set(self.history_evidence_providers) - {
+            "git_log",
+            "operator_rationale",
+        }
+        if unknown_history_providers:
+            raise ValueError(
+                "history_evidence_providers has unknown entries: "
+                f"{sorted(unknown_history_providers)}"
             )
         return self
 
@@ -911,6 +931,8 @@ class ContextReceipt(BaseModel):
     skipped_candidates: list[ContextSkippedCandidate] = []
     semantic_providers: list[SemanticProviderReceipt] = []
     runtime_providers: list[RuntimeProviderReceipt] = []
+    history_providers: list[HistoryProviderReceipt] = []
+    history_eligibility: HistoryEligibilityDecision | None = None
     returned_total: int = 0
     skipped_total: int = 0
     included_edges_total: int = 0

--- a/src/archex/receipt.py
+++ b/src/archex/receipt.py
@@ -28,6 +28,12 @@ from archex.scout import ScoutResult, chunk_handle, file_handle, parse_scout_han
 if TYPE_CHECKING:
     from archex.index.graph import DependencyGraph
     from archex.index.store import IndexStore
+    from archex.integrations.history.eligibility import HistoryEligibilityDecision
+    from archex.integrations.history.models import (
+        ChangeCard,
+        HistoryProviderReceipt,
+        TemporalCouplingObservation,
+    )
     from archex.integrations.runtime.models import RuntimeProviderReceipt
     from archex.integrations.semantic.models import SemanticProviderReceipt
     from archex.models import ContextBundle
@@ -82,6 +88,9 @@ def build_context_receipt(
     skipped_candidates: Iterable[ContextSkippedCandidate] = (),
     semantic_providers: Iterable[SemanticProviderReceipt] = (),
     runtime_providers: Iterable[RuntimeProviderReceipt] = (),
+    history_providers: Iterable[HistoryProviderReceipt] = (),
+    history_change_cards: Iterable[ChangeCard] = (),
+    history_coupling_observations: Iterable[TemporalCouplingObservation] = (),
 ) -> ContextReceipt:
     returned = _returned_context(bundle)
     skipped_all = list(skipped_candidates)
@@ -101,6 +110,30 @@ def build_context_receipt(
         included_all,
         key=lambda item: (item.source, item.target, item.kind.value),
     )[:_MAX_RECEIPT_INCLUDED_EDGES]
+    history_providers_resolved = list(history_providers)
+    history_change_cards_resolved = list(history_change_cards)
+    history_coupling_resolved = list(history_coupling_observations)
+    history_eligibility: HistoryEligibilityDecision | None = None
+    if history_providers_resolved:
+        from archex.integrations.history.eligibility import evaluate_history_eligibility
+        from archex.integrations.history.models import HistoryEvidenceProviderName
+
+        git_log_receipt = next(
+            (
+                r
+                for r in history_providers_resolved
+                if r.provider == HistoryEvidenceProviderName.GIT_LOG
+            ),
+            None,
+        )
+        candidate_file_paths = {item.file_path for item in returned}
+        history_eligibility = evaluate_history_eligibility(
+            history_change_cards_resolved,
+            history_coupling_resolved,
+            candidate_file_paths,
+            git_log_receipt=git_log_receipt,
+            window_commit_count=git_log_receipt.window_commit_count if git_log_receipt else 0,
+        )
     return ContextReceipt(
         query=bundle.query,
         expanded_query=bundle.retrieval_metadata.expanded_query,
@@ -120,6 +153,8 @@ def build_context_receipt(
         skipped_candidates=skipped,
         semantic_providers=list(semantic_providers),
         runtime_providers=list(runtime_providers),
+        history_providers=list(history_providers_resolved),
+        history_eligibility=history_eligibility,
         returned_total=len(returned),
         skipped_total=len(skipped_all),
         included_edges_total=len(included_all),

--- a/src/archex/report/artifact.py
+++ b/src/archex/report/artifact.py
@@ -41,6 +41,7 @@ from archex.impact import (
     git_diff_hunks,
     resolve_diff_symbols,
 )
+from archex.integrations.history.eligibility import HistoryEligibilityDecision  # noqa: TC001
 from archex.languages import EXTENSION_LANGUAGE_MAP
 from archex.models import ContextCompletenessStatus, ContextFreshness, RepoSource
 from archex.scout import chunk_handle, file_handle, symbol_handle
@@ -48,6 +49,11 @@ from archex.serve.generation import read_generation_id
 
 if TYPE_CHECKING:
     from archex.impact import ImpactReport, SymbolImpact
+    from archex.integrations.history.models import (
+        ChangeCard,
+        HistoryProviderReceipt,
+        TemporalCouplingObservation,
+    )
     from archex.integrations.runtime.models import CoverageFileEvidence, RuntimeProfileEvidence
     from archex.models import CodeChunk
 
@@ -126,6 +132,14 @@ class DiffFileChange(BaseModel):
     old_path: str | None = None
     handle: str
     hunks: list[DiffHunk] = []
+    #: M8: count of collected local-history change cards touching this
+    #: file within the eligibility-cleared window. None when the history
+    #: channel is disabled, unconfigured, or below its declared
+    #: density/linkage/relevance threshold -- never a fabricated zero.
+    history_change_count: int | None = None
+    #: M8: unique issue/PR reference identifiers extracted from those
+    #: commits' own subject lines. Empty unless history is eligible.
+    history_linked_references: list[str] = []
 
 
 class SymbolCandidate(BaseModel):
@@ -226,6 +240,10 @@ class DiffAnalysis(BaseModel):
 
     risk_level: ImpactRiskLevel = ImpactRiskLevel.LOW
     risk_reasons: list[str] = []
+    #: M8: the repository-memory eligibility decision for this diff's own
+    #: changed files, when the history channel was configured. None when
+    #: unconfigured -- distinct from a decision that disabled the channel.
+    history_eligibility: HistoryEligibilityDecision | None = None
 
 
 class AnalysisArtifactV1(BaseModel):
@@ -329,6 +347,9 @@ def build_analysis_artifact(source: str | Path, *, base_ref: str) -> AnalysisArt
         )
         coverage_evidence = store.get_runtime_coverage_evidence()
         profile_evidence = store.get_runtime_profile_evidence()
+        history_change_cards = store.get_history_change_cards()
+        history_coupling_observations = store.get_history_coupling_observations()
+        history_provider_receipts = store.get_history_provider_receipts()
     finally:
         store.close()
 
@@ -343,6 +364,9 @@ def build_analysis_artifact(source: str | Path, *, base_ref: str) -> AnalysisArt
         coverage_evidence=coverage_evidence,
         profile_evidence=profile_evidence,
         source_revision=source_revision,
+        history_change_cards=history_change_cards,
+        history_coupling_observations=history_coupling_observations,
+        history_provider_receipts=history_provider_receipts,
     )
     parser_versions = _parser_versions_for_changes(changes)
     excluded_counts = {"unmapped_changed_files": diff.unsupported_files_total}
@@ -526,6 +550,17 @@ def _symbol_candidate(
     )
 
 
+def _history_summary_for_path(path: str, change_cards: list[ChangeCard]) -> tuple[int, list[str]]:
+    """Return ``(change_count, linked_reference_ids)`` for *path*.
+
+    Never a fabricated zero: callers only attach this when the overall
+    history-eligibility decision enabled the channel for this diff.
+    """
+    matching = [card for card in change_cards if path in card.changed_files]
+    references = sorted({ref.identifier for card in matching for ref in card.linked_references})
+    return len(matching), references
+
+
 def _build_diff_analysis(
     *,
     base_ref: str,
@@ -537,20 +572,55 @@ def _build_diff_analysis(
     coverage_evidence: list[CoverageFileEvidence],
     profile_evidence: list[RuntimeProfileEvidence],
     source_revision: str,
+    history_change_cards: list[ChangeCard],
+    history_coupling_observations: list[TemporalCouplingObservation],
+    history_provider_receipts: list[HistoryProviderReceipt],
 ) -> DiffAnalysis:
-    changed_files = [
-        DiffFileChange(
-            path=change.path,
-            status=change.status,
-            old_path=change.old_path,
-            handle=file_handle(change.path),
-            hunks=[
-                DiffHunk(start_line=start, end_line=end)
-                for start, end in hunks.get(change.path, [])
-            ],
+    history_eligibility: HistoryEligibilityDecision | None = None
+    if history_provider_receipts:
+        from archex.integrations.history.eligibility import evaluate_history_eligibility
+        from archex.integrations.history.models import HistoryEvidenceProviderName
+
+        git_log_receipt = next(
+            (
+                r
+                for r in history_provider_receipts
+                if r.provider == HistoryEvidenceProviderName.GIT_LOG
+            ),
+            None,
         )
-        for change in report.changed_files
-    ]
+        candidate_paths = {change.path for change in report.changed_files}
+        history_eligibility = evaluate_history_eligibility(
+            history_change_cards,
+            history_coupling_observations,
+            candidate_paths,
+            git_log_receipt=git_log_receipt,
+            window_commit_count=git_log_receipt.window_commit_count if git_log_receipt else 0,
+        )
+    history_enabled = history_eligibility is not None and history_eligibility.enabled
+
+    changed_files: list[DiffFileChange] = []
+    for change in report.changed_files:
+        history_change_count: int | None = None
+        history_linked_references: list[str] = []
+        if history_enabled:
+            history_change_count, history_linked_references = _history_summary_for_path(
+                change.path, history_change_cards
+            )
+        changed_files.append(
+            DiffFileChange(
+                path=change.path,
+                status=change.status,
+                old_path=change.old_path,
+                handle=file_handle(change.path),
+                hunks=[
+                    DiffHunk(start_line=start, end_line=end)
+                    for start, end in hunks.get(change.path, [])
+                ],
+                history_change_count=history_change_count,
+                history_linked_references=history_linked_references,
+            )
+        )
     changed_total = len(changed_files)
     changed_files = changed_files[:MAX_CHANGED_FILES]
 
@@ -615,6 +685,7 @@ def _build_diff_analysis(
         unsupported_files_total=unsupported_total,
         risk_level=report.risk.level,
         risk_reasons=report.risk.reasons,
+        history_eligibility=history_eligibility,
     )
 
 

--- a/src/archex/serve/generation.py
+++ b/src/archex/serve/generation.py
@@ -56,6 +56,7 @@ def _index_config_fingerprint(index_config: IndexConfig) -> str:
         index_config.identifier_fragment_tokenization,
         ",".join(index_config.semantic_evidence_providers),
         ",".join(index_config.runtime_evidence_providers),
+        ",".join(index_config.history_evidence_providers),
     )
     return "|".join(str(field) for field in fields)
 

--- a/tests/index/test_history_evidence_wiring.py
+++ b/tests/index/test_history_evidence_wiring.py
@@ -1,0 +1,79 @@
+"""Tests for M8's index_repository() wiring: cache metadata, generation
+fingerprint invalidation, and end-to-end repository-memory evidence
+persistence through a real index build.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from archex.api import index_repository
+from archex.index.store import IndexStore
+from archex.integrations.history.models import ProviderAvailability
+from archex.models import Config, IndexConfig, RepoSource
+
+
+class TestIndexRepositoryHistoryEvidenceWiring:
+    def test_default_config_produces_no_history_evidence(self, python_simple_repo: Path) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        store = index_repository(source, config=Config(cache=False), index_config=IndexConfig())
+        try:
+            assert store.get_history_provider_receipts() == []
+            assert store.get_history_change_cards() == []
+        finally:
+            store.close()
+
+    def test_enabled_git_log_provider_collects_real_commit_history(
+        self, python_simple_repo: Path
+    ) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        store = index_repository(
+            source,
+            config=Config(cache=False),
+            index_config=IndexConfig(history_evidence_providers=["git_log"]),
+        )
+        try:
+            receipts = store.get_history_provider_receipts()
+            assert len(receipts) == 1
+            assert receipts[0].availability == ProviderAvailability.AVAILABLE
+            assert receipts[0].window_commit_count >= 1
+            cards = store.get_history_change_cards()
+            assert len(cards) >= 1
+        finally:
+            store.close()
+
+    def test_enabled_operator_rationale_without_evidence_reports_unavailable(
+        self, python_simple_repo: Path
+    ) -> None:
+        source = RepoSource(local_path=str(python_simple_repo))
+        store = index_repository(
+            source,
+            config=Config(cache=False),
+            index_config=IndexConfig(history_evidence_providers=["operator_rationale"]),
+        )
+        try:
+            receipts = store.get_history_provider_receipts()
+            assert len(receipts) == 1
+            assert receipts[0].availability == ProviderAvailability.UNAVAILABLE
+            assert store.get_history_operator_rationale() == []
+        finally:
+            store.close()
+
+
+class TestIndexConfigMetadataCacheValidity:
+    def test_history_evidence_providers_change_invalidates_cache(self, tmp_path: Path) -> None:
+        from archex.api import (
+            _index_config_metadata_matches,  # pyright: ignore[reportPrivateUsage]
+            _set_index_config_metadata,  # pyright: ignore[reportPrivateUsage]
+        )
+
+        db_path = tmp_path / "index.db"
+        store = IndexStore(db_path)
+        try:
+            _set_index_config_metadata(store, IndexConfig(history_evidence_providers=[]))
+            assert _index_config_metadata_matches(store, IndexConfig(history_evidence_providers=[]))
+            assert not _index_config_metadata_matches(
+                store, IndexConfig(history_evidence_providers=["git_log"])
+            )
+        finally:
+            store.close()

--- a/tests/index/test_store.py
+++ b/tests/index/test_store.py
@@ -1258,3 +1258,114 @@ class TestRuntimeProviderReceipts:
         store.set_runtime_coverage_evidence([])
         assert store.get_runtime_provider_receipts() == []
         assert store.get_runtime_coverage_evidence() == []
+
+
+class TestHistoryProviderReceipts:
+    def test_empty_when_unset(self, store: IndexStore) -> None:
+        assert store.get_history_provider_receipts() == []
+        assert store.get_history_change_cards() == []
+        assert store.get_history_coupling_observations() == []
+        assert store.get_history_operator_rationale() == []
+
+    def test_round_trips_receipts(self, store: IndexStore) -> None:
+        from archex.integrations.history.models import (
+            HistoryEvidenceProviderName,
+            HistoryProviderReceipt,
+            ProviderAvailability,
+        )
+
+        receipts = [
+            HistoryProviderReceipt(
+                provider=HistoryEvidenceProviderName.GIT_LOG,
+                availability=ProviderAvailability.AVAILABLE,
+                expected_revision="abc123",
+                observed_revision="abc123",
+                window_commit_count=10,
+                records_collected=12,
+                collected_at="2026-01-01T00:00:00+00:00",
+            ),
+            HistoryProviderReceipt(
+                provider=HistoryEvidenceProviderName.OPERATOR_RATIONALE,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason="no operator rationale found",
+                collected_at="2026-01-01T00:00:00+00:00",
+            ),
+        ]
+        store.set_history_provider_receipts(receipts)
+        assert store.get_history_provider_receipts() == receipts
+
+    def test_round_trips_change_cards(self, store: IndexStore) -> None:
+        from archex.integrations.history.models import ChangeCard
+
+        cards = [
+            ChangeCard(
+                commit_sha="abc",
+                commit_subject="fix bug",
+                committed_at="2026-01-01T00:00:00+00:00",
+                changed_files=["a.py"],
+                revision="abc123",
+            )
+        ]
+        store.set_history_change_cards(cards)
+        assert store.get_history_change_cards() == cards
+
+    def test_round_trips_coupling_observations(self, store: IndexStore) -> None:
+        from archex.integrations.history.models import TemporalCouplingObservation
+
+        observations = [
+            TemporalCouplingObservation(
+                file_a="a.py",
+                file_b="b.py",
+                co_change_count=3,
+                window_commit_count=10,
+                revision="abc123",
+            )
+        ]
+        store.set_history_coupling_observations(observations)
+        assert store.get_history_coupling_observations() == observations
+
+    def test_round_trips_operator_rationale(self, store: IndexStore) -> None:
+        from archex.integrations.history.models import OperatorRationale
+
+        entries = [
+            OperatorRationale(
+                target_path="a.py",
+                rationale="chosen for legacy compatibility",
+                recorded_at="2026-01-01T00:00:00+00:00",
+                revision="abc123",
+            )
+        ]
+        store.set_history_operator_rationale(entries)
+        assert store.get_history_operator_rationale() == entries
+
+    def test_overwrites_prior_receipts_and_evidence(self, store: IndexStore) -> None:
+        from archex.integrations.history.models import (
+            ChangeCard,
+            HistoryEvidenceProviderName,
+            HistoryProviderReceipt,
+            ProviderAvailability,
+        )
+
+        store.set_history_provider_receipts(
+            [
+                HistoryProviderReceipt(
+                    provider=HistoryEvidenceProviderName.GIT_LOG,
+                    availability=ProviderAvailability.UNAVAILABLE,
+                    reason="not a git repo",
+                )
+            ]
+        )
+        store.set_history_change_cards(
+            [
+                ChangeCard(
+                    commit_sha="abc",
+                    commit_subject="s",
+                    committed_at="t",
+                    revision="abc123",
+                )
+            ]
+        )
+        store.set_history_provider_receipts([])
+        store.set_history_change_cards([])
+        assert store.get_history_provider_receipts() == []
+        assert store.get_history_change_cards() == []

--- a/tests/integrations/history/test_eligibility.py
+++ b/tests/integrations/history/test_eligibility.py
@@ -1,0 +1,165 @@
+"""Tests for the M8 repository-memory eligibility policy."""
+
+from __future__ import annotations
+
+import pytest
+
+from archex.integrations.history.eligibility import (
+    MIN_DENSITY,
+    MIN_LINKAGE,
+    MIN_RELEVANCE,
+    HistoryEligibilityDecision,
+    evaluate_history_eligibility,
+)
+from archex.integrations.history.models import (
+    ChangeCard,
+    HistoryEvidenceProviderName,
+    HistoryProviderReceipt,
+    ProviderAvailability,
+    TemporalCouplingObservation,
+)
+
+
+def _card(commit_sha: str, changed_files: list[str]) -> ChangeCard:
+    return ChangeCard(
+        commit_sha=commit_sha,
+        commit_subject="s",
+        committed_at="t",
+        changed_files=changed_files,
+        revision="rev",
+    )
+
+
+def _available_receipt(window_commit_count: int) -> HistoryProviderReceipt:
+    return HistoryProviderReceipt(
+        provider=HistoryEvidenceProviderName.GIT_LOG,
+        availability=ProviderAvailability.AVAILABLE,
+        window_commit_count=window_commit_count,
+    )
+
+
+class TestHistoryEligibilityDecision:
+    def test_rejects_out_of_range_score(self) -> None:
+        with pytest.raises(ValueError, match="density_score"):
+            HistoryEligibilityDecision(
+                enabled=True, density_score=1.5, linkage_score=0.5, relevance_score=0.5
+            )
+
+    def test_reason_required_when_disabled(self) -> None:
+        with pytest.raises(ValueError, match="reason"):
+            HistoryEligibilityDecision(
+                enabled=False, density_score=0.1, linkage_score=0.1, relevance_score=0.1
+            )
+
+
+class TestEvaluateHistoryEligibility:
+    def test_disabled_when_git_log_receipt_missing(self) -> None:
+        decision = evaluate_history_eligibility(
+            [], [], set(), git_log_receipt=None, window_commit_count=0
+        )
+        assert decision.enabled is False
+        assert "unavailable" in decision.reason
+
+    def test_disabled_when_git_log_receipt_unavailable(self) -> None:
+        receipt = HistoryProviderReceipt(
+            provider=HistoryEvidenceProviderName.GIT_LOG,
+            availability=ProviderAvailability.UNAVAILABLE,
+            reason="not a git repo",
+        )
+        decision = evaluate_history_eligibility(
+            [], [], set(), git_log_receipt=receipt, window_commit_count=0
+        )
+        assert decision.enabled is False
+        assert "not a git repo" in decision.reason
+
+    def test_disabled_below_density_threshold(self) -> None:
+        # 1 change card in a 100-commit window -> density far below threshold.
+        cards = [_card("c1", ["a.py"])]
+        decision = evaluate_history_eligibility(
+            cards,
+            [],
+            {"a.py"},
+            git_log_receipt=_available_receipt(100),
+            window_commit_count=100,
+        )
+        assert decision.enabled is False
+        assert "density" in decision.reason
+
+    def test_disabled_below_linkage_threshold(self) -> None:
+        # Dense window, but files never co-change -> zero linkage.
+        cards = [_card(f"c{i}", [f"f{i}.py"]) for i in range(10)]
+        decision = evaluate_history_eligibility(
+            cards,
+            [],
+            {"f0.py"},
+            git_log_receipt=_available_receipt(10),
+            window_commit_count=10,
+        )
+        assert decision.enabled is False
+        assert "linkage" in decision.reason
+
+    def test_disabled_below_relevance_threshold(self) -> None:
+        cards = [_card("c1", ["a.py", "b.py"]), _card("c2", ["a.py", "b.py"])]
+        coupling = [
+            TemporalCouplingObservation(
+                file_a="a.py",
+                file_b="b.py",
+                co_change_count=2,
+                window_commit_count=2,
+                revision="rev",
+            )
+        ]
+        # candidate files are entirely unrelated to the collected history.
+        decision = evaluate_history_eligibility(
+            cards,
+            coupling,
+            {"unrelated.py"},
+            git_log_receipt=_available_receipt(2),
+            window_commit_count=2,
+        )
+        assert decision.enabled is False
+        assert "relevance" in decision.reason
+
+    def test_enabled_when_all_thresholds_clear(self) -> None:
+        cards = [_card("c1", ["a.py", "b.py"]), _card("c2", ["a.py", "b.py"])]
+        coupling = [
+            TemporalCouplingObservation(
+                file_a="a.py",
+                file_b="b.py",
+                co_change_count=2,
+                window_commit_count=2,
+                revision="rev",
+            )
+        ]
+        decision = evaluate_history_eligibility(
+            cards,
+            coupling,
+            {"a.py"},
+            git_log_receipt=_available_receipt(2),
+            window_commit_count=2,
+        )
+        assert decision.enabled is True
+        assert decision.density_score >= MIN_DENSITY
+        assert decision.linkage_score >= MIN_LINKAGE
+        assert decision.relevance_score >= MIN_RELEVANCE
+
+    def test_empty_candidate_paths_yields_zero_relevance(self) -> None:
+        cards = [_card("c1", ["a.py", "b.py"]), _card("c2", ["a.py", "b.py"])]
+        coupling = [
+            TemporalCouplingObservation(
+                file_a="a.py",
+                file_b="b.py",
+                co_change_count=2,
+                window_commit_count=2,
+                revision="rev",
+            )
+        ]
+        decision = evaluate_history_eligibility(
+            cards,
+            coupling,
+            set(),
+            git_log_receipt=_available_receipt(2),
+            window_commit_count=2,
+        )
+        assert decision.enabled is False
+        assert decision.relevance_score == 0.0

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -221,6 +221,25 @@ class TestComputeGenerationId:
         )
         assert a != b
 
+    def test_history_evidence_providers_change_changes_id(self) -> None:
+        a = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(history_evidence_providers=[]),
+        )
+        b = compute_generation_id(
+            schema_version="5",
+            commit_hash="abc123",
+            working_tree_signature="clean",
+            file_count=3,
+            chunk_count=10,
+            index_config=IndexConfig(history_evidence_providers=["git_log"]),
+        )
+        assert a != b
+
     def test_vector_mode_changes_id(self) -> None:
         raw = compute_generation_id(
             schema_version="5",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -790,6 +790,17 @@ class TestIndexConfigValidation:
         with pytest.raises(ValueError, match="unknown entries"):
             IndexConfig(runtime_evidence_providers=["coverage", "bogus"])
 
+    def test_history_evidence_providers_defaults_empty(self) -> None:
+        assert IndexConfig().history_evidence_providers == []
+
+    def test_history_evidence_providers_accepts_known_names(self) -> None:
+        config = IndexConfig(history_evidence_providers=["git_log", "operator_rationale"])
+        assert config.history_evidence_providers == ["git_log", "operator_rationale"]
+
+    def test_history_evidence_providers_rejects_unknown_name(self) -> None:
+        with pytest.raises(ValueError, match="unknown entries"):
+            IndexConfig(history_evidence_providers=["git_log", "bogus"])
+
     def test_quantize_bits_must_be_supported(self) -> None:
         with pytest.raises(ValueError, match="quantize_bits must be one of"):
             IndexConfig(quantize_bits=8)

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+from archex.integrations.history.eligibility import evaluate_history_eligibility
+from archex.integrations.history.models import (
+    ChangeCard,
+    HistoryEvidenceProviderName,
+    HistoryProviderReceipt,
+)
+from archex.integrations.history.models import ProviderAvailability as HistoryProviderAvailability
 from archex.integrations.runtime.models import (
     ProviderAvailability as RuntimeProviderAvailability,
 )
@@ -13,6 +20,7 @@ from archex.integrations.semantic.models import (
     SemanticProviderReceipt,
 )
 from archex.models import (
+    CodeChunk,
     CompressionLossRisk,
     CompressionMetadata,
     CompressionMode,
@@ -30,6 +38,7 @@ from archex.models import (
     Edge,
     EdgeConfidence,
     EdgeKind,
+    RankedChunk,
 )
 from archex.receipt import (
     build_context_receipt,
@@ -279,6 +288,92 @@ def test_build_context_receipt_defaults_runtime_providers_empty() -> None:
     bundle = ContextBundle(query="q", token_count=10, token_budget=100)
     receipt = build_context_receipt(bundle, index_revision="rev", freshness=ContextFreshness.CLEAN)
     assert receipt.runtime_providers == []
+
+
+def test_build_context_receipt_carries_history_providers() -> None:
+    bundle = ContextBundle(query="q", token_count=10, token_budget=100)
+    receipts = [
+        HistoryProviderReceipt(
+            provider=HistoryEvidenceProviderName.GIT_LOG,
+            availability=HistoryProviderAvailability.AVAILABLE,
+            window_commit_count=5,
+            records_collected=5,
+        )
+    ]
+
+    receipt = build_context_receipt(
+        bundle,
+        index_revision="rev",
+        freshness=ContextFreshness.CLEAN,
+        history_providers=receipts,
+    )
+
+    assert receipt.history_providers == receipts
+
+
+def test_build_context_receipt_defaults_history_providers_empty_and_no_eligibility() -> None:
+    bundle = ContextBundle(query="q", token_count=10, token_budget=100)
+    receipt = build_context_receipt(bundle, index_revision="rev", freshness=ContextFreshness.CLEAN)
+    assert receipt.history_providers == []
+    assert receipt.history_eligibility is None
+
+
+def _bundle_with_chunk(file_path: str) -> ContextBundle:
+    chunk = CodeChunk(
+        id="c1",
+        content="x = 1",
+        file_path=file_path,
+        start_line=1,
+        end_line=1,
+        language="python",
+    )
+    return ContextBundle(
+        query="q",
+        token_count=10,
+        token_budget=100,
+        chunks=[RankedChunk(chunk=chunk, final_score=1.0)],
+    )
+
+
+def test_build_context_receipt_computes_history_eligibility_when_providers_present() -> None:
+    bundle = _bundle_with_chunk("a.py")
+    git_log_receipt = HistoryProviderReceipt(
+        provider=HistoryEvidenceProviderName.GIT_LOG,
+        availability=HistoryProviderAvailability.AVAILABLE,
+        window_commit_count=2,
+        records_collected=2,
+    )
+    cards = [
+        ChangeCard(
+            commit_sha="c1",
+            commit_subject="s",
+            committed_at="t",
+            changed_files=["a.py"],
+            revision="rev",
+        ),
+        ChangeCard(
+            commit_sha="c2",
+            commit_subject="s",
+            committed_at="t",
+            changed_files=["a.py"],
+            revision="rev",
+        ),
+    ]
+
+    receipt = build_context_receipt(
+        bundle,
+        index_revision="rev",
+        freshness=ContextFreshness.CLEAN,
+        history_providers=[git_log_receipt],
+        history_change_cards=cards,
+    )
+
+    assert receipt.history_eligibility is not None
+    expected = evaluate_history_eligibility(
+        cards, [], {"a.py"}, git_log_receipt=git_log_receipt, window_commit_count=2
+    )
+    assert receipt.history_eligibility.enabled == expected.enabled
+    assert receipt.history_eligibility.density_score == expected.density_score
 
 
 def test_receipt_edge_from_edge_helper_propagates_provider() -> None:

--- a/tests/test_report_artifact.py
+++ b/tests/test_report_artifact.py
@@ -318,3 +318,77 @@ def test_runtime_sample_count_for_symbol_matches_file_and_qualified_name() -> No
 
     count, revision, stale = _runtime_sample_count_for_symbol("c.py", None, records, "rev-a")
     assert (count, revision, stale) == (None, None, False)
+
+
+def test_history_disabled_by_default_with_sparse_real_repo(
+    impact_diff_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """M8: a real (but commit-sparse) repo enables the git_log provider and
+    successfully collects real evidence (AVAILABLE receipt), but the
+    eligibility policy disables exposure because density is far below
+    threshold -- proving sparse-history results carry no hidden change.
+    """
+    _edit_hub(impact_diff_repo)
+
+    from archex.config import load_index_config as original_load_index_config
+    from archex.models import IndexConfig, RepoSource
+
+    def _patched_load_index_config(source: RepoSource) -> IndexConfig:
+        config = original_load_index_config(source)
+        return config.model_copy(update={"history_evidence_providers": ["git_log"]})
+
+    monkeypatch.setattr("archex.report.artifact.load_index_config", _patched_load_index_config)
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+
+    assert artifact.diff.history_eligibility is not None
+    assert artifact.diff.history_eligibility.enabled is False
+    for change in artifact.diff.changed_files:
+        assert change.history_change_count is None
+        assert change.history_linked_references == []
+
+
+def test_history_eligibility_absent_when_channel_unconfigured(impact_diff_repo: Path) -> None:
+    _edit_hub(impact_diff_repo)
+    artifact = build_analysis_artifact(impact_diff_repo, base_ref="HEAD")
+    assert artifact.diff.history_eligibility is None
+
+
+def test_history_summary_for_path_counts_matching_cards_and_references() -> None:
+    from archex.integrations.history.models import ChangeCard, LinkedReference
+    from archex.report.artifact import (
+        _history_summary_for_path,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    cards = [
+        ChangeCard(
+            commit_sha="c1",
+            commit_subject="s",
+            committed_at="t",
+            changed_files=["a.py", "b.py"],
+            linked_references=[LinkedReference(raw_text="#1", identifier="1")],
+            revision="rev",
+        ),
+        ChangeCard(
+            commit_sha="c2",
+            commit_subject="s",
+            committed_at="t",
+            changed_files=["a.py"],
+            linked_references=[LinkedReference(raw_text="#2", identifier="2")],
+            revision="rev",
+        ),
+        ChangeCard(
+            commit_sha="c3",
+            commit_subject="s",
+            committed_at="t",
+            changed_files=["b.py"],
+            revision="rev",
+        ),
+    ]
+
+    count, references = _history_summary_for_path("a.py", cards)
+    assert count == 2
+    assert references == ["1", "2"]
+
+    count, references = _history_summary_for_path("missing.py", cards)
+    assert count == 0
+    assert references == []


### PR DESCRIPTION
## Stack

Stack-Id: `m8-repository-memory-10606e`
Base: `m8-1-history-evidence-model` (#557)
Position: 2/3

1. `m8-1-history-evidence-model` -> #557
2. `m8-2-eligibility-and-receipts` -> this PR
3. `m8-3-history-evaluation` -> next

Depends on: #557
Upstack: (next PR in stack)

## Summary

M8 (Add Conditional Repository-Memory Evidence), PR 2/3: the density/linkage/relevance eligibility policy, wired into the index pipeline, cache validity, query receipts, and the read-only diff-review artifact, gated entirely by `IndexConfig.history_evidence_providers` (default empty — fully disabled).

- `archex.integrations.history.eligibility`: `evaluate_history_eligibility()` — history is collected unconditionally once `git_log` is enabled, but surfacing is gated on three predeclared thresholds (density/linkage/relevance) computed against the operation's own candidate file set. Any miss (or a missing/unavailable `git_log` receipt) produces an explicit `HistoryEligibilityDecision(enabled=False, reason=...)`.
- `models.py`: `IndexConfig.history_evidence_providers`, `ContextReceipt.history_providers`/`.history_eligibility`.
- `index/store.py`: `IndexStore` persistence for provider receipts, change cards, coupling observations, and operator rationale.
- `api.py`: wires `collect_history_evidence()` into every full-index-build path; adds `history_evidence_providers` to cache-metadata match/set; threads raw history evidence through every `query()` return path (eligibility itself is computed downstream in `build_context_receipt()`).
- `serve/generation.py`: `history_evidence_providers` is part of the generation fingerprint.
- `receipt.py`: `build_context_receipt()` computes `ContextReceipt.history_eligibility` from raw evidence + the bundle's own returned files.
- `report/artifact.py`: `DiffFileChange`/`DiffAnalysis` gain revision-bound history change-count/linked-reference/eligibility fields, populated only when the diff's own eligibility decision enables the channel.

## Verification

- `uv run ruff check .` / `uv run ruff format --check .`: clean (whole repo).
- `uv run pyright .`: 0 errors (whole repo).
- `uv run pytest --junitxml=results.xml --cov-report=xml`: **4342 passed**, 91.39% coverage (repo gate: 85%).
- Targeted new-test run covering eligibility, store round-trip, receipt, generation, wiring, and artifact tests: all green.
