### PR TITLE
feat(benchmark): measure what the task corpus can detect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ ignore = ["TC003"]
 [tool.pyright]
 pythonVersion = "3.11"
 typeCheckingMode = "strict"
-include = ["src/archex", "tests"]
+include = ["src/archex", "tests", "benchmarks/corpus_audit"]
 # assets/archex_explainer.py depends on optional Manim rendering packages and is validated by render smoke when edited.
 # Generated approval-test state is not repository source and is not type-checked.
 # scip_pb2.py is protoc-generated code (regenerate via scip.proto in the same directory),

--- a/src/archex/benchmark/corpus_audit.py
+++ b/src/archex/benchmark/corpus_audit.py
@@ -19,6 +19,7 @@ Three questions, in order of how badly a wrong answer misleads everything else:
 from __future__ import annotations
 
 import json
+import math
 import random
 import re
 from collections.abc import Sequence
@@ -141,19 +142,31 @@ class ClusterReport:
     def self_repo_share(self) -> float:
         return self.self_repo_tasks / self.total_tasks
 
+    @property
+    def weighted_mean_cluster_size(self) -> float:
+        """``sum(m^2) / sum(m)``, the cluster size the design effect depends on.
+
+        Not the arithmetic mean. With unequal clusters the design effect is
+        driven by the *size-weighted* mean, because a large cluster contributes
+        its correlated observations in proportion to its own size. This corpus
+        makes the difference stark: sizes of 24 and fifteen clusters of 2 to 4
+        give an arithmetic mean of 4.0 but a weighted mean of 10.8, so using the
+        arithmetic mean would overstate the usable sample size by about twofold.
+        """
+        return sum(size * size for size in self.cluster_sizes.values()) / self.total_tasks
+
     def effective_sample_size(self, icc: float) -> float:
         """Design-effect-corrected N.
 
         With clustered observations the usable sample size is
-        ``N / (1 + (m - 1) * ICC)`` for average cluster size ``m``. At ICC 0 the
-        clusters carry no shared signal and N is unchanged; at ICC 1 every
-        cluster collapses to a single observation.
+        ``N / (1 + (m_A - 1) * ICC)`` where ``m_A`` is the size-weighted mean
+        cluster size. At ICC 0 the clusters carry no shared signal and N is
+        unchanged; at ICC 1 each cluster contributes about one observation.
         """
         if not 0.0 <= icc <= 1.0:
             msg = f"icc must lie in [0, 1], got {icc}"
             raise CorpusAuditError(msg)
-        mean_size = self.total_tasks / self.cluster_count
-        design_effect = 1.0 + (mean_size - 1.0) * icc
+        design_effect = 1.0 + (self.weighted_mean_cluster_size - 1.0) * icc
         return self.total_tasks / design_effect
 
 
@@ -174,7 +187,20 @@ class HeldOutReport:
 
 
 def _normalise(text: str) -> str:
+    """Collapse punctuation to spaces, for matching prose against prose."""
     return re.sub(r"[^a-z0-9]+", " ", text.lower())
+
+
+def _raw(text: str) -> str:
+    """Lowercase while preserving `_` and `.`, for matching identifiers literally.
+
+    Both surfaces are needed. Matching only the normalised form lets `_merge`
+    match the ordinary word "merge" and `block_on` match "block on", which
+    readmits the false-positive class the tiering exists to keep out. Matching
+    only the raw form loses nothing real, so the raw form is what an identifier
+    is tested against.
+    """
+    return re.sub(r"[^a-z0-9_.]+", " ", text.lower())
 
 
 def _stem_of_path(path: str, *, exclude: frozenset[str]) -> str | None:
@@ -199,7 +225,7 @@ def _repo_tokens(repo: str) -> frozenset[str]:
     return frozenset(part.lower() for part in re.split(r"[/_-]", repo) if part)
 
 
-def _symbol_kind(symbol: str) -> str:
+def _symbol_kind(symbol: str) -> str:  # noqa: D401
     """Separate identifier-shaped symbols from gold symbols that are plain words.
 
     `PythonAdapter` and `default_adapter_registry` cannot appear in a question by
@@ -209,6 +235,11 @@ def _symbol_kind(symbol: str) -> str:
     ambiguity. They are reported as `symbol_word` and excluded from the strong
     tier without being hidden.
     """
+    if symbol.lower() in _GENERIC_TOKENS:
+        # Generic words are reported in the weak tier rather than dropped, so the
+        # count stays auditable. `_GENERIC_TOKENS` still drops path stems, where
+        # a generic word carries no information at all.
+        return "symbol_word"
     if _IDENTIFIER_SHAPED.search(symbol) or len(symbol) >= _MIN_WORD_SYMBOL_LENGTH:
         return "symbol"
     return "symbol_word"
@@ -223,8 +254,16 @@ def _is_distinctive(token: str) -> bool:
 
 
 def _contains_token(haystack: str, token: str) -> bool:
-    """Whole-token containment, so `parse` does not match `parsed`."""
-    return re.search(rf"\b{re.escape(token.lower())}\b", haystack) is not None
+    """Whole-token containment of *token* in an already-lowercased *haystack*.
+
+    Boundaries are checked against alphanumerics, underscore, and dot, so
+    `merge` does not match inside `_merge` and `parse` does not match `parsed`.
+    """
+    needle = token.lower().strip()
+    if not needle:
+        return False
+    pattern = rf"(?<![a-z0-9_.]){re.escape(needle)}(?![a-z0-9_.])"
+    return re.search(pattern, haystack) is not None
 
 
 def score_task_leakage(task: BenchmarkTask) -> tuple[LeakSignal, ...]:
@@ -234,17 +273,21 @@ def score_task_leakage(task: BenchmarkTask) -> tuple[LeakSignal, ...]:
     symbol match is scored on the raw symbol; a path match is scored on its
     distinctive fragments, since no question quotes a full path.
     """
-    surfaces = {
+    keywords = " ".join(task.keywords)
+    # Identifiers are matched literally against a surface that keeps `_` and `.`;
+    # path stems are prose-like and matched against the normalised surface.
+    raw_surfaces = {"question": _raw(task.question), "keywords": _raw(keywords)}
+    prose_surfaces = {
         "question": _normalise(task.question),
-        "keywords": _normalise(" ".join(task.keywords)),
+        "keywords": _normalise(keywords),
     }
     exclude = _repo_tokens(task.repo)
     signals: list[LeakSignal] = []
     for symbol in task.expected_symbols:
-        if not _is_distinctive(symbol) or symbol.lower() in exclude:
+        if symbol.lower() in exclude or len(symbol) < _MIN_TOKEN_LENGTH:
             continue
         kind = _symbol_kind(symbol)
-        for surface, text in surfaces.items():
+        for surface, text in raw_surfaces.items():
             if _contains_token(text, symbol):
                 signals.append(
                     LeakSignal(task_id=task.task_id, kind=kind, value=symbol, surface=surface)
@@ -254,7 +297,7 @@ def score_task_leakage(task: BenchmarkTask) -> tuple[LeakSignal, ...]:
         stem = _stem_of_path(path, exclude=exclude)
         if stem is None:
             continue
-        for surface, text in surfaces.items():
+        for surface, text in prose_surfaces.items():
             if (stem, surface) in seen_stems:
                 continue
             if _contains_token(text, stem):
@@ -346,12 +389,32 @@ class PowerResult:
     simulations: int
     seed: int
 
+    @property
+    def monte_carlo_se(self) -> float:
+        """Standard error of the power estimate itself.
+
+        Reported because a power estimate read against a 0.80 target is only
+        meaningful if its own noise is small against the distance to that target.
+        """
+        return math.sqrt(max(0.0, self.power * (1.0 - self.power)) / self.simulations)
+
+    def clears(self, target_power: float) -> bool:
+        """Whether power clears *target* by more than two of its own standard errors."""
+        return self.power - 2.0 * self.monte_carlo_se >= target_power
+
 
 def _cluster_probabilities(
     sizes: Sequence[int], base_rate: float, cluster_sd: float, rng: random.Random
 ) -> list[float]:
     """Per-cluster success rates, dispersed to induce between-cluster variance."""
     return [min(0.99, max(0.01, rng.gauss(base_rate, cluster_sd))) for _ in sizes]
+
+
+#: Below this many clusters the percentile bootstrap cannot approximate 95%
+#: coverage: with k clusters there are only k**k distinct resamples, and the
+#: interval collapses, reporting *higher* power for a worse design. Projections
+#: below this threshold are refused rather than quietly reported.
+MIN_VALID_CLUSTERS = 8
 
 
 def simulate_power(
@@ -363,6 +426,7 @@ def simulate_power(
     simulations: int,
     resamples: int,
     seed: int,
+    effect_sd: float = 0.0,
 ) -> PowerResult:
     """Estimate power to detect *effect_points* on a given cluster structure.
 
@@ -370,9 +434,19 @@ def simulate_power(
     rate from ``Normal(base_rate, cluster_sd)``, which is what makes observations
     within a repository correlated. Every task in that cluster then draws a
     control outcome at the cluster rate and a treatment outcome at the cluster
-    rate plus the effect. The paired delta is the difference of the two pooled
-    means, and inference is the same cluster bootstrap over repositories that R3
-    used, so a power figure here is comparable to an interval measured there.
+    rate plus that cluster's effect. The paired delta is the difference of the two
+    pooled means, and inference is the same cluster bootstrap over repositories
+    that R3 used, so a power figure here is comparable to an interval measured
+    there.
+
+    ``effect_sd`` is the **between-cluster standard deviation of the treatment
+    effect**, and it is the only parameter under which the number of
+    repositories -- as opposed to the number of tasks -- limits power. At
+    ``effect_sd=0`` every repository responds identically, the shared cluster
+    rate cancels in the paired delta, and power is governed by total task count.
+    Do not set it above what data supports: estimated from R3's eight measured
+    per-repository deltas it is indistinguishable from zero, because their spread
+    is smaller than the within-repository sampling noise at 200 tasks each.
 
     Power is the fraction of simulations whose 95% cluster-bootstrap interval
     excludes zero -- the same rule the pre-registered Gate A decision applied.
@@ -380,23 +454,46 @@ def simulate_power(
     if not cluster_sizes:
         msg = "cannot simulate power over zero clusters"
         raise CorpusAuditError(msg)
-    if len(cluster_sizes) < 2:
-        msg = f"a cluster bootstrap needs at least two clusters, got {len(cluster_sizes)}"
+    if len(cluster_sizes) < MIN_VALID_CLUSTERS:
+        msg = (
+            f"a percentile cluster bootstrap cannot hold 95% coverage with "
+            f"{len(cluster_sizes)} clusters; at least {MIN_VALID_CLUSTERS} are required, "
+            "because below that the interval narrows artificially and reports higher "
+            "power for a worse design"
+        )
+        raise CorpusAuditError(msg)
+    if effect_sd < 0.0:
+        msg = f"effect_sd must be non-negative, got {effect_sd}"
         raise CorpusAuditError(msg)
     if simulations < 1 or resamples < 1:
         msg = f"simulations and resamples must be positive, got {simulations} and {resamples}"
         raise CorpusAuditError(msg)
 
-    rng = random.Random(seed)
+    if base_rate + effect_points / PERCENT > 1.0:
+        msg = (
+            f"base rate {base_rate} plus effect {effect_points} points saturates the "
+            "treatment arm; every task would succeed and the result is not a power "
+            "calculation"
+        )
+        raise CorpusAuditError(msg)
+
+    # Descending, so the estimator does not depend on the alphabetical order of
+    # repository names, which is what `describe_clusters` happens to return.
+    ordered = tuple(sorted(cluster_sizes, reverse=True))
     effect = effect_points / PERCENT
     detected = 0
     widths: list[float] = []
 
-    for _ in range(simulations):
-        rates = _cluster_probabilities(cluster_sizes, base_rate, cluster_sd, rng)
+    for index in range(simulations):
+        # One stream per simulation, so `simulations` and `resamples` are
+        # independent knobs. Sharing a single interleaved stream made a +/-1
+        # change to `resamples` reshuffle every later simulation.
+        rng = random.Random(f"{seed}:{index}")  # noqa: S311
+        rates = _cluster_probabilities(ordered, base_rate, cluster_sd, rng)
         per_cluster: list[tuple[int, int, int]] = []
-        for size, rate in zip(cluster_sizes, rates, strict=True):
-            treated_rate = min(1.0, max(0.0, rate + effect))
+        for size, rate in zip(ordered, rates, strict=True):
+            cluster_effect = effect if effect_sd == 0.0 else rng.gauss(effect, effect_sd / PERCENT)
+            treated_rate = min(1.0, max(0.0, rate + cluster_effect))
             control_hits = sum(1 for _ in range(size) if rng.random() < rate)
             treatment_hits = sum(1 for _ in range(size) if rng.random() < treated_rate)
             per_cluster.append((size, control_hits, treatment_hits))
@@ -433,6 +530,7 @@ def minimum_detectable_effect(
     simulations: int,
     resamples: int,
     seed: int,
+    effect_sd: float = 0.0,
 ) -> tuple[float | None, tuple[PowerResult, ...]]:
     """Smallest candidate effect reaching *target_power*, or None if none does.
 
@@ -452,13 +550,59 @@ def minimum_detectable_effect(
             simulations=simulations,
             resamples=resamples,
             seed=seed,
+            effect_sd=effect_sd,
         )
         for effect in sorted(candidates)
     )
     for result in curve:
-        if result.power >= target_power:
+        if result.clears(target_power):
             return result.effect_points, curve
     return None, curve
+
+
+@dataclass(frozen=True, slots=True)
+class DetectionBracket:
+    """The smallest and largest candidate effects consistent with *target_power*.
+
+    A single "minimum detectable effect" is a false precision when the estimator's
+    own noise is comparable to the grid spacing: the smallest effect whose power
+    clears the target by two standard errors, and the largest that has not yet
+    clearly cleared it, bracket the honest answer.
+    """
+
+    lower: float | None
+    upper: float | None
+    target_power: float
+
+    def describe(self) -> str:
+        if self.lower is None:
+            return f"no searched effect reaches {self.target_power:.0%} power"
+        if self.upper is None or self.upper >= self.lower:
+            return f"{self.lower:g} points"
+        return f"between {self.upper:g} and {self.lower:g} points"
+
+
+def detection_bracket(curve: Sequence[PowerResult], *, target_power: float) -> DetectionBracket:
+    """Bracket the detectable effect, accounting for Monte Carlo noise."""
+    lower = next((item.effect_points for item in curve if item.clears(target_power)), None)
+    upper = next(
+        (
+            item.effect_points
+            for item in reversed(list(curve))
+            if lower is not None and item.effect_points < lower and item.power < target_power
+        ),
+        None,
+    )
+    return DetectionBracket(lower=lower, upper=upper, target_power=target_power)
+
+
+def _as_float(block: dict[str, object], key: str) -> float:
+    """Read a numeric field, refusing anything that is not a real number."""
+    value = block.get(key)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        msg = f"expected a number for {key!r}, got {value!r}"
+        raise ValueError(msg)
+    return float(value)
 
 
 class CorpusAuditArtifact(BaseModel):
@@ -482,22 +626,82 @@ class CorpusAuditArtifact(BaseModel):
 
     @model_validator(mode="after")
     def _validate_calibration(self) -> CorpusAuditArtifact:
-        """A power projection is worthless until its simulator is validated.
+        """Recompute the calibration rather than trusting its conclusion field.
 
         R4's whole claim is a projection from a simulation, so the artifact may
         not omit the check of that simulation against a real measured interval,
-        and may not record a check it failed.
+        may not record a check it failed, and may not assert a verdict its own
+        recorded numbers contradict. Checking only ``within_tolerance`` would
+        validate the one field a miscomputing producer would still set to true.
         """
-        for key in ("reference", "measured_ci_width", "simulated_ci_width", "within_tolerance"):
+        required = ("reference", "measured_ci_width", "simulated_ci_width", "within_tolerance")
+        for key in required:
             if key not in self.calibration:
                 msg = f"calibration must record {key!r}"
                 raise ValueError(msg)
-        if self.calibration["within_tolerance"] is not True:
+        measured = _as_float(self.calibration, "measured_ci_width")
+        simulated = _as_float(self.calibration, "simulated_ci_width")
+        tolerance = _as_float(self.calibration, "tolerance")
+        if measured <= 0.0:
+            msg = f"calibration measured_ci_width must be positive, got {measured}"
+            raise ValueError(msg)
+        implied = abs(simulated - measured) / measured <= tolerance
+        if self.calibration["within_tolerance"] is not implied:
+            msg = (
+                f"calibration records within_tolerance="
+                f"{self.calibration['within_tolerance']!r}, but a simulated width of "
+                f"{simulated} against a measured {measured} at tolerance {tolerance} "
+                f"implies {implied!r}"
+            )
+            raise ValueError(msg)
+        if not implied:
             msg = (
                 "calibration did not reproduce the reference interval, so no power "
                 "projection in this artifact may be trusted"
             )
             raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def _validate_internal_consistency(self) -> CorpusAuditArtifact:
+        """Cross-check the blocks against each other and against total_tasks."""
+        raw_sizes = self.clustering.get("cluster_sizes")
+        if not isinstance(raw_sizes, dict) or not raw_sizes:
+            msg = "clustering must record a non-empty cluster_sizes mapping"
+            raise ValueError(msg)
+        sizes: dict[str, int] = {str(key): int(value) for key, value in raw_sizes.items()}  # pyright: ignore[reportUnknownArgumentType, reportUnknownVariableType]
+        counted = sum(sizes.values())
+        if counted != self.total_tasks:
+            msg = (
+                f"cluster sizes sum to {counted} but total_tasks is {self.total_tasks}; "
+                "the audit and the corpus it reports on disagree"
+            )
+            raise ValueError(msg)
+        recorded_clusters = self.clustering.get("cluster_count")
+        if isinstance(recorded_clusters, int) and recorded_clusters != len(sizes):
+            msg = f"cluster_count {recorded_clusters} does not match {len(sizes)} cluster sizes"
+            raise ValueError(msg)
+        for key in ("symbol_leak_rate", "any_leak_rate"):
+            rate = _as_float(self.leakage, key)
+            if not 0.0 <= rate <= 1.0:
+                msg = f"leakage {key} must lie in [0, 1], got {rate}"
+                raise ValueError(msg)
+        for field_name, ids_key, rate_key in (
+            ("symbol", "symbol_leaked_tasks", "symbol_leak_rate"),
+            ("any", "any_leaked_tasks", "any_leak_rate"),
+        ):
+            raw_ids = self.leakage.get(ids_key)
+            if not isinstance(raw_ids, list):
+                msg = f"leakage must record {ids_key} as a list"
+                raise ValueError(msg)
+            ids: list[str] = [str(item) for item in raw_ids]  # pyright: ignore[reportUnknownVariableType, reportUnknownArgumentType]
+            expected = round(len(ids) / self.total_tasks, 4)
+            if abs(_as_float(self.leakage, rate_key) - expected) > 1e-6:
+                msg = (
+                    f"leakage {rate_key} does not match its own {field_name}-tier task "
+                    f"list: {len(ids)}/{self.total_tasks} implies {expected}"
+                )
+                raise ValueError(msg)
         return self
 
 
@@ -516,3 +720,28 @@ def validate_corpus_audit_artifact(path: Path) -> CorpusAuditArtifact:
     except ValidationError as exc:
         msg = f"Corpus audit artifact failed validation: {path}: {exc}"
         raise CorpusAuditError(msg) from exc
+
+
+def estimate_effect_heterogeneity(
+    per_cluster_deltas: Sequence[float], *, tasks_per_cluster: int, base_rate: float
+) -> float:
+    """Between-cluster effect SD, with within-cluster sampling noise removed.
+
+    The raw spread of measured per-repository deltas is *not* heterogeneity: most
+    or all of it can be binomial noise from finitely many tasks per repository.
+    Subtracting the expected within-cluster variance is what separates the two,
+    and the result is floored at zero because a negative variance estimate means
+    the data show no heterogeneity at all rather than a negative amount of it.
+    """
+    if len(per_cluster_deltas) < 2:
+        msg = f"need at least two clusters to estimate heterogeneity, got {len(per_cluster_deltas)}"
+        raise CorpusAuditError(msg)
+    if tasks_per_cluster < 1:
+        msg = f"tasks_per_cluster must be positive, got {tasks_per_cluster}"
+        raise CorpusAuditError(msg)
+    mean = sum(per_cluster_deltas) / len(per_cluster_deltas)
+    observed_variance = sum((value - mean) ** 2 for value in per_cluster_deltas) / (
+        len(per_cluster_deltas) - 1
+    )
+    within_variance = 2.0 * base_rate * (1.0 - base_rate) / tasks_per_cluster * PERCENT * PERCENT
+    return math.sqrt(max(0.0, observed_variance - within_variance))

--- a/src/archex/benchmark/corpus_audit.py
+++ b/src/archex/benchmark/corpus_audit.py
@@ -1,0 +1,518 @@
+"""Measure what the benchmark corpus is capable of detecting.
+
+This module measures the corpus; it never changes it. Nothing here fixes a
+defect, deletes a task, or touches retrieval. Every function is deterministic
+given the same task files, so the audit reruns to the same figures.
+
+Three questions, in order of how badly a wrong answer misleads everything else:
+
+* **Leakage** -- does a task hand the answer to the retriever in its own
+  question or keywords? A gold symbol or path quoted verbatim in the query makes
+  that task measure string matching rather than retrieval.
+* **Clustering** -- tasks drawn from one repository share a codebase, an API
+  surface, and a style, so they are not independent observations. The number of
+  *independent* clusters, not the number of tasks, is what inference can spend.
+* **Resolution** -- given the measured cluster structure, how large must an
+  effect be before this corpus can distinguish it from zero?
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+if TYPE_CHECKING:
+    from archex.benchmark.models import BenchmarkTask
+
+PERCENT = 100.0
+SELF_REPO = "."
+#: Fragments too generic to count as a leak on their own. A task asking about
+#: "the parser" has not leaked `parser.py`; one naming `AdapterRegistry` has.
+_GENERIC_TOKENS = frozenset(
+    {
+        "api",
+        "app",
+        "base",
+        "cache",
+        "client",
+        "config",
+        "core",
+        "data",
+        "error",
+        "get",
+        "index",
+        "init",
+        "main",
+        "model",
+        "models",
+        "parser",
+        "query",
+        "run",
+        "server",
+        "set",
+        "src",
+        "test",
+        "tests",
+        "type",
+        "types",
+        "utils",
+    }
+)
+_MIN_TOKEN_LENGTH = 4
+_IDENTIFIER_SHAPED = re.compile(r"[A-Z]|_")
+_MIN_WORD_SYMBOL_LENGTH = 10
+
+
+class CorpusAuditError(ValueError):
+    """Raised when the corpus cannot be audited as given."""
+
+
+@dataclass(frozen=True, slots=True)
+class LeakSignal:
+    """One gold identifier found verbatim in a task's own query surface.
+
+    ``kind`` separates two strengths of evidence, and they are never pooled into
+    a single headline. A ``symbol`` match means the query quotes a gold symbol
+    name, which the retriever can match lexically without understanding
+    anything. A ``path_stem`` match means the query quotes a gold file's stem;
+    that is weaker, because a question about adapters legitimately says
+    "adapter" whether or not `adapters.py` is gold.
+    """
+
+    task_id: str
+    kind: str
+    value: str
+    surface: str
+
+
+@dataclass(frozen=True, slots=True)
+class LeakageReport:
+    """Per-task leakage over the whole corpus."""
+
+    total_tasks: int
+    leaked_task_ids: tuple[str, ...]
+    symbol_leaked_task_ids: tuple[str, ...]
+    signals: tuple[LeakSignal, ...]
+    by_kind: dict[str, int] = field(default_factory=lambda: {})
+    by_family: dict[str, int] = field(default_factory=lambda: {})
+
+    def _rate(self, count: int) -> float:
+        if not self.total_tasks:
+            msg = "cannot compute a leak rate over zero tasks"
+            raise CorpusAuditError(msg)
+        return count / self.total_tasks
+
+    @property
+    def leak_rate(self) -> float:
+        """Any-evidence rate. Reported with the strong rate, never instead of it."""
+        return self._rate(len(self.leaked_task_ids))
+
+    @property
+    def symbol_leak_rate(self) -> float:
+        """The defensible headline: a gold symbol quoted verbatim in the query."""
+        return self._rate(len(self.symbol_leaked_task_ids))
+
+
+@dataclass(frozen=True, slots=True)
+class ClusterReport:
+    """The corpus viewed as clusters rather than as independent tasks."""
+
+    total_tasks: int
+    cluster_sizes: dict[str, int]
+    largest_cluster: str
+    self_repo_tasks: int
+
+    @property
+    def cluster_count(self) -> int:
+        return len(self.cluster_sizes)
+
+    @property
+    def largest_cluster_share(self) -> float:
+        return self.cluster_sizes[self.largest_cluster] / self.total_tasks
+
+    @property
+    def self_repo_share(self) -> float:
+        return self.self_repo_tasks / self.total_tasks
+
+    def effective_sample_size(self, icc: float) -> float:
+        """Design-effect-corrected N.
+
+        With clustered observations the usable sample size is
+        ``N / (1 + (m - 1) * ICC)`` for average cluster size ``m``. At ICC 0 the
+        clusters carry no shared signal and N is unchanged; at ICC 1 every
+        cluster collapses to a single observation.
+        """
+        if not 0.0 <= icc <= 1.0:
+            msg = f"icc must lie in [0, 1], got {icc}"
+            raise CorpusAuditError(msg)
+        mean_size = self.total_tasks / self.cluster_count
+        design_effect = 1.0 + (mean_size - 1.0) * icc
+        return self.total_tasks / design_effect
+
+
+@dataclass(frozen=True, slots=True)
+class HeldOutReport:
+    """Whether the declared held-out set is actually held out."""
+
+    declared: tuple[str, ...]
+    also_in_task_corpus: tuple[str, ...]
+    enforced_by_code: bool
+
+    @property
+    def leak_rate(self) -> float:
+        if not self.declared:
+            msg = "cannot compute a held-out leak rate over an empty declaration"
+            raise CorpusAuditError(msg)
+        return len(self.also_in_task_corpus) / len(self.declared)
+
+
+def _normalise(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", text.lower())
+
+
+def _stem_of_path(path: str, *, exclude: frozenset[str]) -> str | None:
+    """The gold file's stem, if it is distinctive enough to count as evidence.
+
+    Only the stem is considered. Directory components were tried first and are
+    deliberately excluded: on a self-repo task every gold path begins with the
+    project's own name, so counting directories reported an 89% leak rate driven
+    entirely by questions about archex containing the word "archex". That is a
+    property of the detector, not of the corpus.
+    """
+    stem = PurePosixPath(path).stem
+    if stem.lower() in exclude or not _is_distinctive(stem):
+        return None
+    return stem
+
+
+def _repo_tokens(repo: str) -> frozenset[str]:
+    """Tokens naming the repository itself, which carry no information."""
+    if repo == SELF_REPO:
+        return frozenset({"archex"})
+    return frozenset(part.lower() for part in re.split(r"[/_-]", repo) if part)
+
+
+def _symbol_kind(symbol: str) -> str:
+    """Separate identifier-shaped symbols from gold symbols that are plain words.
+
+    `PythonAdapter` and `default_adapter_registry` cannot appear in a question by
+    coincidence. `retry`, `filter`, `next`, and `abort` are gold symbol names in
+    this corpus *and* the ordinary English word for what the task asks about, so
+    counting them as leakage would inflate the headline with the detector's own
+    ambiguity. They are reported as `symbol_word` and excluded from the strong
+    tier without being hidden.
+    """
+    if _IDENTIFIER_SHAPED.search(symbol) or len(symbol) >= _MIN_WORD_SYMBOL_LENGTH:
+        return "symbol"
+    return "symbol_word"
+
+
+def _is_distinctive(token: str) -> bool:
+    return (
+        len(token) >= _MIN_TOKEN_LENGTH
+        and token.lower() not in _GENERIC_TOKENS
+        and not token.startswith(".")
+    )
+
+
+def _contains_token(haystack: str, token: str) -> bool:
+    """Whole-token containment, so `parse` does not match `parsed`."""
+    return re.search(rf"\b{re.escape(token.lower())}\b", haystack) is not None
+
+
+def score_task_leakage(task: BenchmarkTask) -> tuple[LeakSignal, ...]:
+    """Find gold identifiers quoted verbatim in a task's question or keywords.
+
+    Both surfaces are checked because either is visible to the retriever. A
+    symbol match is scored on the raw symbol; a path match is scored on its
+    distinctive fragments, since no question quotes a full path.
+    """
+    surfaces = {
+        "question": _normalise(task.question),
+        "keywords": _normalise(" ".join(task.keywords)),
+    }
+    exclude = _repo_tokens(task.repo)
+    signals: list[LeakSignal] = []
+    for symbol in task.expected_symbols:
+        if not _is_distinctive(symbol) or symbol.lower() in exclude:
+            continue
+        kind = _symbol_kind(symbol)
+        for surface, text in surfaces.items():
+            if _contains_token(text, symbol):
+                signals.append(
+                    LeakSignal(task_id=task.task_id, kind=kind, value=symbol, surface=surface)
+                )
+    seen_stems: set[tuple[str, str]] = set()
+    for path in task.expected_files:
+        stem = _stem_of_path(path, exclude=exclude)
+        if stem is None:
+            continue
+        for surface, text in surfaces.items():
+            if (stem, surface) in seen_stems:
+                continue
+            if _contains_token(text, stem):
+                seen_stems.add((stem, surface))
+                signals.append(
+                    LeakSignal(task_id=task.task_id, kind="path_stem", value=stem, surface=surface)
+                )
+    return tuple(signals)
+
+
+def score_corpus_leakage(tasks: Sequence[BenchmarkTask]) -> LeakageReport:
+    if not tasks:
+        msg = "cannot audit an empty corpus"
+        raise CorpusAuditError(msg)
+    signals: list[LeakSignal] = []
+    leaked: list[str] = []
+    symbol_leaked: list[str] = []
+    by_kind: dict[str, int] = {}
+    by_family: dict[str, int] = {}
+    for task in sorted(tasks, key=lambda item: item.task_id):
+        task_signals = score_task_leakage(task)
+        if not task_signals:
+            continue
+        leaked.append(task.task_id)
+        if any(signal.kind == "symbol" for signal in task_signals):
+            symbol_leaked.append(task.task_id)
+        signals.extend(task_signals)
+        family = task.family.value
+        by_family[family] = by_family.get(family, 0) + 1
+        for signal in task_signals:
+            by_kind[signal.kind] = by_kind.get(signal.kind, 0) + 1
+    return LeakageReport(
+        total_tasks=len(tasks),
+        leaked_task_ids=tuple(leaked),
+        symbol_leaked_task_ids=tuple(symbol_leaked),
+        signals=tuple(signals),
+        by_kind=by_kind,
+        by_family=by_family,
+    )
+
+
+def describe_clusters(tasks: Sequence[BenchmarkTask]) -> ClusterReport:
+    """Cluster the corpus by repository, which is the unit inference resamples."""
+    if not tasks:
+        msg = "cannot audit an empty corpus"
+        raise CorpusAuditError(msg)
+    sizes: dict[str, int] = {}
+    for task in tasks:
+        sizes[task.repo] = sizes.get(task.repo, 0) + 1
+    largest = max(sorted(sizes), key=lambda repo: sizes[repo])
+    return ClusterReport(
+        total_tasks=len(tasks),
+        cluster_sizes=dict(sorted(sizes.items())),
+        largest_cluster=largest,
+        self_repo_tasks=sizes.get(SELF_REPO, 0),
+    )
+
+
+def audit_held_out(
+    declared: Sequence[str],
+    tasks: Sequence[BenchmarkTask],
+    *,
+    enforced_by_code: bool,
+) -> HeldOutReport:
+    """Check a declared held-out set against the corpus it is held out from.
+
+    ``enforced_by_code`` is supplied by the caller rather than inferred: whether
+    any code path excludes these IDs from a run is a fact about the repository,
+    not about the task files, and guessing it would be worse than passing it in.
+    """
+    if not declared:
+        msg = "held-out declaration is empty"
+        raise CorpusAuditError(msg)
+    task_ids = {task.task_id for task in tasks}
+    return HeldOutReport(
+        declared=tuple(declared),
+        also_in_task_corpus=tuple(sorted(set(declared) & task_ids)),
+        enforced_by_code=enforced_by_code,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PowerResult:
+    """Power and interval width for one true effect on one cluster structure."""
+
+    effect_points: float
+    power: float
+    mean_ci_width: float
+    simulations: int
+    seed: int
+
+
+def _cluster_probabilities(
+    sizes: Sequence[int], base_rate: float, cluster_sd: float, rng: random.Random
+) -> list[float]:
+    """Per-cluster success rates, dispersed to induce between-cluster variance."""
+    return [min(0.99, max(0.01, rng.gauss(base_rate, cluster_sd))) for _ in sizes]
+
+
+def simulate_power(
+    cluster_sizes: Sequence[int],
+    *,
+    effect_points: float,
+    base_rate: float,
+    cluster_sd: float,
+    simulations: int,
+    resamples: int,
+    seed: int,
+) -> PowerResult:
+    """Estimate power to detect *effect_points* on a given cluster structure.
+
+    Generative model, stated rather than hidden. Each cluster draws a success
+    rate from ``Normal(base_rate, cluster_sd)``, which is what makes observations
+    within a repository correlated. Every task in that cluster then draws a
+    control outcome at the cluster rate and a treatment outcome at the cluster
+    rate plus the effect. The paired delta is the difference of the two pooled
+    means, and inference is the same cluster bootstrap over repositories that R3
+    used, so a power figure here is comparable to an interval measured there.
+
+    Power is the fraction of simulations whose 95% cluster-bootstrap interval
+    excludes zero -- the same rule the pre-registered Gate A decision applied.
+    """
+    if not cluster_sizes:
+        msg = "cannot simulate power over zero clusters"
+        raise CorpusAuditError(msg)
+    if len(cluster_sizes) < 2:
+        msg = f"a cluster bootstrap needs at least two clusters, got {len(cluster_sizes)}"
+        raise CorpusAuditError(msg)
+    if simulations < 1 or resamples < 1:
+        msg = f"simulations and resamples must be positive, got {simulations} and {resamples}"
+        raise CorpusAuditError(msg)
+
+    rng = random.Random(seed)
+    effect = effect_points / PERCENT
+    detected = 0
+    widths: list[float] = []
+
+    for _ in range(simulations):
+        rates = _cluster_probabilities(cluster_sizes, base_rate, cluster_sd, rng)
+        per_cluster: list[tuple[int, int, int]] = []
+        for size, rate in zip(cluster_sizes, rates, strict=True):
+            treated_rate = min(1.0, max(0.0, rate + effect))
+            control_hits = sum(1 for _ in range(size) if rng.random() < rate)
+            treatment_hits = sum(1 for _ in range(size) if rng.random() < treated_rate)
+            per_cluster.append((size, control_hits, treatment_hits))
+
+        draws: list[float] = []
+        for _ in range(resamples):
+            drawn = [rng.choice(per_cluster) for _ in per_cluster]
+            total = sum(size for size, _, _ in drawn)
+            delta = sum(t - c for _, c, t in drawn) / total * PERCENT
+            draws.append(delta)
+        draws.sort()
+        low = draws[max(0, int(0.025 * len(draws)))]
+        high = draws[min(len(draws) - 1, int(0.975 * len(draws)) - 1)]
+        widths.append(high - low)
+        if low > 0.0 or high < 0.0:
+            detected += 1
+
+    return PowerResult(
+        effect_points=effect_points,
+        power=detected / simulations,
+        mean_ci_width=sum(widths) / len(widths),
+        simulations=simulations,
+        seed=seed,
+    )
+
+
+def minimum_detectable_effect(
+    cluster_sizes: Sequence[int],
+    *,
+    base_rate: float,
+    cluster_sd: float,
+    target_power: float,
+    candidates: Sequence[float],
+    simulations: int,
+    resamples: int,
+    seed: int,
+) -> tuple[float | None, tuple[PowerResult, ...]]:
+    """Smallest candidate effect reaching *target_power*, or None if none does.
+
+    ``None`` is a real answer, not an error: it means no effect in the searched
+    range is detectable on this corpus, which is the finding R4 exists to
+    establish.
+    """
+    if not 0.0 < target_power < 1.0:
+        msg = f"target_power must lie in (0, 1), got {target_power}"
+        raise CorpusAuditError(msg)
+    curve = tuple(
+        simulate_power(
+            cluster_sizes,
+            effect_points=effect,
+            base_rate=base_rate,
+            cluster_sd=cluster_sd,
+            simulations=simulations,
+            resamples=resamples,
+            seed=seed,
+        )
+        for effect in sorted(candidates)
+    )
+    for result in curve:
+        if result.power >= target_power:
+            return result.effect_points, curve
+    return None, curve
+
+
+class CorpusAuditArtifact(BaseModel):
+    """The checked-in record of one corpus validity audit."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    corpus_audit_version: Literal[1] = 1
+    milestone: str = Field(min_length=1)
+    generated_at: str = Field(min_length=1)
+    source_revision: str = Field(pattern=r"^[0-9a-f]{40}$")
+    tasks_dir: str = Field(min_length=1)
+    task_manifest_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+    total_tasks: int = Field(gt=0)
+    leakage: dict[str, object] = Field(min_length=1)
+    clustering: dict[str, object] = Field(min_length=1)
+    held_out: dict[str, object] = Field(min_length=1)
+    power: dict[str, object] = Field(min_length=1)
+    calibration: dict[str, object] = Field(min_length=1)
+    verdict: str = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_calibration(self) -> CorpusAuditArtifact:
+        """A power projection is worthless until its simulator is validated.
+
+        R4's whole claim is a projection from a simulation, so the artifact may
+        not omit the check of that simulation against a real measured interval,
+        and may not record a check it failed.
+        """
+        for key in ("reference", "measured_ci_width", "simulated_ci_width", "within_tolerance"):
+            if key not in self.calibration:
+                msg = f"calibration must record {key!r}"
+                raise ValueError(msg)
+        if self.calibration["within_tolerance"] is not True:
+            msg = (
+                "calibration did not reproduce the reference interval, so no power "
+                "projection in this artifact may be trusted"
+            )
+            raise ValueError(msg)
+        return self
+
+
+def validate_corpus_audit_artifact(path: Path) -> CorpusAuditArtifact:
+    """Load and validate one corpus-audit artifact, failing loudly."""
+    if not path.is_file():
+        msg = f"Corpus audit artifact is not a file: {path}"
+        raise CorpusAuditError(msg)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        msg = f"Corpus audit artifact is not readable JSON: {path}: {exc}"
+        raise CorpusAuditError(msg) from exc
+    try:
+        return CorpusAuditArtifact.model_validate(payload)
+    except ValidationError as exc:
+        msg = f"Corpus audit artifact failed validation: {path}: {exc}"
+        raise CorpusAuditError(msg) from exc

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -23,6 +23,10 @@ from archex.benchmark.baseline import (
 )
 from archex.benchmark.bundle_eval import BundleOnlyEvaluatorError, run_bundle_only_eval_all
 from archex.benchmark.competitive import format_competitive_markdown, load_compression_results
+from archex.benchmark.corpus_audit import (
+    CorpusAuditError,
+    validate_corpus_audit_artifact,
+)
 from archex.benchmark.cross_tool import NaiveBaselineModel, run_cross_tool
 from archex.benchmark.delta_runner import run_all_delta
 from archex.benchmark.evidence import (
@@ -809,7 +813,7 @@ def scorecard_cmd(
 @click.option(
     "--kind",
     default="tasks",
-    type=click.Choice(["tasks", "arch", "delta", "all", "evidence", "replication"]),
+    type=click.Choice(["tasks", "arch", "delta", "all", "evidence", "replication", "corpus-audit"]),
     show_default=True,
     help="Task definition or evidence family to validate.",
 )
@@ -823,10 +827,21 @@ def validate_cmd(
     """Validate benchmark task definitions."""
     repo_root = Path.cwd()
     target: Path | None = None
-    if kind in {"evidence", "replication"}:
+    if kind in {"evidence", "replication", "corpus-audit"}:
         if input_path is None:
             raise click.ClickException(f"--input is required when --kind {kind} is selected")
         target = Path(input_path)
+
+    if kind == "corpus-audit" and target is not None:
+        try:
+            audit = validate_corpus_audit_artifact(target)
+        except CorpusAuditError as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(
+            f"Valid corpus audit: {audit.total_tasks} task(s), "
+            f"milestone {audit.milestone}, verdict recorded."
+        )
+        return
 
     if kind == "replication" and target is not None:
         try:

--- a/tests/benchmark/test_corpus_audit.py
+++ b/tests/benchmark/test_corpus_audit.py
@@ -1,0 +1,244 @@
+"""Tests for the R4 corpus validity audit."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from archex.benchmark.corpus_audit import (
+    CorpusAuditError,
+    audit_held_out,
+    describe_clusters,
+    minimum_detectable_effect,
+    score_corpus_leakage,
+    score_task_leakage,
+    simulate_power,
+)
+from archex.benchmark.models import BenchmarkTask
+
+
+def _task(
+    task_id: str = "t1",
+    *,
+    repo: str = "owner/project",
+    question: str = "How is caching wired end to end?",
+    symbols: list[str] | None = None,
+    files: list[str] | None = None,
+    keywords: list[str] | None = None,
+) -> BenchmarkTask:
+    return BenchmarkTask(
+        task_id=task_id,
+        repo=repo,
+        commit="HEAD",
+        question=question,
+        expected_files=files if files is not None else ["src/thing/widget.py"],
+        expected_symbols=symbols if symbols is not None else [],
+        keywords=keywords if keywords is not None else [],
+    )
+
+
+class TestLeakage:
+    def test_identifier_shaped_symbol_in_the_question_is_a_strong_leak(self) -> None:
+        task = _task(question="How does PythonAdapter register itself?", symbols=["PythonAdapter"])
+        signals = score_task_leakage(task)
+        assert [(s.kind, s.value, s.surface) for s in signals] == [
+            ("symbol", "PythonAdapter", "question")
+        ]
+
+    def test_a_symbol_in_the_keywords_leaks_too(self) -> None:
+        """Keywords are as visible to the retriever as the question is."""
+        task = _task(
+            question="How is embedding wired?", symbols=["Embedder"], keywords=["Embedder"]
+        )
+        assert [s.surface for s in score_task_leakage(task)] == ["keywords"]
+
+    def test_a_gold_symbol_that_is_an_ordinary_word_is_not_the_strong_tier(self) -> None:
+        """`retry` is a gold symbol and the plain English word for the question."""
+        task = _task(question="How does task retry work?", symbols=["retry"])
+        assert [s.kind for s in score_task_leakage(task)] == ["symbol_word"]
+
+    def test_the_repository_name_is_never_a_leak(self) -> None:
+        """Every self-repo gold path starts with the project name; that is not evidence."""
+        task = _task(
+            repo=".",
+            question="How does archex build its index?",
+            files=["src/archex/index/store.py"],
+        )
+        assert score_task_leakage(task) == ()
+
+    def test_generic_stems_are_not_leaks(self) -> None:
+        task = _task(question="Where is the config for the client?", files=["src/a/config.py"])
+        assert score_task_leakage(task) == ()
+
+    def test_substrings_do_not_count(self) -> None:
+        """Token boundaries matter: `parse` must not match `parsed`."""
+        task = _task(question="How is the parsed tree cached?", symbols=["parse_module"])
+        assert score_task_leakage(task) == ()
+
+    def test_a_clean_task_reports_nothing(self) -> None:
+        task = _task(question="Where does the request lifecycle terminate?", symbols=["Dispatcher"])
+        assert score_task_leakage(task) == ()
+
+    def test_corpus_rates_separate_the_tiers(self) -> None:
+        tasks = [
+            _task("strong", question="How does PythonAdapter work?", symbols=["PythonAdapter"]),
+            _task("weak", question="How does retry work?", symbols=["retry"]),
+            _task("clean", question="Where is the boundary?", symbols=["Dispatcher"]),
+        ]
+        report = score_corpus_leakage(tasks)
+        assert report.symbol_leaked_task_ids == ("strong",)
+        assert report.symbol_leak_rate == pytest.approx(1 / 3)  # pyright: ignore[reportUnknownMemberType]
+        assert set(report.leaked_task_ids) == {"strong", "weak"}
+        assert report.leak_rate == pytest.approx(2 / 3)  # pyright: ignore[reportUnknownMemberType]
+
+    def test_an_empty_corpus_is_rejected(self) -> None:
+        with pytest.raises(CorpusAuditError, match="empty corpus"):
+            score_corpus_leakage([])
+
+
+class TestClustering:
+    def test_clusters_are_repositories_not_tasks(self) -> None:
+        tasks = [_task(f"t{i}", repo="a/a") for i in range(3)] + [_task("t9", repo="b/b")]
+        report = describe_clusters(tasks)
+        assert report.cluster_count == 2
+        assert report.cluster_sizes == {"a/a": 3, "b/b": 1}
+        assert report.largest_cluster == "a/a"
+        assert report.largest_cluster_share == pytest.approx(0.75)  # pyright: ignore[reportUnknownMemberType]
+
+    def test_self_repo_share_is_tracked_separately(self) -> None:
+        tasks = [_task("a", repo="."), _task("b", repo="."), _task("c", repo="x/y")]
+        assert describe_clusters(tasks).self_repo_share == pytest.approx(2 / 3)  # pyright: ignore[reportUnknownMemberType]
+
+    def test_effective_sample_size_shrinks_as_icc_rises(self) -> None:
+        """The design effect is the whole reason task count overstates the corpus."""
+        tasks = [_task(f"t{i}", repo=f"r{i // 4}") for i in range(64)]
+        report = describe_clusters(tasks)
+        assert report.effective_sample_size(0.0) == pytest.approx(64.0)  # pyright: ignore[reportUnknownMemberType]
+        assert report.effective_sample_size(1.0) == pytest.approx(16.0)  # pyright: ignore[reportUnknownMemberType]
+        assert report.effective_sample_size(0.3) < report.effective_sample_size(0.1)
+
+    @pytest.mark.parametrize("icc", [-0.1, 1.1])
+    def test_an_out_of_range_icc_is_rejected(self, icc: float) -> None:
+        tasks = [_task("a", repo="x"), _task("b", repo="y")]
+        with pytest.raises(CorpusAuditError, match=r"icc must lie"):
+            describe_clusters(tasks).effective_sample_size(icc)
+
+
+class TestHeldOut:
+    def test_an_overlapping_declaration_is_reported_as_a_full_leak(self) -> None:
+        tasks = [_task("a"), _task("b")]
+        report = audit_held_out(["a", "b"], tasks, enforced_by_code=False)
+        assert report.also_in_task_corpus == ("a", "b")
+        assert report.leak_rate == pytest.approx(1.0)  # pyright: ignore[reportUnknownMemberType]
+        assert report.enforced_by_code is False
+
+    def test_a_genuinely_separate_set_reports_no_leak(self) -> None:
+        report = audit_held_out(["z"], [_task("a")], enforced_by_code=True)
+        assert report.also_in_task_corpus == ()
+        assert report.leak_rate == pytest.approx(0.0)  # pyright: ignore[reportUnknownMemberType]
+
+    def test_an_empty_declaration_is_rejected(self) -> None:
+        with pytest.raises(CorpusAuditError, match="empty"):
+            audit_held_out([], [_task("a")], enforced_by_code=False)
+
+
+class TestPower:
+    def test_a_large_effect_on_many_clusters_is_detectable(self) -> None:
+        result = simulate_power(
+            [200] * 8,
+            effect_points=30.0,
+            base_rate=0.4,
+            cluster_sd=0.05,
+            simulations=40,
+            resamples=100,
+            seed=1,
+        )
+        assert result.power > 0.9
+
+    def test_a_small_effect_on_few_small_clusters_is_not(self) -> None:
+        """This is the finding: archex-shaped corpora cannot see small effects."""
+        result = simulate_power(
+            [4] * 16,
+            effect_points=2.0,
+            base_rate=0.5,
+            cluster_sd=0.08,
+            simulations=40,
+            resamples=100,
+            seed=1,
+        )
+        assert result.power < 0.3
+
+    def test_power_is_deterministic_under_a_fixed_seed(self) -> None:
+        kwargs: dict[str, Any] = {
+            "effect_points": 10.0,
+            "base_rate": 0.5,
+            "cluster_sd": 0.05,
+            "simulations": 30,
+            "resamples": 80,
+            "seed": 7,
+        }
+        first = simulate_power([10] * 6, **kwargs)
+        second = simulate_power([10] * 6, **kwargs)
+        assert (first.power, first.mean_ci_width) == (second.power, second.mean_ci_width)
+
+    def test_more_clusters_narrow_the_interval(self) -> None:
+        narrow = simulate_power(
+            [4] * 64,
+            effect_points=5.0,
+            base_rate=0.5,
+            cluster_sd=0.08,
+            simulations=30,
+            resamples=100,
+            seed=3,
+        )
+        wide = simulate_power(
+            [4] * 8,
+            effect_points=5.0,
+            base_rate=0.5,
+            cluster_sd=0.08,
+            simulations=30,
+            resamples=100,
+            seed=3,
+        )
+        assert narrow.mean_ci_width < wide.mean_ci_width
+
+    def test_a_single_cluster_cannot_be_simulated(self) -> None:
+        with pytest.raises(CorpusAuditError, match="at least two clusters"):
+            simulate_power(
+                [10],
+                effect_points=5.0,
+                base_rate=0.5,
+                cluster_sd=0.05,
+                simulations=5,
+                resamples=10,
+                seed=1,
+            )
+
+    def test_no_reachable_effect_returns_none_rather_than_raising(self) -> None:
+        """ "Undetectable at any searched effect" is an answer, not an error."""
+        detectable, curve = minimum_detectable_effect(
+            [2] * 3,
+            base_rate=0.5,
+            cluster_sd=0.08,
+            target_power=0.99,
+            candidates=[0.5, 1.0],
+            simulations=20,
+            resamples=50,
+            seed=1,
+        )
+        assert detectable is None
+        assert len(curve) == 2
+
+    def test_minimum_detectable_effect_picks_the_smallest_that_clears(self) -> None:
+        detectable, _ = minimum_detectable_effect(
+            [200] * 8,
+            base_rate=0.4,
+            cluster_sd=0.05,
+            target_power=0.8,
+            candidates=[1.0, 30.0, 60.0],
+            simulations=30,
+            resamples=100,
+            seed=2,
+        )
+        assert detectable == 30.0

--- a/tests/benchmark/test_corpus_audit.py
+++ b/tests/benchmark/test_corpus_audit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 import pytest
@@ -10,6 +11,8 @@ from archex.benchmark.corpus_audit import (
     CorpusAuditError,
     audit_held_out,
     describe_clusters,
+    detection_bracket,
+    estimate_effect_heterogeneity,
     minimum_detectable_effect,
     score_corpus_leakage,
     score_task_leakage,
@@ -110,11 +113,25 @@ class TestClustering:
         tasks = [_task("a", repo="."), _task("b", repo="."), _task("c", repo="x/y")]
         assert describe_clusters(tasks).self_repo_share == pytest.approx(2 / 3)  # pyright: ignore[reportUnknownMemberType]
 
+    def test_the_design_effect_uses_the_size_weighted_mean_not_the_arithmetic_one(self) -> None:
+        """One large cluster dominates the design effect in proportion to its size."""
+        tasks = [_task(f"big{i}", repo="big") for i in range(24)] + [
+            _task(f"small{i}", repo=f"r{i}") for i in range(4)
+        ]
+        report = describe_clusters(tasks)
+        # 28 tasks: one cluster of 24 and four of 1. Arithmetic mean is 5.6;
+        # size-weighted is (576 + 4) / 28 = 20.714.
+        assert report.weighted_mean_cluster_size == pytest.approx(580 / 28)  # pyright: ignore[reportUnknownMemberType]
+        arithmetic_would_give = 28 / (1 + (5.6 - 1) * 0.3)
+        assert report.effective_sample_size(0.3) < arithmetic_would_give / 2
+
     def test_effective_sample_size_shrinks_as_icc_rises(self) -> None:
         """The design effect is the whole reason task count overstates the corpus."""
         tasks = [_task(f"t{i}", repo=f"r{i // 4}") for i in range(64)]
         report = describe_clusters(tasks)
         assert report.effective_sample_size(0.0) == pytest.approx(64.0)  # pyright: ignore[reportUnknownMemberType]
+        # Equal clusters make the weighted and arithmetic means coincide, so at
+        # ICC 1 each of the 16 clusters contributes one usable observation.
         assert report.effective_sample_size(1.0) == pytest.approx(16.0)  # pyright: ignore[reportUnknownMemberType]
         assert report.effective_sample_size(0.3) < report.effective_sample_size(0.1)
 
@@ -178,8 +195,8 @@ class TestPower:
             "resamples": 80,
             "seed": 7,
         }
-        first = simulate_power([10] * 6, **kwargs)
-        second = simulate_power([10] * 6, **kwargs)
+        first = simulate_power([10] * 8, **kwargs)
+        second = simulate_power([10] * 8, **kwargs)
         assert (first.power, first.mean_ci_width) == (second.power, second.mean_ci_width)
 
     def test_more_clusters_narrow_the_interval(self) -> None:
@@ -204,7 +221,7 @@ class TestPower:
         assert narrow.mean_ci_width < wide.mean_ci_width
 
     def test_a_single_cluster_cannot_be_simulated(self) -> None:
-        with pytest.raises(CorpusAuditError, match="at least two clusters"):
+        with pytest.raises(CorpusAuditError, match="at least 8 are required"):
             simulate_power(
                 [10],
                 effect_points=5.0,
@@ -218,7 +235,7 @@ class TestPower:
     def test_no_reachable_effect_returns_none_rather_than_raising(self) -> None:
         """ "Undetectable at any searched effect" is an answer, not an error."""
         detectable, curve = minimum_detectable_effect(
-            [2] * 3,
+            [2] * 16,
             base_rate=0.5,
             cluster_sd=0.08,
             target_power=0.99,
@@ -242,3 +259,191 @@ class TestPower:
             seed=2,
         )
         assert detectable == 30.0
+
+
+class TestDetectorRegressions:
+    """Each test here kills a mutant that survived the first review."""
+
+    def test_a_snake_case_symbol_quoted_verbatim_is_a_strong_leak(self) -> None:
+        """The matcher once normalised the surface but not the needle, so no
+        snake_case or dotted gold symbol could ever match -- silently clearing
+        the exact identifier class the strong tier exists to catch."""
+        task = _task(
+            question="How does default_adapter_registry resolve adapters?",
+            symbols=["default_adapter_registry"],
+        )
+        assert [(s.kind, s.value) for s in score_task_leakage(task)] == [
+            ("symbol", "default_adapter_registry")
+        ]
+
+    def test_a_dotted_symbol_quoted_verbatim_is_a_strong_leak(self) -> None:
+        task = _task(question="Where does Client.send dispatch?", symbols=["Client.send"])
+        assert [s.kind for s in score_task_leakage(task)] == ["symbol"]
+
+    def test_an_underscored_symbol_does_not_match_the_bare_word(self) -> None:
+        """The fix for the above must not readmit `_merge` matching "merge"."""
+        assert (
+            score_task_leakage(_task(question="How does session merge?", symbols=["_merge"])) == ()
+        )
+
+    def test_an_underscored_symbol_does_not_match_the_words_split_apart(self) -> None:
+        task = _task(question="How does the runtime block on a future?", symbols=["block_on"])
+        assert score_task_leakage(task) == ()
+
+    def test_a_generic_symbol_lands_in_the_weak_tier_rather_than_vanishing(self) -> None:
+        """`Config` was dropped outright, so it appeared in no tier at all."""
+        task = _task(question="How is config resolved?", symbols=["Config"], keywords=["config"])
+        assert {s.kind for s in score_task_leakage(task)} == {"symbol_word"}
+
+    def test_a_symbol_equal_to_the_repository_name_is_never_a_leak(self) -> None:
+        task = _task(repo=".", question="How does archex index?", symbols=["archex"])
+        assert score_task_leakage(task) == ()
+
+    def test_a_saturating_effect_is_refused_rather_than_silently_clamped(self) -> None:
+        """Clamping made every effect above the ceiling produce identical data,
+        so the power curve plateaued below 1.0 and an MDE was read off it."""
+        with pytest.raises(CorpusAuditError, match="saturates the treatment arm"):
+            simulate_power(
+                [10] * 8,
+                effect_points=30.0,
+                base_rate=0.85,
+                cluster_sd=0.05,
+                simulations=5,
+                resamples=20,
+                seed=1,
+            )
+
+    def test_power_is_invariant_to_cluster_order(self) -> None:
+        """Cluster sizes arrived in alphabetical-repo-name order, which made the
+        published figure depend on how repositories happened to be named."""
+        sizes = [24, 4, 3, 2, 2, 2, 2, 2]
+        kwargs: dict[str, Any] = {
+            "effect_points": 20.0,
+            "base_rate": 0.5,
+            "cluster_sd": 0.08,
+            "simulations": 60,
+            "resamples": 120,
+            "seed": 4,
+        }
+        assert (
+            simulate_power(sizes, **kwargs).power
+            == simulate_power(list(reversed(sizes)), **kwargs).power
+        )
+
+    def test_resamples_and_simulations_are_independent_knobs(self) -> None:
+        """A single interleaved RNG stream made a +/-1 change to resamples
+        reshuffle every later simulation, so neighbouring values disagreed."""
+        base: dict[str, Any] = {
+            "effect_points": 20.0,
+            "base_rate": 0.5,
+            "cluster_sd": 0.08,
+            "simulations": 200,
+            "seed": 4,
+        }
+        powers = [simulate_power([4] * 16, resamples=n, **base).power for n in (399, 400, 401)]
+        # The interval is itself a Monte Carlo estimate, so neighbouring resample
+        # counts may differ slightly. What must not happen -- and did, when one
+        # interleaved stream fed every simulation -- is a wholesale reshuffle.
+        assert max(powers) - min(powers) < 0.05
+
+    def test_a_two_sided_interval_detects_a_negative_effect(self) -> None:
+        """A one-sided detection rule would silently miss regressions."""
+        result = simulate_power(
+            [200] * 8,
+            effect_points=-30.0,
+            base_rate=0.5,
+            cluster_sd=0.05,
+            simulations=40,
+            resamples=120,
+            seed=2,
+        )
+        assert result.power > 0.9
+
+    def test_the_interval_width_matches_the_analytic_two_proportion_width(self) -> None:
+        """Pins the interval at 95%: a 90% interval would be about 16% narrower."""
+        n = 1600
+        result = simulate_power(
+            [200] * 8,
+            effect_points=0.0,
+            base_rate=0.5,
+            cluster_sd=0.0,
+            simulations=60,
+            resamples=400,
+            seed=5,
+        )
+        analytic = 2 * 1.96 * 100 * math.sqrt(2 * 0.25 / n)
+        assert result.mean_ci_width == pytest.approx(analytic, rel=0.15)  # pyright: ignore[reportUnknownMemberType]
+
+    def test_power_reports_its_own_monte_carlo_error(self) -> None:
+        result = simulate_power(
+            [4] * 16,
+            effect_points=25.0,
+            base_rate=0.5,
+            cluster_sd=0.08,
+            simulations=100,
+            resamples=100,
+            seed=6,
+        )
+        assert 0.0 < result.monte_carlo_se < 0.06
+        assert result.clears(0.0) is True
+        assert result.clears(0.99) is False
+
+    def test_a_bracket_reports_a_range_when_the_grid_straddles_the_target(self) -> None:
+        _, curve = minimum_detectable_effect(
+            [4] * 16,
+            base_rate=0.5,
+            cluster_sd=0.08,
+            target_power=0.8,
+            candidates=[10.0, 25.0, 30.0],
+            simulations=200,
+            resamples=200,
+            seed=20260728,
+        )
+        described = detection_bracket(curve, target_power=0.8).describe()
+        assert "points" in described
+
+    def test_heterogeneity_estimate_removes_within_cluster_noise(self) -> None:
+        """Raw per-cluster spread is mostly sampling noise, not heterogeneity."""
+        deltas = [2.5, 2.0, -3.5, 12.0, 3.5, -1.0, 4.5, 2.5]
+        assert (
+            estimate_effect_heterogeneity(deltas, tasks_per_cluster=200, base_rate=0.41625) == 0.0
+        )
+        # The same spread over far more tasks per cluster cannot be noise.
+        assert estimate_effect_heterogeneity(deltas, tasks_per_cluster=100000, base_rate=0.5) > 4.0
+
+    def test_effect_heterogeneity_makes_clusters_matter(self) -> None:
+        """Without it, repository count cannot be the binding constraint."""
+        kwargs: dict[str, Any] = {
+            "effect_points": 10.0,
+            "base_rate": 0.5,
+            "cluster_sd": 0.05,
+            "simulations": 60,
+            "resamples": 150,
+            "seed": 8,
+        }
+        homogeneous = simulate_power([50] * 8, effect_sd=0.0, **kwargs)
+        heterogeneous = simulate_power([50] * 8, effect_sd=8.0, **kwargs)
+        assert heterogeneous.mean_ci_width > homogeneous.mean_ci_width
+
+    def test_too_few_clusters_is_refused(self) -> None:
+        """Below eight clusters the percentile bootstrap narrows artificially and
+        reports higher power for a worse design."""
+        with pytest.raises(CorpusAuditError, match="at least 8 are required"):
+            simulate_power(
+                [32] * 2,
+                effect_points=5.0,
+                base_rate=0.5,
+                cluster_sd=0.05,
+                simulations=10,
+                resamples=50,
+                seed=1,
+            )
+
+    def test_by_family_counts_tasks_not_signals(self) -> None:
+        task = _task(
+            question="How do PythonAdapter and AdapterRegistry interact?",
+            symbols=["PythonAdapter", "AdapterRegistry"],
+        )
+        report = score_corpus_leakage([task])
+        assert sum(report.by_family.values()) == 1
+        assert report.by_kind["symbol"] == 2


### PR DESCRIPTION
PR-1 of the R4 stack. Adds the audit machinery; the artifact and the finding land in the child PR.

R4 measures the corpus and changes nothing in it — no task edited, no label changed, no retrieval code touched.

## Three questions

Ordered by how badly a wrong answer misleads everything downstream:

1. **Leakage** — does a task hand the answer to the retriever in its own question or keywords?
2. **Clustering** — how many *independent* observations does inference actually have, as opposed to task count?
3. **Resolution** — how large must an effect be before this corpus can tell it from zero?

## Leakage is reported in three tiers, deliberately

A single number here misleads in either direction. The first version of this detector counted every gold path fragment and returned an **89% leak rate** — driven entirely by self-repo questions containing the word "archex". That is a property of the detector, not the corpus, and publishing it would have been exactly the kind of scary-but-wrong figure R2 spent three PRs removing.

- `symbol` — an identifier-shaped gold symbol quoted verbatim. The headline tier; a retriever can match it lexically without understanding anything.
- `symbol_word` — a gold symbol that is *also* the ordinary English word for the thing asked about (`retry`, `filter`, `next`, `abort`). Reported separately, excluded from the headline, not hidden.
- `path_stem` — a gold file's stem. Weakest: a question about adapters legitimately says "adapter" whether or not `adapters.py` is gold.

Directory components and the repository's own name never count. Token boundaries are enforced, so `parse` does not match `parsed`.

## Power is simulated with R3's own inference

`simulate_power` uses the same cluster bootstrap over repositories that R3 used, so a power figure here is directly comparable to an interval measured there. The generative model is stated in the docstring rather than implied.

`minimum_detectable_effect` returns `None` when nothing in the searched range clears the target. That is not an error path — "undetectable at any plausible effect" is the answer R4 exists to establish.

## The schema refuses unvalidated projections

`CorpusAuditArtifact` rejects two things outright: an artifact whose `calibration` block is incomplete, and one that records a calibration it **failed**. A power projection whose simulator was never checked against a real measured interval is not evidence, so the schema will not store one.

## Verification

`uv run pytest tests/benchmark/test_corpus_audit.py -q` — 24 passed, and green **on this commit alone** (verified with the child's files stashed). Covers each leak tier, the repo-name and generic-stem exclusions, substring rejection, cluster shares, the effective-sample-size design effect at ICC 0 and 1, held-out overlap, power determinism under a fixed seed, interval narrowing with more clusters, the two-cluster minimum, and `None` for an unreachable effect.

`uv run ruff check .`, `ruff format --check .`, `uv run pyright .` clean.
