### PR TITLE
chore(gitignore): drop rules already covered by the global excludes file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,21 +205,3 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
-
-# Agentic Systems
-.agent
-.campaign/
-.claude/
-.gemini
-.opencode/
-
-# Developer workspace; tracked reassessment contracts are explicit exceptions.
-!.docs/
-.docs/*
-!.docs/DEVELOPMENT_PLAN.md
-!.docs/EXECUTION_PROMPTS.md
-!.docs/spikes/
-!.docs/spikes/**
-.archex/*
-!.archex/baselines/
-!.archex/baselines/**


### PR DESCRIPTION
Removes the repo-local `# Agentic Systems` / `.docs` / `.archex` block. The global `core.excludesFile` already ignores `.agent`, `.claude/`, `.gemini`, `.opencode/`, `.archex/`, and `.docs/`, so those lines were restating it.

Verified: `git status` reports no newly visible files after the removal, so the working tree is unchanged in practice.

## What this does not change

`.gitignore` never untracks anything. The four tracked planning contracts and `.archex/baselines/pre-promotion.json` stay in the index and stay editable:

```
.docs/DEVELOPMENT_PLAN.md
.docs/EXECUTION_PROMPTS.md
.docs/spikes/TEMPLATE.md
.docs/spikes/S0-replication-gate.md
.archex/baselines/pre-promotion.json
```

## What it does change, latently

The block carried two negations — `!.docs/spikes/**` and `!.archex/baselines/**` — that made **new** files trackable inside those globally ignored directories. Those are gone, so `git add` will silently skip a future pre-registration or baseline rather than erroring.

That matters for one specific mechanism. R6, R10, and R12–R15 each require a pre-registration under `.docs/spikes/` that merges **before** its first run, with commit order as the proof; that is what made Gate A falsifiable in R3 (`557c5683` is a git ancestor of the evidence). An ignored file has no commit and cannot prove ordering.

So before any of those milestones runs, the pre-registration substrate needs a tracked home. The natural candidate is `benchmarks/preregistrations/`, which is already tracked and already holds the evidence artifacts — a deliberate move rather than a mechanism lost by omission. Filed as an open item in the post-R3 state notes.

Also drops `.campaign/`, which the global file does not cover. The directory does not exist in this checkout.
