### PR TITLE
feat(mcp): add tool-scoping to server registration

### DIFF
--- a/src/archex/cli/install_client_cmd.py
+++ b/src/archex/cli/install_client_cmd.py
@@ -87,6 +87,18 @@ def _is_interactive() -> bool:
     default=False,
     help="Install client config even if the archex mcp runtime is missing.",
 )
+@click.option(
+    "--tool-scope",
+    default=None,
+    help=(
+        "Scope the tools the registered `archex mcp` server advertises: "
+        "'all' (default, every tool), a named profile ('core' excludes "
+        "the graph_* cluster, 'graph' is only the graph_* cluster), or a "
+        "comma-separated explicit tool-name allowlist. Written into the "
+        "client config as `archex mcp --tools <value>`; omit for the "
+        "existing unscoped `archex mcp` behavior."
+    ),
+)
 def install_client_cmd(
     client_or_source: str | None,
     source_opt: str | None,
@@ -98,6 +110,7 @@ def install_client_cmd(
     allow_missing_mcp: bool,
     all_detected: bool,
     yes: bool,
+    tool_scope: str | None,
 ) -> None:
     """Install MCP client configuration for archex (preview with --dry-run)."""
     if hooks and remove_hooks:
@@ -151,7 +164,7 @@ def install_client_cmd(
             )
 
             discovered = discover_clients(source)
-            plans = build_discovered_install_plans(discovered, source)
+            plans = build_discovered_install_plans(discovered, source, tool_scope=tool_scope)
             if dry_run:
                 click.echo(render_multiple_install_preview(plans), nl=False)
                 if agent_file is not None:
@@ -198,7 +211,7 @@ def install_client_cmd(
                 click.echo("\nNo configured clients found.")
                 return
 
-            plans = build_discovered_install_plans(discovered, source)
+            plans = build_discovered_install_plans(discovered, source, tool_scope=tool_scope)
             click.echo(
                 f"\nInstall archex MCP registration for {len(plans)} detected clients? [y/N] ",
                 nl=False,
@@ -256,6 +269,7 @@ def install_client_cmd(
             cast("ClientName", client),
             source,
             scope=cast("ClientScope | None", scope),
+            tool_scope=tool_scope,
         )
         if dry_run:
             click.echo(render_client_install_preview(plan), nl=False)

--- a/src/archex/cli/main.py
+++ b/src/archex/cli/main.py
@@ -20,6 +20,7 @@ from archex.cli.index_cmd import index_cmd
 from archex.cli.init_cmd import init_cmd
 from archex.cli.install_client_cmd import install_client_cmd
 from archex.cli.mcp_cmd import mcp_cmd
+from archex.cli.mcp_schema_size_cmd import mcp_schema_size_cmd
 from archex.cli.metrics_cmd import metrics_cmd
 from archex.cli.onboard_cmd import onboard_cmd
 from archex.cli.outline_cmd import outline_cmd
@@ -55,6 +56,7 @@ cli.add_command(reset_cmd)
 cli.add_command(doctor_cmd)
 cli.add_command(dogfood_cmd)
 cli.add_command(mcp_cmd)
+cli.add_command(mcp_schema_size_cmd)
 cli.add_command(metrics_cmd)
 cli.add_command(tree_cmd)
 cli.add_command(outline_cmd)

--- a/src/archex/cli/mcp_cmd.py
+++ b/src/archex/cli/mcp_cmd.py
@@ -22,17 +22,30 @@ import click
     type=int,
     help="Debounce interval for filesystem refreshes.",
 )
-def mcp_cmd(watch: bool, watch_path: str, watch_debounce_ms: int) -> None:
+@click.option(
+    "--tools",
+    default=None,
+    help=(
+        "Scope the tools this server advertises via list_tools(): 'all' "
+        "(default, every tool), a named profile ('core' excludes the "
+        "graph_* cluster, 'graph' is only the graph_* cluster), or a "
+        "comma-separated explicit tool-name allowlist. Every tool name "
+        "still dispatches regardless of scoping -- this only shrinks the "
+        "advertised schema surface, see `archex mcp-schema-size`."
+    ),
+)
+def mcp_cmd(watch: bool, watch_path: str, watch_debounce_ms: int, tools: str | None) -> None:
     """Start the archex MCP server (stdio transport).
 
-    Exposes 17 MCP tools (analyze_repo, query_repo, scout_repo, compare_repos,
-    get_file_tree, get_file_outline, search_symbols, get_symbol,
-    get_symbols_batch, get_impact, explain_target, generate_onboarding, and
-    the graph_* lookup/neighbors/path/stats/hubs tools). Connect an
-    MCP-compatible client (e.g. Claude Code) to stdin/stdout.
+    Exposes 18 MCP tools (analyze_repo, scout_repo, query_repo, context,
+    compare_repos, get_file_tree, get_file_outline, search_symbols,
+    get_symbol, get_symbols_batch, get_impact, explain_target,
+    generate_onboarding, and the graph_* lookup/neighbors/path/stats/hubs
+    tools) unless narrowed with --tools. Connect an MCP-compatible client
+    (e.g. Claude Code) to stdin/stdout.
     """
     try:
-        from archex.integrations.mcp import run_stdio_server
+        from archex.integrations.mcp import resolve_tool_scope, run_stdio_server
     except ImportError as exc:
         raise click.ClickException(
             "MCP integration requires the `mcp` Python package.\n\n"
@@ -44,10 +57,16 @@ def mcp_cmd(watch: bool, watch_path: str, watch_debounce_ms: int) -> None:
             "  uv sync --extra mcp"
         ) from exc
 
+    try:
+        tool_names = resolve_tool_scope(tools)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
     asyncio.run(
         run_stdio_server(
             watch=watch,
             watch_path=watch_path,
             watch_debounce_ms=watch_debounce_ms,
+            tool_names=tool_names,
         )
     )

--- a/src/archex/cli/mcp_schema_size_cmd.py
+++ b/src/archex/cli/mcp_schema_size_cmd.py
@@ -1,0 +1,54 @@
+"""CLI mcp-schema-size subcommand: measure serialized MCP tool-schema size."""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+
+@click.command("mcp-schema-size")
+@click.option(
+    "--tools",
+    default=None,
+    help=(
+        "Tool scope to measure: 'all' (default, every tool), a named "
+        "profile ('core' excludes the graph_* cluster, 'graph' is only "
+        "the graph_* cluster), or a comma-separated explicit tool-name "
+        "allowlist."
+    ),
+)
+@click.option(
+    "--format",
+    "format_",
+    type=click.Choice(["text", "json"]),
+    default="text",
+    show_default=True,
+    help="Output format.",
+)
+def mcp_schema_size_cmd(tools: str | None, format_: str) -> None:
+    """Measure the serialized MCP tool-schema size for a tool scope.
+
+    Reports total and per-tool character counts of the JSON schema archex's
+    MCP server would advertise via list_tools() for the given scope, so a
+    client can compare 'all' against a narrower scope before choosing
+    `archex mcp --tools ...` or `archex install-client --tool-scope ...`.
+    """
+    from archex.integrations.mcp import measure_tool_schema_size, resolve_tool_scope
+
+    try:
+        tool_names = resolve_tool_scope(tools)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    report = measure_tool_schema_size(tool_names)
+    if format_ == "json":
+        click.echo(json.dumps({"scope": tools or "all", **report}, indent=2, sort_keys=True))
+        return
+
+    click.echo(f"Scope: {tools or 'all'}")
+    click.echo(f"Tools: {report['tool_count']}")
+    click.echo(f"Total serialized schema size: {report['total_chars']} chars")
+    click.echo("\nPer-tool:")
+    for name, size in sorted(report["per_tool_chars"].items()):
+        click.echo(f"  {name}: {size} chars")

--- a/src/archex/cli/setup_cmd.py
+++ b/src/archex/cli/setup_cmd.py
@@ -20,6 +20,7 @@ from archex.client_setup import (
     write_hook_install_plan,
 )
 from archex.doctor import mcp_runtime_available
+from archex.integrations.mcp import resolve_tool_scope
 from archex.metrics.policy import resolve_metrics_policy, set_metrics_enabled, set_trace_enabled
 from archex.project import init_project
 from archex.status import inspect_project_status
@@ -105,7 +106,11 @@ def apply_init_index(
 
 
 def apply_clients_guidance(
-    source: Path, preflight: PreflightState, dry_run: bool, clients_flag: bool | None
+    source: Path,
+    preflight: PreflightState,
+    dry_run: bool,
+    clients_flag: bool | None,
+    tool_scope: str | None = None,
 ) -> dict[str, list[dict[str, str | bool]]]:
     """Apply MCP client registration and agent guidance.
 
@@ -125,7 +130,7 @@ def apply_clients_guidance(
     else:
         should_configure_clients = True
         clients = discover_clients(source)
-        plans = build_discovered_install_plans(clients, source)
+        plans = build_discovered_install_plans(clients, source, tool_scope=tool_scope)
         if not plans:
             actions.append({"type": "client_install", "status": "skipped_no_clients"})
         else:
@@ -248,6 +253,16 @@ def print_final_summary(
     default="text",
     help="Output format.",
 )
+@click.option(
+    "--tool-scope",
+    default=None,
+    help=(
+        "Scope the tools any registered `archex mcp` server advertises: "
+        "'all' (default, every tool), a named profile ('core' excludes "
+        "the graph_* cluster, 'graph' is only the graph_* cluster), or a "
+        "comma-separated explicit tool-name allowlist."
+    ),
+)
 def setup_cmd(
     source: Path,
     dry_run: bool,
@@ -256,8 +271,14 @@ def setup_cmd(
     metrics: bool | None,
     hooks: bool,
     format_: Literal["text", "json"],
+    tool_scope: str | None,
 ) -> None:
     """Guided onboarding wizard."""
+    if tool_scope is not None:
+        try:
+            resolve_tool_scope(tool_scope)
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
     preflight = run_preflight(source)
 
     if (
@@ -286,7 +307,7 @@ def setup_cmd(
             "preflight": asdict(preflight),
             "planned_actions": actions,
             "clients_guidance": apply_clients_guidance(
-                source, preflight, dry_run=True, clients_flag=clients
+                source, preflight, dry_run=True, clients_flag=clients, tool_scope=tool_scope
             )["clients_guidance"],
             "metrics_hooks": apply_metrics_hooks(
                 source, preflight, dry_run=True, metrics_flag=metrics, hooks_flag=hooks
@@ -313,9 +334,9 @@ def setup_cmd(
             click.echo("- Index is fresh (skipped)")
 
         click.echo("--- Clients & Agent Guidance ---")
-        cg_actions = apply_clients_guidance(source, preflight, dry_run=True, clients_flag=clients)[
-            "clients_guidance"
-        ]
+        cg_actions = apply_clients_guidance(
+            source, preflight, dry_run=True, clients_flag=clients, tool_scope=tool_scope
+        )["clients_guidance"]
         for action in cg_actions:
             name = action.get("client") or action.get("file") or action["type"]
             click.echo(f"- {name}: {action['status']}")
@@ -331,7 +352,9 @@ def setup_cmd(
     if yes:
         click.echo("--- Executing Setup ---")
         results = apply_init_index(source, preflight, dry_run=False)
-        cg_results = apply_clients_guidance(source, preflight, dry_run=False, clients_flag=clients)
+        cg_results = apply_clients_guidance(
+            source, preflight, dry_run=False, clients_flag=clients, tool_scope=tool_scope
+        )
         mh_results = apply_metrics_hooks(
             source, preflight, dry_run=False, metrics_flag=metrics, hooks_flag=hooks
         )
@@ -397,20 +420,25 @@ def setup_cmd(
     # Clients (MCP) — registers the full 18-tool surface (context, query,
     # scout, graph inspection, impact analysis, etc.). Every tool's schema
     # is resent on every turn regardless of use, so this is worth it when
-    # you want that full surface, not just grep/glob augmentation.
+    # you want that full surface, not just grep/glob augmentation. Pass
+    # --tool-scope (e.g. 'core', 'graph', or an explicit tool-name
+    # allowlist) to register a narrower surface and cut that per-turn cost.
     do_clients = clients
     if do_clients is None and preflight.discovered_clients and preflight.mcp_runtime_available:
         click.echo(
             "\nMCP registers all 18 archex tools with your client (context, query, scout, "
             "graph inspection, impact analysis, and more) — the richest surface, at the cost "
-            "of resending every tool's schema on every turn."
+            "of resending every tool's schema on every turn. Use --tool-scope to register "
+            "fewer tools instead."
         )
         do_clients = click.confirm(
             f"Configure {len(preflight.discovered_clients)} discovered MCP clients?",
             default=True,
         )
 
-    cg_results = apply_clients_guidance(source, preflight, dry_run=False, clients_flag=do_clients)
+    cg_results = apply_clients_guidance(
+        source, preflight, dry_run=False, clients_flag=do_clients, tool_scope=tool_scope
+    )
     results["clients_guidance"].extend(cg_results["clients_guidance"])
 
     # Metrics

--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -11,6 +11,7 @@ from typing import Literal, cast
 
 from archex.integrations.codex_hook import HOOK_MATCHER as CODEX_HOOK_MATCHER
 from archex.integrations.hook import HOOK_MATCHER
+from archex.integrations.mcp import resolve_tool_scope
 
 ClientName = Literal["claude-code", "codex", "cursor", "opencode", "pi", "omp"]
 ClientScope = Literal["project", "user"]
@@ -167,12 +168,15 @@ def discover_clients(source: str | Path | None = None) -> list[DiscoveredClient]
 def build_discovered_install_plans(
     discovered: list[DiscoveredClient],
     source: str | Path | None = None,
+    tool_scope: str | None = None,
 ) -> list[ClientInstallPlan]:
     plans: list[ClientInstallPlan] = []
     for d in discovered:
         if d.is_installed:
             s = source if d.scope == "project" else None
-            plans.append(build_client_install_plan(d.client, s, scope=d.scope))
+            plans.append(
+                build_client_install_plan(d.client, s, scope=d.scope, tool_scope=tool_scope)
+            )
     return plans
 
 
@@ -198,13 +202,14 @@ def build_client_install_plan(
     source: str | Path | None = None,
     *,
     scope: ClientScope | None = None,
+    tool_scope: str | None = None,
 ) -> ClientInstallPlan:
     selected_scope = _resolve_scope(client, source, scope)
     if client in _USER_ONLY_CLIENTS and selected_scope != "user":
         raise ValueError(f"{client} client config supports only --scope user")
     repo_root = Path(source if source is not None else ".").expanduser().resolve()
     target_path = _target_path(client, repo_root, selected_scope)
-    content = _render_content(client)
+    content = _render_content(client, tool_scope)
     return ClientInstallPlan(
         client=client,
         scope=selected_scope,
@@ -1420,16 +1425,31 @@ def _target_path(client: ClientName, repo_root: Path, scope: ClientScope) -> Pat
     raise ValueError(f"unsupported client: {client}")
 
 
-def _render_content(client: ClientName) -> str:
+def _mcp_args(tool_scope: str | None) -> list[str]:
+    """CLI args for the `archex mcp` server command.
+
+    `None` preserves the existing unscoped `["mcp"]` args exactly (backward
+    compatible with every config archex has ever written). A non-`None`
+    scope is validated via `resolve_tool_scope` before being embedded --
+    an unknown tool name in `tool_scope` fails at install time, not
+    silently inside a client's own MCP server subprocess.
+    """
+    if tool_scope is None or resolve_tool_scope(tool_scope) is None:
+        return ["mcp"]
+    return ["mcp", "--tools", tool_scope]
+
+
+def _render_content(client: ClientName, tool_scope: str | None = None) -> str:
+    args = _mcp_args(tool_scope)
     if client == "codex":
-        return '[mcp_servers.archex]\ncommand = "archex"\nargs = ["mcp"]\n'
+        return f'[mcp_servers.archex]\ncommand = "archex"\nargs = {json.dumps(args)}\n'
     if client == "opencode":
         payload = {
             "$schema": _OPENCODE_SCHEMA,
             "mcp": {
                 "archex": {
                     "type": "local",
-                    "command": ["archex", "mcp"],
+                    "command": ["archex", *args],
                     "enabled": True,
                 }
             },
@@ -1440,7 +1460,7 @@ def _render_content(client: ClientName) -> str:
             "mcpServers": {
                 "archex": {
                     "command": "archex",
-                    "args": ["mcp"],
+                    "args": args,
                 }
             }
         }
@@ -1451,7 +1471,7 @@ def _render_content(client: ClientName) -> str:
             "mcpServers": {
                 "archex": {
                     "command": "archex",
-                    "args": ["mcp"],
+                    "args": args,
                 }
             },
         }
@@ -1460,7 +1480,7 @@ def _render_content(client: ClientName) -> str:
         "mcpServers": {
             "archex": {
                 "command": "archex",
-                "args": ["mcp"],
+                "args": args,
             }
         }
     }

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -1462,8 +1462,726 @@ async def _run_mcp_tool(
     raise ValueError(f"Unknown tool: {name!r}")
 
 
-def build_server(runtime: QueryRuntime | None = None) -> Any:
+def _tool_schemas() -> list[dict[str, Any]]:
+    """Full unscoped MCP tool schema definitions (name/description/inputSchema).
+
+    Single source of truth for `build_server`'s `list_tools()` handler, tool-scope
+    filtering (`resolve_tool_scope`), and the `archex mcp-schema-size` measurement
+    command, so scoping and reported schema sizes can never drift from the tools
+    the server actually registers.
+    """
+    return [
+        {
+            "name": "analyze_repo",
+            "description": (
+                "Analyze a code repository and return an architecture profile including "
+                "modules, design patterns, interfaces, dependency graph, and architectural "
+                "decisions. Works with local paths and remote Git URLs."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo_url": {
+                        "type": "string",
+                        "description": (
+                            "Local filesystem path or HTTP(S) Git URL of the repository."
+                        ),
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["json", "markdown"],
+                        "default": "json",
+                        "description": "Output format for the architecture profile.",
+                    },
+                },
+                "required": ["repo_url"],
+            },
+        },
+        {
+            "name": "scout_repo",
+            "description": (
+                "Return a compact structural scout map for a repository question. "
+                "The map contains ranked files, module boundaries, top symbols, graph "
+                "sketches, and stable file/symbol/chunk handles, but no code bodies."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo_url": {
+                        "type": "string",
+                        "description": (
+                            "Local filesystem path or HTTP(S) Git URL of the repository."
+                        ),
+                    },
+                    "question": {
+                        "type": "string",
+                        "description": "Natural-language scout question.",
+                    },
+                    "budget": {
+                        "type": "integer",
+                        "default": DEFAULT_SCOUT_TOKEN_BUDGET,
+                        "description": "Hard token cap for the scout map.",
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["json", "markdown"],
+                        "default": "json",
+                    },
+                },
+                "required": ["repo_url", "question"],
+            },
+        },
+        {
+            "name": "query_repo",
+            "description": (
+                "Retrieve relevant code context from a repository to answer a "
+                "natural-language question. Returns a ranked set of code chunks "
+                "within the specified token budget, suitable for use as LLM context."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo_url": {
+                        "type": "string",
+                        "description": (
+                            "Local filesystem path or HTTP(S) Git URL of the repository."
+                        ),
+                    },
+                    "question": {
+                        "type": "string",
+                        "description": ("Natural-language question to answer from the codebase."),
+                    },
+                    "budget": {
+                        "type": "integer",
+                        "description": (
+                            "Optional explicit token budget override. Omit to use "
+                            "adaptive intent routing with the 8192 product ceiling."
+                        ),
+                    },
+                    "profile": {
+                        "type": "string",
+                        "enum": ["fast", "balanced", "deep"],
+                        "description": (
+                            "Optional named retrieval profile: 'fast' (bm25 only, zero "
+                            "vector/model work), 'balanced' (adds module prefiltering), "
+                            "or 'deep' (adds vector search and reranking). Omit to use "
+                            "the repo's configured retrieval settings unchanged."
+                        ),
+                    },
+                },
+                "required": ["repo_url", "question"],
+            },
+        },
+        {
+            "name": "context",
+            "description": (
+                "Primary agent-facing context retrieval: query, intent, profile, "
+                "filters, budgets, and handles as one contract. Returns a compact "
+                "candidate map, exact fetch handles, selected code, relation paths, "
+                "the route decision, a receipt, and a recommended next action. A "
+                "thin facade over query_repo — query_repo and the other specialized "
+                "tools remain fully supported."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo_url": {
+                        "type": "string",
+                        "description": (
+                            "Local filesystem path or HTTP(S) Git URL of the repository."
+                        ),
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": ("Natural-language question to answer from the codebase."),
+                    },
+                    "intent": {
+                        "type": "string",
+                        "enum": [intent.value for intent in QueryIntent],
+                        "description": (
+                            "Optional: pin the query intent instead of "
+                            "auto-classifying it from the query text. Determines "
+                            "the scoring-weight preset and default token budget."
+                        ),
+                    },
+                    "profile": {
+                        "type": "string",
+                        "enum": [profile.value for profile in RetrievalProfile],
+                        "description": (
+                            "Optional named retrieval profile. Omit to use the "
+                            "repo's configured retrieval settings unchanged."
+                        ),
+                    },
+                    "filters": {
+                        "type": "object",
+                        "description": (
+                            "Optional deterministic post-retrieval candidate "
+                            "filters — never changes ranking or adds candidates."
+                        ),
+                        "properties": {
+                            "include_paths": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": (
+                                    "fnmatch glob(s) a candidate's file path must match."
+                                ),
+                            },
+                            "exclude_paths": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": (
+                                    "fnmatch glob(s) that exclude a candidate by file path."
+                                ),
+                            },
+                            "languages": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": ("Restrict returned candidates to these languages."),
+                            },
+                        },
+                    },
+                    "budgets": {
+                        "type": "object",
+                        "description": "Optional token-budget input.",
+                        "properties": {
+                            "token_budget": {
+                                "type": "integer",
+                                "description": (
+                                    "Explicit token budget override. Omit to resolve "
+                                    "from 'intent' or the query's own auto-scaling."
+                                ),
+                            },
+                        },
+                    },
+                    "handles": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": (
+                            "Optional exact fetch handle(s) — bypasses broad search "
+                            "and returns exactly these candidates."
+                        ),
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["json", "markdown"],
+                        "description": "Output format. Defaults to 'json'.",
+                    },
+                },
+                "required": ["repo_url", "query"],
+            },
+        },
+        {
+            "name": "compare_repos",
+            "description": (
+                "Compare two code repositories across architectural dimensions such as "
+                "API surface, error handling, concurrency model, testing, "
+                "state management, and configuration."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo_a": {
+                        "type": "string",
+                        "description": "Local path or HTTP(S) URL of the first repository.",
+                    },
+                    "repo_b": {
+                        "type": "string",
+                        "description": "Local path or HTTP(S) URL of the second repository.",
+                    },
+                    "dimensions": {
+                        "type": "string",
+                        "default": "api_surface,error_handling",
+                        "description": (
+                            "Comma-separated dimensions to compare. "
+                            "Supported: api_surface, error_handling, concurrency, "
+                            "testing, state_management, configuration."
+                        ),
+                    },
+                },
+                "required": ["repo_a", "repo_b"],
+            },
+        },
+        {
+            "name": "get_file_tree",
+            "description": (
+                "Return a hierarchical file tree for a repository, optionally filtered "
+                "by language and depth."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo_url": {
+                        "type": "string",
+                        "description": "Local path or HTTP(S) URL of the repository.",
+                    },
+                    "max_depth": {
+                        "type": "integer",
+                        "default": 5,
+                        "description": "Maximum directory depth to traverse.",
+                    },
+                    "language": {
+                        "type": "string",
+                        "description": "Filter results to files of this language.",
+                    },
+                },
+                "required": ["repo_url"],
+            },
+        },
+        {
+            "name": "get_file_outline",
+            "description": (
+                "Return a structural outline of a single file — symbols, classes, "
+                "functions, and their locations."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo_url": {
+                        "type": "string",
+                        "description": "Local path or HTTP(S) URL of the repository.",
+                    },
+                    "file_path": {
+                        "type": "string",
+                        "description": "Relative path of the file within the repository.",
+                    },
+                },
+                "required": ["repo_url", "file_path"],
+            },
+        },
+        {
+            "name": "search_symbols",
+            "description": (
+                "Search for symbols (functions, classes, variables) in a repository "
+                "by name, kind, and/or language."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo_url": {
+                        "type": "string",
+                        "description": "Local path or HTTP(S) URL of the repository.",
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Search query to match against symbol names.",
+                    },
+                    "kind": {
+                        "type": "string",
+                        "description": "Filter by symbol kind (e.g. function, class).",
+                    },
+                    "language": {
+                        "type": "string",
+                        "description": "Filter by programming language.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Maximum number of results to return.",
+                    },
+                },
+                "required": ["repo_url", "query"],
+            },
+        },
+        {
+            "name": "get_symbol",
+            "description": "Retrieve a single symbol by its stable symbol ID.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo_url": {
+                        "type": "string",
+                        "description": "Local path or HTTP(S) URL of the repository.",
+                    },
+                    "symbol_id": {
+                        "type": "string",
+                        "description": "Stable symbol identifier.",
+                    },
+                },
+                "required": ["repo_url", "symbol_id"],
+            },
+        },
+        {
+            "name": "get_symbols_batch",
+            "description": (
+                "Retrieve multiple symbols by their stable symbol IDs in a single call. "
+                "Maximum 50 IDs per request."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo_url": {
+                        "type": "string",
+                        "description": "Local path or HTTP(S) URL of the repository.",
+                    },
+                    "symbol_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "List of stable symbol identifiers (max 50).",
+                    },
+                },
+                "required": ["repo_url", "symbol_ids"],
+            },
+        },
+        {
+            "name": "get_impact",
+            "description": (
+                "Analyze deterministic blast radius for changed files: affected files, "
+                "modules, public interfaces, test surface, and a risk assessment. Uses "
+                "git diff against a base ref, or an explicit changed-file list. Pass "
+                "'diff' to additionally resolve the diff to touched symbols and classify "
+                "each with a LOW/MEDIUM/HIGH risk tier from deterministic graph signals."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo_url": {
+                        "type": "string",
+                        "description": (
+                            "Local filesystem path of the repository. Git diff mode "
+                            "requires a local checkout."
+                        ),
+                    },
+                    "base": {
+                        "type": "string",
+                        "default": "main",
+                        "description": (
+                            "Base ref for git diff mode. Ignored when changed_files "
+                            "or diff is provided."
+                        ),
+                    },
+                    "changed_files": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": (
+                            "Explicit changed file paths, bypassing git diff mode. "
+                            "Cannot be combined with diff."
+                        ),
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["json", "markdown"],
+                        "default": "json",
+                        "description": "Output format for the impact report.",
+                    },
+                    "diff": {
+                        "type": "string",
+                        "description": (
+                            "Enable diff-scoped symbol impact: resolve the diff (this "
+                            "ref vs. the working tree) to touched symbols with a "
+                            "per-symbol risk tier. Adds affected_symbols to the report; "
+                            "output is unchanged when omitted. Cannot be combined with "
+                            "changed_files."
+                        ),
+                    },
+                },
+                "required": ["repo_url"],
+            },
+        },
+        {
+            "name": "explain_target",
+            "description": (
+                "Explain a file, symbol, or module from indexed structural data: public "
+                "interfaces, internal symbols, imports/imported-by, module context, and "
+                "complexity signals."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo_url": {
+                        "type": "string",
+                        "description": (
+                            "Local path or HTTP(S) URL of the repository. Required "
+                            "unless graph_path is given."
+                        ),
+                    },
+                    "target": {
+                        "type": "string",
+                        "description": (
+                            "File path or `path::name#kind` symbol identifier to "
+                            "explain. Mutually exclusive with module_name."
+                        ),
+                    },
+                    "module_name": {
+                        "type": "string",
+                        "description": ("Module path to explain. Mutually exclusive with target."),
+                    },
+                    "graph_path": {
+                        "type": "string",
+                        "description": (
+                            "Read an exported graph artifact instead of indexing repo_url."
+                        ),
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["json", "markdown"],
+                        "default": "json",
+                        "description": "Output format for the explain context.",
+                    },
+                },
+                "required": [],
+            },
+        },
+        {
+            "name": "generate_onboarding",
+            "description": (
+                "Generate a deterministic onboarding guide from graph/index data: "
+                "repository overview, architecture modules, entry points, public "
+                "interfaces, recommended reading order, complexity hotspots, test "
+                "surface, and configuration surface. Markdown-only output."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "repo_url": {
+                        "type": "string",
+                        "description": (
+                            "Local path or HTTP(S) URL of the repository. Required "
+                            "unless graph_path is given."
+                        ),
+                    },
+                    "graph_path": {
+                        "type": "string",
+                        "description": (
+                            "Read an exported graph artifact instead of indexing repo_url."
+                        ),
+                    },
+                    "max_files": {
+                        "type": "integer",
+                        "default": 40,
+                        "description": "Maximum paths per capped section.",
+                    },
+                },
+                "required": [],
+            },
+        },
+        {
+            "name": "graph_lookup",
+            "description": (
+                "Look up graph nodes in an exported architecture graph artifact without "
+                "indexing source files. Exact node IDs and paths win over fuzzy matches."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "graph_path": {"type": "string", "description": "Path to archgraph JSON."},
+                    "node": {
+                        "type": "string",
+                        "description": "Node ID, path, label, or query.",
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["json", "markdown"],
+                        "default": "json",
+                    },
+                    "limit": {"type": "integer", "default": 25},
+                    "hub_degree": {"type": "integer", "default": 50},
+                    "token_budget": {
+                        "type": "integer",
+                        "default": DEFAULT_GRAPH_TOKEN_BUDGET,
+                        "description": "Maximum markdown content tokens to return.",
+                    },
+                },
+                "required": ["graph_path", "node"],
+            },
+        },
+        {
+            "name": "graph_neighbors",
+            "description": (
+                "Return graph neighbors for a node from an exported artifact without "
+                "indexing source files. Edges include kind, confidence, and evidence."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "graph_path": {"type": "string", "description": "Path to archgraph JSON."},
+                    "node": {
+                        "type": "string",
+                        "description": "Node ID, path, label, or query.",
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["json", "markdown"],
+                        "default": "json",
+                    },
+                    "direction": {
+                        "type": "string",
+                        "enum": ["out", "in", "both"],
+                        "default": "both",
+                    },
+                    "depth": {"type": "integer", "default": 1},
+                    "limit": {"type": "integer", "default": 25},
+                    "hub_degree": {"type": "integer", "default": 50},
+                    "token_budget": {
+                        "type": "integer",
+                        "default": DEFAULT_GRAPH_TOKEN_BUDGET,
+                        "description": "Maximum markdown content tokens to return.",
+                    },
+                },
+                "required": ["graph_path", "node"],
+            },
+        },
+        {
+            "name": "graph_path",
+            "description": (
+                "Find a shortest structural path between two graph nodes from an exported "
+                "artifact without indexing source files."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "graph_path": {"type": "string", "description": "Path to archgraph JSON."},
+                    "source": {"type": "string", "description": "Source node ID or path."},
+                    "target": {"type": "string", "description": "Target node ID or path."},
+                    "format": {
+                        "type": "string",
+                        "enum": ["json", "markdown"],
+                        "default": "json",
+                    },
+                    "direction": {
+                        "type": "string",
+                        "enum": ["out", "in", "both"],
+                        "default": "both",
+                    },
+                    "max_edges": {"type": "integer", "default": 100},
+                    "hub_degree": {"type": "integer", "default": 50},
+                    "token_budget": {
+                        "type": "integer",
+                        "default": DEFAULT_GRAPH_TOKEN_BUDGET,
+                        "description": "Maximum markdown content tokens to return.",
+                    },
+                },
+                "required": ["graph_path", "source", "target"],
+            },
+        },
+        {
+            "name": "graph_stats",
+            "description": (
+                "Return deterministic graph stats and hub summaries from an exported "
+                "artifact without indexing source files."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "graph_path": {"type": "string", "description": "Path to archgraph JSON."},
+                    "format": {
+                        "type": "string",
+                        "enum": ["json", "markdown"],
+                        "default": "json",
+                    },
+                    "hub_limit": {"type": "integer", "default": 10},
+                    "hub_degree": {"type": "integer", "default": 50},
+                    "token_budget": {
+                        "type": "integer",
+                        "default": DEFAULT_GRAPH_TOKEN_BUDGET,
+                        "description": "Maximum markdown content tokens to return.",
+                    },
+                },
+                "required": ["graph_path"],
+            },
+        },
+        {
+            "name": "graph_hubs",
+            "description": (
+                "Return high-degree graph hubs from an exported artifact without indexing "
+                "source files."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "graph_path": {"type": "string", "description": "Path to archgraph JSON."},
+                    "format": {
+                        "type": "string",
+                        "enum": ["json", "markdown"],
+                        "default": "json",
+                    },
+                    "limit": {"type": "integer", "default": 25},
+                    "threshold": {"type": "integer"},
+                    "hub_degree": {"type": "integer", "default": 50},
+                    "token_budget": {
+                        "type": "integer",
+                        "default": DEFAULT_GRAPH_TOKEN_BUDGET,
+                        "description": "Maximum markdown content tokens to return.",
+                    },
+                },
+                "required": ["graph_path"],
+            },
+        },
+    ]
+
+
+#: Every MCP tool name archex registers, in registration order. Derived from
+#: `_tool_schemas()` so it can never drift from the tools `build_server` exposes.
+ALL_TOOL_NAMES: tuple[str, ...] = tuple(schema["name"] for schema in _tool_schemas())
+
+_GRAPH_TOOL_NAMES: frozenset[str] = frozenset(
+    {"graph_lookup", "graph_neighbors", "graph_path", "graph_stats", "graph_hubs"}
+)
+
+#: Named convenience tool-scope profiles for `archex mcp --tools` and
+#: `install-client`/`setup --tool-scope`. "all" (every tool, the unscoped
+#: default) is intentionally absent here -- `resolve_tool_scope` treats it,
+#: `None`, and the empty string as the same "no filtering" case so callers
+#: can test `is None` instead of special-casing a profile name.
+TOOL_SCOPE_PROFILES: dict[str, frozenset[str]] = {
+    "core": frozenset(ALL_TOOL_NAMES) - _GRAPH_TOOL_NAMES,
+    "graph": _GRAPH_TOOL_NAMES,
+}
+
+
+def resolve_tool_scope(spec: str | None) -> frozenset[str] | None:
+    """Resolve a `--tools`/`--tool-scope` spec into a set of tool names.
+
+    `None`, the empty string, or `"all"` mean unscoped -- every registered
+    tool, the current default behavior. Otherwise `spec` is either a named
+    profile from `TOOL_SCOPE_PROFILES` or a comma-separated explicit
+    allowlist of tool names.
+
+    Raises:
+        ValueError: `spec` names a tool that does not exist, so a typo
+            fails fast instead of silently registering zero tools.
+    """
+    if spec is None or spec.strip() in ("", "all"):
+        return None
+    if spec in TOOL_SCOPE_PROFILES:
+        return TOOL_SCOPE_PROFILES[spec]
+    names = frozenset(name.strip() for name in spec.split(",") if name.strip())
+    unknown = names - frozenset(ALL_TOOL_NAMES)
+    if unknown:
+        raise ValueError(
+            f"Unknown MCP tool name(s): {', '.join(sorted(unknown))}. "
+            f"Known tools: {', '.join(ALL_TOOL_NAMES)}"
+        )
+    return names
+
+
+def measure_tool_schema_size(tool_names: frozenset[str] | None = None) -> dict[str, Any]:
+    """Serialized MCP tool-schema size for `tool_names` (`None` means every tool).
+
+    Serializes each tool's `{name, description, inputSchema}` as compact,
+    sort-keyed JSON -- the same shape `list_tools()` advertises -- so the
+    reported byte counts track what a client actually registers.
+    """
+    schemas = _tool_schemas()
+    if tool_names is not None:
+        schemas = [schema for schema in schemas if schema["name"] in tool_names]
+    per_tool_chars = {schema["name"]: len(json.dumps(schema, sort_keys=True)) for schema in schemas}
+    return {
+        "tool_count": len(schemas),
+        "total_chars": sum(per_tool_chars.values()),
+        "per_tool_chars": per_tool_chars,
+    }
+
+
+def build_server(
+    runtime: QueryRuntime | None = None, tool_names: frozenset[str] | None = None
+) -> Any:
     """Build and return a configured MCP Server instance.
+
+    `tool_names`, when given, scopes the tools this server advertises via
+    `list_tools()` to exactly that subset (see `resolve_tool_scope`). Every
+    tool name still dispatches through `call_tool` regardless of scoping --
+    scoping only shrinks the advertised schema surface, it never changes
+    which tool names a client can successfully call.
 
     Raises:
         ImportError: If the `mcp` package is not installed.
@@ -1483,651 +2201,10 @@ def build_server(runtime: QueryRuntime | None = None) -> Any:
 
     @server.list_tools()  # pyright: ignore[reportUnusedFunction]
     async def list_tools() -> list[mcp_types.Tool]:  # pyright: ignore[reportUnusedFunction]
-        return [
-            mcp_types.Tool(
-                name="analyze_repo",
-                description=(
-                    "Analyze a code repository and return an architecture profile including "
-                    "modules, design patterns, interfaces, dependency graph, and architectural "
-                    "decisions. Works with local paths and remote Git URLs."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "repo_url": {
-                            "type": "string",
-                            "description": (
-                                "Local filesystem path or HTTP(S) Git URL of the repository."
-                            ),
-                        },
-                        "format": {
-                            "type": "string",
-                            "enum": ["json", "markdown"],
-                            "default": "json",
-                            "description": "Output format for the architecture profile.",
-                        },
-                    },
-                    "required": ["repo_url"],
-                },
-            ),
-            mcp_types.Tool(
-                name="scout_repo",
-                description=(
-                    "Return a compact structural scout map for a repository question. "
-                    "The map contains ranked files, module boundaries, top symbols, graph "
-                    "sketches, and stable file/symbol/chunk handles, but no code bodies."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "repo_url": {
-                            "type": "string",
-                            "description": (
-                                "Local filesystem path or HTTP(S) Git URL of the repository."
-                            ),
-                        },
-                        "question": {
-                            "type": "string",
-                            "description": "Natural-language scout question.",
-                        },
-                        "budget": {
-                            "type": "integer",
-                            "default": DEFAULT_SCOUT_TOKEN_BUDGET,
-                            "description": "Hard token cap for the scout map.",
-                        },
-                        "format": {
-                            "type": "string",
-                            "enum": ["json", "markdown"],
-                            "default": "json",
-                        },
-                    },
-                    "required": ["repo_url", "question"],
-                },
-            ),
-            mcp_types.Tool(
-                name="query_repo",
-                description=(
-                    "Retrieve relevant code context from a repository to answer a "
-                    "natural-language question. Returns a ranked set of code chunks "
-                    "within the specified token budget, suitable for use as LLM context."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "repo_url": {
-                            "type": "string",
-                            "description": (
-                                "Local filesystem path or HTTP(S) Git URL of the repository."
-                            ),
-                        },
-                        "question": {
-                            "type": "string",
-                            "description": (
-                                "Natural-language question to answer from the codebase."
-                            ),
-                        },
-                        "budget": {
-                            "type": "integer",
-                            "description": (
-                                "Optional explicit token budget override. Omit to use "
-                                "adaptive intent routing with the 8192 product ceiling."
-                            ),
-                        },
-                        "profile": {
-                            "type": "string",
-                            "enum": ["fast", "balanced", "deep"],
-                            "description": (
-                                "Optional named retrieval profile: 'fast' (bm25 only, zero "
-                                "vector/model work), 'balanced' (adds module prefiltering), "
-                                "or 'deep' (adds vector search and reranking). Omit to use "
-                                "the repo's configured retrieval settings unchanged."
-                            ),
-                        },
-                    },
-                    "required": ["repo_url", "question"],
-                },
-            ),
-            mcp_types.Tool(
-                name="context",
-                description=(
-                    "Primary agent-facing context retrieval: query, intent, profile, "
-                    "filters, budgets, and handles as one contract. Returns a compact "
-                    "candidate map, exact fetch handles, selected code, relation paths, "
-                    "the route decision, a receipt, and a recommended next action. A "
-                    "thin facade over query_repo — query_repo and the other specialized "
-                    "tools remain fully supported."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "repo_url": {
-                            "type": "string",
-                            "description": (
-                                "Local filesystem path or HTTP(S) Git URL of the repository."
-                            ),
-                        },
-                        "query": {
-                            "type": "string",
-                            "description": (
-                                "Natural-language question to answer from the codebase."
-                            ),
-                        },
-                        "intent": {
-                            "type": "string",
-                            "enum": [intent.value for intent in QueryIntent],
-                            "description": (
-                                "Optional: pin the query intent instead of "
-                                "auto-classifying it from the query text. Determines "
-                                "the scoring-weight preset and default token budget."
-                            ),
-                        },
-                        "profile": {
-                            "type": "string",
-                            "enum": [profile.value for profile in RetrievalProfile],
-                            "description": (
-                                "Optional named retrieval profile. Omit to use the "
-                                "repo's configured retrieval settings unchanged."
-                            ),
-                        },
-                        "filters": {
-                            "type": "object",
-                            "description": (
-                                "Optional deterministic post-retrieval candidate "
-                                "filters — never changes ranking or adds candidates."
-                            ),
-                            "properties": {
-                                "include_paths": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": (
-                                        "fnmatch glob(s) a candidate's file path must match."
-                                    ),
-                                },
-                                "exclude_paths": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": (
-                                        "fnmatch glob(s) that exclude a candidate by file path."
-                                    ),
-                                },
-                                "languages": {
-                                    "type": "array",
-                                    "items": {"type": "string"},
-                                    "description": (
-                                        "Restrict returned candidates to these languages."
-                                    ),
-                                },
-                            },
-                        },
-                        "budgets": {
-                            "type": "object",
-                            "description": "Optional token-budget input.",
-                            "properties": {
-                                "token_budget": {
-                                    "type": "integer",
-                                    "description": (
-                                        "Explicit token budget override. Omit to resolve "
-                                        "from 'intent' or the query's own auto-scaling."
-                                    ),
-                                },
-                            },
-                        },
-                        "handles": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": (
-                                "Optional exact fetch handle(s) — bypasses broad search "
-                                "and returns exactly these candidates."
-                            ),
-                        },
-                        "format": {
-                            "type": "string",
-                            "enum": ["json", "markdown"],
-                            "description": "Output format. Defaults to 'json'.",
-                        },
-                    },
-                    "required": ["repo_url", "query"],
-                },
-            ),
-            mcp_types.Tool(
-                name="compare_repos",
-                description=(
-                    "Compare two code repositories across architectural dimensions such as "
-                    "API surface, error handling, concurrency model, testing, "
-                    "state management, and configuration."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "repo_a": {
-                            "type": "string",
-                            "description": "Local path or HTTP(S) URL of the first repository.",
-                        },
-                        "repo_b": {
-                            "type": "string",
-                            "description": "Local path or HTTP(S) URL of the second repository.",
-                        },
-                        "dimensions": {
-                            "type": "string",
-                            "default": "api_surface,error_handling",
-                            "description": (
-                                "Comma-separated dimensions to compare. "
-                                "Supported: api_surface, error_handling, concurrency, "
-                                "testing, state_management, configuration."
-                            ),
-                        },
-                    },
-                    "required": ["repo_a", "repo_b"],
-                },
-            ),
-            mcp_types.Tool(
-                name="get_file_tree",
-                description=(
-                    "Return a hierarchical file tree for a repository, optionally filtered "
-                    "by language and depth."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "repo_url": {
-                            "type": "string",
-                            "description": "Local path or HTTP(S) URL of the repository.",
-                        },
-                        "max_depth": {
-                            "type": "integer",
-                            "default": 5,
-                            "description": "Maximum directory depth to traverse.",
-                        },
-                        "language": {
-                            "type": "string",
-                            "description": "Filter results to files of this language.",
-                        },
-                    },
-                    "required": ["repo_url"],
-                },
-            ),
-            mcp_types.Tool(
-                name="get_file_outline",
-                description=(
-                    "Return a structural outline of a single file — symbols, classes, "
-                    "functions, and their locations."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "repo_url": {
-                            "type": "string",
-                            "description": "Local path or HTTP(S) URL of the repository.",
-                        },
-                        "file_path": {
-                            "type": "string",
-                            "description": "Relative path of the file within the repository.",
-                        },
-                    },
-                    "required": ["repo_url", "file_path"],
-                },
-            ),
-            mcp_types.Tool(
-                name="search_symbols",
-                description=(
-                    "Search for symbols (functions, classes, variables) in a repository "
-                    "by name, kind, and/or language."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "repo_url": {
-                            "type": "string",
-                            "description": "Local path or HTTP(S) URL of the repository.",
-                        },
-                        "query": {
-                            "type": "string",
-                            "description": "Search query to match against symbol names.",
-                        },
-                        "kind": {
-                            "type": "string",
-                            "description": "Filter by symbol kind (e.g. function, class).",
-                        },
-                        "language": {
-                            "type": "string",
-                            "description": "Filter by programming language.",
-                        },
-                        "limit": {
-                            "type": "integer",
-                            "default": 20,
-                            "description": "Maximum number of results to return.",
-                        },
-                    },
-                    "required": ["repo_url", "query"],
-                },
-            ),
-            mcp_types.Tool(
-                name="get_symbol",
-                description="Retrieve a single symbol by its stable symbol ID.",
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "repo_url": {
-                            "type": "string",
-                            "description": "Local path or HTTP(S) URL of the repository.",
-                        },
-                        "symbol_id": {
-                            "type": "string",
-                            "description": "Stable symbol identifier.",
-                        },
-                    },
-                    "required": ["repo_url", "symbol_id"],
-                },
-            ),
-            mcp_types.Tool(
-                name="get_symbols_batch",
-                description=(
-                    "Retrieve multiple symbols by their stable symbol IDs in a single call. "
-                    "Maximum 50 IDs per request."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "repo_url": {
-                            "type": "string",
-                            "description": "Local path or HTTP(S) URL of the repository.",
-                        },
-                        "symbol_ids": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": "List of stable symbol identifiers (max 50).",
-                        },
-                    },
-                    "required": ["repo_url", "symbol_ids"],
-                },
-            ),
-            mcp_types.Tool(
-                name="get_impact",
-                description=(
-                    "Analyze deterministic blast radius for changed files: affected files, "
-                    "modules, public interfaces, test surface, and a risk assessment. Uses "
-                    "git diff against a base ref, or an explicit changed-file list. Pass "
-                    "'diff' to additionally resolve the diff to touched symbols and classify "
-                    "each with a LOW/MEDIUM/HIGH risk tier from deterministic graph signals."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "repo_url": {
-                            "type": "string",
-                            "description": (
-                                "Local filesystem path of the repository. Git diff mode "
-                                "requires a local checkout."
-                            ),
-                        },
-                        "base": {
-                            "type": "string",
-                            "default": "main",
-                            "description": (
-                                "Base ref for git diff mode. Ignored when changed_files "
-                                "or diff is provided."
-                            ),
-                        },
-                        "changed_files": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": (
-                                "Explicit changed file paths, bypassing git diff mode. "
-                                "Cannot be combined with diff."
-                            ),
-                        },
-                        "format": {
-                            "type": "string",
-                            "enum": ["json", "markdown"],
-                            "default": "json",
-                            "description": "Output format for the impact report.",
-                        },
-                        "diff": {
-                            "type": "string",
-                            "description": (
-                                "Enable diff-scoped symbol impact: resolve the diff (this "
-                                "ref vs. the working tree) to touched symbols with a "
-                                "per-symbol risk tier. Adds affected_symbols to the report; "
-                                "output is unchanged when omitted. Cannot be combined with "
-                                "changed_files."
-                            ),
-                        },
-                    },
-                    "required": ["repo_url"],
-                },
-            ),
-            mcp_types.Tool(
-                name="explain_target",
-                description=(
-                    "Explain a file, symbol, or module from indexed structural data: public "
-                    "interfaces, internal symbols, imports/imported-by, module context, and "
-                    "complexity signals."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "repo_url": {
-                            "type": "string",
-                            "description": (
-                                "Local path or HTTP(S) URL of the repository. Required "
-                                "unless graph_path is given."
-                            ),
-                        },
-                        "target": {
-                            "type": "string",
-                            "description": (
-                                "File path or `path::name#kind` symbol identifier to "
-                                "explain. Mutually exclusive with module_name."
-                            ),
-                        },
-                        "module_name": {
-                            "type": "string",
-                            "description": (
-                                "Module path to explain. Mutually exclusive with target."
-                            ),
-                        },
-                        "graph_path": {
-                            "type": "string",
-                            "description": (
-                                "Read an exported graph artifact instead of indexing repo_url."
-                            ),
-                        },
-                        "format": {
-                            "type": "string",
-                            "enum": ["json", "markdown"],
-                            "default": "json",
-                            "description": "Output format for the explain context.",
-                        },
-                    },
-                    "required": [],
-                },
-            ),
-            mcp_types.Tool(
-                name="generate_onboarding",
-                description=(
-                    "Generate a deterministic onboarding guide from graph/index data: "
-                    "repository overview, architecture modules, entry points, public "
-                    "interfaces, recommended reading order, complexity hotspots, test "
-                    "surface, and configuration surface. Markdown-only output."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "repo_url": {
-                            "type": "string",
-                            "description": (
-                                "Local path or HTTP(S) URL of the repository. Required "
-                                "unless graph_path is given."
-                            ),
-                        },
-                        "graph_path": {
-                            "type": "string",
-                            "description": (
-                                "Read an exported graph artifact instead of indexing repo_url."
-                            ),
-                        },
-                        "max_files": {
-                            "type": "integer",
-                            "default": 40,
-                            "description": "Maximum paths per capped section.",
-                        },
-                    },
-                    "required": [],
-                },
-            ),
-            mcp_types.Tool(
-                name="graph_lookup",
-                description=(
-                    "Look up graph nodes in an exported architecture graph artifact without "
-                    "indexing source files. Exact node IDs and paths win over fuzzy matches."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "graph_path": {"type": "string", "description": "Path to archgraph JSON."},
-                        "node": {
-                            "type": "string",
-                            "description": "Node ID, path, label, or query.",
-                        },
-                        "format": {
-                            "type": "string",
-                            "enum": ["json", "markdown"],
-                            "default": "json",
-                        },
-                        "limit": {"type": "integer", "default": 25},
-                        "hub_degree": {"type": "integer", "default": 50},
-                        "token_budget": {
-                            "type": "integer",
-                            "default": DEFAULT_GRAPH_TOKEN_BUDGET,
-                            "description": "Maximum markdown content tokens to return.",
-                        },
-                    },
-                    "required": ["graph_path", "node"],
-                },
-            ),
-            mcp_types.Tool(
-                name="graph_neighbors",
-                description=(
-                    "Return graph neighbors for a node from an exported artifact without "
-                    "indexing source files. Edges include kind, confidence, and evidence."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "graph_path": {"type": "string", "description": "Path to archgraph JSON."},
-                        "node": {
-                            "type": "string",
-                            "description": "Node ID, path, label, or query.",
-                        },
-                        "format": {
-                            "type": "string",
-                            "enum": ["json", "markdown"],
-                            "default": "json",
-                        },
-                        "direction": {
-                            "type": "string",
-                            "enum": ["out", "in", "both"],
-                            "default": "both",
-                        },
-                        "depth": {"type": "integer", "default": 1},
-                        "limit": {"type": "integer", "default": 25},
-                        "hub_degree": {"type": "integer", "default": 50},
-                        "token_budget": {
-                            "type": "integer",
-                            "default": DEFAULT_GRAPH_TOKEN_BUDGET,
-                            "description": "Maximum markdown content tokens to return.",
-                        },
-                    },
-                    "required": ["graph_path", "node"],
-                },
-            ),
-            mcp_types.Tool(
-                name="graph_path",
-                description=(
-                    "Find a shortest structural path between two graph nodes from an exported "
-                    "artifact without indexing source files."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "graph_path": {"type": "string", "description": "Path to archgraph JSON."},
-                        "source": {"type": "string", "description": "Source node ID or path."},
-                        "target": {"type": "string", "description": "Target node ID or path."},
-                        "format": {
-                            "type": "string",
-                            "enum": ["json", "markdown"],
-                            "default": "json",
-                        },
-                        "direction": {
-                            "type": "string",
-                            "enum": ["out", "in", "both"],
-                            "default": "both",
-                        },
-                        "max_edges": {"type": "integer", "default": 100},
-                        "hub_degree": {"type": "integer", "default": 50},
-                        "token_budget": {
-                            "type": "integer",
-                            "default": DEFAULT_GRAPH_TOKEN_BUDGET,
-                            "description": "Maximum markdown content tokens to return.",
-                        },
-                    },
-                    "required": ["graph_path", "source", "target"],
-                },
-            ),
-            mcp_types.Tool(
-                name="graph_stats",
-                description=(
-                    "Return deterministic graph stats and hub summaries from an exported "
-                    "artifact without indexing source files."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "graph_path": {"type": "string", "description": "Path to archgraph JSON."},
-                        "format": {
-                            "type": "string",
-                            "enum": ["json", "markdown"],
-                            "default": "json",
-                        },
-                        "hub_limit": {"type": "integer", "default": 10},
-                        "hub_degree": {"type": "integer", "default": 50},
-                        "token_budget": {
-                            "type": "integer",
-                            "default": DEFAULT_GRAPH_TOKEN_BUDGET,
-                            "description": "Maximum markdown content tokens to return.",
-                        },
-                    },
-                    "required": ["graph_path"],
-                },
-            ),
-            mcp_types.Tool(
-                name="graph_hubs",
-                description=(
-                    "Return high-degree graph hubs from an exported artifact without indexing "
-                    "source files."
-                ),
-                inputSchema={
-                    "type": "object",
-                    "properties": {
-                        "graph_path": {"type": "string", "description": "Path to archgraph JSON."},
-                        "format": {
-                            "type": "string",
-                            "enum": ["json", "markdown"],
-                            "default": "json",
-                        },
-                        "limit": {"type": "integer", "default": 25},
-                        "threshold": {"type": "integer"},
-                        "hub_degree": {"type": "integer", "default": 50},
-                        "token_budget": {
-                            "type": "integer",
-                            "default": DEFAULT_GRAPH_TOKEN_BUDGET,
-                            "description": "Maximum markdown content tokens to return.",
-                        },
-                    },
-                    "required": ["graph_path"],
-                },
-            ),
-        ]
+        schemas = _tool_schemas()
+        if tool_names is not None:
+            schemas = [schema for schema in schemas if schema["name"] in tool_names]
+        return [mcp_types.Tool(**schema) for schema in schemas]
 
     @server.call_tool()  # pyright: ignore[reportUnusedFunction]
     async def call_tool(  # pyright: ignore[reportUnusedFunction]
@@ -2213,6 +2290,7 @@ async def run_stdio_server(
     watch: bool = False,
     watch_path: str = ".",
     watch_debounce_ms: int = 300,
+    tool_names: frozenset[str] | None = None,
 ) -> None:
     """Run the archex MCP server over stdio."""
     try:
@@ -2230,7 +2308,7 @@ async def run_stdio_server(
     # across every query_repo call so repeat warm queries against the same
     # generation skip re-hydrating from SQLite.
     runtime = QueryRuntime()
-    server = build_server(runtime=runtime)
+    server = build_server(runtime=runtime, tool_names=tool_names)
     try:
         async with stdio_server() as (read_stream, write_stream):
             init_opts = server.create_initialization_options()

--- a/tests/cli/test_install_client.py
+++ b/tests/cli/test_install_client.py
@@ -562,3 +562,52 @@ def test_install_client_discovers_agent_files(
 
     content = agent_file.read_text(encoding="utf-8")
     assert "<!-- archex:mcp-guidance start -->" in content
+
+
+# ---------------------------------------------------------------------------
+# --tool-scope tests (M11)
+# ---------------------------------------------------------------------------
+
+
+def test_install_client_tool_scope_default_omits_tools_arg(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = CliRunner().invoke(cli, ["install-client", "claude-code", str(repo), "--dry-run"])
+    assert result.exit_code == 0
+    assert '"args": [\n        "mcp"\n      ]' in result.output.replace("\r\n", "\n")
+
+
+def test_install_client_tool_scope_writes_tools_arg(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = CliRunner().invoke(
+        cli,
+        ["install-client", "claude-code", str(repo), "--tool-scope", "core"],
+    )
+    assert result.exit_code == 0
+    payload = json.loads((repo / ".mcp.json").read_text(encoding="utf-8"))
+    assert payload["mcpServers"]["archex"]["args"] == ["mcp", "--tools", "core"]
+
+
+def test_install_client_tool_scope_codex_toml_embeds_tools_arg(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = CliRunner().invoke(
+        cli,
+        ["install-client", "codex", str(repo), "--tool-scope", "graph"],
+    )
+    assert result.exit_code == 0
+    content = (repo / ".codex" / "config.toml").read_text(encoding="utf-8")
+    assert 'args = ["mcp", "--tools", "graph"]' in content
+
+
+def test_install_client_tool_scope_unknown_tool_name_fails_cleanly(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = CliRunner().invoke(
+        cli,
+        ["install-client", "claude-code", str(repo), "--dry-run", "--tool-scope", "not_a_tool"],
+    )
+    assert result.exit_code != 0
+    assert "Unknown MCP tool name" in result.output
+    assert not (repo / ".mcp.json").exists()

--- a/tests/cli/test_mcp_schema_size.py
+++ b/tests/cli/test_mcp_schema_size.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+
+
+def test_mcp_schema_size_default_text_format() -> None:
+    result = CliRunner().invoke(cli, ["mcp-schema-size"])
+    assert result.exit_code == 0
+    assert "Scope: all" in result.output
+    assert "Total serialized schema size:" in result.output
+    assert "query_repo:" in result.output
+
+
+def test_mcp_schema_size_json_format_reports_full_report() -> None:
+    result = CliRunner().invoke(cli, ["mcp-schema-size", "--format", "json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["scope"] == "all"
+    assert payload["tool_count"] == len(payload["per_tool_chars"])
+    assert payload["total_chars"] == sum(payload["per_tool_chars"].values())
+
+
+def test_mcp_schema_size_scoped_is_strictly_smaller_than_all() -> None:
+    full = json.loads(CliRunner().invoke(cli, ["mcp-schema-size", "--format", "json"]).output)
+    scoped = json.loads(
+        CliRunner().invoke(cli, ["mcp-schema-size", "--tools", "core", "--format", "json"]).output
+    )
+    assert scoped["scope"] == "core"
+    assert scoped["tool_count"] < full["tool_count"]
+    assert scoped["total_chars"] < full["total_chars"]
+    assert set(scoped["per_tool_chars"]).issubset(set(full["per_tool_chars"]))
+
+
+def test_mcp_schema_size_explicit_allowlist() -> None:
+    result = CliRunner().invoke(
+        cli, ["mcp-schema-size", "--tools", "query_repo,context", "--format", "json"]
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["tool_count"] == 2
+    assert set(payload["per_tool_chars"]) == {"query_repo", "context"}
+
+
+def test_mcp_schema_size_unknown_tool_name_fails_cleanly() -> None:
+    result = CliRunner().invoke(cli, ["mcp-schema-size", "--tools", "not_a_real_tool"])
+    assert result.exit_code != 0
+    assert "Unknown MCP tool name" in result.output

--- a/tests/cli/test_setup_cmd.py
+++ b/tests/cli/test_setup_cmd.py
@@ -155,3 +155,51 @@ def test_setup_yes_with_clients_appends_agent_guidance(
     assert updated.startswith(original_content)
     assert "<!-- archex:mcp-guidance start -->" in updated
     assert updated != original_content
+
+
+def test_setup_yes_with_clients_and_tool_scope_writes_scoped_codex_registration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.check_call(["git", "init", str(repo)])
+    (repo / "hello.py").write_text("print('hello')")
+    codex_config = repo / ".codex" / "config.toml"
+    codex_config.parent.mkdir()
+    codex_config.write_text("", encoding="utf-8")
+    monkeypatch.setattr(setup_cmd, "mcp_runtime_available", _mcp_runtime_available_stub)
+
+    result = CliRunner().invoke(
+        cli, ["setup", str(repo), "--yes", "--clients", "--tool-scope", "core"]
+    )
+
+    assert result.exit_code == 0
+    written = codex_config.read_text(encoding="utf-8")
+    assert 'args = ["mcp", "--tools", "core"]' in written
+
+
+def test_setup_unknown_tool_scope_fails_cleanly_not_a_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: setup --tool-scope must validate up front like
+    install-client/mcp do, not let resolve_tool_scope's ValueError escape
+    uncaught from deep inside build_discovered_install_plans."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.check_call(["git", "init", str(repo)])
+    (repo / "hello.py").write_text("print('hello')")
+    codex_config = repo / ".codex" / "config.toml"
+    codex_config.parent.mkdir()
+    codex_config.write_text("", encoding="utf-8")
+    monkeypatch.setattr(setup_cmd, "mcp_runtime_available", _mcp_runtime_available_stub)
+
+    result = CliRunner().invoke(
+        cli, ["setup", str(repo), "--yes", "--clients", "--tool-scope", "not_a_real_tool"]
+    )
+
+    assert result.exit_code != 0
+    assert "Unknown MCP tool name" in result.output
+    assert "Traceback" not in result.output
+    assert codex_config.read_text(encoding="utf-8") == ""

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -751,7 +751,9 @@ class TestRunStdioServer:
             async def run(self, *args: object, **kwargs: object) -> None:
                 return None
 
-        def fake_build_server(runtime: QueryRuntime | None = None) -> object:
+        def fake_build_server(
+            runtime: QueryRuntime | None = None, tool_names: frozenset[str] | None = None
+        ) -> object:
             captured["runtime"] = runtime
             return FakeServer()
 
@@ -1732,3 +1734,136 @@ class TestHandleContextEndToEnd:
         assert (
             second_envelope["content"][0]["chunk"]["content"] == expected_chunk["chunk"]["content"]
         )
+
+
+# ---------------------------------------------------------------------------
+# Tool-scoping tests (M11)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveToolScope:
+    def test_none_means_unscoped(self) -> None:
+        assert mcp_integration.resolve_tool_scope(None) is None
+
+    def test_empty_string_means_unscoped(self) -> None:
+        assert mcp_integration.resolve_tool_scope("") is None
+        assert mcp_integration.resolve_tool_scope("   ") is None
+
+    def test_all_means_unscoped(self) -> None:
+        assert mcp_integration.resolve_tool_scope("all") is None
+
+    def test_named_profile_core_excludes_graph_tools(self) -> None:
+        scope = mcp_integration.resolve_tool_scope("core")
+        assert scope is not None
+        assert "graph_lookup" not in scope
+        assert "query_repo" in scope
+        assert scope == frozenset(mcp_integration.ALL_TOOL_NAMES) - {
+            "graph_lookup",
+            "graph_neighbors",
+            "graph_path",
+            "graph_stats",
+            "graph_hubs",
+        }
+
+    def test_named_profile_graph_is_exactly_the_five_graph_tools(self) -> None:
+        scope = mcp_integration.resolve_tool_scope("graph")
+        assert scope == {
+            "graph_lookup",
+            "graph_neighbors",
+            "graph_path",
+            "graph_stats",
+            "graph_hubs",
+        }
+
+    def test_explicit_comma_separated_allowlist(self) -> None:
+        scope = mcp_integration.resolve_tool_scope("query_repo, context ,get_impact")
+        assert scope == {"query_repo", "context", "get_impact"}
+
+    def test_unknown_tool_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown MCP tool name"):
+            mcp_integration.resolve_tool_scope("query_repo,not_a_real_tool")
+
+
+class TestAllToolNames:
+    @pytest.mark.asyncio
+    async def test_matches_live_list_tools_output(self) -> None:
+        """ALL_TOOL_NAMES must never drift from what list_tools() actually returns."""
+        server = build_server()
+        from mcp import types as mcp_types
+
+        handler = server.request_handlers[mcp_types.ListToolsRequest]
+        result = (await handler(mcp_types.ListToolsRequest(method="tools/list", params=None))).root
+        assert isinstance(result, mcp_types.ListToolsResult)
+        live_names = {t.name for t in result.tools}
+        assert live_names == set(mcp_integration.ALL_TOOL_NAMES)
+
+
+class TestMeasureToolSchemaSize:
+    def test_unscoped_covers_every_tool(self) -> None:
+        report = mcp_integration.measure_tool_schema_size(None)
+        assert report["tool_count"] == len(mcp_integration.ALL_TOOL_NAMES)
+        assert set(report["per_tool_chars"]) == set(mcp_integration.ALL_TOOL_NAMES)
+        assert report["total_chars"] == sum(report["per_tool_chars"].values())
+
+    def test_scoped_is_strictly_smaller_than_unscoped(self) -> None:
+        full = mcp_integration.measure_tool_schema_size(None)
+        scoped = mcp_integration.measure_tool_schema_size(
+            mcp_integration.resolve_tool_scope("core")
+        )
+        assert scoped["tool_count"] < full["tool_count"]
+        assert scoped["total_chars"] < full["total_chars"]
+        assert set(scoped["per_tool_chars"]).issubset(set(full["per_tool_chars"]))
+
+    def test_per_tool_chars_match_individual_serialization(self) -> None:
+        report = mcp_integration.measure_tool_schema_size(frozenset({"get_symbol"}))
+        schema = next(s for s in mcp_integration._tool_schemas() if s["name"] == "get_symbol")  # pyright: ignore[reportPrivateUsage]
+        assert report["per_tool_chars"]["get_symbol"] == len(json.dumps(schema, sort_keys=True))
+
+
+class TestBuildServerToolScoping:
+    @pytest.mark.asyncio
+    async def test_list_tools_scoped_is_strict_subset_of_unscoped(self) -> None:
+        from mcp import types as mcp_types
+
+        full_server = build_server()
+        full_handler = full_server.request_handlers[mcp_types.ListToolsRequest]
+        full_result = (
+            await full_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
+        ).root
+        assert isinstance(full_result, mcp_types.ListToolsResult)
+        full_names = {t.name for t in full_result.tools}
+
+        scoped_server = build_server(tool_names=frozenset({"query_repo", "context"}))
+        scoped_handler = scoped_server.request_handlers[mcp_types.ListToolsRequest]
+        scoped_result = (
+            await scoped_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
+        ).root
+        assert isinstance(scoped_result, mcp_types.ListToolsResult)
+        scoped_names = {t.name for t in scoped_result.tools}
+
+        assert scoped_names == {"query_repo", "context"}
+        assert scoped_names < full_names
+
+    @pytest.mark.asyncio
+    async def test_call_tool_dispatch_unaffected_by_scoping(self) -> None:
+        """A tool name outside the advertised scope still dispatches and
+        returns unchanged results -- scoping only shrinks list_tools()."""
+        from mcp import types as mcp_types
+
+        with patch(
+            "archex.integrations.mcp.handle_analyze_repo", return_value='{"repo": {}}'
+        ) as mock_handle:
+            server = build_server(tool_names=frozenset({"query_repo"}))
+            handler = server.request_handlers[mcp_types.CallToolRequest]
+            req = mcp_types.CallToolRequest(
+                method="tools/call",
+                params=mcp_types.CallToolRequestParams(
+                    name="analyze_repo",
+                    arguments={"repo_url": "/fake/repo"},
+                ),
+            )
+            server_result = await handler(req)
+            result = server_result.root
+            assert isinstance(result, mcp_types.CallToolResult)
+            assert not result.isError
+            mock_handle.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -822,6 +822,7 @@ class TestMcpCmd:
         mock_run_stdio = MagicMock()
         mock_mcp_module = MagicMock()
         mock_mcp_module.run_stdio_server = mock_run_stdio
+        mock_mcp_module.resolve_tool_scope = MagicMock(return_value=None)
 
         runner = CliRunner()
         with (
@@ -830,7 +831,9 @@ class TestMcpCmd:
         ):
             result = runner.invoke(cli, ["mcp"])
         assert result.exit_code == 0, result.output
-        mock_run_stdio.assert_called_once_with(watch=False, watch_path=".", watch_debounce_ms=300)
+        mock_run_stdio.assert_called_once_with(
+            watch=False, watch_path=".", watch_debounce_ms=300, tool_names=None
+        )
         mock_asyncio_run.assert_called_once_with(mock_run_stdio.return_value)
 
     def test_mcp_watch_options_pass_to_server(self) -> None:
@@ -839,6 +842,7 @@ class TestMcpCmd:
         mock_run_stdio = MagicMock()
         mock_mcp_module = MagicMock()
         mock_mcp_module.run_stdio_server = mock_run_stdio
+        mock_mcp_module.resolve_tool_scope = MagicMock(return_value=None)
 
         runner = CliRunner()
         with (
@@ -851,7 +855,9 @@ class TestMcpCmd:
             )
 
         assert result.exit_code == 0, result.output
-        mock_run_stdio.assert_called_once_with(watch=True, watch_path="src", watch_debounce_ms=50)
+        mock_run_stdio.assert_called_once_with(
+            watch=True, watch_path="src", watch_debounce_ms=50, tool_names=None
+        )
         mock_asyncio_run.assert_called_once_with(mock_run_stdio.return_value)
 
 


### PR DESCRIPTION
## Stack

Stack-Id: `m11-mcp-schema-overhead`
Base: `main`
Position: 1/3

1. `m11-1-tool-scoping` -> this PR
2. `m11-2-trimmed-descriptions` -> follow-up PR
3. `m11-3-graph-query` -> follow-up PR

Depends on: (none — root)

## Summary

M11 PR-1: tool-scoping mechanism for the MCP server (`.docs/DEVELOPMENT_PLAN.md` §4 M11).

- `archex.integrations.mcp`: `_tool_schemas()` becomes the single pure-Python source of truth for every tool's `{name, description, inputSchema}`, shared by `build_server()`'s `list_tools()` handler, `resolve_tool_scope()`, and `measure_tool_schema_size()`.
- `build_server(tool_names=...)` / `run_stdio_server(tool_names=...)`: an optional `frozenset[str]` scopes `list_tools()` to a subset. `call_tool` dispatch is untouched — every tool name still resolves regardless of scoping, so no currently-registered client config can break.
- `resolve_tool_scope(spec)`: `None`/`""`/`"all"` → unscoped (current default, byte-identical behavior); `"core"` → every tool except the 5 `graph_*` tools; `"graph"` → only the 5 `graph_*` tools; or a comma-separated explicit allowlist. Unknown tool name → `ValueError`.
- `archex mcp --tools <scope>`: new flag, defaults to unscoped.
- `archex mcp-schema-size [--tools SCOPE] [--format text|json]`: new command reporting total/per-tool serialized schema size (chars) for a scope — lets an operator measure the win before narrowing.
- `install-client --tool-scope` / `setup --tool-scope`: writes `archex mcp --tools <scope>` into the registered client's args when a scope is given; omitted → `["mcp"]`, byte-identical to every existing config archex has ever written.

## Verification (local)

```
uv sync --all-extras
uv run ruff check .            # All checks passed!
uv run ruff format --check .   # 498 files already formatted
uv run pyright .               # 0 errors, 0 warnings, 0 informations
uv run pytest --junitxml=results.xml --cov-report=xml -q
# 4454 passed, 9 deselected in 281.78s; coverage 91.38% (>= 85% gate)
```

Manual smoke:
- `archex mcp-schema-size` (all): 18 tools, 14270 chars total.
- `archex mcp-schema-size --tools core`: 13 tools, 10665 chars — strict subset, smaller.
- `archex install-client claude-code . --dry-run` (no `--tool-scope`): `args: ["mcp"]` — unchanged from current behavior.
- `archex install-client claude-code . --tool-scope core`: `args: ["mcp", "--tools", "core"]`.
- `archex install-client codex . --dry-run --tool-scope graph`: `args = ["mcp", "--tools", "graph"]` in the written TOML.
- `archex mcp --tools not_a_tool` / `archex mcp-schema-size --tools not_a_tool`: clean `ClickException`, no traceback.

## Scope

In: tool-scoping mechanism (`resolve_tool_scope`, `build_server`/`run_stdio_server` wiring), `--tools`/`--tool-scope` CLI surface, `mcp-schema-size` measurement command, and the corresponding tests.
Out (this PR): trimmed tool descriptions and the checked-in schema-size baseline artifact (PR-2), `graph_query` consolidation (PR-3). No retrieval, ranking, receipt, or Python API behavior changes.
