### PR TITLE
docs(spikes): add pre-registration template

### DIFF
--- a/.docs/spikes/TEMPLATE.md
+++ b/.docs/spikes/TEMPLATE.md
@@ -1,0 +1,46 @@
+# Spike Pre-registration Template
+
+Copy this file to `.docs/spikes/<spike-id>.md`. Complete every required field and commit the file before the first data-generating run. Do not revise a pre-registration after data exists; record a new, explicitly post-hoc document instead.
+
+## Study identity
+
+- **Spike ID and title:**
+- **Evidence class:** `replication` | `adaptation` | `original`
+- **Decision owner and date:**
+- **First-run commit:** Leave blank until the pre-registration commit has merged; then record the first commit allowed to generate data.
+
+## Hypothesis
+
+State one falsifiable directional or equivalence hypothesis. Name the treatment, control, target population, and the primary comparison family.
+
+## Primary metric
+
+Name exactly one primary metric. Define its numerator, denominator, aggregation level, direction of improvement, and measurement procedure. Label every other metric exploratory.
+
+## SESOI
+
+State the smallest effect size of interest before data collection. Derive it from the user or operator decision that changes at that effect size, not from observed variance.
+
+## Decision margins
+
+Derive each quantity separately from utility, cost, and risk. Do not substitute one margin for another or derive any margin from observed standard deviation.
+
+- **Minimum worthwhile gain (MWG):** State the smallest beneficial improvement worth adopting and its utility basis.
+- **Non-inferiority margin (NIM):** State the maximum acceptable loss against the control and its cost basis.
+- **Equivalence margin (EQM):** State a strictly positive interval around zero that is practically negligible and its utility basis.
+
+## Clustering unit
+
+Name the independent unit resampled by inference, explain why observations are clustered under it, and state how repeated observations remain within that cluster.
+
+## Kill criterion
+
+State the result or feasibility condition that stops the spike, the resulting disposition, and the evidence required to apply it. A null result is a valid outcome when declared here.
+
+## Run and analysis boundary
+
+Freeze the treatment matrix, inputs, seeds, exclusion rules, and analysis procedure. Record the command and immutable input revisions before the first run.
+
+## Post-hoc changes
+
+Record only changes made after data exists. For each, state the timestamp, reason, affected field, and why the result is exploratory.


### PR DESCRIPTION
## Summary

- Add the mandatory pre-registration template before any spike is defined.
- Require a falsifiable hypothesis, one primary metric, SESOI, separately derived utility-based MWG/NIM/EQM, a clustering unit, a kill criterion, and an evidence class.
- Make post-data changes explicit rather than silently revising a study contract.

## Stack

Stack-Id: `r1-freeze-prereg-5e3a1c`
Original position: 2/2
Current base: `main`

1. `docs/r1-freeze-mechanism-work` -> #568 (merged)
2. `docs/r1-pre-registration-template` -> this PR

Depends on: #568 (merged)
Upstack: (none — leaf)

## Validation

- `git ls-files --error-unmatch .docs/spikes/TEMPLATE.md`: passed
- `git check-ignore -v .docs/DEVELOPMENT_PLAN_HISTORY.md`: passed
- `git diff --name-only origin/main..HEAD -- src/`: passed (no output)
- `uv run ruff check . && uv run ruff format --check . && uv run pyright . && uv run pytest`: passed; 4,471 passed, 9 deselected.

## Risk and rollback

The template adds mandatory study-design fields without changing runtime behavior. Revert this PR to remove the template; no product code or release artifact changes.