### PR TITLE
feat(status): add dimensioned evidence-linked status surface (M9 PR-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ The mounted repository owns `.archex/`, so indexes survive container restarts an
 | `archex doctor` | Text/JSON diagnostics for index health, staleness, local model cache presence, grammar availability by tier, MCP registration, model security, and `.archex/` disk usage. |
 | Repo-local `.archex/` | Generated state: settings, metadata, SQLite index, optional vectors, graph artifacts, dogfood history. Keep it uncommitted. |
 | Local usage metrics | Calculation rules, privacy boundaries, default-off versus opt-in behavior, export/delete controls, and retention live in [LOCAL_METRICS](docs/LOCAL_METRICS.md). |
+| `archex report status-card` | Opt-in, dimensioned documentation/release status summary: doc-link, ADR, and CODEOWNERS-style ownership evidence (each disabled unless its `documentation_evidence_providers` entry is configured) plus local CHANGELOG/CI-workflow evidence. Every dimension links to immutable local evidence; there is no composite score or letter grade, and the output is never written back into the repository automatically — paste it into your own README by hand if you want to publish it. |
 
 ## Measured results
 
@@ -352,6 +353,7 @@ archex report diff --base origin/main --format json
 archex report diff --base origin/main --format markdown
 archex report diff --base origin/main --format html > report.html
 archex report delta --base origin/main --format markdown
+archex report status-card --format markdown  # M9, opt-in: dimensioned doc/ADR/ownership + release evidence, disabled unless configured
 
 # Benchmarks and gates
 archex benchmark headtohead report --input .archex/headtohead --format markdown

--- a/src/archex/cli/report_cmd.py
+++ b/src/archex/cli/report_cmd.py
@@ -6,6 +6,7 @@ import click
 
 from archex.exceptions import ArchexError
 from archex.report.artifact import ReportArtifactError, build_analysis_artifact
+from archex.report.status_card import StatusCardError, build_status_card
 
 
 @click.group("report")
@@ -69,3 +70,35 @@ def delta_cmd(source: str, base: str, output_format: str) -> None:
         click.echo(delta.to_markdown(), nl=False)
         return
     click.echo(delta.to_json())
+
+
+@report_cmd.command("status-card")
+@click.argument("source", required=False, default=".")
+@click.option(
+    "--format",
+    "output_format",
+    default="markdown",
+    type=click.Choice(["json", "markdown"]),
+    help="Output format.",
+)
+def status_card_cmd(source: str, output_format: str) -> None:
+    """Build and render the dimensioned, evidence-linked documentation/release status card.
+
+    Every dimension is UNKNOWN unless its corresponding provider is
+    configured on the index (documentation_evidence_providers). Never
+    computes a composite score or letter grade, and never writes the
+    result back into SOURCE -- pipe the output into your own README by
+    hand when you want to publish it.
+    """
+    try:
+        card = build_status_card(source)
+    except (ArchexError, StatusCardError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if output_format == "json":
+        click.echo(card.to_json())
+        return
+
+    from archex.report.render_status_card import render_status_card_markdown
+
+    click.echo(render_status_card_markdown(card), nl=False)

--- a/src/archex/report/render_status_card.py
+++ b/src/archex/report/render_status_card.py
@@ -1,0 +1,38 @@
+"""Markdown projection of a StatusCard (M9).
+
+Projects ``StatusCard`` semantics without adding any -- in particular,
+never computes or displays a composite score, letter grade, or health
+rating across dimensions. Suitable for pasting into a project's own
+README as a "Status" section (never auto-injected; that decision and edit
+stay with the project's own maintainers).
+"""
+
+from __future__ import annotations
+
+from archex.report.status_card import StatusCard, StatusDimension, StatusDimensionState
+
+
+def _render_dimension(dimension: StatusDimension) -> list[str]:
+    label = "Evidenced" if dimension.state == StatusDimensionState.EVIDENCED else "Unknown"
+    lines = [f"### {dimension.name}", "", f"**{label}** — {dimension.detail}", ""]
+    if dimension.evidence:
+        lines.append("Evidence:")
+        lines.extend(f"- `{item.location}` — {item.description}" for item in dimension.evidence)
+        lines.append("")
+    return lines
+
+
+def render_status_card_markdown(card: StatusCard) -> str:
+    lines: list[str] = [
+        f"# Documentation & Release Status: {card.source_identity}",
+        "",
+        f"Generated at `{card.generated_at}` for revision `{card.revision[:12] or 'unknown'}`.",
+        "",
+        "Every dimension below is independent and links to immutable local "
+        "evidence. There is no composite score or letter grade — evaluate "
+        "each dimension on its own.",
+        "",
+    ]
+    for dimension in card.dimensions:
+        lines.extend(_render_dimension(dimension))
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/archex/report/status_card.py
+++ b/src/archex/report/status_card.py
@@ -1,0 +1,327 @@
+"""StatusCard: a dimensioned, evidence-linked documentation/release status summary (M9).
+
+Deliberately not a scored artifact: every dimension carries its own
+factual, evidence-linked state (``evidenced`` or ``unknown``) and there is
+no field anywhere in this module -- on ``StatusDimension`` or on
+``StatusCard`` itself -- that aggregates dimensions into a single score,
+letter grade, or health rating. A reader must weigh each dimension
+independently; archex never claims an overall verdict about a repository's
+documentation or release posture.
+
+Unlike M7's runtime/coverage evidence and M8's history evidence, which are
+diff-scoped (attached to a specific changed file or symbol), this card is
+repository-scoped: it summarizes the whole M9 documentation-evidence
+channel (doc links, ADR records, ownership records) plus locally
+verifiable release/CI evidence, read from the same read-only index every
+other report command uses. Building the card never mutates the analyzed
+repository -- it only reads a previously built index and files already on
+disk (``CHANGELOG.md``, ``.github/workflows/``).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from enum import StrEnum
+from pathlib import Path
+
+from pydantic import BaseModel, model_validator
+
+from archex.api import index_repository
+from archex.cache import CacheManager
+from archex.config import load_config, load_index_config
+from archex.integrations.docs.models import (
+    AdrRecord,
+    DocEvidenceProviderName,
+    DocProviderReceipt,
+    DocumentationLink,
+    OwnershipRecord,
+    ProviderAvailability,
+)
+from archex.models import RepoSource
+
+STATUS_CARD_SCHEMA_VERSION = "1.0.0"
+
+#: Bounds how many example evidence entries one dimension lists -- keeps the
+#: card small and reviewable rather than dumping every collected record.
+MAX_DIMENSION_EVIDENCE = 10
+
+#: Conventional read-only CI workflow locations checked for the "Release &
+#: CI evidence" dimension, in order. Presence is evidence of a pinned,
+#: read-only example existing -- never a claim about its current run state.
+_CI_WORKFLOW_CANDIDATES = (".github/workflows/report-diff.yml",)
+
+_CHANGELOG_VERSION_PATTERN = re.compile(r"^## \[([^\]]+)\](?:\s*-\s*(.+))?$", re.MULTILINE)
+
+
+class StatusCardError(ValueError):
+    """Raised when a status card cannot be built."""
+
+
+class StatusDimensionState(StrEnum):
+    """A dimension's own evidence state. Never combined across dimensions."""
+
+    EVIDENCED = "evidenced"
+    UNKNOWN = "unknown"
+
+
+class StatusDimensionEvidence(BaseModel):
+    """One concrete, locally verifiable pointer backing a dimension's state."""
+
+    description: str
+    location: str
+
+    @model_validator(mode="after")
+    def _validate_evidence(self) -> StatusDimensionEvidence:
+        if not self.description.strip():
+            raise ValueError("description must not be empty")
+        if not self.location.strip():
+            raise ValueError("location must not be empty")
+        return self
+
+
+class StatusDimension(BaseModel):
+    """One independent, evidence-linked axis of the status card.
+
+    ``detail`` is always a factual statement (a count, a path, a verbatim
+    declared value) -- never a subjective rating. ``evidence`` must be
+    non-empty whenever ``state`` is ``EVIDENCED``: a dimension claiming
+    evidence exists must point at it.
+    """
+
+    name: str
+    state: StatusDimensionState
+    detail: str
+    provider: str
+    evidence: list[StatusDimensionEvidence] = []
+
+    @model_validator(mode="after")
+    def _validate_dimension(self) -> StatusDimension:
+        if not self.name.strip():
+            raise ValueError("name must not be empty")
+        if not self.detail.strip():
+            raise ValueError("detail must not be empty")
+        if self.state == StatusDimensionState.EVIDENCED and not self.evidence:
+            raise ValueError("evidence must not be empty when state is EVIDENCED")
+        return self
+
+
+class StatusCard(BaseModel):
+    """The canonical, read-only dimensioned status card every renderer projects.
+
+    There is intentionally no ``score``, ``grade``, or ``health`` field on
+    this model, on ``StatusDimension``, or anywhere in this module: the
+    absence is structural, not a runtime check, so no code path can
+    construct a composite rating even by accident.
+    """
+
+    schema_version: str = STATUS_CARD_SCHEMA_VERSION
+    source_identity: str
+    revision: str
+    generated_at: str
+    dimensions: list[StatusDimension]
+
+    def to_json(self) -> str:
+        return json.dumps(self.model_dump(mode="json"), indent=2, sort_keys=True)
+
+
+def _provider_receipt(
+    receipts: list[DocProviderReceipt], provider: DocEvidenceProviderName
+) -> DocProviderReceipt | None:
+    return next((receipt for receipt in receipts if receipt.provider == provider), None)
+
+
+def _unknown_dimension(name: str, provider: str, reason: str) -> StatusDimension:
+    return StatusDimension(
+        name=name, state=StatusDimensionState.UNKNOWN, detail=reason, provider=provider
+    )
+
+
+def _doc_link_dimension(
+    doc_links: list[DocumentationLink], receipts: list[DocProviderReceipt]
+) -> StatusDimension:
+    receipt = _provider_receipt(receipts, DocEvidenceProviderName.DOC_LINK)
+    if receipt is None:
+        return _unknown_dimension(
+            "Documentation linkage", "doc_link", "doc_link provider not configured for this index"
+        )
+    if receipt.availability != ProviderAvailability.AVAILABLE or not doc_links:
+        return _unknown_dimension(
+            "Documentation linkage",
+            "doc_link",
+            receipt.reason or "doc_link provider produced no evidence",
+        )
+    documented_files = sorted({link.target_path for link in doc_links})
+    return StatusDimension(
+        name="Documentation linkage",
+        state=StatusDimensionState.EVIDENCED,
+        detail=(
+            f"{len(doc_links)} documentation link(s) reference {len(documented_files)} "
+            "distinct source path(s)"
+        ),
+        provider="doc_link",
+        evidence=[
+            StatusDimensionEvidence(
+                description=f"linked from {link.doc_path}", location=link.target_path
+            )
+            for link in doc_links[:MAX_DIMENSION_EVIDENCE]
+        ],
+    )
+
+
+def _adr_dimension(
+    adr_records: list[AdrRecord], receipts: list[DocProviderReceipt]
+) -> StatusDimension:
+    receipt = _provider_receipt(receipts, DocEvidenceProviderName.ADR)
+    if receipt is None:
+        return _unknown_dimension(
+            "ADR provenance", "adr", "adr provider not configured for this index"
+        )
+    if receipt.availability != ProviderAvailability.AVAILABLE or not adr_records:
+        return _unknown_dimension(
+            "ADR provenance", "adr", receipt.reason or "adr provider produced no evidence"
+        )
+    return StatusDimension(
+        name="ADR provenance",
+        state=StatusDimensionState.EVIDENCED,
+        detail=f"{len(adr_records)} architecture-decision-record(s) found",
+        provider="adr",
+        evidence=[
+            StatusDimensionEvidence(
+                description=f"{record.adr_id}: {record.title} (status: {record.status})",
+                location=record.doc_path,
+            )
+            for record in adr_records[:MAX_DIMENSION_EVIDENCE]
+        ],
+    )
+
+
+def _ownership_dimension(
+    ownership_records: list[OwnershipRecord], receipts: list[DocProviderReceipt]
+) -> StatusDimension:
+    receipt = _provider_receipt(receipts, DocEvidenceProviderName.OWNERSHIP)
+    if receipt is None:
+        return _unknown_dimension(
+            "Ownership coverage", "ownership", "ownership provider not configured for this index"
+        )
+    if receipt.availability != ProviderAvailability.AVAILABLE or not ownership_records:
+        return _unknown_dimension(
+            "Ownership coverage",
+            "ownership",
+            receipt.reason or "ownership provider produced no evidence",
+        )
+    return StatusDimension(
+        name="Ownership coverage",
+        state=StatusDimensionState.EVIDENCED,
+        detail=f"{len(ownership_records)} ownership pattern(s) declared",
+        provider="ownership",
+        evidence=[
+            StatusDimensionEvidence(
+                description=f"{record.path_pattern} -> {', '.join(record.owners)}",
+                location=record.source_path,
+            )
+            for record in ownership_records[:MAX_DIMENSION_EVIDENCE]
+        ],
+    )
+
+
+def _latest_released_changelog_entry(repo_root: Path) -> tuple[str, str] | None:
+    """Return ``(version, date)`` for the most recent *released* CHANGELOG entry.
+
+    Skips a leading ``## [Unreleased]`` heading -- that section describes
+    staged, not-yet-published changes, so it is never presented as release
+    evidence.
+    """
+    changelog_path = repo_root / "CHANGELOG.md"
+    if not changelog_path.is_file():
+        return None
+    try:
+        text = changelog_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return None
+    for match in _CHANGELOG_VERSION_PATTERN.finditer(text):
+        version = match.group(1).strip()
+        if version.lower() == "unreleased":
+            continue
+        date = (match.group(2) or "").strip()
+        return version, date
+    return None
+
+
+def _release_dimension(repo_root: Path) -> StatusDimension:
+    changelog_entry = _latest_released_changelog_entry(repo_root)
+    ci_workflow = next(
+        (candidate for candidate in _CI_WORKFLOW_CANDIDATES if (repo_root / candidate).is_file()),
+        None,
+    )
+    if changelog_entry is None and ci_workflow is None:
+        return _unknown_dimension(
+            "Release & CI evidence",
+            "release",
+            "no released CHANGELOG.md entry and no pinned read-only CI workflow found",
+        )
+    evidence: list[StatusDimensionEvidence] = []
+    detail_parts: list[str] = []
+    if changelog_entry is not None:
+        version, date = changelog_entry
+        label = f"{version} ({date})" if date else version
+        detail_parts.append(f"latest released version is {label}")
+        evidence.append(
+            StatusDimensionEvidence(description=f"CHANGELOG entry {label}", location="CHANGELOG.md")
+        )
+    if ci_workflow is not None:
+        detail_parts.append("a pinned read-only CI workflow is present")
+        evidence.append(
+            StatusDimensionEvidence(
+                description="pinned read-only CI workflow", location=ci_workflow
+            )
+        )
+    return StatusDimension(
+        name="Release & CI evidence",
+        state=StatusDimensionState.EVIDENCED,
+        detail="; ".join(detail_parts),
+        provider="release",
+        evidence=evidence,
+    )
+
+
+def build_status_card(source: str | Path) -> StatusCard:
+    """Build the canonical dimensioned status card for *source*.
+
+    Ensures a current index via ``index_repository`` (the same read-side
+    contract every other analysis command uses). Every dimension is
+    ``UNKNOWN`` unless its corresponding provider is configured on the
+    index and produced real evidence -- there is no default-enabled
+    dimension.
+    """
+    repo_root = Path(source).expanduser().resolve()
+    repo_source = RepoSource(local_path=str(source))
+    config = load_config(repo_source)
+    index_config = load_index_config(repo_source)
+
+    store = index_repository(repo_source, config=config, index_config=index_config)
+    try:
+        doc_links = store.get_documentation_links()
+        adr_records = store.get_documentation_adr_records()
+        ownership_records = store.get_documentation_ownership_records()
+        receipts = store.get_documentation_provider_receipts()
+        source_revision = (
+            store.get_metadata("commit_hash") or CacheManager.git_head(str(repo_root)) or ""
+        )
+    finally:
+        store.close()
+
+    dimensions = [
+        _doc_link_dimension(doc_links, receipts),
+        _adr_dimension(adr_records, receipts),
+        _ownership_dimension(ownership_records, receipts),
+        _release_dimension(repo_root),
+    ]
+
+    return StatusCard(
+        source_identity=repo_source.url or repo_source.local_path or str(repo_root),
+        revision=source_revision,
+        generated_at=str(time.time()),
+        dimensions=dimensions,
+    )

--- a/src/archex/report/status_card.py
+++ b/src/archex/report/status_card.py
@@ -48,8 +48,10 @@ STATUS_CARD_SCHEMA_VERSION = "1.0.0"
 MAX_DIMENSION_EVIDENCE = 10
 
 #: Conventional read-only CI workflow locations checked for the "Release &
-#: CI evidence" dimension, in order. Presence is evidence of a pinned,
-#: read-only example existing -- never a claim about its current run state.
+#: CI evidence" dimension, in order. Presence is reported as evidence of a
+#: CI workflow example existing at that path -- this dimension does not
+#: itself parse the file to verify pinning or permissions, and never
+#: claims its current run state.
 _CI_WORKFLOW_CANDIDATES = (".github/workflows/report-diff.yml",)
 
 _CHANGELOG_VERSION_PATTERN = re.compile(r"^## \[([^\]]+)\](?:\s*-\s*(.+))?$", re.MULTILINE)
@@ -259,7 +261,7 @@ def _release_dimension(repo_root: Path) -> StatusDimension:
         return _unknown_dimension(
             "Release & CI evidence",
             "release",
-            "no released CHANGELOG.md entry and no pinned read-only CI workflow found",
+            "no released CHANGELOG.md entry and no CI workflow example found",
         )
     evidence: list[StatusDimensionEvidence] = []
     detail_parts: list[str] = []
@@ -271,11 +273,13 @@ def _release_dimension(repo_root: Path) -> StatusDimension:
             StatusDimensionEvidence(description=f"CHANGELOG entry {label}", location="CHANGELOG.md")
         )
     if ci_workflow is not None:
-        detail_parts.append("a pinned read-only CI workflow is present")
+        # Reports presence only -- this dimension does not itself parse the
+        # workflow's pin/permission content, so it never claims "pinned" or
+        # "read-only" as a fact it did not check. That specific property is
+        # independently verified by tests/test_report_ci_workflow.py.
+        detail_parts.append("a CI workflow example is present")
         evidence.append(
-            StatusDimensionEvidence(
-                description="pinned read-only CI workflow", location=ci_workflow
-            )
+            StatusDimensionEvidence(description="CI workflow example", location=ci_workflow)
         )
     return StatusDimension(
         name="Release & CI evidence",

--- a/tests/test_receipt.py
+++ b/tests/test_receipt.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from archex.integrations.docs.models import DocEvidenceProviderName, DocProviderReceipt
+from archex.integrations.docs.models import ProviderAvailability as DocProviderAvailability
 from archex.integrations.history.eligibility import evaluate_history_eligibility
 from archex.integrations.history.models import (
     ChangeCard,
@@ -316,6 +318,32 @@ def test_build_context_receipt_defaults_history_providers_empty_and_no_eligibili
     receipt = build_context_receipt(bundle, index_revision="rev", freshness=ContextFreshness.CLEAN)
     assert receipt.history_providers == []
     assert receipt.history_eligibility is None
+
+
+def test_build_context_receipt_carries_documentation_providers() -> None:
+    bundle = ContextBundle(query="q", token_count=10, token_budget=100)
+    receipts = [
+        DocProviderReceipt(
+            provider=DocEvidenceProviderName.DOC_LINK,
+            availability=DocProviderAvailability.AVAILABLE,
+            records_collected=3,
+        )
+    ]
+
+    receipt = build_context_receipt(
+        bundle,
+        index_revision="rev",
+        freshness=ContextFreshness.CLEAN,
+        documentation_providers=receipts,
+    )
+
+    assert receipt.documentation_providers == receipts
+
+
+def test_build_context_receipt_defaults_documentation_providers_empty() -> None:
+    bundle = ContextBundle(query="q", token_count=10, token_budget=100)
+    receipt = build_context_receipt(bundle, index_revision="rev", freshness=ContextFreshness.CLEAN)
+    assert receipt.documentation_providers == []
 
 
 def _bundle_with_chunk(file_path: str) -> ContextBundle:

--- a/tests/test_report_render_status_card.py
+++ b/tests/test_report_render_status_card.py
@@ -1,0 +1,79 @@
+"""Tests for the StatusCard markdown renderer (M9)."""
+
+from __future__ import annotations
+
+import re
+
+from archex.report.render_status_card import render_status_card_markdown
+from archex.report.status_card import (
+    StatusCard,
+    StatusDimension,
+    StatusDimensionEvidence,
+    StatusDimensionState,
+)
+
+_BANNED_PATTERNS = (
+    re.compile(r"grade\s*[:=]", re.IGNORECASE),
+    re.compile(r"\boverall\s*(score|grade|rating|health)\b", re.IGNORECASE),
+    re.compile(r"\bhealth\s*score\b", re.IGNORECASE),
+    re.compile(r"^\s*[A-F][+-]?\s*$", re.MULTILINE),
+)
+
+
+def _sample_card() -> StatusCard:
+    return StatusCard(
+        source_identity="example/repo",
+        revision="0123456789ab",
+        generated_at="123.0",
+        dimensions=[
+            StatusDimension(
+                name="Documentation linkage",
+                state=StatusDimensionState.EVIDENCED,
+                detail="3 documentation link(s) reference 2 distinct source path(s)",
+                provider="doc_link",
+                evidence=[
+                    StatusDimensionEvidence(description="linked from README.md", location="a.py")
+                ],
+            ),
+            StatusDimension(
+                name="ADR provenance",
+                state=StatusDimensionState.UNKNOWN,
+                detail="no ADR directory found",
+                provider="adr",
+            ),
+        ],
+    )
+
+
+class TestRenderStatusCardMarkdown:
+    def test_includes_source_identity_and_revision(self) -> None:
+        markdown = render_status_card_markdown(_sample_card())
+        assert "example/repo" in markdown
+        assert "0123456789ab" in markdown
+
+    def test_renders_each_dimension_by_name(self) -> None:
+        markdown = render_status_card_markdown(_sample_card())
+        assert "### Documentation linkage" in markdown
+        assert "### ADR provenance" in markdown
+
+    def test_evidenced_dimension_lists_its_evidence(self) -> None:
+        markdown = render_status_card_markdown(_sample_card())
+        assert "**Evidenced**" in markdown
+        assert "`a.py`" in markdown
+        assert "linked from README.md" in markdown
+
+    def test_unknown_dimension_shows_reason_without_evidence_list(self) -> None:
+        markdown = render_status_card_markdown(_sample_card())
+        adr_section = markdown.split("### ADR provenance", 1)[1]
+        assert "**Unknown**" in adr_section
+        assert "no ADR directory found" in adr_section
+        assert "Evidence:" not in adr_section
+
+    def test_never_renders_a_composite_grade_or_overall_score(self) -> None:
+        markdown = render_status_card_markdown(_sample_card())
+        for pattern in _BANNED_PATTERNS:
+            assert not pattern.search(markdown), pattern.pattern
+
+    def test_states_no_composite_score_disclaimer(self) -> None:
+        markdown = render_status_card_markdown(_sample_card())
+        assert "no composite score or letter grade" in markdown.lower()

--- a/tests/test_report_status_card.py
+++ b/tests/test_report_status_card.py
@@ -1,0 +1,161 @@
+"""Tests for the M9 dimensioned StatusCard model and builder.
+
+Covers `build_status_card`'s projection of M9's documentation-evidence
+channel plus locally verifiable release/CI evidence into one canonical,
+never-scored status card.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from archex.report.status_card import (
+    StatusCard,
+    StatusDimension,
+    StatusDimensionEvidence,
+    StatusDimensionState,
+    build_status_card,
+)
+
+if TYPE_CHECKING:
+    from archex.models import IndexConfig, RepoSource
+
+
+def _enable_documentation_providers(monkeypatch: pytest.MonkeyPatch, providers: list[str]) -> None:
+    from archex.config import load_index_config as original_load_index_config
+
+    def _patched(source: RepoSource) -> IndexConfig:
+        config = original_load_index_config(source)
+        return config.model_copy(update={"documentation_evidence_providers": providers})
+
+    monkeypatch.setattr("archex.report.status_card.load_index_config", _patched)
+
+
+class TestStatusDimensionEvidence:
+    def test_rejects_empty_description(self) -> None:
+        with pytest.raises(ValueError, match="description"):
+            StatusDimensionEvidence(description=" ", location="README.md")
+
+    def test_rejects_empty_location(self) -> None:
+        with pytest.raises(ValueError, match="location"):
+            StatusDimensionEvidence(description="a link", location=" ")
+
+
+class TestStatusDimension:
+    def test_rejects_empty_name(self) -> None:
+        with pytest.raises(ValueError, match="name"):
+            StatusDimension(
+                name=" ", state=StatusDimensionState.UNKNOWN, detail="not configured", provider="x"
+            )
+
+    def test_rejects_empty_detail(self) -> None:
+        with pytest.raises(ValueError, match="detail"):
+            StatusDimension(name="X", state=StatusDimensionState.UNKNOWN, detail=" ", provider="x")
+
+    def test_evidenced_state_requires_evidence(self) -> None:
+        with pytest.raises(ValueError, match="evidence"):
+            StatusDimension(
+                name="X",
+                state=StatusDimensionState.EVIDENCED,
+                detail="found something",
+                provider="x",
+            )
+
+    def test_unknown_state_allows_no_evidence(self) -> None:
+        dimension = StatusDimension(
+            name="X", state=StatusDimensionState.UNKNOWN, detail="not configured", provider="x"
+        )
+        assert dimension.evidence == []
+
+
+class TestStatusCardHasNoCompositeField:
+    """Structural guardrail: no score/grade/health field exists on the model.
+
+    The absence must be a type-design fact, not a runtime check, so no
+    call site can construct or emit a composite rating even by accident.
+    """
+
+    _BANNED_SUBSTRINGS = ("score", "grade", "health", "rating", "rank")
+
+    def test_status_card_fields_have_no_banned_names(self) -> None:
+        for field_name in StatusCard.model_fields:
+            lowered = field_name.lower()
+            assert not any(banned in lowered for banned in self._BANNED_SUBSTRINGS), field_name
+
+    def test_status_dimension_fields_have_no_banned_names(self) -> None:
+        for field_name in StatusDimension.model_fields:
+            lowered = field_name.lower()
+            assert not any(banned in lowered for banned in self._BANNED_SUBSTRINGS), field_name
+
+
+class TestBuildStatusCard:
+    def test_dimensions_are_unknown_without_configured_providers(
+        self, python_simple_repo: Path
+    ) -> None:
+        card = build_status_card(python_simple_repo)
+
+        by_provider = {dimension.provider: dimension for dimension in card.dimensions}
+        assert by_provider["doc_link"].state == StatusDimensionState.UNKNOWN
+        assert by_provider["adr"].state == StatusDimensionState.UNKNOWN
+        assert by_provider["ownership"].state == StatusDimensionState.UNKNOWN
+
+    def test_doc_link_dimension_evidenced_when_configured_and_present(
+        self, python_simple_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (python_simple_repo / "README.md").write_text("See [main](main.py).\n")
+        _enable_documentation_providers(monkeypatch, ["doc_link"])
+
+        card = build_status_card(python_simple_repo)
+
+        by_provider = {dimension.provider: dimension for dimension in card.dimensions}
+        doc_link = by_provider["doc_link"]
+        assert doc_link.state == StatusDimensionState.EVIDENCED
+        assert any(item.location == "main.py" for item in doc_link.evidence)
+
+    def test_release_dimension_reads_changelog_and_ci_workflow(
+        self, python_simple_repo: Path
+    ) -> None:
+        (python_simple_repo / "CHANGELOG.md").write_text(
+            "# Changelog\n\n## [Unreleased]\n\n### Added\n\n- staged work\n\n"
+            "## [1.2.3] - 2026-01-01\n\n### Added\n\n- first release\n"
+        )
+        workflow_dir = python_simple_repo / ".github" / "workflows"
+        workflow_dir.mkdir(parents=True)
+        (workflow_dir / "report-diff.yml").write_text("name: Report diff\n")
+
+        card = build_status_card(python_simple_repo)
+
+        by_provider = {dimension.provider: dimension for dimension in card.dimensions}
+        release = by_provider["release"]
+        assert release.state == StatusDimensionState.EVIDENCED
+        assert "1.2.3" in release.detail
+        assert "Unreleased" not in release.detail
+
+    def test_release_dimension_unknown_without_any_local_evidence(
+        self, python_simple_repo: Path
+    ) -> None:
+        card = build_status_card(python_simple_repo)
+
+        by_provider = {dimension.provider: dimension for dimension in card.dimensions}
+        assert by_provider["release"].state == StatusDimensionState.UNKNOWN
+
+    def test_to_json_round_trips(self, python_simple_repo: Path) -> None:
+        card = build_status_card(python_simple_repo)
+        restored = StatusCard.model_validate_json(card.to_json())
+        assert restored.source_identity == card.source_identity
+        assert len(restored.dimensions) == len(card.dimensions)
+
+    def test_deterministic_evidence_bound(
+        self, python_simple_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        readme = python_simple_repo / "README.md"
+        lines = "\n".join(f"See [x{i}](main.py) too." for i in range(20))
+        readme.write_text(lines + "\n")
+        _enable_documentation_providers(monkeypatch, ["doc_link"])
+
+        card = build_status_card(python_simple_repo)
+        by_provider = {dimension.provider: dimension for dimension in card.dimensions}
+        assert len(by_provider["doc_link"].evidence) <= 10

--- a/tests/test_report_status_card.py
+++ b/tests/test_report_status_card.py
@@ -78,7 +78,19 @@ class TestStatusCardHasNoCompositeField:
     call site can construct or emit a composite rating even by accident.
     """
 
-    _BANNED_SUBSTRINGS = ("score", "grade", "health", "rating", "rank")
+    _BANNED_SUBSTRINGS = (
+        "score",
+        "grade",
+        "health",
+        "rating",
+        "rank",
+        "tier",
+        "level",
+        "verdict",
+        "overall",
+        "aggregate",
+        "composite",
+    )
 
     def test_status_card_fields_have_no_banned_names(self) -> None:
         for field_name in StatusCard.model_fields:
@@ -87,6 +99,11 @@ class TestStatusCardHasNoCompositeField:
 
     def test_status_dimension_fields_have_no_banned_names(self) -> None:
         for field_name in StatusDimension.model_fields:
+            lowered = field_name.lower()
+            assert not any(banned in lowered for banned in self._BANNED_SUBSTRINGS), field_name
+
+    def test_status_dimension_evidence_fields_have_no_banned_names(self) -> None:
+        for field_name in StatusDimensionEvidence.model_fields:
             lowered = field_name.lower()
             assert not any(banned in lowered for banned in self._BANNED_SUBSTRINGS), field_name
 

--- a/tests/test_report_status_card_cmd.py
+++ b/tests/test_report_status_card_cmd.py
@@ -1,0 +1,47 @@
+"""Tests for the `archex report status-card` CLI command (M9)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+
+
+class TestReportStatusCardCmd:
+    def test_default_format_is_markdown(self, python_simple_repo: Path) -> None:
+        runner = CliRunner()
+
+        result = runner.invoke(cli, ["report", "status-card", str(python_simple_repo)])
+
+        assert result.exit_code == 0, result.output
+        assert result.output.startswith("# Documentation & Release Status:")
+        assert "### Documentation linkage" in result.output
+
+    def test_json_format_round_trips(self, python_simple_repo: Path) -> None:
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli, ["report", "status-card", str(python_simple_repo), "--format", "json"]
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["schema_version"] == "1.0.0"
+        assert len(payload["dimensions"]) == 4
+
+    def test_json_output_has_no_composite_score_field(self, python_simple_repo: Path) -> None:
+        runner = CliRunner()
+
+        result = runner.invoke(
+            cli, ["report", "status-card", str(python_simple_repo), "--format", "json"]
+        )
+
+        payload = json.loads(result.output)
+        top_level_keys = {key.lower() for key in payload}
+        assert not top_level_keys & {"score", "grade", "health", "rating"}
+        for dimension in payload["dimensions"]:
+            dimension_keys = {key.lower() for key in dimension}
+            assert not dimension_keys & {"score", "grade", "health", "rating"}


### PR DESCRIPTION
## Stack

Stack-Id: `m9-documentation-status-3afee1`
Base: `main`
Position: 2/3

1. `m9-1-documentation-evidence-model` -> #560
2. `m9-2-dimensioned-status-surface` -> this PR
3. `m9-3-immutable-ci-release-evidence` -> (next)

Depends on: #560
Upstack: PR-3 (immutable CI/release evidence)

## Summary

M9 (Add Documentation Graph and Dimensioned Status Evidence Conditionally), PR-2 of 3: a dimensioned, evidence-linked status card built from PR-1's documentation evidence plus local release/CI evidence.

- `archex report status-card SOURCE --format json|markdown` — new opt-in read-only report command.
- `StatusCard`/`StatusDimension`: structurally never scored — no `score`/`grade`/`health`/`rating` field exists anywhere in the model (a dedicated test enumerates `model_fields` to guarantee this), and every `EVIDENCED` dimension must carry non-empty evidence pointers.
- Four independent dimensions: Documentation linkage, ADR provenance, Ownership coverage (each `UNKNOWN` unless its `documentation_evidence_providers` entry is configured and produced real evidence), and Release & CI evidence (reads the latest **released** CHANGELOG entry and checks for a pinned read-only CI workflow — never a live CI-state claim).
- Markdown renderer includes an explicit "no composite score or letter grade" disclaimer and is tested to never emit a grade-assignment pattern.
- Output is never written back into `SOURCE` — publishing into a project's own README stays a manual, human-reviewed edit.

## Validation

- `uv run ruff check .` — pass
- `uv run ruff format --check .` — pass
- `uv run pyright .` — 0 errors
- `uv run pytest --junitxml=results.xml --cov-report=xml` — 4409 passed, 91.35% coverage (>= 85% gate)
- Manual smoke test: `archex report status-card .` against this repo (real CHANGELOG/CI evidence, correctly `UNKNOWN` for unconfigured doc/ADR/ownership dimensions) and again with `documentation_evidence_providers=["doc_link"]` enabled (53 real links found in this repo's own README/docs).
