### PR TITLE
fix(benchmark): space S7 measured turns by one minute

### DIFF
--- a/src/archex/benchmark/determinism_economics.py
+++ b/src/archex/benchmark/determinism_economics.py
@@ -43,6 +43,7 @@ STUDY_INSTRUCTION = (
     "Use only the selected source context."
 )
 CACHE_TTL_SECONDS = 301
+TURN_DELAY_SECONDS = 60
 
 TurnOrders: TypeAlias = tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]
 
@@ -577,6 +578,8 @@ def run_measurement(
                 )
                 _validate_measured_receipt(receipt, arm, turn_index)
                 measured.append(receipt)
+                if turn_index < 3:
+                    time.sleep(TURN_DELAY_SECONDS)
         if arm_index < len(OrderingArm) - 1:
             time.sleep(CACHE_TTL_SECONDS)
     artifact = DeterminismEconomicsArtifact(

--- a/tests/benchmark/test_determinism_economics.py
+++ b/tests/benchmark/test_determinism_economics.py
@@ -16,6 +16,7 @@ from archex.benchmark.determinism_economics import (
     perturbed_orders,
     provider_receipt_from_response,
     request_payload,
+    run_measurement,
     run_preflight,
     validate_provider_receipts,
 )
@@ -243,6 +244,44 @@ def test_receipt_validation_rejects_prefix_not_in_frozen_matrix(
 
     with pytest.raises(ValueError, match="rendered-prefix SHA-256"):
         validate_provider_receipts(receipts, fixture, preflight=True)
+
+
+def test_measurement_waits_between_turns_and_isolates_arms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _fixture()
+    sleeps: list[int] = []
+
+    def fake_call(
+        *, session: FrozenSession, arm: OrderingArm, turn_index: int, phase: str, api_key: str
+    ) -> ProviderReceipt:
+        del api_key
+        if phase == "prewarm":
+            return _receipt(
+                session, arm, turn_index, phase, cached_tokens=0, cache_write_tokens=100
+            )
+        if phase == "replay":
+            return _receipt(
+                session, arm, turn_index, phase, cached_tokens=100, cache_write_tokens=0
+            )
+        if turn_index == 1 or arm is not OrderingArm.DETERMINISTIC:
+            return _receipt(
+                session, arm, turn_index, phase, cached_tokens=0, cache_write_tokens=100
+            )
+        return _receipt(session, arm, turn_index, phase, cached_tokens=100, cache_write_tokens=0)
+
+    monkeypatch.setattr("archex.benchmark.determinism_economics.call_openrouter", fake_call)
+    monkeypatch.setattr("archex.benchmark.determinism_economics.time.sleep", sleeps.append)
+
+    artifact = run_measurement(
+        fixture=fixture,
+        preregistration_commit="c" * 40,
+        api_key="test-key",
+    )
+
+    assert len(artifact.measurement_receipts) == 108
+    assert sleeps.count(60) == 72
+    assert sleeps.count(301) == 3
 
 
 def test_preflight_fails_on_zero_cache_read(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Wait 60 seconds after each measured Turn 1 and Turn 2 receipt before issuing the following turn.
- Preserve the registered 301-second preflight and inter-arm cache-isolation waits.
- Cover the full timing schedule with a provider-free test.

## Why

The registered S7 protocol requires Turn 2 to begin one minute after Turn 1 completes and applies the same spacing to Turn 3. The initial harness sent the next turn immediately, violating that protocol and increasing transient provider overload risk.

## Verification

- `uv run ruff check src/archex/benchmark/determinism_economics.py tests/benchmark/test_determinism_economics.py`
- `uv run pyright src/archex/benchmark/determinism_economics.py tests/benchmark/test_determinism_economics.py`
- `uv run pytest --no-cov tests/benchmark/test_determinism_economics.py`
