### PR TITLE
feat(docs): add typed documentation evidence relations (M9 PR-1)

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -130,6 +130,7 @@ if TYPE_CHECKING:
 
     from archex.index.embeddings.base import Embedder
     from archex.index.rerank import CrossEncoderReranker
+    from archex.integrations.docs.models import DocProviderReceipt
     from archex.integrations.history.models import (
         ChangeCard,
         HistoryProviderReceipt,
@@ -175,7 +176,10 @@ def _index_config_metadata_matches(store: IndexStore, index_config: IndexConfig)
     if stored_runtime_providers != ",".join(index_config.runtime_evidence_providers):
         return False
     stored_history_providers = store.get_metadata("history_evidence_providers") or ""
-    return stored_history_providers == ",".join(index_config.history_evidence_providers)
+    if stored_history_providers != ",".join(index_config.history_evidence_providers):
+        return False
+    stored_documentation_providers = store.get_metadata("documentation_evidence_providers") or ""
+    return stored_documentation_providers == ",".join(index_config.documentation_evidence_providers)
 
 
 def _set_index_config_metadata(store: IndexStore, index_config: IndexConfig) -> None:
@@ -191,6 +195,10 @@ def _set_index_config_metadata(store: IndexStore, index_config: IndexConfig) -> 
     )
     store.set_metadata(
         "history_evidence_providers", ",".join(index_config.history_evidence_providers)
+    )
+    store.set_metadata(
+        "documentation_evidence_providers",
+        ",".join(index_config.documentation_evidence_providers),
     )
 
 
@@ -311,6 +319,26 @@ def _full_index(
                 store.set_history_coupling_observations(history_coupling_observations)
                 store.set_history_operator_rationale(history_rationale)
                 store.set_history_provider_receipts(history_receipts)
+            if effective_index_config.documentation_evidence_providers:
+                from archex.index.documentation_evidence import collect_documentation_evidence
+
+                documentation_revision = (
+                    cloned_head or cache.git_head(source.local_path) or source.commit or ""
+                )
+                (
+                    documentation_links,
+                    documentation_adr_records,
+                    documentation_ownership_records,
+                    documentation_receipts,
+                ) = collect_documentation_evidence(
+                    repo_path,
+                    effective_index_config.documentation_evidence_providers,
+                    expected_revision=documentation_revision,
+                )
+                store.set_documentation_links(documentation_links)
+                store.set_documentation_adr_records(documentation_adr_records)
+                store.set_documentation_ownership_records(documentation_ownership_records)
+                store.set_documentation_provider_receipts(documentation_receipts)
             edges = graph.file_edges()
             store.replace_file_states(compute_file_states(repo_path, files))
             store.insert_edges(edges)
@@ -1583,6 +1611,7 @@ def _refresh_receipt(
     history_providers: list[HistoryProviderReceipt] | None = None,
     history_change_cards: list[ChangeCard] | None = None,
     history_coupling_observations: list[TemporalCouplingObservation] | None = None,
+    documentation_providers: list[DocProviderReceipt] | None = None,
 ) -> None:
     skipped = list(bundle.receipt.skipped_candidates) if bundle.receipt is not None else []
     if freshness != ContextFreshness.CLEAN:
@@ -1606,6 +1635,11 @@ def _refresh_receipt(
         if history_providers is not None
         else (bundle.receipt.history_providers if bundle.receipt is not None else [])
     )
+    resolved_documentation_providers = (
+        documentation_providers
+        if documentation_providers is not None
+        else (bundle.receipt.documentation_providers if bundle.receipt is not None else [])
+    )
     bundle.receipt = build_context_receipt(
         bundle,
         index_revision=index_revision,
@@ -1618,6 +1652,7 @@ def _refresh_receipt(
         history_providers=resolved_history_providers,
         history_change_cards=history_change_cards or [],
         history_coupling_observations=history_coupling_observations or [],
+        documentation_providers=resolved_documentation_providers,
     )
 
 
@@ -1640,6 +1675,7 @@ def _finalize_context_bundle(
     history_providers: list[HistoryProviderReceipt] | None = None,
     history_change_cards: list[ChangeCard] | None = None,
     history_coupling_observations: list[TemporalCouplingObservation] | None = None,
+    documentation_providers: list[DocProviderReceipt] | None = None,
 ) -> ContextBundle:
     _attach_vector_metadata(bundle, index_config)
     _attach_index_metadata(
@@ -1680,6 +1716,7 @@ def _finalize_context_bundle(
         history_providers=history_providers,
         history_change_cards=history_change_cards,
         history_coupling_observations=history_coupling_observations,
+        documentation_providers=documentation_providers,
     )
     return bundle
 
@@ -2232,6 +2269,7 @@ def query(
                     history_providers=search_store.get_history_provider_receipts(),
                     history_change_cards=search_store.get_history_change_cards(),
                     history_coupling_observations=search_store.get_history_coupling_observations(),
+                    documentation_providers=search_store.get_documentation_provider_receipts(),
                 )
             finally:
                 store.close()
@@ -2390,6 +2428,27 @@ def query(
                 store.set_history_coupling_observations(history_coupling_observations)
                 store.set_history_operator_rationale(history_rationale)
                 store.set_history_provider_receipts(history_receipts)
+            documentation_receipts: list[DocProviderReceipt] = []
+            if index_config.documentation_evidence_providers:
+                from archex.index.documentation_evidence import collect_documentation_evidence
+
+                documentation_revision = (
+                    cloned_head or cache.git_head(source.local_path) or source.commit or ""
+                )
+                (
+                    documentation_links,
+                    documentation_adr_records,
+                    documentation_ownership_records,
+                    documentation_receipts,
+                ) = collect_documentation_evidence(
+                    repo_path,
+                    index_config.documentation_evidence_providers,
+                    expected_revision=documentation_revision,
+                )
+                store.set_documentation_links(documentation_links)
+                store.set_documentation_adr_records(documentation_adr_records)
+                store.set_documentation_ownership_records(documentation_ownership_records)
+                store.set_documentation_provider_receipts(documentation_receipts)
             edges = graph.file_edges()
             from archex.index.delta import compute_file_states
 
@@ -2533,6 +2592,7 @@ def query(
                     history_providers=history_receipts,
                     history_change_cards=history_change_cards,
                     history_coupling_observations=history_coupling_observations,
+                    documentation_providers=documentation_receipts,
                 )
                 return pt
 
@@ -2686,6 +2746,7 @@ def query(
             history_providers=history_receipts,
             history_change_cards=history_change_cards,
             history_coupling_observations=history_coupling_observations,
+            documentation_providers=documentation_receipts,
         )
     finally:
         cleanup()

--- a/src/archex/index/documentation_evidence.py
+++ b/src/archex/index/documentation_evidence.py
@@ -1,0 +1,166 @@
+"""Conditional documentation-graph evidence collection (M9): dispatch configured providers.
+
+Zero-cost when no provider names are requested (the default): no provider
+module import happens beyond this module's own top-level imports, and no
+provider runs. Enabling a provider by name runs it against the given
+repository root and revision, and folds every non-``AVAILABLE`` outcome
+(unavailable or partial) into an explicit receipt rather than a silent gap.
+
+Kept structurally separate from ``archex.index.semantic_evidence`` (M6),
+``archex.index.runtime_evidence`` (M7), and ``archex.index.history_evidence``
+(M8): every conditional evidence channel is independently disableable and
+independently rollback-able, so none of them import or depend on each
+other. Collected documentation, ADR, and ownership evidence is never
+folded into ``DependencyGraph`` -- it is stored and surfaced separately
+from code-dependency edges.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+from typing import TYPE_CHECKING
+
+from archex.integrations.docs.adr_provider import AdrProvider
+from archex.integrations.docs.doc_link_provider import DocLinkProvider
+from archex.integrations.docs.models import (
+    DocEvidenceProviderName,
+    DocProviderReceipt,
+    ProviderAvailability,
+)
+from archex.integrations.docs.ownership_provider import OwnershipProvider
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from archex.integrations.docs.models import AdrRecord, DocumentationLink, OwnershipRecord
+    from archex.integrations.docs.provider import (
+        AdrEvidenceProvider,
+        DocLinkEvidenceProvider,
+        OwnershipEvidenceProvider,
+    )
+
+logger = logging.getLogger(__name__)
+
+#: Provider names accepted by ``IndexConfig.documentation_evidence_providers``.
+KNOWN_DOCUMENTATION_EVIDENCE_PROVIDERS = frozenset({"doc_link", "adr", "ownership"})
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(tz=_dt.UTC).isoformat()
+
+
+def _collect_doc_link(
+    provider: DocLinkEvidenceProvider, repo_root: Path, expected_revision: str
+) -> tuple[list[DocumentationLink], DocProviderReceipt]:
+    try:
+        return provider.collect(repo_root, expected_revision=expected_revision)
+    except Exception as exc:
+        logger.warning(
+            "documentation evidence provider 'doc_link' raised during collect()", exc_info=True
+        )
+        return [], DocProviderReceipt(
+            provider=DocEvidenceProviderName.DOC_LINK,
+            availability=ProviderAvailability.UNAVAILABLE,
+            reason=f"provider raised {type(exc).__name__}: {exc}",
+            expected_revision=expected_revision,
+            collected_at=_now_iso(),
+        )
+
+
+def _collect_adr(
+    provider: AdrEvidenceProvider, repo_root: Path, expected_revision: str
+) -> tuple[list[AdrRecord], DocProviderReceipt]:
+    try:
+        return provider.collect(repo_root, expected_revision=expected_revision)
+    except Exception as exc:
+        logger.warning(
+            "documentation evidence provider 'adr' raised during collect()", exc_info=True
+        )
+        return [], DocProviderReceipt(
+            provider=DocEvidenceProviderName.ADR,
+            availability=ProviderAvailability.UNAVAILABLE,
+            reason=f"provider raised {type(exc).__name__}: {exc}",
+            expected_revision=expected_revision,
+            collected_at=_now_iso(),
+        )
+
+
+def _collect_ownership(
+    provider: OwnershipEvidenceProvider, repo_root: Path, expected_revision: str
+) -> tuple[list[OwnershipRecord], DocProviderReceipt]:
+    try:
+        return provider.collect(repo_root, expected_revision=expected_revision)
+    except Exception as exc:
+        logger.warning(
+            "documentation evidence provider 'ownership' raised during collect()", exc_info=True
+        )
+        return [], DocProviderReceipt(
+            provider=DocEvidenceProviderName.OWNERSHIP,
+            availability=ProviderAvailability.UNAVAILABLE,
+            reason=f"provider raised {type(exc).__name__}: {exc}",
+            expected_revision=expected_revision,
+            collected_at=_now_iso(),
+        )
+
+
+def collect_documentation_evidence(
+    repo_root: Path,
+    provider_names: list[str],
+    *,
+    expected_revision: str,
+    doc_link_provider: DocLinkEvidenceProvider | None = None,
+    adr_provider: AdrEvidenceProvider | None = None,
+    ownership_provider: OwnershipEvidenceProvider | None = None,
+) -> tuple[
+    list[DocumentationLink],
+    list[AdrRecord],
+    list[OwnershipRecord],
+    list[DocProviderReceipt],
+]:
+    """Run every provider named in *provider_names* against *repo_root*.
+
+    Returns ``([], [], [], [])`` immediately when *provider_names* is empty
+    -- the default path adds no cost. *expected_revision* labels every
+    collected record; every provider reads only the current working tree,
+    so no staleness comparison against a separately-collected manifest
+    applies here (unlike M7's coverage/profile evidence or M8's operator
+    rationale). *doc_link_provider*/*adr_provider*/*ownership_provider* let
+    a caller inject an already-configured provider; the corresponding
+    stock provider is used when omitted.
+
+    A provider must never raise for ordinary unavailability, but this is an
+    external boundary (a built-in provider's own bug, or a caller-injected
+    custom provider), so every ``collect()`` call is defended here: an
+    unexpected exception degrades that one provider to an explicit
+    ``UNAVAILABLE`` receipt rather than aborting the entire index build.
+    """
+    if not provider_names:
+        return [], [], [], []
+    unknown = set(provider_names) - KNOWN_DOCUMENTATION_EVIDENCE_PROVIDERS
+    if unknown:
+        raise ValueError(f"unknown documentation evidence providers: {sorted(unknown)}")
+
+    doc_links: list[DocumentationLink] = []
+    adr_records: list[AdrRecord] = []
+    ownership_records: list[OwnershipRecord] = []
+    receipts: list[DocProviderReceipt] = []
+
+    if "doc_link" in provider_names:
+        resolved_doc_link = doc_link_provider or DocLinkProvider()
+        doc_links, doc_link_receipt = _collect_doc_link(
+            resolved_doc_link, repo_root, expected_revision
+        )
+        receipts.append(doc_link_receipt)
+    if "adr" in provider_names:
+        resolved_adr = adr_provider or AdrProvider()
+        adr_records, adr_receipt = _collect_adr(resolved_adr, repo_root, expected_revision)
+        receipts.append(adr_receipt)
+    if "ownership" in provider_names:
+        resolved_ownership = ownership_provider or OwnershipProvider()
+        ownership_records, ownership_receipt = _collect_ownership(
+            resolved_ownership, repo_root, expected_revision
+        )
+        receipts.append(ownership_receipt)
+
+    return doc_links, adr_records, ownership_records, receipts

--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -9,6 +9,12 @@ import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+from archex.integrations.docs.models import (
+    AdrRecord,
+    DocProviderReceipt,
+    DocumentationLink,
+    OwnershipRecord,
+)
 from archex.integrations.history.models import (
     ChangeCard,
     HistoryProviderReceipt,
@@ -43,6 +49,10 @@ _HISTORY_PROVIDER_RECEIPTS_KEY = "history_provider_receipts"
 _HISTORY_CHANGE_CARDS_KEY = "history_change_cards"
 _HISTORY_COUPLING_OBSERVATIONS_KEY = "history_coupling_observations"
 _HISTORY_OPERATOR_RATIONALE_KEY = "history_operator_rationale"
+_DOCUMENTATION_PROVIDER_RECEIPTS_KEY = "documentation_provider_receipts"
+_DOCUMENTATION_LINKS_KEY = "documentation_links"
+_DOCUMENTATION_ADR_RECORDS_KEY = "documentation_adr_records"
+_DOCUMENTATION_OWNERSHIP_RECORDS_KEY = "documentation_ownership_records"
 
 logger = logging.getLogger(__name__)
 
@@ -992,6 +1002,80 @@ class IndexStore:
         if not raw:
             return []
         return [OperatorRationale.model_validate(item) for item in json.loads(raw)]
+
+    def set_documentation_provider_receipts(self, receipts: list[DocProviderReceipt]) -> None:
+        """Persist the M9 conditional documentation-graph provider receipts for this build."""
+        self.set_metadata(
+            _DOCUMENTATION_PROVIDER_RECEIPTS_KEY,
+            json.dumps([r.model_dump(mode="json") for r in receipts], sort_keys=True),
+        )
+
+    def get_documentation_provider_receipts(self) -> list[DocProviderReceipt]:
+        """Return the persisted M9 documentation-graph provider receipts, if any.
+
+        Empty when no documentation provider was configured for this build —
+        a store built before M9 or with ``documentation_evidence_providers``
+        unset has no receipts, which is a fully expected, honest empty
+        result, not an error.
+        """
+        raw = self.get_metadata(_DOCUMENTATION_PROVIDER_RECEIPTS_KEY)
+        if not raw:
+            return []
+        return [DocProviderReceipt.model_validate(item) for item in json.loads(raw)]
+
+    def set_documentation_links(self, links: list[DocumentationLink]) -> None:
+        """Persist the M9 revision-bound markdown documentation links for this build."""
+        self.set_metadata(
+            _DOCUMENTATION_LINKS_KEY,
+            json.dumps([link.model_dump(mode="json") for link in links], sort_keys=True),
+        )
+
+    def get_documentation_links(self) -> list[DocumentationLink]:
+        """Return the persisted M9 documentation links, if any.
+
+        Empty when the doc_link provider was not configured or produced no
+        available evidence for this build.
+        """
+        raw = self.get_metadata(_DOCUMENTATION_LINKS_KEY)
+        if not raw:
+            return []
+        return [DocumentationLink.model_validate(item) for item in json.loads(raw)]
+
+    def set_documentation_adr_records(self, records: list[AdrRecord]) -> None:
+        """Persist the M9 revision-bound architecture-decision-record evidence for this build."""
+        self.set_metadata(
+            _DOCUMENTATION_ADR_RECORDS_KEY,
+            json.dumps([r.model_dump(mode="json") for r in records], sort_keys=True),
+        )
+
+    def get_documentation_adr_records(self) -> list[AdrRecord]:
+        """Return the persisted M9 ADR records, if any.
+
+        Empty when the adr provider was not configured or produced no
+        available evidence for this build.
+        """
+        raw = self.get_metadata(_DOCUMENTATION_ADR_RECORDS_KEY)
+        if not raw:
+            return []
+        return [AdrRecord.model_validate(item) for item in json.loads(raw)]
+
+    def set_documentation_ownership_records(self, records: list[OwnershipRecord]) -> None:
+        """Persist the M9 revision-bound CODEOWNERS-style ownership evidence for this build."""
+        self.set_metadata(
+            _DOCUMENTATION_OWNERSHIP_RECORDS_KEY,
+            json.dumps([r.model_dump(mode="json") for r in records], sort_keys=True),
+        )
+
+    def get_documentation_ownership_records(self) -> list[OwnershipRecord]:
+        """Return the persisted M9 ownership records, if any.
+
+        Empty when the ownership provider was not configured or produced no
+        available evidence for this build.
+        """
+        raw = self.get_metadata(_DOCUMENTATION_OWNERSHIP_RECORDS_KEY)
+        if not raw:
+            return []
+        return [OwnershipRecord.model_validate(item) for item in json.loads(raw)]
 
     def needs_reindex(self) -> bool:
         """Return True if the store contains chunks without symbol_ids (pre-stable-ID data)."""

--- a/src/archex/integrations/docs/_markdown.py
+++ b/src/archex/integrations/docs/_markdown.py
@@ -1,0 +1,63 @@
+"""Shared local-markdown-link extraction used by the doc_link and adr providers.
+
+Internal helper module: never imported outside ``archex.integrations.docs``.
+Extraction is purely local-text regex matching against files already on
+disk -- no network access, no remote link resolution, and no fabrication of
+a relation to a path that does not exist under the repository root.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+#: Matches ``[text](target)`` markdown links. Deliberately does not match
+#: reference-style links (``[text][ref]``) or bare autolinks -- the common,
+#: unambiguous case is sufficient local evidence without a full CommonMark
+#: parser dependency.
+_LINK_PATTERN = re.compile(r"\[([^\]\n]+)\]\(([^)\s]+)\)")
+
+#: Bounds how many candidate links one document contributes, keeping a
+#: pathological document (a huge generated index page) from dominating a
+#: run's evidence set.
+MAX_LINKS_PER_DOCUMENT = 200
+
+
+def extract_markdown_links(doc_path: Path, repo_root: Path) -> list[tuple[str, str]]:
+    """Return ``(link_text, target_path)`` pairs for links in *doc_path* that
+    resolve to a real file under *repo_root*.
+
+    ``target_path`` is repo-root-relative with POSIX separators. Remote
+    URLs, mailto links, and in-page anchors are never resolved or recorded.
+    A link resolved relative to *doc_path*'s own directory first, falling
+    back to resolution relative to *repo_root* (both are conventional
+    markdown-link resolution bases); any target escaping *repo_root* is
+    discarded.
+    """
+    try:
+        text = doc_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return []
+
+    results: list[tuple[str, str]] = []
+    for link_text, raw_target in _LINK_PATTERN.findall(text)[:MAX_LINKS_PER_DOCUMENT]:
+        resolved = _resolve_link_target(raw_target, doc_path=doc_path, repo_root=repo_root)
+        if resolved is not None:
+            results.append((link_text.strip(), resolved))
+    return results
+
+
+def _resolve_link_target(raw_target: str, *, doc_path: Path, repo_root: Path) -> str | None:
+    target = raw_target.split("#", maxsplit=1)[0].strip()
+    if not target or "://" in target or target.startswith(("mailto:", "#")):
+        return None
+
+    for base in (doc_path.parent, repo_root):
+        candidate = (base / target).resolve()
+        try:
+            relative = candidate.relative_to(repo_root.resolve())
+        except ValueError:
+            continue
+        if candidate.is_file():
+            return relative.as_posix()
+    return None

--- a/src/archex/integrations/docs/adr_provider.py
+++ b/src/archex/integrations/docs/adr_provider.py
@@ -1,0 +1,149 @@
+"""ADR evidence provider: reads local architecture-decision-records already on disk.
+
+Scans a bounded, conventional set of ADR directories (``docs/adr``,
+``.docs/adr``, ``doc/adr``, ``adr``) for markdown files and reads each
+file's title, declared status text, and referenced source paths. Status is
+read verbatim from the document (for example ``"Accepted"`` or
+``"Superseded"``) -- never inferred, normalized, or scored. A repository
+with no ADR directory is a fully expected, honest ``UNAVAILABLE`` outcome,
+not an error.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from pathlib import Path
+
+from archex.integrations.docs._markdown import extract_markdown_links
+from archex.integrations.docs.models import (
+    AdrRecord,
+    DocEvidenceProviderName,
+    DocProviderReceipt,
+    ProviderAvailability,
+)
+
+#: Conventional ADR directories, checked in this order relative to the
+#: repository root.
+_ADR_DIR_NAMES = ("docs/adr", ".docs/adr", "doc/adr", "adr")
+
+#: Hard cap on ADR files scanned per run.
+MAX_ADR_FILES = 200
+
+_TITLE_PATTERN = re.compile(r"^#\s+(.+)$", re.MULTILINE)
+_STATUS_PATTERN = re.compile(r"^\s*(?:##\s*)?status\s*[:\-]\s*(.+)$", re.IGNORECASE | re.MULTILINE)
+_LEADING_ID_PATTERN = re.compile(r"^(\d+)")
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(tz=_dt.UTC).isoformat()
+
+
+def _find_adr_dir(repo_root: Path) -> Path | None:
+    for dirname in _ADR_DIR_NAMES:
+        candidate = repo_root / dirname
+        if candidate.is_dir() and any(candidate.glob("*.md")):
+            return candidate
+    return None
+
+
+def _adr_id_for(path: Path, fallback_index: int) -> str:
+    match = _LEADING_ID_PATTERN.match(path.stem)
+    if match:
+        return match.group(1)
+    return path.stem or f"adr-{fallback_index}"
+
+
+def _title_for(text: str, path: Path) -> str:
+    match = _TITLE_PATTERN.search(text)
+    if match:
+        return match.group(1).strip()
+    return path.stem.replace("-", " ").replace("_", " ").strip() or path.stem
+
+
+def _status_for(text: str) -> str:
+    match = _STATUS_PATTERN.search(text)
+    if match:
+        return match.group(1).strip().rstrip(".")
+    return "unknown"
+
+
+class AdrProvider:
+    """Reads local architecture-decision-records from a conventional directory."""
+
+    @property
+    def name(self) -> DocEvidenceProviderName:
+        return DocEvidenceProviderName.ADR
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> DocProviderReceipt:
+        adr_dir = _find_adr_dir(repo_root)
+        if adr_dir is None:
+            checked = ", ".join(_ADR_DIR_NAMES)
+            return DocProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason=f"no ADR directory found at any of: {checked} (under {repo_root})",
+                expected_revision=expected_revision,
+                observed_revision=expected_revision,
+                collected_at=_now_iso(),
+            )
+        files = sorted(adr_dir.glob("*.md"))[:MAX_ADR_FILES]
+        return DocProviderReceipt(
+            provider=self.name,
+            availability=ProviderAvailability.AVAILABLE,
+            expected_revision=expected_revision,
+            observed_revision=expected_revision,
+            sources_scanned=len(files),
+            collected_at=_now_iso(),
+        )
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[AdrRecord], DocProviderReceipt]:
+        probe_receipt = self.probe(repo_root, expected_revision=expected_revision)
+        if probe_receipt.availability != ProviderAvailability.AVAILABLE:
+            return [], probe_receipt
+
+        adr_dir = _find_adr_dir(repo_root)
+        if adr_dir is None:
+            # Directory removed between probe() and collect() (unlikely
+            # filesystem race) -- handled explicitly rather than assumed.
+            return [], DocProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason=f"ADR directory disappeared during collection (under {repo_root})",
+                expected_revision=expected_revision,
+                observed_revision=expected_revision,
+                collected_at=_now_iso(),
+            )
+        files = sorted(adr_dir.glob("*.md"))[:MAX_ADR_FILES]
+
+        records: list[AdrRecord] = []
+        for index, path in enumerate(files):
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            doc_relative = path.relative_to(repo_root).as_posix()
+            referenced = sorted({target for _, target in extract_markdown_links(path, repo_root)})
+            records.append(
+                AdrRecord(
+                    adr_id=_adr_id_for(path, index),
+                    title=_title_for(text, path),
+                    status=_status_for(text),
+                    doc_path=doc_relative,
+                    referenced_paths=referenced,
+                    revision=expected_revision,
+                )
+            )
+
+        receipt = DocProviderReceipt(
+            provider=self.name,
+            availability=ProviderAvailability.AVAILABLE,
+            expected_revision=expected_revision,
+            observed_revision=expected_revision,
+            sources_scanned=len(files),
+            records_collected=len(records),
+            collected_at=_now_iso(),
+        )
+        return records, receipt

--- a/src/archex/integrations/docs/doc_link_provider.py
+++ b/src/archex/integrations/docs/doc_link_provider.py
@@ -1,0 +1,116 @@
+"""Doc-link evidence provider: reads local markdown documentation already on disk.
+
+Scans a bounded, conventional set of markdown roots (``README.md`` at the
+repository root, plus ``docs/`` and ``.docs/`` trees) for markdown links
+that resolve to a real file under the repository root. Never fetches a
+remote page, never resolves a reference-style link, and never records a
+link whose target does not exist locally -- an aspirational or broken link
+is not documentation evidence.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+
+from archex.integrations.docs._markdown import extract_markdown_links
+from archex.integrations.docs.models import (
+    DocEvidenceProviderName,
+    DocProviderReceipt,
+    DocumentationLink,
+    ProviderAvailability,
+)
+
+#: Conventional markdown documentation roots, checked in this order.
+#: ``README.md`` is a single file; the other two are directory trees.
+_DOC_ROOT_NAMES = ("README.md", "docs", ".docs")
+
+#: Hard cap on markdown files scanned per run -- bounds cost and receipt
+#: size the same way other providers cap emitted records.
+MAX_DOC_FILES = 200
+
+#: Hard cap on emitted documentation links per run.
+MAX_DOCUMENTATION_LINKS = 1000
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(tz=_dt.UTC).isoformat()
+
+
+def _discover_markdown_files(repo_root: Path) -> list[Path]:
+    readme = repo_root / "README.md"
+    files: list[Path] = [readme] if readme.is_file() else []
+    for dirname in ("docs", ".docs"):
+        root = repo_root / dirname
+        if root.is_dir():
+            files.extend(sorted(p for p in root.rglob("*.md") if p.is_file()))
+    return files[:MAX_DOC_FILES]
+
+
+class DocLinkProvider:
+    """Reads markdown documentation links from the working tree already on disk."""
+
+    @property
+    def name(self) -> DocEvidenceProviderName:
+        return DocEvidenceProviderName.DOC_LINK
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> DocProviderReceipt:
+        files = _discover_markdown_files(repo_root)
+        if not files:
+            return DocProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason=(
+                    f"no markdown documentation found under {repo_root} "
+                    f"(checked {', '.join(_DOC_ROOT_NAMES)})"
+                ),
+                expected_revision=expected_revision,
+                observed_revision=expected_revision,
+                collected_at=_now_iso(),
+            )
+        return DocProviderReceipt(
+            provider=self.name,
+            availability=ProviderAvailability.AVAILABLE,
+            expected_revision=expected_revision,
+            observed_revision=expected_revision,
+            sources_scanned=len(files),
+            collected_at=_now_iso(),
+        )
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[DocumentationLink], DocProviderReceipt]:
+        probe_receipt = self.probe(repo_root, expected_revision=expected_revision)
+        if probe_receipt.availability != ProviderAvailability.AVAILABLE:
+            return [], probe_receipt
+
+        files = _discover_markdown_files(repo_root)
+        links: list[DocumentationLink] = []
+        for doc_path in files:
+            doc_relative = doc_path.relative_to(repo_root).as_posix()
+            for link_text, target_path in extract_markdown_links(doc_path, repo_root):
+                if target_path == doc_relative:
+                    continue
+                links.append(
+                    DocumentationLink(
+                        doc_path=doc_relative,
+                        target_path=target_path,
+                        link_text=link_text,
+                        revision=expected_revision,
+                    )
+                )
+                if len(links) >= MAX_DOCUMENTATION_LINKS:
+                    break
+            if len(links) >= MAX_DOCUMENTATION_LINKS:
+                break
+
+        receipt = DocProviderReceipt(
+            provider=self.name,
+            availability=ProviderAvailability.AVAILABLE,
+            expected_revision=expected_revision,
+            observed_revision=expected_revision,
+            sources_scanned=len(files),
+            records_collected=len(links),
+            collected_at=_now_iso(),
+        )
+        return links, receipt

--- a/src/archex/integrations/docs/models.py
+++ b/src/archex/integrations/docs/models.py
@@ -1,0 +1,162 @@
+"""Documentation-graph (conditional doc/ADR/ownership) evidence models (M9) — pure Pydantic.
+
+These types describe conditional, provider-sourced local documentation
+evidence: markdown documentation links, architecture-decision-record
+provenance, and CODEOWNERS-style ownership records. Structurally distinct
+from Tree-sitter syntax evidence and from M6/M7/M8's semantic/runtime/
+history evidence -- documentation evidence is never added to
+``DependencyGraph`` as an edge and is never described as a code
+dependency. A markdown file that mentions a source path is evidence of
+association (this file is discussed, owned, or decided about here), never
+of an import, call, or reference relationship between two code artifacts.
+
+Every item is revision-bound and every provider run yields an explicit
+availability receipt; providers never silently apply stale evidence or
+fabricate documentation, ownership, or decision records.
+
+Collection never harvests a remote source: every provider reads only
+files already present on local disk under the repository root (markdown
+documentation, ADR files, and a CODEOWNERS-style ownership manifest).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, model_validator
+
+
+class DocEvidenceProviderName(StrEnum):
+    """Identifies which conditional documentation-graph evidence provider produced a record."""
+
+    DOC_LINK = "doc_link"
+    ADR = "adr"
+    OWNERSHIP = "ownership"
+
+
+class ProviderAvailability(StrEnum):
+    """Explicit availability state for a documentation-graph evidence provider run.
+
+    Mirrors ``archex.integrations.semantic.models.ProviderAvailability`` (M6),
+    ``archex.integrations.runtime.models.ProviderAvailability`` (M7), and
+    ``archex.integrations.history.models.ProviderAvailability`` (M8) in shape
+    but is kept independent: every conditional evidence channel is
+    separately disableable and separately rollback-able. ``UNAVAILABLE``,
+    ``PARTIAL``, and ``STALE`` are first-class outcomes -- an unusable or
+    revision-mismatched provider must produce one of these states with a
+    reason rather than silently contributing zero records or applying
+    evidence collected against a different revision.
+    """
+
+    AVAILABLE = "available"
+    PARTIAL = "partial"
+    UNAVAILABLE = "unavailable"
+    STALE = "stale"
+    UNKNOWN = "unknown"
+
+
+class DocumentationLink(BaseModel):
+    """One local markdown document's reference to a source path.
+
+    Never a dependency claim: ``doc_path`` is the markdown file that
+    contains the reference and ``target_path`` is the source path it
+    mentions, resolved and confirmed to exist under the repository root at
+    ``revision`` -- a reference to a path that does not resolve locally is
+    never recorded.
+    """
+
+    doc_path: str
+    target_path: str
+    link_text: str
+    revision: str
+
+    @model_validator(mode="after")
+    def _validate_link(self) -> DocumentationLink:
+        if not self.doc_path.strip():
+            raise ValueError("doc_path must not be empty")
+        if not self.target_path.strip():
+            raise ValueError("target_path must not be empty")
+        if not self.revision.strip():
+            raise ValueError("revision must not be empty")
+        return self
+
+
+class AdrRecord(BaseModel):
+    """One architecture-decision-record's metadata and the source paths it references.
+
+    ``status`` is the ADR's own declared status text (for example
+    ``"Accepted"`` or ``"Superseded"``), read verbatim from the document --
+    archex never infers or normalizes it into a health signal.
+    """
+
+    adr_id: str
+    title: str
+    status: str
+    doc_path: str
+    referenced_paths: list[str] = []
+    revision: str
+
+    @model_validator(mode="after")
+    def _validate_adr(self) -> AdrRecord:
+        if not self.adr_id.strip():
+            raise ValueError("adr_id must not be empty")
+        if not self.title.strip():
+            raise ValueError("title must not be empty")
+        if not self.doc_path.strip():
+            raise ValueError("doc_path must not be empty")
+        if not self.revision.strip():
+            raise ValueError("revision must not be empty")
+        return self
+
+
+class OwnershipRecord(BaseModel):
+    """One CODEOWNERS-style path-pattern-to-owner mapping.
+
+    ``source_path`` is the ownership manifest the pattern was read from --
+    never inferred from commit authorship or any other heuristic.
+    """
+
+    path_pattern: str
+    owners: list[str]
+    source_path: str
+    revision: str
+
+    @model_validator(mode="after")
+    def _validate_ownership(self) -> OwnershipRecord:
+        if not self.path_pattern.strip():
+            raise ValueError("path_pattern must not be empty")
+        if not self.owners:
+            raise ValueError("owners must not be empty")
+        if not self.source_path.strip():
+            raise ValueError("source_path must not be empty")
+        if not self.revision.strip():
+            raise ValueError("revision must not be empty")
+        return self
+
+
+class DocProviderReceipt(BaseModel):
+    """Availability, revision-validity, and completeness receipt for one provider run.
+
+    Always produced, whether or not the provider was usable. ``reason`` is
+    required whenever ``availability`` is not ``AVAILABLE`` so an unusable or
+    stale provider is always explained rather than silently absent.
+    """
+
+    provider: DocEvidenceProviderName
+    availability: ProviderAvailability
+    reason: str = ""
+    expected_revision: str = ""
+    observed_revision: str | None = None
+    sources_scanned: int = 0
+    records_collected: int = 0
+    collected_at: str = ""
+
+    @model_validator(mode="after")
+    def _validate_receipt(self) -> DocProviderReceipt:
+        if self.availability != ProviderAvailability.AVAILABLE and not self.reason.strip():
+            raise ValueError(f"reason is required when availability is {self.availability!r}")
+        if self.sources_scanned < 0:
+            raise ValueError("sources_scanned must be non-negative")
+        if self.records_collected < 0:
+            raise ValueError("records_collected must be non-negative")
+        return self

--- a/src/archex/integrations/docs/ownership_provider.py
+++ b/src/archex/integrations/docs/ownership_provider.py
@@ -1,0 +1,133 @@
+"""Ownership evidence provider: reads a local CODEOWNERS-style manifest already on disk.
+
+Reads a conventional CODEOWNERS file (``.github/CODEOWNERS``, ``CODEOWNERS``,
+or ``docs/CODEOWNERS``, checked in that order -- GitHub's own precedence) and
+parses ``pattern owner1 owner2 ...`` lines into ``OwnershipRecord``s. Owners
+are recorded verbatim from the file; archex never infers ownership from
+commit authorship or any other heuristic. A "no owner" override line (a
+bare pattern with no owners, used by GitHub to unset inherited ownership)
+is skipped -- it asserts an absence, not a positive ownership claim this
+provider can carry as evidence.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from pathlib import Path
+
+from archex.integrations.docs.models import (
+    DocEvidenceProviderName,
+    DocProviderReceipt,
+    OwnershipRecord,
+    ProviderAvailability,
+)
+
+#: Conventional CODEOWNERS locations, checked in GitHub's own precedence
+#: order, relative to the repository root.
+_CODEOWNERS_PATHS = (".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS")
+
+#: Hard cap on ownership lines parsed per run.
+MAX_OWNERSHIP_RECORDS = 500
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(tz=_dt.UTC).isoformat()
+
+
+def _find_codeowners(repo_root: Path) -> Path | None:
+    for relative in _CODEOWNERS_PATHS:
+        candidate = repo_root / relative
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+class OwnershipProvider:
+    """Reads local CODEOWNERS-style ownership records from the working tree."""
+
+    @property
+    def name(self) -> DocEvidenceProviderName:
+        return DocEvidenceProviderName.OWNERSHIP
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> DocProviderReceipt:
+        codeowners = _find_codeowners(repo_root)
+        if codeowners is None:
+            checked = ", ".join(_CODEOWNERS_PATHS)
+            return DocProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason=f"no CODEOWNERS file found at any of: {checked} (under {repo_root})",
+                expected_revision=expected_revision,
+                observed_revision=expected_revision,
+                collected_at=_now_iso(),
+            )
+        return DocProviderReceipt(
+            provider=self.name,
+            availability=ProviderAvailability.AVAILABLE,
+            expected_revision=expected_revision,
+            observed_revision=expected_revision,
+            sources_scanned=1,
+            collected_at=_now_iso(),
+        )
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[OwnershipRecord], DocProviderReceipt]:
+        probe_receipt = self.probe(repo_root, expected_revision=expected_revision)
+        if probe_receipt.availability != ProviderAvailability.AVAILABLE:
+            return [], probe_receipt
+
+        codeowners = _find_codeowners(repo_root)
+        if codeowners is None:
+            return [], DocProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason=f"CODEOWNERS file disappeared during collection (under {repo_root})",
+                expected_revision=expected_revision,
+                observed_revision=expected_revision,
+                collected_at=_now_iso(),
+            )
+
+        try:
+            text = codeowners.read_text(encoding="utf-8", errors="ignore")
+        except OSError as exc:
+            return [], DocProviderReceipt(
+                provider=self.name,
+                availability=ProviderAvailability.UNAVAILABLE,
+                reason=f"could not read {codeowners}: {exc}",
+                expected_revision=expected_revision,
+                observed_revision=expected_revision,
+                collected_at=_now_iso(),
+            )
+
+        source_relative = codeowners.relative_to(repo_root).as_posix()
+        records: list[OwnershipRecord] = []
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            tokens = stripped.split()
+            if len(tokens) < 2:
+                continue  # bare pattern with no owners: an override, not evidence
+            pattern, owners = tokens[0], tokens[1:]
+            records.append(
+                OwnershipRecord(
+                    path_pattern=pattern,
+                    owners=owners,
+                    source_path=source_relative,
+                    revision=expected_revision,
+                )
+            )
+            if len(records) >= MAX_OWNERSHIP_RECORDS:
+                break
+
+        receipt = DocProviderReceipt(
+            provider=self.name,
+            availability=ProviderAvailability.AVAILABLE,
+            expected_revision=expected_revision,
+            observed_revision=expected_revision,
+            sources_scanned=1,
+            records_collected=len(records),
+            collected_at=_now_iso(),
+        )
+        return records, receipt

--- a/src/archex/integrations/docs/provider.py
+++ b/src/archex/integrations/docs/provider.py
@@ -1,0 +1,110 @@
+"""Documentation-graph (conditional doc/ADR/ownership) evidence provider contracts (M9).
+
+A provider turns local repository state (markdown documentation already on
+disk, a conventional ADR directory, or a CODEOWNERS-style ownership
+manifest) into typed evidence records plus a ``DocProviderReceipt``
+describing whether the run actually produced usable evidence. Providers
+must never raise for ordinary unavailability (no markdown found, no ADR
+directory present, no ownership manifest present) -- that is an expected
+outcome represented by an ``UNAVAILABLE``/``PARTIAL``/``STALE`` receipt,
+never a fallback record and never an exception that would abort indexing.
+No provider ever contacts a remote service: every one reads only files
+already present on local disk under the repository root.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from archex.integrations.docs.models import (
+        AdrRecord,
+        DocProviderReceipt,
+        DocumentationLink,
+        OwnershipRecord,
+    )
+
+
+class DocLinkEvidenceProvider(Protocol):
+    """A conditional local-markdown-documentation-link evidence source."""
+
+    @property
+    def name(self) -> str:
+        """The provider identity recorded on every receipt it produces."""
+        ...
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> DocProviderReceipt:
+        """Cheaply check availability without collecting evidence.
+
+        Must not raise for ordinary unavailability; returns a receipt whose
+        ``availability`` reflects what was found (no markdown documentation,
+        or ``AVAILABLE`` when a full collect is expected to produce
+        evidence).
+        """
+        ...
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[DocumentationLink], DocProviderReceipt]:
+        """Collect documentation links bound to *expected_revision*.
+
+        Returns ``([], receipt)`` with an explanatory non-``AVAILABLE``
+        receipt when the provider cannot run, rather than raising.
+        """
+        ...
+
+
+class AdrEvidenceProvider(Protocol):
+    """A conditional local-architecture-decision-record evidence source."""
+
+    @property
+    def name(self) -> str:
+        """The provider identity recorded on every receipt it produces."""
+        ...
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> DocProviderReceipt:
+        """Cheaply check availability without collecting evidence.
+
+        Must not raise for ordinary unavailability; see
+        ``DocLinkEvidenceProvider.probe``.
+        """
+        ...
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[AdrRecord], DocProviderReceipt]:
+        """Collect ADR records bound to *expected_revision*.
+
+        Returns ``([], receipt)`` with an explanatory non-``AVAILABLE``
+        receipt when no ADR directory is present, rather than raising.
+        """
+        ...
+
+
+class OwnershipEvidenceProvider(Protocol):
+    """A conditional local CODEOWNERS-style ownership evidence source."""
+
+    @property
+    def name(self) -> str:
+        """The provider identity recorded on every receipt it produces."""
+        ...
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> DocProviderReceipt:
+        """Cheaply check availability without collecting evidence.
+
+        Must not raise for ordinary unavailability; see
+        ``DocLinkEvidenceProvider.probe``.
+        """
+        ...
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[OwnershipRecord], DocProviderReceipt]:
+        """Collect ownership records bound to *expected_revision*.
+
+        Returns ``([], receipt)`` with an explanatory non-``AVAILABLE``
+        receipt when no ownership manifest is present, rather than raising.
+        """
+        ...

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, model_validator
 
 from archex.index.quantize import SUPPORTED_BITS
+from archex.integrations.docs.models import DocProviderReceipt  # noqa: TCH001
 from archex.integrations.history.eligibility import HistoryEligibilityDecision  # noqa: TCH001
 from archex.integrations.history.models import HistoryProviderReceipt  # noqa: TCH001
 from archex.integrations.lsap_models import LSAPEnrichment  # noqa: TCH001
@@ -299,6 +300,15 @@ class IndexConfig(BaseModel):
     #: predeclared density/linkage/relevance eligibility policy
     #: (archex.integrations.history.eligibility) before it is ever surfaced.
     history_evidence_providers: list[str] = []
+    #: Conditional local-markdown-documentation-link, ADR, and CODEOWNERS-
+    #: style ownership evidence providers to run at index time (M9). Empty
+    #: by default: no provider runs. Accepted values: "doc_link", "adr",
+    #: "ownership". Kept independent from semantic_evidence_providers/
+    #: runtime_evidence_providers/history_evidence_providers -- every
+    #: conditional evidence channel is separately disableable and
+    #: separately rollback-able. Collected relations are never folded into
+    #: DependencyGraph and are never described as a code dependency.
+    documentation_evidence_providers: list[str] = []
 
     @model_validator(mode="after")
     def _validate_index_config(self) -> IndexConfig:
@@ -341,6 +351,16 @@ class IndexConfig(BaseModel):
             raise ValueError(
                 "history_evidence_providers has unknown entries: "
                 f"{sorted(unknown_history_providers)}"
+            )
+        unknown_documentation_providers = set(self.documentation_evidence_providers) - {
+            "doc_link",
+            "adr",
+            "ownership",
+        }
+        if unknown_documentation_providers:
+            raise ValueError(
+                "documentation_evidence_providers has unknown entries: "
+                f"{sorted(unknown_documentation_providers)}"
             )
         return self
 
@@ -933,6 +953,7 @@ class ContextReceipt(BaseModel):
     runtime_providers: list[RuntimeProviderReceipt] = []
     history_providers: list[HistoryProviderReceipt] = []
     history_eligibility: HistoryEligibilityDecision | None = None
+    documentation_providers: list[DocProviderReceipt] = []
     returned_total: int = 0
     skipped_total: int = 0
     included_edges_total: int = 0

--- a/src/archex/receipt.py
+++ b/src/archex/receipt.py
@@ -28,6 +28,7 @@ from archex.scout import ScoutResult, chunk_handle, file_handle, parse_scout_han
 if TYPE_CHECKING:
     from archex.index.graph import DependencyGraph
     from archex.index.store import IndexStore
+    from archex.integrations.docs.models import DocProviderReceipt
     from archex.integrations.history.eligibility import HistoryEligibilityDecision
     from archex.integrations.history.models import (
         ChangeCard,
@@ -91,6 +92,7 @@ def build_context_receipt(
     history_providers: Iterable[HistoryProviderReceipt] = (),
     history_change_cards: Iterable[ChangeCard] = (),
     history_coupling_observations: Iterable[TemporalCouplingObservation] = (),
+    documentation_providers: Iterable[DocProviderReceipt] = (),
 ) -> ContextReceipt:
     returned = _returned_context(bundle)
     skipped_all = list(skipped_candidates)
@@ -155,6 +157,7 @@ def build_context_receipt(
         runtime_providers=list(runtime_providers),
         history_providers=list(history_providers_resolved),
         history_eligibility=history_eligibility,
+        documentation_providers=list(documentation_providers),
         returned_total=len(returned),
         skipped_total=len(skipped_all),
         included_edges_total=len(included_all),

--- a/tests/index/test_documentation_evidence.py
+++ b/tests/index/test_documentation_evidence.py
@@ -1,0 +1,240 @@
+"""Tests for the conditional documentation-graph evidence dispatcher (M9)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from archex.index.documentation_evidence import collect_documentation_evidence
+from archex.integrations.docs.models import (
+    AdrRecord,
+    DocEvidenceProviderName,
+    DocProviderReceipt,
+    DocumentationLink,
+    OwnershipRecord,
+    ProviderAvailability,
+)
+from archex.models import EdgeKind, IndexConfig
+
+_REVISION = "a" * 40
+
+
+class _StubDocLinkProvider:
+    def __init__(self, *, raise_error: bool = False) -> None:
+        self._raise_error = raise_error
+
+    @property
+    def name(self) -> str:
+        return "doc_link"
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> DocProviderReceipt:
+        del repo_root, expected_revision
+        return DocProviderReceipt(
+            provider=DocEvidenceProviderName.DOC_LINK,
+            availability=ProviderAvailability.AVAILABLE,
+        )
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[DocumentationLink], DocProviderReceipt]:
+        del repo_root
+        if self._raise_error:
+            raise RuntimeError("boom")
+        return (
+            [
+                DocumentationLink(
+                    doc_path="README.md",
+                    target_path="src/a.py",
+                    link_text="a",
+                    revision=expected_revision,
+                )
+            ],
+            DocProviderReceipt(
+                provider=DocEvidenceProviderName.DOC_LINK,
+                availability=ProviderAvailability.AVAILABLE,
+                records_collected=1,
+            ),
+        )
+
+
+class _StubAdrProvider:
+    @property
+    def name(self) -> str:
+        return "adr"
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> DocProviderReceipt:
+        del repo_root, expected_revision
+        return DocProviderReceipt(
+            provider=DocEvidenceProviderName.ADR, availability=ProviderAvailability.AVAILABLE
+        )
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[AdrRecord], DocProviderReceipt]:
+        del repo_root
+        return (
+            [
+                AdrRecord(
+                    adr_id="0001",
+                    title="Use X",
+                    status="Accepted",
+                    doc_path="docs/adr/0001.md",
+                    revision=expected_revision,
+                )
+            ],
+            DocProviderReceipt(
+                provider=DocEvidenceProviderName.ADR,
+                availability=ProviderAvailability.AVAILABLE,
+                records_collected=1,
+            ),
+        )
+
+
+class _StubOwnershipProvider:
+    @property
+    def name(self) -> str:
+        return "ownership"
+
+    def probe(self, repo_root: Path, *, expected_revision: str) -> DocProviderReceipt:
+        del repo_root, expected_revision
+        return DocProviderReceipt(
+            provider=DocEvidenceProviderName.OWNERSHIP,
+            availability=ProviderAvailability.AVAILABLE,
+        )
+
+    def collect(
+        self, repo_root: Path, *, expected_revision: str
+    ) -> tuple[list[OwnershipRecord], DocProviderReceipt]:
+        del repo_root
+        return (
+            [
+                OwnershipRecord(
+                    path_pattern="/src/",
+                    owners=["@team"],
+                    source_path="CODEOWNERS",
+                    revision=expected_revision,
+                )
+            ],
+            DocProviderReceipt(
+                provider=DocEvidenceProviderName.OWNERSHIP,
+                availability=ProviderAvailability.AVAILABLE,
+                records_collected=1,
+            ),
+        )
+
+
+class TestCollectDocumentationEvidence:
+    def test_returns_empty_when_no_providers_requested(self, tmp_path: Path) -> None:
+        links, adr, ownership, receipts = collect_documentation_evidence(
+            tmp_path, [], expected_revision=_REVISION
+        )
+        assert links == []
+        assert adr == []
+        assert ownership == []
+        assert receipts == []
+
+    def test_rejects_unknown_provider_name(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="unknown documentation evidence providers"):
+            collect_documentation_evidence(tmp_path, ["bogus"], expected_revision=_REVISION)
+
+    def test_uses_injected_doc_link_provider(self, tmp_path: Path) -> None:
+        links, adr, ownership, receipts = collect_documentation_evidence(
+            tmp_path,
+            ["doc_link"],
+            expected_revision=_REVISION,
+            doc_link_provider=_StubDocLinkProvider(),
+        )
+        assert len(links) == 1
+        assert adr == []
+        assert ownership == []
+        assert len(receipts) == 1
+        assert receipts[0].provider == DocEvidenceProviderName.DOC_LINK
+
+    def test_runs_all_three_providers_when_all_requested(self, tmp_path: Path) -> None:
+        links, adr, ownership, receipts = collect_documentation_evidence(
+            tmp_path,
+            ["doc_link", "adr", "ownership"],
+            expected_revision=_REVISION,
+            doc_link_provider=_StubDocLinkProvider(),
+            adr_provider=_StubAdrProvider(),
+            ownership_provider=_StubOwnershipProvider(),
+        )
+        assert len(links) == 1
+        assert len(adr) == 1
+        assert len(ownership) == 1
+        assert len(receipts) == 3
+
+    def test_provider_exception_degrades_to_unavailable_receipt(self, tmp_path: Path) -> None:
+        links, _adr, _ownership, receipts = collect_documentation_evidence(
+            tmp_path,
+            ["doc_link"],
+            expected_revision=_REVISION,
+            doc_link_provider=_StubDocLinkProvider(raise_error=True),
+        )
+        assert links == []
+        assert len(receipts) == 1
+        assert receipts[0].availability == ProviderAvailability.UNAVAILABLE
+        assert "boom" in receipts[0].reason
+
+    def test_default_providers_report_unavailable_on_bare_directory(self, tmp_path: Path) -> None:
+        links, adr, ownership, receipts = collect_documentation_evidence(
+            tmp_path, ["doc_link", "adr", "ownership"], expected_revision=_REVISION
+        )
+        assert links == []
+        assert adr == []
+        assert ownership == []
+        assert {r.provider for r in receipts} == {
+            DocEvidenceProviderName.DOC_LINK,
+            DocEvidenceProviderName.ADR,
+            DocEvidenceProviderName.OWNERSHIP,
+        }
+        assert all(r.availability == ProviderAvailability.UNAVAILABLE for r in receipts)
+
+
+class TestDocumentationEvidenceGraphDistinctness:
+    """M9's typed doc/ADR/ownership relations must never fold into DependencyGraph.
+
+    Structurally distinct from M6's semantic-evidence channel, which does add
+    typed edges to the graph: documentation evidence is association, never a
+    code dependency, so it is stored and surfaced separately (never as an
+    ``Edge``/``EdgeKind`` member) and reading it back never produces graph
+    edges of any kind.
+    """
+
+    def test_full_index_never_adds_documentation_graph_edges(
+        self, python_simple_repo: Path
+    ) -> None:
+        from archex.api import index_repository
+        from archex.models import Config, RepoSource
+
+        source = RepoSource(local_path=str(python_simple_repo))
+        (python_simple_repo / "README.md").write_text("See [main](main.py) for the entry point.\n")
+
+        baseline_store = index_repository(
+            source, config=Config(cache=False), index_config=IndexConfig()
+        )
+        try:
+            baseline_edges = baseline_store.get_edges()
+            assert baseline_store.get_documentation_provider_receipts() == []
+        finally:
+            baseline_store.close()
+
+        store = index_repository(
+            source,
+            config=Config(cache=False),
+            index_config=IndexConfig(documentation_evidence_providers=["doc_link"]),
+        )
+        try:
+            edges = store.get_edges()
+            assert len(edges) == len(baseline_edges)
+            assert all(edge.kind != EdgeKind.SEMANTIC_DEFINITION for edge in edges)
+
+            [receipt] = store.get_documentation_provider_receipts()
+            assert receipt.provider == DocEvidenceProviderName.DOC_LINK
+            assert receipt.availability == ProviderAvailability.AVAILABLE
+
+            links = store.get_documentation_links()
+            assert any(link.target_path == "main.py" for link in links)
+        finally:
+            store.close()

--- a/tests/integrations/docs/__init__.py
+++ b/tests/integrations/docs/__init__.py
@@ -1,0 +1,1 @@
+"""Documentation graph evidence tests (M9)."""

--- a/tests/integrations/docs/test_adr_provider.py
+++ b/tests/integrations/docs/test_adr_provider.py
@@ -1,0 +1,77 @@
+"""Tests for the ADR documentation evidence provider (M9)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from archex.integrations.docs.adr_provider import AdrProvider
+from archex.integrations.docs.models import ProviderAvailability
+
+_REVISION = "a" * 40
+
+
+class TestAdrProviderProbe:
+    def test_unavailable_when_no_adr_directory(self, tmp_path: Path) -> None:
+        provider = AdrProvider()
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.UNAVAILABLE
+        assert "no ADR directory" in receipt.reason
+
+    def test_available_when_adr_directory_present(self, tmp_path: Path) -> None:
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0001-use-x.md").write_text("# Use X\n\nStatus: Accepted\n")
+        provider = AdrProvider()
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.AVAILABLE
+        assert receipt.sources_scanned == 1
+
+
+class TestAdrProviderCollect:
+    def test_reads_title_status_and_id_from_filename(self, tmp_path: Path) -> None:
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0001-use-x.md").write_text(
+            "# Use X for caching\n\nStatus: Accepted\n\nSee [a](../../src/a.py).\n"
+        )
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "a.py").write_text("x = 1\n")
+
+        provider = AdrProvider()
+        records, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+
+        assert receipt.availability == ProviderAvailability.AVAILABLE
+        assert len(records) == 1
+        record = records[0]
+        assert record.adr_id == "0001"
+        assert record.title == "Use X for caching"
+        assert record.status == "Accepted"
+        assert record.referenced_paths == ["src/a.py"]
+        assert record.revision == _REVISION
+
+    def test_status_unknown_when_not_declared(self, tmp_path: Path) -> None:
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0002-no-status.md").write_text("# Untitled decision\n")
+
+        provider = AdrProvider()
+        records, _receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+
+        assert records[0].status == "unknown"
+
+    def test_returns_probe_receipt_unchanged_when_unavailable(self, tmp_path: Path) -> None:
+        provider = AdrProvider()
+        records, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert records == []
+        assert receipt.availability == ProviderAvailability.UNAVAILABLE
+
+    def test_checks_dot_docs_adr_fallback(self, tmp_path: Path) -> None:
+        adr_dir = tmp_path / ".docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0003-fallback.md").write_text("# Fallback location\n")
+
+        provider = AdrProvider()
+        records, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+
+        assert receipt.availability == ProviderAvailability.AVAILABLE
+        assert records[0].doc_path == ".docs/adr/0003-fallback.md"

--- a/tests/integrations/docs/test_doc_link_provider.py
+++ b/tests/integrations/docs/test_doc_link_provider.py
@@ -1,0 +1,72 @@
+"""Tests for the doc-link documentation evidence provider (M9)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from archex.integrations.docs.doc_link_provider import DocLinkProvider
+from archex.integrations.docs.models import ProviderAvailability
+
+_REVISION = "a" * 40
+
+
+class TestDocLinkProviderProbe:
+    def test_unavailable_when_no_markdown_present(self, tmp_path: Path) -> None:
+        provider = DocLinkProvider()
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.UNAVAILABLE
+        assert "no markdown documentation" in receipt.reason
+
+    def test_available_when_readme_present(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("# Repo\n")
+        provider = DocLinkProvider()
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.AVAILABLE
+        assert receipt.sources_scanned == 1
+
+
+class TestDocLinkProviderCollect:
+    def test_collects_links_resolving_to_real_files(self, tmp_path: Path) -> None:
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "a.py").write_text("x = 1\n")
+        (tmp_path / "README.md").write_text(
+            "See [module a](src/a.py) and [ghost](src/missing.py) and "
+            "[remote](https://example.com/a.py).\n"
+        )
+        provider = DocLinkProvider()
+        links, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+
+        assert receipt.availability == ProviderAvailability.AVAILABLE
+        assert [link.target_path for link in links] == ["src/a.py"]
+        assert links[0].doc_path == "README.md"
+        assert links[0].link_text == "module a"
+        assert links[0].revision == _REVISION
+        assert receipt.records_collected == 1
+
+    def test_scans_docs_and_dot_docs_trees(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("# Repo\n")
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "a.py").write_text("x = 1\n")
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "guide.md").write_text("See [a](../src/a.py).\n")
+        (tmp_path / ".docs").mkdir()
+        (tmp_path / ".docs" / "notes.md").write_text("See [a again](../src/a.py).\n")
+
+        provider = DocLinkProvider()
+        links, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+
+        doc_paths = {link.doc_path for link in links}
+        assert doc_paths == {"docs/guide.md", ".docs/notes.md"}
+        assert receipt.sources_scanned == 3
+
+    def test_never_records_link_to_nonexistent_target(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("See [ghost](does/not/exist.py).\n")
+        provider = DocLinkProvider()
+        links, _receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert links == []
+
+    def test_returns_probe_receipt_unchanged_when_unavailable(self, tmp_path: Path) -> None:
+        provider = DocLinkProvider()
+        links, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert links == []
+        assert receipt.availability == ProviderAvailability.UNAVAILABLE

--- a/tests/integrations/docs/test_models.py
+++ b/tests/integrations/docs/test_models.py
@@ -1,0 +1,120 @@
+"""Tests for documentation-graph (doc/ADR/ownership) evidence models (M9)."""
+
+from __future__ import annotations
+
+import pytest
+
+from archex.integrations.docs.models import (
+    AdrRecord,
+    DocEvidenceProviderName,
+    DocProviderReceipt,
+    DocumentationLink,
+    OwnershipRecord,
+    ProviderAvailability,
+)
+
+
+class TestDocumentationLink:
+    def test_rejects_empty_doc_path(self) -> None:
+        with pytest.raises(ValueError, match="doc_path"):
+            DocumentationLink(doc_path=" ", target_path="src/a.py", link_text="a", revision="r")
+
+    def test_rejects_empty_target_path(self) -> None:
+        with pytest.raises(ValueError, match="target_path"):
+            DocumentationLink(doc_path="README.md", target_path=" ", link_text="a", revision="r")
+
+    def test_rejects_empty_revision(self) -> None:
+        with pytest.raises(ValueError, match="revision"):
+            DocumentationLink(
+                doc_path="README.md", target_path="src/a.py", link_text="a", revision=" "
+            )
+
+    def test_accepts_valid_link(self) -> None:
+        link = DocumentationLink(
+            doc_path="README.md", target_path="src/a.py", link_text="module a", revision="rev"
+        )
+        assert link.target_path == "src/a.py"
+
+
+class TestAdrRecord:
+    def test_rejects_empty_adr_id(self) -> None:
+        with pytest.raises(ValueError, match="adr_id"):
+            AdrRecord(
+                adr_id=" ",
+                title="Use X",
+                status="Accepted",
+                doc_path="docs/adr/0001.md",
+                revision="r",
+            )
+
+    def test_rejects_empty_title(self) -> None:
+        with pytest.raises(ValueError, match="title"):
+            AdrRecord(
+                adr_id="0001",
+                title=" ",
+                status="Accepted",
+                doc_path="docs/adr/0001.md",
+                revision="r",
+            )
+
+    def test_accepts_valid_record(self) -> None:
+        record = AdrRecord(
+            adr_id="0001",
+            title="Use X",
+            status="Accepted",
+            doc_path="docs/adr/0001.md",
+            referenced_paths=["src/a.py"],
+            revision="rev",
+        )
+        assert record.status == "Accepted"
+        assert record.referenced_paths == ["src/a.py"]
+
+
+class TestOwnershipRecord:
+    def test_rejects_empty_pattern(self) -> None:
+        with pytest.raises(ValueError, match="path_pattern"):
+            OwnershipRecord(
+                path_pattern=" ", owners=["@team"], source_path="CODEOWNERS", revision="r"
+            )
+
+    def test_rejects_empty_owners(self) -> None:
+        with pytest.raises(ValueError, match="owners"):
+            OwnershipRecord(path_pattern="/src/", owners=[], source_path="CODEOWNERS", revision="r")
+
+    def test_accepts_valid_record(self) -> None:
+        record = OwnershipRecord(
+            path_pattern="/src/", owners=["@team"], source_path="CODEOWNERS", revision="rev"
+        )
+        assert record.owners == ["@team"]
+
+
+class TestDocProviderReceipt:
+    def test_reason_required_when_unavailable(self) -> None:
+        with pytest.raises(ValueError, match="reason"):
+            DocProviderReceipt(
+                provider=DocEvidenceProviderName.DOC_LINK,
+                availability=ProviderAvailability.UNAVAILABLE,
+            )
+
+    def test_reason_not_required_when_available(self) -> None:
+        receipt = DocProviderReceipt(
+            provider=DocEvidenceProviderName.DOC_LINK,
+            availability=ProviderAvailability.AVAILABLE,
+        )
+        assert receipt.reason == ""
+
+    def test_rejects_negative_sources_scanned(self) -> None:
+        with pytest.raises(ValueError, match="sources_scanned"):
+            DocProviderReceipt(
+                provider=DocEvidenceProviderName.ADR,
+                availability=ProviderAvailability.AVAILABLE,
+                sources_scanned=-1,
+            )
+
+    def test_rejects_negative_records_collected(self) -> None:
+        with pytest.raises(ValueError, match="records_collected"):
+            DocProviderReceipt(
+                provider=DocEvidenceProviderName.OWNERSHIP,
+                availability=ProviderAvailability.AVAILABLE,
+                records_collected=-1,
+            )

--- a/tests/integrations/docs/test_ownership_provider.py
+++ b/tests/integrations/docs/test_ownership_provider.py
@@ -1,0 +1,68 @@
+"""Tests for the ownership (CODEOWNERS-style) documentation evidence provider (M9)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from archex.integrations.docs.models import ProviderAvailability
+from archex.integrations.docs.ownership_provider import OwnershipProvider
+
+_REVISION = "a" * 40
+
+
+class TestOwnershipProviderProbe:
+    def test_unavailable_when_no_codeowners_file(self, tmp_path: Path) -> None:
+        provider = OwnershipProvider()
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.UNAVAILABLE
+        assert "no CODEOWNERS file" in receipt.reason
+
+    def test_available_when_github_codeowners_present(self, tmp_path: Path) -> None:
+        github_dir = tmp_path / ".github"
+        github_dir.mkdir()
+        (github_dir / "CODEOWNERS").write_text("/src/ @team-core\n")
+        provider = OwnershipProvider()
+        receipt = provider.probe(tmp_path, expected_revision=_REVISION)
+        assert receipt.availability == ProviderAvailability.AVAILABLE
+        assert receipt.sources_scanned == 1
+
+
+class TestOwnershipProviderCollect:
+    def test_parses_pattern_and_owners(self, tmp_path: Path) -> None:
+        (tmp_path / "CODEOWNERS").write_text(
+            "# comment\n\n/src/ @team-core @alice\n/docs/ @team-docs\n"
+        )
+        provider = OwnershipProvider()
+        records, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+
+        assert receipt.availability == ProviderAvailability.AVAILABLE
+        assert len(records) == 2
+        assert records[0].path_pattern == "/src/"
+        assert records[0].owners == ["@team-core", "@alice"]
+        assert records[0].source_path == "CODEOWNERS"
+        assert records[0].revision == _REVISION
+
+    def test_skips_no_owner_override_lines(self, tmp_path: Path) -> None:
+        (tmp_path / "CODEOWNERS").write_text("/generated/\n/src/ @team-core\n")
+        provider = OwnershipProvider()
+        records, _receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert [r.path_pattern for r in records] == ["/src/"]
+
+    def test_prefers_github_codeowners_over_root(self, tmp_path: Path) -> None:
+        (tmp_path / "CODEOWNERS").write_text("/root/ @root-team\n")
+        github_dir = tmp_path / ".github"
+        github_dir.mkdir()
+        (github_dir / "CODEOWNERS").write_text("/gh/ @gh-team\n")
+
+        provider = OwnershipProvider()
+        records, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+
+        assert receipt.sources_scanned == 1
+        assert records[0].source_path == ".github/CODEOWNERS"
+        assert records[0].path_pattern == "/gh/"
+
+    def test_returns_probe_receipt_unchanged_when_unavailable(self, tmp_path: Path) -> None:
+        provider = OwnershipProvider()
+        records, receipt = provider.collect(tmp_path, expected_revision=_REVISION)
+        assert records == []
+        assert receipt.availability == ProviderAvailability.UNAVAILABLE


### PR DESCRIPTION
## Stack

Stack-Id: `m9-documentation-status-3afee1`
Base: `main`
Position: 1/3

1. `m9-1-documentation-evidence-model` -> this PR
2. `m9-2-dimensioned-status-surface` -> (next)
3. `m9-3-immutable-ci-release-evidence` -> (next)

Depends on: (none - root)
Upstack: PR-2 (dimensioned status surface)

## Summary

M9 (Add Documentation Graph and Dimensioned Status Evidence Conditionally), PR-1 of 3: typed doc/ADR/ownership evidence relations, distinct from code-dependency edges.

- `archex.integrations.docs`: `DocumentationLink`, `AdrRecord`, `OwnershipRecord`, `DocProviderReceipt` models plus `DocLinkProvider`/`AdrProvider`/`OwnershipProvider` (`probe()`/`collect()`), each reading only local files already on disk (README/`docs/`/`.docs/` markdown, a conventional ADR directory, a CODEOWNERS-style manifest). Unavailable is an explicit, honest receipt state, never a fallback.
- `archex.index.documentation_evidence.collect_documentation_evidence()`: dispatcher gated by `IndexConfig.documentation_evidence_providers` (default `[]` — fully disabled, zero cost, zero behavior change).
- `IndexStore`/`api.py`/`receipt.py` wiring: persists evidence, threads `documentation_providers` through the query-time `ContextReceipt`.
- Proved structurally distinct from code dependencies: never folded into `DependencyGraph`/`EdgeKind` — a dedicated test builds a real self-repo index with `documentation_evidence_providers=["doc_link"]` enabled and asserts byte-identical graph edges vs the channel disabled.

## Validation

- `uv run ruff check .` — pass
- `uv run ruff format --check .` — pass
- `uv run pyright .` — 0 errors
- `uv run pytest --junitxml=results.xml --cov-report=xml` — 4384 passed, 91.30% coverage (>= 85% gate)
