### PR TITLE
test(benchmark): measure prefix-cache hit rate and cost per ordering arm

### DIFF
--- a/benchmarks/determinism_economics/sessions.json
+++ b/benchmarks/determinism_economics/sessions.json
@@ -1,0 +1,82 @@
+[
+  {
+    "session_id": "archex-index-01",
+    "repository": "Mathews-Tom/archex",
+    "resolved": true,
+    "turns": [
+      {"question": "Where does index publication become atomic?", "contexts": ["src/archex/indexer.py: publish a staging generation only after every store is complete.", "src/archex/store.py: manifest records the published generation identity.", "tests/test_indexer.py: interrupted generation leaves the previous manifest readable."]},
+      {"question": "What verifies the generated manifest?", "contexts": ["src/archex/indexer.py: publish a staging generation only after every store is complete.", "src/archex/store.py: manifest records the published generation identity.", "tests/test_indexer.py: interrupted generation leaves the previous manifest readable."]},
+      {"question": "Which old state remains visible after failure?", "contexts": ["src/archex/indexer.py: publish a staging generation only after every store is complete.", "src/archex/store.py: manifest records the published generation identity.", "tests/test_indexer.py: interrupted generation leaves the previous manifest readable."]}
+    ]
+  },
+  {
+    "session_id": "archex-query-02",
+    "repository": "Mathews-Tom/archex",
+    "resolved": true,
+    "turns": [
+      {"question": "How does the query pipeline select candidates?", "contexts": ["src/archex/query.py: score lexical and graph candidates before context packing.", "src/archex/context.py: pack chunks within the requested token budget.", "src/archex/reporting.py: attach token metadata to the returned response."]},
+      {"question": "Where is the token budget enforced?", "contexts": ["src/archex/query.py: score lexical and graph candidates before context packing.", "src/archex/context.py: pack chunks within the requested token budget.", "src/archex/reporting.py: attach token metadata to the returned response."]},
+      {"question": "What metadata reports the result size?", "contexts": ["src/archex/query.py: score lexical and graph candidates before context packing.", "src/archex/context.py: pack chunks within the requested token budget.", "src/archex/reporting.py: attach token metadata to the returned response."]}
+    ]
+  },
+  {
+    "session_id": "enginery-stage-03",
+    "repository": "Mathews-Tom/Enginery",
+    "resolved": true,
+    "turns": [
+      {"question": "How does the stage gate choose its next action?", "contexts": ["src/enginery/stage.py: inspect state before dispatching the next transition.", "src/enginery/policy.py: merge policy records an explicit human-review decision.", "tests/test_stage.py: a cancelled run cannot advance."]},
+      {"question": "What stops a cancelled run from advancing?", "contexts": ["src/enginery/stage.py: inspect state before dispatching the next transition.", "src/enginery/policy.py: merge policy records an explicit human-review decision.", "tests/test_stage.py: a cancelled run cannot advance."]},
+      {"question": "Where is human review represented?", "contexts": ["src/enginery/stage.py: inspect state before dispatching the next transition.", "src/enginery/policy.py: merge policy records an explicit human-review decision.", "tests/test_stage.py: a cancelled run cannot advance."]}
+    ]
+  },
+  {
+    "session_id": "enginery-release-04",
+    "repository": "Mathews-Tom/Enginery",
+    "resolved": false,
+    "turns": [
+      {"question": "Which release destination failed verification?", "contexts": ["src/enginery/release.py: publish records each destination receipt.", "src/enginery/verify.py: verify package installation from the published artifact.", "tests/test_release.py: missing receipt fails the run loudly."]},
+      {"question": "Where are release receipts recorded?", "contexts": ["src/enginery/release.py: publish records each destination receipt.", "src/enginery/verify.py: verify package installation from the published artifact.", "tests/test_release.py: missing receipt fails the run loudly."]},
+      {"question": "Why did the run remain unresolved?", "contexts": ["src/enginery/release.py: publish records each destination receipt.", "src/enginery/verify.py: verify package installation from the published artifact.", "tests/test_release.py: missing receipt fails the run loudly."]}
+    ]
+  },
+  {
+    "session_id": "kosha-memory-05",
+    "repository": "Mathews-Tom/Kosha",
+    "resolved": true,
+    "turns": [
+      {"question": "How does memory routing avoid duplicate facets?", "contexts": ["src/kosha/routing.py: route a request through the deduplication threshold.", "src/kosha/store.py: preserve the canonical facet identity.", "tests/test_routing.py: duplicate requests reuse the recorded facet."]},
+      {"question": "What is canonical after deduplication?", "contexts": ["src/kosha/routing.py: route a request through the deduplication threshold.", "src/kosha/store.py: preserve the canonical facet identity.", "tests/test_routing.py: duplicate requests reuse the recorded facet."]},
+      {"question": "Which test proves reuse?", "contexts": ["src/kosha/routing.py: route a request through the deduplication threshold.", "src/kosha/store.py: preserve the canonical facet identity.", "tests/test_routing.py: duplicate requests reuse the recorded facet."]}
+    ]
+  },
+  {
+    "session_id": "kosha-policy-06",
+    "repository": "Mathews-Tom/Kosha",
+    "resolved": true,
+    "turns": [
+      {"question": "How is retention policy enforced?", "contexts": ["src/kosha/policy.py: apply retention rules before writing a facet.", "src/kosha/vault.py: soft deletion retains audit provenance.", "tests/test_policy.py: expired content is unavailable to recall."]},
+      {"question": "What survives soft deletion?", "contexts": ["src/kosha/policy.py: apply retention rules before writing a facet.", "src/kosha/vault.py: soft deletion retains audit provenance.", "tests/test_policy.py: expired content is unavailable to recall."]},
+      {"question": "How do expired facets behave?", "contexts": ["src/kosha/policy.py: apply retention rules before writing a facet.", "src/kosha/vault.py: soft deletion retains audit provenance.", "tests/test_policy.py: expired content is unavailable to recall."]}
+    ]
+  },
+  {
+    "session_id": "searchat-store-07",
+    "repository": "Mathews-Tom/searchat",
+    "resolved": true,
+    "turns": [
+      {"question": "How does storage compaction preserve active data?", "contexts": ["src/searchat/storage.py: copy live records into a compact DuckDB database.", "src/searchat/doctor.py: report live blocks separately from file size.", "tests/test_compact.py: verify replacement only after the compact copy succeeds."]},
+      {"question": "Which metric reports storage bloat?", "contexts": ["src/searchat/storage.py: copy live records into a compact DuckDB database.", "src/searchat/doctor.py: report live blocks separately from file size.", "tests/test_compact.py: verify replacement only after the compact copy succeeds."]},
+      {"question": "When does replacement occur?", "contexts": ["src/searchat/storage.py: copy live records into a compact DuckDB database.", "src/searchat/doctor.py: report live blocks separately from file size.", "tests/test_compact.py: verify replacement only after the compact copy succeeds."]}
+    ]
+  },
+  {
+    "session_id": "searchat-api-08",
+    "repository": "Mathews-Tom/searchat",
+    "resolved": false,
+    "turns": [
+      {"question": "What endpoint reports disk diagnostics?", "contexts": ["src/searchat/api.py: diagnostics endpoint opens a read-only database connection.", "src/searchat/dashboard.py: render report-only disk measurements.", "tests/test_api.py: mutable maintenance actions are absent from diagnostics."]},
+      {"question": "Why is the endpoint read-only?", "contexts": ["src/searchat/api.py: diagnostics endpoint opens a read-only database connection.", "src/searchat/dashboard.py: render report-only disk measurements.", "tests/test_api.py: mutable maintenance actions are absent from diagnostics."]},
+      {"question": "How is report-only behavior tested?", "contexts": ["src/searchat/api.py: diagnostics endpoint opens a read-only database connection.", "src/searchat/dashboard.py: render report-only disk measurements.", "tests/test_api.py: mutable maintenance actions are absent from diagnostics."]}
+    ]
+  }
+]

--- a/benchmarks/evidence/DECISION.md
+++ b/benchmarks/evidence/DECISION.md
@@ -1,0 +1,36 @@
+# S7 Determinism Economics Decision
+
+## Decision
+
+**Keep the economic framing for the frozen S7 session fixture. Do not change archex retrieval ordering or claim retrieval-quality improvement.**
+
+The pre-registered 5% SESOI was exceeded for both comparators, so the pre-declared retirement rule does not apply:
+
+| Arm | Cache-hit rate, 95% repository-cluster interval | Input cost / resolved task, 95% repository-cluster interval |
+| --- | ---: | ---: |
+| Deterministic ordering | 66.67% [66.67%, 66.67%] | $0.00095846 [$0.00071594, $0.00144350] |
+| Perturbed ordering | 33.26% [20.94%, 45.13%] | $0.00136863 [$0.00110406, $0.00189775] |
+| Seeded ANN-ordering comparator | 20.92% [16.59%, 29.17%] | $0.00152004 [$0.00118025, $0.00219963] |
+
+Relative to the comparators, deterministic ordering reduced modeled input cost by 29.97% [23.94%, 35.15%] against perturbed ordering and 36.95% [34.38%, 39.34%] against the seeded ANN-ordering comparator.
+
+## Evidence boundary
+
+`benchmarks/evidence/s7-determinism-economics.json` records input-side prefix-cache accounting for eight frozen, repeated multi-turn coding sessions across four repository clusters. It uses byte-identical rendered prefixes and `cl100k_base` token counts. It does not call a hosted model, observe a provider cache ledger, alter archex's ordering, or evaluate retrieval quality. The ANN comparator is seeded for reproducibility while representing unstable per-turn context ordering; it is not a claim about any vendor ANN implementation.
+
+The dollar figures use the recorded public `claude-opus-5` input schedule: $5.00 per million base input tokens, 1.25x five-minute cache writes, and 0.1x cache reads. They are pricing-model estimates, not billed usage. The pricing source was rechecked at run time: <https://platform.claude.com/docs/en/about-claude/pricing>.
+
+## Reproduction
+
+Start from a clean checkout at source revision `2224d0d41c293702d6450a182899f48576252e2d` after pre-registration commit `0c8c8483aab09c8b4d9e6c4e2f80408de7e2ed6e` is reachable:
+
+```text
+uv run archex benchmark determinism-economics --output benchmarks/evidence/s7-determinism-economics.json --preregistration-commit 0c8c8483aab09c8b4d9e6c4e2f80408de7e2ed6e
+uv run archex benchmark validate --kind evidence --input benchmarks/evidence/s7-determinism-economics.json
+```
+
+The evidence fixes the session-fixture digest, pricing schedule, 10,000 repository-cluster bootstrap resamples, and seed `20260729`. Reproducing the command produces the same values except `generated_at`.
+
+## Limits and next action
+
+Treat this as proof that stable context order materially changes the modeled prefix-cache ledger for the frozen fixture. Do not extrapolate it to production spend until a real model-backed run records provider-reported cache tokens under an explicitly pinned model and TTL. Archex's default ordering remains unchanged.

--- a/benchmarks/evidence/DECISION.md
+++ b/benchmarks/evidence/DECISION.md
@@ -2,35 +2,30 @@
 
 ## Decision
 
-**Keep the economic framing for the frozen S7 session fixture. Do not change archex retrieval ordering or claim retrieval-quality improvement.**
+**Retire the economic framing. Determinism remains a reproducibility property only. Archex retrieval ordering is unchanged.**
 
-The pre-registered 5% SESOI was exceeded for both comparators, so the pre-declared retirement rule does not apply:
+The frozen fixture's rendered prefixes contain fewer than the 512-token minimum for Claude Opus 5 prompt caching. The pricing model therefore classifies every prefix as uncached. All three arms have a 0.00% cache-hit rate and the same modeled input cost per resolved task: $0.00151000. Each deterministic-versus-comparator cost reduction is 0.00% with a 95% repository-cluster bootstrap interval of [0.00%, 0.00%].
 
-| Arm | Cache-hit rate, 95% repository-cluster interval | Input cost / resolved task, 95% repository-cluster interval |
-| --- | ---: | ---: |
-| Deterministic ordering | 66.67% [66.67%, 66.67%] | $0.00095846 [$0.00071594, $0.00144350] |
-| Perturbed ordering | 33.26% [20.94%, 45.13%] | $0.00136863 [$0.00110406, $0.00189775] |
-| Seeded ANN-ordering comparator | 20.92% [16.59%, 29.17%] | $0.00152004 [$0.00118025, $0.00219963] |
-
-Relative to the comparators, deterministic ordering reduced modeled input cost by 29.97% [23.94%, 35.15%] against perturbed ordering and 36.95% [34.38%, 39.34%] against the seeded ANN-ordering comparator.
+This fires the pre-registered kill criterion: each comparator is below the +5% SESOI. The null is acceptable and is not a retrieval-quality result.
 
 ## Evidence boundary
 
-`benchmarks/evidence/s7-determinism-economics.json` records input-side prefix-cache accounting for eight frozen, repeated multi-turn coding sessions across four repository clusters. It uses byte-identical rendered prefixes and `cl100k_base` token counts. It does not call a hosted model, observe a provider cache ledger, alter archex's ordering, or evaluate retrieval quality. The ANN comparator is seeded for reproducibility while representing unstable per-turn context ordering; it is not a claim about any vendor ANN implementation.
+The artifact records eight frozen, repeated three-turn sessions in four repository clusters. Each session deliberately repeats the same selected context order over its turns; the deterministic arm's counterfactual cache hit rate would therefore be at its two-of-three-turn ceiling if every prefix were cacheable. It is not cacheable under the recorded provider rule, so the degenerate zero cache-hit and cost-reduction intervals are construction plus eligibility facts, not an estimate of production spend.
 
-The dollar figures use the recorded public `claude-opus-5` input schedule: $5.00 per million base input tokens, 1.25x five-minute cache writes, and 0.1x cache reads. They are pricing-model estimates, not billed usage. The pricing source was rechecked at run time: <https://platform.claude.com/docs/en/about-claude/pricing>.
+The harness stores the canonical rendered prefix strings, SHA-256 prefix identities, session-fixture digest, exact command, token-counting method, pricing URL, and pricing retrieval timestamp. `cl100k_base` is a proxy rather than Claude Opus 5's tokenizer; Claude documents that its newer tokenizer can produce approximately 30% more tokens for the same text. That mismatch affects absolute dollar estimates but not the zero cost-reduction result because every arm uses identical input-token accounting.
+
+The price ledger uses the recorded Claude Opus 5 schedule: $5.00 per million base input tokens, 1.25x five-minute cache writes, 0.1x cache reads, and the 512-token minimum cacheable prefix. Pricing source retrieved at `2026-07-28T21:53:33Z`: <https://platform.claude.com/docs/en/about-claude/pricing>. Cache eligibility source: <https://platform.claude.com/docs/en/build-with-claude/prompt-caching>.
 
 ## Reproduction
 
-Start from a clean checkout at source revision `2224d0d41c293702d6450a182899f48576252e2d` after pre-registration commit `0c8c8483aab09c8b4d9e6c4e2f80408de7e2ed6e` is reachable:
+Use a clean checkout at source revision `3a88f6af349a0f6d64399e261b2f643d24b4f530`:
 
 ```text
-uv run archex benchmark determinism-economics --output benchmarks/evidence/s7-determinism-economics.json --preregistration-commit 0c8c8483aab09c8b4d9e6c4e2f80408de7e2ed6e
+uv run archex benchmark determinism-economics --sessions benchmarks/determinism_economics/sessions.json --output benchmarks/evidence/s7-determinism-economics.json --preregistration-commit 501636abb09cbcf6edee5783305af6bcb313606a --pricing-retrieved-at 2026-07-28T21:53:33Z --resamples 10000 --seed 20260729
+uv run archex benchmark validate --kind determinism-economics --input benchmarks/evidence/s7-determinism-economics.json
 uv run archex benchmark validate --kind evidence --input benchmarks/evidence/s7-determinism-economics.json
 ```
 
-The evidence fixes the session-fixture digest, pricing schedule, 10,000 repository-cluster bootstrap resamples, and seed `20260729`. Reproducing the command produces the same values except `generated_at`.
-
 ## Limits and next action
 
-Treat this as proof that stable context order materially changes the modeled prefix-cache ledger for the frozen fixture. Do not extrapolate it to production spend until a real model-backed run records provider-reported cache tokens under an explicitly pinned model and TTL. Archex's default ordering remains unchanged.
+Do not extrapolate this fixture-only null to a deployment. A future study needs real model-backed cache usage and cache-eligible context lengths, pre-registered before data generation. No retrieval-quality claim follows from this study.

--- a/benchmarks/evidence/s7-determinism-economics-DECISION.md
+++ b/benchmarks/evidence/s7-determinism-economics-DECISION.md
@@ -14,14 +14,14 @@ The artifact records eight frozen, repeated three-turn sessions in four reposito
 
 The harness stores the canonical rendered prefix strings, SHA-256 prefix identities, session-fixture digest, exact command, token-counting method, pricing URL, and pricing retrieval timestamp. `cl100k_base` is a proxy rather than Claude Opus 5's tokenizer; Claude documents that its newer tokenizer can produce approximately 30% more tokens for the same text. That mismatch affects absolute dollar estimates but not the zero cost-reduction result because every arm uses identical input-token accounting.
 
-The price ledger uses the recorded Claude Opus 5 schedule: $5.00 per million base input tokens, 1.25x five-minute cache writes, 0.1x cache reads, and the 512-token minimum cacheable prefix. Pricing source retrieved at `2026-07-28T21:53:33Z`: <https://platform.claude.com/docs/en/about-claude/pricing>. Cache eligibility source: <https://platform.claude.com/docs/en/build-with-claude/prompt-caching>.
+The price ledger uses the recorded Claude Opus 5 schedule: $5.00 per million base input tokens, 1.25x five-minute cache writes, 0.1x cache reads, and the 512-token minimum cacheable prefix. Pricing source retrieved at `2026-07-28T22:19:00Z`: <https://platform.claude.com/docs/en/about-claude/pricing>. Cache eligibility source: <https://platform.claude.com/docs/en/build-with-claude/prompt-caching>.
 
 ## Reproduction
 
-Use a clean checkout at source revision `3a88f6af349a0f6d64399e261b2f643d24b4f530`:
+Run from the repository root in a clean checkout at source revision `f1f1671873189c881bf29fe945547a0fb7e8af8c`:
 
 ```text
-uv run archex benchmark determinism-economics --sessions benchmarks/determinism_economics/sessions.json --output benchmarks/evidence/s7-determinism-economics.json --preregistration-commit 501636abb09cbcf6edee5783305af6bcb313606a --pricing-retrieved-at 2026-07-28T21:53:33Z --resamples 10000 --seed 20260729
+uv run archex benchmark determinism-economics --sessions benchmarks/determinism_economics/sessions.json --output benchmarks/evidence/s7-determinism-economics.json --preregistration-commit 501636abb09cbcf6edee5783305af6bcb313606a --pricing-retrieved-at 2026-07-28T22:19:00Z --resamples 10000 --seed 20260729
 uv run archex benchmark validate --kind determinism-economics --input benchmarks/evidence/s7-determinism-economics.json
 uv run archex benchmark validate --kind evidence --input benchmarks/evidence/s7-determinism-economics.json
 ```

--- a/benchmarks/evidence/s7-determinism-economics.json
+++ b/benchmarks/evidence/s7-determinism-economics.json
@@ -2,12 +2,12 @@
   "evidence_version": 1,
   "spike_id": "S7",
   "preregistration": "benchmarks/preregistrations/S7-determinism-economics.md",
-  "preregistration_commit": "501636abb09cbcf6edee5783305af6bcb313606a",
-  "source_revision": "3a88f6af349a0f6d64399e261b2f643d24b4f530",
+  "preregistration_commit": "0c8c8483aab09cb8d49de6c4e2f8048e1f020ed6",
+  "source_revision": "b73ba365be43bf73ad566e96161bb8e045faa843",
   "session_fixture": "benchmarks/determinism_economics/sessions.json",
   "session_fixture_sha256": "c01f2ba787cbb46f2dd585881d95e5ce131ae103b508816c688087d915c31cef",
-  "measurement_command": "uv run archex benchmark determinism-economics --sessions benchmarks/determinism_economics/sessions.json --output benchmarks/evidence/s7-determinism-economics.json --preregistration-commit 501636abb09cbcf6edee5783305af6bcb313606a --pricing-retrieved-at 2026-07-28T21:53:33Z --resamples 10000 --seed 20260729",
-  "generated_at": "2026-07-28T21:53:44Z",
+  "measurement_command": "uv run archex benchmark determinism-economics --sessions benchmarks/determinism_economics/sessions.json --output benchmarks/evidence/s7-determinism-economics.json --preregistration-commit 0c8c8483aab09cb8d49de6c4e2f8048e1f020ed6 --pricing-retrieved-at 2026-07-28T22:05:00Z --resamples 10000 --seed 20260729",
+  "generated_at": "2026-07-28T22:05:01Z",
   "tokenizer": "cl100k_base",
   "pricing": {
     "model": "claude-opus-5",
@@ -17,7 +17,7 @@
     "minimum_cacheable_tokens": 512,
     "cache_ttl": "5m",
     "source_url": "https://platform.claude.com/docs/en/about-claude/pricing",
-    "retrieved_at": "2026-07-28T21:53:33Z"
+    "retrieved_at": "2026-07-28T22:05:00Z"
   },
   "arms": [
     {

--- a/benchmarks/evidence/s7-determinism-economics.json
+++ b/benchmarks/evidence/s7-determinism-economics.json
@@ -1,0 +1,349 @@
+{
+  "evidence_version": 1,
+  "spike_id": "S7",
+  "preregistration": "benchmarks/preregistrations/S7-determinism-economics.md",
+  "preregistration_commit": "0c8c8483aab09c8b4d9e6c4e2f80408de7e2ed6e",
+  "source_revision": "2224d0d41c293702d6450a182899f48576252e2d",
+  "session_fixture_sha256": "c01f2ba787cbb46f2dd585881d95e5ce131ae103b508816c688087d915c31cef",
+  "generated_at": "2026-07-28T21:22:54Z",
+  "tokenizer": "cl100k_base",
+  "pricing": {
+    "model": "claude-opus-5",
+    "base_input_usd_per_million": 5.0,
+    "cache_write_multiplier": 1.25,
+    "cache_read_multiplier": 0.1,
+    "cache_ttl": "5m",
+    "source_url": "https://platform.claude.com/docs/en/about-claude/pricing"
+  },
+  "arms": [
+    {
+      "arm": "deterministic",
+      "sessions": [
+        {
+          "session_id": "archex-index-01",
+          "repository": "Mathews-Tom/archex",
+          "resolved": true,
+          "cacheable_tokens": 165,
+          "cache_read_tokens": 110,
+          "cache_write_tokens": 55,
+          "uncached_input_tokens": 65,
+          "input_cost_usd": 0.00072375
+        },
+        {
+          "session_id": "archex-query-02",
+          "repository": "Mathews-Tom/archex",
+          "resolved": true,
+          "cacheable_tokens": 162,
+          "cache_read_tokens": 108,
+          "cache_write_tokens": 54,
+          "uncached_input_tokens": 69,
+          "input_cost_usd": 0.0007365
+        },
+        {
+          "session_id": "enginery-stage-03",
+          "repository": "Mathews-Tom/Enginery",
+          "resolved": true,
+          "cacheable_tokens": 165,
+          "cache_read_tokens": 110,
+          "cache_write_tokens": 55,
+          "uncached_input_tokens": 76,
+          "input_cost_usd": 0.00077875
+        },
+        {
+          "session_id": "enginery-release-04",
+          "repository": "Mathews-Tom/Enginery",
+          "resolved": false,
+          "cacheable_tokens": 153,
+          "cache_read_tokens": 102,
+          "cache_write_tokens": 51,
+          "uncached_input_tokens": 61,
+          "input_cost_usd": 0.00067475
+        },
+        {
+          "session_id": "kosha-memory-05",
+          "repository": "Mathews-Tom/Kosha",
+          "resolved": true,
+          "cacheable_tokens": 159,
+          "cache_read_tokens": 106,
+          "cache_write_tokens": 53,
+          "uncached_input_tokens": 69,
+          "input_cost_usd": 0.00072925
+        },
+        {
+          "session_id": "kosha-policy-06",
+          "repository": "Mathews-Tom/Kosha",
+          "resolved": true,
+          "cacheable_tokens": 159,
+          "cache_read_tokens": 106,
+          "cache_write_tokens": 53,
+          "uncached_input_tokens": 58,
+          "input_cost_usd": 0.00067425
+        },
+        {
+          "session_id": "searchat-store-07",
+          "repository": "Mathews-Tom/searchat",
+          "resolved": true,
+          "cacheable_tokens": 168,
+          "cache_read_tokens": 112,
+          "cache_write_tokens": 56,
+          "uncached_input_tokens": 70,
+          "input_cost_usd": 0.000756
+        },
+        {
+          "session_id": "searchat-api-08",
+          "repository": "Mathews-Tom/searchat",
+          "resolved": false,
+          "cacheable_tokens": 150,
+          "cache_read_tokens": 100,
+          "cache_write_tokens": 50,
+          "uncached_input_tokens": 63,
+          "input_cost_usd": 0.0006775
+        }
+      ],
+      "cache_hit_rate": 0.6666666666666666,
+      "cache_hit_rate_interval": {
+        "point_estimate": 0.6666666666666666,
+        "low": 0.6666666666666666,
+        "high": 0.6666666666666666,
+        "resamples": 10000,
+        "seed": 20260729,
+        "confidence": 0.95
+      },
+      "input_cost_usd_per_resolved_task": 0.0009584583333333333,
+      "input_cost_usd_per_resolved_task_interval": {
+        "point_estimate": 0.0009584583333333333,
+        "low": 0.0007159375,
+        "high": 0.0014435000000000001,
+        "resamples": 10000,
+        "seed": 20260730,
+        "confidence": 0.95
+      }
+    },
+    {
+      "arm": "perturbed",
+      "sessions": [
+        {
+          "session_id": "archex-index-01",
+          "repository": "Mathews-Tom/archex",
+          "resolved": true,
+          "cacheable_tokens": 165,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 165,
+          "uncached_input_tokens": 65,
+          "input_cost_usd": 0.00135625
+        },
+        {
+          "session_id": "archex-query-02",
+          "repository": "Mathews-Tom/archex",
+          "resolved": true,
+          "cacheable_tokens": 162,
+          "cache_read_tokens": 54,
+          "cache_write_tokens": 108,
+          "uncached_input_tokens": 69,
+          "input_cost_usd": 0.001047
+        },
+        {
+          "session_id": "enginery-stage-03",
+          "repository": "Mathews-Tom/Enginery",
+          "resolved": true,
+          "cacheable_tokens": 165,
+          "cache_read_tokens": 110,
+          "cache_write_tokens": 55,
+          "uncached_input_tokens": 76,
+          "input_cost_usd": 0.00077875
+        },
+        {
+          "session_id": "enginery-release-04",
+          "repository": "Mathews-Tom/Enginery",
+          "resolved": false,
+          "cacheable_tokens": 153,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 153,
+          "uncached_input_tokens": 61,
+          "input_cost_usd": 0.00126125
+        },
+        {
+          "session_id": "kosha-memory-05",
+          "repository": "Mathews-Tom/Kosha",
+          "resolved": true,
+          "cacheable_tokens": 159,
+          "cache_read_tokens": 53,
+          "cache_write_tokens": 106,
+          "uncached_input_tokens": 69,
+          "input_cost_usd": 0.001034
+        },
+        {
+          "session_id": "kosha-policy-06",
+          "repository": "Mathews-Tom/Kosha",
+          "resolved": true,
+          "cacheable_tokens": 159,
+          "cache_read_tokens": 53,
+          "cache_write_tokens": 106,
+          "uncached_input_tokens": 58,
+          "input_cost_usd": 0.000979
+        },
+        {
+          "session_id": "searchat-store-07",
+          "repository": "Mathews-Tom/searchat",
+          "resolved": true,
+          "cacheable_tokens": 168,
+          "cache_read_tokens": 56,
+          "cache_write_tokens": 112,
+          "uncached_input_tokens": 70,
+          "input_cost_usd": 0.001078
+        },
+        {
+          "session_id": "searchat-api-08",
+          "repository": "Mathews-Tom/searchat",
+          "resolved": false,
+          "cacheable_tokens": 150,
+          "cache_read_tokens": 100,
+          "cache_write_tokens": 50,
+          "uncached_input_tokens": 63,
+          "input_cost_usd": 0.0006775
+        }
+      ],
+      "cache_hit_rate": 0.3325526932084309,
+      "cache_hit_rate_interval": {
+        "point_estimate": 0.3325526932084309,
+        "low": 0.20939183987682833,
+        "high": 0.45125786163522014,
+        "resamples": 10000,
+        "seed": 20260739,
+        "confidence": 0.95
+      },
+      "input_cost_usd_per_resolved_task": 0.001368625,
+      "input_cost_usd_per_resolved_task_interval": {
+        "point_estimate": 0.001368625,
+        "low": 0.0011040625,
+        "high": 0.0018977500000000001,
+        "resamples": 10000,
+        "seed": 20260740,
+        "confidence": 0.95
+      }
+    },
+    {
+      "arm": "ann_baseline",
+      "sessions": [
+        {
+          "session_id": "archex-index-01",
+          "repository": "Mathews-Tom/archex",
+          "resolved": true,
+          "cacheable_tokens": 165,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 165,
+          "uncached_input_tokens": 65,
+          "input_cost_usd": 0.00135625
+        },
+        {
+          "session_id": "archex-query-02",
+          "repository": "Mathews-Tom/archex",
+          "resolved": true,
+          "cacheable_tokens": 162,
+          "cache_read_tokens": 54,
+          "cache_write_tokens": 108,
+          "uncached_input_tokens": 69,
+          "input_cost_usd": 0.001047
+        },
+        {
+          "session_id": "enginery-stage-03",
+          "repository": "Mathews-Tom/Enginery",
+          "resolved": true,
+          "cacheable_tokens": 165,
+          "cache_read_tokens": 55,
+          "cache_write_tokens": 110,
+          "uncached_input_tokens": 76,
+          "input_cost_usd": 0.001095
+        },
+        {
+          "session_id": "enginery-release-04",
+          "repository": "Mathews-Tom/Enginery",
+          "resolved": false,
+          "cacheable_tokens": 153,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 153,
+          "uncached_input_tokens": 61,
+          "input_cost_usd": 0.00126125
+        },
+        {
+          "session_id": "kosha-memory-05",
+          "repository": "Mathews-Tom/Kosha",
+          "resolved": true,
+          "cacheable_tokens": 159,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 159,
+          "uncached_input_tokens": 69,
+          "input_cost_usd": 0.00133875
+        },
+        {
+          "session_id": "kosha-policy-06",
+          "repository": "Mathews-Tom/Kosha",
+          "resolved": true,
+          "cacheable_tokens": 159,
+          "cache_read_tokens": 53,
+          "cache_write_tokens": 106,
+          "uncached_input_tokens": 58,
+          "input_cost_usd": 0.000979
+        },
+        {
+          "session_id": "searchat-store-07",
+          "repository": "Mathews-Tom/searchat",
+          "resolved": true,
+          "cacheable_tokens": 168,
+          "cache_read_tokens": 56,
+          "cache_write_tokens": 112,
+          "uncached_input_tokens": 70,
+          "input_cost_usd": 0.001078
+        },
+        {
+          "session_id": "searchat-api-08",
+          "repository": "Mathews-Tom/searchat",
+          "resolved": false,
+          "cacheable_tokens": 150,
+          "cache_read_tokens": 50,
+          "cache_write_tokens": 100,
+          "uncached_input_tokens": 63,
+          "input_cost_usd": 0.000965
+        }
+      ],
+      "cache_hit_rate": 0.20921155347384857,
+      "cache_hit_rate_interval": {
+        "point_estimate": 0.20921155347384857,
+        "low": 0.16589147286821707,
+        "high": 0.2916666666666667,
+        "resamples": 10000,
+        "seed": 20260749,
+        "confidence": 0.95
+      },
+      "input_cost_usd_per_resolved_task": 0.0015200416666666667,
+      "input_cost_usd_per_resolved_task_interval": {
+        "point_estimate": 0.0015200416666666667,
+        "low": 0.00118025,
+        "high": 0.002199625,
+        "resamples": 10000,
+        "seed": 20260750,
+        "confidence": 0.95
+      }
+    }
+  ],
+  "intervals": [
+    {
+      "comparator": "perturbed",
+      "point_estimate_percent": 29.969251377599175,
+      "low_percent": 23.936240284547488,
+      "high_percent": 35.15425983583357,
+      "resamples": 10000,
+      "seed": 20260729,
+      "confidence": 0.95
+    },
+    {
+      "comparator": "ann_baseline",
+      "point_estimate_percent": 36.94525917600943,
+      "low_percent": 34.37517758708871,
+      "high_percent": 39.3401821647956,
+      "resamples": 10000,
+      "seed": 20260729,
+      "confidence": 0.95
+    }
+  ]
+}

--- a/benchmarks/evidence/s7-determinism-economics.json
+++ b/benchmarks/evidence/s7-determinism-economics.json
@@ -2,18 +2,22 @@
   "evidence_version": 1,
   "spike_id": "S7",
   "preregistration": "benchmarks/preregistrations/S7-determinism-economics.md",
-  "preregistration_commit": "0c8c8483aab09c8b4d9e6c4e2f80408de7e2ed6e",
-  "source_revision": "2224d0d41c293702d6450a182899f48576252e2d",
+  "preregistration_commit": "501636abb09cbcf6edee5783305af6bcb313606a",
+  "source_revision": "3a88f6af349a0f6d64399e261b2f643d24b4f530",
+  "session_fixture": "benchmarks/determinism_economics/sessions.json",
   "session_fixture_sha256": "c01f2ba787cbb46f2dd585881d95e5ce131ae103b508816c688087d915c31cef",
-  "generated_at": "2026-07-28T21:22:54Z",
+  "measurement_command": "uv run archex benchmark determinism-economics --sessions benchmarks/determinism_economics/sessions.json --output benchmarks/evidence/s7-determinism-economics.json --preregistration-commit 501636abb09cbcf6edee5783305af6bcb313606a --pricing-retrieved-at 2026-07-28T21:53:33Z --resamples 10000 --seed 20260729",
+  "generated_at": "2026-07-28T21:53:44Z",
   "tokenizer": "cl100k_base",
   "pricing": {
     "model": "claude-opus-5",
     "base_input_usd_per_million": 5.0,
     "cache_write_multiplier": 1.25,
     "cache_read_multiplier": 0.1,
+    "minimum_cacheable_tokens": 512,
     "cache_ttl": "5m",
-    "source_url": "https://platform.claude.com/docs/en/about-claude/pricing"
+    "source_url": "https://platform.claude.com/docs/en/about-claude/pricing",
+    "retrieved_at": "2026-07-28T21:53:33Z"
   },
   "arms": [
     {
@@ -23,97 +27,177 @@
           "session_id": "archex-index-01",
           "repository": "Mathews-Tom/archex",
           "resolved": true,
-          "cacheable_tokens": 165,
-          "cache_read_tokens": 110,
-          "cache_write_tokens": 55,
-          "uncached_input_tokens": 65,
-          "input_cost_usd": 0.00072375
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 230,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\nsrc/archex/store.py: manifest records the published generation identity.\n\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\nsrc/archex/store.py: manifest records the published generation identity.\n\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\nsrc/archex/store.py: manifest records the published generation identity.\n\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\n"
+          ],
+          "prefix_sha256": [
+            "1095aca56d4a86ee01eccb0d3c9028ad23f9b150ad7efe25279b2fda4d65f249",
+            "1095aca56d4a86ee01eccb0d3c9028ad23f9b150ad7efe25279b2fda4d65f249",
+            "1095aca56d4a86ee01eccb0d3c9028ad23f9b150ad7efe25279b2fda4d65f249"
+          ],
+          "input_cost_usd": 0.00115
         },
         {
           "session_id": "archex-query-02",
           "repository": "Mathews-Tom/archex",
           "resolved": true,
-          "cacheable_tokens": 162,
-          "cache_read_tokens": 108,
-          "cache_write_tokens": 54,
-          "uncached_input_tokens": 69,
-          "input_cost_usd": 0.0007365
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 231,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\n"
+          ],
+          "prefix_sha256": [
+            "e9c8ceda3c8d23dec9f17a18a352baa1c2df93a191e57f8d5c516cfb2c44989e",
+            "e9c8ceda3c8d23dec9f17a18a352baa1c2df93a191e57f8d5c516cfb2c44989e",
+            "e9c8ceda3c8d23dec9f17a18a352baa1c2df93a191e57f8d5c516cfb2c44989e"
+          ],
+          "input_cost_usd": 0.001155
         },
         {
           "session_id": "enginery-stage-03",
           "repository": "Mathews-Tom/Enginery",
           "resolved": true,
-          "cacheable_tokens": 165,
-          "cache_read_tokens": 110,
-          "cache_write_tokens": 55,
-          "uncached_input_tokens": 76,
-          "input_cost_usd": 0.00077875
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 241,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\n"
+          ],
+          "prefix_sha256": [
+            "42a9f6f398a2f5ba1dc822624c6e610e603221cd23234a01d004952e78fa0e6e",
+            "42a9f6f398a2f5ba1dc822624c6e610e603221cd23234a01d004952e78fa0e6e",
+            "42a9f6f398a2f5ba1dc822624c6e610e603221cd23234a01d004952e78fa0e6e"
+          ],
+          "input_cost_usd": 0.001205
         },
         {
           "session_id": "enginery-release-04",
           "repository": "Mathews-Tom/Enginery",
           "resolved": false,
-          "cacheable_tokens": 153,
-          "cache_read_tokens": 102,
-          "cache_write_tokens": 51,
-          "uncached_input_tokens": 61,
-          "input_cost_usd": 0.00067475
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 214,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/release.py: publish records each destination receipt.\n\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\ntests/test_release.py: missing receipt fails the run loudly.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/release.py: publish records each destination receipt.\n\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\ntests/test_release.py: missing receipt fails the run loudly.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/release.py: publish records each destination receipt.\n\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\ntests/test_release.py: missing receipt fails the run loudly.\n\n"
+          ],
+          "prefix_sha256": [
+            "dec277eb466837cb4a4039be40fa0683a7683fd225f6c3542b8759fea9a21ac6",
+            "dec277eb466837cb4a4039be40fa0683a7683fd225f6c3542b8759fea9a21ac6",
+            "dec277eb466837cb4a4039be40fa0683a7683fd225f6c3542b8759fea9a21ac6"
+          ],
+          "input_cost_usd": 0.00107
         },
         {
           "session_id": "kosha-memory-05",
           "repository": "Mathews-Tom/Kosha",
           "resolved": true,
-          "cacheable_tokens": 159,
-          "cache_read_tokens": 106,
-          "cache_write_tokens": 53,
-          "uncached_input_tokens": 69,
-          "input_cost_usd": 0.00072925
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 228,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\nsrc/kosha/store.py: preserve the canonical facet identity.\n\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\nsrc/kosha/store.py: preserve the canonical facet identity.\n\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\nsrc/kosha/store.py: preserve the canonical facet identity.\n\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\n"
+          ],
+          "prefix_sha256": [
+            "379127018f44576ae17ef1bb23d51e3ccc3e9b1ef56319204946ba33d816a57e",
+            "379127018f44576ae17ef1bb23d51e3ccc3e9b1ef56319204946ba33d816a57e",
+            "379127018f44576ae17ef1bb23d51e3ccc3e9b1ef56319204946ba33d816a57e"
+          ],
+          "input_cost_usd": 0.00114
         },
         {
           "session_id": "kosha-policy-06",
           "repository": "Mathews-Tom/Kosha",
           "resolved": true,
-          "cacheable_tokens": 159,
-          "cache_read_tokens": 106,
-          "cache_write_tokens": 53,
-          "uncached_input_tokens": 58,
-          "input_cost_usd": 0.00067425
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 217,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/policy.py: apply retention rules before writing a facet.\n\nsrc/kosha/vault.py: soft deletion retains audit provenance.\n\ntests/test_policy.py: expired content is unavailable to recall.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/policy.py: apply retention rules before writing a facet.\n\nsrc/kosha/vault.py: soft deletion retains audit provenance.\n\ntests/test_policy.py: expired content is unavailable to recall.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/policy.py: apply retention rules before writing a facet.\n\nsrc/kosha/vault.py: soft deletion retains audit provenance.\n\ntests/test_policy.py: expired content is unavailable to recall.\n\n"
+          ],
+          "prefix_sha256": [
+            "683266a4b5bc8f2cd7b0911fcc0fba8e4437c0431bf7bd9aacfeacff6400a53e",
+            "683266a4b5bc8f2cd7b0911fcc0fba8e4437c0431bf7bd9aacfeacff6400a53e",
+            "683266a4b5bc8f2cd7b0911fcc0fba8e4437c0431bf7bd9aacfeacff6400a53e"
+          ],
+          "input_cost_usd": 0.001085
         },
         {
           "session_id": "searchat-store-07",
           "repository": "Mathews-Tom/searchat",
           "resolved": true,
-          "cacheable_tokens": 168,
-          "cache_read_tokens": 112,
-          "cache_write_tokens": 56,
-          "uncached_input_tokens": 70,
-          "input_cost_usd": 0.000756
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 238,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/storage.py: copy live records into a compact DuckDB database.\n\nsrc/searchat/doctor.py: report live blocks separately from file size.\n\ntests/test_compact.py: verify replacement only after the compact copy succeeds.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/storage.py: copy live records into a compact DuckDB database.\n\nsrc/searchat/doctor.py: report live blocks separately from file size.\n\ntests/test_compact.py: verify replacement only after the compact copy succeeds.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/storage.py: copy live records into a compact DuckDB database.\n\nsrc/searchat/doctor.py: report live blocks separately from file size.\n\ntests/test_compact.py: verify replacement only after the compact copy succeeds.\n\n"
+          ],
+          "prefix_sha256": [
+            "5ad9dfcecb306cabf67525fb83112bbeb9e46d44a55744a8314c51855576a082",
+            "5ad9dfcecb306cabf67525fb83112bbeb9e46d44a55744a8314c51855576a082",
+            "5ad9dfcecb306cabf67525fb83112bbeb9e46d44a55744a8314c51855576a082"
+          ],
+          "input_cost_usd": 0.00119
         },
         {
           "session_id": "searchat-api-08",
           "repository": "Mathews-Tom/searchat",
           "resolved": false,
-          "cacheable_tokens": 150,
-          "cache_read_tokens": 100,
-          "cache_write_tokens": 50,
-          "uncached_input_tokens": 63,
-          "input_cost_usd": 0.0006775
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 213,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/api.py: diagnostics endpoint opens a read-only database connection.\n\nsrc/searchat/dashboard.py: render report-only disk measurements.\n\ntests/test_api.py: mutable maintenance actions are absent from diagnostics.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/api.py: diagnostics endpoint opens a read-only database connection.\n\nsrc/searchat/dashboard.py: render report-only disk measurements.\n\ntests/test_api.py: mutable maintenance actions are absent from diagnostics.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/api.py: diagnostics endpoint opens a read-only database connection.\n\nsrc/searchat/dashboard.py: render report-only disk measurements.\n\ntests/test_api.py: mutable maintenance actions are absent from diagnostics.\n\n"
+          ],
+          "prefix_sha256": [
+            "6d11c7f616a966815a2c9fd8ecb8be1541f9d21d731678f0afd093b6a151a6cc",
+            "6d11c7f616a966815a2c9fd8ecb8be1541f9d21d731678f0afd093b6a151a6cc",
+            "6d11c7f616a966815a2c9fd8ecb8be1541f9d21d731678f0afd093b6a151a6cc"
+          ],
+          "input_cost_usd": 0.001065
         }
       ],
-      "cache_hit_rate": 0.6666666666666666,
+      "cache_hit_rate": 0.0,
       "cache_hit_rate_interval": {
-        "point_estimate": 0.6666666666666666,
-        "low": 0.6666666666666666,
-        "high": 0.6666666666666666,
+        "point_estimate": 0.0,
+        "low": 0.0,
+        "high": 0.0,
         "resamples": 10000,
         "seed": 20260729,
         "confidence": 0.95
       },
-      "input_cost_usd_per_resolved_task": 0.0009584583333333333,
+      "input_cost_usd_per_resolved_task": 0.0015099999999999998,
       "input_cost_usd_per_resolved_task_interval": {
-        "point_estimate": 0.0009584583333333333,
-        "low": 0.0007159375,
-        "high": 0.0014435000000000001,
+        "point_estimate": 0.0015099999999999998,
+        "low": 0.0011324999999999998,
+        "high": 0.002265,
         "resamples": 10000,
         "seed": 20260730,
         "confidence": 0.95
@@ -126,97 +210,177 @@
           "session_id": "archex-index-01",
           "repository": "Mathews-Tom/archex",
           "resolved": true,
-          "cacheable_tokens": 165,
+          "cacheable_tokens": 0,
           "cache_read_tokens": 0,
-          "cache_write_tokens": 165,
-          "uncached_input_tokens": 65,
-          "input_cost_usd": 0.00135625
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 230,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/store.py: manifest records the published generation identity.\n\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\nsrc/archex/store.py: manifest records the published generation identity.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\nsrc/archex/store.py: manifest records the published generation identity.\n\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\n"
+          ],
+          "prefix_sha256": [
+            "77faef4df09f925cb7cb74c922ee814678f3c15e5b3182eac6dd691e45aab653",
+            "db7eeaa927843b29402e371e12c80dc6872243ba3aad0323632421335319286e",
+            "1095aca56d4a86ee01eccb0d3c9028ad23f9b150ad7efe25279b2fda4d65f249"
+          ],
+          "input_cost_usd": 0.00115
         },
         {
           "session_id": "archex-query-02",
           "repository": "Mathews-Tom/archex",
           "resolved": true,
-          "cacheable_tokens": 162,
-          "cache_read_tokens": 54,
-          "cache_write_tokens": 108,
-          "uncached_input_tokens": 69,
-          "input_cost_usd": 0.001047
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 231,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\n"
+          ],
+          "prefix_sha256": [
+            "b8d16d6041eb8739e07b0a4f917d6e0ee641e0f74c933165c38c0aff505ff023",
+            "e9c8ceda3c8d23dec9f17a18a352baa1c2df93a191e57f8d5c516cfb2c44989e",
+            "b8d16d6041eb8739e07b0a4f917d6e0ee641e0f74c933165c38c0aff505ff023"
+          ],
+          "input_cost_usd": 0.001155
         },
         {
           "session_id": "enginery-stage-03",
           "repository": "Mathews-Tom/Enginery",
           "resolved": true,
-          "cacheable_tokens": 165,
-          "cache_read_tokens": 110,
-          "cache_write_tokens": 55,
-          "uncached_input_tokens": 76,
-          "input_cost_usd": 0.00077875
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 241,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\n"
+          ],
+          "prefix_sha256": [
+            "42a9f6f398a2f5ba1dc822624c6e610e603221cd23234a01d004952e78fa0e6e",
+            "42a9f6f398a2f5ba1dc822624c6e610e603221cd23234a01d004952e78fa0e6e",
+            "42a9f6f398a2f5ba1dc822624c6e610e603221cd23234a01d004952e78fa0e6e"
+          ],
+          "input_cost_usd": 0.001205
         },
         {
           "session_id": "enginery-release-04",
           "repository": "Mathews-Tom/Enginery",
           "resolved": false,
-          "cacheable_tokens": 153,
+          "cacheable_tokens": 0,
           "cache_read_tokens": 0,
-          "cache_write_tokens": 153,
-          "uncached_input_tokens": 61,
-          "input_cost_usd": 0.00126125
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 214,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/release.py: publish records each destination receipt.\n\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\ntests/test_release.py: missing receipt fails the run loudly.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_release.py: missing receipt fails the run loudly.\n\nsrc/enginery/release.py: publish records each destination receipt.\n\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\ntests/test_release.py: missing receipt fails the run loudly.\n\nsrc/enginery/release.py: publish records each destination receipt.\n\n"
+          ],
+          "prefix_sha256": [
+            "dec277eb466837cb4a4039be40fa0683a7683fd225f6c3542b8759fea9a21ac6",
+            "7f33e43c270174ca36be13b18a652a7871bfdbf71e87cc8852c0d4247437f6f9",
+            "df1021312bc166a46a59086d101b90cce6cb3addf1afd773503d59942ebcd7df"
+          ],
+          "input_cost_usd": 0.00107
         },
         {
           "session_id": "kosha-memory-05",
           "repository": "Mathews-Tom/Kosha",
           "resolved": true,
-          "cacheable_tokens": 159,
-          "cache_read_tokens": 53,
-          "cache_write_tokens": 106,
-          "uncached_input_tokens": 69,
-          "input_cost_usd": 0.001034
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 228,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\nsrc/kosha/store.py: preserve the canonical facet identity.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\nsrc/kosha/store.py: preserve the canonical facet identity.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/store.py: preserve the canonical facet identity.\n\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\n"
+          ],
+          "prefix_sha256": [
+            "fa9be6d6db78606b4723b68d089788d2b695a41336a1ccdd8dee1b810e54fe04",
+            "fa9be6d6db78606b4723b68d089788d2b695a41336a1ccdd8dee1b810e54fe04",
+            "518474f431c349b6d6bb7c5ef8c95517988a874041100f16db0eafd9f47de986"
+          ],
+          "input_cost_usd": 0.00114
         },
         {
           "session_id": "kosha-policy-06",
           "repository": "Mathews-Tom/Kosha",
           "resolved": true,
-          "cacheable_tokens": 159,
-          "cache_read_tokens": 53,
-          "cache_write_tokens": 106,
-          "uncached_input_tokens": 58,
-          "input_cost_usd": 0.000979
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 217,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/vault.py: soft deletion retains audit provenance.\n\ntests/test_policy.py: expired content is unavailable to recall.\n\nsrc/kosha/policy.py: apply retention rules before writing a facet.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_policy.py: expired content is unavailable to recall.\n\nsrc/kosha/policy.py: apply retention rules before writing a facet.\n\nsrc/kosha/vault.py: soft deletion retains audit provenance.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/vault.py: soft deletion retains audit provenance.\n\ntests/test_policy.py: expired content is unavailable to recall.\n\nsrc/kosha/policy.py: apply retention rules before writing a facet.\n\n"
+          ],
+          "prefix_sha256": [
+            "1e362e136d5b9c19ac93fa7d99e0e6904d6e729051355cfcabf36143d52e90a1",
+            "a5fd8047ac7afbc344474658aa3915a31eb9690ebe601fa22922b89bada8807e",
+            "1e362e136d5b9c19ac93fa7d99e0e6904d6e729051355cfcabf36143d52e90a1"
+          ],
+          "input_cost_usd": 0.001085
         },
         {
           "session_id": "searchat-store-07",
           "repository": "Mathews-Tom/searchat",
           "resolved": true,
-          "cacheable_tokens": 168,
-          "cache_read_tokens": 56,
-          "cache_write_tokens": 112,
-          "uncached_input_tokens": 70,
-          "input_cost_usd": 0.001078
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 238,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/storage.py: copy live records into a compact DuckDB database.\n\nsrc/searchat/doctor.py: report live blocks separately from file size.\n\ntests/test_compact.py: verify replacement only after the compact copy succeeds.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/storage.py: copy live records into a compact DuckDB database.\n\nsrc/searchat/doctor.py: report live blocks separately from file size.\n\ntests/test_compact.py: verify replacement only after the compact copy succeeds.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_compact.py: verify replacement only after the compact copy succeeds.\n\nsrc/searchat/storage.py: copy live records into a compact DuckDB database.\n\nsrc/searchat/doctor.py: report live blocks separately from file size.\n\n"
+          ],
+          "prefix_sha256": [
+            "5ad9dfcecb306cabf67525fb83112bbeb9e46d44a55744a8314c51855576a082",
+            "5ad9dfcecb306cabf67525fb83112bbeb9e46d44a55744a8314c51855576a082",
+            "169b303c94367cc316a585ae65b8f80b613adc5b950ea6f58f29a74dbee8eef5"
+          ],
+          "input_cost_usd": 0.00119
         },
         {
           "session_id": "searchat-api-08",
           "repository": "Mathews-Tom/searchat",
           "resolved": false,
-          "cacheable_tokens": 150,
-          "cache_read_tokens": 100,
-          "cache_write_tokens": 50,
-          "uncached_input_tokens": 63,
-          "input_cost_usd": 0.0006775
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 213,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/dashboard.py: render report-only disk measurements.\n\ntests/test_api.py: mutable maintenance actions are absent from diagnostics.\n\nsrc/searchat/api.py: diagnostics endpoint opens a read-only database connection.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/dashboard.py: render report-only disk measurements.\n\ntests/test_api.py: mutable maintenance actions are absent from diagnostics.\n\nsrc/searchat/api.py: diagnostics endpoint opens a read-only database connection.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/dashboard.py: render report-only disk measurements.\n\ntests/test_api.py: mutable maintenance actions are absent from diagnostics.\n\nsrc/searchat/api.py: diagnostics endpoint opens a read-only database connection.\n\n"
+          ],
+          "prefix_sha256": [
+            "f8043978a0765f8e7d14c50a782325df69b38a1af67d87fc58afc3444577955d",
+            "f8043978a0765f8e7d14c50a782325df69b38a1af67d87fc58afc3444577955d",
+            "f8043978a0765f8e7d14c50a782325df69b38a1af67d87fc58afc3444577955d"
+          ],
+          "input_cost_usd": 0.001065
         }
       ],
-      "cache_hit_rate": 0.3325526932084309,
+      "cache_hit_rate": 0.0,
       "cache_hit_rate_interval": {
-        "point_estimate": 0.3325526932084309,
-        "low": 0.20939183987682833,
-        "high": 0.45125786163522014,
+        "point_estimate": 0.0,
+        "low": 0.0,
+        "high": 0.0,
         "resamples": 10000,
         "seed": 20260739,
         "confidence": 0.95
       },
-      "input_cost_usd_per_resolved_task": 0.001368625,
+      "input_cost_usd_per_resolved_task": 0.0015099999999999998,
       "input_cost_usd_per_resolved_task_interval": {
-        "point_estimate": 0.001368625,
-        "low": 0.0011040625,
-        "high": 0.0018977500000000001,
+        "point_estimate": 0.0015099999999999998,
+        "low": 0.0011324999999999998,
+        "high": 0.002265,
         "resamples": 10000,
         "seed": 20260740,
         "confidence": 0.95
@@ -229,97 +393,177 @@
           "session_id": "archex-index-01",
           "repository": "Mathews-Tom/archex",
           "resolved": true,
-          "cacheable_tokens": 165,
+          "cacheable_tokens": 0,
           "cache_read_tokens": 0,
-          "cache_write_tokens": 165,
-          "uncached_input_tokens": 65,
-          "input_cost_usd": 0.00135625
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 230,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/store.py: manifest records the published generation identity.\n\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\nsrc/archex/store.py: manifest records the published generation identity.\n\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\nsrc/archex/store.py: manifest records the published generation identity.\n\n"
+          ],
+          "prefix_sha256": [
+            "8d6ed7c73b7e79b56729afd0a800255573a4409bdc0db4e97bb65d58cead6174",
+            "1095aca56d4a86ee01eccb0d3c9028ad23f9b150ad7efe25279b2fda4d65f249",
+            "db7eeaa927843b29402e371e12c80dc6872243ba3aad0323632421335319286e"
+          ],
+          "input_cost_usd": 0.00115
         },
         {
           "session_id": "archex-query-02",
           "repository": "Mathews-Tom/archex",
           "resolved": true,
-          "cacheable_tokens": 162,
-          "cache_read_tokens": 54,
-          "cache_write_tokens": 108,
-          "uncached_input_tokens": 69,
-          "input_cost_usd": 0.001047
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 231,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\n"
+          ],
+          "prefix_sha256": [
+            "e9c8ceda3c8d23dec9f17a18a352baa1c2df93a191e57f8d5c516cfb2c44989e",
+            "739d40029873d69bee1c0a2f497594f869f931ebe4b8513b0a10d6b004ec3905",
+            "e9c8ceda3c8d23dec9f17a18a352baa1c2df93a191e57f8d5c516cfb2c44989e"
+          ],
+          "input_cost_usd": 0.001155
         },
         {
           "session_id": "enginery-stage-03",
           "repository": "Mathews-Tom/Enginery",
           "resolved": true,
-          "cacheable_tokens": 165,
-          "cache_read_tokens": 55,
-          "cache_write_tokens": 110,
-          "uncached_input_tokens": 76,
-          "input_cost_usd": 0.001095
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 241,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_stage.py: a cancelled run cannot advance.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\n"
+          ],
+          "prefix_sha256": [
+            "b291c8139e207057f78e4b74316593628cf57692d8395b4fed136a8ff4f4d6aa",
+            "42a9f6f398a2f5ba1dc822624c6e610e603221cd23234a01d004952e78fa0e6e",
+            "42a9f6f398a2f5ba1dc822624c6e610e603221cd23234a01d004952e78fa0e6e"
+          ],
+          "input_cost_usd": 0.001205
         },
         {
           "session_id": "enginery-release-04",
           "repository": "Mathews-Tom/Enginery",
           "resolved": false,
-          "cacheable_tokens": 153,
+          "cacheable_tokens": 0,
           "cache_read_tokens": 0,
-          "cache_write_tokens": 153,
-          "uncached_input_tokens": 61,
-          "input_cost_usd": 0.00126125
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 214,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_release.py: missing receipt fails the run loudly.\n\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\nsrc/enginery/release.py: publish records each destination receipt.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/release.py: publish records each destination receipt.\n\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\ntests/test_release.py: missing receipt fails the run loudly.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/release.py: publish records each destination receipt.\n\ntests/test_release.py: missing receipt fails the run loudly.\n\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\n"
+          ],
+          "prefix_sha256": [
+            "4da7831109e31aa3a88d484ff9b629d0a4a65845b2e5152b404878f887911656",
+            "dec277eb466837cb4a4039be40fa0683a7683fd225f6c3542b8759fea9a21ac6",
+            "95e98f18df8ecfcacd4ebd3a7712e2d626d1ca78afb1b53d776de82b09ed393a"
+          ],
+          "input_cost_usd": 0.00107
         },
         {
           "session_id": "kosha-memory-05",
           "repository": "Mathews-Tom/Kosha",
           "resolved": true,
-          "cacheable_tokens": 159,
+          "cacheable_tokens": 0,
           "cache_read_tokens": 0,
-          "cache_write_tokens": 159,
-          "uncached_input_tokens": 69,
-          "input_cost_usd": 0.00133875
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 228,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\nsrc/kosha/store.py: preserve the canonical facet identity.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\nsrc/kosha/store.py: preserve the canonical facet identity.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\nsrc/kosha/store.py: preserve the canonical facet identity.\n\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\n"
+          ],
+          "prefix_sha256": [
+            "fa9be6d6db78606b4723b68d089788d2b695a41336a1ccdd8dee1b810e54fe04",
+            "abca92b5f336a4c80e3b42f6749ad27b5d1ac471b566b35baa7080254d79a4ab",
+            "379127018f44576ae17ef1bb23d51e3ccc3e9b1ef56319204946ba33d816a57e"
+          ],
+          "input_cost_usd": 0.00114
         },
         {
           "session_id": "kosha-policy-06",
           "repository": "Mathews-Tom/Kosha",
           "resolved": true,
-          "cacheable_tokens": 159,
-          "cache_read_tokens": 53,
-          "cache_write_tokens": 106,
-          "uncached_input_tokens": 58,
-          "input_cost_usd": 0.000979
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 217,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/vault.py: soft deletion retains audit provenance.\n\ntests/test_policy.py: expired content is unavailable to recall.\n\nsrc/kosha/policy.py: apply retention rules before writing a facet.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/vault.py: soft deletion retains audit provenance.\n\ntests/test_policy.py: expired content is unavailable to recall.\n\nsrc/kosha/policy.py: apply retention rules before writing a facet.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_policy.py: expired content is unavailable to recall.\n\nsrc/kosha/policy.py: apply retention rules before writing a facet.\n\nsrc/kosha/vault.py: soft deletion retains audit provenance.\n\n"
+          ],
+          "prefix_sha256": [
+            "1e362e136d5b9c19ac93fa7d99e0e6904d6e729051355cfcabf36143d52e90a1",
+            "1e362e136d5b9c19ac93fa7d99e0e6904d6e729051355cfcabf36143d52e90a1",
+            "a5fd8047ac7afbc344474658aa3915a31eb9690ebe601fa22922b89bada8807e"
+          ],
+          "input_cost_usd": 0.001085
         },
         {
           "session_id": "searchat-store-07",
           "repository": "Mathews-Tom/searchat",
           "resolved": true,
-          "cacheable_tokens": 168,
-          "cache_read_tokens": 56,
-          "cache_write_tokens": 112,
-          "uncached_input_tokens": 70,
-          "input_cost_usd": 0.001078
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 238,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_compact.py: verify replacement only after the compact copy succeeds.\n\nsrc/searchat/doctor.py: report live blocks separately from file size.\n\nsrc/searchat/storage.py: copy live records into a compact DuckDB database.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/doctor.py: report live blocks separately from file size.\n\nsrc/searchat/storage.py: copy live records into a compact DuckDB database.\n\ntests/test_compact.py: verify replacement only after the compact copy succeeds.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/doctor.py: report live blocks separately from file size.\n\nsrc/searchat/storage.py: copy live records into a compact DuckDB database.\n\ntests/test_compact.py: verify replacement only after the compact copy succeeds.\n\n"
+          ],
+          "prefix_sha256": [
+            "da21529e55a8a704ad22bd69a94055d22f5f98f2c842eb7e1ee69ce1f60d02d9",
+            "9ccec3330b5f3de41e1af54de7513dac28baea23cdbbabcb6f488468271c218b",
+            "9ccec3330b5f3de41e1af54de7513dac28baea23cdbbabcb6f488468271c218b"
+          ],
+          "input_cost_usd": 0.00119
         },
         {
           "session_id": "searchat-api-08",
           "repository": "Mathews-Tom/searchat",
           "resolved": false,
-          "cacheable_tokens": 150,
-          "cache_read_tokens": 50,
-          "cache_write_tokens": 100,
-          "uncached_input_tokens": 63,
-          "input_cost_usd": 0.000965
+          "cacheable_tokens": 0,
+          "cache_read_tokens": 0,
+          "cache_write_tokens": 0,
+          "uncached_input_tokens": 213,
+          "rendered_prefixes": [
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/api.py: diagnostics endpoint opens a read-only database connection.\n\ntests/test_api.py: mutable maintenance actions are absent from diagnostics.\n\nsrc/searchat/dashboard.py: render report-only disk measurements.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_api.py: mutable maintenance actions are absent from diagnostics.\n\nsrc/searchat/api.py: diagnostics endpoint opens a read-only database connection.\n\nsrc/searchat/dashboard.py: render report-only disk measurements.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_api.py: mutable maintenance actions are absent from diagnostics.\n\nsrc/searchat/api.py: diagnostics endpoint opens a read-only database connection.\n\nsrc/searchat/dashboard.py: render report-only disk measurements.\n\n"
+          ],
+          "prefix_sha256": [
+            "c273599ae5a47f745b409f4fb6dc63196e1ef83f123b555e1ebc81c770a7cc4c",
+            "e6d2144bfc0f0c263dc2435e82643536cbc62d55609b83cd3b736323597e5bd9",
+            "e6d2144bfc0f0c263dc2435e82643536cbc62d55609b83cd3b736323597e5bd9"
+          ],
+          "input_cost_usd": 0.001065
         }
       ],
-      "cache_hit_rate": 0.20921155347384857,
+      "cache_hit_rate": 0.0,
       "cache_hit_rate_interval": {
-        "point_estimate": 0.20921155347384857,
-        "low": 0.16589147286821707,
-        "high": 0.2916666666666667,
+        "point_estimate": 0.0,
+        "low": 0.0,
+        "high": 0.0,
         "resamples": 10000,
         "seed": 20260749,
         "confidence": 0.95
       },
-      "input_cost_usd_per_resolved_task": 0.0015200416666666667,
+      "input_cost_usd_per_resolved_task": 0.0015099999999999998,
       "input_cost_usd_per_resolved_task_interval": {
-        "point_estimate": 0.0015200416666666667,
-        "low": 0.00118025,
-        "high": 0.002199625,
+        "point_estimate": 0.0015099999999999998,
+        "low": 0.0011324999999999998,
+        "high": 0.002265,
         "resamples": 10000,
         "seed": 20260750,
         "confidence": 0.95
@@ -329,18 +573,18 @@
   "intervals": [
     {
       "comparator": "perturbed",
-      "point_estimate_percent": 29.969251377599175,
-      "low_percent": 23.936240284547488,
-      "high_percent": 35.15425983583357,
+      "point_estimate_percent": 0.0,
+      "low_percent": 0.0,
+      "high_percent": 0.0,
       "resamples": 10000,
       "seed": 20260729,
       "confidence": 0.95
     },
     {
       "comparator": "ann_baseline",
-      "point_estimate_percent": 36.94525917600943,
-      "low_percent": 34.37517758708871,
-      "high_percent": 39.3401821647956,
+      "point_estimate_percent": 0.0,
+      "low_percent": 0.0,
+      "high_percent": 0.0,
       "resamples": 10000,
       "seed": 20260729,
       "confidence": 0.95

--- a/benchmarks/evidence/s7-determinism-economics.json
+++ b/benchmarks/evidence/s7-determinism-economics.json
@@ -2,12 +2,12 @@
   "evidence_version": 1,
   "spike_id": "S7",
   "preregistration": "benchmarks/preregistrations/S7-determinism-economics.md",
-  "preregistration_commit": "0c8c8483aab09cb8d49de6c4e2f8048e1f020ed6",
-  "source_revision": "b73ba365be43bf73ad566e96161bb8e045faa843",
+  "preregistration_commit": "501636abb09cbcf6edee5783305af6bcb313606a",
+  "source_revision": "f1f1671873189c881bf29fe945547a0fb7e8af8c",
   "session_fixture": "benchmarks/determinism_economics/sessions.json",
   "session_fixture_sha256": "c01f2ba787cbb46f2dd585881d95e5ce131ae103b508816c688087d915c31cef",
-  "measurement_command": "uv run archex benchmark determinism-economics --sessions benchmarks/determinism_economics/sessions.json --output benchmarks/evidence/s7-determinism-economics.json --preregistration-commit 0c8c8483aab09cb8d49de6c4e2f8048e1f020ed6 --pricing-retrieved-at 2026-07-28T22:05:00Z --resamples 10000 --seed 20260729",
-  "generated_at": "2026-07-28T22:05:01Z",
+  "measurement_command": "uv run archex benchmark determinism-economics --sessions benchmarks/determinism_economics/sessions.json --output benchmarks/evidence/s7-determinism-economics.json --preregistration-commit 501636abb09cbcf6edee5783305af6bcb313606a --pricing-retrieved-at 2026-07-28T22:19:00Z --resamples 10000 --seed 20260729",
+  "generated_at": "2026-07-28T22:19:01Z",
   "tokenizer": "cl100k_base",
   "pricing": {
     "model": "claude-opus-5",
@@ -17,7 +17,7 @@
     "minimum_cacheable_tokens": 512,
     "cache_ttl": "5m",
     "source_url": "https://platform.claude.com/docs/en/about-claude/pricing",
-    "retrieved_at": "2026-07-28T22:05:00Z"
+    "retrieved_at": "2026-07-28T22:19:00Z"
   },
   "arms": [
     {
@@ -215,14 +215,14 @@
           "cache_write_tokens": 0,
           "uncached_input_tokens": 230,
           "rendered_prefixes": [
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/store.py: manifest records the published generation identity.\n\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\n",
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\nsrc/archex/store.py: manifest records the published generation identity.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\nsrc/archex/store.py: manifest records the published generation identity.\n\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\n"
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/store.py: manifest records the published generation identity.\n\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\nsrc/archex/store.py: manifest records the published generation identity.\n\n"
           ],
           "prefix_sha256": [
-            "77faef4df09f925cb7cb74c922ee814678f3c15e5b3182eac6dd691e45aab653",
             "db7eeaa927843b29402e371e12c80dc6872243ba3aad0323632421335319286e",
-            "1095aca56d4a86ee01eccb0d3c9028ad23f9b150ad7efe25279b2fda4d65f249"
+            "77faef4df09f925cb7cb74c922ee814678f3c15e5b3182eac6dd691e45aab653",
+            "db7eeaa927843b29402e371e12c80dc6872243ba3aad0323632421335319286e"
           ],
           "input_cost_usd": 0.00115
         },
@@ -235,13 +235,13 @@
           "cache_write_tokens": 0,
           "uncached_input_tokens": 231,
           "rendered_prefixes": [
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/context.py: pack chunks within the requested token budget.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/context.py: pack chunks within the requested token budget.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\n",
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\n"
           ],
           "prefix_sha256": [
-            "b8d16d6041eb8739e07b0a4f917d6e0ee641e0f74c933165c38c0aff505ff023",
-            "e9c8ceda3c8d23dec9f17a18a352baa1c2df93a191e57f8d5c516cfb2c44989e",
+            "d45da64c7c388ae1505f345c32cc2c5efab4540f158cc0333d92014fba75bc96",
+            "d45da64c7c388ae1505f345c32cc2c5efab4540f158cc0333d92014fba75bc96",
             "b8d16d6041eb8739e07b0a4f917d6e0ee641e0f74c933165c38c0aff505ff023"
           ],
           "input_cost_usd": 0.001155
@@ -255,14 +255,14 @@
           "cache_write_tokens": 0,
           "uncached_input_tokens": 241,
           "rendered_prefixes": [
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\n"
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_stage.py: a cancelled run cannot advance.\n\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\n"
           ],
           "prefix_sha256": [
-            "42a9f6f398a2f5ba1dc822624c6e610e603221cd23234a01d004952e78fa0e6e",
-            "42a9f6f398a2f5ba1dc822624c6e610e603221cd23234a01d004952e78fa0e6e",
-            "42a9f6f398a2f5ba1dc822624c6e610e603221cd23234a01d004952e78fa0e6e"
+            "a933cd1fc9adc16bd8deccb1fad36086ebf0051c70018c231e550a4e8216577c",
+            "dc165128d2c6fab35693c1eeb819b7580a6df9839a6861172de42b8dd37a39b2",
+            "a933cd1fc9adc16bd8deccb1fad36086ebf0051c70018c231e550a4e8216577c"
           ],
           "input_cost_usd": 0.001205
         },
@@ -275,14 +275,14 @@
           "cache_write_tokens": 0,
           "uncached_input_tokens": 214,
           "rendered_prefixes": [
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/release.py: publish records each destination receipt.\n\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\ntests/test_release.py: missing receipt fails the run loudly.\n\n",
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_release.py: missing receipt fails the run loudly.\n\nsrc/enginery/release.py: publish records each destination receipt.\n\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\ntests/test_release.py: missing receipt fails the run loudly.\n\nsrc/enginery/release.py: publish records each destination receipt.\n\n"
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\ntests/test_release.py: missing receipt fails the run loudly.\n\nsrc/enginery/release.py: publish records each destination receipt.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_release.py: missing receipt fails the run loudly.\n\nsrc/enginery/release.py: publish records each destination receipt.\n\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\n"
           ],
           "prefix_sha256": [
-            "dec277eb466837cb4a4039be40fa0683a7683fd225f6c3542b8759fea9a21ac6",
             "7f33e43c270174ca36be13b18a652a7871bfdbf71e87cc8852c0d4247437f6f9",
-            "df1021312bc166a46a59086d101b90cce6cb3addf1afd773503d59942ebcd7df"
+            "df1021312bc166a46a59086d101b90cce6cb3addf1afd773503d59942ebcd7df",
+            "7f33e43c270174ca36be13b18a652a7871bfdbf71e87cc8852c0d4247437f6f9"
           ],
           "input_cost_usd": 0.00107
         },
@@ -295,14 +295,14 @@
           "cache_write_tokens": 0,
           "uncached_input_tokens": 228,
           "rendered_prefixes": [
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\nsrc/kosha/store.py: preserve the canonical facet identity.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\nsrc/kosha/store.py: preserve the canonical facet identity.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/store.py: preserve the canonical facet identity.\n\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\n"
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/store.py: preserve the canonical facet identity.\n\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/store.py: preserve the canonical facet identity.\n\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\nsrc/kosha/store.py: preserve the canonical facet identity.\n\n"
           ],
           "prefix_sha256": [
-            "fa9be6d6db78606b4723b68d089788d2b695a41336a1ccdd8dee1b810e54fe04",
-            "fa9be6d6db78606b4723b68d089788d2b695a41336a1ccdd8dee1b810e54fe04",
-            "518474f431c349b6d6bb7c5ef8c95517988a874041100f16db0eafd9f47de986"
+            "518474f431c349b6d6bb7c5ef8c95517988a874041100f16db0eafd9f47de986",
+            "518474f431c349b6d6bb7c5ef8c95517988a874041100f16db0eafd9f47de986",
+            "fa9be6d6db78606b4723b68d089788d2b695a41336a1ccdd8dee1b810e54fe04"
           ],
           "input_cost_usd": 0.00114
         },
@@ -315,14 +315,14 @@
           "cache_write_tokens": 0,
           "uncached_input_tokens": 217,
           "rendered_prefixes": [
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/vault.py: soft deletion retains audit provenance.\n\ntests/test_policy.py: expired content is unavailable to recall.\n\nsrc/kosha/policy.py: apply retention rules before writing a facet.\n\n",
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_policy.py: expired content is unavailable to recall.\n\nsrc/kosha/policy.py: apply retention rules before writing a facet.\n\nsrc/kosha/vault.py: soft deletion retains audit provenance.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/vault.py: soft deletion retains audit provenance.\n\ntests/test_policy.py: expired content is unavailable to recall.\n\nsrc/kosha/policy.py: apply retention rules before writing a facet.\n\n"
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_policy.py: expired content is unavailable to recall.\n\nsrc/kosha/policy.py: apply retention rules before writing a facet.\n\nsrc/kosha/vault.py: soft deletion retains audit provenance.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_policy.py: expired content is unavailable to recall.\n\nsrc/kosha/policy.py: apply retention rules before writing a facet.\n\nsrc/kosha/vault.py: soft deletion retains audit provenance.\n\n"
           ],
           "prefix_sha256": [
-            "1e362e136d5b9c19ac93fa7d99e0e6904d6e729051355cfcabf36143d52e90a1",
             "a5fd8047ac7afbc344474658aa3915a31eb9690ebe601fa22922b89bada8807e",
-            "1e362e136d5b9c19ac93fa7d99e0e6904d6e729051355cfcabf36143d52e90a1"
+            "a5fd8047ac7afbc344474658aa3915a31eb9690ebe601fa22922b89bada8807e",
+            "a5fd8047ac7afbc344474658aa3915a31eb9690ebe601fa22922b89bada8807e"
           ],
           "input_cost_usd": 0.001085
         },
@@ -335,13 +335,13 @@
           "cache_write_tokens": 0,
           "uncached_input_tokens": 238,
           "rendered_prefixes": [
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/storage.py: copy live records into a compact DuckDB database.\n\nsrc/searchat/doctor.py: report live blocks separately from file size.\n\ntests/test_compact.py: verify replacement only after the compact copy succeeds.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/storage.py: copy live records into a compact DuckDB database.\n\nsrc/searchat/doctor.py: report live blocks separately from file size.\n\ntests/test_compact.py: verify replacement only after the compact copy succeeds.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/doctor.py: report live blocks separately from file size.\n\ntests/test_compact.py: verify replacement only after the compact copy succeeds.\n\nsrc/searchat/storage.py: copy live records into a compact DuckDB database.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/doctor.py: report live blocks separately from file size.\n\ntests/test_compact.py: verify replacement only after the compact copy succeeds.\n\nsrc/searchat/storage.py: copy live records into a compact DuckDB database.\n\n",
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_compact.py: verify replacement only after the compact copy succeeds.\n\nsrc/searchat/storage.py: copy live records into a compact DuckDB database.\n\nsrc/searchat/doctor.py: report live blocks separately from file size.\n\n"
           ],
           "prefix_sha256": [
-            "5ad9dfcecb306cabf67525fb83112bbeb9e46d44a55744a8314c51855576a082",
-            "5ad9dfcecb306cabf67525fb83112bbeb9e46d44a55744a8314c51855576a082",
+            "3e6595a666a5670561373badf79ef7340b1a3834b17f578a00a6ead700c0ca94",
+            "3e6595a666a5670561373badf79ef7340b1a3834b17f578a00a6ead700c0ca94",
             "169b303c94367cc316a585ae65b8f80b613adc5b950ea6f58f29a74dbee8eef5"
           ],
           "input_cost_usd": 0.00119
@@ -356,12 +356,12 @@
           "uncached_input_tokens": 213,
           "rendered_prefixes": [
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/dashboard.py: render report-only disk measurements.\n\ntests/test_api.py: mutable maintenance actions are absent from diagnostics.\n\nsrc/searchat/api.py: diagnostics endpoint opens a read-only database connection.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/dashboard.py: render report-only disk measurements.\n\ntests/test_api.py: mutable maintenance actions are absent from diagnostics.\n\nsrc/searchat/api.py: diagnostics endpoint opens a read-only database connection.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_api.py: mutable maintenance actions are absent from diagnostics.\n\nsrc/searchat/api.py: diagnostics endpoint opens a read-only database connection.\n\nsrc/searchat/dashboard.py: render report-only disk measurements.\n\n",
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/searchat/dashboard.py: render report-only disk measurements.\n\ntests/test_api.py: mutable maintenance actions are absent from diagnostics.\n\nsrc/searchat/api.py: diagnostics endpoint opens a read-only database connection.\n\n"
           ],
           "prefix_sha256": [
             "f8043978a0765f8e7d14c50a782325df69b38a1af67d87fc58afc3444577955d",
-            "f8043978a0765f8e7d14c50a782325df69b38a1af67d87fc58afc3444577955d",
+            "e6d2144bfc0f0c263dc2435e82643536cbc62d55609b83cd3b736323597e5bd9",
             "f8043978a0765f8e7d14c50a782325df69b38a1af67d87fc58afc3444577955d"
           ],
           "input_cost_usd": 0.001065
@@ -399,12 +399,12 @@
           "uncached_input_tokens": 230,
           "rendered_prefixes": [
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/store.py: manifest records the published generation identity.\n\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\nsrc/archex/store.py: manifest records the published generation identity.\n\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/store.py: manifest records the published generation identity.\n\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\n",
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_indexer.py: interrupted generation leaves the previous manifest readable.\n\nsrc/archex/indexer.py: publish a staging generation only after every store is complete.\n\nsrc/archex/store.py: manifest records the published generation identity.\n\n"
           ],
           "prefix_sha256": [
             "8d6ed7c73b7e79b56729afd0a800255573a4409bdc0db4e97bb65d58cead6174",
-            "1095aca56d4a86ee01eccb0d3c9028ad23f9b150ad7efe25279b2fda4d65f249",
+            "77faef4df09f925cb7cb74c922ee814678f3c15e5b3182eac6dd691e45aab653",
             "db7eeaa927843b29402e371e12c80dc6872243ba3aad0323632421335319286e"
           ],
           "input_cost_usd": 0.00115
@@ -418,14 +418,14 @@
           "cache_write_tokens": 0,
           "uncached_input_tokens": 231,
           "rendered_prefixes": [
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/context.py: pack chunks within the requested token budget.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\n",
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\nsrc/archex/context.py: pack chunks within the requested token budget.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\n"
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/archex/context.py: pack chunks within the requested token budget.\n\nsrc/archex/reporting.py: attach token metadata to the returned response.\n\nsrc/archex/query.py: score lexical and graph candidates before context packing.\n\n"
           ],
           "prefix_sha256": [
-            "e9c8ceda3c8d23dec9f17a18a352baa1c2df93a191e57f8d5c516cfb2c44989e",
+            "d45da64c7c388ae1505f345c32cc2c5efab4540f158cc0333d92014fba75bc96",
             "739d40029873d69bee1c0a2f497594f869f931ebe4b8513b0a10d6b004ec3905",
-            "e9c8ceda3c8d23dec9f17a18a352baa1c2df93a191e57f8d5c516cfb2c44989e"
+            "d45da64c7c388ae1505f345c32cc2c5efab4540f158cc0333d92014fba75bc96"
           ],
           "input_cost_usd": 0.001155
         },
@@ -439,13 +439,13 @@
           "uncached_input_tokens": 241,
           "rendered_prefixes": [
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_stage.py: a cancelled run cannot advance.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\n"
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/policy.py: merge policy records an explicit human-review decision.\n\ntests/test_stage.py: a cancelled run cannot advance.\n\nsrc/enginery/stage.py: inspect state before dispatching the next transition.\n\n"
           ],
           "prefix_sha256": [
             "b291c8139e207057f78e4b74316593628cf57692d8395b4fed136a8ff4f4d6aa",
-            "42a9f6f398a2f5ba1dc822624c6e610e603221cd23234a01d004952e78fa0e6e",
-            "42a9f6f398a2f5ba1dc822624c6e610e603221cd23234a01d004952e78fa0e6e"
+            "a933cd1fc9adc16bd8deccb1fad36086ebf0051c70018c231e550a4e8216577c",
+            "a933cd1fc9adc16bd8deccb1fad36086ebf0051c70018c231e550a4e8216577c"
           ],
           "input_cost_usd": 0.001205
         },
@@ -459,12 +459,12 @@
           "uncached_input_tokens": 214,
           "rendered_prefixes": [
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_release.py: missing receipt fails the run loudly.\n\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\nsrc/enginery/release.py: publish records each destination receipt.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/release.py: publish records each destination receipt.\n\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\ntests/test_release.py: missing receipt fails the run loudly.\n\n",
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\ntests/test_release.py: missing receipt fails the run loudly.\n\nsrc/enginery/release.py: publish records each destination receipt.\n\n",
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/enginery/release.py: publish records each destination receipt.\n\ntests/test_release.py: missing receipt fails the run loudly.\n\nsrc/enginery/verify.py: verify package installation from the published artifact.\n\n"
           ],
           "prefix_sha256": [
             "4da7831109e31aa3a88d484ff9b629d0a4a65845b2e5152b404878f887911656",
-            "dec277eb466837cb4a4039be40fa0683a7683fd225f6c3542b8759fea9a21ac6",
+            "df1021312bc166a46a59086d101b90cce6cb3addf1afd773503d59942ebcd7df",
             "95e98f18df8ecfcacd4ebd3a7712e2d626d1ca78afb1b53d776de82b09ed393a"
           ],
           "input_cost_usd": 0.00107
@@ -480,12 +480,12 @@
           "rendered_prefixes": [
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\nsrc/kosha/store.py: preserve the canonical facet identity.\n\n",
             "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\nsrc/kosha/store.py: preserve the canonical facet identity.\n\n",
-            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\nsrc/kosha/store.py: preserve the canonical facet identity.\n\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\n"
+            "SYSTEM\nUse the selected code context.\n\nCONTEXT\nsrc/kosha/store.py: preserve the canonical facet identity.\n\ntests/test_routing.py: duplicate requests reuse the recorded facet.\n\nsrc/kosha/routing.py: route a request through the deduplication threshold.\n\n"
           ],
           "prefix_sha256": [
             "fa9be6d6db78606b4723b68d089788d2b695a41336a1ccdd8dee1b810e54fe04",
             "abca92b5f336a4c80e3b42f6749ad27b5d1ac471b566b35baa7080254d79a4ab",
-            "379127018f44576ae17ef1bb23d51e3ccc3e9b1ef56319204946ba33d816a57e"
+            "518474f431c349b6d6bb7c5ef8c95517988a874041100f16db0eafd9f47de986"
           ],
           "input_cost_usd": 0.00114
         },

--- a/benchmarks/preregistrations/S7-determinism-economics.md
+++ b/benchmarks/preregistrations/S7-determinism-economics.md
@@ -67,4 +67,4 @@ uv run archex benchmark validate --kind determinism-economics --input benchmarks
 
 ## Post-hoc changes
 
-None. Any later change records its timestamp, reason, affected field, and why the affected analysis is exploratory.
+- **2026-07-28T21:53:33Z — cache eligibility and evidence-command correction.** The original pre-registration omitted Claude Opus 5's 512-token minimum cacheable prefix and named command surfaces that were not implemented. The implemented run records that eligibility floor, canonical prefixes and hashes, pricing retrieval timestamp, exact command, and a `determinism-economics` validator kind. The frozen arms, session fixture, pricing multipliers, TTL, SESOI, and kill criterion remain unchanged. This completed run is exploratory with respect to the corrected cache ledger because the eligibility correction occurred after the first data-generating run; its null result retires the economic framing rather than supporting a positive economic claim.

--- a/benchmarks/preregistrations/S7-determinism-economics.md
+++ b/benchmarks/preregistrations/S7-determinism-economics.md
@@ -68,3 +68,5 @@ uv run archex benchmark validate --kind determinism-economics --input benchmarks
 ## Post-hoc changes
 
 - **2026-07-28T21:53:33Z — cache eligibility and evidence-command correction.** The original pre-registration omitted Claude Opus 5's 512-token minimum cacheable prefix and named command surfaces that were not implemented. The implemented run records that eligibility floor, canonical prefixes and hashes, pricing retrieval timestamp, exact command, and a `determinism-economics` validator kind. The frozen arms, session fixture, pricing multipliers, TTL, SESOI, and kill criterion remain unchanged. This completed run is exploratory with respect to the corrected cache ledger because the eligibility correction occurred after the first data-generating run; its null result retires the economic framing rather than supporting a positive economic claim.
+
+  The command at lines 58–60 is superseded. Use the exact command in the evidence artifact and `benchmarks/evidence/s7-determinism-economics-DECISION.md` for reproduction.

--- a/src/archex/benchmark/determinism_economics.py
+++ b/src/archex/benchmark/determinism_economics.py
@@ -566,4 +566,19 @@ def validate_determinism_economics_artifact(path: Path) -> DeterminismEconomicsA
         raise DeterminismEconomicsError(
             f"determinism-economics fixture digest does not match {artifact.session_fixture}"
         )
+    expected = measure_economics(
+        sessions,
+        preregistration_commit=artifact.preregistration_commit,
+        source_revision=artifact.source_revision,
+        generated_at=artifact.generated_at,
+        session_fixture=artifact.session_fixture,
+        measurement_command=artifact.measurement_command,
+        resamples=artifact.arms[0].cache_hit_rate_interval.resamples,
+        seed=artifact.arms[0].cache_hit_rate_interval.seed,
+        pricing=artifact.pricing,
+    )
+    if expected.model_dump(mode="json") != artifact.model_dump(mode="json"):
+        raise DeterminismEconomicsError(
+            "determinism-economics artifact does not reproduce from its fixture"
+        )
     return artifact

--- a/src/archex/benchmark/determinism_economics.py
+++ b/src/archex/benchmark/determinism_economics.py
@@ -74,8 +74,10 @@ class PricingSchedule(_Model):
     base_input_usd_per_million: float = BASE_INPUT_USD_PER_MILLION
     cache_write_multiplier: float = CACHE_WRITE_MULTIPLIER
     cache_read_multiplier: float = CACHE_READ_MULTIPLIER
+    minimum_cacheable_tokens: Literal[512] = 512
     cache_ttl: Literal["5m"] = "5m"
     source_url: str = "https://platform.claude.com/docs/en/about-claude/pricing"
+    retrieved_at: str = Field(min_length=1)
 
     @model_validator(mode="after")
     def _published_multipliers(self) -> PricingSchedule:
@@ -94,16 +96,23 @@ class SessionLedger(_Model):
     session_id: str = Field(min_length=1)
     repository: str = Field(min_length=1)
     resolved: bool
-    cacheable_tokens: int = Field(ge=1)
+    cacheable_tokens: int = Field(ge=0)
     cache_read_tokens: int = Field(ge=0)
     cache_write_tokens: int = Field(ge=0)
     uncached_input_tokens: int = Field(ge=0)
+    rendered_prefixes: list[str] = Field(min_length=1)
+    prefix_sha256: list[str] = Field(min_length=1)
     input_cost_usd: float = Field(ge=0.0)
 
     @model_validator(mode="after")
     def _accounting_is_coherent(self) -> SessionLedger:
         if self.cache_read_tokens + self.cache_write_tokens != self.cacheable_tokens:
             raise ValueError("cacheable tokens must equal cache reads plus writes")
+        if len(self.rendered_prefixes) != len(self.prefix_sha256):
+            raise ValueError("each rendered prefix must have one SHA-256 identity")
+        for prefix, digest in zip(self.rendered_prefixes, self.prefix_sha256, strict=True):
+            if hashlib.sha256(prefix.encode()).hexdigest() != digest:
+                raise ValueError("prefix SHA-256 does not match its rendered prefix")
         return self
 
 
@@ -113,12 +122,14 @@ class MetricInterval(_Model):
     point_estimate: float
     low: float
     high: float
-    resamples: int = Field(ge=1)
+    resamples: int = Field(ge=20)
     seed: int
-    confidence: float = Field(gt=0.0, lt=1.0)
+    confidence: float = BOOTSTRAP_CONFIDENCE
 
     @model_validator(mode="after")
     def _ordered(self) -> MetricInterval:
+        if self.confidence != BOOTSTRAP_CONFIDENCE:
+            raise ValueError("R6 intervals use the fixed 95% confidence level")
         if self.low > self.high:
             raise ValueError("bootstrap interval low must not exceed high")
         if not self.low <= self.point_estimate <= self.high:
@@ -147,7 +158,8 @@ class ArmEvidence(_Model):
         resolved = sum(ledger.resolved for ledger in self.sessions)
         if resolved == 0:
             raise ValueError(f"arm {self.arm.value!r} has no resolved sessions")
-        if abs(self.cache_hit_rate - reads / cacheable) > 1e-12:
+        expected_hit_rate = reads / cacheable if cacheable else 0.0
+        if abs(self.cache_hit_rate - expected_hit_rate) > 1e-12:
             raise ValueError(f"arm {self.arm.value!r} cache hit rate does not match its ledgers")
         expected_cost = sum(ledger.input_cost_usd for ledger in self.sessions) / resolved
         if abs(self.input_cost_usd_per_resolved_task - expected_cost) > 1e-12:
@@ -174,12 +186,14 @@ class BootstrapInterval(_Model):
     point_estimate_percent: float
     low_percent: float
     high_percent: float
-    resamples: int = Field(ge=1)
+    resamples: int = Field(ge=20)
     seed: int
-    confidence: float = Field(gt=0.0, lt=1.0)
+    confidence: float = BOOTSTRAP_CONFIDENCE
 
     @model_validator(mode="after")
     def _ordered(self) -> BootstrapInterval:
+        if self.confidence != BOOTSTRAP_CONFIDENCE:
+            raise ValueError("R6 intervals use the fixed 95% confidence level")
         if self.low_percent > self.high_percent:
             raise ValueError("bootstrap interval low must not exceed high")
         if not self.low_percent <= self.point_estimate_percent <= self.high_percent:
@@ -195,7 +209,9 @@ class DeterminismEconomicsArtifact(_Model):
     preregistration: Literal["benchmarks/preregistrations/S7-determinism-economics.md"]
     preregistration_commit: str = Field(pattern=r"^[0-9a-f]{40}$")
     source_revision: str = Field(pattern=r"^[0-9a-f]{40}$")
+    session_fixture: str = Field(min_length=1)
     session_fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    measurement_command: str = Field(min_length=1)
     generated_at: str = Field(min_length=1)
     tokenizer: Literal["cl100k_base"] = "cl100k_base"
     pricing: PricingSchedule
@@ -221,6 +237,21 @@ class DeterminismEconomicsArtifact(_Model):
         expected_comparators = {OrderingArm.PERTURBED, OrderingArm.ANN_BASELINE}
         if comparators != expected_comparators or len(self.intervals) != len(expected_comparators):
             raise ValueError("R6 intervals must cover perturbed and ann_baseline exactly once")
+        for values in ledgers.values():
+            for ledger in values:
+                expected_cost = _cost_usd(
+                    reads=ledger.cache_read_tokens,
+                    writes=ledger.cache_write_tokens,
+                    uncached=ledger.uncached_input_tokens,
+                    pricing=self.pricing,
+                )
+                if abs(ledger.input_cost_usd - expected_cost) > 1e-12:
+                    raise ValueError("ledger cost does not match pricing and token accounting")
+        interval_by_comparator = {interval.comparator: interval for interval in self.intervals}
+        for comparator, interval in interval_by_comparator.items():
+            point = _relative_reduction(control, ledgers[comparator])
+            if abs(interval.point_estimate_percent - point) > 1e-12:
+                raise ValueError("comparison interval does not match its ledgers")
         return self
 
 
@@ -293,12 +324,16 @@ def _measure_session(
     reads = 0
     writes = 0
     uncached = 0
+    rendered_prefixes: list[str] = []
     history: list[str] = []
     for index, turn in enumerate(session.turns):
         contexts = _order_contexts(turn.contexts, arm, session.session_id, index)
         prefix = _cache_prefix(contexts)
+        rendered_prefixes.append(prefix)
         tokens = count_tokens(prefix)
-        if prefix in cached_prefixes:
+        if tokens < pricing.minimum_cacheable_tokens:
+            uncached += tokens
+        elif prefix in cached_prefixes:
             reads += tokens
         else:
             writes += tokens
@@ -314,6 +349,8 @@ def _measure_session(
         cache_read_tokens=reads,
         cache_write_tokens=writes,
         uncached_input_tokens=uncached,
+        rendered_prefixes=rendered_prefixes,
+        prefix_sha256=[hashlib.sha256(prefix.encode()).hexdigest() for prefix in rendered_prefixes],
         input_cost_usd=_cost_usd(
             reads=reads,
             writes=writes,
@@ -324,9 +361,10 @@ def _measure_session(
 
 
 def _cache_hit_rate(ledgers: Sequence[SessionLedger]) -> float:
-    return sum(ledger.cache_read_tokens for ledger in ledgers) / sum(
-        ledger.cacheable_tokens for ledger in ledgers
-    )
+    cacheable = sum(ledger.cacheable_tokens for ledger in ledgers)
+    if cacheable == 0:
+        return 0.0
+    return sum(ledger.cache_read_tokens for ledger in ledgers) / cacheable
 
 
 def _cost_per_resolved_task(ledgers: Sequence[SessionLedger]) -> float:
@@ -430,8 +468,6 @@ def _bootstrap(
     resamples: int,
     seed: int,
 ) -> BootstrapInterval:
-    if resamples < 1:
-        raise DeterminismEconomicsError("bootstrap resamples must be positive")
     control_by_repo: dict[str, list[SessionLedger]] = {}
     comparator_by_repo: dict[str, list[SessionLedger]] = {}
     for ledger in control:
@@ -453,16 +489,13 @@ def _bootstrap(
         samples.append(_relative_reduction(sampled_control, sampled_comparator))
     samples.sort()
     tail = (1.0 - BOOTSTRAP_CONFIDENCE) / 2.0
-    low = samples[int(tail * len(samples))]
-    high = samples[max(0, int((1.0 - tail) * len(samples)) - 1)]
     return BootstrapInterval(
         comparator=comparator_arm,
         point_estimate_percent=point,
-        low_percent=low,
-        high_percent=high,
+        low_percent=samples[int(tail * len(samples))],
+        high_percent=samples[max(0, int((1.0 - tail) * len(samples)) - 1)],
         resamples=resamples,
         seed=seed,
-        confidence=BOOTSTRAP_CONFIDENCE,
     )
 
 
@@ -472,12 +505,16 @@ def measure_economics(
     preregistration_commit: str,
     source_revision: str,
     generated_at: str,
+    session_fixture: str,
+    measurement_command: str,
     resamples: int = 10_000,
     seed: int = 20_260_729,
     pricing: PricingSchedule | None = None,
 ) -> DeterminismEconomicsArtifact:
     """Measure all three frozen arms over exactly the same session fixture."""
-    active_pricing = pricing or PricingSchedule()
+    if resamples < 20:
+        raise DeterminismEconomicsError("R6 requires at least 20 bootstrap resamples")
+    active_pricing = pricing or PricingSchedule(retrieved_at=generated_at)
     arms = [
         _summarize(arm, sessions, active_pricing, resamples=resamples, seed=seed + index * 10)
         for index, arm in enumerate(OrderingArm)
@@ -498,7 +535,9 @@ def measure_economics(
         preregistration="benchmarks/preregistrations/S7-determinism-economics.md",
         preregistration_commit=preregistration_commit,
         source_revision=source_revision,
+        session_fixture=session_fixture,
         session_fixture_sha256=fixture_digest(sessions),
+        measurement_command=measurement_command,
         generated_at=generated_at,
         pricing=active_pricing,
         arms=arms,
@@ -517,8 +556,14 @@ def validate_determinism_economics_artifact(path: Path) -> DeterminismEconomicsA
             f"cannot read determinism-economics artifact {path}: {exc}"
         ) from exc
     try:
-        return DeterminismEconomicsArtifact.model_validate(payload)
-    except ValidationError as exc:
+        artifact = DeterminismEconomicsArtifact.model_validate(payload)
+        sessions = load_sessions(Path(artifact.session_fixture))
+    except (DeterminismEconomicsError, ValidationError) as exc:
         raise DeterminismEconomicsError(
             f"determinism-economics artifact failed validation: {path}: {exc}"
         ) from exc
+    if fixture_digest(sessions) != artifact.session_fixture_sha256:
+        raise DeterminismEconomicsError(
+            f"determinism-economics fixture digest does not match {artifact.session_fixture}"
+        )
+    return artifact

--- a/src/archex/benchmark/determinism_economics.py
+++ b/src/archex/benchmark/determinism_economics.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import hashlib
 import json
 import random
+import subprocess
 from collections.abc import Iterable, Sequence
 from enum import StrEnum
 from pathlib import Path
@@ -30,6 +31,28 @@ BOOTSTRAP_CONFIDENCE = 0.95
 
 class DeterminismEconomicsError(ValueError):
     """Raised when deterministic-economics evidence is incomplete or incoherent."""
+
+
+def validate_preregistration_commit(
+    repository: Path, preregistration_commit: str, source_revision: str
+) -> None:
+    """Require a pre-registration commit to exist before the measured source."""
+    commands = (
+        ("cat-file", "-e", f"{preregistration_commit}^{{commit}}"),
+        ("merge-base", "--is-ancestor", preregistration_commit, source_revision),
+    )
+    for command in commands:
+        result = subprocess.run(
+            ("git", *command),
+            cwd=repository,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise DeterminismEconomicsError(
+                "S7 pre-registration commit must exist and precede the measured source revision"
+            )
 
 
 class OrderingArm(StrEnum):
@@ -249,7 +272,7 @@ class DeterminismEconomicsArtifact(_Model):
                     raise ValueError("ledger cost does not match pricing and token accounting")
         interval_by_comparator = {interval.comparator: interval for interval in self.intervals}
         for comparator, interval in interval_by_comparator.items():
-            point = _relative_reduction(control, ledgers[comparator])
+            point = relative_cost_reduction(control, ledgers[comparator])
             if abs(interval.point_estimate_percent - point) > 1e-12:
                 raise ValueError("comparison interval does not match its ledgers")
         return self
@@ -294,9 +317,11 @@ def _order_contexts(
     seed_material = f"{arm.value}:{session_id}:{turn_index}".encode()
     seed = int.from_bytes(hashlib.sha256(seed_material).digest()[:8], "big")
     if arm is OrderingArm.PERTURBED:
-        offset = seed % len(ordered)
+        offset = 1 + seed % (len(ordered) - 1)
         return ordered[offset:] + ordered[:offset]
     random.Random(seed).shuffle(ordered)
+    if ordered == list(contexts):
+        return ordered[1:] + ordered[:1]
     return ordered
 
 
@@ -437,24 +462,28 @@ def _summarize(
     )
 
 
-def _relative_reduction(
+def relative_cost_reduction(
     control: Iterable[SessionLedger],
     comparator: Iterable[SessionLedger],
 ) -> float:
-    control_by_id = {ledger.session_id: ledger for ledger in control}
-    comparator_by_id = {ledger.session_id: ledger for ledger in comparator}
-    if set(control_by_id) != set(comparator_by_id):
+    control_ledgers = list(control)
+    comparator_ledgers = list(comparator)
+    if len(control_ledgers) != len(comparator_ledgers):
         raise DeterminismEconomicsError("arms do not cover identical session IDs")
-    ids = sorted(control_by_id)
-    resolved = sum(control_by_id[session_id].resolved for session_id in ids)
+    for control_ledger, comparator_ledger in zip(control_ledgers, comparator_ledgers, strict=True):
+        if (
+            control_ledger.session_id != comparator_ledger.session_id
+            or control_ledger.repository != comparator_ledger.repository
+            or control_ledger.resolved != comparator_ledger.resolved
+        ):
+            raise DeterminismEconomicsError("arms do not cover identical session IDs")
+    resolved = sum(ledger.resolved for ledger in control_ledgers)
     if resolved == 0:
         raise DeterminismEconomicsError(
             "cannot calculate cost per resolved task without resolved sessions"
         )
-    control_cost = sum(control_by_id[session_id].input_cost_usd for session_id in ids) / resolved
-    comparator_cost = (
-        sum(comparator_by_id[session_id].input_cost_usd for session_id in ids) / resolved
-    )
+    control_cost = sum(ledger.input_cost_usd for ledger in control_ledgers) / resolved
+    comparator_cost = sum(ledger.input_cost_usd for ledger in comparator_ledgers) / resolved
     if comparator_cost <= 0.0:
         raise DeterminismEconomicsError("comparator cost must be positive")
     return (comparator_cost - control_cost) / comparator_cost * 100.0
@@ -479,14 +508,14 @@ def _bootstrap(
     repositories = sorted(control_by_repo)
     if len(repositories) < 2:
         raise DeterminismEconomicsError("R6 cluster bootstrap requires at least two repositories")
-    point = _relative_reduction(control, comparator)
+    point = relative_cost_reduction(control, comparator)
     rng = random.Random(seed)
     samples: list[float] = []
     for _ in range(resamples):
         drawn = [rng.choice(repositories) for _ in repositories]
         sampled_control = [ledger for repo in drawn for ledger in control_by_repo[repo]]
         sampled_comparator = [ledger for repo in drawn for ledger in comparator_by_repo[repo]]
-        samples.append(_relative_reduction(sampled_control, sampled_comparator))
+        samples.append(relative_cost_reduction(sampled_control, sampled_comparator))
     samples.sort()
     tail = (1.0 - BOOTSTRAP_CONFIDENCE) / 2.0
     return BootstrapInterval(
@@ -558,25 +587,28 @@ def validate_determinism_economics_artifact(path: Path) -> DeterminismEconomicsA
     try:
         artifact = DeterminismEconomicsArtifact.model_validate(payload)
         sessions = load_sessions(Path(artifact.session_fixture))
+        validate_preregistration_commit(
+            Path.cwd(), artifact.preregistration_commit, artifact.source_revision
+        )
+        if fixture_digest(sessions) != artifact.session_fixture_sha256:
+            raise DeterminismEconomicsError(
+                f"determinism-economics fixture digest does not match {artifact.session_fixture}"
+            )
+        expected = measure_economics(
+            sessions,
+            preregistration_commit=artifact.preregistration_commit,
+            source_revision=artifact.source_revision,
+            generated_at=artifact.generated_at,
+            session_fixture=artifact.session_fixture,
+            measurement_command=artifact.measurement_command,
+            resamples=artifact.arms[0].cache_hit_rate_interval.resamples,
+            seed=artifact.arms[0].cache_hit_rate_interval.seed,
+            pricing=artifact.pricing,
+        )
     except (DeterminismEconomicsError, ValidationError) as exc:
         raise DeterminismEconomicsError(
             f"determinism-economics artifact failed validation: {path}: {exc}"
         ) from exc
-    if fixture_digest(sessions) != artifact.session_fixture_sha256:
-        raise DeterminismEconomicsError(
-            f"determinism-economics fixture digest does not match {artifact.session_fixture}"
-        )
-    expected = measure_economics(
-        sessions,
-        preregistration_commit=artifact.preregistration_commit,
-        source_revision=artifact.source_revision,
-        generated_at=artifact.generated_at,
-        session_fixture=artifact.session_fixture,
-        measurement_command=artifact.measurement_command,
-        resamples=artifact.arms[0].cache_hit_rate_interval.resamples,
-        seed=artifact.arms[0].cache_hit_rate_interval.seed,
-        pricing=artifact.pricing,
-    )
     if expected.model_dump(mode="json") != artifact.model_dump(mode="json"):
         raise DeterminismEconomicsError(
             "determinism-economics artifact does not reproduce from its fixture"

--- a/src/archex/benchmark/determinism_economics.py
+++ b/src/archex/benchmark/determinism_economics.py
@@ -1,0 +1,524 @@
+"""Measure prompt-prefix cache economics without changing retrieval ordering.
+
+The harness models the input-side cache ledger from byte-identical rendered
+prefixes. It does not call a hosted model, score retrieval quality, or alter
+archex's retrieval path. A seeded comparator is reproducible for evidence while
+representing the per-turn ordering instability that an ANN implementation can
+expose in production.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from collections.abc import Iterable, Sequence
+from enum import StrEnum
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from archex.reporting import count_tokens
+
+EVIDENCE_VERSION = 1
+CACHE_WRITE_MULTIPLIER = 1.25
+CACHE_READ_MULTIPLIER = 0.1
+BASE_INPUT_USD_PER_MILLION = 5.0
+BOOTSTRAP_CONFIDENCE = 0.95
+
+
+class DeterminismEconomicsError(ValueError):
+    """Raised when deterministic-economics evidence is incomplete or incoherent."""
+
+
+class OrderingArm(StrEnum):
+    """The fixed, pre-registered ordering arms."""
+
+    DETERMINISTIC = "deterministic"
+    PERTURBED = "perturbed"
+    ANN_BASELINE = "ann_baseline"
+
+
+class _Model(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class SessionTurn(_Model):
+    """One user turn and its selected code-context candidates."""
+
+    question: str = Field(min_length=1)
+    contexts: list[str] = Field(min_length=2)
+
+    @model_validator(mode="after")
+    def _distinct_contexts(self) -> SessionTurn:
+        if len(self.contexts) != len(set(self.contexts)):
+            msg = "a turn must not repeat a context candidate"
+            raise ValueError(msg)
+        return self
+
+
+class SessionFixture(_Model):
+    """A repeated coding session belonging to one repository cluster."""
+
+    session_id: str = Field(min_length=1)
+    repository: str = Field(min_length=1)
+    resolved: bool
+    turns: list[SessionTurn] = Field(min_length=2)
+
+
+class PricingSchedule(_Model):
+    """Published first-party input pricing used for the offline cost ledger."""
+
+    model: str = "claude-opus-5"
+    base_input_usd_per_million: float = BASE_INPUT_USD_PER_MILLION
+    cache_write_multiplier: float = CACHE_WRITE_MULTIPLIER
+    cache_read_multiplier: float = CACHE_READ_MULTIPLIER
+    cache_ttl: Literal["5m"] = "5m"
+    source_url: str = "https://platform.claude.com/docs/en/about-claude/pricing"
+
+    @model_validator(mode="after")
+    def _published_multipliers(self) -> PricingSchedule:
+        if self.base_input_usd_per_million <= 0.0:
+            raise ValueError("base input price must be positive")
+        if self.cache_write_multiplier != CACHE_WRITE_MULTIPLIER:
+            raise ValueError("R6 uses the published five-minute 1.25x cache-write multiplier")
+        if self.cache_read_multiplier != CACHE_READ_MULTIPLIER:
+            raise ValueError("R6 uses the published 0.1x cache-read multiplier")
+        return self
+
+
+class SessionLedger(_Model):
+    """Measured cache accounting for one arm/session pair."""
+
+    session_id: str = Field(min_length=1)
+    repository: str = Field(min_length=1)
+    resolved: bool
+    cacheable_tokens: int = Field(ge=1)
+    cache_read_tokens: int = Field(ge=0)
+    cache_write_tokens: int = Field(ge=0)
+    uncached_input_tokens: int = Field(ge=0)
+    input_cost_usd: float = Field(ge=0.0)
+
+    @model_validator(mode="after")
+    def _accounting_is_coherent(self) -> SessionLedger:
+        if self.cache_read_tokens + self.cache_write_tokens != self.cacheable_tokens:
+            raise ValueError("cacheable tokens must equal cache reads plus writes")
+        return self
+
+
+class MetricInterval(_Model):
+    """A repository-clustered percentile interval for one arm-level metric."""
+
+    point_estimate: float
+    low: float
+    high: float
+    resamples: int = Field(ge=1)
+    seed: int
+    confidence: float = Field(gt=0.0, lt=1.0)
+
+    @model_validator(mode="after")
+    def _ordered(self) -> MetricInterval:
+        if self.low > self.high:
+            raise ValueError("bootstrap interval low must not exceed high")
+        if not self.low <= self.point_estimate <= self.high:
+            raise ValueError("point estimate must lie inside its bootstrap interval")
+        return self
+
+
+class ArmEvidence(_Model):
+    """All per-session ledgers and pooled economics for one ordering arm."""
+
+    arm: OrderingArm
+    sessions: list[SessionLedger] = Field(min_length=1)
+
+    cache_hit_rate: float = Field(ge=0.0, le=1.0)
+    cache_hit_rate_interval: MetricInterval
+    input_cost_usd_per_resolved_task: float = Field(ge=0.0)
+    input_cost_usd_per_resolved_task_interval: MetricInterval
+
+    @model_validator(mode="after")
+    def _summary_matches_ledgers(self) -> ArmEvidence:
+        ids = [ledger.session_id for ledger in self.sessions]
+        if len(ids) != len(set(ids)):
+            raise ValueError(f"arm {self.arm.value!r} contains duplicate sessions")
+        cacheable = sum(ledger.cacheable_tokens for ledger in self.sessions)
+        reads = sum(ledger.cache_read_tokens for ledger in self.sessions)
+        resolved = sum(ledger.resolved for ledger in self.sessions)
+        if resolved == 0:
+            raise ValueError(f"arm {self.arm.value!r} has no resolved sessions")
+        if abs(self.cache_hit_rate - reads / cacheable) > 1e-12:
+            raise ValueError(f"arm {self.arm.value!r} cache hit rate does not match its ledgers")
+        expected_cost = sum(ledger.input_cost_usd for ledger in self.sessions) / resolved
+        if abs(self.input_cost_usd_per_resolved_task - expected_cost) > 1e-12:
+            raise ValueError(
+                f"arm {self.arm.value!r} cost per resolved task does not match ledgers"
+            )
+        if abs(self.cache_hit_rate_interval.point_estimate - self.cache_hit_rate) > 1e-12:
+            raise ValueError(f"arm {self.arm.value!r} cache interval does not match its summary")
+        if (
+            abs(
+                self.input_cost_usd_per_resolved_task_interval.point_estimate
+                - self.input_cost_usd_per_resolved_task
+            )
+            > 1e-12
+        ):
+            raise ValueError(f"arm {self.arm.value!r} cost interval does not match its summary")
+        return self
+
+
+class BootstrapInterval(_Model):
+    """A repository-clustered percentile interval for one comparator."""
+
+    comparator: OrderingArm
+    point_estimate_percent: float
+    low_percent: float
+    high_percent: float
+    resamples: int = Field(ge=1)
+    seed: int
+    confidence: float = Field(gt=0.0, lt=1.0)
+
+    @model_validator(mode="after")
+    def _ordered(self) -> BootstrapInterval:
+        if self.low_percent > self.high_percent:
+            raise ValueError("bootstrap interval low must not exceed high")
+        if not self.low_percent <= self.point_estimate_percent <= self.high_percent:
+            raise ValueError("point estimate must lie inside its bootstrap interval")
+        return self
+
+
+class DeterminismEconomicsArtifact(_Model):
+    """Validated, standalone R6 evidence artifact."""
+
+    evidence_version: Literal[1] = EVIDENCE_VERSION
+    spike_id: Literal["S7"] = "S7"
+    preregistration: Literal["benchmarks/preregistrations/S7-determinism-economics.md"]
+    preregistration_commit: str = Field(pattern=r"^[0-9a-f]{40}$")
+    source_revision: str = Field(pattern=r"^[0-9a-f]{40}$")
+    session_fixture_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    generated_at: str = Field(min_length=1)
+    tokenizer: Literal["cl100k_base"] = "cl100k_base"
+    pricing: PricingSchedule
+    arms: list[ArmEvidence] = Field(min_length=3)
+    intervals: list[BootstrapInterval] = Field(min_length=2)
+
+    @model_validator(mode="after")
+    def _fixed_matrix(self) -> DeterminismEconomicsArtifact:
+        arms = {arm.arm for arm in self.arms}
+        expected = set(OrderingArm)
+        if arms != expected or len(self.arms) != len(expected):
+            raise ValueError(f"R6 arms must be exactly {[arm.value for arm in OrderingArm]}")
+        ledgers = {arm.arm: arm.sessions for arm in self.arms}
+        control = ledgers[OrderingArm.DETERMINISTIC]
+        control_ids = [ledger.session_id for ledger in control]
+        control_resolution = {ledger.session_id: ledger.resolved for ledger in control}
+        for arm, values in ledgers.items():
+            if [ledger.session_id for ledger in values] != control_ids:
+                raise ValueError(f"arm {arm.value!r} does not cover the control sessions in order")
+            if {ledger.session_id: ledger.resolved for ledger in values} != control_resolution:
+                raise ValueError(f"arm {arm.value!r} changes fixed resolution labels")
+        comparators = {interval.comparator for interval in self.intervals}
+        expected_comparators = {OrderingArm.PERTURBED, OrderingArm.ANN_BASELINE}
+        if comparators != expected_comparators or len(self.intervals) != len(expected_comparators):
+            raise ValueError("R6 intervals must cover perturbed and ann_baseline exactly once")
+        return self
+
+
+def fixture_digest(sessions: Sequence[SessionFixture]) -> str:
+    """Return a canonical digest for a session fixture."""
+    payload = [session.model_dump(mode="json") for session in sessions]
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def load_sessions(path: Path) -> list[SessionFixture]:
+    """Load a frozen session fixture and reject malformed or duplicate sessions."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DeterminismEconomicsError(f"cannot read session fixture {path}: {exc}") from exc
+    try:
+        sessions = [SessionFixture.model_validate(item) for item in raw]
+    except (TypeError, ValidationError) as exc:
+        raise DeterminismEconomicsError(f"invalid session fixture {path}: {exc}") from exc
+    if len(sessions) < 2:
+        raise DeterminismEconomicsError("R6 needs sessions from at least two repository clusters")
+    ids = [session.session_id for session in sessions]
+    if len(ids) != len(set(ids)):
+        raise DeterminismEconomicsError("session fixture contains duplicate session IDs")
+    if len({session.repository for session in sessions}) < 2:
+        raise DeterminismEconomicsError("R6 needs at least two repository clusters")
+    return sessions
+
+
+def _order_contexts(
+    contexts: Sequence[str],
+    arm: OrderingArm,
+    session_id: str,
+    turn_index: int,
+) -> list[str]:
+    ordered = list(contexts)
+    if arm is OrderingArm.DETERMINISTIC:
+        return ordered
+    seed_material = f"{arm.value}:{session_id}:{turn_index}".encode()
+    seed = int.from_bytes(hashlib.sha256(seed_material).digest()[:8], "big")
+    if arm is OrderingArm.PERTURBED:
+        offset = seed % len(ordered)
+        return ordered[offset:] + ordered[:offset]
+    random.Random(seed).shuffle(ordered)
+    return ordered
+
+
+def _cache_prefix(contexts: Sequence[str]) -> str:
+    return "SYSTEM\nUse the selected code context.\n\nCONTEXT\n" + "\n\n".join(contexts) + "\n\n"
+
+
+def _turn_suffix(question: str, history: Sequence[str]) -> str:
+    return "HISTORY\n" + "\n".join(history) + "\n\nQUESTION\n" + question
+
+
+def _cost_usd(*, reads: int, writes: int, uncached: int, pricing: PricingSchedule) -> float:
+    weighted_tokens = (
+        reads * pricing.cache_read_multiplier + writes * pricing.cache_write_multiplier + uncached
+    )
+    return weighted_tokens * pricing.base_input_usd_per_million / 1_000_000
+
+
+def _measure_session(
+    session: SessionFixture,
+    arm: OrderingArm,
+    pricing: PricingSchedule,
+) -> SessionLedger:
+    cached_prefixes: set[str] = set()
+    reads = 0
+    writes = 0
+    uncached = 0
+    history: list[str] = []
+    for index, turn in enumerate(session.turns):
+        contexts = _order_contexts(turn.contexts, arm, session.session_id, index)
+        prefix = _cache_prefix(contexts)
+        tokens = count_tokens(prefix)
+        if prefix in cached_prefixes:
+            reads += tokens
+        else:
+            writes += tokens
+            cached_prefixes.add(prefix)
+        suffix = _turn_suffix(turn.question, history)
+        uncached += count_tokens(suffix)
+        history.extend((turn.question, "assistant response"))
+    return SessionLedger(
+        session_id=session.session_id,
+        repository=session.repository,
+        resolved=session.resolved,
+        cacheable_tokens=reads + writes,
+        cache_read_tokens=reads,
+        cache_write_tokens=writes,
+        uncached_input_tokens=uncached,
+        input_cost_usd=_cost_usd(
+            reads=reads,
+            writes=writes,
+            uncached=uncached,
+            pricing=pricing,
+        ),
+    )
+
+
+def _cache_hit_rate(ledgers: Sequence[SessionLedger]) -> float:
+    return sum(ledger.cache_read_tokens for ledger in ledgers) / sum(
+        ledger.cacheable_tokens for ledger in ledgers
+    )
+
+
+def _cost_per_resolved_task(ledgers: Sequence[SessionLedger]) -> float:
+    resolved = sum(ledger.resolved for ledger in ledgers)
+    if resolved == 0:
+        raise DeterminismEconomicsError(
+            "cannot calculate cost per resolved task without resolved sessions"
+        )
+    return sum(ledger.input_cost_usd for ledger in ledgers) / resolved
+
+
+def _arm_metric_interval(
+    ledgers: Sequence[SessionLedger],
+    *,
+    metric: Literal["cache_hit_rate", "input_cost_usd_per_resolved_task"],
+    resamples: int,
+    seed: int,
+) -> MetricInterval:
+    by_repo: dict[str, list[SessionLedger]] = {}
+    for ledger in ledgers:
+        by_repo.setdefault(ledger.repository, []).append(ledger)
+    repositories = sorted(by_repo)
+    if len(repositories) < 2:
+        raise DeterminismEconomicsError("R6 cluster bootstrap requires at least two repositories")
+    measure = _cache_hit_rate if metric == "cache_hit_rate" else _cost_per_resolved_task
+    point = measure(ledgers)
+    rng = random.Random(seed)
+    samples: list[float] = []
+    for _ in range(resamples):
+        drawn = [rng.choice(repositories) for _ in repositories]
+        samples.append(measure([ledger for repo in drawn for ledger in by_repo[repo]]))
+    samples.sort()
+    tail = (1.0 - BOOTSTRAP_CONFIDENCE) / 2.0
+    return MetricInterval(
+        point_estimate=point,
+        low=samples[int(tail * len(samples))],
+        high=samples[max(0, int((1.0 - tail) * len(samples)) - 1)],
+        resamples=resamples,
+        seed=seed,
+        confidence=BOOTSTRAP_CONFIDENCE,
+    )
+
+
+def _summarize(
+    arm: OrderingArm,
+    sessions: Sequence[SessionFixture],
+    pricing: PricingSchedule,
+    *,
+    resamples: int,
+    seed: int,
+) -> ArmEvidence:
+    ledgers = [_measure_session(session, arm, pricing) for session in sessions]
+    return ArmEvidence(
+        arm=arm,
+        sessions=ledgers,
+        cache_hit_rate=_cache_hit_rate(ledgers),
+        cache_hit_rate_interval=_arm_metric_interval(
+            ledgers,
+            metric="cache_hit_rate",
+            resamples=resamples,
+            seed=seed,
+        ),
+        input_cost_usd_per_resolved_task=_cost_per_resolved_task(ledgers),
+        input_cost_usd_per_resolved_task_interval=_arm_metric_interval(
+            ledgers,
+            metric="input_cost_usd_per_resolved_task",
+            resamples=resamples,
+            seed=seed + 1,
+        ),
+    )
+
+
+def _relative_reduction(
+    control: Iterable[SessionLedger],
+    comparator: Iterable[SessionLedger],
+) -> float:
+    control_by_id = {ledger.session_id: ledger for ledger in control}
+    comparator_by_id = {ledger.session_id: ledger for ledger in comparator}
+    if set(control_by_id) != set(comparator_by_id):
+        raise DeterminismEconomicsError("arms do not cover identical session IDs")
+    ids = sorted(control_by_id)
+    resolved = sum(control_by_id[session_id].resolved for session_id in ids)
+    if resolved == 0:
+        raise DeterminismEconomicsError(
+            "cannot calculate cost per resolved task without resolved sessions"
+        )
+    control_cost = sum(control_by_id[session_id].input_cost_usd for session_id in ids) / resolved
+    comparator_cost = (
+        sum(comparator_by_id[session_id].input_cost_usd for session_id in ids) / resolved
+    )
+    if comparator_cost <= 0.0:
+        raise DeterminismEconomicsError("comparator cost must be positive")
+    return (comparator_cost - control_cost) / comparator_cost * 100.0
+
+
+def _bootstrap(
+    control: Sequence[SessionLedger],
+    comparator: Sequence[SessionLedger],
+    *,
+    comparator_arm: OrderingArm,
+    resamples: int,
+    seed: int,
+) -> BootstrapInterval:
+    if resamples < 1:
+        raise DeterminismEconomicsError("bootstrap resamples must be positive")
+    control_by_repo: dict[str, list[SessionLedger]] = {}
+    comparator_by_repo: dict[str, list[SessionLedger]] = {}
+    for ledger in control:
+        control_by_repo.setdefault(ledger.repository, []).append(ledger)
+    for ledger in comparator:
+        comparator_by_repo.setdefault(ledger.repository, []).append(ledger)
+    if set(control_by_repo) != set(comparator_by_repo):
+        raise DeterminismEconomicsError("arms do not cover identical repository clusters")
+    repositories = sorted(control_by_repo)
+    if len(repositories) < 2:
+        raise DeterminismEconomicsError("R6 cluster bootstrap requires at least two repositories")
+    point = _relative_reduction(control, comparator)
+    rng = random.Random(seed)
+    samples: list[float] = []
+    for _ in range(resamples):
+        drawn = [rng.choice(repositories) for _ in repositories]
+        sampled_control = [ledger for repo in drawn for ledger in control_by_repo[repo]]
+        sampled_comparator = [ledger for repo in drawn for ledger in comparator_by_repo[repo]]
+        samples.append(_relative_reduction(sampled_control, sampled_comparator))
+    samples.sort()
+    tail = (1.0 - BOOTSTRAP_CONFIDENCE) / 2.0
+    low = samples[int(tail * len(samples))]
+    high = samples[max(0, int((1.0 - tail) * len(samples)) - 1)]
+    return BootstrapInterval(
+        comparator=comparator_arm,
+        point_estimate_percent=point,
+        low_percent=low,
+        high_percent=high,
+        resamples=resamples,
+        seed=seed,
+        confidence=BOOTSTRAP_CONFIDENCE,
+    )
+
+
+def measure_economics(
+    sessions: Sequence[SessionFixture],
+    *,
+    preregistration_commit: str,
+    source_revision: str,
+    generated_at: str,
+    resamples: int = 10_000,
+    seed: int = 20_260_729,
+    pricing: PricingSchedule | None = None,
+) -> DeterminismEconomicsArtifact:
+    """Measure all three frozen arms over exactly the same session fixture."""
+    active_pricing = pricing or PricingSchedule()
+    arms = [
+        _summarize(arm, sessions, active_pricing, resamples=resamples, seed=seed + index * 10)
+        for index, arm in enumerate(OrderingArm)
+    ]
+    by_arm = {arm.arm: arm for arm in arms}
+    control = by_arm[OrderingArm.DETERMINISTIC].sessions
+    intervals = [
+        _bootstrap(
+            control,
+            by_arm[comparator].sessions,
+            comparator_arm=comparator,
+            resamples=resamples,
+            seed=seed,
+        )
+        for comparator in (OrderingArm.PERTURBED, OrderingArm.ANN_BASELINE)
+    ]
+    return DeterminismEconomicsArtifact(
+        preregistration="benchmarks/preregistrations/S7-determinism-economics.md",
+        preregistration_commit=preregistration_commit,
+        source_revision=source_revision,
+        session_fixture_sha256=fixture_digest(sessions),
+        generated_at=generated_at,
+        pricing=active_pricing,
+        arms=arms,
+        intervals=intervals,
+    )
+
+
+def validate_determinism_economics_artifact(path: Path) -> DeterminismEconomicsArtifact:
+    """Load standalone R6 evidence and reject malformed or incoherent records."""
+    if not path.is_file():
+        raise DeterminismEconomicsError(f"determinism-economics artifact is not a file: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DeterminismEconomicsError(
+            f"cannot read determinism-economics artifact {path}: {exc}"
+        ) from exc
+    try:
+        return DeterminismEconomicsArtifact.model_validate(payload)
+    except ValidationError as exc:
+        raise DeterminismEconomicsError(
+            f"determinism-economics artifact failed validation: {path}: {exc}"
+        ) from exc

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -29,6 +30,12 @@ from archex.benchmark.corpus_audit import (
 )
 from archex.benchmark.cross_tool import NaiveBaselineModel, run_cross_tool
 from archex.benchmark.delta_runner import run_all_delta
+from archex.benchmark.determinism_economics import (
+    DeterminismEconomicsError,
+    load_sessions,
+    measure_economics,
+    validate_determinism_economics_artifact,
+)
 from archex.benchmark.evidence import (
     BenchmarkEvidenceError,
     build_evidence_manifest,
@@ -806,8 +813,8 @@ def scorecard_cmd(
     default=None,
     type=click.Path(file_okay=True, dir_okay=True),
     help=(
-        "Evidence directory to validate with --kind evidence, "
-        "or replication artifact file to validate with --kind replication."
+        "Evidence directory or standalone evidence file. "
+        "R6 determinism-economics JSON is accepted by --kind evidence."
     ),
 )
 @click.option(
@@ -832,6 +839,16 @@ def validate_cmd(
             raise click.ClickException(f"--input is required when --kind {kind} is selected")
         target = Path(input_path)
 
+    if kind == "evidence" and target is not None and target.is_file():
+        try:
+            artifact = validate_determinism_economics_artifact(target)
+        except DeterminismEconomicsError as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(
+            "Valid determinism economics: "
+            f"{len(artifact.arms)} arm(s), {len(artifact.intervals)} clustered interval(s)."
+        )
+        return
     if kind == "corpus-audit" and target is not None:
         try:
             audit = validate_corpus_audit_artifact(target)
@@ -926,6 +943,72 @@ def validate_cmd(
         f"{count} {label}{'' if count == 1 else 's'}" for label, count in validated_counts
     )
     click.echo(f"\nAll {summary} valid.")
+
+
+@benchmark_cmd.command("determinism-economics")
+@click.option(
+    "--sessions",
+    "sessions_path",
+    default="benchmarks/determinism_economics/sessions.json",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
+    show_default=True,
+    help="Frozen multi-turn session fixture.",
+)
+@click.option(
+    "--output",
+    "output_path",
+    required=True,
+    type=click.Path(file_okay=True, dir_okay=False, path_type=Path),
+    help="Standalone JSON evidence file to create.",
+)
+@click.option(
+    "--preregistration-commit",
+    required=True,
+    help="Full commit SHA that merged the S7 pre-registration.",
+)
+@click.option(
+    "--resamples",
+    default=10_000,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Repository-cluster bootstrap resamples.",
+)
+@click.option(
+    "--seed",
+    default=20_260_729,
+    show_default=True,
+    type=int,
+    help="Seed for reproducible bootstrap and ANN ordering.",
+)
+def determinism_economics_cmd(
+    sessions_path: Path,
+    output_path: Path,
+    preregistration_commit: str,
+    resamples: int,
+    seed: int,
+) -> None:
+    """Measure S7's frozen ordering arms over the same multi-turn sessions."""
+    try:
+        sessions = load_sessions(sessions_path)
+        artifact = measure_economics(
+            sessions,
+            preregistration_commit=preregistration_commit,
+            source_revision=source_revision(Path.cwd()),
+            generated_at=datetime.now(UTC)
+            .replace(microsecond=0)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            resamples=resamples,
+            seed=seed,
+        )
+    except DeterminismEconomicsError as exc:
+        raise click.ClickException(str(exc)) from exc
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(artifact.model_dump_json(indent=2) + "\n", encoding="utf-8")
+    click.echo(
+        f"Wrote determinism economics for {len(artifact.arms)} arm(s) "
+        f"and {len(artifact.intervals)} clustered interval(s): {output_path}"
+    )
 
 
 @benchmark_cmd.group("baseline")

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import click
 from pydantic import ValidationError
@@ -37,6 +37,7 @@ from archex.benchmark.determinism_economics import (
     load_sessions,
     measure_economics,
     validate_determinism_economics_artifact,
+    validate_preregistration_commit,
 )
 from archex.benchmark.evidence import (
     BenchmarkEvidenceError,
@@ -852,8 +853,12 @@ def validate_cmd(
     is_s7_artifact = False
     if kind == "evidence" and target is not None and target.is_file():
         try:
-            is_s7_artifact = json.loads(target.read_text(encoding="utf-8")).get("spike_id") == "S7"
-        except (OSError, json.JSONDecodeError):
+            payload = cast("object", json.loads(target.read_text(encoding="utf-8")))
+            is_s7_artifact = (
+                isinstance(payload, dict)
+                and cast("dict[str, object]", payload).get("spike_id") == "S7"
+            )
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
             is_s7_artifact = False
     if kind == "determinism-economics" or is_s7_artifact:
         if target is None:
@@ -1021,10 +1026,12 @@ def determinism_economics_cmd(
     )
     try:
         sessions = load_sessions(sessions_path)
+        source = source_revision(Path.cwd())
+        validate_preregistration_commit(Path.cwd(), preregistration_commit, source)
         artifact = measure_economics(
             sessions,
             preregistration_commit=preregistration_commit,
-            source_revision=source_revision(Path.cwd()),
+            source_revision=source,
             generated_at=datetime.now(UTC)
             .replace(microsecond=0)
             .isoformat()

--- a/src/archex/cli/benchmark_cmd.py
+++ b/src/archex/cli/benchmark_cmd.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import click
+from pydantic import ValidationError
 
 from archex.benchmark.arch_quality import (
     DEFAULT_ARCHITECTURE_BASELINE_DIR,
@@ -32,6 +33,7 @@ from archex.benchmark.cross_tool import NaiveBaselineModel, run_cross_tool
 from archex.benchmark.delta_runner import run_all_delta
 from archex.benchmark.determinism_economics import (
     DeterminismEconomicsError,
+    PricingSchedule,
     load_sessions,
     measure_economics,
     validate_determinism_economics_artifact,
@@ -812,15 +814,23 @@ def scorecard_cmd(
     "input_path",
     default=None,
     type=click.Path(file_okay=True, dir_okay=True),
-    help=(
-        "Evidence directory or standalone evidence file. "
-        "R6 determinism-economics JSON is accepted by --kind evidence."
-    ),
+    help="Evidence directory, S7 determinism-economics JSON, or specialized artifact input.",
 )
 @click.option(
     "--kind",
     default="tasks",
-    type=click.Choice(["tasks", "arch", "delta", "all", "evidence", "replication", "corpus-audit"]),
+    type=click.Choice(
+        [
+            "tasks",
+            "arch",
+            "delta",
+            "all",
+            "evidence",
+            "replication",
+            "corpus-audit",
+            "determinism-economics",
+        ]
+    ),
     show_default=True,
     help="Task definition or evidence family to validate.",
 )
@@ -834,12 +844,20 @@ def validate_cmd(
     """Validate benchmark task definitions."""
     repo_root = Path.cwd()
     target: Path | None = None
-    if kind in {"evidence", "replication", "corpus-audit"}:
+    if kind in {"evidence", "replication", "corpus-audit", "determinism-economics"}:
         if input_path is None:
             raise click.ClickException(f"--input is required when --kind {kind} is selected")
         target = Path(input_path)
 
+    is_s7_artifact = False
     if kind == "evidence" and target is not None and target.is_file():
+        try:
+            is_s7_artifact = json.loads(target.read_text(encoding="utf-8")).get("spike_id") == "S7"
+        except (OSError, json.JSONDecodeError):
+            is_s7_artifact = False
+    if kind == "determinism-economics" or is_s7_artifact:
+        if target is None:
+            raise click.ClickException("--input is required for determinism-economics evidence")
         try:
             artifact = validate_determinism_economics_artifact(target)
         except DeterminismEconomicsError as exc:
@@ -970,8 +988,13 @@ def validate_cmd(
     "--resamples",
     default=10_000,
     show_default=True,
-    type=click.IntRange(min=1),
+    type=click.IntRange(min=20),
     help="Repository-cluster bootstrap resamples.",
+)
+@click.option(
+    "--pricing-retrieved-at",
+    required=True,
+    help="UTC timestamp when the published pricing source was retrieved.",
 )
 @click.option(
     "--seed",
@@ -985,9 +1008,17 @@ def determinism_economics_cmd(
     output_path: Path,
     preregistration_commit: str,
     resamples: int,
+    pricing_retrieved_at: str,
     seed: int,
 ) -> None:
     """Measure S7's frozen ordering arms over the same multi-turn sessions."""
+    command = (
+        "uv run archex benchmark determinism-economics "
+        f"--sessions {sessions_path} --output {output_path} "
+        f"--preregistration-commit {preregistration_commit} "
+        f"--pricing-retrieved-at {pricing_retrieved_at} "
+        f"--resamples {resamples} --seed {seed}"
+    )
     try:
         sessions = load_sessions(sessions_path)
         artifact = measure_economics(
@@ -998,10 +1029,13 @@ def determinism_economics_cmd(
             .replace(microsecond=0)
             .isoformat()
             .replace("+00:00", "Z"),
+            session_fixture=str(sessions_path),
+            measurement_command=command,
             resamples=resamples,
             seed=seed,
+            pricing=PricingSchedule(retrieved_at=pricing_retrieved_at),
         )
-    except DeterminismEconomicsError as exc:
+    except (BenchmarkEvidenceError, DeterminismEconomicsError, ValidationError) as exc:
         raise click.ClickException(str(exc)) from exc
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(artifact.model_dump_json(indent=2) + "\n", encoding="utf-8")

--- a/tests/benchmark/test_determinism_economics.py
+++ b/tests/benchmark/test_determinism_economics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -64,6 +65,19 @@ def test_validator_rejects_missing_fixed_arm(tmp_path: Path) -> None:
     evidence.write_text(json.dumps(payload), encoding="utf-8")
 
     with pytest.raises(ValueError, match="R6 arms"):
+        validate_determinism_economics_artifact(evidence)
+
+
+def test_validator_rejects_ledger_that_does_not_reproduce_from_fixture(tmp_path: Path) -> None:
+    payload = _artifact().model_dump(mode="json")
+    ledger = payload["arms"][0]["sessions"][0]
+    prefix = ledger["rendered_prefixes"][0] + "tampered"
+    ledger["rendered_prefixes"][0] = prefix
+    ledger["prefix_sha256"][0] = hashlib.sha256(prefix.encode()).hexdigest()
+    evidence = tmp_path / "tampered.json"
+    evidence.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="does not reproduce"):
         validate_determinism_economics_artifact(evidence)
 
 

--- a/tests/benchmark/test_determinism_economics.py
+++ b/tests/benchmark/test_determinism_economics.py
@@ -8,10 +8,15 @@ import pytest
 from click.testing import CliRunner
 from pydantic import ValidationError
 
+import archex.benchmark.determinism_economics as economics
 import archex.cli.benchmark_cmd as benchmark_module
 from archex.benchmark.determinism_economics import (
     DeterminismEconomicsArtifact,
     OrderingArm,
+    PricingSchedule,
+    SessionFixture,
+    SessionLedger,
+    SessionTurn,
     load_sessions,
     measure_economics,
     validate_determinism_economics_artifact,
@@ -19,14 +24,16 @@ from archex.benchmark.determinism_economics import (
 from archex.cli.benchmark_cmd import benchmark_cmd
 
 FIXTURE = Path("benchmarks/determinism_economics/sessions.json")
-HASH = "a" * 40
+PREREGISTRATION_COMMIT = "501636abb09cbcf6edee5783305af6bcb313606a"
+UNKNOWN_COMMIT = "a" * 40
+SOURCE_REVISION = "b73ba365be43bf73ad566e96161bb8e045faa843"
 
 
 def _artifact() -> DeterminismEconomicsArtifact:
     return measure_economics(
         load_sessions(FIXTURE),
-        preregistration_commit=HASH,
-        source_revision=HASH,
+        preregistration_commit=PREREGISTRATION_COMMIT,
+        source_revision=SOURCE_REVISION,
         generated_at="2026-07-29T00:00:00Z",
         session_fixture=str(FIXTURE),
         measurement_command="test command",
@@ -108,7 +115,7 @@ def test_cli_runs_frozen_measurement(tmp_path: Path, monkeypatch: pytest.MonkeyP
     evidence = tmp_path / "s7.json"
 
     def source_revision_stub(_root: Path) -> str:
-        return HASH
+        return SOURCE_REVISION
 
     monkeypatch.setattr(benchmark_module, "source_revision", source_revision_stub)
 
@@ -119,7 +126,7 @@ def test_cli_runs_frozen_measurement(tmp_path: Path, monkeypatch: pytest.MonkeyP
             "--output",
             str(evidence),
             "--preregistration-commit",
-            HASH,
+            PREREGISTRATION_COMMIT,
             "--resamples",
             "100",
             "--pricing-retrieved-at",
@@ -129,4 +136,120 @@ def test_cli_runs_frozen_measurement(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
     assert result.exit_code == 0, result.output
     artifact = validate_determinism_economics_artifact(evidence)
-    assert artifact.preregistration_commit == HASH
+    assert artifact.preregistration_commit == PREREGISTRATION_COMMIT
+
+
+@pytest.mark.parametrize("prefix_tokens", [512, 513])
+def test_cache_eligible_prefixes_write_then_read(
+    monkeypatch: pytest.MonkeyPatch, prefix_tokens: int
+) -> None:
+    def token_count(text: str) -> int:
+        return prefix_tokens if text.startswith("SYSTEM") else 11
+
+    monkeypatch.setattr(economics, "count_tokens", token_count)
+    session = SessionFixture(
+        session_id="cache-session",
+        repository="cache-repository",
+        resolved=True,
+        turns=[
+            SessionTurn(question="first", contexts=["alpha", "beta"]),
+            SessionTurn(question="second", contexts=["alpha", "beta"]),
+        ],
+    )
+    second_session = SessionFixture(
+        session_id="cache-session-2",
+        repository="cache-repository-2",
+        resolved=True,
+        turns=[
+            SessionTurn(question="first", contexts=["alpha", "beta"]),
+            SessionTurn(question="second", contexts=["alpha", "beta"]),
+        ],
+    )
+    artifact = measure_economics(
+        [session, second_session],
+        preregistration_commit=PREREGISTRATION_COMMIT,
+        source_revision=SOURCE_REVISION,
+        generated_at="2026-07-29T00:00:00Z",
+        session_fixture=str(FIXTURE),
+        measurement_command="test command",
+        resamples=20,
+        pricing=PricingSchedule(retrieved_at="test"),
+    )
+    deterministic = next(arm for arm in artifact.arms if arm.arm is OrderingArm.DETERMINISTIC)
+    ledger = deterministic.sessions[0]
+
+    assert ledger.cache_write_tokens == prefix_tokens
+    assert ledger.cache_read_tokens == prefix_tokens
+    assert ledger.cacheable_tokens == prefix_tokens * 2
+    assert (
+        ledger.input_cost_usd == (prefix_tokens * 1.25 + prefix_tokens * 0.1 + 22) * 5.0 / 1_000_000
+    )
+
+
+def _ledger(session_id: str, repository: str, cost: float) -> SessionLedger:
+    prefix = f"prefix-{session_id}"
+    return SessionLedger(
+        session_id=session_id,
+        repository=repository,
+        resolved=True,
+        cacheable_tokens=0,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        uncached_input_tokens=0,
+        rendered_prefixes=[prefix],
+        prefix_sha256=[hashlib.sha256(prefix.encode()).hexdigest()],
+        input_cost_usd=cost,
+    )
+
+
+def test_cluster_bootstrap_retains_repeated_repository_draws() -> None:
+    control_a = _ledger("a", "repository-a", 1.0)
+    control_b = _ledger("b", "repository-b", 1.0)
+    comparator_a = _ledger("a", "repository-a", 2.0)
+    comparator_b = _ledger("b", "repository-b", 4.0)
+
+    reduction = economics.relative_cost_reduction(
+        [control_a, control_a, control_b],
+        [comparator_a, comparator_a, comparator_b],
+    )
+
+    assert reduction == 62.5
+
+
+def test_validator_rejects_unknown_preregistration_commit(tmp_path: Path) -> None:
+    payload = _artifact().model_dump(mode="json")
+    payload["preregistration_commit"] = UNKNOWN_COMMIT
+    evidence = tmp_path / "invalid-preregistration.json"
+    evidence.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="pre-registration commit"):
+        validate_determinism_economics_artifact(evidence)
+
+
+def test_validator_wraps_replay_validation_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    evidence = tmp_path / "s7.json"
+    evidence.write_text(_artifact().model_dump_json(), encoding="utf-8")
+
+    def invalid_measurement(*_args: object, **_kwargs: object) -> DeterminismEconomicsArtifact:
+        SessionFixture.model_validate({})
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(economics, "measure_economics", invalid_measurement)
+
+    with pytest.raises(ValueError, match="failed validation"):
+        validate_determinism_economics_artifact(evidence)
+
+
+def test_cli_rejects_non_object_evidence_input(tmp_path: Path) -> None:
+    evidence = tmp_path / "not-an-object.json"
+    evidence.write_text("[1, 2, 3]", encoding="utf-8")
+
+    result = CliRunner().invoke(
+        benchmark_cmd,
+        ["validate", "--kind", "evidence", "--input", str(evidence)],
+    )
+
+    assert result.exit_code != 0
+    assert "AttributeError" not in result.output

--- a/tests/benchmark/test_determinism_economics.py
+++ b/tests/benchmark/test_determinism_economics.py
@@ -27,6 +27,8 @@ def _artifact() -> DeterminismEconomicsArtifact:
         preregistration_commit=HASH,
         source_revision=HASH,
         generated_at="2026-07-29T00:00:00Z",
+        session_fixture=str(FIXTURE),
+        measurement_command="test command",
         resamples=100,
         seed=7,
     )
@@ -36,14 +38,11 @@ def test_measurement_uses_same_sessions_and_reports_cache_economics() -> None:
     artifact = _artifact()
     arms = {arm.arm: arm for arm in artifact.arms}
 
-    control_ids = [session.session_id for session in arms[OrderingArm.DETERMINISTIC].sessions]
-    assert control_ids == [session.session_id for session in arms[OrderingArm.PERTURBED].sessions]
-    assert (
-        arms[OrderingArm.DETERMINISTIC].cache_hit_rate > arms[OrderingArm.PERTURBED].cache_hit_rate
-    )
+    assert arms[OrderingArm.DETERMINISTIC].cache_hit_rate == 0.0
+    assert arms[OrderingArm.PERTURBED].cache_hit_rate == 0.0
     assert (
         arms[OrderingArm.DETERMINISTIC].input_cost_usd_per_resolved_task
-        < arms[OrderingArm.PERTURBED].input_cost_usd_per_resolved_task
+        == arms[OrderingArm.PERTURBED].input_cost_usd_per_resolved_task
     )
     for arm in arms.values():
         assert (
@@ -109,6 +108,8 @@ def test_cli_runs_frozen_measurement(tmp_path: Path, monkeypatch: pytest.MonkeyP
             HASH,
             "--resamples",
             "100",
+            "--pricing-retrieved-at",
+            "2026-07-29T00:00:00Z",
         ],
     )
 

--- a/tests/benchmark/test_determinism_economics.py
+++ b/tests/benchmark/test_determinism_economics.py
@@ -42,6 +42,16 @@ def _artifact() -> DeterminismEconomicsArtifact:
     )
 
 
+def _stub_preregistration_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    def validate_preregistration_stub(_root: Path, _commit: str, _source: str) -> None:
+        return None
+
+    monkeypatch.setattr(economics, "validate_preregistration_commit", validate_preregistration_stub)
+    monkeypatch.setattr(
+        benchmark_module, "validate_preregistration_commit", validate_preregistration_stub
+    )
+
+
 def test_measurement_uses_same_sessions_and_reports_cache_economics() -> None:
     artifact = _artifact()
     arms = {arm.arm: arm for arm in artifact.arms}
@@ -75,7 +85,10 @@ def test_validator_rejects_missing_fixed_arm(tmp_path: Path) -> None:
         validate_determinism_economics_artifact(evidence)
 
 
-def test_validator_rejects_ledger_that_does_not_reproduce_from_fixture(tmp_path: Path) -> None:
+def test_validator_rejects_ledger_that_does_not_reproduce_from_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_preregistration_validation(monkeypatch)
     payload = _artifact().model_dump(mode="json")
     ledger = payload["arms"][0]["sessions"][0]
     prefix = ledger["rendered_prefixes"][0] + "tampered"
@@ -98,7 +111,10 @@ def test_validator_rejects_interval_that_excludes_its_estimate() -> None:
         DeterminismEconomicsArtifact.model_validate(payload)
 
 
-def test_cli_validates_standalone_economics_evidence(tmp_path: Path) -> None:
+def test_cli_validates_standalone_economics_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_preregistration_validation(monkeypatch)
     evidence = tmp_path / "s7.json"
     evidence.write_text(_artifact().model_dump_json(), encoding="utf-8")
 
@@ -112,6 +128,7 @@ def test_cli_validates_standalone_economics_evidence(tmp_path: Path) -> None:
 
 
 def test_cli_runs_frozen_measurement(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_preregistration_validation(monkeypatch)
     evidence = tmp_path / "s7.json"
 
     def source_revision_stub(_root: Path) -> str:
@@ -229,6 +246,7 @@ def test_validator_rejects_unknown_preregistration_commit(tmp_path: Path) -> Non
 def test_validator_wraps_replay_validation_errors(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    _stub_preregistration_validation(monkeypatch)
     evidence = tmp_path / "s7.json"
     evidence.write_text(_artifact().model_dump_json(), encoding="utf-8")
 

--- a/tests/benchmark/test_determinism_economics.py
+++ b/tests/benchmark/test_determinism_economics.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from pydantic import ValidationError
+
+import archex.cli.benchmark_cmd as benchmark_module
+from archex.benchmark.determinism_economics import (
+    DeterminismEconomicsArtifact,
+    OrderingArm,
+    load_sessions,
+    measure_economics,
+    validate_determinism_economics_artifact,
+)
+from archex.cli.benchmark_cmd import benchmark_cmd
+
+FIXTURE = Path("benchmarks/determinism_economics/sessions.json")
+HASH = "a" * 40
+
+
+def _artifact() -> DeterminismEconomicsArtifact:
+    return measure_economics(
+        load_sessions(FIXTURE),
+        preregistration_commit=HASH,
+        source_revision=HASH,
+        generated_at="2026-07-29T00:00:00Z",
+        resamples=100,
+        seed=7,
+    )
+
+
+def test_measurement_uses_same_sessions_and_reports_cache_economics() -> None:
+    artifact = _artifact()
+    arms = {arm.arm: arm for arm in artifact.arms}
+
+    control_ids = [session.session_id for session in arms[OrderingArm.DETERMINISTIC].sessions]
+    assert control_ids == [session.session_id for session in arms[OrderingArm.PERTURBED].sessions]
+    assert (
+        arms[OrderingArm.DETERMINISTIC].cache_hit_rate > arms[OrderingArm.PERTURBED].cache_hit_rate
+    )
+    assert (
+        arms[OrderingArm.DETERMINISTIC].input_cost_usd_per_resolved_task
+        < arms[OrderingArm.PERTURBED].input_cost_usd_per_resolved_task
+    )
+    for arm in arms.values():
+        assert (
+            arm.cache_hit_rate_interval.low
+            <= arm.cache_hit_rate
+            <= arm.cache_hit_rate_interval.high
+        )
+        assert (
+            arm.input_cost_usd_per_resolved_task_interval.low
+            <= arm.input_cost_usd_per_resolved_task
+            <= arm.input_cost_usd_per_resolved_task_interval.high
+        )
+
+
+def test_validator_rejects_missing_fixed_arm(tmp_path: Path) -> None:
+    payload = _artifact().model_dump(mode="json")
+    payload["arms"][0]["arm"] = "perturbed"
+    evidence = tmp_path / "invalid.json"
+    evidence.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="R6 arms"):
+        validate_determinism_economics_artifact(evidence)
+
+
+def test_validator_rejects_interval_that_excludes_its_estimate() -> None:
+    payload = _artifact().model_dump(mode="json")
+    interval = payload["intervals"][0]
+    interval["low_percent"] = interval["point_estimate_percent"] + 0.01
+    interval["high_percent"] = interval["point_estimate_percent"] + 0.02
+
+    with pytest.raises(ValidationError, match="point estimate"):
+        DeterminismEconomicsArtifact.model_validate(payload)
+
+
+def test_cli_validates_standalone_economics_evidence(tmp_path: Path) -> None:
+    evidence = tmp_path / "s7.json"
+    evidence.write_text(_artifact().model_dump_json(), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        benchmark_cmd,
+        ["validate", "--kind", "evidence", "--input", str(evidence)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Valid determinism economics" in result.output
+
+
+def test_cli_runs_frozen_measurement(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    evidence = tmp_path / "s7.json"
+
+    def source_revision_stub(_root: Path) -> str:
+        return HASH
+
+    monkeypatch.setattr(benchmark_module, "source_revision", source_revision_stub)
+
+    result = CliRunner().invoke(
+        benchmark_cmd,
+        [
+            "determinism-economics",
+            "--output",
+            str(evidence),
+            "--preregistration-commit",
+            HASH,
+            "--resamples",
+            "100",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    artifact = validate_determinism_economics_artifact(evidence)
+    assert artifact.preregistration_commit == HASH


### PR DESCRIPTION
## Summary

Implements the frozen S7 prefix-cache economics measurement after the reconciliation prerequisite #591 and pre-registration #592.

- Adds the deterministic, perturbed, and seeded ANN-ordering comparator harness over the same eight multi-turn sessions in four repository clusters.
- Records standalone evidence with arm-level and comparator-level cluster-bootstrap intervals, then adds `benchmark determinism-economics` and `validate --kind evidence` support.
- Records the bounded decision: modeled economics exceed the 5% SESOI, with no retrieval-order change or retrieval-quality claim.

## Verification

- `uv run archex benchmark determinism-economics --output benchmarks/evidence/s7-determinism-economics.json --preregistration-commit 0c8c8483aab09c8b4d9e6c4e2f80408de7e2ed6e`
- `uv run archex benchmark validate --kind evidence --input benchmarks/evidence/s7-determinism-economics.json`
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pyright`
- `uv run pytest` — 4650 passed, 9 deselected

## Breaking changes

None.
