### PR TITLE
fix(mcp): migrate server to MCP 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "click>=8.1",
     "pyyaml>=6.0",
     "rich==14.3.3",
-    "mcp>=1.0",
+    "mcp>=2.0,<3.0",
     "watchdog>=6.0.0",
 ]
 
@@ -144,7 +144,7 @@ dev = [
     "httpx>=0.27",
     "langchain-core>=0.2",
     "llama-index-core>=0.10",
-    "mcp>=1.0",
+    "mcp>=2.0,<3.0",
     "pre-commit>=3.7",
     "pyright>=1.1",
     "pytest>=9.0.2",

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -9,7 +9,12 @@ import threading
 import time
 from collections import OrderedDict
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import mcp.types as mcp_types
+    from mcp.server.context import ServerRequestContext
+
 
 from archex.api import (
     analyze,
@@ -2627,55 +2632,67 @@ def build_server(
     if runtime is None:
         runtime = QueryRuntime()
 
-    server: Server[None, Any] = Server("archex")  # type: ignore[type-arg]
     gate = DisclosureGate(enabled=disclosure)
 
-    @server.list_tools()  # pyright: ignore[reportUnusedFunction]
-    async def list_tools() -> list[mcp_types.Tool]:  # pyright: ignore[reportUnusedFunction]
+    async def list_tools(
+        _request_context: ServerRequestContext[Any, Any],
+        _params: mcp_types.PaginatedRequestParams | None,
+    ) -> mcp_types.ListToolsResult:
         visible = gate.visible(tool_names)
         schemas = _tool_schemas()
         if visible is not None:
             schemas = [schema for schema in schemas if schema["name"] in visible]
-        return [mcp_types.Tool(**schema) for schema in schemas]
+        return mcp_types.ListToolsResult(
+            tools=[
+                mcp_types.Tool(
+                    name=schema["name"],
+                    description=schema["description"],
+                    input_schema=schema["inputSchema"],
+                )
+                for schema in schemas
+            ]
+        )
 
-    @server.call_tool()  # pyright: ignore[reportUnusedFunction]
-    async def call_tool(  # pyright: ignore[reportUnusedFunction]
-        name: str,
-        arguments: dict[str, Any],
-    ) -> list[mcp_types.TextContent]:
+    async def call_tool(
+        request_context: ServerRequestContext[Any, Any],
+        params: mcp_types.CallToolRequestParams,
+    ) -> mcp_types.CallToolResult:
         loop = asyncio.get_running_loop()
         advertised_before = gate.visible(tool_names)
-        result_text = await _run_mcp_tool(loop, name, arguments, runtime)
+        try:
+            result_text = await _run_mcp_tool(loop, params.name, params.arguments or {}, runtime)
+        except Exception as exc:  # noqa: BLE001 - MCP tool failures are model-visible results
+            return mcp_types.CallToolResult(
+                content=[mcp_types.TextContent(type="text", text=str(exc))],
+                is_error=True,
+            )
         # Only after the call succeeded: a failed retrieval has not demonstrated
         # that this session needs the wider surface.
-        if gate.observe_call(name) and gate.visible(tool_names) != advertised_before:
+        if gate.observe_call(params.name) and gate.visible(tool_names) != advertised_before:
             # Opening does not always change what is advertised: a scope disjoint
             # from the retrieval core is served in full either way. Announcing an
             # identical list would cost the client a pointless tools/list.
             gate.mark_announce_pending()
-        if gate.announce_pending and await _announce_tool_list_changed(server):
+        if gate.announce_pending and await _announce_tool_list_changed(request_context):
             gate.mark_announced()
 
-        return [mcp_types.TextContent(type="text", text=result_text)]
+        return mcp_types.CallToolResult(
+            content=[mcp_types.TextContent(type="text", text=result_text)]
+        )
 
-    return server
+    return Server("archex", on_list_tools=list_tools, on_call_tool=call_tool)
 
 
-async def _announce_tool_list_changed(server: Any) -> bool:
+async def _announce_tool_list_changed(request_context: ServerRequestContext[Any, Any]) -> bool:
     """Tell the client its tool list grew. Returns whether the client was told.
 
-    Never raises. A client that never registered a session, or one whose
-    transport has already gone away, must not turn a successful retrieval into a
-    failed tool call. But a lost notification is not free either: for a
-    model-controlled client it is the only thing that puts the wider surface in
-    front of the model, so the caller retries on the next call and this logs
-    loudly enough for an operator to see.
+    Never raises. A session whose transport has already gone away must not turn a
+    successful retrieval into a failed tool call. But a lost notification is not
+    free either: for a model-controlled client it is the only thing that puts the
+    wider surface in front of the model, so the caller retries on the next call
+    and this logs loudly enough for an operator to see.
     """
-    try:
-        session = server.request_context.session
-    except LookupError:
-        logger.warning("no MCP session to announce the tool-list change to; will retry")
-        return False
+    session = request_context.session
     try:
         await session.send_tool_list_changed()
     except Exception:  # noqa: BLE001 - see docstring: never fail the caller's tool call

--- a/tests/integrations/test_mcp.py
+++ b/tests/integrations/test_mcp.py
@@ -8,11 +8,14 @@ import json
 import os
 import time
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
 
 import pytest
 
 pytest.importorskip("mcp", reason="mcp not installed")
+
 
 from archex.context_facade import ContextResult, ContextRouteDecision
 from archex.explain import ExplainError
@@ -64,6 +67,32 @@ from archex.reporting import count_tokens
 from archex.serve.intent import QueryIntent
 from archex.serve.modality import BudgetTier, QueryModality
 from archex.serve.renderers.xml import render_xml, render_xml_envelope
+
+
+class _TestServerSession:
+    async def send_tool_list_changed(self) -> None:
+        return None
+
+
+def _mcp_request_handler(server: Any, method: str) -> Any:
+    """Adapt MCP 2's public handler entry to direct handler tests."""
+    from mcp.server.context import ServerRequestContext
+
+    entry = server.get_request_handler(method)
+    assert entry is not None, f"missing MCP handler for {method}"
+    session: Any = _TestServerSession()
+    request_context = ServerRequestContext(
+        session=session,
+        lifespan_context={},
+        protocol_version="2025-11-25",
+        method=method,
+    )
+
+    async def invoke(request: Any) -> SimpleNamespace:
+        return SimpleNamespace(root=await entry.handler(request_context, request.params))
+
+    return invoke
+
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -693,7 +722,6 @@ class TestHandleCompareRepos:
 class TestBuildServerImportError:
     def test_build_server_raises_import_error_when_mcp_missing(self) -> None:
         import builtins
-        from typing import Any
 
         original_import: Any = builtins.__import__
 
@@ -714,7 +742,6 @@ class TestRunStdioServer:
     async def test_run_stdio_server_import_error(self) -> None:
         """run_stdio_server raises ImportError when mcp.server.stdio is missing."""
         import builtins
-        from typing import Any
 
         original_import: Any = builtins.__import__
 
@@ -782,16 +809,12 @@ class TestBuildServer:
         assert server.name == "archex"
 
     def test_server_has_list_tools_handler(self) -> None:
-        from mcp import types as mcp_types
-
         server = build_server()
-        assert mcp_types.ListToolsRequest in server.request_handlers
+        assert server.get_request_handler("tools/list") is not None
 
     def test_server_has_call_tool_handler(self) -> None:
-        from mcp import types as mcp_types
-
         server = build_server()
-        assert mcp_types.CallToolRequest in server.request_handlers
+        assert server.get_request_handler("tools/call") is not None
 
     @pytest.mark.asyncio
     async def test_list_tools_returns_core_tools(self) -> None:
@@ -799,7 +822,7 @@ class TestBuildServer:
         # Call the registered list_tools handler directly
         from mcp import types as mcp_types
 
-        handler = server.request_handlers[mcp_types.ListToolsRequest]
+        handler = _mcp_request_handler(server, "tools/list")
         req = mcp_types.ListToolsRequest(method="tools/list", params=None)
         server_result = await handler(req)
         result = server_result.root
@@ -810,10 +833,10 @@ class TestBuildServer:
         assert "compare_repos" in tool_names
 
         query_repo = next(tool for tool in result.tools if tool.name == "query_repo")
-        budget_schema = query_repo.inputSchema["properties"]["budget"]
+        budget_schema = query_repo.input_schema["properties"]["budget"]
         assert "default" not in budget_schema
         assert "Omit to use adaptive intent routing" in budget_schema["description"]
-        profile_schema = query_repo.inputSchema["properties"]["profile"]
+        profile_schema = query_repo.input_schema["properties"]["profile"]
         assert profile_schema["enum"] == ["fast", "balanced", "deep"]
 
     @pytest.mark.asyncio
@@ -822,7 +845,7 @@ class TestBuildServer:
             server = build_server()
             from mcp import types as mcp_types
 
-            handler = server.request_handlers[mcp_types.CallToolRequest]
+            handler = _mcp_request_handler(server, "tools/call")
             req = mcp_types.CallToolRequest(
                 method="tools/call",
                 params=mcp_types.CallToolRequestParams(
@@ -831,7 +854,7 @@ class TestBuildServer:
                 ),
             )
             # Force list_tools to populate tool cache
-            list_handler = server.request_handlers[mcp_types.ListToolsRequest]
+            list_handler = _mcp_request_handler(server, "tools/list")
             await list_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
 
             server_result = await handler(req)
@@ -848,7 +871,7 @@ class TestBuildServer:
             server = build_server()
             from mcp import types as mcp_types
 
-            handler = server.request_handlers[mcp_types.CallToolRequest]
+            handler = _mcp_request_handler(server, "tools/call")
             req = mcp_types.CallToolRequest(
                 method="tools/call",
                 params=mcp_types.CallToolRequestParams(
@@ -856,7 +879,7 @@ class TestBuildServer:
                     arguments={"repo_url": "/fake", "question": "what?", "budget": 4000},
                 ),
             )
-            list_handler = server.request_handlers[mcp_types.ListToolsRequest]
+            list_handler = _mcp_request_handler(server, "tools/list")
             await list_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
 
             server_result = await handler(req)
@@ -872,7 +895,7 @@ class TestBuildServer:
             server = build_server()
             from mcp import types as mcp_types
 
-            handler = server.request_handlers[mcp_types.CallToolRequest]
+            handler = _mcp_request_handler(server, "tools/call")
             req = mcp_types.CallToolRequest(
                 method="tools/call",
                 params=mcp_types.CallToolRequestParams(
@@ -880,7 +903,7 @@ class TestBuildServer:
                     arguments={"repo_a": "/a", "repo_b": "/b", "dimensions": "api_surface"},
                 ),
             )
-            list_handler = server.request_handlers[mcp_types.ListToolsRequest]
+            list_handler = _mcp_request_handler(server, "tools/list")
             await list_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
 
             server_result = await handler(req)
@@ -890,13 +913,13 @@ class TestBuildServer:
             assert result.content[0].type == "text"
 
     @pytest.mark.asyncio
-    async def test_call_tool_unknown_name_raises(self) -> None:
+    async def test_call_tool_unknown_name_returns_error(self) -> None:
         server = build_server()
         from mcp import types as mcp_types
 
-        handler = server.request_handlers[mcp_types.CallToolRequest]
+        handler = _mcp_request_handler(server, "tools/call")
         # Populate tool cache first
-        list_handler = server.request_handlers[mcp_types.ListToolsRequest]
+        list_handler = _mcp_request_handler(server, "tools/list")
         await list_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
 
         req = mcp_types.CallToolRequest(
@@ -906,18 +929,20 @@ class TestBuildServer:
                 arguments={},
             ),
         )
-        # The MCP server converts unhandled exceptions to error results
         server_result = await handler(req)
         result = server_result.root
-        # Should be an error result (isError=True) or ValidationError for bad tool name
-        assert result.isError or isinstance(result, mcp_types.CallToolResult)
+        assert isinstance(result, mcp_types.CallToolResult)
+        assert result.is_error is True
+        content = result.content[0]
+        assert isinstance(content, mcp_types.TextContent)
+        assert content.text == "Unknown tool: 'nonexistent_tool'"
 
     @pytest.mark.asyncio
     async def test_list_tools_returns_graph_tools(self) -> None:
         server = build_server()
         from mcp import types as mcp_types
 
-        handler = server.request_handlers[mcp_types.ListToolsRequest]
+        handler = _mcp_request_handler(server, "tools/list")
         req = mcp_types.ListToolsRequest(method="tools/list", params=None)
         server_result = await handler(req)
         result = server_result.root
@@ -937,8 +962,8 @@ class TestBuildServer:
         assert "context" in tool_names
         assert "session" in tool_names
         session_tool = next(tool for tool in result.tools if tool.name == "session")
-        assert session_tool.inputSchema["required"] == ["repo_url", "action"]
-        assert session_tool.inputSchema["properties"]["action"]["enum"] == [
+        assert session_tool.input_schema["required"] == ["repo_url", "action"]
+        assert session_tool.input_schema["properties"]["action"]["enum"] == [
             "record",
             "list",
             "invalidate",
@@ -958,8 +983,8 @@ class TestBuildServer:
                 server = build_server(runtime=runtime)
                 from mcp import types as mcp_types
 
-                handler = server.request_handlers[mcp_types.CallToolRequest]
-                list_handler = server.request_handlers[mcp_types.ListToolsRequest]
+                handler = _mcp_request_handler(server, "tools/call")
+                list_handler = _mcp_request_handler(server, "tools/list")
                 await list_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
                 req = mcp_types.CallToolRequest(
                     method="tools/call",
@@ -983,8 +1008,8 @@ class TestBuildServer:
             server = build_server()
             from mcp import types as mcp_types
 
-            handler = server.request_handlers[mcp_types.CallToolRequest]
-            list_handler = server.request_handlers[mcp_types.ListToolsRequest]
+            handler = _mcp_request_handler(server, "tools/call")
+            list_handler = _mcp_request_handler(server, "tools/list")
             await list_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
             req = mcp_types.CallToolRequest(
                 method="tools/call",
@@ -1012,8 +1037,8 @@ class TestBuildServer:
             server = build_server(runtime=runtime)
             from mcp import types as mcp_types
 
-            handler = server.request_handlers[mcp_types.CallToolRequest]
-            list_handler = server.request_handlers[mcp_types.ListToolsRequest]
+            handler = _mcp_request_handler(server, "tools/call")
+            list_handler = _mcp_request_handler(server, "tools/list")
             await list_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
 
             def _call(question: str) -> mcp_types.CallToolRequest:
@@ -1715,8 +1740,8 @@ class TestHandleContextEndToEnd:
         server = build_server()
         from mcp import types as mcp_types
 
-        handler = server.request_handlers[mcp_types.CallToolRequest]
-        list_handler = server.request_handlers[mcp_types.ListToolsRequest]
+        handler = _mcp_request_handler(server, "tools/call")
+        list_handler = _mcp_request_handler(server, "tools/list")
         await list_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
 
         def _call(query: str, handles: list[str] | None = None) -> mcp_types.CallToolRequest:
@@ -1733,7 +1758,9 @@ class TestHandleContextEndToEnd:
 
         first = (await handler(_call("how does authentication work?"))).root
         assert isinstance(first, mcp_types.CallToolResult)
-        first_envelope = json.loads(first.content[0].text)  # type: ignore[union-attr]
+        first_content = first.content[0]
+        assert isinstance(first_content, mcp_types.TextContent)
+        first_envelope = json.loads(first_content.text)
         handle = first_envelope["fetch_handles"][0]
         expected_chunk = next(
             item for item in first_envelope["content"] if item["chunk"]["id"] in handle
@@ -1741,7 +1768,9 @@ class TestHandleContextEndToEnd:
 
         second = (await handler(_call("ignored query text", handles=[handle]))).root
         assert isinstance(second, mcp_types.CallToolResult)
-        second_envelope = json.loads(second.content[0].text)  # type: ignore[union-attr]
+        second_content = second.content[0]
+        assert isinstance(second_content, mcp_types.TextContent)
+        second_envelope = json.loads(second_content.text)
 
         assert second_envelope["route"]["handles_mode"] is True
         assert second_envelope["fetch_handles"] == [handle]
@@ -1806,7 +1835,7 @@ class TestAllToolNames:
         server = build_server()
         from mcp import types as mcp_types
 
-        handler = server.request_handlers[mcp_types.ListToolsRequest]
+        handler = _mcp_request_handler(server, "tools/list")
         result = (await handler(mcp_types.ListToolsRequest(method="tools/list", params=None))).root
         assert isinstance(result, mcp_types.ListToolsResult)
         live_names = {t.name for t in result.tools}
@@ -1841,7 +1870,7 @@ class TestBuildServerToolScoping:
         from mcp import types as mcp_types
 
         full_server = build_server()
-        full_handler = full_server.request_handlers[mcp_types.ListToolsRequest]
+        full_handler = _mcp_request_handler(full_server, "tools/list")
         full_result = (
             await full_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
         ).root
@@ -1849,7 +1878,7 @@ class TestBuildServerToolScoping:
         full_names = {t.name for t in full_result.tools}
 
         scoped_server = build_server(tool_names=frozenset({"query_repo", "context"}))
-        scoped_handler = scoped_server.request_handlers[mcp_types.ListToolsRequest]
+        scoped_handler = _mcp_request_handler(scoped_server, "tools/list")
         scoped_result = (
             await scoped_handler(mcp_types.ListToolsRequest(method="tools/list", params=None))
         ).root
@@ -1869,7 +1898,7 @@ class TestBuildServerToolScoping:
             "archex.integrations.mcp.handle_analyze_repo", return_value='{"repo": {}}'
         ) as mock_handle:
             server = build_server(tool_names=frozenset({"query_repo"}))
-            handler = server.request_handlers[mcp_types.CallToolRequest]
+            handler = _mcp_request_handler(server, "tools/call")
             req = mcp_types.CallToolRequest(
                 method="tools/call",
                 params=mcp_types.CallToolRequestParams(
@@ -1880,7 +1909,7 @@ class TestBuildServerToolScoping:
             server_result = await handler(req)
             result = server_result.root
             assert isinstance(result, mcp_types.CallToolResult)
-            assert not result.isError
+            assert not result.is_error
             mock_handle.assert_called_once()
 
 
@@ -1898,17 +1927,17 @@ class TestGraphQueryConsolidation:
     async def _call(server: object, name: str, arguments: dict[str, object]) -> str:
         from mcp import types as mcp_types
 
-        handler = server.request_handlers[mcp_types.CallToolRequest]  # type: ignore[attr-defined]
+        handler = _mcp_request_handler(server, "tools/call")
         req = mcp_types.CallToolRequest(
             method="tools/call",
             params=mcp_types.CallToolRequestParams(name=name, arguments=arguments),
         )
         result = (await handler(req)).root
         assert isinstance(result, mcp_types.CallToolResult)
-        assert not result.isError
-        text = result.content[0].text  # type: ignore[union-attr]
-        assert isinstance(text, str)
-        return text
+        assert not result.is_error
+        content = result.content[0]
+        assert isinstance(content, mcp_types.TextContent)
+        return content.text
 
     @staticmethod
     def _normalize(response_text: str) -> dict[str, object]:
@@ -2006,7 +2035,7 @@ class TestGraphQueryConsolidation:
         server = build_server()
         from mcp import types as mcp_types
 
-        handler = server.request_handlers[mcp_types.CallToolRequest]
+        handler = _mcp_request_handler(server, "tools/call")
         req = mcp_types.CallToolRequest(
             method="tools/call",
             params=mcp_types.CallToolRequestParams(
@@ -2016,14 +2045,14 @@ class TestGraphQueryConsolidation:
         )
         result = (await handler(req)).root
         assert isinstance(result, mcp_types.CallToolResult)
-        assert result.isError
+        assert result.is_error
 
     @pytest.mark.asyncio
     async def test_all_five_original_graph_tools_still_registered(self) -> None:
         server = build_server()
         from mcp import types as mcp_types
 
-        handler = server.request_handlers[mcp_types.ListToolsRequest]
+        handler = _mcp_request_handler(server, "tools/list")
         result = (await handler(mcp_types.ListToolsRequest(method="tools/list", params=None))).root
         assert isinstance(result, mcp_types.ListToolsResult)
         tool_names = {t.name for t in result.tools}

--- a/tests/integrations/test_mcp_disclosure.py
+++ b/tests/integrations/test_mcp_disclosure.py
@@ -8,10 +8,12 @@ is the property that lets the default change safely.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, nullcontext, suppress
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -224,7 +226,7 @@ class TestListChangedCapability:
             notification_options=NotificationOptions(tools_changed=True)
         )
         assert opts.capabilities.tools is not None
-        assert opts.capabilities.tools.listChanged is True
+        assert opts.capabilities.tools.list_changed is True
 
 
 class TestGateThroughARealSession:
@@ -239,11 +241,14 @@ class TestGateThroughARealSession:
     @staticmethod
     @asynccontextmanager
     async def _session(
-        *, disclosure: bool, tool_names: frozenset[str] | None = None
+        *,
+        disclosure: bool,
+        tool_names: frozenset[str] | None = None,
+        stub_tools: bool = True,
     ) -> AsyncIterator[tuple[Any, list[Any]]]:
-        from unittest.mock import patch
-
-        from mcp.shared.memory import create_connected_server_and_client_session
+        from mcp.client.session import ClientSession
+        from mcp.server.lowlevel import NotificationOptions
+        from mcp.shared.memory import create_client_server_memory_streams
 
         notifications: list[Any] = []
 
@@ -255,12 +260,29 @@ class TestGateThroughARealSession:
         ) -> str:
             return f"ran {name}"
 
-        with patch("archex.integrations.mcp._run_mcp_tool", side_effect=fake_run_mcp_tool):
+        patcher = (
+            patch("archex.integrations.mcp._run_mcp_tool", side_effect=fake_run_mcp_tool)
+            if stub_tools
+            else nullcontext()
+        )
+        with patcher:
             server = build_server(tool_names=tool_names, disclosure=disclosure)
-            async with create_connected_server_and_client_session(
-                server, message_handler=record
-            ) as client:
-                yield client, notifications
+            initial_options = server.create_initialization_options(
+                notification_options=NotificationOptions(tools_changed=disclosure)
+            )
+            async with create_client_server_memory_streams() as (client_streams, server_streams):
+                server_task = asyncio.create_task(
+                    server.run(*server_streams, initial_options, raise_exceptions=True)
+                )
+                try:
+                    async with ClientSession(*client_streams, message_handler=record) as client:
+                        await client.initialize()
+                        yield client, notifications
+                finally:
+                    if not server_task.done():
+                        server_task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await server_task
 
     @pytest.mark.asyncio
     async def test_a_fresh_session_is_advertised_only_the_retrieval_core(self) -> None:
@@ -278,7 +300,22 @@ class TestGateThroughARealSession:
             assert "graph_hubs" not in advertised
 
             result = await client.call_tool("graph_hubs", {"repo_url": "."})
-            assert result.isError is False
+            assert result.is_error is False
+
+    @pytest.mark.asyncio
+    async def test_a_bad_tool_call_returns_an_error_without_ending_the_session(self) -> None:
+        from mcp import types as mcp_types
+
+        async with self._session(disclosure=True, stub_tools=False) as (client, _):
+            result = await client.call_tool("graph_hubs", {})
+
+            assert result.is_error is True
+            content = result.content[0]
+            assert isinstance(content, mcp_types.TextContent)
+            assert "graph_path" in content.text
+            assert {tool.name for tool in (await client.list_tools()).tools} == set(
+                DISCLOSURE_CORE_TOOL_NAMES
+            )
 
     @pytest.mark.asyncio
     async def test_retrieving_expands_the_surface_and_tells_the_client(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -267,7 +267,7 @@ requires-dist = [
     { name = "leidenalg", marker = "extra == 'graph'", specifier = ">=0.10" },
     { name = "llama-index-core", marker = "extra == 'llamaindex'", specifier = ">=0.10" },
     { name = "lsp-client", marker = "python_full_version >= '3.12' and extra == 'lsap'", specifier = ">=0.3" },
-    { name = "mcp", specifier = ">=1.0" },
+    { name = "mcp", specifier = ">=2.0,<3.0" },
     { name = "networkx", specifier = ">=3.3" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "protobuf", marker = "extra == 'scip'", specifier = ">=7.35.1" },
@@ -301,7 +301,7 @@ dev = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "langchain-core", specifier = ">=0.2" },
     { name = "llama-index-core", specifier = ">=0.10" },
-    { name = "mcp", specifier = ">=1.0" },
+    { name = "mcp", specifier = ">=2.0,<3.0" },
     { name = "pre-commit", specifier = ">=3.7" },
     { name = "pyright", specifier = ">=1.1" },
     { name = "pytest", specifier = ">=9.0.2" },
@@ -1078,6 +1078,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074 },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1093,12 +1106,29 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943 }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960 },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427 },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382 },
 ]
 
 [[package]]
@@ -1131,11 +1161,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582 }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008 },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550 },
 ]
 
 [[package]]
@@ -1519,15 +1549,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1537,9 +1567,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005 }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615 },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980 },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649 },
 ]
 
 [[package]]
@@ -2078,6 +2121,18 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018 },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -2550,9 +2605,9 @@ name = "pydantic-settings"
 version = "2.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826 }
 wheels = [
@@ -3853,6 +3908,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296 },
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063 },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994 },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- migrate Archex's low-level MCP server from the removed 1.x decorators to the MCP 2 callback API
- preserve model-visible tool errors and session survival for malformed tool calls
- migrate integration coverage to MCP 2 handler and in-memory session interfaces

## Validation

- `uv run pytest -o addopts='' tests/integrations/test_mcp.py tests/integrations/test_mcp_disclosure.py tests/test_cli.py::TestMcpCmd -q`
- `uv run ruff check src/archex/integrations/mcp.py tests/integrations/test_mcp.py tests/integrations/test_mcp_disclosure.py`
- `uv run ruff format --check src/archex/integrations/mcp.py tests/integrations/test_mcp.py tests/integrations/test_mcp_disclosure.py`
- `uv run pyright src/archex/integrations/mcp.py tests/integrations/test_mcp.py tests/integrations/test_mcp_disclosure.py`
- clean `uv tool run --from . archex mcp` initialize handshake

Closes #612