### PR TITLE
chore(release): prepare 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.27.0] - 2026-08-18
+
+### Added
+
+- **Explicit project-session ledger and bounded Claude Code primer.** `archex session record|list|invalidate|delete|prime` and the `session` MCP tool store only explicit tasks, decisions, blockers, and rationale in repo-local `.archex/session.db`, scoped to the active worktree and branch. `archex install-client claude-code --session-primer` installs an opt-in `SessionStart` hook that injects fresh, receipt-bearing context on startup or resume without blocking the session.
+
+### Changed
+
+- **MCP schema-surface measurements and help reflect the 20-tool current surface.** The recorded `session` tool schema adds 1,382 characters to the ungated MCP surface (4,192 measured tokens after first retrieval); the disclosure default remains 765 tokens.
+
 ## [0.26.0] - 2026-08-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archex"
-version = "0.26.0"
+version = "0.27.0"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "archex"
-version = "0.26.0"
+version = "0.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Prepares `archex` 0.27.0 after PR #614.

- Bumps package metadata and `uv.lock` from 0.26.0 to 0.27.0.
- Adds the release changelog for the explicit repo-local project-session ledger, opt-in Claude Code SessionStart primer, and refreshed 20-tool MCP schema-surface measurements.

## Validation

- `uv lock --check`
- `uv run archex --version` → `0.27.0`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`

No breaking changes.