### PR TITLE
fix(benchmark): accept live OpenRouter completion cost field

### DIFF
--- a/src/archex/benchmark/determinism_economics.py
+++ b/src/archex/benchmark/determinism_economics.py
@@ -465,7 +465,7 @@ def call_openrouter(
         raise DeterminismEconomicsError(f"OpenRouter HTTP {exc.code}: {body}") from exc
     except (URLError, TimeoutError, json.JSONDecodeError) as exc:
         raise DeterminismEconomicsError(f"OpenRouter request failed: {exc}") from exc
-    return _receipt_from_response(
+    return provider_receipt_from_response(
         raw=raw,
         session=session,
         arm=arm,
@@ -476,7 +476,7 @@ def call_openrouter(
     )
 
 
-def _receipt_from_response(
+def provider_receipt_from_response(
     *,
     raw: dict[str, Any],
     session: FrozenSession,
@@ -512,7 +512,7 @@ def _receipt_from_response(
             usage=usage,
             total_cost=float(usage["cost"]),
             upstream_inference_prompt_cost=float(costs["upstream_inference_prompt_cost"]),
-            completion_cost=float(costs["upstream_inference_completion_cost"]),
+            completion_cost=float(costs["upstream_inference_completions_cost"]),
             prompt_tokens=int(usage["prompt_tokens"]),
             cache_write_tokens=int(details.get("cache_write_tokens", 0)),
             cached_tokens=int(details.get("cached_tokens", 0)),

--- a/tests/benchmark/test_determinism_economics.py
+++ b/tests/benchmark/test_determinism_economics.py
@@ -14,6 +14,7 @@ from archex.benchmark.determinism_economics import (
     SessionFixture,
     ann_baseline_orders,
     perturbed_orders,
+    provider_receipt_from_response,
     request_payload,
     run_preflight,
     validate_provider_receipts,
@@ -99,6 +100,34 @@ def _receipt(
         cached_tokens=cached_tokens,
         completion_tokens=1,
     )
+
+
+def test_receipt_parser_accepts_current_openrouter_completion_cost_key() -> None:
+    receipt = provider_receipt_from_response(
+        raw={
+            "model": MODEL,
+            "provider": "Anthropic",
+            "id": "generation",
+            "usage": {
+                "cost": 0.01,
+                "prompt_tokens": 100,
+                "completion_tokens": 1,
+                "prompt_tokens_details": {"cache_write_tokens": 100, "cached_tokens": 0},
+                "cost_details": {
+                    "upstream_inference_prompt_cost": 0.001,
+                    "upstream_inference_completions_cost": 0.009,
+                },
+            },
+        },
+        session=_session(0),
+        arm=OrderingArm.DETERMINISTIC,
+        turn_index=1,
+        phase="measurement",
+        prefix_sha256="0" * 64,
+        request_timestamp="2026-07-29T00:00:00Z",
+    )
+
+    assert receipt.completion_cost == 0.009
 
 
 def test_request_payload_keeps_question_after_cacheable_context() -> None:


### PR DESCRIPTION
## Summary

- Parse OpenRouter's current `upstream_inference_completions_cost` receipt key.
- Keep the provider receipt strict and add a regression test using the observed response schema.

## Why

The first live S7 preflight request failed before creating evidence because the response uses the plural `completions` key. No fixture or evidence was accepted from that failed attempt.

## Verification

- `uv run ruff check src/archex/benchmark/determinism_economics.py tests/benchmark/test_determinism_economics.py`
- `uv run pyright src/archex/benchmark/determinism_economics.py tests/benchmark/test_determinism_economics.py`
- `uv run pytest --no-cov tests/benchmark/test_determinism_economics.py`
