### PR TITLE
docs(contributing): freeze mechanism work until Gate A

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,19 @@ All checks must pass before submitting a PR. CI runs lint, format check, type ch
 - **Type checking:** pyright strict mode
 - **Target Python:** 3.11+
 
+## Strategic Reassessment Freeze
+
+Until Gate A passes on R3's external replication verdict, contributors must not:
+
+- add a new retrieval lane;
+- attempt to promote a retrieval path to the default;
+- add a new language tier; or
+- add a new MCP tool.
+
+The unstarted forward milestones from the prior plan — M2, M3, M4, M5, and M10 — are **SUSPENDED — pending strategic-reassessment Gate A**. Do not resume them. The governing contract and the recorded lift condition are in tracked `.docs/DEVELOPMENT_PLAN.md` §3 (Gate A) and §6 (R3).
+
+R5, MCP retrieval-gated tool disclosure, is the sole carve-out before Gate A. It may change how existing MCP tools are exposed, but must not add or remove a tool capability or change tool behavior.
+
 ## Adding a Language Adapter
 
 Language adapters live in `src/archex/parse/adapters/`. Each adapter implements the `LanguageAdapter` protocol defined in `src/archex/parse/adapters/base.py`.


### PR DESCRIPTION
## Summary

- Freeze unstarted prior-plan forward milestones pending strategic-reassessment Gate A.
- Prohibit new retrieval lanes, default-promotion attempts, language tiers, and MCP tools until Gate A passes.
- Name R5 as the sole, behavior-preserving MCP exposure carve-out.

## Stack

Stack-Id: `r1-freeze-prereg-5e3a1c`
Base: `main`
Position: 1/2

1. `docs/r1-freeze-mechanism-work` -> this PR
2. `docs/r1-pre-registration-template` -> #570

Depends on: #569 (merged reconciliation prerequisite)
Upstack: #570

## Validation

- `git diff --name-only origin/main..HEAD -- src/`: passed (no output)
- Full local gate: passed cumulatively on #570; no executable behavior changed.

## Risk and rollback

The policy could be ignored. The clause is explicit and reviewable; reverting this PR removes the freeze.