### PR TITLE
docs(plan): reconcile R4 audit disposition

### DIFF
--- a/.docs/DEVELOPMENT_PLAN.md
+++ b/.docs/DEVELOPMENT_PLAN.md
@@ -156,7 +156,7 @@ A milestone in the `unversioned` set that later proves user-visible moves to a t
 
 > **Gate A.** Pass = at least one published win reproduced inside its pre-registered equivalence band → R7 is authorized. Fail = no published win reproduces in its own setup → **stop all research work**; every archex null to date is attributable to implementation, R7–R16 are cancelled, and the program reduces to Section A + Section C outputs plus a root-cause engineering effort. An arm that cannot be run at all is neither a pass nor a fail; it is recorded as unrunnable with its blocking evidence, and Gate A is decided by the remaining arms. Recorded in `GATE-A.md` and the ledger. Not renegotiable.
 
-#### R4 — S2 corpus validity audit `BLOCKING`
+#### R4 — S2 corpus validity audit `COMPLETE — VALIDITY DISPOSITION RECORDED`
 
 | Field | Value |
 | --- | --- |
@@ -164,12 +164,12 @@ A milestone in the `unversioned` set that later proves user-visible moves to a t
 | In / Out of scope | In: leakage scoring, clustering statistics, held-out leak measurement, power simulation, and a calibration of that simulation against R3's RepoEval corpus. Out: fixing the corpus; deleting tasks; changing retrieval; deriving MWG/NIM/EQM, which existed to feed cancelled R9. |
 | Depends on | `R1`, and `R3`'s measured interval as a calibration input |
 | Target release | `unversioned` |
-| Deliverables | A leakage score for every `benchmarks/tasks/*.yaml` (gold symbol or path appearing verbatim in `question` or `keywords`; 8 of 21 previously confirmed in the `loc_*` family — re-count, do not assume); ICC over repo clusters with the items-per-cluster distribution and largest-cluster share (**re-counted at R4's design gate**: 64 top-level tasks over 16 distinct repo values, largest cluster 24 self-repo = 37.5%; the plan's earlier 66 was wrong); an empirical held-out leak measurement for `benchmarks/held_out.txt` (**corrected at R4's design gate**: the plan previously noted only `archex_project_status` and `archex_query_pipeline` as tuning-set members. In fact all five held-out IDs are top-level tasks in `benchmarks/tasks/` — `tests/benchmark/test_generalization.py:29` asserts exactly that — and no code under `src/` or `.github/` excludes them from a run, so the held-out set is a labelling convention with no runtime separation. R4 must measure and report that, not restate the old note); a power simulation over the measured cluster-size distribution reporting the minimum detectable effect at the current N and how many **independent repositories** would be needed to resolve an effect the size R3 targeted (+4.88 points); the same simulation applied to R3's 8-cluster RepoEval structure and checked against its measured interval width, as a validation point rather than a projection; `benchmarks/evidence/s2-corpus-validity.json`. |
-| Acceptance | Every deliverable is present in the artifact. The simulation is validated against R3's measured interval before any projection about archex's corpus is believed. The report states plainly, and in one line, whether any realistic number of independent repositories makes a literature-sized effect detectable here. A negative answer is the expected and acceptable outcome. |
-| Verification | `uv run archex benchmark validate --kind replication --input benchmarks/evidence/s2-corpus-validity.json` is **not** applicable — this is an internal measurement, not a replication. R4 names its own validator at its design gate per §7's evidence-artifact rule; the audit script must rerun deterministically to the same figures; full gate green. |
-| Design reevaluation | Re-count the corpus before auditing; task counts have changed across milestones and the previously quoted 66 and 64 disagree. Resolve §7's evidence-artifact defect for this milestone's artifact shape. Dependents: none surviving — R9 and R10 are cancelled, so R4's output feeds the disposition decision and the root-cause effort, not a downstream analysis plan. |
+| Deliverables | A leakage score for every `benchmarks/tasks/*.yaml`: 9 of 21 `loc_*` tasks have an identifier-shaped gold symbol quoted in the query, and 19 of 64 tasks leak at this symbol tier (29.69%). Clustering statistics over the 64 top-level tasks and 16 distinct `repo` values, including the items-per-cluster distribution, largest self-repo cluster (24 tasks, 37.5%), and an effective-N sensitivity across explicitly assumed ICC values. The task corpus contains labels but no per-task outcome series, so it cannot identify an empirical ICC; the report must not imply otherwise. An empirical held-out leak measurement for `benchmarks/held_out.txt`: all five declared IDs are top-level tasks, and no code under `src/` or `.github/` excludes them from a run, so the held-out set is a labelling convention with no runtime separation. A power simulation over the measured cluster-size distribution reporting the minimum detectable effect at the current N and how many total tasks under the current 16-cluster structure are needed to resolve the +4.88-point literature-sized effect; the same simulation applied to R3's 8-cluster RepoEval structure and checked against its measured interval width; `benchmarks/evidence/s2-corpus-validity.json`. |
+| Acceptance | Every deliverable is present in the artifact. The simulation is calibrated against R3's measured interval before any projection about archex's corpus is believed. The report states plainly, in one line, whether a realistic expansion of the current corpus makes a literature-sized effect detectable. A negative answer is the expected and acceptable outcome. |
+| Verification | `uv run archex benchmark validate --kind corpus-audit --input benchmarks/evidence/s2-corpus-validity.json` exits 0; the audit script reruns deterministically to the same stable figures; full gate green. |
+| Design reevaluation | Resolved at delivery: the corpus was re-counted, the evidence-artifact validator accepts this artifact shape, and R3's measured interval calibrates the simulation. Dependents: none surviving — R9 and R10 are cancelled, so R4's output feeds the disposition decision and root-cause effort, not a downstream analysis plan. |
 | Risks & rollback | Risk: the simulation shows no reachable N for any candidate metric. That is the **finding**, not a failure, and it is the strongest available evidence about what this program can and cannot conclude. Rollback: revert; measurement only. |
-| Est. PRs | 3 |
+| Est. PRs | 2 after the merged R4 design reconciliation prerequisite |
 
 ### Section C — Zero-research-risk product wins
 
@@ -254,7 +254,7 @@ R5 shipped regardless of Gate A. R6 is cancelled because its session fixture nev
 | Risks & rollback | Risk: the corpus's gold-context schema does not map cleanly onto region-level metrics. Mitigation: map at file+symbol granularity first and record the loss explicitly rather than approximating. Rollback: revert the adapter. |
 | Est. PRs | 4 |
 
-#### R9 — Clustered inference and pre-registered analysis
+#### R9 — Clustered inference and pre-registered analysis `CANCELLED — GATE A FAIL`
 
 | Field | Value |
 | --- | --- |
@@ -269,7 +269,7 @@ R5 shipped regardless of Gate A. R6 is cancelled because its session fixture nev
 | Risks & rollback | Risk: the eligibility matrix is written permissively and stops constraining anything. Mitigation: the refusal test is the acceptance criterion. Rollback: revert. |
 | Est. PRs | 4 |
 
-#### R10 — S1 cost model, pilot, and full sweep
+#### R10 — S1 cost model, pilot, and full sweep `CANCELLED — GATE A FAIL`
 
 | Field | Value |
 | --- | --- |
@@ -406,16 +406,16 @@ R5 shipped regardless of Gate A. R6 is cancelled because its session fixture nev
 
 ## 8. Critical Path
 
-**Realized 2026-07-28.** R1, R2, and R3 are complete. Gate A failed, so the critical path below is what remains, not what was originally planned. The cancelled path is preserved in the second table for the record.
+**Realized 2026-07-28.** R1–R5 are complete. Gate A failed, so the critical path below is what remains, not what was originally planned. The cancelled path is preserved in the second table for the record.
 
 | Order | Milestone | Gate | Blocking reason |
 | --- | --- | --- | --- |
 | 1 | R1 | — | Complete |
 | 2 | R3 | **Gate A — FAILED** | Complete; verdict in `GATE-A.md`, not renegotiable |
 | 3 | R2 | — | Complete |
-| 4 | **R4** | — | Next. Re-scoped by Gate A: it no longer supplies R9's margins, it answers whether any corpus this project can assemble could detect a literature-sized effect at all. That answer decides the program's disposition. |
-| 5 | R5 | — | R5 merged and shipped in the claims-and-cost train (`v0.25.0`). R6 is cancelled — its frozen fixture never crossed the cache-eligibility floor, so no economics result exists; it carried no release train. |
-| 6 | Root-cause effort | — | Mandated by the Gate A fail clause; scope is set after R4 reports, since R4 supplies the resolution figure the root-cause question turns on. |
+| 4 | R4 | — | Complete. At 64 tasks over 16 repository clusters, a +4.88-point literature-sized effect has 0.108 power; the calibrated current-structure projection reaches 80% at about 2,048 total tasks. |
+| 5 | R5 | — | Complete; merged and shipped in the claims-and-cost train (`v0.25.0`). |
+| 6 | **Root-cause effort** | — | Next unblocked work. R4 establishes the required scale and validity defects; scope must address them rather than add another retrieval mechanism. |
 
 R6.1 is cancelled — two provider attempts returned `503 Overloaded` without usable receipts and a third reported zero prewarm cache-write usage. It is retained in §6 as a protocol record, not a remaining critical-path milestone.
 

--- a/.docs/EXECUTION_PROMPTS.md
+++ b/.docs/EXECUTION_PROMPTS.md
@@ -1,6 +1,6 @@
 # Execution Prompts — archex Strategic Reassessment Program
 
-One `/goal` block per active milestone in `.docs/DEVELOPMENT_PLAN.md` §6. Each block is self-contained and paste-ready. Run order follows §8 Critical Path; R6 and R6.1 are cancelled.
+This file preserves execution prompts and disposition records for the strategic-reassessment milestones. R1–R5 are complete; R6/R6.1 and R7–R16 are cancelled. A future authorized root-cause effort must follow the current §8 Critical Path.
 
 Milestone IDs are `R`-prefixed. **Never reuse `M1`–`M17`** — that numbering is bound to the prior plan by tracked references in `CHANGELOG.md` and `benchmarks/results/m*/DECISION.md`.
 
@@ -168,50 +168,14 @@ DONE: design verdict, the reviewed stack, the merge verdict, and the Gate A outc
 
 ---
 
-### R4 — S2 corpus validity audit (BLOCKING)
+### R4 — S2 corpus validity audit `COMPLETE — VALIDITY DISPOSITION RECORDED`
 
 ```text
-/goal Deliver milestone R4 (S2 corpus validity audit) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
+No execution prompt. R4 completed after the R4-DG-001 reconciliation PR #581 and merged PRs #582 and #583.
 
-CONTEXT: DEVELOPMENT_PLAN.md §6 Section B R4 + .docs/strategic-reassessment/03-SPIKES.md S2 and 00-DIAGNOSIS.md §1.2-1.4. Preconditions: R1 merged. Runs in parallel with R3. Repo: as above.
-OBJECTIVE: Quantify exactly how much the existing corpus can detect, so later effect sizes and equivalence margins are grounded rather than assumed. Success contract: a leakage score for all benchmarks/tasks/*.yaml (gold symbol or path appearing verbatim in question or keywords; 8 of 21 already confirmed in the loc_* family); ICC over repo clusters with items-per-cluster distribution and largest-cluster share (known: 24/64 self-repo = 37.5%); an empirical held-out leak measurement for benchmarks/held_out.txt (note archex_project_status and archex_query_pipeline are self-repo-cluster members that also appear in the tuning set); a power simulation over the measured cluster-size distribution reporting how many INDEPENDENT REPOS make a utility-derived EQM reachable; separately derived MWG, NIM, and EQM per candidate primary metric with EQM strictly positive; benchmarks/evidence/s2-corpus-validity.json.
-RELEASE TRAIN: target=unversioned; included milestones=R4; preparation trigger=n/a; required artifacts=none; release verification=n/a; publication=not requested.
+The checked-in corpus-audit evidence records 64 tasks across 16 repository clusters, 29.69% identifier-symbol leakage, 100% held-out overlap with no enforcing code path, and a calibrated finding that +4.88 points has 0.108 power at the current N. The calibrated projection requires about 2,048 total tasks under the current 16-cluster structure. Validate it with:
 
-PRE-IMPLEMENTATION DESIGN GATE:
-1. Read this milestone, its source-map rows, current prompt, and `.docs/DEVELOPMENT_PLAN_HISTORY.md` when present.
-2. Inspect the current codebase plus merged predecessor diffs, merged predecessor PR outcomes, CI/check evidence, and predecessor verification output.
-3. Revalidate objective, interfaces, dependencies, acceptance, verification, risks, release train, and every listed dependent milestone (R9, R10).
-4. Append one ledger entry with the fields listed in DEVELOPMENT_PLAN_HISTORY.md.
-5. If no material mismatch exists, report `DESIGN GO — PLAN REVISION: none`; this authorizes implementation.
-6. If a mismatch exists, update both authoritative artifacts for R4 and every affected future milestone, append the revision ID, and report `DESIGN GO — PLAN REVISION: <entry IDs>`.
-7. If validity cannot be established, report `DESIGN NO-GO — REASON: <evidence>` and stop.
-
-SPECIFIC GATE CHECK: re-count the corpus before auditing. Task counts have changed across milestones; do not assume 64 or 66.
-
-RECONCILIATION RULE: A material revision opens `docs(plan): reconcile R4 design` as a docs-only prerequisite PR, reviewed, green, and externally merged before any code PR.
-
-PLANNED STACK:
-0. Conditional prerequisite `docs(plan): reconcile R4 design`.
-1. PR-1 `test(benchmark): score label leakage across the task corpus` — scope: an audit script plus its tests; commits: leakage scorer, tests; verification: the scorer reruns deterministically
-2. PR-2 `test(benchmark): measure clustering, held-out leakage, and ICC` (on PR-1) — scope: clustering statistics, held-out leak measurement; commits: ICC/effective-N, held-out leak
-3. PR-3 `docs(benchmark): derive MWG/NIM/EQM and publish the validity audit` (on PR-2) — scope: power simulation, margins, benchmarks/evidence/s2-corpus-validity.json; commits: simulation, margins, artifact; verification: `uv run archex benchmark validate --kind evidence --input benchmarks/evidence/s2-corpus-validity.json` exits 0
-
-CONSTRAINTS: measure only — fix no corpus defect, delete no task, change no retrieval; EQM must be strictly positive and derived from practical utility and cost, NEVER from observed SD; MWG, NIM, and EQM are three distinct quantities and must not be conflated; the existing +0.05 F1 / no-regression / p95<=3000ms product rule is a NIM and must not be reused as an EQM.
-VERIFICATION (must pass): `uv run archex benchmark validate --kind evidence --input benchmarks/evidence/s2-corpus-validity.json` exits 0; the audit script reruns deterministically to the same figures; the full local gate is green.
-REVIEW:
-Per PR:
-- Scope matches its purpose; every statistic is reproducible from a recorded command; behavior is meaningfully tested.
-- Failures are loud; no statistic is reported without its computation being inspectable.
-- History is atomic, conventional, attribution-free, and free of unrelated formatting churn.
-- PR-specific verification output is captured.
-Whole stack:
-- Bases form one valid stack; CI is green; no regression coverage removed without replacement.
-- The report states plainly, per candidate primary metric, whether ANY realistic corpus size makes its EQM reachable. A metric with no reachable EQM is retired here, not after R10.
-- Report PR URLs, bases, verification, risks, manual gates, and review completion.
-FINAL VERDICTS:
-- Report the design verdict before the merge verdict.
-- Then report exactly one merge verdict: `GO — RELEASE: unversioned — RELEASE PREP: not-required` or `NO-GO — RELEASE: unversioned — REASON: <blocking gate>`.
-DONE: design verdict with evidence; when authorized, a reviewed stack with a release-aware merge verdict and evidence.
+uv run archex benchmark validate --kind corpus-audit --input benchmarks/evidence/s2-corpus-validity.json
 ```
 
 ---
@@ -288,502 +252,100 @@ Do not rerun this protocol, relax receipt validation, change provider routing, o
 
 ---
 
-### R7 — Real-agent execution harness
+### R7 — Real-agent execution harness `CANCELLED — GATE A FAIL`
 
 ```text
-/goal Deliver milestone R7 (Real-agent execution harness) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
+No execution prompt. Gate A failed and Section D is cancelled.
 
-CONTEXT: DEVELOPMENT_PLAN.md §6 Section D R7 + .docs/strategic-reassessment/03-SPIKES.md S1 and 00-DIAGNOSIS.md §1.1. Preconditions: R3 merged WITH A GATE A PASS, and R4 merged. Repo: as above. Relevant code: src/archex/benchmark/bundle_eval.py (existing opt-in operator-supplied-evaluator lane), src/archex/benchmark/fixed_agent.py (the ten-line stand-in this milestone replaces).
-OBJECTIVE: Put a real model in archex's benchmark loop for the first time, with context construction as the only manipulated variable. Success contract: a driver extending bundle_eval.py that holds model, scaffold, prompt template, and temperature fixed and records them in provenance, with N>=3 seeds; the six conditions {ripgrep-agent, BM25-only, dense-only, archex default, archex + symbolic rerank, oracle gold, full-repo dump} as selectable arms; first-class cost instrumentation emitting tokens-to-resolution, tool-calls-to-resolution, wall clock, and $/resolved-task per run; two-level outcome capture (resolve rate AND retrieved-context P/R/F1 against the gold diff).
-RELEASE TRAIN: target=unversioned; included milestones=R7; preparation trigger=n/a; required artifacts=none; release verification=n/a; publication=not requested.
-
-PRE-IMPLEMENTATION DESIGN GATE:
-1. Read this milestone, its source-map rows, current prompt, and `.docs/DEVELOPMENT_PLAN_HISTORY.md` when present.
-2. Inspect the current codebase plus merged predecessor diffs, merged predecessor PR outcomes, CI/check evidence, and predecessor verification output. Confirm GATE-A.md records a PASS.
-3. Revalidate objective, interfaces, dependencies, acceptance, verification, risks, release train, and every listed dependent milestone (R8, R9, R10, R12, R13, R14, R15).
-4. Append one ledger entry with the fields listed in DEVELOPMENT_PLAN_HISTORY.md.
-5. If no material mismatch exists, report `DESIGN GO — PLAN REVISION: none`; this authorizes implementation.
-6. If a mismatch exists, update both authoritative artifacts for R7 and every affected future milestone, append the revision ID, and report `DESIGN GO — PLAN REVISION: <entry IDs>`.
-7. If validity cannot be established, report `DESIGN NO-GO — REASON: <evidence>` and stop.
-
-SPECIFIC GATE CHECK: resolve DEVELOPMENT_PLAN.md §2's GAP naming the fixed model and scaffold, and record both in §2, BEFORE writing the driver. Changing either later invalidates every downstream comparison. Also re-read bundle_eval.py's existing operator-supplied-evaluator contract and extend it rather than building a parallel harness. A Gate A FAIL means this milestone does not run at all.
-
-RECONCILIATION RULE: A material revision opens `docs(plan): reconcile R7 design` as a docs-only prerequisite PR, reviewed, green, and externally merged before any code PR.
-
-PLANNED STACK:
-0. Conditional prerequisite `docs(plan): reconcile R7 design` — including the model/scaffold pin.
-1. PR-1 `feat(benchmark): add a fixed-agent driver over the bundle-eval lane` — scope: src/archex/benchmark/bundle_eval.py and a new driver module; commits: driver, provenance pin, seeds
-2. PR-2 `feat(benchmark): implement the six context conditions as selectable arms` (on PR-1) — scope: condition registry; commits: arms, config serialization
-3. PR-3 `feat(benchmark): instrument per-run cost as a first-class output` (on PR-2) — scope: cost fields on the result model; commits: instrumentation, tests asserting non-null
-4. PR-4 `feat(benchmark): capture two-level outcomes against the gold diff` (on PR-3) — scope: outcome capture; commits: resolve-rate and context P/R/F1
-5. PR-5 `refactor(benchmark): retire the fixed_agent stand-in from the real-agent path` (on PR-4) — scope: src/archex/benchmark/fixed_agent.py call sites; commits: removal from this path, tests
-
-CONSTRAINTS: run no sweep here (that is R10); wire no external corpus here (that is R8); implement no statistics here (that is R9); the real-agent harness is benchmark-only and must never touch the product default path; `compute_fixed_agent_search_turns` must not appear anywhere in the new path.
-VERIFICATION (must pass): `uv run pytest tests/ -k "agent_harness or bundle_eval"` green, including a test asserting that two arms' serialized run configurations differ ONLY in the context condition; a two-task, two-condition, one-seed smoke run completes and emits populated (never None) cost fields; re-running one task with the same seed reproduces the same trajectory-level decisions; the full local gate is green.
-REVIEW:
-Per PR:
-- Scope matches its purpose; contracts match the reconciled plan; behavior is meaningfully tested.
-- Failures are loud; a missing cost field or an unpinned model raises rather than defaults.
-- History is atomic, conventional, attribution-free, and free of unrelated formatting churn.
-- PR-specific verification output is captured.
-Whole stack:
-- Bases form one valid stack; CI is green; no regression coverage removed without replacement.
-- The product default path is untouched; determinism and the no-hosted-inference boundary hold for `archex query`.
-- Report PR URLs, bases, verification, risks, manual gates, and review completion.
-FINAL VERDICTS:
-- Report the design verdict before the merge verdict.
-- Then report exactly one merge verdict: `GO — RELEASE: unversioned — RELEASE PREP: not-required` or `NO-GO — RELEASE: unversioned — REASON: <blocking gate>`.
-DONE: design verdict with evidence; when authorized, a reviewed stack with a release-aware merge verdict and evidence.
+R7 required a Gate A pass. It must not be revived without a new authorized program and fresh pre-registration.
 ```
 
 ---
 
-### R8 — External corpus adapters and decontamination
+### R8 — External corpus adapters and decontamination `CANCELLED — GATE A FAIL`
 
 ```text
-/goal Deliver milestone R8 (External corpus adapters and decontamination) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
+No execution prompt. Gate A failed and Section D is cancelled.
 
-CONTEXT: DEVELOPMENT_PLAN.md §6 Section D R8 + .docs/strategic-reassessment/02-STRATEGY.md §C1 elements 1 and 6, and 01-LITERATURE-POSITION.md §3. Preconditions: R7 merged. Repo: as above.
-OBJECTIVE: Replace self-authored labels with external, human-annotated gold contexts, and make contamination a shipped artifact rather than a footnote. Success contract: a ContextBench (arXiv:2602.05892 — 1136 tasks, 66 repos, 8 languages) loader mapping its gold contexts onto the harness's two-level outcome; an optional SWE-Explore (arXiv:2606.07297) loader; a MinHash+LSH overlap audit reported per task and checked in as a first-class artifact; corpus provenance recorded on every run.
-RELEASE TRAIN: target=unversioned; included milestones=R8; preparation trigger=n/a; required artifacts=none; release verification=n/a; publication=not requested.
-
-PRE-IMPLEMENTATION DESIGN GATE:
-1. Read this milestone, its source-map rows, current prompt, and `.docs/DEVELOPMENT_PLAN_HISTORY.md` when present.
-2. Inspect the current codebase plus merged predecessor diffs, merged predecessor PR outcomes, CI/check evidence, and predecessor verification output.
-3. Revalidate objective, interfaces, dependencies, acceptance, verification, risks, release train, and every listed dependent milestone (R9, R10, R11, R16).
-4. Append one ledger entry with the fields listed in DEVELOPMENT_PLAN_HISTORY.md.
-5. If no material mismatch exists, report `DESIGN GO — PLAN REVISION: none`; this authorizes implementation.
-6. If a mismatch exists, update both authoritative artifacts for R8 and every affected future milestone, append the revision ID, and report `DESIGN GO — PLAN REVISION: <entry IDs>`.
-7. If validity cannot be established, report `DESIGN NO-GO — REASON: <evidence>` and stop.
-
-SPECIFIC GATE CHECK: confirm the corpus licence permits redistributing derived traces, because R11 and R16 plan to publish them. A licence that forbids it is a material mismatch requiring a plan revision to R11/R16, not a workaround here.
-
-RECONCILIATION RULE: A material revision opens `docs(plan): reconcile R8 design` as a docs-only prerequisite PR, reviewed, green, and externally merged before any code PR.
-
-PLANNED STACK:
-0. Conditional prerequisite `docs(plan): reconcile R8 design`.
-1. PR-1 `feat(benchmark): add a pinned ContextBench corpus loader` — scope: corpus adapter; commits: loader, pin, provenance; verification: the loader reports the expected task and repo counts for the pinned release
-2. PR-2 `feat(benchmark): map gold contexts onto two-level outcomes` (on PR-1) — scope: outcome mapping; commits: file+symbol mapping, explicit loss record
-3. PR-3 `feat(benchmark): add a per-task decontamination audit` (on PR-2) — scope: MinHash+LSH overlap audit; commits: audit, artifact; verification: `uv run archex benchmark validate --kind evidence` exits 0 on the audit artifact
-4. PR-4 `feat(benchmark): add the optional SWE-Explore loader` (on PR-3) — scope: second adapter; commits: loader, tests
-
-CONSTRAINTS: author no new task; modify no gold label; every task must carry a repo cluster ID and a decontamination score; if the gold-context schema does not map cleanly onto region-level metrics, map at file+symbol granularity and record the loss EXPLICITLY rather than approximating.
-VERIFICATION (must pass): the loader reports the expected task and repo counts for the pinned corpus release; `uv run archex benchmark validate --kind evidence` exits 0 on the decontamination artifact; no task in the evaluation path originates from benchmarks/tasks/ — asserted by a test; the full local gate is green.
-REVIEW:
-Per PR:
-- Scope matches its purpose; contracts match the reconciled plan; behavior is meaningfully tested.
-- Failures are loud; a corpus-version mismatch raises rather than silently loading a different task set.
-- History is atomic, conventional, attribution-free, and free of unrelated formatting churn.
-- PR-specific verification output is captured.
-Whole stack:
-- Bases form one valid stack; CI is green; no regression coverage removed without replacement.
-- The audit artifact is reproducible from a recorded command.
-- Report PR URLs, bases, verification, risks, manual gates, and review completion.
-FINAL VERDICTS:
-- Report the design verdict before the merge verdict.
-- Then report exactly one merge verdict: `GO — RELEASE: unversioned — RELEASE PREP: not-required` or `NO-GO — RELEASE: unversioned — REASON: <blocking gate>`.
-DONE: design verdict with evidence; when authorized, a reviewed stack with a release-aware merge verdict and evidence.
+R8 depended on R7's real-agent harness. It must not be revived without a new authorized program and fresh pre-registration.
 ```
 
 ---
 
-### R9 — Clustered inference and pre-registered analysis
+### R9 — Clustered inference and pre-registered analysis `CANCELLED — GATE A FAIL`
 
 ```text
-/goal Deliver milestone R9 (Clustered inference and pre-registered analysis) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
+No execution prompt. Gate A failed and Section D is cancelled.
 
-CONTEXT: DEVELOPMENT_PLAN.md §6 Section D R9 and §7 Statistical discipline + .docs/strategic-reassessment/03-SPIKES.md preamble. Preconditions: R8 merged; R4's margins available. Repo: as above.
-OBJECTIVE: Make the analysis defensible before any result exists, using the margins R4 derived. Success contract: a cluster bootstrap resampling REPOSITORIES, not tasks; ICC and effective N on every report; TOST against R4's utility-derived EQM producing three-valued verdicts (superior / equivalent / inconclusive at this N); one declared primary metric and one primary comparison family with everything else labelled exploratory in every rendered table; a predeclared, checked-in, machine-readable eligibility matrix recording per arm the layer, comparison_group, eligible corpora, supported languages, modes, applicable metrics, and a mandatory exclusion_reason for every excluded cell.
-RELEASE TRAIN: target=unversioned; included milestones=R9; preparation trigger=n/a; required artifacts=none; release verification=n/a; publication=not requested.
-
-PRE-IMPLEMENTATION DESIGN GATE:
-1. Read this milestone, its source-map rows, current prompt, and `.docs/DEVELOPMENT_PLAN_HISTORY.md` when present.
-2. Inspect the current codebase plus merged predecessor diffs, merged predecessor PR outcomes, CI/check evidence, and predecessor verification output.
-3. Revalidate objective, interfaces, dependencies, acceptance, verification, risks, release train, and every listed dependent milestone (R10, R12, R13, R14, R15, R16).
-4. Append one ledger entry with the fields listed in DEVELOPMENT_PLAN_HISTORY.md.
-5. If no material mismatch exists, report `DESIGN GO — PLAN REVISION: none`; this authorizes implementation.
-6. If a mismatch exists, update both authoritative artifacts for R9 and every affected future milestone, append the revision ID, and report `DESIGN GO — PLAN REVISION: <entry IDs>`.
-7. If validity cannot be established, report `DESIGN NO-GO — REASON: <evidence>` and stop.
-
-SPECIFIC GATE CHECK: re-read R4's margins. If R4 retired the intended primary metric as having no reachable EQM, choose and record the replacement HERE, before any analysis code is written.
-
-RECONCILIATION RULE: A material revision opens `docs(plan): reconcile R9 design` as a docs-only prerequisite PR, reviewed, green, and externally merged before any code PR.
-
-PLANNED STACK:
-0. Conditional prerequisite `docs(plan): reconcile R9 design`.
-1. PR-1 `feat(benchmark): add a repository-clustered bootstrap` — scope: bootstrap over clusters, ICC, effective N; commits: bootstrap, ICC; verification: a test asserting resampling is over repositories, not tasks
-2. PR-2 `feat(benchmark): add TOST equivalence with three-valued verdicts` (on PR-1) — scope: TOST against R4's EQM; commits: TOST, verdict rendering
-3. PR-3 `feat(benchmark): declare the primary metric and label exploratory rows` (on PR-2) — scope: primary declaration, table rendering; commits: declaration, exploratory labelling
-4. PR-4 `feat(benchmark): enforce a predeclared eligibility matrix` (on PR-3) — scope: machine-readable matrix, runner refusal; commits: matrix, refusal; verification: a test asserting the runner raises on an undeclared cell
-
-CONSTRAINTS: run no sweep here; interpret no result here; cluster identity is GLOBAL — a repo appearing in two corpora resolves to one cluster and lands on one side of any split; an unsupported language yields an excluded cell with a reason, never a zero; an inapplicable metric renders `n/a`, never 0.
-VERIFICATION (must pass): `uv run pytest tests/ -k "cluster_bootstrap or tost or eligibility"` green, including a test asserting the runner raises on an undeclared cell and a test asserting global cluster identity; the full local gate is green.
-REVIEW:
-Per PR:
-- Scope matches its purpose; contracts match the reconciled plan; behavior is meaningfully tested.
-- Failures are loud; an undeclared cell raises rather than rendering.
-- History is atomic, conventional, attribution-free, and free of unrelated formatting churn.
-- PR-specific verification output is captured.
-Whole stack:
-- Bases form one valid stack; CI is green; no regression coverage removed without replacement.
-- The eligibility matrix genuinely constrains — the refusal test is the proof, not the matrix's existence.
-- Report PR URLs, bases, verification, risks, manual gates, and review completion.
-FINAL VERDICTS:
-- Report the design verdict before the merge verdict.
-- Then report exactly one merge verdict: `GO — RELEASE: unversioned — RELEASE PREP: not-required` or `NO-GO — RELEASE: unversioned — REASON: <blocking gate>`.
-DONE: design verdict with evidence; when authorized, a reviewed stack with a release-aware merge verdict and evidence.
+R9 required R8's external-corpus adapter and R4's now-retired margin derivation. R4 instead established the current corpus's inability to resolve a literature-sized effect; R9 must not be revived without a new authorized program and fresh pre-registration.
 ```
 
 ---
 
-### R10 — S1 cost model, pilot, and full sweep (Gate B)
+### R10 — S1 cost model, pilot, and full sweep `CANCELLED — GATE A FAIL`
 
 ```text
-/goal Deliver milestone R10 (S1 cost model, pilot, and full sweep) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
+No execution prompt. Gate A failed and Section D is cancelled.
 
-CONTEXT: DEVELOPMENT_PLAN.md §6 Section D R10 + .docs/strategic-reassessment/03-SPIKES.md S1 and 05-ROADMAP.md §3. Preconditions: R9 merged. Repo: as above.
-OBJECTIVE: Produce the first measurement in archex's history of whether context quality changes agentic outcomes. Success contract: a cost model computed against current pricing BEFORE any sweep, resolving DEVELOPMENT_PLAN.md §2's budget GAP; a 3-repo x 6-condition x 3-seed pilot used ONLY for plumbing and variance estimation; a cluster-stratified sweep (stratify by repo; never subsample tasks within a repo); .docs/spikes/S1-context-isolation.md pre-registered and merged before the sweep; benchmarks/evidence/s1-context-isolation.json; GATE-B.md.
-RELEASE TRAIN: target=unversioned; included milestones=R10; preparation trigger=n/a; required artifacts=none; release verification=n/a; publication=not requested.
-
-PRE-IMPLEMENTATION DESIGN GATE:
-1. Read this milestone, its source-map rows, current prompt, and `.docs/DEVELOPMENT_PLAN_HISTORY.md` when present.
-2. Inspect the current codebase plus merged predecessor diffs, merged predecessor PR outcomes, CI/check evidence, and predecessor verification output.
-3. Revalidate objective, interfaces, dependencies, acceptance, verification, risks, release train, and every listed dependent milestone (R11, R12, R13, R14, R15, R16).
-4. Append one ledger entry with the fields listed in DEVELOPMENT_PLAN_HISTORY.md.
-5. If no material mismatch exists, report `DESIGN GO — PLAN REVISION: none`; this authorizes implementation.
-6. If a mismatch exists, update both authoritative artifacts for R10 and every affected future milestone, append the revision ID, and report `DESIGN GO — PLAN REVISION: <entry IDs>`.
-7. If validity cannot be established, report `DESIGN NO-GO — REASON: <evidence>` and stop.
-
-SPECIFIC GATE CHECK: compute the real cost FIRST. A figure materially above the operator's ceiling is `DESIGN NO-GO` for R10 — reduce seeds or conditions, NEVER the cluster count. Independent clusters are the scarce resource.
-
-RECONCILIATION RULE: A material revision opens `docs(plan): reconcile R10 design` as a docs-only prerequisite PR, reviewed, green, and externally merged before any code PR.
-
-PLANNED STACK:
-0. Conditional prerequisite `docs(plan): reconcile R10 design`.
-1. PR-1 `docs(benchmark): compute the sweep cost model against current pricing` — scope: cost model, budget resolution in DEVELOPMENT_PLAN.md §2; commits: model, GAP resolution
-2. PR-2 `test(benchmark): run the plumbing pilot and report variance only` (on PR-1) — scope: pilot run, report; commits: pilot, variance report; verification: the pilot report contains variance and completion statistics ONLY, no per-condition outcome means
-3. PR-3 `docs(spikes): pre-register S1 context isolation` (on PR-2) — scope: .docs/spikes/S1-context-isolation.md only; gate: MUST merge before the sweep — commit order is the proof
-4. PR-4 `test(benchmark): execute the cluster-stratified sweep and record Gate B` (on PR-3) — scope: sweep, benchmarks/evidence/s1-context-isolation.json, GATE-B.md; commits: sweep, evidence, verdict; verification: `uv run archex benchmark validate --kind evidence --input benchmarks/evidence/s1-context-isolation.json` exits 0
-
-CONSTRAINTS: change no mechanism; run no payload spike; do not inspect the pilot's effect direction; stratify by repository; checkpoint per cluster so a budget overrun yields a run reported as PARTIAL with its cluster count, never aggregated as if complete; every reported figure carries a cluster-bootstrapped interval and a three-valued verdict.
-VERIFICATION (must pass): `uv run archex benchmark validate --kind evidence --input benchmarks/evidence/s1-context-isolation.json` exits 0; the recorded sweep command reruns; the pre-registration merged before the sweep, verifiable by commit order; the full local gate is green.
-REVIEW:
-Per PR:
-- Scope matches its purpose; contracts match the reconciled plan; behavior is meaningfully tested.
-- Failures are loud; a partial sweep is labelled partial, never averaged into a headline.
-- History is atomic, conventional, attribution-free, and free of unrelated formatting churn.
-- PR-specific verification output is captured.
-Whole stack:
-- Bases form one valid stack; CI is green; no regression coverage removed without replacement.
-- GATE-B.md states the oracle-vs-ripgrep spread against R4's pre-declared SESOI in one line, without editorialising.
-- Report PR URLs, bases, verification, risks, manual gates, and review completion.
-FINAL VERDICTS:
-- Report the design verdict before the merge verdict.
-- Then report exactly one merge verdict: `GO — RELEASE: unversioned — RELEASE PREP: not-required` or `NO-GO — RELEASE: unversioned — REASON: <blocking gate>`.
-- Additionally report the Gate B outcome verbatim: `GATE B PASS — oracle-vs-ripgrep spread <x> exceeds SESOI <y>` or `GATE B FAIL — spread <x> below SESOI <y>`.
-- A Gate B FAIL is the program's headline finding, not a failure. R12 and R14 still proceed; R13 and R15 become optional; product positioning shifts to P1/P2/P3 per 04-PRODUCT-AND-ECONOMICS.md §3. Do not pivot the program again on a Gate B fail — write the paper. Pre-declared and not renegotiable.
-DONE: design verdict, the reviewed stack, the merge verdict, and the Gate B outcome with evidence.
+R10 depended on cancelled R9 and on the real-agent harness path that Gate A blocked. It must not be revived without a new authorized program and fresh pre-registration.
 ```
 
 ---
 
-### R11 — Harness extraction to a standalone public repository
+### R11 — Harness extraction to a standalone public repository `CANCELLED — GATE A FAIL`
 
 ```text
-/goal Deliver milestone R11 (Harness extraction to a standalone public repository) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
+No execution prompt. Gate A failed and Section D is cancelled.
 
-CONTEXT: DEVELOPMENT_PLAN.md §6 Section D R11 + .docs/strategic-reassessment/04-PRODUCT-AND-ECONOMICS.md §2. Preconditions: R10 merged. Repo: as above.
-OBJECTIVE: Make the instrument independently installable, versionable, and citable, and remove the "vendor benchmarks itself" structural conflict. Success contract: a new public repository containing the harness, corpus adapters, eligibility matrix, analysis, and reproduction instructions, depending on archex as ONE ARM AMONG SIX; archex retains only what its own CLI needs; a pointer from docs/ to the new repository.
-RELEASE TRAIN: target=none (separate repository; out of scope for archex versioning); included milestones=R11; preparation trigger=n/a; required artifacts=none; release verification=n/a; publication=separate-repo release.
-
-PRE-IMPLEMENTATION DESIGN GATE:
-1. Read this milestone, its source-map rows, current prompt, and `.docs/DEVELOPMENT_PLAN_HISTORY.md` when present.
-2. Inspect the current codebase plus merged predecessor diffs, merged predecessor PR outcomes, CI/check evidence, and predecessor verification output.
-3. Revalidate objective, interfaces, dependencies, acceptance, verification, risks, release train, and every listed dependent milestone (R16).
-4. Append one ledger entry with the fields listed in DEVELOPMENT_PLAN_HISTORY.md.
-5. If no material mismatch exists, report `DESIGN GO — PLAN REVISION: none`; this authorizes implementation.
-6. If a mismatch exists, update both authoritative artifacts for R11 and every affected future milestone, append the revision ID, and report `DESIGN GO — PLAN REVISION: <entry IDs>`.
-7. If validity cannot be established, report `DESIGN NO-GO — REASON: <evidence>` and stop.
-
-SPECIFIC GATE CHECK: confirm R8's corpus licence permits redistributing derived traces from the new repository. A negative answer changes R16's scope and must be recorded as a plan revision before extraction.
-
-RECONCILIATION RULE: A material revision opens `docs(plan): reconcile R11 design` as a docs-only prerequisite PR, reviewed, green, and externally merged before any code PR.
-
-PLANNED STACK:
-0. Conditional prerequisite `docs(plan): reconcile R11 design`.
-1. PR-1 `feat(bench-repo): scaffold the standalone harness package` — scope: new repository scaffold, packaging, CI; commits: scaffold, CI
-2. PR-2 `feat(bench-repo): port harness, adapters, eligibility matrix, and analysis` (on PR-1) — scope: additive port; commits: harness, adapters, analysis
-3. PR-3 `docs(bench-repo): add reproduction instructions and the archex arm` (on PR-2) — scope: README, reproduction command; commits: docs, arm registration
-4. PR-4 `refactor(benchmark): remove the extracted surface from archex` (on PR-3) — scope: archex removals, docs pointer; commits: removal, pointer; verification: `uv run pytest` green in archex
-
-CONSTRAINTS: extract ADDITIVELY first and remove only in PR-4, so a rollback reverts one PR; move no archex retrieval code; archex must remain one selectable arm, never a privileged default.
-VERIFICATION (must pass): in a clean environment, install the extracted package and run its smoke command to completion WITHOUT a working copy of this repository beyond the published archex package; `uv run pytest` green in archex; the full local gate is green.
-REVIEW:
-Per PR:
-- Scope matches its purpose; contracts match the reconciled plan; behavior is meaningfully tested.
-- Failures are loud; a missing dependency fails at install, not at first run.
-- History is atomic, conventional, attribution-free, and free of unrelated formatting churn.
-- PR-specific verification output is captured.
-Whole stack:
-- Bases form one valid stack; CI is green in both repositories; no regression coverage removed without replacement.
-- archex's own benchmark CLI still works after the removal PR.
-- Report PR URLs, bases, verification, risks, manual gates, and review completion.
-FINAL VERDICTS:
-- Report the design verdict before the merge verdict.
-- Then report exactly one merge verdict: `GO — RELEASE: none — RELEASE PREP: not-required` or `NO-GO — RELEASE: none — REASON: <blocking gate>`.
-DONE: design verdict with evidence; when authorized, a reviewed stack with a release-aware merge verdict and evidence.
+R11 depended on R10's cancelled evaluation instrument. It must not be revived without a new authorized program and fresh pre-registration.
 ```
 
 ---
 
-### R12 — S6 long context versus retrieval, matched, on code
+### R12 — S6 long context versus retrieval, matched, on code `CANCELLED — GATE A FAIL`
 
 ```text
-/goal Deliver milestone R12 (S6 long context versus retrieval) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
+No execution prompt. Gate A failed and Section E is cancelled.
 
-CONTEXT: DEVELOPMENT_PLAN.md §6 Section E R12 + .docs/strategic-reassessment/03-SPIKES.md S6 and 01-LITERATURE-POSITION.md §2. Preconditions: R10 merged. First payload milestone — reuses R10's harness wholesale. Repo: as above.
-OBJECTIVE: Run the matched head-to-head nobody has run: does retrieval still help when the whole repo fits in the window? Success contract: .docs/spikes/S6-longcontext-vs-retrieval.md pre-registered; the same tasks and model across retrieved-budget-packed, full-repo dump, and retrieved-then-dumped, sweeping total context length; benchmarks/evidence/s6-longcontext-vs-retrieval.json reporting resolve rate and $/resolved-task per arm per context length with cluster-bootstrapped intervals.
-RELEASE TRAIN: target=unversioned; included milestones=R12; preparation trigger=n/a; required artifacts=none; release verification=n/a; publication=not requested.
-
-PRE-IMPLEMENTATION DESIGN GATE:
-1. Read this milestone, its source-map rows, current prompt, and `.docs/DEVELOPMENT_PLAN_HISTORY.md` when present.
-2. Inspect the current codebase plus merged predecessor diffs, merged predecessor PR outcomes, CI/check evidence, and predecessor verification output.
-3. Revalidate objective, interfaces, dependencies, acceptance, verification, risks, release train, and every listed dependent milestone (R16).
-4. Append one ledger entry with the fields listed in DEVELOPMENT_PLAN_HISTORY.md.
-5. If no material mismatch exists, report `DESIGN GO — PLAN REVISION: none`; this authorizes implementation.
-6. If a mismatch exists, update both authoritative artifacts for R12 and every affected future milestone, append the revision ID, and report `DESIGN GO — PLAN REVISION: <entry IDs>`.
-7. If validity cannot be established, report `DESIGN NO-GO — REASON: <evidence>` and stop.
-
-SPECIFIC GATE CHECK: confirm the pinned model's context limit still admits the full-repo arm for the chosen repos. If it does not, report the excluded repos as excluded cells with a reason in R9's eligibility matrix — never shrink the corpus silently.
-
-RECONCILIATION RULE: A material revision opens `docs(plan): reconcile R12 design` as a docs-only prerequisite PR, reviewed, green, and externally merged before any code PR.
-
-PLANNED STACK:
-0. Conditional prerequisite `docs(plan): reconcile R12 design`.
-1. PR-1 `docs(spikes): pre-register S6 long-context versus retrieval` — scope: .docs/spikes/S6-longcontext-vs-retrieval.md only; gate: MUST merge before any run
-2. PR-2 `feat(benchmark): add full-dump and retrieved-then-dumped arms with a length sweep` (on PR-1) — scope: arms, sweep; commits: arms, sweep config
-3. PR-3 `test(benchmark): run the matched comparison and publish evidence` (on PR-2) — scope: run, benchmarks/evidence/s6-longcontext-vs-retrieval.json; commits: run, evidence; verification: `uv run archex benchmark validate --kind evidence --input benchmarks/evidence/s6-longcontext-vs-retrieval.json` exits 0
-
-CONSTRAINTS: introduce no new mechanism; all three arms run on the same task set with the same model; report cost alongside quality at EVERY context length.
-VERIFICATION (must pass): `uv run archex benchmark validate --kind evidence --input benchmarks/evidence/s6-longcontext-vs-retrieval.json` exits 0; the full local gate is green.
-REVIEW:
-Per PR:
-- Scope matches its purpose; the pre-registration merged before the run; behavior is meaningfully tested.
-- Failures are loud; a context-limit overflow raises rather than truncating silently.
-- History is atomic, conventional, attribution-free, and free of unrelated formatting churn.
-- PR-specific verification output is captured.
-Whole stack:
-- Bases form one valid stack; CI is green; no regression coverage removed without replacement.
-- The report states which arm wins per length band with a three-valued verdict. There is no kill criterion — both outcomes are informative, and if full-dump wins, that is the program's most important finding and must be reported as such, not buried.
-- Report PR URLs, bases, verification, risks, manual gates, and review completion.
-FINAL VERDICTS:
-- Report the design verdict before the merge verdict.
-- Then report exactly one merge verdict: `GO — RELEASE: unversioned — RELEASE PREP: not-required` or `NO-GO — RELEASE: unversioned — REASON: <blocking gate>`.
-DONE: design verdict with evidence; when authorized, a reviewed stack with a release-aware merge verdict and evidence.
+R12 depended on R10's cancelled evaluation instrument. It must not be revived without a new authorized program and fresh pre-registration.
 ```
 
 ---
 
-### R13 — S3 strong-baseline replication of published graph-expansion gains
+### R13 — S3 strong-baseline replication of published graph-expansion gains `CANCELLED — GATE A FAIL`
 
 ```text
-/goal Deliver milestone R13 (S3 strong-baseline replication) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
+No execution prompt. Gate A failed and Section E is cancelled.
 
-CONTEXT: DEVELOPMENT_PLAN.md §6 Section E R13 + .docs/strategic-reassessment/03-SPIKES.md S3, 00-DIAGNOSIS.md §2.1, and 01-LITERATURE-POSITION.md §1. Preconditions: R10 merged; R3 passed Gate A. Repo: as above.
-OBJECTIVE: Test whether the field's reported graph-expansion gains survive a strong baseline — the single result that converts archex's dead nulls into a citable field-level correction. Success contract: .docs/spikes/S3-strong-baseline.md pre-registered; 2-3 of {RepoHyper, GraphCoder, RepoGraph, DraCo} each reproduced against the paper's OWN weak baseline first (replication class, per R3's rule) and then measured against archex's strong BM25F+graph baseline; benchmarks/evidence/s3-strong-baseline.json reporting the DELTA-OF-DELTAS with intervals.
-RELEASE TRAIN: target=unversioned; included milestones=R13; preparation trigger=n/a; required artifacts=none; release verification=n/a; publication=not requested.
-
-PRE-IMPLEMENTATION DESIGN GATE:
-1. Read this milestone, its source-map rows, current prompt, and `.docs/DEVELOPMENT_PLAN_HISTORY.md` when present.
-2. Inspect the current codebase plus merged predecessor diffs, merged predecessor PR outcomes, CI/check evidence, and predecessor verification output.
-3. Revalidate objective, interfaces, dependencies, acceptance, verification, risks, release train, and every listed dependent milestone (R16).
-4. Append one ledger entry with the fields listed in DEVELOPMENT_PLAN_HISTORY.md.
-5. If no material mismatch exists, report `DESIGN GO — PLAN REVISION: none`; this authorizes implementation.
-6. If a mismatch exists, update both authoritative artifacts for R13 and every affected future milestone, append the revision ID, and report `DESIGN GO — PLAN REVISION: <entry IDs>`.
-7. If validity cannot be established, report `DESIGN NO-GO — REASON: <evidence>` and stop.
-
-SPECIFIC GATE CHECK: confirm each chosen paper's artifact is fetchable and its baseline is specified precisely enough to reproduce. Drop any paper that is not, and record why. Do not substitute an approximation of a paper's baseline.
-
-RECONCILIATION RULE: A material revision opens `docs(plan): reconcile R13 design` as a docs-only prerequisite PR, reviewed, green, and externally merged before any code PR.
-
-PLANNED STACK:
-0. Conditional prerequisite `docs(plan): reconcile R13 design`.
-1. PR-1 `docs(spikes): pre-register S3 strong-baseline replication` — scope: .docs/spikes/S3-strong-baseline.md only; gate: MUST merge before any run
-2. PR-2 `test(replication): reproduce paper A against its own baseline` (on PR-1) — scope: benchmarks/replication/<paper-a>/; commits: harness, run
-3. PR-3 `test(replication): reproduce paper B against its own baseline` (on PR-2) — scope: benchmarks/replication/<paper-b>/; commits: harness, run
-4. PR-4 `test(benchmark): measure both mechanisms against the archex strong baseline` (on PR-3) — scope: strong-baseline arms; commits: arms, runs
-5. PR-5 `docs(benchmark): publish the delta-of-deltas` (on PR-4) — scope: benchmarks/evidence/s3-strong-baseline.json; commits: evidence; verification: `uv run archex benchmark validate --kind evidence --input benchmarks/evidence/s3-strong-baseline.json` exits 0
-
-CONSTRAINTS: promote no mechanism to the archex default; label every arm `replication` or `adaptation`; a paper whose own baseline does not reproduce is reported `inconclusive` and EXCLUDED from the delta-of-deltas, never silently folded in; the headline quantity is the delta-of-deltas, not either delta alone.
-VERIFICATION (must pass): `uv run archex benchmark validate --kind evidence --input benchmarks/evidence/s3-strong-baseline.json` exits 0; every recorded reproduction command reruns; the full local gate is green.
-REVIEW:
-Per PR:
-- Scope matches its purpose; every reproduction is pinned and rerunnable; behavior is meaningfully tested.
-- Failures are loud; a non-reproducing baseline is reported, not approximated around.
-- History is atomic, conventional, attribution-free, and free of unrelated formatting churn.
-- PR-specific verification output is captured.
-Whole stack:
-- Bases form one valid stack; CI is green; no regression coverage removed without replacement.
-- If NO paper's own baseline reproduces, the milestone reports `inconclusive` and stops — it cannot distinguish "gains are baseline artifacts" from "our reimplementation is wrong." Pre-declared.
-- Report PR URLs, bases, verification, risks, manual gates, and review completion.
-FINAL VERDICTS:
-- Report the design verdict before the merge verdict.
-- Then report exactly one merge verdict: `GO — RELEASE: unversioned — RELEASE PREP: not-required` or `NO-GO — RELEASE: unversioned — REASON: <blocking gate>`.
-DONE: design verdict with evidence; when authorized, a reviewed stack with a release-aware merge verdict and evidence.
+R13 depended on R10's cancelled evaluation instrument. It must not be revived without a new authorized program and fresh pre-registration.
 ```
 
 ---
 
-### R14 — S4 certified context receipt
+### R14 — S4 certified context receipt `CANCELLED — GATE A FAIL`
 
 ```text
-/goal Deliver milestone R14 (S4 certified context receipt) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
+No execution prompt. Gate A failed and Section E is cancelled.
 
-CONTEXT: DEVELOPMENT_PLAN.md §6 Section E R14 + .docs/strategic-reassessment/02-STRATEGY.md §C2 and 01-LITERATURE-POSITION.md §G2-G3. Preconditions: R10 merged. Repo: as above. Requires NO change to the retrieval pipeline.
-OBJECTIVE: Turn the receipt's asserted completeness verdict into two independently measured, falsifiable properties. Success contract: a monotone submodular coverage function f(S) over code-structural units (referenced symbols, k-hop call/import edges at declining weight, touched type definitions, file breadth) with monotonicity and submodularity PROVEN in the design document; the certificate f(returned)/f(greedy(budget)) emitted into the receipt for whatever the upstream retriever produced; a ReproRAG-style (arXiv:2509.18869) reproducibility score for the hybrid index; correlation of both against R10's resolve rate and gold-context F1; negative controls — random selection, the prior null MMR packer, and greedy-vs-brute-force on small instances; a head-to-head against a learned sufficiency classifier.
-RELEASE TRAIN: target=> GAP: version not source-traceable — operator selects at preparation time (train certified-receipt); included milestones=R14; preparation trigger=R14 externally merged AND its promotion verdict is GO; required artifacts=both (pyproject.toml version + CHANGELOG.md); release verification=full local gate green plus the certificate correlation artifact checked in; publication=git tag then `uv build` then `uv publish` then `gh release create` (manual).
-
-PRE-IMPLEMENTATION DESIGN GATE:
-1. Read this milestone, its source-map rows, current prompt, and `.docs/DEVELOPMENT_PLAN_HISTORY.md` when present.
-2. Inspect the current codebase plus merged predecessor diffs, merged predecessor PR outcomes, CI/check evidence, and predecessor verification output.
-3. Revalidate objective, interfaces, dependencies, acceptance, verification, risks, release train, and every listed dependent milestone (R16).
-4. Append one ledger entry with the fields listed in DEVELOPMENT_PLAN_HISTORY.md.
-5. If no material mismatch exists, report `DESIGN GO — PLAN REVISION: none`; this authorizes implementation.
-6. If a mismatch exists, update both authoritative artifacts for R14 and every affected future milestone, append the revision ID, and report `DESIGN GO — PLAN REVISION: <entry IDs>`.
-7. If validity cannot be established, report `DESIGN NO-GO — REASON: <evidence>` and stop.
-
-SPECIFIC GATE CHECK: confirm the coverage function's units are computable for every language tier, not just `full`. A tier-limited certificate must declare its scope in the receipt rather than silently degrading.
-
-RECONCILIATION RULE: A material revision opens `docs(plan): reconcile R14 design` as a docs-only prerequisite PR, reviewed, green, and externally merged before any code PR.
-
-PLANNED STACK:
-0. Conditional prerequisite `docs(plan): reconcile R14 design`.
-1. PR-1 `docs(design): define and prove the structural coverage function` — scope: design document with the monotonicity and submodularity proofs; commits: definition, proofs
-2. PR-2 `feat(serve): emit a retriever-agnostic coverage certificate in the receipt` (on PR-1) — scope: certificate computation, receipt field; commits: certificate, receipt; verification: a byte-identity test for retrieval output with certification on and off
-3. PR-3 `feat(index): add a reproducibility score for the hybrid index` (on PR-2) — scope: ReproRAG-style scoring; commits: score, tests
-4. PR-4 `test(benchmark): add negative controls and the learned-classifier head-to-head` (on PR-3) — scope: random-selection, MMR, brute-force controls, classifier arm; commits: controls, arm; verification: a non-vacuity test asserting random scores materially below greedy
-5. PR-5 `docs(benchmark): publish the certificate correlation evidence` (on PR-4) — scope: correlation artifact, CHANGELOG.md; commits: evidence, changelog
-
-CONSTRAINTS: change retrieval, ranking, and packing in no way — retrieval output must be BYTE-IDENTICAL with certification on and off; write the submodularity proof out, never assert it; certify an arbitrary upstream result set, demonstrated by certifying a non-archex arm; the certificate must be computed locally with no hosted inference.
-VERIFICATION (must pass): `uv run pytest tests/ -k "coverage_certificate or reproducibility_score"` green, including the byte-identity test and the non-vacuity test; `uv run archex benchmark validate --kind evidence` exits 0 on the correlation artifact; the full local gate is green.
-REVIEW:
-Per PR:
-- Scope matches its purpose; contracts match the reconciled plan; behavior is meaningfully tested.
-- Failures are loud; an uncomputable coverage unit raises or declares reduced scope, never silently returns a smaller certificate.
-- History is atomic, conventional, attribution-free, and free of unrelated formatting churn.
-- PR-specific verification output is captured.
-Whole stack:
-- Bases form one valid stack; CI is green; no regression coverage removed without replacement.
-- Correlations are reported with cluster-bootstrapped intervals and three-valued verdicts.
-- If NEITHER the certificate nor the reproducibility score correlates with anything, publish the null, drop product line P2, and DO NOT fire the certified-receipt release train. Pre-declared.
-- Report PR URLs, bases, verification, risks, manual gates, and review completion.
-FINAL VERDICTS:
-- Report the design verdict before the merge verdict.
-- Then report exactly one merge verdict: `GO — RELEASE: certified-receipt (> GAP: version) — RELEASE PREP: pending` or `NO-GO — RELEASE: certified-receipt — REASON: <blocking gate>`.
-- A null correlation is a `GO` for merge but explicitly changes the release target to `unversioned` via a plan revision; the train does not fire on a null.
-DONE: design verdict with evidence; when authorized, a reviewed stack with a release-aware merge verdict and evidence.
+R14 depended on R10's cancelled evaluation instrument. It must not be revived without a new authorized program and fresh pre-registration.
 ```
 
 ---
 
-### R15 — S5 co-change and ownership ranking fusion
+### R15 — S5 co-change and ownership ranking fusion `CANCELLED — GATE A FAIL`
 
 ```text
-/goal Deliver milestone R15 (S5 co-change and ownership ranking fusion) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
+No execution prompt. Gate A failed and Section E is cancelled.
 
-CONTEXT: DEVELOPMENT_PLAN.md §6 Section E R15 + .docs/strategic-reassessment/01-LITERATURE-POSITION.md §G4 and 03-SPIKES.md S5. Preconditions: R10 merged. Repo: as above. Existing collectors to REUSE: src/archex/integrations/history (git log, 200-commit window, issue/PR reference extraction) and src/archex/integrations/docs (doc links, ADRs, ownership).
-OBJECTIVE: Test the one mechanism direction with a 20-year replicated evidence base that no shipping tool uses, by connecting collectors this repo already has but never wired into ranking. Success contract: a one-day stratum-sizing report measuring what fraction of gold files are UNREACHABLE from query anchors via the static import/call graph, merged BEFORE any mechanism is implemented; if >=10%, a pairwise co-change edge type with independent confidence plus an ownership prior, both fused into ranking as a benchmark-only arm, measured stratified by reachability and pre-registered before any outcome is inspected.
-RELEASE TRAIN: target=unversioned; included milestones=R15; preparation trigger=n/a; required artifacts=none; release verification=n/a; publication=not requested.
-
-PRE-IMPLEMENTATION DESIGN GATE:
-1. Read this milestone, its source-map rows, current prompt, and `.docs/DEVELOPMENT_PLAN_HISTORY.md` when present.
-2. Inspect the current codebase plus merged predecessor diffs, merged predecessor PR outcomes, CI/check evidence, and predecessor verification output.
-3. Revalidate objective, interfaces, dependencies, acceptance, verification, risks, release train, and every listed dependent milestone (R16).
-4. Append one ledger entry with the fields listed in DEVELOPMENT_PLAN_HISTORY.md.
-5. If no material mismatch exists, report `DESIGN GO — PLAN REVISION: none`; this authorizes implementation.
-6. If a mismatch exists, update both authoritative artifacts for R15 and every affected future milestone, append the revision ID, and report `DESIGN GO — PLAN REVISION: <entry IDs>`.
-7. If validity cannot be established, report `DESIGN NO-GO — REASON: <evidence>` and stop.
-
-SPECIFIC GATE CHECK: read benchmarks/results/m8_repository_memory/DECISION.md and m9_documentation_status/DECISION.md FIRST. Both measured bit-for-bit identical to control BECAUSE the evidence is never read by search, ranking, or expansion. This milestone's entire delta from those is the FUSION step. If the diff touches a collector module, the milestone has drifted.
-
-RECONCILIATION RULE: A material revision opens `docs(plan): reconcile R15 design` as a docs-only prerequisite PR, reviewed, green, and externally merged before any code PR.
-
-PLANNED STACK:
-0. Conditional prerequisite `docs(plan): reconcile R15 design`.
-1. PR-1 `test(benchmark): size the graph-unreachable gold-file stratum` — scope: sizing query and report; commits: query, report; gate: MUST merge before any mechanism work; if the stratum is under 10%, STOP HERE and the report is the milestone's deliverable
-2. PR-2 `docs(spikes): pre-register S5 co-change fusion` (on PR-1) — scope: .docs/spikes/S5-cochange-fusion.md only; gate: MUST merge before any outcome is inspected
-3. PR-3 `feat(index): fuse a pairwise co-change edge into ranking as a benchmark-only arm` (on PR-2) — scope: edge type, confidence, fusion; commits: edge, fusion; verification: an `archex_query` byte-identity test
-4. PR-4 `test(benchmark): measure the arm stratified by reachability` (on PR-3) — scope: stratified run, evidence; commits: run, evidence
-
-CONSTRAINTS: rebuild NO collection — the history and docs collectors already exist and the diff must touch no collector module; the arm is benchmark-only and `archex_query` scoring must stay byte-identical; the pre-registered primary is gold-file recall within the UNREACHABLE stratum, with non-inferiority on the reachable stratum as the guard; effect-size expectation is modest (r~0.54, significant only combined with change entropy) — do not oversell.
-VERIFICATION (must pass): the sizing query reruns to the same fraction; if implemented, `uv run pytest tests/ -k "cochange or ownership_prior"` green including the `archex_query` byte-identity test; the full local gate is green.
-REVIEW:
-Per PR:
-- Scope matches its purpose; contracts match the reconciled plan; behavior is meaningfully tested.
-- Failures are loud; a repo without sufficient history yields a neutral fallback that is recorded, not a silent zero.
-- History is atomic, conventional, attribution-free, and free of unrelated formatting churn.
-- PR-specific verification output is captured.
-Whole stack:
-- Bases form one valid stack; CI is green; no regression coverage removed without replacement.
-- The sizing report merged before any mechanism work, verifiable by commit order.
-- A stratum under 10% is a pre-declared stop: the mechanism has no addressable surface and the sizing report is the deliverable. This is not a failure.
-- Report PR URLs, bases, verification, risks, manual gates, and review completion.
-FINAL VERDICTS:
-- Report the design verdict before the merge verdict.
-- Then report exactly one merge verdict: `GO — RELEASE: unversioned — RELEASE PREP: not-required` or `NO-GO — RELEASE: unversioned — REASON: <blocking gate>`.
-DONE: design verdict with evidence; when authorized, a reviewed stack with a release-aware merge verdict and evidence.
+R15 depended on R10's cancelled evaluation instrument. It must not be revived without a new authorized program and fresh pre-registration.
 ```
 
 ---
 
-### R16 — Public artifact release and Gate C disposition
+### R16 — Public artifact release and Gate C disposition `CANCELLED — GATE A FAIL`
 
 ```text
-/goal Deliver milestone R16 (Public artifact release and Gate C disposition) from DEVELOPMENT_PLAN.md as a reviewed stack of PRs.
+No execution prompt. Gate A failed before Gates B and C could apply.
 
-CONTEXT: DEVELOPMENT_PLAN.md §6 Section F R16 + .docs/strategic-reassessment/02-STRATEGY.md §C1 elements 1-7 and 05-ROADMAP.md §4 Gate C. Preconditions: R11, R12, R13, R14, R15 merged. Repo: as above plus the extracted public repository from R11.
-OBJECTIVE: Assemble the program's evidence into a public, reproducible artifact set and record the publication decision. Success contract: the extracted repository made public with every context-variant trace, the decontamination audit, the eligibility matrix, and a SINGLE reproduction command; GATE-C.md recording assembly against the seven elements of 02-STRATEGY.md §C1 and the decision between a datasets-and-benchmarks submission alone versus adding the human arm (IRB, recruitment, ~8 additional weeks); docs/WHY_ARCHEX.md and README stating only claims the program measured.
-RELEASE TRAIN: target=none (separate repository); included milestones=R16; preparation trigger=n/a; required artifacts=none; release verification=n/a; publication=separate-repo release.
-
-PRE-IMPLEMENTATION DESIGN GATE:
-1. Read this milestone, its source-map rows, current prompt, and `.docs/DEVELOPMENT_PLAN_HISTORY.md` when present.
-2. Inspect the current codebase plus merged predecessor diffs, merged predecessor PR outcomes, CI/check evidence, and predecessor verification output. Read GATE-A.md and GATE-B.md.
-3. Revalidate objective, interfaces, dependencies, acceptance, verification, risks, release train, and dependent milestones (none — terminal).
-4. Append one ledger entry with the fields listed in DEVELOPMENT_PLAN_HISTORY.md.
-5. If no material mismatch exists, report `DESIGN GO — PLAN REVISION: none`; this authorizes implementation.
-6. If a mismatch exists, update both authoritative artifacts for R16, append the revision ID, and report `DESIGN GO — PLAN REVISION: <entry IDs>`.
-7. If validity cannot be established, report `DESIGN NO-GO — REASON: <evidence>` and stop.
-
-SPECIFIC GATE CHECK: re-check EVERY corpus and model licence before publishing traces. Assume anything published is permanent.
-
-HUMAN REVIEW GATE: Do not make the repository public until a human reviews the licence check, the trace contents for any leaked private path or credential, and the rollback note. Publication is irreversible in practice.
-
-RECONCILIATION RULE: A material revision opens `docs(plan): reconcile R16 design` as a docs-only prerequisite PR, reviewed, green, and externally merged before any code PR.
-
-PLANNED STACK:
-0. Conditional prerequisite `docs(plan): reconcile R16 design`.
-1. PR-1 `docs(bench-repo): assemble traces, audit, and matrix for release` — scope: artifact assembly, licence check; commits: assembly, licence record
-2. PR-2 `docs(bench-repo): add the single-command reproduction path` (on PR-1) — scope: reproduction command, README; commits: command, docs; verification: a clean-environment reproduction of one headline figure
-3. PR-3 `docs(gate): record the Gate C disposition` (on PR-2) — scope: GATE-C.md; commits: seven-element assembly, submission decision
-4. PR-4 `docs: restate archex claims against measured evidence only` (on PR-3) — scope: README.md, docs/WHY_ARCHEX.md; commits: claim restatement; verification: every numeric claim greps to an artifact in the index
-
-CONSTRAINTS: write no paper here; run no human-subjects study here — R16 records the DECISION about the human arm only; publish no trace whose licence was not verified.
-VERIFICATION (must pass): in a clean environment, clone the public repository and reproduce one headline figure end to end using the documented command and no private input; `grep` every numeric claim in README.md and docs/ against the artifact index and confirm each resolves; the full local gate is green.
-REVIEW:
-Per PR:
-- Scope matches its purpose; contracts match the reconciled plan; behavior is meaningfully tested.
-- Failures are loud; a trace with an unverified licence blocks the release rather than shipping with a caveat.
-- History is atomic, conventional, attribution-free, and free of unrelated formatting churn.
-- PR-specific verification output is captured.
-Whole stack:
-- Bases form one valid stack; CI is green in both repositories; no regression coverage removed without replacement.
-- GATE-C.md addresses all seven elements explicitly, marking each present or absent — an absent element is stated, never omitted.
-- No claim in README.md or docs/ lacks a checked-in artifact.
-- The human review gate is signed off before the repository is made public.
-- Report PR URLs, bases, verification, risks, manual gates, and review completion.
-FINAL VERDICTS:
-- Report the design verdict before the merge verdict.
-- Then report exactly one merge verdict: `GO — RELEASE: none — RELEASE PREP: not-required` or `NO-GO — RELEASE: none — REASON: <blocking gate>`.
-- Additionally report the Gate C disposition: `GATE C — D&B ONLY` or `GATE C — D&B PLUS HUMAN ARM (+~8 weeks, IRB required)`.
-DONE: design verdict, the reviewed stack, the merge verdict, and the Gate C disposition with evidence.
+R16 depended on the cancelled R7–R15 program. It must not be revived without a new authorized program and fresh pre-registration.
 ```


### PR DESCRIPTION
## Summary

- Align the completed R4 audit contract with its merged evidence and dedicated validator.
- Mark R7–R16 as cancelled after Gate A failed; update the critical path to the root-cause effort.
- Remove stale claims that R4 produced empirical ICC, MWG/NIM/EQM, or a repository-count projection.

## Stack

Stack-Id: `r4-audit-reconcile-20260730`
Base: `main`
Position: 1/1

Depends on: none — docs-only reconciliation after merged R4 PRs #582 and #583.
Upstack: none.

## Validation

- `uv run archex benchmark validate --kind corpus-audit --input benchmarks/evidence/s2-corpus-validity.json`
- Deterministic audit rerun: stable payload equals the checked-in artifact after excluding generation metadata.
- `uv run pytest tests/benchmark/test_corpus_audit.py tests/benchmark/test_corpus_audit_artifact.py --no-cov` — 56 passed.
- `uv run ruff check . && uv run ruff format --check . && uv run pyright . && uv run pytest -q` — 4,654 passed, 91.37% coverage.
- All three Mermaid blocks in `.docs/DEVELOPMENT_PLAN.md` parse with Mermaid 11.

## Risk

Docs-only. No retrieval behavior, benchmark tasks, evidence data, or release metadata changed.