### PR TITLE
refactor(mcp): trim verbose tool descriptions

### DIFF
--- a/benchmarks/results/m11_mcp_schema_overhead/BASELINE.json
+++ b/benchmarks/results/m11_mcp_schema_overhead/BASELINE.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "milestone": "M11",
+  "measured_at": "2026-07-24",
+  "measured_with": "archex mcp-schema-size --format json",
+  "method": "len(json.dumps({name, description, inputSchema}, sort_keys=True)) per tool; sum for total_chars. 'before' = archex.integrations.mcp state after PR-1 (m11-1-tool-scoping, tool-scoping mechanism, no description changes). 'after' = this PR (m11-2-trimmed-descriptions) after trimming get_impact/explain_target/graph_* descriptions.",
+  "profiles": {
+    "all": {
+      "before": {
+        "tool_count": 18,
+        "total_chars": 14270
+      },
+      "after": {
+        "tool_count": 18,
+        "total_chars": 13907
+      }
+    },
+    "core": {
+      "before": {
+        "tool_count": 13,
+        "total_chars": 10665
+      },
+      "after": {
+        "tool_count": 13,
+        "total_chars": 10435
+      }
+    },
+    "graph": {
+      "before": {
+        "tool_count": 5,
+        "total_chars": 3605
+      },
+      "after": {
+        "tool_count": 5,
+        "total_chars": 3472
+      }
+    }
+  },
+  "per_tool_chars_after": {
+    "analyze_repo": 570,
+    "compare_repos": 718,
+    "context": 2279,
+    "explain_target": 892,
+    "generate_onboarding": 715,
+    "get_file_outline": 433,
+    "get_file_tree": 503,
+    "get_impact": 1118,
+    "get_symbol": 352,
+    "get_symbols_batch": 456,
+    "graph_hubs": 584,
+    "graph_lookup": 676,
+    "graph_neighbors": 812,
+    "graph_path": 826,
+    "graph_stats": 574,
+    "query_repo": 1007,
+    "scout_repo": 703,
+    "search_symbols": 689
+  }
+}

--- a/benchmarks/results/m11_mcp_schema_overhead/DECISION.md
+++ b/benchmarks/results/m11_mcp_schema_overhead/DECISION.md
@@ -1,0 +1,58 @@
+# M11 PR-2 — Trimmed MCP tool descriptions: schema-size measurement
+
+Milestone: reduce the fixed per-turn MCP tool-schema context cost
+(`.docs/DEVELOPMENT_PLAN.md` §4 M11). This PR trims the heaviest tool
+descriptions (`get_impact`, `explain_target`, and the five `graph_*`
+tools) while preserving model-callable intent — every mutual-exclusion,
+precedence, and behavior-selecting fact a caller needs to construct a
+correct call stays in the trimmed text; only redundant framing prose
+("Return ...", "from an exported artifact without indexing source
+files" repeated identically across all five `graph_*` tools) was cut.
+
+## Method
+
+`archex mcp-schema-size --format json` serializes each tool's
+`{name, description, inputSchema}` as compact, sort-keyed JSON and sums
+the character count — the same shape a client actually registers via
+`list_tools()`. Measured once on `m11-1-tool-scoping` (tool-scoping
+mechanism only, no description changes — the "before" baseline) and
+once on this PR's tip (the "after" figure), for the `all` (unscoped),
+`core`, and `graph` scope profiles introduced by PR-1.
+
+```
+uv run archex mcp-schema-size --format json
+uv run archex mcp-schema-size --tools core --format json
+uv run archex mcp-schema-size --tools graph --format json
+```
+
+## Results
+
+| Scope | Tools | Before (chars) | After (chars) | Reduction |
+| --- | ---: | ---: | ---: | ---: |
+| `all` (unscoped) | 18 | 14270 | 13907 | 363 (2.5%) |
+| `core` | 13 | 10665 | 10435 | 230 (2.2%) |
+| `graph` | 5 | 3605 | 3472 | 133 (3.7%) |
+
+Per-tool: `get_impact` 1330 -> 1118 (-212, -15.9%), `explain_target` 910
+-> 892 (-18, -2.0%), `graph_lookup` 715 -> 676 (-39), `graph_neighbors`
+839 -> 812 (-27), `graph_path` 849 -> 826 (-23), `graph_stats` 597 ->
+574 (-23), `graph_hubs` 605 -> 584 (-21). Every other tool's schema is
+byte-identical (untouched by this PR).
+
+Raw before/after numbers and the full post-trim per-tool breakdown are
+checked in at `BASELINE.json` in this directory; `test_schema_size.py`
+(added in this PR) asserts the current unscoped total never exceeds the
+recorded `after` value for any of the three profiles, guarding against
+a future PR silently re-bloating a description back past this baseline.
+
+## Decision
+
+Ship as-is. The reduction is modest (2-4% depending on scope) because
+the schemas are already fairly terse `inputSchema` property
+descriptions dominate their size, not prose — but it is real, verified,
+and stacks with PR-1's tool-scoping (which cuts far more: `core` alone
+drops the unscoped 18-tool, 14270-char surface to 13-tool, 10435 chars
+post-trim, a 26.9% reduction) and PR-3's `graph_query` consolidation.
+No retrieval, ranking, receipt, CLI, or Python API behavior changed —
+this PR only rewrites `description` string literals in
+`src/archex/integrations/mcp.py`.

--- a/benchmarks/results/m11_mcp_schema_overhead/DECISION.md
+++ b/benchmarks/results/m11_mcp_schema_overhead/DECISION.md
@@ -40,10 +40,11 @@ Per-tool: `get_impact` 1330 -> 1118 (-212, -15.9%), `explain_target` 910
 byte-identical (untouched by this PR).
 
 Raw before/after numbers and the full post-trim per-tool breakdown are
-checked in at `BASELINE.json` in this directory; `test_schema_size.py`
-(added in this PR) asserts the current unscoped total never exceeds the
-recorded `after` value for any of the three profiles, guarding against
-a future PR silently re-bloating a description back past this baseline.
+checked in at `BASELINE.json` in this directory;
+`tests/integrations/test_mcp_schema_size_baseline.py` (added in this
+PR) asserts the current unscoped total never exceeds the recorded
+`after` value for any of the three profiles, guarding against a future
+PR silently re-bloating a description back past this baseline.
 
 ## Decision
 

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -1825,11 +1825,10 @@ def _tool_schemas() -> list[dict[str, Any]]:
         {
             "name": "get_impact",
             "description": (
-                "Analyze deterministic blast radius for changed files: affected files, "
-                "modules, public interfaces, test surface, and a risk assessment. Uses "
-                "git diff against a base ref, or an explicit changed-file list. Pass "
-                "'diff' to additionally resolve the diff to touched symbols and classify "
-                "each with a LOW/MEDIUM/HIGH risk tier from deterministic graph signals."
+                "Deterministic blast-radius impact analysis for changed files: affected "
+                "files, modules, public interfaces, test surface, risk assessment. Diffs "
+                "against a base ref or an explicit changed-file list; pass 'diff' for "
+                "per-symbol LOW/MEDIUM/HIGH risk tiers."
             ),
             "inputSchema": {
                 "type": "object",
@@ -1837,24 +1836,22 @@ def _tool_schemas() -> list[dict[str, Any]]:
                     "repo_url": {
                         "type": "string",
                         "description": (
-                            "Local filesystem path of the repository. Git diff mode "
-                            "requires a local checkout."
+                            "Local repository path (git diff mode requires a local checkout)."
                         ),
                     },
                     "base": {
                         "type": "string",
                         "default": "main",
                         "description": (
-                            "Base ref for git diff mode. Ignored when changed_files "
-                            "or diff is provided."
+                            "Base ref for git diff mode; ignored if changed_files or diff is set."
                         ),
                     },
                     "changed_files": {
                         "type": "array",
                         "items": {"type": "string"},
                         "description": (
-                            "Explicit changed file paths, bypassing git diff mode. "
-                            "Cannot be combined with diff."
+                            "Explicit changed files, bypassing git diff mode. Mutually "
+                            "exclusive with diff."
                         ),
                     },
                     "format": {
@@ -1866,11 +1863,9 @@ def _tool_schemas() -> list[dict[str, Any]]:
                     "diff": {
                         "type": "string",
                         "description": (
-                            "Enable diff-scoped symbol impact: resolve the diff (this "
-                            "ref vs. the working tree) to touched symbols with a "
-                            "per-symbol risk tier. Adds affected_symbols to the report; "
-                            "output is unchanged when omitted. Cannot be combined with "
-                            "changed_files."
+                            "Resolve the diff (this ref vs. working tree) to touched symbols "
+                            "with a per-symbol risk tier, added as affected_symbols. Mutually "
+                            "exclusive with changed_files."
                         ),
                     },
                 },
@@ -1880,9 +1875,8 @@ def _tool_schemas() -> list[dict[str, Any]]:
         {
             "name": "explain_target",
             "description": (
-                "Explain a file, symbol, or module from indexed structural data: public "
-                "interfaces, internal symbols, imports/imported-by, module context, and "
-                "complexity signals."
+                "Structural explain for a file, symbol, or module: public interfaces, "
+                "internal symbols, imports/imported-by, module context, complexity signals."
             ),
             "inputSchema": {
                 "type": "object",
@@ -1957,8 +1951,8 @@ def _tool_schemas() -> list[dict[str, Any]]:
         {
             "name": "graph_lookup",
             "description": (
-                "Look up graph nodes in an exported architecture graph artifact without "
-                "indexing source files. Exact node IDs and paths win over fuzzy matches."
+                "Look up nodes in an exported graph artifact (no reindexing). Exact "
+                "ID/path matches win over fuzzy ones."
             ),
             "inputSchema": {
                 "type": "object",
@@ -1987,8 +1981,8 @@ def _tool_schemas() -> list[dict[str, Any]]:
         {
             "name": "graph_neighbors",
             "description": (
-                "Return graph neighbors for a node from an exported artifact without "
-                "indexing source files. Edges include kind, confidence, and evidence."
+                "Graph neighbors for a node from an exported artifact (no reindexing). "
+                "Edges carry kind, confidence, evidence."
             ),
             "inputSchema": {
                 "type": "object",
@@ -2023,8 +2017,8 @@ def _tool_schemas() -> list[dict[str, Any]]:
         {
             "name": "graph_path",
             "description": (
-                "Find a shortest structural path between two graph nodes from an exported "
-                "artifact without indexing source files."
+                "Shortest structural path between two nodes in an exported graph "
+                "artifact (no reindexing)."
             ),
             "inputSchema": {
                 "type": "object",
@@ -2056,8 +2050,8 @@ def _tool_schemas() -> list[dict[str, Any]]:
         {
             "name": "graph_stats",
             "description": (
-                "Return deterministic graph stats and hub summaries from an exported "
-                "artifact without indexing source files."
+                "Deterministic graph stats and hub summary from an exported artifact "
+                "(no reindexing)."
             ),
             "inputSchema": {
                 "type": "object",
@@ -2081,10 +2075,7 @@ def _tool_schemas() -> list[dict[str, Any]]:
         },
         {
             "name": "graph_hubs",
-            "description": (
-                "Return high-degree graph hubs from an exported artifact without indexing "
-                "source files."
-            ),
+            "description": ("High-degree hubs from an exported graph artifact (no reindexing)."),
             "inputSchema": {
                 "type": "object",
                 "properties": {

--- a/tests/integrations/test_mcp_schema_size_baseline.py
+++ b/tests/integrations/test_mcp_schema_size_baseline.py
@@ -1,0 +1,66 @@
+"""M11 PR-2: guard the checked-in MCP tool-schema size baseline.
+
+Asserts the current, live `measure_tool_schema_size()` output for each
+scope profile recorded in `benchmarks/results/m11_mcp_schema_overhead/
+BASELINE.json` never exceeds the checked-in `after` figure -- a future
+PR that re-bloats a tool description (or adds a new tool without
+trimming elsewhere) fails loudly here instead of silently eroding the
+M11 reduction.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp", reason="mcp not installed")
+
+from archex.integrations.mcp import measure_tool_schema_size, resolve_tool_scope
+
+_BASELINE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "benchmarks"
+    / "results"
+    / "m11_mcp_schema_overhead"
+    / "BASELINE.json"
+)
+
+
+def _load_baseline() -> dict[str, object]:
+    return json.loads(_BASELINE_PATH.read_text(encoding="utf-8"))
+
+
+class TestSchemaSizeBaseline:
+    def test_baseline_file_exists_and_parses(self) -> None:
+        baseline = _load_baseline()
+        assert baseline["milestone"] == "M11"
+        assert set(baseline["profiles"]) == {"all", "core", "graph"}  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("scope_name", ["all", "core", "graph"])
+    def test_current_size_does_not_exceed_recorded_after(self, scope_name: str) -> None:
+        baseline = _load_baseline()
+        profile = baseline["profiles"][scope_name]  # type: ignore[index]
+        recorded_after = profile["after"]  # type: ignore[index]
+
+        tool_names = resolve_tool_scope(None if scope_name == "all" else scope_name)
+        current = measure_tool_schema_size(tool_names)
+
+        assert current["tool_count"] == recorded_after["tool_count"]  # type: ignore[index]
+        assert current["total_chars"] <= recorded_after["total_chars"]  # type: ignore[index]
+
+    def test_unscoped_size_decreased_from_recorded_before(self) -> None:
+        """The M11 acceptance row: the full unscoped listing's total schema
+        size decreases from the pre-change (PR-1) baseline."""
+        baseline = _load_baseline()
+        before_total = baseline["profiles"]["all"]["before"]["total_chars"]  # type: ignore[index]
+
+        current = measure_tool_schema_size(None)
+        assert current["total_chars"] < before_total
+
+    def test_per_tool_chars_after_matches_current_unscoped_measurement(self) -> None:
+        baseline = _load_baseline()
+        recorded_per_tool = baseline["per_tool_chars_after"]
+        current = measure_tool_schema_size(None)
+        assert current["per_tool_chars"] == recorded_per_tool


### PR DESCRIPTION
## Stack

Stack-Id: `m11-mcp-schema-overhead`
Base: `m11-1-tool-scoping` (#563)
Position: 2/3

1. `m11-1-tool-scoping` -> #563
2. `m11-2-trimmed-descriptions` -> this PR
3. `m11-3-graph-query` -> follow-up PR

Depends on: #563
Upstack: (PR-3, not yet opened)

## Summary

M11 PR-2: trim the heaviest tool descriptions and add a checked-in schema-size baseline artifact + regression test.

- Trimmed `get_impact` (top-level + 4 property descriptions), `explain_target` (top-level), and all five `graph_*` top-level descriptions — cut redundant framing prose ("Return ...", the identically-repeated "from an exported artifact without indexing source files" across all 5 graph tools) while preserving every mutual-exclusion, precedence, and behavior-selecting fact a caller needs. Every other tool's schema is byte-identical.
- `benchmarks/results/m11_mcp_schema_overhead/BASELINE.json` + `DECISION.md`: checked-in before/after `archex mcp-schema-size` measurement for the `all`/`core`/`graph` scope profiles PR-1 introduced, with method and full per-tool breakdown.
- `tests/integrations/test_mcp_schema_size_baseline.py`: guards the baseline — current unscoped total stays under the recorded `before` figure, and no scope's current total exceeds its recorded `after` figure, so a future PR that re-bloats a description fails a test instead of silently eroding the reduction.

## Results

| Scope | Tools | Before (chars) | After (chars) | Reduction |
| --- | ---: | ---: | ---: | ---: |
| `all` (unscoped) | 18 | 14270 | 13907 | 363 (2.5%) |
| `core` | 13 | 10665 | 10435 | 230 (2.2%) |
| `graph` | 5 | 3605 | 3472 | 133 (3.7%) |

Full per-tool breakdown in `DECISION.md`.

## Verification (local)

```
uv sync --all-extras
uv run ruff check .            # All checks passed!
uv run ruff format --check .   # 499 files already formatted
uv run pyright .               # 0 errors, 0 warnings, 0 informations
uv run pytest --junitxml=results.xml --cov-report=xml -q
# 4460 passed, 9 deselected in 278.14s; coverage 91.38% (>= 85% gate)
```

## Scope

In: description trims for `get_impact`/`explain_target`/`graph_*`, checked-in schema-size baseline, regression test.
Out (this PR): `graph_query` consolidation (PR-3). No retrieval, ranking, receipt, CLI-flag, or Python API behavior changes — every diff is a `description` string literal plus new test/artifact files.
