### PR TITLE
docs(contributing): link strategic reassessment freeze

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Until Gate A passes on R3's external replication verdict, contributors must not:
 - add a new language tier; or
 - add a new MCP tool.
 
-The unstarted forward milestones from the prior plan — M2, M3, M4, M5, and M10 — are **SUSPENDED — pending strategic-reassessment Gate A**. Do not resume them. The governing contract and the recorded lift condition are in tracked `.docs/DEVELOPMENT_PLAN.md` §3 (Gate A) and §6 (R3).
+The unstarted forward milestones from the prior plan — M2, M3, M4, M5, and M10 — are **SUSPENDED — pending strategic-reassessment Gate A**. Do not resume them. The local strategic-reassessment record is `.docs/strategic-reassessment/`; the governing contract and recorded lift condition are in tracked `.docs/DEVELOPMENT_PLAN.md` §3 (Gate A) and §6 (R3).
 
 R5, MCP retrieval-gated tool disclosure, is the sole carve-out before Gate A. It may change how existing MCP tools are exposed, but must not add or remove a tool capability or change tool behavior.
 


### PR DESCRIPTION
## Summary

- Restore the explicit `.docs/strategic-reassessment/` pointer required by R1 for suspended prior-plan milestones.
- Retain the tracked `.docs/DEVELOPMENT_PLAN.md` Gate A/R3 authority, so fresh clones still have a reviewable lift condition.

## Scope

- Base: `main`
- One documentation-only change in `CONTRIBUTING.md`.
- No product-code, version, changelog, release, or behavior change.

## Validation

- `git diff --name-only origin/main..HEAD -- src/`: passed (no output).
- `git diff --check origin/main..HEAD`: passed.

## Risk and rollback

This restores a documentation pointer only. Revert this PR to remove it.