### PR TITLE
chore(release): prepare 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.25.0] - 2026-07-28
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archex"
-version = "0.24.0"
+version = "0.25.0"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "archex"
-version = "0.24.0"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Release preparation for the **claims-and-cost** train. Trigger fired: R2 and R5 both externally merged.

## Version choice: `0.25.0`, verified not assumed

`AGENTS.md` maps `feat` → MINOR. Checked empirically rather than by diff size:

- **5 `feat` commits** since `v0.24.0` (`feat(mcp)` ×2, `feat(benchmark)` ×2, `feat(assets)` ×1)
- **4 new `@click.option`/`@click.command`** lines under `src/archex/cli/`
- No `!` or `BREAKING CHANGE:` footer outside a benchmark-only artifact version

`v0.25.0` is free.

## Contents

All eight `[Unreleased]` entries move into the release section. R2 and R5 are the train's named milestones; R3 and R4 are `unversioned` (they trigger no release) and M6–M9 were left behind by the 0.24.0 cut, which the plan's train row anticipates: *"Carries the pre-existing `[Unreleased]` prior-M6–M9 entries."*

They ship in this sdist regardless of which section they sit in, so leaving any under `[Unreleased]` after the tag would misdescribe what `0.25.0` contains.

## Release verification, per the plan's train row

Both required checks pass on this commit:

```
$ uv run ruff check . && uv run ruff format --check . && uv run pyright . && uv run pytest
0 errors, 0 warnings, 0 informations
4645 passed, 9 deselected — coverage 91.58%

$ uv run archex mcp-schema-size --format json     # "reports the reduced total"
765 tokens gated, 3859 after retrieval

$ uv run archex --version
archex, version 0.25.0
```

## Diff

Three lines: `pyproject.toml` version, the `CHANGELOG.md` header, and `uv.lock`'s own `archex` version pin — `uv lock` pins the project's version, so a bump without it leaves the lockfile stale.

Tag, PyPI publish, and the GitHub release follow this merge, manually — there is no release CI workflow.
