### PR TITLE
feat(mcp): gate tool disclosure on the client actually retrieving

### DIFF
--- a/src/archex/cli/mcp_cmd.py
+++ b/src/archex/cli/mcp_cmd.py
@@ -27,15 +27,40 @@ import click
     default=None,
     help=(
         "Scope the tools this server advertises via list_tools(): 'all' "
-        "(default, every tool), a named profile ('core' excludes the "
-        "graph_* cluster, 'graph' is only the graph_* cluster), or a "
-        "comma-separated explicit tool-name allowlist. Every tool name "
-        "still dispatches regardless of scoping -- this only shrinks the "
-        "advertised schema surface, see `archex mcp-schema-size`."
+        "(every tool), a named profile ('core' excludes the graph_* cluster, "
+        "'graph' is only the graph_* cluster, 'disclosure' is the "
+        "retrieval-gated minimum), or a comma-separated explicit tool-name "
+        "allowlist. Every tool name still dispatches regardless of scoping -- "
+        "this only shrinks the advertised schema surface, see "
+        "`archex mcp-schema-size`."
     ),
 )
-def mcp_cmd(watch: bool, watch_path: str, watch_debounce_ms: int, tools: str | None) -> None:
+@click.option(
+    "--disclosure/--no-disclosure",
+    default=True,
+    show_default=True,
+    help=(
+        "Advertise only the retrieval entry points until the client retrieves, "
+        "then advertise everything and send notifications/tools/list_changed. "
+        "Cuts the fixed per-turn schema cost from 3859 to 765 tokens. Pass "
+        "--no-disclosure for the pre-R5 behavior, which every client can use. "
+        "Note --tools does not disable the gate: it bounds what is advertised "
+        "once the gate opens, so --tools all still starts minimal. Tools remain "
+        "callable either way, so a client with hardcoded tool names is unaffected."
+    ),
+)
+def mcp_cmd(
+    watch: bool,
+    watch_path: str,
+    watch_debounce_ms: int,
+    tools: str | None,
+    disclosure: bool,
+) -> None:
     """Start the archex MCP server (stdio transport).
+
+    Advertises the retrieval entry points (context, query_repo) up front and
+    the remaining tools once the client retrieves; pass --no-disclosure to
+    advertise all of them from the start.
 
     Exposes 19 MCP tools (analyze_repo, scout_repo, query_repo, context,
     compare_repos, get_file_tree, get_file_outline, search_symbols,
@@ -69,5 +94,6 @@ def mcp_cmd(watch: bool, watch_path: str, watch_debounce_ms: int, tools: str | N
             watch_path=watch_path,
             watch_debounce_ms=watch_debounce_ms,
             tool_names=tool_names,
+            disclosure=disclosure,
         )
     )

--- a/src/archex/cli/mcp_schema_size_cmd.py
+++ b/src/archex/cli/mcp_schema_size_cmd.py
@@ -29,7 +29,7 @@ import click
 def mcp_schema_size_cmd(tools: str | None, format_: str) -> None:
     """Measure the serialized MCP tool-schema size for a tool scope.
 
-    Reports total and per-tool character counts of the JSON schema archex's
+    Reports total and per-tool character and token counts of the JSON schema archex's
     MCP server would advertise via list_tools() for the given scope, so a
     client can compare 'all' against a narrower scope before choosing
     `archex mcp --tools ...` or `archex install-client --tool-scope ...`.
@@ -48,7 +48,11 @@ def mcp_schema_size_cmd(tools: str | None, format_: str) -> None:
 
     click.echo(f"Scope: {tools or 'all'}")
     click.echo(f"Tools: {report['tool_count']}")
-    click.echo(f"Total serialized schema size: {report['total_chars']} chars")
+    click.echo(
+        f"Total serialized schema size: {report['total_chars']} chars, "
+        f"{report['total_tokens']} tokens"
+    )
     click.echo("\nPer-tool:")
+    tokens = report["per_tool_tokens"]
     for name, size in sorted(report["per_tool_chars"].items()):
-        click.echo(f"  {name}: {size} chars")
+        click.echo(f"  {name}: {size} chars, {tokens[name]} tokens")

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -2259,6 +2259,27 @@ _GRAPH_TOOL_NAMES: frozenset[str] = frozenset(
     {"graph_lookup", "graph_neighbors", "graph_path", "graph_stats", "graph_hubs"}
 )
 
+#: The tools advertised before a client has retrieved anything.
+#:
+#: Both are retrieval entry points, which is what makes the gate coherent: a
+#: client is charged for the two tools it needs to *start*, and for the rest only
+#: once it has demonstrated it is actually retrieving. Sized against R5's
+#: 1000-token acceptance bar -- `context` is 534 tokens and `query_repo` 231, for
+#: 765 with headroom, against 3859 for the full surface.
+#:
+#: Narrowing what is advertised never narrows what is *callable*: `build_server`'s
+#: `call_tool` dispatches by name whatever `list_tools` returned, so a client
+#: holding a hardcoded tool name keeps working through the gate. That is a
+#: fallback for hardcoded callers, not the reachability mechanism -- MCP tools are
+#: model-controlled, so what puts the wider surface back in front of a model is
+#: the `tools/list_changed` notification and the declared `listChanged` capability.
+#:
+#: Public, unlike `_GRAPH_TOOL_NAMES` beside it, because this set is R5's
+#: behavioural contract: its exact membership is pinned by a test and named in
+#: the compatibility matrix. The graph cluster is an implementation detail of a
+#: profile. The rule is public iff a test or the CLI must import it by name.
+DISCLOSURE_CORE_TOOL_NAMES: frozenset[str] = frozenset({"context", "query_repo"})
+
 #: Named convenience tool-scope profiles for `archex mcp --tools` and
 #: `install-client`/`setup --tool-scope`. "all" (every tool, the unscoped
 #: default) is intentionally absent here -- `resolve_tool_scope` treats it,
@@ -2267,6 +2288,7 @@ _GRAPH_TOOL_NAMES: frozenset[str] = frozenset(
 TOOL_SCOPE_PROFILES: dict[str, frozenset[str]] = {
     "core": frozenset(ALL_TOOL_NAMES) - _GRAPH_TOOL_NAMES,
     "graph": _GRAPH_TOOL_NAMES,
+    "disclosure": DISCLOSURE_CORE_TOOL_NAMES,
 }
 
 
@@ -2301,21 +2323,108 @@ def measure_tool_schema_size(tool_names: frozenset[str] | None = None) -> dict[s
 
     Serializes each tool's `{name, description, inputSchema}` as compact,
     sort-keyed JSON -- the same shape `list_tools()` advertises -- so the
-    reported byte counts track what a client actually registers.
+    reported counts track what a client actually registers.
+
+    Reports tokens as well as characters. Characters are what the wire carries;
+    tokens are what the context window is billed in, and every schema-size
+    target this project sets is stated in tokens, so measuring only characters
+    left the target uncheckable by the command meant to check it.
     """
     schemas = _tool_schemas()
     if tool_names is not None:
         schemas = [schema for schema in schemas if schema["name"] in tool_names]
-    per_tool_chars = {schema["name"]: len(json.dumps(schema, sort_keys=True)) for schema in schemas}
+    serialized = {schema["name"]: json.dumps(schema, sort_keys=True) for schema in schemas}
+    per_tool_chars = {name: len(text) for name, text in serialized.items()}
+    per_tool_tokens = {name: count_tokens(text) for name, text in serialized.items()}
     return {
         "tool_count": len(schemas),
         "total_chars": sum(per_tool_chars.values()),
+        "total_tokens": sum(per_tool_tokens.values()),
         "per_tool_chars": per_tool_chars,
+        "per_tool_tokens": per_tool_tokens,
     }
 
 
+class DisclosureGate:
+    """Tracks whether a session has retrieved, and so earned the full tool surface.
+
+    A fresh session is advertised only `DISCLOSURE_CORE_TOOL_NAMES`. The first
+    successful call to one of those retrieval tools opens the gate, after which
+    `list_tools()` advertises everything. The point is to stop charging every
+    session for a schema surface most of them never use.
+
+    Reachability is preserved by the `tools/list_changed` notification the server
+    sends on opening, not by dispatch-by-name: MCP tools are model-controlled, so
+    a model only calls what it was shown. Dispatch-by-name surviving a closed
+    gate is what keeps *hardcoded* callers working; it is a fallback, not the
+    mechanism.
+
+    Opening is one-way and per-server: a session that has retrieved does not go
+    back to the minimal surface.
+    """
+
+    def __init__(self, *, enabled: bool) -> None:
+        self._enabled = enabled
+        self._open = not enabled
+        self._announce_pending = False
+
+    @property
+    def is_open(self) -> bool:
+        return self._open
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def announce_pending(self) -> bool:
+        """Whether the client still owes a `tools/list_changed` it has not received.
+
+        Set when the advertised set actually grew, cleared only once a send
+        succeeds. Kept separate from `is_open` so a dropped notification is
+        retried on the next call instead of stranding the client on the minimal
+        list for the rest of the session.
+        """
+        return self._announce_pending
+
+    def visible(self, tool_names: frozenset[str] | None) -> frozenset[str] | None:
+        """The names to advertise now, intersected with any explicit scope.
+
+        An explicit scope that shares no tool with the retrieval core is served
+        as asked rather than intersected to nothing. A client that narrowed its
+        own scope has already made the cost decision the gate exists to make for
+        it, and intersecting to zero would advertise nothing while every tool
+        stayed callable -- strictly worse than serving the scope.
+        """
+        if self._open:
+            return tool_names
+        if tool_names is None:
+            return DISCLOSURE_CORE_TOOL_NAMES
+        gated = tool_names & DISCLOSURE_CORE_TOOL_NAMES
+        return gated or tool_names
+
+    def observe_call(self, name: str) -> bool:
+        """Record a tool call. Returns True only on the transition that opens it.
+
+        A disabled gate starts open, so the first test covers both.
+        """
+        if self._open or name not in DISCLOSURE_CORE_TOOL_NAMES:
+            return False
+        self._open = True
+        return True
+
+    def mark_announce_pending(self) -> None:
+        self._announce_pending = True
+
+    def mark_announced(self) -> None:
+        self._announce_pending = False
+
+
 def build_server(
-    runtime: QueryRuntime | None = None, tool_names: frozenset[str] | None = None
+    runtime: QueryRuntime | None = None,
+    tool_names: frozenset[str] | None = None,
+    *,
+    disclosure: bool = False,
 ) -> Any:
     """Build and return a configured MCP Server instance.
 
@@ -2324,6 +2433,27 @@ def build_server(
     tool name still dispatches through `call_tool` regardless of scoping --
     scoping only shrinks the advertised schema surface, it never changes
     which tool names a client can successfully call.
+
+    `disclosure` adds a retrieval gate on top of that: until the client calls a
+    retrieval tool, only `DISCLOSURE_CORE_TOOL_NAMES` are advertised, and the
+    expansion is announced with `notifications/tools/list_changed`.
+
+    That notification is what makes the gate safe, and it is load-bearing rather
+    than a courtesy. MCP tools are model-controlled: a model only calls what it
+    was shown, so for the ordinary path the notification -- plus the declared
+    `listChanged` capability that entitles a client to act on it, see
+    `run_stdio_server` -- is the whole mechanism that puts the wider surface back
+    in front of the model. Dispatch-by-name surviving a closed gate rescues only
+    *hardcoded* callers: an agent file that names tools directly, or a script.
+
+    The two settings compose rather than override: `tool_names` bounds what is
+    advertised *once the gate opens*, so `tool_names=None` (`--tools all`) still
+    starts at the minimal set. `disclosure=False` is the only way back to
+    advertising everything from the first `list_tools()`.
+
+    `disclosure` defaults to False here and in `run_stdio_server` so a library
+    caller keeps pre-R5 behaviour, while the `archex mcp` CLI defaults it on --
+    the gate is a cost decision for interactive sessions, not for embedders.
 
     Raises:
         ImportError: If the `mcp` package is not installed.
@@ -2340,12 +2470,14 @@ def build_server(
         runtime = QueryRuntime()
 
     server: Server[None, Any] = Server("archex")  # type: ignore[type-arg]
+    gate = DisclosureGate(enabled=disclosure)
 
     @server.list_tools()  # pyright: ignore[reportUnusedFunction]
     async def list_tools() -> list[mcp_types.Tool]:  # pyright: ignore[reportUnusedFunction]
+        visible = gate.visible(tool_names)
         schemas = _tool_schemas()
-        if tool_names is not None:
-            schemas = [schema for schema in schemas if schema["name"] in tool_names]
+        if visible is not None:
+            schemas = [schema for schema in schemas if schema["name"] in visible]
         return [mcp_types.Tool(**schema) for schema in schemas]
 
     @server.call_tool()  # pyright: ignore[reportUnusedFunction]
@@ -2354,11 +2486,44 @@ def build_server(
         arguments: dict[str, Any],
     ) -> list[mcp_types.TextContent]:
         loop = asyncio.get_running_loop()
+        advertised_before = gate.visible(tool_names)
         result_text = await _run_mcp_tool(loop, name, arguments, runtime)
+        # Only after the call succeeded: a failed retrieval has not demonstrated
+        # that this session needs the wider surface.
+        if gate.observe_call(name) and gate.visible(tool_names) != advertised_before:
+            # Opening does not always change what is advertised: a scope disjoint
+            # from the retrieval core is served in full either way. Announcing an
+            # identical list would cost the client a pointless tools/list.
+            gate.mark_announce_pending()
+        if gate.announce_pending and await _announce_tool_list_changed(server):
+            gate.mark_announced()
 
         return [mcp_types.TextContent(type="text", text=result_text)]
 
     return server
+
+
+async def _announce_tool_list_changed(server: Any) -> bool:
+    """Tell the client its tool list grew. Returns whether the client was told.
+
+    Never raises. A client that never registered a session, or one whose
+    transport has already gone away, must not turn a successful retrieval into a
+    failed tool call. But a lost notification is not free either: for a
+    model-controlled client it is the only thing that puts the wider surface in
+    front of the model, so the caller retries on the next call and this logs
+    loudly enough for an operator to see.
+    """
+    try:
+        session = server.request_context.session
+    except LookupError:
+        logger.warning("no MCP session to announce the tool-list change to; will retry")
+        return False
+    try:
+        await session.send_tool_list_changed()
+    except Exception:  # noqa: BLE001 - see docstring: never fail the caller's tool call
+        logger.warning("could not announce MCP tool-list change; will retry", exc_info=True)
+        return False
+    return True
 
 
 def _ignored_watch_path(path: str) -> bool:
@@ -2433,9 +2598,11 @@ async def run_stdio_server(
     watch_path: str = ".",
     watch_debounce_ms: int = 300,
     tool_names: frozenset[str] | None = None,
+    disclosure: bool = False,
 ) -> None:
     """Run the archex MCP server over stdio."""
     try:
+        from mcp.server.lowlevel import NotificationOptions
         from mcp.server.stdio import stdio_server
     except ImportError as exc:
         raise ImportError(
@@ -2450,10 +2617,19 @@ async def run_stdio_server(
     # across every query_repo call so repeat warm queries against the same
     # generation skip re-hydrating from SQLite.
     runtime = QueryRuntime()
-    server = build_server(runtime=runtime, tool_names=tool_names)
+    server = build_server(runtime=runtime, tool_names=tool_names, disclosure=disclosure)
     try:
         async with stdio_server() as (read_stream, write_stream):
-            init_opts = server.create_initialization_options()
+            # A client only honours `notifications/tools/list_changed` if the
+            # server declared the capability during initialization; the SDK
+            # defaults it to False. Without this the gate would be a permanent
+            # tool-hiding mechanism for any spec-compliant client, since it
+            # would be entitled to never re-fetch the list it was first given.
+            # Declared only when the gate is on -- an ungated server's tool
+            # list genuinely never changes, and promising otherwise is a lie.
+            init_opts = server.create_initialization_options(
+                notification_options=NotificationOptions(tools_changed=disclosure)
+            )
             await server.run(read_stream, write_stream, init_opts, raise_exceptions=True)
     finally:
         runtime.close()

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -745,16 +745,21 @@ class TestRunStdioServer:
             yield (None, None)
 
         class FakeServer:
-            def create_initialization_options(self) -> object:
+            def create_initialization_options(self, notification_options: object = None) -> object:
+                captured["notification_options"] = notification_options
                 return object()
 
             async def run(self, *args: object, **kwargs: object) -> None:
                 return None
 
         def fake_build_server(
-            runtime: QueryRuntime | None = None, tool_names: frozenset[str] | None = None
+            runtime: QueryRuntime | None = None,
+            tool_names: frozenset[str] | None = None,
+            *,
+            disclosure: bool = False,
         ) -> object:
             captured["runtime"] = runtime
+            captured["disclosure"] = disclosure
             return FakeServer()
 
         with (

--- a/tests/integrations/test_mcp_disclosure.py
+++ b/tests/integrations/test_mcp_disclosure.py
@@ -1,0 +1,318 @@
+"""R5: retrieval-gated MCP tool disclosure.
+
+The bar R5 has to clear is stated in tokens, so these tests assert tokens, not
+characters. The gate's whole point is to stop charging every session for a schema
+surface most sessions never use -- while never making a tool unreachable, which
+is the property that lets the default change safely.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mcp", reason="mcp not installed")
+
+from archex.integrations.mcp import (
+    ALL_TOOL_NAMES,
+    DISCLOSURE_CORE_TOOL_NAMES,
+    TOOL_SCOPE_PROFILES,
+    DisclosureGate,
+    build_server,
+    measure_tool_schema_size,
+    resolve_tool_scope,
+)
+
+#: R5's acceptance bar.
+DISCLOSURE_TOKEN_BUDGET = 1000
+
+
+class TestDisclosureBudget:
+    def test_the_disclosure_scope_fits_the_acceptance_budget(self) -> None:
+        report = measure_tool_schema_size(DISCLOSURE_CORE_TOOL_NAMES)
+        assert report["total_tokens"] < DISCLOSURE_TOKEN_BUDGET
+
+    def test_the_measured_cost_is_pinned_not_merely_under_the_bar(self) -> None:
+        """`< 1000` tolerates 999, a 30% erosion of a 765-token result.
+
+        The reported figure is what the decision document and CHANGELOG quote, so
+        it is pinned directly. Widen deliberately if a core tool's schema changes.
+        """
+        report = measure_tool_schema_size(DISCLOSURE_CORE_TOOL_NAMES)
+        assert 740 <= report["total_tokens"] <= 790, "measured 765 at R5"
+
+    def test_disclosure_is_a_large_cut_against_the_full_surface(self) -> None:
+        """Pins the published reduction, not a ratio the budget already implies.
+
+        `disclosure / full < 0.30` could never fail independently: 0.30 of the
+        full surface is above the budget test's own ceiling, and adding any tool
+        outside the core *raises* the denominator, making it easier to pass. The
+        published claim is the reduction, so assert that.
+        """
+        disclosure = measure_tool_schema_size(DISCLOSURE_CORE_TOOL_NAMES)["total_tokens"]
+        full = measure_tool_schema_size(None)["total_tokens"]
+        assert isinstance(disclosure, int)
+        assert isinstance(full, int)
+        assert 1 - disclosure / full > 0.75, "CHANGELOG and DECISION.md claim 80.2%"
+
+    def test_the_measurement_reports_tokens_as_well_as_characters(self) -> None:
+        """The bar is in tokens; measuring only chars left it uncheckable."""
+        report = measure_tool_schema_size(None)
+        assert report["total_tokens"] > 0
+        assert report["total_chars"] > report["total_tokens"]
+        assert set(report["per_tool_tokens"]) == set(report["per_tool_chars"])
+
+    def test_per_tool_tokens_sum_to_the_total(self) -> None:
+        report = measure_tool_schema_size(None)
+        assert sum(report["per_tool_tokens"].values()) == report["total_tokens"]
+
+    def test_a_single_tool_measures_to_a_known_value(self) -> None:
+        """The sum-to-total check cannot detect a tokenization error; this can."""
+        report = measure_tool_schema_size(frozenset({"context"}))
+        assert 514 <= report["total_tokens"] <= 554, "measured 534 at R5"
+
+    def test_every_disclosure_tool_is_a_registered_tool(self) -> None:
+        assert frozenset(ALL_TOOL_NAMES) >= DISCLOSURE_CORE_TOOL_NAMES
+
+    def test_the_core_membership_is_pinned_exactly(self) -> None:
+        """The constant IS the contract, so equality, not a superset.
+
+        A superset check tolerates shrinking it. Dropping `query_repo` would take
+        archex's headline retrieval tool out of the first `list_tools()` and leave
+        the suite green.
+        """
+        assert frozenset({"context", "query_repo"}) == DISCLOSURE_CORE_TOOL_NAMES
+
+    def test_disclosure_is_selectable_as_a_named_scope(self) -> None:
+        assert resolve_tool_scope("disclosure") == DISCLOSURE_CORE_TOOL_NAMES
+        assert TOOL_SCOPE_PROFILES["disclosure"] == DISCLOSURE_CORE_TOOL_NAMES
+
+
+class TestDisclosureGate:
+    def test_a_disabled_gate_is_open_from_the_start(self) -> None:
+        gate = DisclosureGate(enabled=False)
+        assert gate.is_open is True
+        assert gate.visible(None) is None
+
+    def test_an_enabled_gate_starts_closed_and_hides_the_wider_surface(self) -> None:
+        gate = DisclosureGate(enabled=True)
+        assert gate.is_open is False
+        assert gate.visible(None) == DISCLOSURE_CORE_TOOL_NAMES
+
+    def test_retrieving_opens_the_gate_exactly_once(self) -> None:
+        gate = DisclosureGate(enabled=True)
+        first = next(iter(sorted(DISCLOSURE_CORE_TOOL_NAMES)))
+        assert gate.observe_call(first) is True
+        assert gate.observe_call(first) is False, "opening must be reported once, not per call"
+        assert gate.is_open is True
+        assert gate.visible(None) is None
+
+    def test_a_non_retrieval_call_does_not_open_the_gate(self) -> None:
+        """Otherwise any tool call would defeat the gate on the first turn."""
+        gate = DisclosureGate(enabled=True)
+        assert gate.observe_call("get_file_tree") is False
+        assert gate.is_open is False
+
+    def test_an_explicit_scope_still_bounds_what_the_gate_reveals(self) -> None:
+        """`--tools core --disclosure` must never advertise outside `core`."""
+        core = TOOL_SCOPE_PROFILES["core"]
+        gate = DisclosureGate(enabled=True)
+        gated = gate.visible(core)
+        assert gated is not None
+        assert gated < core, "a closed gate must narrow an explicit scope"
+        gate.observe_call("context")
+        assert gate.visible(core) == core
+
+    def test_a_disabled_gate_never_opens_on_a_call(self) -> None:
+        """`observe_call` must not claim a transition on an ungated server."""
+        assert DisclosureGate(enabled=False).observe_call("context") is False
+
+    def test_a_scope_disjoint_from_the_core_is_not_gated_to_nothing(self) -> None:
+        """`graph` shares no tool with the retrieval core.
+
+        Intersecting would advertise zero tools while every tool stayed callable,
+        which is strictly worse than serving the scope. (The gate would still
+        open -- an unadvertised `context` call dispatches fine -- so "it could
+        never open" is not the reason.) A client that narrowed its own scope has
+        already made the cost decision.
+        """
+        graph = TOOL_SCOPE_PROFILES["graph"]
+        gate = DisclosureGate(enabled=True)
+        assert gate.visible(graph) == graph
+
+    def test_the_gate_reports_whether_it_is_enabled(self) -> None:
+        assert DisclosureGate(enabled=True).enabled is True
+        assert DisclosureGate(enabled=False).enabled is False
+
+
+def test_an_unscoped_server_is_still_gated() -> None:
+    """`--tools all` bounds what opens, it does not disable the gate.
+
+    Documented explicitly because the opposite is the natural guess, and an
+    operator who guessed wrong would think they had restored the full surface.
+    """
+    gate = DisclosureGate(enabled=True)
+    assert gate.visible(resolve_tool_scope("all")) == DISCLOSURE_CORE_TOOL_NAMES
+
+
+def test_disabling_disclosure_is_the_only_way_back_to_everything() -> None:
+    assert DisclosureGate(enabled=False).visible(resolve_tool_scope("all")) is None
+
+
+class TestListChangedCapability:
+    """The gate is only safe if the client knows the list can change.
+
+    A client honours `notifications/tools/list_changed` only when the server
+    declared the capability at initialization, and the SDK defaults it off. If
+    this regresses, the gate silently becomes a permanent tool-hiding mechanism
+    for every spec-compliant client: it is entitled to never re-fetch, so the
+    17 tools disclosed after the first retrieval would never become visible.
+    """
+
+    @staticmethod
+    async def _declared_tools_changed(*, disclosure: bool) -> bool:
+        from contextlib import asynccontextmanager
+        from unittest.mock import patch
+
+        from archex.integrations.mcp import run_stdio_server
+
+        captured: dict[str, Any] = {}
+
+        @asynccontextmanager
+        async def fake_stdio_server() -> AsyncIterator[tuple[None, None]]:
+            yield (None, None)
+
+        class FakeServer:
+            def create_initialization_options(self, notification_options: Any = None) -> object:
+                captured["opts"] = notification_options
+                return object()
+
+            async def run(self, *args: object, **kwargs: object) -> None:
+                return None
+
+        with (
+            patch("archex.integrations.mcp.build_server", return_value=FakeServer()),
+            patch("mcp.server.stdio.stdio_server", fake_stdio_server),
+            patch("archex.serve.runtime.QueryRuntime.close"),
+        ):
+            await run_stdio_server(disclosure=disclosure)
+
+        opts = captured["opts"]
+        assert opts is not None, "no notification options were declared at all"
+        return bool(opts.tools_changed)
+
+    @pytest.mark.asyncio
+    async def test_the_gated_server_declares_the_capability(self) -> None:
+        assert await self._declared_tools_changed(disclosure=True) is True
+
+    @pytest.mark.asyncio
+    async def test_the_ungated_server_does_not_promise_changes(self) -> None:
+        """An ungated tool list genuinely never changes; saying it might is a lie."""
+        assert await self._declared_tools_changed(disclosure=False) is False
+
+    def test_the_capability_reaches_the_wire_shape(self) -> None:
+        """Guards the SDK contract the above relies on: the flag really does
+        become `listChanged` in the declared tools capability."""
+        from mcp.server.lowlevel import NotificationOptions
+
+        server = build_server(disclosure=True)
+        opts = server.create_initialization_options(
+            notification_options=NotificationOptions(tools_changed=True)
+        )
+        assert opts.capabilities.tools is not None
+        assert opts.capabilities.tools.listChanged is True
+
+
+class TestGateThroughARealSession:
+    """Drives the gate through `build_server`'s own handlers over a real client
+    session, because the premise the whole change rests on -- an unadvertised
+    tool still dispatches -- had no coverage at all.
+
+    `_run_mcp_tool` is stubbed so these test the gate rather than the tools: no
+    index, no repo, deterministic.
+    """
+
+    @staticmethod
+    @asynccontextmanager
+    async def _session(
+        *, disclosure: bool, tool_names: frozenset[str] | None = None
+    ) -> AsyncIterator[tuple[Any, list[Any]]]:
+        from unittest.mock import patch
+
+        from mcp.shared.memory import create_connected_server_and_client_session
+
+        notifications: list[Any] = []
+
+        async def record(message: Any) -> None:
+            notifications.append(message)
+
+        async def fake_run_mcp_tool(
+            loop: object, name: str, arguments: dict[str, Any], runtime: object
+        ) -> str:
+            return f"ran {name}"
+
+        with patch("archex.integrations.mcp._run_mcp_tool", side_effect=fake_run_mcp_tool):
+            server = build_server(tool_names=tool_names, disclosure=disclosure)
+            async with create_connected_server_and_client_session(
+                server, message_handler=record
+            ) as client:
+                yield client, notifications
+
+    @pytest.mark.asyncio
+    async def test_a_fresh_session_is_advertised_only_the_retrieval_core(self) -> None:
+        async with self._session(disclosure=True) as (client, _):
+            names = {t.name for t in (await client.list_tools()).tools}
+            assert names == set(DISCLOSURE_CORE_TOOL_NAMES)
+
+    @pytest.mark.asyncio
+    async def test_an_unadvertised_tool_still_dispatches_through_a_closed_gate(
+        self,
+    ) -> None:
+        """The fallback that keeps hardcoded callers working."""
+        async with self._session(disclosure=True) as (client, _):
+            advertised = {t.name for t in (await client.list_tools()).tools}
+            assert "graph_hubs" not in advertised
+
+            result = await client.call_tool("graph_hubs", {"repo_url": "."})
+            assert result.isError is False
+
+    @pytest.mark.asyncio
+    async def test_retrieving_expands_the_surface_and_tells_the_client(self) -> None:
+        from mcp import types as mcp_types
+
+        async with self._session(disclosure=True) as (client, notifications):
+            assert len((await client.list_tools()).tools) == len(DISCLOSURE_CORE_TOOL_NAMES)
+
+            await client.call_tool("query_repo", {"repo_url": ".", "question": "q"})
+
+            after = {t.name for t in (await client.list_tools()).tools}
+            assert after == set(ALL_TOOL_NAMES)
+            assert any(
+                isinstance(getattr(n, "root", n), mcp_types.ToolListChangedNotification)
+                for n in notifications
+            ), "the client was never told its tool list grew"
+
+    @pytest.mark.asyncio
+    async def test_an_ungated_session_advertises_everything_immediately(self) -> None:
+        async with self._session(disclosure=False) as (client, notifications):
+            assert {t.name for t in (await client.list_tools()).tools} == set(ALL_TOOL_NAMES)
+            await client.call_tool("query_repo", {"repo_url": ".", "question": "q"})
+            assert notifications == [], "nothing changed, so nothing to announce"
+
+    @pytest.mark.asyncio
+    async def test_a_disjoint_scope_is_not_announced_because_nothing_changed(
+        self,
+    ) -> None:
+        """`--tools graph` advertises the same five tools before and after."""
+        async with self._session(disclosure=True, tool_names=TOOL_SCOPE_PROFILES["graph"]) as (
+            client,
+            notifications,
+        ):
+            before = {t.name for t in (await client.list_tools()).tools}
+            await client.call_tool("query_repo", {"repo_url": ".", "question": "q"})
+            after = {t.name for t in (await client.list_tools()).tools}
+            assert before == after == set(TOOL_SCOPE_PROFILES["graph"])
+            assert notifications == [], "a pointless tools/list round trip"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -832,9 +832,32 @@ class TestMcpCmd:
             result = runner.invoke(cli, ["mcp"])
         assert result.exit_code == 0, result.output
         mock_run_stdio.assert_called_once_with(
-            watch=False, watch_path=".", watch_debounce_ms=300, tool_names=None
+            watch=False,
+            watch_path=".",
+            watch_debounce_ms=300,
+            tool_names=None,
+            disclosure=True,
         )
         mock_asyncio_run.assert_called_once_with(mock_run_stdio.return_value)
+
+    def test_mcp_no_disclosure_restores_the_pre_r5_surface(self) -> None:
+        """The documented escape hatch for a client that cannot re-fetch."""
+        from unittest.mock import MagicMock, patch
+
+        mock_run_stdio = MagicMock()
+        mock_mcp_module = MagicMock()
+        mock_mcp_module.run_stdio_server = mock_run_stdio
+        mock_mcp_module.resolve_tool_scope = MagicMock(return_value=None)
+
+        runner = CliRunner()
+        with (
+            patch.dict("sys.modules", {"archex.integrations.mcp": mock_mcp_module}),
+            patch("archex.cli.mcp_cmd.asyncio.run"),
+        ):
+            result = runner.invoke(cli, ["mcp", "--no-disclosure"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_run_stdio.call_args.kwargs["disclosure"] is False
 
     def test_mcp_watch_options_pass_to_server(self) -> None:
         from unittest.mock import MagicMock, patch
@@ -856,7 +879,11 @@ class TestMcpCmd:
 
         assert result.exit_code == 0, result.output
         mock_run_stdio.assert_called_once_with(
-            watch=True, watch_path="src", watch_debounce_ms=50, tool_names=None
+            watch=True,
+            watch_path="src",
+            watch_debounce_ms=50,
+            tool_names=None,
+            disclosure=True,
         )
         mock_asyncio_run.assert_called_once_with(mock_run_stdio.return_value)
 


### PR DESCRIPTION
PR-1 of the R5 stack. Based on `docs/r5-reconcile-design` (#584).

Cuts the fixed per-turn MCP tool-schema cost by advertising only the two retrieval entry points until the client demonstrates it is actually retrieving.

## Result

| Scope | Tools | Chars | Tokens |
| --- | --- | --- | --- |
| `all` (previous default) | 19 | 15 602 | 3 859 |
| `core` (M11) | 14 | 12 130 | 2 908 |
| **`disclosure` (new default)** | **2** | **3 286** | **765** |

**765 tokens against R5's 1 000-token bar, an 80.2% reduction.** `core` was the obvious alternative default and misses at 2 908 — no scope advertising more than about three tools clears the bar, which is why this needed a gate rather than a smaller profile.

`archex mcp-schema-size` now reports tokens as well as characters. Every schema-size target this project sets is stated in tokens and the command measured only characters, which left the acceptance bar uncheckable by the command named to check it.

## Why this is safe — corrected after review

My first version of this description rested safety on "unadvertised does not mean uncallable". That property is real, and is now pinned by an end-to-end session test that calls an unadvertised `graph_hubs` through a closed gate and gets a non-error result. **But it is not the mechanism.**

MCP tools are model-controlled: a model only calls what it was shown. Dispatch-by-name rescues *hardcoded* callers — a script, or an agent file that names tools directly, as archex's own guidance block does. What restores the surface for the ordinary path is `notifications/tools/list_changed`, **under a declared `listChanged` capability**.

That capability was missing. The SDK defaults `NotificationOptions.tools_changed` to `False`, so the first implementation declared `listChanged=false` and then sent the notification anyway. A spec-compliant client may treat the list as static and never re-fetch — which would have made this a permanent tool-hiding mechanism for 17 of 19 tools, the exact regression the design exists to avoid. Both reviewers independently confirmed it.

Fixed: `run_stdio_server` declares `tools_changed=disclosure`, asserted in **both** polarities, since an ungated server must not promise changes it will never send. Verified by reverting the fix and watching the guard fail.

## Also hardened after review

- **A dropped announcement is retried.** It used to open the gate, attempt one send, and swallow the failure at `debug` — leaving the client on 2 tools for the session. Now the pending announcement is tracked separately from openness, retried on the next call, and logged at `warning`.
- **No spurious notification.** Opening does not always change what is advertised: a scope disjoint from the retrieval core is served in full either way. Announcing an identical list cost a pointless `tools/list`.
- **Membership is pinned by equality**, not a superset — dropping `query_repo` would have taken archex's headline retrieval tool out of the first `list_tools()` with the suite green.
- **The token figure is pinned**, not merely under the bar. `< 1000` tolerated 999, a 30% erosion, and the ratio assertion mathematically could never fail independently.
- A wrong docstring rationale corrected: a disjoint scope's gate *can* open — believing otherwise is what hid the spurious-notification bug.

## Verification

- `uv run pytest -q` — 4 634 passed, coverage 91.57%
- `uv run ruff check .`, `ruff format --check .`, `uv run pyright .` clean
- Mutation-checked: no suppression, gate starts open, and never-clear-pending each fail; reverting the capability fix fails its guard.

The client compatibility path lands in PR-2, the decision record in PR-3.
