### PR TITLE
fix(benchmark): pace S7 preflight receipt pairs

### DIFF
--- a/src/archex/benchmark/determinism_economics.py
+++ b/src/archex/benchmark/determinism_economics.py
@@ -44,6 +44,7 @@ STUDY_INSTRUCTION = (
 )
 CACHE_TTL_SECONDS = 301
 TURN_DELAY_SECONDS = 60
+PREFLIGHT_PAIR_DELAY_SECONDS = 60
 
 TurnOrders: TypeAlias = tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]
 
@@ -554,6 +555,8 @@ def run_preflight(fixture: SessionFixture, api_key: str) -> list[ProviderReceipt
                 if replay.cached_tokens <= 0:
                     raise DeterminismEconomicsError("replay receipt has zero cached_tokens")
                 receipts.extend((prewarm, replay))
+                if len(receipts) < 168:
+                    time.sleep(PREFLIGHT_PAIR_DELAY_SECONDS)
     if len(receipts) != 168:
         raise DeterminismEconomicsError(f"expected 168 preflight receipts, got {len(receipts)}")
     return receipts

--- a/tests/benchmark/test_determinism_economics.py
+++ b/tests/benchmark/test_determinism_economics.py
@@ -71,6 +71,10 @@ def _fixture() -> SessionFixture:
     )
 
 
+def _sleep_noop(_seconds: float) -> None:
+    return None
+
+
 def _receipt(
     session: FrozenSession,
     arm: OrderingArm,
@@ -211,6 +215,7 @@ def test_preflight_requires_every_unique_prefix_pair(
         "archex.benchmark.determinism_economics.call_openrouter",
         fake_call,
     )
+    monkeypatch.setattr("archex.benchmark.determinism_economics.time.sleep", _sleep_noop)
 
     receipts = run_preflight(fixture, "test-key")
 
@@ -239,6 +244,7 @@ def test_receipt_validation_rejects_prefix_not_in_frozen_matrix(
         )
 
     monkeypatch.setattr("archex.benchmark.determinism_economics.call_openrouter", fake_call)
+    monkeypatch.setattr("archex.benchmark.determinism_economics.time.sleep", _sleep_noop)
     receipts = run_preflight(fixture, "test-key")
     receipts[0] = receipts[0].model_copy(update={"rendered_prefix_sha256": "0" * 64})
 
@@ -280,7 +286,7 @@ def test_measurement_waits_between_turns_and_isolates_arms(
     )
 
     assert len(artifact.measurement_receipts) == 108
-    assert sleeps.count(60) == 72
+    assert sleeps.count(60) == 155
     assert sleeps.count(301) == 3
 
 


### PR DESCRIPTION
## Summary

- Space distinct S7 prewarm/replay prefix pairs by 60 seconds.
- Keep each pair itself consecutive so the replay remains inside the documented cache TTL.
- Extend the provider-free timing test to cover all 83 preflight gaps, 72 measured turn gaps, and three 301-second cache-isolation gaps.

## Why

OpenRouter returned provider `503 Overloaded` during rapid preflight requests. Pacing independent pairs preserves the registered cache protocol and prevents a transient provider-capacity response from being confused with a cache result.

## Verification

- `uv run ruff check src/archex/benchmark/determinism_economics.py tests/benchmark/test_determinism_economics.py`
- `uv run pyright src/archex/benchmark/determinism_economics.py tests/benchmark/test_determinism_economics.py`
- `uv run pytest --no-cov tests/benchmark/test_determinism_economics.py`
