### PR TITLE
docs(plan): reconcile R6.1 design

### DIFF
--- a/.docs/DEVELOPMENT_PLAN.md
+++ b/.docs/DEVELOPMENT_PLAN.md
@@ -10,7 +10,7 @@ Milestones are prefixed `R` (reassessment). **Do not reuse `M1`–`M17`** — th
 | --- | --- | --- |
 | §6 Section A — Freeze & truth-in-claims | R1, R2 | `05-ROADMAP.md` §1 (Phase 0); `04-PRODUCT-AND-ECONOMICS.md` §1.1–1.3; `00-DIAGNOSIS.md` §1.1, §5 |
 | §6 Section B — Validity gates | R3, R4 | `05-ROADMAP.md` §2 Lanes A–B; `03-SPIKES.md` S0, S2; `00-DIAGNOSIS.md` §1.2–1.4, §2 |
-| §6 Section C — Zero-research-risk product wins | R5, R6 | `05-ROADMAP.md` §2 Lane C; `03-SPIKES.md` S7; `01-LITERATURE-POSITION.md` §G6; `00-DIAGNOSIS.md` §3 |
+| §6 Section C — Zero-research-risk product wins | R5, R6, R6.1 | `05-ROADMAP.md` §2 Lane C; `03-SPIKES.md` S7; `01-LITERATURE-POSITION.md` §G6; `00-DIAGNOSIS.md` §3 |
 | §6 Section D — The instrument | R7–R11 | `05-ROADMAP.md` §3; `03-SPIKES.md` S1; `02-STRATEGY.md` §C1; `04-PRODUCT-AND-ECONOMICS.md` §2 |
 | §6 Section E — Payload | R12–R15 | `05-ROADMAP.md` §4; `03-SPIKES.md` S3–S6; `01-LITERATURE-POSITION.md` §G2–G5 |
 | §6 Section F — Publication & disposition | R16 | `05-ROADMAP.md` §4 Gate C; `02-STRATEGY.md` §C1 elements 1–7 |
@@ -45,6 +45,7 @@ graph TD
   R4[R4 S2 corpus validity audit]
   R5[R5 MCP retrieval-gated tool disclosure]
   R6[R6 S7 economics study - cancelled]
+  R61[R6.1 S7 cache-eligible economics replacement]
   R7[R7 Real-agent execution harness]
   R8[R8 External corpus adapters and decontamination]
   R9[R9 Clustered inference and analysis]
@@ -61,6 +62,7 @@ graph TD
   R1 --> R4
   R1 --> R5
   R1 --> R6
+  R1 --> R61
   R3 --> R7
   R4 --> R7
   R7 --> R8
@@ -86,7 +88,7 @@ Gate A sat on R3's verdict and blocked R7. **It failed on 2026-07-28** (`GATE-A.
 | --- | --- | --- | --- | --- | --- |
 | `> GAP: version not source-traceable — operator selects at preparation time` (train **claims-and-cost**) | `R2, R5` | Both externally merged. Carries the pre-existing `[Unreleased]` prior-M6–M9 entries. | both (version update in `pyproject.toml` + `CHANGELOG.md`) | `uv run ruff check . && uv run ruff format --check . && uv run pyright . && uv run pytest` all green on the release commit; `uv run archex mcp-schema-size --format json` reports the reduced total | `git tag` → `uv build` → `uv publish` → `gh release create`. Manual; no release CI workflow exists. |
 | `> GAP: version not source-traceable — operator selects at preparation time` (train **certified-receipt**) | `R14` | R14 externally merged **and** its promotion verdict is GO. | both | full gate above, plus R14's certificate correlation artifact checked in | same manual sequence |
-| `unversioned` | `R1, R3, R4, R7, R8, R9, R10, R12, R13, R15` | n/a — merged to `main`, no release preparation. | none | per-milestone verification in §6 | not requested |
+| `unversioned` | `R1, R3, R4, R6.1, R7, R8, R9, R10, R12, R13, R15` | n/a — merged to `main`, no release preparation. | none | per-milestone verification in §6 | not requested |
 | `none` | `R11, R16` | n/a — artifacts land in a separate public repository, not in the `archex` distribution. | none | per-milestone verification in §6 | separate-repo release, out of scope for `archex` versioning |
 | `none` (cancelled) | `R6` | n/a — invalid study closed without merge. | none | validity record in §6 | not requested |
 
@@ -116,7 +118,7 @@ A milestone in the `unversioned` set that later proves user-visible moves to a t
 | Deliverables | Prior forward milestones marked `SUSPENDED — pending strategic-reassessment Gate A` with a pointer to `.docs/strategic-reassessment/`; a freeze clause in `CONTRIBUTING.md` prohibiting new retrieval lanes, default-promotion attempts, new language tiers, and new MCP tools until Gate A; a tracked `.docs/spikes/TEMPLATE.md` requiring hypothesis, primary metric, SESOI, separately-derived MWG/NIM/EQM (EQM strictly positive, utility-derived), clustering unit, kill criterion, and evidence class (replication / adaptation / original); `.docs/DEVELOPMENT_PLAN_HISTORY.md` seeded. |
 | Acceptance | `.docs/spikes/TEMPLATE.md` is tracked and enumerates all eight required fields. `CONTRIBUTING.md` contains the freeze clause naming the four prohibited change classes and Gate A as the lift condition. `git check-ignore -v .docs/DEVELOPMENT_PLAN_HISTORY.md` exits 0. No file under `src/` changed. |
 | Verification | `git ls-files --error-unmatch .docs/spikes/TEMPLATE.md` exits 0; `git check-ignore -v .docs/DEVELOPMENT_PLAN_HISTORY.md` exits 0; `git diff --name-only <base>..HEAD -- src/` prints nothing; `uv run ruff check . && uv run ruff format --check . && uv run pyright . && uv run pytest` green. |
-| Design reevaluation | Confirm no forward milestone from the prior plan was silently resumed after 2026-07-24. Dependents requiring review if this changes: R2, R3, R4, R5, R6. |
+| Design reevaluation | Confirm no forward milestone from the prior plan was silently resumed after 2026-07-24. Dependents requiring review if this changes: R2, R3, R4, R5, R6, R6.1. |
 | Risks & rollback | Risk: a freeze is ignored or a pre-registration remains invisible to commit-order review. Mitigation: the `CONTRIBUTING.md` clause and tracked `.docs/spikes/` exception are reviewable artifacts. Rollback: revert the stack. |
 | Est. PRs | 2 |
 
@@ -131,7 +133,7 @@ A milestone in the `unversioned` set that later proves user-visible moves to a t
 | Deliverables | README and `docs/LOCAL_METRICS.md` savings headline re-pointed at `savings_pct_vs_targeted_read` (`src/archex/metrics/math.py`); the self-repo row withdrawn from every quoted figure; `benchmarks/cross-tool-efficiency/` and `docs/LOCAL_BENCHMARK_EVIDENCE.md` annotated with the `tokens_at_recall` blind-read semantics (`src/archex/benchmark/cross_tool.py`) and the measured median/mean/max units-read distribution; `BenchmarkScorecardRow.downstream_success_rate` renamed `required_file_completeness_rate` (`src/archex/benchmark/scorecard.py`) with its docstring stating it is a function of required-file recall and that no model is in the loop; `CHANGELOG.md` `[Unreleased]` entry. |
 | Acceptance | No tracked file quotes `445×`, `673×`, `99.78%`, or `99.64%`. Every remaining savings figure names its baseline in the same sentence. `grep -r downstream_success_rate src/ tests/ docs/` returns no hits. The scorecard markdown column header reads `Required-File Completeness`. Full gate green. |
 | Verification | `grep -rn "downstream_success_rate\|445×\|673×\|99\.78\|99\.64" src tests docs README.md benchmarks/*.md` returns nothing; `uv run pytest tests/ -k "scorecard or metrics or cross_tool"` green; full gate green. |
-| Design reevaluation | Re-confirm `savings_pct_vs_targeted_read` is populated on the live ledger path before re-pointing the headline at it. Dependents: R6, R10, R16. |
+| Design reevaluation | Re-confirm `savings_pct_vs_targeted_read` is populated on the live ledger path before re-pointing the headline at it. Dependents: R6, R6.1, R10, R16. |
 | Risks & rollback | Risk: a rename breaks a checked-in evidence reader. Mitigation: `archex benchmark validate --kind evidence` over every artifact in `benchmarks/evidence/` before merge. Rollback: revert the stack; no data is destroyed. |
 | Est. PRs | 3 |
 
@@ -171,7 +173,7 @@ A milestone in the `unversioned` set that later proves user-visible moves to a t
 
 ### Section C — Zero-research-risk product wins
 
-R5 shipped regardless of Gate A. R6 is cancelled because its session fixture never reached the cache-eligibility floor.
+R5 shipped regardless of Gate A. R6 is cancelled because its session fixture never reached the cache-eligibility floor. R6.1 is a separately authorized, no-product-change replacement that cannot reopen Gate A or revive R6's invalid artifact.
 
 #### R5 — MCP retrieval-gated tool disclosure
 
@@ -202,6 +204,21 @@ R5 shipped regardless of Gate A. R6 is cancelled because its session fixture nev
 | Design reevaluation | Pricing remains current: cache read 0.1× and 5-minute cache write 1.25×. This preserves the pricing schedule only; it does not repair an ineligible fixture. R16 remains cancelled by Gate A. |
 | Risks & rollback | Risk: describing a mechanism-not-fired run as an economic null. Mitigation: R6 is cancelled and PR #593 is closed without merge. Rollback: none; the invalid run is retained only in closed-PR history. |
 | Est. PRs | 3 planned: PR #591 reconciliation and PR #592 pre-registration merged; PR #593 closed without merge. |
+
+#### R6.1 — S7 determinism as prefix-cache economics replacement `PENDING — FRESH PRE-REGISTRATION REQUIRED`
+
+| Field | Value |
+| --- | --- |
+| Objective | Measure whether archex's unchanged deterministic ordering changes provider-observed input-side prefix-cache cost per fixed resolved maintenance session, using only a fresh, cache-eligible fixture. This is an independent, post-Gate-A study authorization; it cannot reopen Gate A, revive R6 or PR #593, or support a product or retrieval-quality claim. |
+| In / Out of scope | In: one pre-registered three-turn, `token_budget: 8192` session for each of 12 independent repositories: the self-repo plus at least one task from every current external corpus family, selected from existing pinned tasks; shipped-default retrieval to freeze the same selected context and fixed resolution labels for all arms; deterministic, seed-recorded perturbed, and seed-recorded ANN-style ordering of those same chunks; provider-native token-count, prewarm, and replay receipts; paired repository-cluster bootstrap. Out: a product retrieval or ordering change, live ANN retrieval, retrieval-quality or task-resolution comparisons, local token estimates as eligibility proof, R6's fixture or closed artifact, and any successor to cancelled R7–R16. |
+| Depends on | `R1`; R6's no-go record is a non-execution constraint, not a reusable predecessor artifact. |
+| Target release | `unversioned` |
+| Deliverables | A new immutable pre-registration at `benchmarks/preregistrations/S7-determinism-economics-r6.1.md`, naming Claude Opus 5, the official pricing/cache source URL and retrieval timestamp, the documented model-specific cache-eligibility floor retrieved at its PR-1 design gate, a `+5%` minimum worthwhile gain (MWG), a `-5%` non-inferiority margin (NIM), and a `[-5%, +5%]` equivalence region (EQM): the MWG is the smallest reduction that changes an operator's cost decision, the NIM is the largest added cost that remains acceptable, and the EQM is the no-decision-change band; a committed frozen session fixture and exact provider eligibility receipts, each carrying rendered-prefix SHA-256, model, count-token result, prewarm/replay usage, and source revision; a dedicated ordering-economics runner and validator; `benchmarks/evidence/s7-determinism-economics-r6.1.json` with arm ledgers, `original` evidence class, per-cell `superior` / `equivalent` / `inconclusive at this N` disposition, repository-clustered intervals, pricing provenance, fixture digest, and exact command; and `benchmarks/evidence/S7-R6.1-DECISION.md`. |
+| Acceptance | The new pre-registration merges before fixture construction or data generation. Every rendered prefix in every arm has at least the pre-registered provider-native cache-eligibility floor and an exact-SHA prewarm/replay pair with nonzero cache creation and cache read tokens; a missing, stale, mismatched, or zero receipt fails validation. A non-fired arm lacks its requested prewarm/replay pair or provider usage fields; cache-use receipts are evidence of mechanism engagement, not a replacement for an observed cost effect. All arms use the same session IDs, source chunks, labels, and model-price schedule, differing only in context order. The artifact rejects an undeclared or non-fired arm and labels every cell `superior`, `equivalent`, or `inconclusive at this N`. Its decision explicitly retires the economic framing when either comparator's point estimate is below the `+5%` MWG or 95% repository-clustered interval includes zero; that outcome is valid and leaves determinism only as a reproducibility property. If both comparators clear those pre-declared bars, the only positive license is an original, fixture-bounded observed input-cost result; it authorizes no product, retrieval-quality, literature, Gate-A, or default-ordering claim. |
+| Verification | `uv run archex benchmark determinism-economics --sessions benchmarks/determinism_economics_r6_1/sessions.json --output benchmarks/evidence/s7-determinism-economics-r6.1.json --preregistration-commit <merged-SHA>` regenerates the artifact from the frozen fixture; `uv run archex benchmark validate --kind determinism-economics-r6-1 --input benchmarks/evidence/s7-determinism-economics-r6.1.json` exits 0; an independent fixture review recomputes every rendered-prefix SHA and receipt linkage before the data-generating run; full gate green. |
+| Design reevaluation | Before PR-1, confirm the official provider documentation for Claude Opus 5 records its model-specific cache-eligibility floor, 5-minute cache writes at 1.25× base input, cache reads at 0.1× base input, and five-minute TTL; record those values in the pre-registration. A pricing change invalidates only dollar interpretation; absent, changed, or incompatible eligibility/cache semantics is a design no-go that blocks the run. Before PR-2, confirm the provider client's configured authentication chain supplies credentials and quota without printing a secret; absent access blocks fixture construction and evidence generation, never justifies a local-counter substitute. Before PR-2, inspect the selected 12 task revisions and ensure no repository repeats. Before PR-3, independently inspect the committed fixture and receipts, enforce the frozen three-arm-by-12-repository matrix, and confirm the requested cache mechanism engaged for every arm. Dependents: none; R16 remains cancelled. |
+| Risks & rollback | Risk: provider credentials, quota, pricing, cache TTL, or the exact-prefix mechanism prevents a valid measurement. Mitigation: fail closed on provider receipts and cache-use provenance; never reinterpret a mechanism-not-fired cell as a null. Risk: the seed-recorded ANN-style comparator is mistaken for a retrieval treatment. Mitigation: document and validate that it reorders exactly the same frozen chunks. Rollback: revert the benchmark-only stack; product ordering remains unchanged. |
+| Est. PRs | 3, after reconciliation PR #595 merges |
 
 ### Section D — The instrument `CANCELLED — GATE A FAIL`
 
@@ -369,15 +386,17 @@ R5 shipped regardless of Gate A. R6 is cancelled because its session fixture nev
 
 ## 7. Cross-Cutting Concerns
 
-**Statistical discipline (applies to R4, R6, R9, R10, R12–R15).** MWG, NIM, and EQM are three distinct quantities and are never conflated; EQM is strictly positive and utility-derived, never derived from observed SD. archex's existing `+0.05 F1 / no-regression / p95 ≤ 3000 ms` product rule is a non-inferiority margin and must not be reused as an equivalence margin. Primary intervals come from a cluster bootstrap resampling repositories. Every cell resolves to `superior`, `equivalent`, or `inconclusive at this N`.
+**Statistical discipline (applies to R4, R6.1, R9, R10, R12–R15).** MWG, NIM, and EQM are three distinct quantities and are never conflated; EQM is strictly positive and utility-derived, never derived from observed SD. archex's existing `+0.05 F1 / no-regression / p95 ≤ 3000 ms` product rule is a non-inferiority margin and must not be reused as an equivalence margin. Primary intervals come from a cluster bootstrap resampling repositories. Every cell resolves to `superior`, `equivalent`, or `inconclusive at this N`.
 
-**Evidence classing (applies to R3, R13, R14, R15).** Every arm is labelled `replication`, `adaptation`, or `original`. An adaptation-class null licenses only "as implemented here, on this corpus, it did not clear a cost-justified bar" — never a refutation of the literature. R3 is the program's replication anchor; no null anywhere claims more than adaptation class until R3 passes.
+**R6.1 margin justification.** Its pre-registration records the three `5%` quantities separately: `+5%` MWG is the smallest input-side cost reduction that changes the retain/retire decision; `-5%` NIM is the maximum input-side cost increase still acceptable to that decision; `[-5%, +5%]` EQM is the band in which the decision cannot change. These are operator-utility thresholds, not SD-derived statistical thresholds. Its primary decision also retains the pre-declared interval-includes-zero retirement rule.
 
-**Pre-registration (applies to R3, R6, R10, R12–R15; only R3 survived Gate A; R6 was subsequently cancelled at its own design gate, R6-DG-002).** Every spike pre-registration is a tracked file that merges before its first run and uses commit order as proof. A metric, margin, or hypothesis added after data exists is labelled post-hoc in every table. **New pre-registrations live in `benchmarks/preregistrations/`** — `.docs/` is ignored by the global excludes file, so a pre-registration written there is silently untrackable and the commit-order proof cannot exist. R3's `.docs/spikes/S0-replication-gate.md` stays at its historical path: it is tracked, closed, and referenced by `GATE-A.md`, both evidence artifacts, and their guard test.
+**Evidence classing (applies to R3, R6.1, R13, R14, R15).** Every arm is labelled `replication`, `adaptation`, or `original`. An adaptation-class null licenses only "as implemented here, on this corpus, it did not clear a cost-justified bar" — never a refutation of the literature. R3 is the program's replication anchor; no null anywhere claims more than adaptation class until R3 passes. R6.1 is `original` and cannot make a literature or product claim after Gate A failed.
 
-**Evidence-artifact validation (applies to R3, R4, R10, R12–R15).** `archex benchmark validate --kind evidence` validates an evidence *directory* carrying a `manifest.json`, archex task IDs, and archex strategy names; it rejects a file path outright. A milestone whose deliverable is a single artifact under `benchmarks/evidence/*.json` therefore cannot be verified by that command and must name a validator that accepts its artifact. R3 adds `--kind replication` for external-reproduction artifacts. Every milestone above whose §6 verification names `--kind evidence` over a `.json` file inherits this defect and resolves it at its own design gate, either by emitting a conforming directory or by naming a validator for its shape.
+**Pre-registration (applies to R3, R6, R6.1, R10, R12–R15; only R3 survived Gate A; R6 was subsequently cancelled at its own design gate, R6-DG-002).** Every spike pre-registration is a tracked file that merges before its first run and uses commit order as proof. A metric, margin, or hypothesis added after data exists is labelled post-hoc in every table. **New pre-registrations live in `benchmarks/preregistrations/`** — `.docs/` is ignored by the global excludes file, so a pre-registration written there is silently untrackable and the commit-order proof cannot exist. R3's `.docs/spikes/S0-replication-gate.md` stays at its historical path: it is tracked, closed, and referenced by `GATE-A.md`, both evidence artifacts, and their guard test.
 
-**Determinism and no-hosted-inference boundary.** archex's default path stays deterministic, local, and free of hosted inference and API keys. R7's real-agent harness is benchmark-only and never on the product default path; R14's certificate is computed locally and must leave retrieval output byte-identical.
+**Evidence-artifact validation (applies to R3, R4, R6.1, R10, R12–R15).** `archex benchmark validate --kind evidence` validates an evidence *directory* carrying a `manifest.json`, archex task IDs, and archex strategy names; it rejects a file path outright. A milestone whose deliverable is a single artifact under `benchmarks/evidence/*.json` therefore cannot be verified by that command and must name a validator that accepts its artifact. R3 adds `--kind replication` for external-reproduction artifacts. Every milestone above whose §6 verification names `--kind evidence` over a `.json` file inherits this defect and resolves it at its own design gate, either by emitting a conforming directory or by naming a validator for its shape.
+
+**Determinism and no-hosted-inference boundary.** archex's default path stays deterministic, local, and free of hosted inference and API keys. R6.1 uses a benchmark-only, seed-recorded ordering comparator that emits one permutation during fixture construction and replays it from the committed fixture at measurement time; it never performs ANN retrieval or runs on a product path. R6.1's hosted provider calls are limited to its benchmark-only eligibility and replay harness and must leave product retrieval output byte-identical. R7's real-agent harness is benchmark-only and never on the product default path; R14's certificate is computed locally and must leave retrieval output byte-identical.
 
 **Freeze scope.** From R1 until Gate A: no new retrieval lanes, no default-promotion attempts, no new language tiers, no new MCP tools. R5 is exempt because it removes cost rather than adding surface, and it is named in the freeze clause as the single carve-out.
 
@@ -395,8 +414,9 @@ R5 shipped regardless of Gate A. R6 is cancelled because its session fixture nev
 | 2 | R3 | **Gate A — FAILED** | Complete; verdict in `GATE-A.md`, not renegotiable |
 | 3 | R2 | — | Complete |
 | 4 | **R4** | — | Next. Re-scoped by Gate A: it no longer supplies R9's margins, it answers whether any corpus this project can assemble could detect a literature-sized effect at all. That answer decides the program's disposition. |
-| 5 | R5 | — | Section C delivery complete: R5 merged and shipped in the claims-and-cost train (`v0.25.0`). R6 is cancelled — its frozen fixture never crossed the cache-eligibility floor, so no economics result exists; it carried no release train. |
-| 6 | Root-cause effort | — | Mandated by the Gate A fail clause; scope is set after R4 reports, since R4 supplies the resolution figure the root-cause question turns on. |
+| 5 | R5 | — | R5 merged and shipped in the claims-and-cost train (`v0.25.0`). R6 is cancelled — its frozen fixture never crossed the cache-eligibility floor, so no economics result exists; it carried no release train. |
+| 6 | **R6.1** | Fresh pre-registration, independent cache-eligibility review | Separately authorized ordering-only replacement. It cannot reopen Gate A, revive R6, or authorize a product or retrieval-quality claim. |
+| 7 | Root-cause effort | — | Mandated by the Gate A fail clause; scope is set after R4 reports, since R4 supplies the resolution figure the root-cause question turns on. |
 
 ```mermaid
 graph LR
@@ -404,6 +424,7 @@ graph LR
   R1 --> R3
   R1 --> R4
   R1 --> R5
+  R1 --> R6_1[R6.1]
   R3 -->|Gate A FAIL| R4
   R4 --> RC[Root-cause effort]
   R2 --> T[claims-and-cost train]

--- a/.docs/EXECUTION_PROMPTS.md
+++ b/.docs/EXECUTION_PROMPTS.md
@@ -1,6 +1,6 @@
 # Execution Prompts — archex Strategic Reassessment Program
 
-One `/goal` block per milestone in `.docs/DEVELOPMENT_PLAN.md` §6. Each block is self-contained and paste-ready. Run order follows §8 Critical Path; R2 and R5 run in parallel off R1, and R11/R15 run in parallel off R10. R6 is cancelled.
+One `/goal` block per milestone in `.docs/DEVELOPMENT_PLAN.md` §6. Each block is self-contained and paste-ready. Run order follows §8 Critical Path; R6 is cancelled and R6.1 is its separately authorized, ordering-only replacement.
 
 Milestone IDs are `R`-prefixed. **Never reuse `M1`–`M17`** — that numbering is bound to the prior plan by tracked references in `CHANGELOG.md` and `benchmarks/results/m*/DECISION.md`.
 
@@ -15,7 +15,7 @@ Milestone IDs are `R`-prefixed. **Never reuse `M1`–`M17`** — that numbering 
 - A shared mismatch in a proposed parallel wave blocks product-code work in every affected lane. Do not continue scaffolding, partial implementation, or isolated ledger writes while reconciliation is pending.
 - `GO` only makes the milestone stack merge-eligible. Release preparation stays deferred until every milestone in its train is externally merged.
 - **Gates A, B, and C are declared in advance and are not renegotiable after seeing results.** Adjusting a threshold post-hoc is a plan violation.
-- **Pre-registration ordering is load-bearing.** Where a milestone requires a pre-registration, its tracked `.docs/spikes/` file merges before the first run and commit order is the proof.
+- **Pre-registration ordering is load-bearing.** Where a milestone requires a pre-registration, its tracked file merges before the first run and commit order is the proof. New pre-registrations belong in `benchmarks/preregistrations/`; only R3's historical, already-tracked record remains under `.docs/spikes/`.
 - Never solicit an external/bot code review. The configured reviewer runs automatically.
 - The full local gate referenced below is: `uv run ruff check . && uv run ruff format --check . && uv run pyright . && uv run pytest`.
 
@@ -272,6 +272,55 @@ No execution prompt. R6 is cancelled.
 PR #592 merged the S7 pre-registration. PR #593 was reviewed and closed without merge after independent replay found every rendered prefix cache-ineligible: 72 prefixes across all three arms (24 per arm) were 50–56 `cl100k_base` tokens, below the recorded 512-token Claude Opus 5 floor. The resulting zero cache hits and zero cost deltas are construction facts, not an economics null, so the 5% kill criterion is not triggered.
 
 Do not revive this run, merge its closed branch, or make an economics claim from its artifact. A replacement requires a new milestone, a fresh pre-registration, and an independently inspected cache-eligible session fixture before any data-generating command.
+```
+
+---
+
+### R6.1 — S7 determinism as prefix-cache economics replacement `PENDING — FRESH PRE-REGISTRATION REQUIRED`
+
+```text
+/goal Deliver milestone R6.1 (S7 determinism as prefix-cache economics replacement) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
+
+CONTEXT: DEVELOPMENT_PLAN.md §6 Section C R6.1 + .docs/strategic-reassessment/03-SPIKES.md S7 + 01-LITERATURE-POSITION.md §G6. Preconditions: R1 merged; R6 remains cancelled and PR #593 remains closed without merge. This is an explicitly authorized, benchmark-only replacement after Gate A failed; no successor milestone is reopened. Repo: Python 3.11+, uv, pytest, ruff, pyright strict, GitHub Actions CI. Relevant boundaries: the shipped default retrieval path and `benchmarks/preregistrations/`.
+OBJECTIVE: Measure provider-observed prefix-cache economics over a fresh cache-eligible, frozen, 12-repository, three-turn maintenance-session fixture. Each session uses `token_budget: 8192`; the 12 repositories comprise the self-repo plus at least one task from every current external corpus family. The same selected chunks, session IDs, resolution labels, model-price schedule, and turn content apply to deterministic, seed-recorded perturbed, and seed-recorded ANN-style ordering arms; only rendered context order differs. The comparator emits a permutation during fixture construction and replays that recorded order at measurement time; it performs no live ANN retrieval. Success contract: a fresh pre-registration merged before fixture construction or data generation; every prefix meets the pre-registered provider-native eligibility floor and has exact-SHA prewarm/replay cache-use receipts; a valid artifact records `original` evidence class and paired repository-cluster bootstrap intervals with per-cell `superior` / `equivalent` / `inconclusive at this N` dispositions; and the decision retires economics for either comparator below the `+5%` MWG or whose 95% interval includes zero.
+RELEASE TRAIN: target=unversioned; included milestones=R6.1; preparation trigger=n/a; required artifacts=none; release verification=n/a; publication=not requested.
+
+PRE-IMPLEMENTATION DESIGN GATE:
+1. Read this milestone, its source-map rows, current prompt, `.docs/DEVELOPMENT_PLAN_HISTORY.md` when present, R6's cancellation record, and the current pre-registration template.
+2. Inspect the current codebase plus merged R1 predecessor diffs, merged predecessor PR outcomes, CI/check evidence, and the current provider pricing/cache documentation.
+3. Revalidate objective, interfaces, dependencies, acceptance, verification, risks, release train, the 12-repository matrix, and every listed dependent milestone (none; R16 remains cancelled).
+4. Append one ledger entry with the fields listed in DEVELOPMENT_PLAN_HISTORY.md.
+5. If no material mismatch exists, report `DESIGN GO — PLAN REVISION: none`; this authorizes implementation.
+6. If a mismatch exists, update both authoritative artifacts for R6.1 and every affected future milestone, append the revision ID, and report `DESIGN GO — PLAN REVISION: <entry IDs>`.
+7. If validity cannot be established, report `DESIGN NO-GO — REASON: <evidence>` and stop.
+
+SPECIFIC GATE CHECK: before PR-1, confirm on official provider documentation that Claude Opus 5 has a documented model-specific cache-eligibility floor, 5-minute cache writes cost 1.25× base input, cache reads cost 0.1× base input, and the replay TTL is five minutes; record those values in the pre-registration. Before PR-2, confirm the provider client's configured authentication chain supplies credentials and quota without printing a secret. A changed price invalidates dollar interpretation but not hit-rate interpretation; absent, changed, or incompatible eligibility/cache semantics is a design no-go that blocks the run. Missing credentials, quota, or provider receipt support blocks fixture construction and evidence generation. Do not substitute `cl100k_base` or another local estimate for a provider-native receipt.
+
+RECONCILIATION RULE: R6.1-DG-001 is material. PR #595, `docs(plan): reconcile R6.1 design`, is the docs-only prerequisite containing the matching plan and prompt update; it must be reviewed, green, and externally merged before any code or data PR. After it merges, rerun this gate and require `DESIGN GO — PLAN REVISION: none`.
+
+PLANNED STACK:
+0. Conditional prerequisite `docs(plan): reconcile R6.1 design` (PR #595) — scope: authoritative plan and execution prompt only; must externally merge before PR-1.
+1. PR-1 `docs(spikes): pre-register cache-eligible S7 replacement` — scope: `benchmarks/preregistrations/S7-determinism-economics-r6.1.md` only; fixes the 12 pinned task/revision rows, three-turn question sequences, `token_budget: 8192`, self-repo-plus-corpus-family selection rule, arm matrix, seeds, Claude Opus 5 cache-floor/pricing lookup URL and timestamp, distinct `+5%` MWG / `-5%` NIM / `[-5%, +5%]` EQM utility justification, `original` evidence class, per-cell `superior` / `equivalent` / `inconclusive at this N` disposition rules, 10,000-resample paired repository bootstrap, and provider receipt gate; MUST merge before fixture construction or any data-generating command.
+2. PR-2 `test(benchmark): freeze and inspect cache-eligible S7 sessions` (on PR-1) — scope: benchmark-only fixture construction, committed 12-repository session fixture, recorded seed comparator permutations, exact provider Count Tokens and prewarm/replay receipts, matrix digest, and focused tests; merge only after an independent fixture review recomputes every rendered-prefix SHA and receipt linkage. It must fail if any arm has a different chunk identity, label, model, pricing, or missing, zero, or mismatched prewarm/replay receipt.
+3. PR-3 `test(benchmark): measure S7 ordering cache economics` (on PR-2) — scope: ordering-economics runner, dedicated JSON validator, focused tests, `benchmarks/evidence/s7-determinism-economics-r6.1.json`, and `benchmarks/evidence/S7-R6.1-DECISION.md`; commits: runner and validators, frozen-fixture run, decision. Run only after PR-2 merges and the independent fixture review is recorded.
+
+CONSTRAINTS: change archex's retrieval, ranking, and ordering in no way; do not expose the provider client on a product path; use no API key from source or artifact; compare no retrieval quality, task resolution, or live ANN behavior; do not use the invalid R6 fixture or artifact; model an ANN arm as a seed-recorded reordering of identical chunks; do not batch arms in a way that shares a cache state; reject every undeclared matrix cell or arm lacking a requested prewarm/replay receipt or returned provider usage fields.
+VERIFICATION (must pass): the pre-registration commit is an ancestor of fixture and evidence commits; `uv run archex benchmark determinism-economics --sessions benchmarks/determinism_economics_r6_1/sessions.json --output benchmarks/evidence/s7-determinism-economics-r6.1.json --preregistration-commit <merged-SHA>` regenerates the artifact; `uv run archex benchmark validate --kind determinism-economics-r6-1 --input benchmarks/evidence/s7-determinism-economics-r6.1.json` exits 0; mutation tests prove matrix-digest tampering, missing receipt linkage, zero cache reads/writes, and an arm lacking required usage fields fail; full local gate green.
+REVIEW:
+Per PR:
+- Scope matches its purpose; the fresh pre-registration merges before fixture construction or data generation; no R6 artifact is reused.
+- Failures are loud; no missing provider receipt, changed SHA, cache-ineligible prefix, zero cache-use receipt, undeclared cell, or arm lacking required usage fields can record an economic result.
+- History is atomic, conventional, attribution-free, and free of unrelated formatting churn.
+- PR-specific verification output is captured.
+Whole stack:
+- Bases form one valid stack; CI is green; no regression coverage removed without replacement.
+- Independent review verifies provider token counts and prewarm/replay receipts before the measurement command, then verifies every arm made the requested cache-enabled prewarm and replay calls and returned their provider usage fields.
+- The decision has no retrieval-quality, product, literature, or Gate-A claim. If either comparison fails the `+5%` MWG or includes zero, it explicitly retires the economic framing and preserves determinism only as reproducibility. If both clear, it licenses only an original, fixture-bounded observed input-cost result and authorizes no product, default-ordering, retrieval-quality, literature, or Gate-A claim.
+- Report PR URLs, bases, verification, risks, manual gates, and review completion.
+FINAL VERDICTS:
+- Report the design verdict before the merge verdict.
+- Then report exactly one merge verdict: `GO — RELEASE: unversioned — RELEASE PREP: not-required` or `NO-GO — RELEASE: unversioned — REASON: <blocking gate>`.
+DONE: design verdict with evidence; when authorized, a reviewed stack with a release-aware merge verdict and evidence.
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Adds the separately authorized R6.1 ordering-only replacement for cancelled R6.
- Preserves R6 and closed PR #593 as invalid, non-reusable records; R6.1 cannot reopen Gate A or support product, retrieval-quality, or literature claims.
- Freezes the 12-repository fixture, provider-native cache eligibility, receipt, matrix, bootstrap, and 5% decision requirements before any data-generating work.

## Verification

- R6.1 plan/prompt completeness, three-PR count agreement, acyclic `R1 → R6.1` dependency, release-train membership, and cancellation constraints checked programmatically.
- All three `DEVELOPMENT_PLAN.md` Mermaid diagrams parsed with Mermaid 11.
- `git diff --check`
- `uv run ruff check . && uv run ruff format --check . && uv run pyright . && uv run pytest` — 4,645 passed, 9 deselected.

## Manual gates

- A fresh pre-registration must merge before fixture construction or data generation.
- Provider credentials and quota are currently unavailable in this environment. They block PR-2 fixture construction and evidence generation; no local-token fallback is permitted.
