### PR TITLE
fix(benchmark): expose OpenRouter error receipts

### DIFF
--- a/src/archex/benchmark/determinism_economics.py
+++ b/src/archex/benchmark/determinism_economics.py
@@ -488,7 +488,10 @@ def provider_receipt_from_response(
 ) -> ProviderReceipt:
     usage_value = raw.get("usage")
     if not isinstance(usage_value, dict):
-        raise DeterminismEconomicsError("OpenRouter response lacks usage")
+        error = raw.get("error")
+        raise DeterminismEconomicsError(
+            f"OpenRouter response lacks usage; fields={sorted(raw)}; error={error!r}"
+        )
     usage = cast("dict[str, Any]", usage_value)
     details_value = usage.get("prompt_tokens_details")
     costs_value = usage.get("cost_details")

--- a/tests/benchmark/test_determinism_economics.py
+++ b/tests/benchmark/test_determinism_economics.py
@@ -130,6 +130,22 @@ def test_receipt_parser_accepts_current_openrouter_completion_cost_key() -> None
     assert receipt.completion_cost == 0.009
 
 
+def test_receipt_parser_reports_provider_error_without_usage() -> None:
+    with pytest.raises(
+        DeterminismEconomicsError,
+        match="error={'message': 'provider overloaded'}",
+    ):
+        provider_receipt_from_response(
+            raw={"error": {"message": "provider overloaded"}},
+            session=_session(0),
+            arm=OrderingArm.DETERMINISTIC,
+            turn_index=1,
+            phase="measurement",
+            prefix_sha256="0" * 64,
+            request_timestamp="2026-07-29T00:00:00Z",
+        )
+
+
 def test_request_payload_keeps_question_after_cacheable_context() -> None:
     session = _session(0)
 


### PR DESCRIPTION
## Summary

- Include OpenRouter's public error payload and top-level response fields when a successful HTTP response lacks usage metadata.
- Add a regression test for a provider overload response.

## Why

The live S7 study failed loudly, but the original error discarded the provider response body. This change keeps receipt validation strict while making the next failure actionable.

## Verification

- `uv run ruff check src/archex/benchmark/determinism_economics.py tests/benchmark/test_determinism_economics.py`
- `uv run pyright src/archex/benchmark/determinism_economics.py tests/benchmark/test_determinism_economics.py`
- `uv run pytest --no-cov tests/benchmark/test_determinism_economics.py`
