### PR TITLE
feat(mcp): give clients that cannot re-fetch a documented opt-out

### DIFF
--- a/docs/CLIENT_COMPATIBILITY_MATRIX.md
+++ b/docs/CLIENT_COMPATIBILITY_MATRIX.md
@@ -75,6 +75,27 @@ Registering an MCP server is necessary but not sufficient for an agent to actual
 - **Surfacing** — the client/harness must expose the registered tools to the agent. Harnesses with on-demand tool discovery (e.g. oh-my-pi / Pi) treat a registered server's tools as *discoverable* but keep them out of the default tool set; the agent must activate them before the first call.
 - **Invocation** — the agent must choose to call `query_repo` / `scout_repo` / `analyze_repo` instead of reading files by hand.
 
+### Retrieval-gated disclosure (R5)
+
+`archex mcp` advertises only the two retrieval entry points — `context` and `query_repo` — until the client calls one of them, then advertises everything and sends `notifications/tools/list_changed`. That cuts the fixed per-turn schema cost from **3 859 tokens to 765**, an 80.2% reduction, measurable with `archex mcp-schema-size --tools disclosure`.
+
+**What makes this safe is the notification, not the dispatch.** MCP tools are model-controlled: a model only calls what it was shown. So for the ordinary path, the thing that puts the other 17 tools back in front of the model is `tools/list_changed` — which archex is entitled to have honoured because the gated server declares the `listChanged` capability at initialization.
+
+Dispatch-by-name surviving a closed gate is a *fallback*, not the mechanism: `call_tool` dispatches by name whatever `list_tools()` returned, which rescues **hardcoded** callers — a script, or an agent file that names tools directly, as archex's own guidance block does. It does not help a model that was never shown the tool.
+
+| Client behaviour | What to do |
+| --- | --- |
+| Honours `notifications/tools/list_changed` | Nothing. The default is correct and cheapest. |
+| Ignores the notification, calls tools by hardcoded name | Nothing. Those calls still dispatch. |
+| Ignores the notification and builds its tool list only from `list_tools()` | `--no-disclosure`. Its model would otherwise never see the other 17 tools. |
+| Needs every tool visible in `list_tools()` before it will call anything | `archex install-client <client> --no-disclosure`, `archex setup --no-disclosure`, or `archex mcp --no-disclosure` by hand. Pays the full per-turn cost, sees everything immediately. |
+
+One behavioural consequence worth knowing: the MCP client SDK validates a call's arguments against the schema it has cached from `list_tools()`, so through a closed gate a call to a not-yet-advertised tool is **not** validated client-side and reaches the server instead of failing fast. The window is one round trip for a client that honours the notification, and the whole session for one that does not — another reason for the third row above.
+
+`--tools` does **not** disable the gate. It bounds what is advertised *once the gate opens*, so `archex mcp --tools all` still starts at the minimal set. `--no-disclosure` is the only opt-out. That is the opposite of the natural guess, which is why it is stated here and in `archex mcp --help`.
+
+Configs written without `--no-disclosure` are byte-identical to the ones archex wrote before R5, so no existing install churns.
+
 archex cannot change a harness's tool-gating, but it ships a ready-to-paste agent-file guidance prompt that names the MCP tools and the activation step. Append it to a global or repo-specific agent file (`CLAUDE.md`, `AGENTS.md`, ...):
 
 ```bash

--- a/src/archex/cli/install_client_cmd.py
+++ b/src/archex/cli/install_client_cmd.py
@@ -99,6 +99,19 @@ def _is_interactive() -> bool:
         "existing unscoped `archex mcp` behavior."
     ),
 )
+@click.option(
+    "--no-disclosure",
+    "no_disclosure",
+    is_flag=True,
+    default=False,
+    help=(
+        "Write a config that advertises every tool from the first list_tools() "
+        "instead of gating on retrieval. The compatibility path for a client "
+        "that cannot re-fetch its tool list after "
+        "notifications/tools/list_changed: it pays the full per-turn schema "
+        "cost but never waits to see a tool."
+    ),
+)
 def install_client_cmd(
     client_or_source: str | None,
     source_opt: str | None,
@@ -111,6 +124,7 @@ def install_client_cmd(
     all_detected: bool,
     yes: bool,
     tool_scope: str | None,
+    no_disclosure: bool,
 ) -> None:
     """Install MCP client configuration for archex (preview with --dry-run)."""
     if hooks and remove_hooks:
@@ -164,7 +178,9 @@ def install_client_cmd(
             )
 
             discovered = discover_clients(source)
-            plans = build_discovered_install_plans(discovered, source, tool_scope=tool_scope)
+            plans = build_discovered_install_plans(
+                discovered, source, tool_scope=tool_scope, disclosure=not no_disclosure
+            )
             if dry_run:
                 click.echo(render_multiple_install_preview(plans), nl=False)
                 if agent_file is not None:
@@ -211,7 +227,9 @@ def install_client_cmd(
                 click.echo("\nNo configured clients found.")
                 return
 
-            plans = build_discovered_install_plans(discovered, source, tool_scope=tool_scope)
+            plans = build_discovered_install_plans(
+                discovered, source, tool_scope=tool_scope, disclosure=not no_disclosure
+            )
             click.echo(
                 f"\nInstall archex MCP registration for {len(plans)} detected clients? [y/N] ",
                 nl=False,
@@ -270,6 +288,7 @@ def install_client_cmd(
             source,
             scope=cast("ClientScope | None", scope),
             tool_scope=tool_scope,
+            disclosure=not no_disclosure,
         )
         if dry_run:
             click.echo(render_client_install_preview(plan), nl=False)

--- a/src/archex/cli/setup_cmd.py
+++ b/src/archex/cli/setup_cmd.py
@@ -111,6 +111,7 @@ def apply_clients_guidance(
     dry_run: bool,
     clients_flag: bool | None,
     tool_scope: str | None = None,
+    disclosure: bool = True,
 ) -> dict[str, list[dict[str, str | bool]]]:
     """Apply MCP client registration and agent guidance.
 
@@ -130,7 +131,9 @@ def apply_clients_guidance(
     else:
         should_configure_clients = True
         clients = discover_clients(source)
-        plans = build_discovered_install_plans(clients, source, tool_scope=tool_scope)
+        plans = build_discovered_install_plans(
+            clients, source, tool_scope=tool_scope, disclosure=disclosure
+        )
         if not plans:
             actions.append({"type": "client_install", "status": "skipped_no_clients"})
         else:
@@ -263,6 +266,19 @@ def print_final_summary(
         "comma-separated explicit tool-name allowlist."
     ),
 )
+@click.option(
+    "--no-disclosure",
+    "no_disclosure",
+    is_flag=True,
+    default=False,
+    help=(
+        "Write configs that advertise every tool from the first list_tools() "
+        "instead of gating on retrieval. The compatibility path for a client "
+        "that cannot re-fetch its tool list after "
+        "notifications/tools/list_changed: it pays the full per-turn schema "
+        "cost but never waits to see a tool."
+    ),
+)
 def setup_cmd(
     source: Path,
     dry_run: bool,
@@ -272,6 +288,7 @@ def setup_cmd(
     hooks: bool,
     format_: Literal["text", "json"],
     tool_scope: str | None,
+    no_disclosure: bool,
 ) -> None:
     """Guided onboarding wizard."""
     if tool_scope is not None:
@@ -307,7 +324,12 @@ def setup_cmd(
             "preflight": asdict(preflight),
             "planned_actions": actions,
             "clients_guidance": apply_clients_guidance(
-                source, preflight, dry_run=True, clients_flag=clients, tool_scope=tool_scope
+                source,
+                preflight,
+                dry_run=True,
+                clients_flag=clients,
+                tool_scope=tool_scope,
+                disclosure=not no_disclosure,
             )["clients_guidance"],
             "metrics_hooks": apply_metrics_hooks(
                 source, preflight, dry_run=True, metrics_flag=metrics, hooks_flag=hooks
@@ -335,7 +357,12 @@ def setup_cmd(
 
         click.echo("--- Clients & Agent Guidance ---")
         cg_actions = apply_clients_guidance(
-            source, preflight, dry_run=True, clients_flag=clients, tool_scope=tool_scope
+            source,
+            preflight,
+            dry_run=True,
+            clients_flag=clients,
+            tool_scope=tool_scope,
+            disclosure=not no_disclosure,
         )["clients_guidance"]
         for action in cg_actions:
             name = action.get("client") or action.get("file") or action["type"]
@@ -353,7 +380,12 @@ def setup_cmd(
         click.echo("--- Executing Setup ---")
         results = apply_init_index(source, preflight, dry_run=False)
         cg_results = apply_clients_guidance(
-            source, preflight, dry_run=False, clients_flag=clients, tool_scope=tool_scope
+            source,
+            preflight,
+            dry_run=False,
+            clients_flag=clients,
+            tool_scope=tool_scope,
+            disclosure=not no_disclosure,
         )
         mh_results = apply_metrics_hooks(
             source, preflight, dry_run=False, metrics_flag=metrics, hooks_flag=hooks
@@ -440,7 +472,12 @@ def setup_cmd(
         )
 
     cg_results = apply_clients_guidance(
-        source, preflight, dry_run=False, clients_flag=do_clients, tool_scope=tool_scope
+        source,
+        preflight,
+        dry_run=False,
+        clients_flag=do_clients,
+        tool_scope=tool_scope,
+        disclosure=not no_disclosure,
     )
     results["clients_guidance"].extend(cg_results["clients_guidance"])
 

--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -169,13 +169,16 @@ def build_discovered_install_plans(
     discovered: list[DiscoveredClient],
     source: str | Path | None = None,
     tool_scope: str | None = None,
+    disclosure: bool = True,
 ) -> list[ClientInstallPlan]:
     plans: list[ClientInstallPlan] = []
     for d in discovered:
         if d.is_installed:
             s = source if d.scope == "project" else None
             plans.append(
-                build_client_install_plan(d.client, s, scope=d.scope, tool_scope=tool_scope)
+                build_client_install_plan(
+                    d.client, s, scope=d.scope, tool_scope=tool_scope, disclosure=disclosure
+                )
             )
     return plans
 
@@ -203,13 +206,14 @@ def build_client_install_plan(
     *,
     scope: ClientScope | None = None,
     tool_scope: str | None = None,
+    disclosure: bool = True,
 ) -> ClientInstallPlan:
     selected_scope = _resolve_scope(client, source, scope)
     if client in _USER_ONLY_CLIENTS and selected_scope != "user":
         raise ValueError(f"{client} client config supports only --scope user")
     repo_root = Path(source if source is not None else ".").expanduser().resolve()
     target_path = _target_path(client, repo_root, selected_scope)
-    content = _render_content(client, tool_scope)
+    content = _render_content(client, tool_scope, disclosure=disclosure)
     return ClientInstallPlan(
         client=client,
         scope=selected_scope,
@@ -1425,7 +1429,7 @@ def _target_path(client: ClientName, repo_root: Path, scope: ClientScope) -> Pat
     raise ValueError(f"unsupported client: {client}")
 
 
-def _mcp_args(tool_scope: str | None) -> list[str]:
+def _mcp_args(tool_scope: str | None, *, disclosure: bool = True) -> list[str]:
     """CLI args for the `archex mcp` server command.
 
     `None` preserves the existing unscoped `["mcp"]` args exactly (backward
@@ -1433,14 +1437,25 @@ def _mcp_args(tool_scope: str | None) -> list[str]:
     scope is validated via `resolve_tool_scope` before being embedded --
     an unknown tool name in `tool_scope` fails at install time, not
     silently inside a client's own MCP server subprocess.
+
+    `disclosure=False` writes `--no-disclosure`, which is the compatibility
+    path for a client that cannot re-fetch its tool list: it pays the full
+    schema cost every turn but sees every tool from the first `list_tools()`.
+    The default is left implicit rather than written as `--disclosure`, so
+    configs stay byte-identical to the ones archex already wrote.
     """
-    if tool_scope is None or resolve_tool_scope(tool_scope) is None:
-        return ["mcp"]
-    return ["mcp", "--tools", tool_scope]
+    args = ["mcp"]
+    if tool_scope is not None and resolve_tool_scope(tool_scope) is not None:
+        args += ["--tools", tool_scope]
+    if not disclosure:
+        args.append("--no-disclosure")
+    return args
 
 
-def _render_content(client: ClientName, tool_scope: str | None = None) -> str:
-    args = _mcp_args(tool_scope)
+def _render_content(
+    client: ClientName, tool_scope: str | None = None, *, disclosure: bool = True
+) -> str:
+    args = _mcp_args(tool_scope, disclosure=disclosure)
     if client == "codex":
         return f'[mcp_servers.archex]\ncommand = "archex"\nargs = {json.dumps(args)}\n'
     if client == "opencode":

--- a/tests/integrations/test_mcp_disclosure.py
+++ b/tests/integrations/test_mcp_disclosure.py
@@ -8,6 +8,7 @@ is the property that lets the default change safely.
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -316,3 +317,92 @@ class TestGateThroughARealSession:
             after = {t.name for t in (await client.list_tools()).tools}
             assert before == after == set(TOOL_SCOPE_PROFILES["graph"])
             assert notifications == [], "a pointless tools/list round trip"
+
+
+class TestClientCompatibilityPath:
+    """`install-client --no-disclosure` is the documented path for a client that
+    cannot re-fetch its tool list.
+
+    Asserted through the rendered client config rather than the arg builder, so
+    these pin what actually lands on disk.
+    """
+
+    @staticmethod
+    def _args(tool_scope: str | None = None, *, disclosure: bool = True) -> list[str]:
+        from archex.client_setup import build_client_install_plan
+
+        plan = build_client_install_plan(
+            "claude-code",
+            ".",
+            scope="project",
+            tool_scope=tool_scope,
+            disclosure=disclosure,
+        )
+        content: dict[str, Any] = json.loads(plan.content)
+        return content["mcpServers"]["archex"]["args"]
+
+    def test_the_default_config_is_byte_identical_to_the_pre_r5_one(self) -> None:
+        """Existing installs must not churn, so the default stays implicit."""
+        assert self._args() == ["mcp"]
+
+    def test_the_compatibility_path_writes_the_opt_out(self) -> None:
+        assert self._args(disclosure=False) == ["mcp", "--no-disclosure"]
+
+    def test_a_scope_and_the_compatibility_path_compose(self) -> None:
+        assert self._args("core", disclosure=False) == [
+            "mcp",
+            "--tools",
+            "core",
+            "--no-disclosure",
+        ]
+
+    def test_a_scope_alone_is_unchanged_by_r5(self) -> None:
+        assert self._args("core") == ["mcp", "--tools", "core"]
+
+    def test_setup_offers_the_same_opt_out_as_install_client(self) -> None:
+        """`setup` is the primary onboarding command and the docs promise the flag.
+
+        Without this, `--no-disclosure` existed only on `install-client` while
+        `apply_clients_guidance`'s `disclosure` parameter sat unreachable.
+        """
+        from click.testing import CliRunner
+
+        from archex.cli.main import cli
+
+        result = CliRunner().invoke(cli, ["setup", "--help"])
+        assert result.exit_code == 0
+        assert "--no-disclosure" in result.output
+
+    def test_setups_opt_out_reaches_the_rendered_config(self) -> None:
+        """A flag that parses but never reaches the plan builder is dead code."""
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from click.testing import CliRunner
+
+        from archex.cli.main import cli
+        from archex.cli.setup_cmd import run_preflight
+
+        if not run_preflight(Path(".")).mcp_runtime_available:
+            pytest.skip("client planning is skipped when the mcp runtime is unavailable")
+
+        seen: list[bool] = []
+        real = None
+
+        def spy(*args: Any, **kwargs: Any) -> Any:
+            seen.append(bool(kwargs["disclosure"]))
+            assert real is not None
+            return real(*args, **kwargs)
+
+        import archex.cli.setup_cmd as setup_mod
+
+        real = setup_mod.build_discovered_install_plans
+        with patch.object(setup_mod, "build_discovered_install_plans", side_effect=spy):
+            runner = CliRunner()
+            runner.invoke(cli, ["setup", ".", "--dry-run", "--clients", "--format", "json"])
+            runner.invoke(
+                cli,
+                ["setup", ".", "--dry-run", "--clients", "--no-disclosure", "--format", "json"],
+            )
+
+        assert seen == [True, False], "the flag never reached the plan builder"


### PR DESCRIPTION
PR-2 of the R5 stack. Based on `feat/r5-retrieval-gated-disclosure` (#585).

PR-1 changed what a fresh session sees. This PR gives the clients that cannot cope a supported way out, and documents which clients need it.

## The opt-out, on both onboarding commands

```
$ archex install-client claude-code . --scope project --no-disclosure --dry-run
"args": ["mcp", "--no-disclosure"]

$ archex setup . --no-disclosure          # same flag, primary onboarding path
$ archex install-client claude-code . --scope project --dry-run
"args": ["mcp"]
```

**The default stays implicit.** No `--disclosure` is written, so generated configs are byte-identical to pre-R5 and no existing install churns. The flag composes with `--tool-scope`: `["mcp", "--tools", "core", "--no-disclosure"]`.

`setup` was a review catch: the threading parameter existed but no `click.option` did, so `setup --no-disclosure` exited 2 while this PR's own commit message and the decision document both claimed it worked. `apply_clients_guidance`'s `disclosure` argument was unreachable dead code. Now wired through all four call sites, with a test that spies the plan builder and fails if the flag stops arriving.

## Which clients need what — reframed after review

| Client behaviour | What to do |
| --- | --- |
| Honours `notifications/tools/list_changed` | Nothing. Default is correct and cheapest. |
| Ignores the notification, calls tools by hardcoded name | Nothing. Those calls still dispatch. |
| Ignores the notification and builds its list only from `list_tools()` | `--no-disclosure`. Its model would otherwise never see the other 17 tools. |
| Needs every tool visible before calling anything | `--no-disclosure`. Full per-turn cost, everything immediately. |

The third row is new and it is the one that matters. The earlier two-row table framed safety around dispatch-by-name, which only rescues **hardcoded** callers — MCP tools are model-controlled, so a model never shown a tool will not call it. A client that ignores the notification and builds its list from `list_tools()` alone is not "fine, tools stay callable"; it is stranded, and needs the opt-out.

Also newly documented: through a closed gate a call to a not-yet-advertised tool is **not validated client-side**, because the SDK validates against its cached schema. A malformed hardcoded call that used to fail fast now reaches the server.

## The counter-intuitive part

`--tools` does **not** disable the gate. It bounds what is advertised *once the gate opens*, so `archex mcp --tools all` still starts minimal. `--no-disclosure` is the only opt-out — the opposite of the natural guess, so it is stated in the matrix, in `archex mcp --help`, in `build_server`'s docstring, and pinned by `test_an_unscoped_server_is_still_gated`. I had this wrong in a first draft myself.

## Verification

- `uv run pytest -q` — 4 640 passed, coverage 91.58%
- `uv run ruff check .`, `ruff format --check .`, `uv run pyright .` clean
- Reverting the `setup` threading fails its test; the default-config test pins byte-identity with pre-R5.

A reviewer independently rendered all six client renderers across six scopes against `main` and found zero diffs outside the new `disclosure` profile.
