### PR TITLE
chore(release): prepare 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.28.0] - 2026-08-23
+
+### Fixed
+
+- **MCP 2 runtime compatibility.** `archex mcp` now uses the MCP 2 low-level callback API, so a clean `uv tool install archex` no longer resolves an SDK that crashes at startup with `AttributeError: 'Server' object has no attribute 'list_tools'`. Malformed MCP tool calls now return model-visible errors without ending the stdio session.
+
 ## [0.27.0] - 2026-08-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archex"
-version = "0.27.0"
+version = "0.28.0"
 description = "Architecture extraction & codebase intelligence for the agentic era"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/tests/benchmark/test_external_mcp.py
+++ b/tests/benchmark/test_external_mcp.py
@@ -43,9 +43,9 @@ def test_run_external_mcp_runs_bootstrap_commands(tmp_path: Path) -> None:
     server = tmp_path / "server.py"
     server.write_text(
         """\
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-mcp = FastMCP("benchmark-fixture", json_response=True)
+mcp = MCPServer("benchmark-fixture")
 
 
 @mcp.tool()
@@ -101,9 +101,9 @@ def test_run_external_mcp_scores_fixture_server(tmp_path: Path) -> None:
     server = tmp_path / "server.py"
     server.write_text(
         """\
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-mcp = FastMCP("benchmark-fixture", json_response=True)
+mcp = MCPServer("benchmark-fixture")
 
 
 @mcp.tool()

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 
 [[package]]
 name = "archex"
-version = "0.27.0"
+version = "0.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Prepare the v0.28.0 release for MCP 2 runtime compatibility.

The release also updates the external-MCP benchmark fixture to MCP 2's `MCPServer` API. This restores the CI coverage that launched the fixture through the removed `FastMCP` import path.

## Validation

- `uv lock --check`
- `uv run archex --version` → `archex, version 0.28.0`
- `uv run pytest -o addopts='' tests/benchmark/test_external_mcp.py -q`
- `uv run ruff check tests/benchmark/test_external_mcp.py`
- `uv run pyright tests/benchmark/test_external_mcp.py`

The tagged release will be built, clean-install tested, published to PyPI, and released on GitHub after this preparation commit merges.