### PR TITLE
feat(benchmark): add pinned Graft comparison adapter

### DIFF
--- a/benchmarks/headtohead/README.md
+++ b/benchmarks/headtohead/README.md
@@ -49,13 +49,23 @@ Local reproduction of one lane uses the adapter contract in `scripts/run_graphif
 
 Graphify token-efficiency cells in the public reports count the graph reference listing returned by `graphify query`, not returned source code. They are useful as within-lane efficiency signals, but they are not bundle-for-bundle comparisons against archex or `ccc`.
 
-### Pinned Graft comparison protocol (pre-registered, not yet run)
+### Graft (pinned adapter, evidence pending)
 
-Graft is the second graph-memory tool queued for this harness. Its protocol is frozen in [`benchmarks/preregistrations/R19-graft-graph-memory-comparison.md`](../preregistrations/R19-graft-graph-memory-comparison.md), which merges before any Graft cell is generated. **No Graft lane, artifact, or number exists yet**; this section records the frozen protocol so the commit order proves the protocol predates the data.
+Graft is the second graph-memory tool in this harness. Its protocol is frozen in [`benchmarks/preregistrations/R19-graft-graph-memory-comparison.md`](../preregistrations/R19-graft-graph-memory-comparison.md), which merged before any Graft cell was generated. The adapter, the two manifest lanes (`graft_build_plus_query`, `graft_query_warm`), and the operator runner exist; **no Graft artifact or number exists yet**, so both lanes are absent from the report until all 19 task artifacts are checked in for each mode.
 
-The pin is the released package `@nanonets/graft@0.16.0` (npm integrity `sha512-L3E5F1aDYJDCARgfR7O2VaMt8xwO1XNYyHiW2n1WhKnj87gPqoxoZJGNbGXfw6XeA9JSJX3naA36RZ+jDf4AcQ==`, MIT), whose `gitHead` `aa1e2bb0f6326068ac64886da1e67fa25a7804de` is the commit tagged `v0.16.0`. A source checkout declaring an unpublished version is not a released artifact and is not pinnable.
+The pin is the released package `@nanonets/graft@0.16.0` (npm integrity `sha512-L3E5F1aDYJDCARgfR7O2VaMt8xwO1XNYyHiW2n1WhKnj87gPqoxoZJGNbGXfw6XeA9JSJX3naA36RZ+jDf4AcQ==`, MIT), whose `gitHead` `aa1e2bb0f6326068ac64886da1e67fa25a7804de` is the commit tagged `v0.16.0`. A source checkout declaring an unpublished version is not a released artifact and is not pinnable. `src/archex/benchmark/graft.py` holds that pinned identity as constants and rejects any artifact that disagrees with it.
 
 The measured protocol, in short: structural mode only (`build` without `--deep`, so no API key and no spend); the graph directory outside the task repository with `--no-gitignore --no-ignore`, so the checkout the other lanes measure stays pristine; `ask --no-refresh` for every measured query, because a default `ask` silently repairs graph drift and would fold synchronization into query latency; freshness read only from `check --json`'s `graph` section, since context cards are a `--deep` artifact and are always absent here; rank taken from the emitted `hits` order rather than `hits[].score`, which is not monotonically descending; `-n 10` to match the external retrieval lane's frozen limit; a per-task extraction tier, because Graft covers the two Rust tasks through a signature-only WASM tier rather than its native tier; and `DO_NOT_TRACK=1` plus `CI=1` on install and every invocation.
+
+Install once per machine (network-dependent: a transitive `tree-sitter-cli` install downloads a platform binary from GitHub release assets, and a transient `ECONNRESET` there is retried rather than recorded as a Graft failure):
+
+```bash
+CI=1 DO_NOT_TRACK=1 npm install -g @nanonets/graft@0.16.0
+```
+
+One cell is produced by `scripts/run_graft_headtohead_lane.py`, which reads the stdin payload (`task`, `repo_path`, `graph_dir`, `lane`, `tool`, `mode`, `graft`, optional `binary`) and emits one artifact JSON on stdout. The cold lane builds the graph and asks; the warm lane asks only, against the graph the cold lane built in the same `graph_dir`, and refuses to run when no graph is there. `graph_dir` must live outside the task repository, and both the adapter and the runner reject a `graph_dir` inside it.
+
+Every Graft artifact records the pinned package, npm integrity, source commit, command shape, `ask` output digest, timing mode, extraction tier, Graft's own query mode, the rank basis, the freshness source, the returned-unit split (symbol vs whole-file hits), and the returned-source count. Whole-file hits name a required file but carry no source even under `--source`, so they count toward required-file recall and contribute nothing to the returned-source and token-efficiency cells. A cell that could not be measured is retained as an explicit failure artifact with zeroed metrics and a reason; it is never dropped.
 
 Graft, like Graphify, will be reported as a graph-memory lane and never as a direct retrieval-equivalent winner, and no result from it may change an archex retrieval default.
 

--- a/benchmarks/headtohead/manifest.yaml
+++ b/benchmarks/headtohead/manifest.yaml
@@ -75,4 +75,20 @@ graph_memory_lanes:
     args: [run, python, scripts/run_graphify_headtohead_lane.py]
     artifact_dir: benchmarks/headtohead/results/graphify_query_warm
     operational_notes: "local AST-only Graphify code graph; warm lane measures query-only against a prebuilt graph; token-efficiency cells count the graph reference listing returned by `graphify query`, not returned source code"
+  - tool: graft
+    mode: build_plus_query
+    package_name: "@nanonets/graft"
+    version: "0.16.0"
+    command: uv
+    args: [run, python, scripts/run_graft_headtohead_lane.py]
+    artifact_dir: benchmarks/headtohead/results/graft_build_plus_query
+    operational_notes: "pinned released @nanonets/graft structural graph; cold lane includes the per-task graph build plus the first graph-backed answer; build runs without --deep so no model is called and no key is required"
+  - tool: graft
+    mode: query_warm
+    package_name: "@nanonets/graft"
+    version: "0.16.0"
+    command: uv
+    args: [run, python, scripts/run_graft_headtohead_lane.py]
+    artifact_dir: benchmarks/headtohead/results/graft_query_warm
+    operational_notes: "pinned released @nanonets/graft structural graph; warm lane measures ask --no-refresh only, against the graph the cold lane built; freshness is probed separately from check --json's graph section and never folded into query latency"
 raw_read_strategy: raw_ripgrep

--- a/benchmarks/headtohead/results/manifest.yaml
+++ b/benchmarks/headtohead/results/manifest.yaml
@@ -75,4 +75,20 @@ graph_memory_lanes:
     args: [run, python, scripts/run_graphify_headtohead_lane.py]
     artifact_dir: benchmarks/headtohead/results/graphify_query_warm
     operational_notes: "local AST-only Graphify code graph; warm lane measures query-only against a prebuilt graph; token-efficiency cells count the graph reference listing returned by `graphify query`, not returned source code"
+  - tool: graft
+    mode: build_plus_query
+    package_name: "@nanonets/graft"
+    version: "0.16.0"
+    command: uv
+    args: [run, python, scripts/run_graft_headtohead_lane.py]
+    artifact_dir: benchmarks/headtohead/results/graft_build_plus_query
+    operational_notes: "pinned released @nanonets/graft structural graph; cold lane includes the per-task graph build plus the first graph-backed answer; build runs without --deep so no model is called and no key is required"
+  - tool: graft
+    mode: query_warm
+    package_name: "@nanonets/graft"
+    version: "0.16.0"
+    command: uv
+    args: [run, python, scripts/run_graft_headtohead_lane.py]
+    artifact_dir: benchmarks/headtohead/results/graft_query_warm
+    operational_notes: "pinned released @nanonets/graft structural graph; warm lane measures ask --no-refresh only, against the graph the cold lane built; freshness is probed separately from check --json's graph section and never folded into query latency"
 raw_read_strategy: raw_ripgrep

--- a/scripts/run_graft_headtohead_lane.py
+++ b/scripts/run_graft_headtohead_lane.py
@@ -1,0 +1,398 @@
+"""Run one pinned Graft graph-memory lane from the adapter stdin contract.
+
+Reads a JSON payload on stdin with:
+- ``task``: BenchmarkTask JSON
+- ``repo_path``: checked-out repository path (never modified)
+- ``graph_dir``: graph directory, which must live outside ``repo_path``
+- ``lane``: graft_build_plus_query | graft_query_warm
+- ``tool``: graph-memory tool id (``graft``)
+- ``mode``: build_plus_query | query_warm
+- ``graft``: {package_name, version, npm_integrity, source_commit, result_cardinality}
+- ``binary`` (optional): graft executable, default ``graft``
+
+Writes one GraftArtifact JSON document to stdout.
+
+This script owns the frozen protocol in
+`benchmarks/preregistrations/R19-graft-graph-memory-comparison.md`: structural
+`build` (no ``--deep``), a graph directory outside the repository with
+``--no-gitignore --no-ignore``, ``ask ... --no-refresh`` for every measured
+query, and a freshness probe that is measured separately and never folded into
+warm latency. The cold lane builds then asks; the warm lane asks only, against
+the graph the cold lane already built.
+
+A cell that cannot be measured is written as a recorded failure artifact
+(``status: failed``) instead of being dropped. A protocol violation the operator
+must fix — a graph directory inside the repository, or a warm lane with no
+prebuilt graph — exits non-zero instead.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from archex.benchmark.graft import (
+    GraftArtifact,
+    GraftAskOutput,
+    GraftCellStatus,
+    GraftGraphFreshness,
+    graft_extraction_tier,
+    parse_graft_ask_output,
+    parse_graft_check_output,
+)
+from archex.benchmark.graph_memory import GraphMemoryAdapterError, artifact_digest, now_iso
+from archex.benchmark.models import BenchmarkTask, GraphMemoryLaneMode
+from archex.benchmark.region_metrics import ReturnedRegion, compute_region_metrics
+from archex.benchmark.strategies import (
+    completion_result_from_missing,
+    compute_bundle_completion_penalty,
+    compute_f1,
+    compute_map,
+    compute_mrr,
+    compute_ndcg,
+    compute_precision,
+    compute_recall,
+    compute_required_file_metrics,
+    compute_token_efficiency,
+    count_file_tokens,
+)
+from archex.reporting import count_tokens
+
+
+class GraftProtocolError(RuntimeError):
+    """Raised when the operator's invocation violates the frozen protocol."""
+
+
+def _env() -> dict[str, str]:
+    env = dict(os.environ)
+    env["CI"] = "1"
+    env["DO_NOT_TRACK"] = "1"
+    return env
+
+
+def _run(command: list[str]) -> tuple[subprocess.CompletedProcess[bytes], float]:
+    started = time.perf_counter()
+    completed = subprocess.run(command, capture_output=True, check=False, env=_env())
+    return completed, (time.perf_counter() - started) * 1000
+
+
+def _require_success(completed: subprocess.CompletedProcess[bytes], command: list[str]) -> None:
+    if completed.returncode != 0:
+        detail = (
+            completed.stderr.decode("utf-8", "replace").strip()
+            or completed.stdout.decode("utf-8", "replace").strip()
+            or "no output"
+        )
+        raise GraphMemoryAdapterError(
+            f"{shlex.join(command)} failed with exit {completed.returncode}: {detail}"
+        )
+
+
+def _sanitized_reason(exc: Exception, *, repo_path: Path, graph_dir: Path) -> str:
+    """A recorded failure is published, so its reason carries no machine paths.
+
+    The artifact's ``command`` is already written with ``<repo>``/``<graph-dir>``
+    placeholders; a failure reason quoting the resolved command or a tool's stderr would
+    otherwise leak the operator's home directory into checked-in evidence.
+    """
+    reason = str(exc).replace(str(repo_path), "<repo>").replace(str(graph_dir), "<graph-dir>")
+    home = str(Path.home())
+    return reason.replace(home, "<home>")
+
+
+def _returned_regions(ask: GraftAskOutput) -> list[ReturnedRegion]:
+    """Ranked returned units. Whole-file hits carry no source, so they contribute none."""
+    regions: list[ReturnedRegion] = []
+    for hit in ask.hits:
+        if hit.start_line is None or hit.end_line is None or not hit.code:
+            continue
+        regions.append(
+            ReturnedRegion(
+                path=hit.path,
+                start_line=hit.start_line,
+                end_line=hit.end_line,
+                symbol=hit.title,
+                tokens=max(1, count_tokens(hit.code)),
+            )
+        )
+    return regions
+
+
+def _command_text(
+    *,
+    binary: str,
+    question: str,
+    cardinality: int,
+    includes_build_cost: bool,
+) -> str:
+    ask = (
+        f"{binary} --dir <graph-dir> ask {shlex.quote(question)} -n {cardinality} "
+        "--source --no-refresh --json <repo>"
+    )
+    if includes_build_cost:
+        return f"{binary} --dir <graph-dir> build --no-gitignore --no-ignore <repo> && {ask}"
+    return ask
+
+
+def _failure_artifact(
+    *,
+    task: BenchmarkTask,
+    lane: str,
+    mode: GraphMemoryLaneMode,
+    graft: dict[str, object],
+    command_text: str,
+    reason: str,
+    output_digest: str,
+    query_mode: str,
+) -> GraftArtifact:
+    includes_build_cost = mode is GraphMemoryLaneMode.BUILD_PLUS_QUERY
+    return GraftArtifact(
+        task_id=task.task_id,
+        lane=lane,
+        command=command_text,
+        includes_build_cost=includes_build_cost,
+        graft_package=str(graft["package_name"]),
+        graft_version=str(graft["version"]),
+        npm_integrity=str(graft["npm_integrity"]),
+        source_commit=str(graft["source_commit"]),
+        status=GraftCellStatus.FAILED,
+        failure_reason=reason,
+        timing_mode=mode.value,
+        extraction_tier=graft_extraction_tier(task.languages),
+        query_mode=query_mode,
+        result_cardinality=int(str(graft["result_cardinality"])),
+        returned_units=0,
+        symbol_hits=0,
+        whole_file_hits=0,
+        returned_source_units=0,
+        output_digest=output_digest,
+        tokens_total=0,
+        tokens_input=0,
+        tokens_output=0,
+        tool_calls=2 if includes_build_cost else 1,
+        files_accessed=0,
+        recall=0.0,
+        precision=0.0,
+        f1_score=0.0,
+        mrr=0.0,
+        ndcg=0.0,
+        map_score=0.0,
+        required_file_recall=0.0,
+        missed_required_file_rate=1.0,
+        missed_required_task_rate=1.0,
+        all_required_files_present=False,
+        token_efficiency=0.0,
+        token_efficiency_with_completion=0.0,
+        cold_start_ms=0.0,
+        warm_latency_ms=0.0,
+        wall_time_ms=0.0,
+        cache_state="cold" if includes_build_cost else "warm",
+        cached=not includes_build_cost,
+        timestamp=now_iso(),
+        operational_notes="recorded failure; retained and counted, never dropped",
+        local_offline_posture="local structural graph only; no model call",
+        backend="graft-structural",
+    )
+
+
+def main() -> int:
+    payload = json.loads(sys.stdin.read())
+    task = BenchmarkTask.model_validate(payload["task"])
+    repo_path = Path(payload["repo_path"]).resolve()
+    graph_dir = Path(payload["graph_dir"]).resolve()
+    lane = str(payload["lane"])
+    mode = GraphMemoryLaneMode(str(payload["mode"]))
+    graft = dict(payload["graft"])
+    binary = str(payload.get("binary", "graft"))
+    cardinality = int(str(graft["result_cardinality"]))
+    includes_build_cost = mode is GraphMemoryLaneMode.BUILD_PLUS_QUERY
+
+    if graph_dir == repo_path or repo_path in graph_dir.parents:
+        raise GraftProtocolError(
+            f"graph_dir {graph_dir} is inside the task repository {repo_path}; the measured "
+            "checkout must stay pristine"
+        )
+
+    command_text = _command_text(
+        binary=binary,
+        question=task.question,
+        cardinality=cardinality,
+        includes_build_cost=includes_build_cost,
+    )
+
+    build_command = [
+        binary,
+        "--dir",
+        str(graph_dir),
+        "build",
+        "--no-gitignore",
+        "--no-ignore",
+        str(repo_path),
+    ]
+    ask_command = [
+        binary,
+        "--dir",
+        str(graph_dir),
+        "ask",
+        task.question,
+        "-n",
+        str(cardinality),
+        "--source",
+        "--no-refresh",
+        "--json",
+        str(repo_path),
+    ]
+    check_command = [binary, "--dir", str(graph_dir), "check", "--json", str(repo_path)]
+
+    build_ms = 0.0
+    if includes_build_cost:
+        graph_dir.parent.mkdir(parents=True, exist_ok=True)
+        completed, build_ms = _run(build_command)
+        _require_success(completed, build_command)
+    else:
+        probe, _ = _run(check_command)
+        _require_success(probe, check_command)
+        if parse_graft_check_output(probe.stdout).missing:
+            raise GraftProtocolError(
+                f"warm lane {lane!r} found no prebuilt graph in {graph_dir}; run the "
+                "build_plus_query lane for this task first"
+            )
+
+    ask_completed, ask_ms = _run(ask_command)
+    ask_digest_source = ask_completed.stdout
+    try:
+        _require_success(ask_completed, ask_command)
+        ask = parse_graft_ask_output(ask_completed.stdout)
+    except GraphMemoryAdapterError as exc:
+        artifact = _failure_artifact(
+            task=task,
+            lane=lane,
+            mode=mode,
+            graft=graft,
+            command_text=command_text,
+            reason=_sanitized_reason(exc, repo_path=repo_path, graph_dir=graph_dir),
+            output_digest=artifact_digest(ask_digest_source),
+            query_mode="unattributable",
+        )
+        sys.stdout.write(artifact.model_dump_json())
+        return 0
+
+    # The freshness probe is measured separately and never folded into query latency. It is an
+    # exploratory signal, so a probe failure is recorded rather than allowed to discard an
+    # already-attributable primary-metric measurement.
+    check_completed, check_ms = _run(check_command)
+    freshness: GraftGraphFreshness | None = None
+    if check_completed.returncode == 0:
+        try:
+            freshness = parse_graft_check_output(check_completed.stdout)
+        except GraphMemoryAdapterError:
+            freshness = None
+
+    result_files = list(ask.result_files)
+    result_file_set = set(result_files)
+    source_hits = ask.source_bearing_hits
+    tokens_output = sum(count_tokens(hit.code or "") for hit in source_hits)
+    # Whole-file hits return no source, so per the frozen protocol they contribute to neither
+    # the returned-source count nor the token-efficiency baseline.
+    source_files = sorted({hit.path for hit in source_hits})
+    tokens_input = count_file_tokens(repo_path, source_files) if source_files else 0
+    completion_tokens, completion_files = compute_bundle_completion_penalty(
+        repo_path,
+        result_file_set,
+        task.expected_files,
+    )
+    (
+        required_file_recall,
+        missed_required_file_rate,
+        missed_required_task_rate,
+        all_required_files_present,
+        present,
+        missing,
+    ) = compute_required_file_metrics(result_file_set, task.expected_files)
+    recall = compute_recall(result_file_set, task.expected_files)
+    precision = compute_precision(result_file_set, task.expected_files)
+    region_metrics = (
+        compute_region_metrics(_returned_regions(ask), task.expected_regions)
+        if task.expected_regions
+        else None
+    )
+
+    artifact = GraftArtifact(
+        task_id=task.task_id,
+        lane=lane,
+        command=command_text,
+        includes_build_cost=includes_build_cost,
+        graft_package=str(graft["package_name"]),
+        graft_version=str(graft["version"]),
+        npm_integrity=str(graft["npm_integrity"]),
+        source_commit=str(graft["source_commit"]),
+        status=GraftCellStatus.OK,
+        timing_mode=mode.value,
+        extraction_tier=graft_extraction_tier(task.languages),
+        query_mode=ask.query_mode,
+        result_cardinality=cardinality,
+        returned_units=len(ask.hits),
+        symbol_hits=ask.symbol_hits,
+        whole_file_hits=ask.whole_file_hits,
+        returned_source_units=len(source_hits),
+        graph_ok=freshness.ok if freshness is not None else False,
+        graph_nodes=freshness.nodes if freshness is not None else 0,
+        output_digest=ask.digest,
+        tokens_total=tokens_output,
+        tokens_input=tokens_input,
+        tokens_output=tokens_output,
+        tool_calls=2 if includes_build_cost else 1,
+        files_accessed=len(result_file_set),
+        recall=recall,
+        precision=precision,
+        f1_score=compute_f1(recall, precision),
+        mrr=compute_mrr(result_files, task.expected_files),
+        ndcg=compute_ndcg(result_files, task.expected_files),
+        map_score=compute_map(result_files, task.expected_files),
+        required_file_recall=required_file_recall,
+        missed_required_file_rate=missed_required_file_rate,
+        missed_required_task_rate=missed_required_task_rate,
+        all_required_files_present=all_required_files_present,
+        required_files_present=present,
+        required_files_missing=missing,
+        result_files=result_files,
+        task_completion_result=completion_result_from_missing(completion_files),
+        bundle_completion_tokens=completion_tokens,
+        bundle_completion_files=completion_files,
+        token_efficiency=compute_token_efficiency(tokens_output, tokens_input),
+        token_efficiency_with_completion=compute_token_efficiency(
+            tokens_output + completion_tokens,
+            tokens_input + completion_tokens,
+        ),
+        cold_start_ms=build_ms,
+        warm_latency_ms=ask_ms,
+        wall_time_ms=build_ms + ask_ms,
+        cache_state="cold" if includes_build_cost else "warm",
+        cached=not includes_build_cost,
+        freshness_latency_ms=check_ms,
+        freshness_measured=freshness is not None,
+        freshness_correct=freshness is not None and freshness.ok and not freshness.missing,
+        region_recall=region_metrics.region_recall if region_metrics is not None else None,
+        line_recall=region_metrics.line_recall if region_metrics is not None else None,
+        context_noise_ratio=(
+            region_metrics.context_noise_ratio if region_metrics is not None else None
+        ),
+        timestamp=now_iso(),
+        operational_notes=(
+            "pinned released @nanonets/graft structural graph; "
+            "build without --deep, ask with --no-refresh, freshness probed separately"
+        ),
+        local_offline_posture="local structural graph only; no model call",
+        backend="graft-structural",
+    )
+    sys.stdout.write(artifact.model_dump_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/archex/benchmark/graft.py
+++ b/src/archex/benchmark/graft.py
@@ -1,0 +1,617 @@
+"""Pinned Graft adapter for the graph-memory comparison lanes.
+
+Graft (`@nanonets/graft`) is a graph-memory tool: `graft build` writes a
+persistent structural code graph, `graft ask` answers against it. It joins the
+public head-to-head harness through the tool-neutral contract in
+:mod:`archex.benchmark.graph_memory`, plus the pinned identity and output
+normalization here.
+
+Everything in this module follows the frozen protocol in
+`benchmarks/preregistrations/R19-graft-graph-memory-comparison.md`:
+
+* structural mode only — `build` without `--deep`, so no model is called, no API
+  key is required, and no spend occurs;
+* the graph directory lives outside the task repository and `--no-gitignore
+  --no-ignore` are passed, so the checkout the other lanes measure stays pristine;
+* every measured query passes `--no-refresh`, because a default `graft ask`
+  silently repairs graph drift and would fold synchronization into query latency;
+* freshness is read only from `check --json`'s `graph` section, because `context`
+  is permanently absent in structural mode;
+* rank is the emitted `hits` order, never a re-sort by `hits[].score`, which is
+  not monotonically descending;
+* a hit's returned file is the path component of its `pointer`. Symbol hits
+  (`<path>:L<start>-L<end>`) carry source; whole-file hits (bare `<path>`) carry
+  none even under `--source`, so they count toward required-file recall but
+  contribute no returned source.
+
+The adapter fails closed on any artifact that contradicts those facts: no source
+is inferred, no cell is dropped, and a cell that could not be measured is
+retained as an explicit failure instead of a missing row.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from shutil import which
+from typing import TYPE_CHECKING, cast
+
+from pydantic import Field, ValidationError
+
+from archex.benchmark.graph_memory import (
+    GraphMemoryAdapterError,
+    GraphMemoryArtifact,
+    GraphMemoryUnavailableError,
+    artifact_digest,
+    result_from_graph_memory_artifact,
+    validate_graph_memory_cost_semantics,
+    validate_graph_memory_identity,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from archex.benchmark.models import (
+        BenchmarkResult,
+        BenchmarkTask,
+        GraphMemoryLaneConfig,
+    )
+
+GRAFT_PACKAGE = "@nanonets/graft"
+"""Released npm package the comparison is pinned to."""
+
+GRAFT_NPM_INTEGRITY = (
+    "sha512-L3E5F1aDYJDCARgfR7O2VaMt8xwO1XNYyHiW2n1WhKnj87gPqoxoZJGNbGXfw6XeA9JSJX3"
+    "naA36RZ+jDf4AcQ=="
+)
+"""npm distribution integrity of `@nanonets/graft@0.16.0`."""
+
+GRAFT_SOURCE_COMMIT = "aa1e2bb0f6326068ac64886da1e67fa25a7804de"
+"""Package `gitHead`, equal to the commit tagged `v0.16.0`."""
+
+GRAFT_RESULT_CARDINALITY = 10
+"""Frozen `-n` for every measured query; matches the external retrieval lane's limit."""
+
+GRAFT_RANK_BASIS = "emitted_hits_order"
+"""Only valid rank basis: `hits[].score` is not monotonically descending."""
+
+GRAFT_FRESHNESS_SOURCE = "check_json_graph"
+"""Only valid freshness source: `check --json`'s `context` section is a `--deep` artifact."""
+
+GRAFT_DEPTH_TIER_LANGUAGES = frozenset(
+    {
+        "python",
+        "javascript",
+        "typescript",
+        "tsx",
+        "jsx",
+        "go",
+        "java",
+        "kotlin",
+        "swift",
+        "php",
+        "r",
+    }
+)
+"""Languages Graft extracts with a hand-written (native depth-tier) extractor."""
+
+
+class GraftExtractionTier(StrEnum):
+    """Which Graft extractor tier covered a task's languages.
+
+    ``depth`` is the hand-written per-language extractor. ``breadth`` is the
+    language-agnostic WASM extractor: signature-only, with no receiver typing.
+    The two are never presented as equivalent coverage.
+    """
+
+    DEPTH = "depth"
+    BREADTH = "breadth"
+
+
+class GraftCellStatus(StrEnum):
+    """Whether a planned Graft cell produced a measurement or a recorded failure."""
+
+    OK = "ok"
+    FAILED = "failed"
+
+
+class GraftArtifact(GraphMemoryArtifact):
+    """Schema for one ``{task_id}.json`` Graft lane artifact.
+
+    Adds the pinned released-package identity, the protocol posture that had to
+    hold while the cell ran, and the returned-unit split that keeps whole-file
+    hits out of the returned-source counts.
+    """
+
+    graft_package: str = GRAFT_PACKAGE
+    graft_version: str
+    npm_integrity: str
+    source_commit: str
+    status: GraftCellStatus = GraftCellStatus.OK
+    failure_reason: str | None = None
+    timing_mode: str
+    extraction_tier: GraftExtractionTier
+    query_mode: str
+    rank_basis: str = GRAFT_RANK_BASIS
+    freshness_source: str = GRAFT_FRESHNESS_SOURCE
+    result_cardinality: int = Field(ge=1)
+    deep_summaries: bool = False
+    no_refresh: bool = True
+    graph_dir_outside_repo: bool = True
+    telemetry_disabled: bool = True
+    returned_units: int = Field(ge=0)
+    symbol_hits: int = Field(ge=0)
+    whole_file_hits: int = Field(ge=0)
+    returned_source_units: int = Field(ge=0)
+    graph_ok: bool = False
+    graph_nodes: int = Field(default=0, ge=0)
+    output_digest: str
+
+
+@dataclass(frozen=True)
+class GraftHit:
+    """One ``hits[]`` entry, at the rank Graft emitted it."""
+
+    rank: int
+    pointer: str
+    path: str
+    start_line: int | None
+    end_line: int | None
+    title: str | None
+    code: str | None
+
+    @property
+    def is_whole_file(self) -> bool:
+        """A bare ``<path>`` pointer names a file, not a symbol span."""
+        return self.start_line is None
+
+
+@dataclass(frozen=True)
+class GraftAskOutput:
+    """Normalized `graft ask --json` output for one measured query."""
+
+    query_mode: str
+    hits: tuple[GraftHit, ...]
+    result_files: tuple[str, ...]
+    digest: str
+
+    @property
+    def symbol_hits(self) -> int:
+        return sum(1 for hit in self.hits if not hit.is_whole_file)
+
+    @property
+    def whole_file_hits(self) -> int:
+        return sum(1 for hit in self.hits if hit.is_whole_file)
+
+    @property
+    def source_bearing_hits(self) -> tuple[GraftHit, ...]:
+        return tuple(hit for hit in self.hits if not hit.is_whole_file and hit.code)
+
+
+@dataclass(frozen=True)
+class GraftGraphFreshness:
+    """The `graph` section of `graft check --json`; the only valid freshness signal."""
+
+    ok: bool
+    missing: bool
+    nodes: int
+
+
+def graft_extraction_tier(languages: Sequence[str] | None) -> GraftExtractionTier:
+    """Return the tier Graft uses for ``languages``.
+
+    Any language outside the hand-written depth tier drops the whole cell to the
+    breadth tier, because that is the coverage the answer was actually built from.
+    An unlabeled task cannot claim depth coverage.
+    """
+    normalized = [language.strip().lower() for language in languages or [] if language.strip()]
+    if not normalized:
+        return GraftExtractionTier.BREADTH
+    if all(language in GRAFT_DEPTH_TIER_LANGUAGES for language in normalized):
+        return GraftExtractionTier.DEPTH
+    return GraftExtractionTier.BREADTH
+
+
+def _decode_json_object(raw: bytes, *, what: str) -> dict[str, object]:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise GraphMemoryAdapterError(f"{what} is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise GraphMemoryAdapterError(f"{what} must be a JSON object")
+    return cast("dict[str, object]", payload)
+
+
+def _split_pointer(pointer: str) -> tuple[str, int | None, int | None]:
+    """Split a Graft pointer into its path and optional 1-indexed line span."""
+    path, separator, span = pointer.rpartition(":")
+    if not separator:
+        return pointer, None, None
+    start, dash, end = span.partition("-")
+    if not dash or not start.startswith("L") or not end.startswith("L"):
+        return pointer, None, None
+    try:
+        return path, int(start[1:]), int(end[1:])
+    except ValueError:
+        return pointer, None, None
+
+
+def parse_graft_ask_output(raw: bytes) -> GraftAskOutput:
+    """Normalize `graft ask --json` bytes into ranked hits and returned files.
+
+    Rank is the emitted order. A hit whose pointer names no repository path is a
+    non-attributable answer and fails the cell rather than being inferred away.
+    """
+    payload = _decode_json_object(raw, what="graft ask output")
+    raw_hits = payload.get("hits", [])
+    if not isinstance(raw_hits, list):
+        raise GraphMemoryAdapterError("graft ask output 'hits' must be a JSON array")
+
+    hits: list[GraftHit] = []
+    result_files: list[str] = []
+    for rank, entry in enumerate(cast("list[object]", raw_hits), start=1):
+        if not isinstance(entry, dict):
+            raise GraphMemoryAdapterError(f"graft ask hit {rank} must be a JSON object")
+        hit_fields = cast("dict[str, object]", entry)
+        raw_pointer = hit_fields.get("pointer")
+        pointer = raw_pointer.strip() if isinstance(raw_pointer, str) else ""
+        if not pointer:
+            raise GraphMemoryAdapterError(
+                f"graft ask hit {rank} has no pointer; source and paths are never inferred"
+            )
+        path, start_line, end_line = _split_pointer(pointer)
+        if not path:
+            raise GraphMemoryAdapterError(
+                f"graft ask hit {rank} pointer {pointer!r} names no repository path"
+            )
+        code = hit_fields.get("code")
+        title = hit_fields.get("title")
+        hits.append(
+            GraftHit(
+                rank=rank,
+                pointer=pointer,
+                path=path,
+                start_line=start_line,
+                end_line=end_line,
+                title=title if isinstance(title, str) else None,
+                code=code if isinstance(code, str) and code else None,
+            )
+        )
+        if path not in result_files:
+            result_files.append(path)
+
+    query_mode = payload.get("mode")
+    return GraftAskOutput(
+        query_mode=query_mode if isinstance(query_mode, str) and query_mode else "unknown",
+        hits=tuple(hits),
+        result_files=tuple(result_files),
+        digest=artifact_digest(raw),
+    )
+
+
+def parse_graft_check_output(raw: bytes) -> GraftGraphFreshness:
+    """Read freshness from the `graph` section of `graft check --json`."""
+    payload = _decode_json_object(raw, what="graft check output")
+    graph = payload.get("graph")
+    if not isinstance(graph, dict):
+        raise GraphMemoryAdapterError(
+            "graft check output has no 'graph' section; 'context' is a --deep artifact "
+            "and is never a valid freshness source here"
+        )
+    graph_fields = cast("dict[str, object]", graph)
+    nodes = graph_fields.get("nodes")
+    return GraftGraphFreshness(
+        ok=graph_fields.get("ok") is True,
+        missing=graph_fields.get("missing") is not False,
+        nodes=nodes if isinstance(nodes, int) and not isinstance(nodes, bool) else 0,
+    )
+
+
+def _validate_artifact(
+    config: GraphMemoryLaneConfig,
+    artifact: GraftArtifact,
+    *,
+    source: str,
+) -> None:
+    lane = config.name
+    validate_graph_memory_identity(
+        config,
+        artifact,
+        source=source,
+        package=artifact.graft_package,
+        version=artifact.graft_version,
+    )
+    if artifact.npm_integrity != GRAFT_NPM_INTEGRITY:
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} npm_integrity {artifact.npm_integrity!r} "
+            f"does not match the pinned released artifact"
+        )
+    if artifact.source_commit != GRAFT_SOURCE_COMMIT:
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} source_commit {artifact.source_commit!r} "
+            f"does not match the pinned {GRAFT_SOURCE_COMMIT!r}"
+        )
+    if artifact.timing_mode != config.mode.value:
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} timing_mode {artifact.timing_mode!r} "
+            f"does not match lane mode {config.mode.value!r}"
+        )
+    if artifact.rank_basis != GRAFT_RANK_BASIS:
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} rank_basis must be {GRAFT_RANK_BASIS!r}; "
+            "hits[].score is not monotonically descending"
+        )
+    if artifact.freshness_source != GRAFT_FRESHNESS_SOURCE:
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} freshness_source must be {GRAFT_FRESHNESS_SOURCE!r}"
+        )
+    if artifact.result_cardinality != GRAFT_RESULT_CARDINALITY:
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} result_cardinality "
+            f"{artifact.result_cardinality} does not match the frozen "
+            f"{GRAFT_RESULT_CARDINALITY}"
+        )
+    if artifact.deep_summaries:
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} ran paid --deep summaries, which are out of scope"
+        )
+    if not artifact.no_refresh:
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} must be measured with --no-refresh; a default "
+            "ask repairs graph drift and folds synchronization into query latency"
+        )
+    if not artifact.graph_dir_outside_repo:
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} must keep its graph directory outside the "
+            "task repository so the measured checkout stays pristine"
+        )
+    if not artifact.telemetry_disabled:
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} must run with telemetry disabled "
+            "(CI=1 and DO_NOT_TRACK=1)"
+        )
+    if artifact.symbol_hits + artifact.whole_file_hits != artifact.returned_units:
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} returned_units {artifact.returned_units} does not "
+            f"equal symbol_hits {artifact.symbol_hits} + whole_file_hits "
+            f"{artifact.whole_file_hits}"
+        )
+    if artifact.returned_source_units > artifact.symbol_hits:
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} reports more returned_source_units than symbol "
+            "hits; whole-file hits carry no source even under --source"
+        )
+    if len(artifact.output_digest) != 64 or any(
+        char not in "0123456789abcdef" for char in artifact.output_digest
+    ):
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} output_digest must be a lowercase SHA-256 digest"
+        )
+
+    if artifact.status is GraftCellStatus.FAILED:
+        _validate_failed_cell(artifact, lane=lane, source=source)
+        return
+    if artifact.failure_reason is not None:
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} is status 'ok' but records a failure_reason"
+        )
+    if bool(artifact.result_files) != (artifact.returned_units > 0):
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} returned_units {artifact.returned_units} and "
+            f"{len(artifact.result_files)} returned file(s) disagree"
+        )
+    validate_graph_memory_cost_semantics(config, artifact, source=source)
+
+
+def _validate_failed_cell(artifact: GraftArtifact, *, lane: str, source: str) -> None:
+    """A recorded failure is retained and counted; it must not look like a measurement."""
+    if not (artifact.failure_reason or "").strip():
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} is status 'failed' but records no failure_reason"
+        )
+    if artifact.result_files or artifact.required_files_present:
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} is status 'failed' but reports returned files"
+        )
+    scored = (
+        artifact.recall,
+        artifact.precision,
+        artifact.required_file_recall,
+        artifact.token_efficiency,
+        artifact.cold_start_ms,
+        artifact.warm_latency_ms,
+    )
+    if any(value != 0.0 for value in scored):
+        raise GraphMemoryAdapterError(
+            f"graft lane {lane!r} {source} is status 'failed' but reports non-zero metrics"
+        )
+
+
+def _extra_provenance(artifact: GraftArtifact) -> dict[str, str]:
+    return {
+        "graft_package": artifact.graft_package,
+        "graft_version": artifact.graft_version,
+        "graft_npm_integrity": artifact.npm_integrity,
+        "graft_source_commit": artifact.source_commit,
+        "graft_status": artifact.status.value,
+        "graft_timing_mode": artifact.timing_mode,
+        "graft_extraction_tier": artifact.extraction_tier.value,
+        "graft_query_mode": artifact.query_mode,
+        "graft_rank_basis": artifact.rank_basis,
+        "graft_freshness_source": artifact.freshness_source,
+        "graft_result_cardinality": str(artifact.result_cardinality),
+        "graft_deep_summaries": str(artifact.deep_summaries).lower(),
+        "graft_no_refresh": str(artifact.no_refresh).lower(),
+        "graft_telemetry_disabled": str(artifact.telemetry_disabled).lower(),
+        "graft_returned_units": str(artifact.returned_units),
+        "graft_symbol_hits": str(artifact.symbol_hits),
+        "graft_whole_file_hits": str(artifact.whole_file_hits),
+        "graft_returned_source_units": str(artifact.returned_source_units),
+        "graft_graph_nodes": str(artifact.graph_nodes),
+        "graft_output_digest": artifact.output_digest,
+        **(
+            {"graft_failure_reason": artifact.failure_reason}
+            if artifact.failure_reason is not None
+            else {}
+        ),
+    }
+
+
+def _result_from_artifact(
+    config: GraphMemoryLaneConfig,
+    artifact: GraftArtifact,
+    *,
+    run_mode: str,
+    artifact_path: Path | None = None,
+    digest: str | None = None,
+) -> BenchmarkResult:
+    return result_from_graph_memory_artifact(
+        config,
+        artifact,
+        run_mode=run_mode,
+        package=artifact.graft_package,
+        version=artifact.graft_version,
+        extra_provenance=_extra_provenance(artifact),
+        artifact_path=artifact_path,
+        digest=digest,
+    )
+
+
+def load_graft_artifact(
+    config: GraphMemoryLaneConfig,
+    *,
+    task_id: str,
+    artifact_dir: Path,
+    expected_tier: GraftExtractionTier | None = None,
+) -> BenchmarkResult:
+    """Import one operator-produced Graft lane artifact for ``task_id``."""
+    artifact_path = artifact_dir / f"{task_id}.json"
+    if not artifact_path.is_file():
+        raise GraphMemoryAdapterError(
+            f"graft lane {config.name!r} artifact not found: {artifact_path}"
+        )
+    raw = artifact_path.read_bytes()
+    try:
+        artifact = GraftArtifact.model_validate_json(raw)
+    except ValidationError as exc:
+        raise GraphMemoryAdapterError(
+            f"graft lane {config.name!r} artifact {artifact_path} is invalid: {exc}"
+        ) from exc
+    if artifact.task_id != task_id:
+        raise GraphMemoryAdapterError(
+            f"graft lane {config.name!r} artifact {artifact_path} has task_id "
+            f"{artifact.task_id!r}, expected {task_id!r}"
+        )
+    _validate_artifact(config, artifact, source=f"artifact {artifact_path}")
+    if expected_tier is not None and artifact.extraction_tier is not expected_tier:
+        raise GraphMemoryAdapterError(
+            f"graft lane {config.name!r} artifact {artifact_path} records extraction_tier "
+            f"{artifact.extraction_tier.value!r}, but the task's languages resolve to "
+            f"{expected_tier.value!r}; a mislabeled tier corrupts the depth-tier subset"
+        )
+    return _result_from_artifact(
+        config,
+        artifact,
+        run_mode="artifact",
+        artifact_path=artifact_path,
+        digest=artifact_digest(raw),
+    )
+
+
+def run_graft_lane(
+    config: GraphMemoryLaneConfig,
+    *,
+    task: BenchmarkTask,
+    repo_path: Path | None,
+    graph_dir: Path | None = None,
+) -> BenchmarkResult:
+    """Produce one Graft lane result via artifact import or local command mode.
+
+    Local mode runs the configured operator command, which owns the frozen
+    protocol and writes one Graft artifact JSON to stdout. ``graph_dir`` is
+    passed through so the warm lane queries the graph the cold lane built, and
+    it must live outside ``repo_path``.
+    """
+    if config.artifact_dir is not None:
+        return load_graft_artifact(
+            config,
+            task_id=task.task_id,
+            artifact_dir=Path(config.artifact_dir),
+            expected_tier=graft_extraction_tier(task.languages),
+        )
+    if which(config.command) is None:
+        raise GraphMemoryUnavailableError(
+            f"graft lane {config.name!r} command {config.command!r} not found; "
+            "set graph_memory_lanes[].artifact_dir to import operator artifacts instead"
+        )
+    if repo_path is None:
+        raise GraphMemoryAdapterError(
+            f"graft lane {config.name!r} local execution requires repo_path"
+        )
+    if graph_dir is None:
+        raise GraphMemoryAdapterError(
+            f"graft lane {config.name!r} local execution requires graph_dir outside the "
+            "task repository"
+        )
+    if (
+        graph_dir.resolve() == repo_path.resolve()
+        or repo_path.resolve() in graph_dir.resolve().parents
+    ):
+        raise GraphMemoryAdapterError(
+            f"graft lane {config.name!r} graph_dir {graph_dir} is inside the task "
+            "repository; the measured checkout must stay pristine"
+        )
+
+    payload = {
+        "task": task.model_dump(mode="json"),
+        "repo_path": str(repo_path),
+        "graph_dir": str(graph_dir),
+        "lane": config.name,
+        "tool": config.tool.value,
+        "mode": config.mode.value,
+        "graft": {
+            "package_name": config.package_name,
+            "version": config.version,
+            "npm_integrity": GRAFT_NPM_INTEGRITY,
+            "source_commit": GRAFT_SOURCE_COMMIT,
+            "result_cardinality": GRAFT_RESULT_CARDINALITY,
+        },
+    }
+    command = [config.command, *config.args]
+    env = {**os.environ, "CI": "1", "DO_NOT_TRACK": "1", **config.env}
+    try:
+        completed = subprocess.run(
+            command,
+            input=json.dumps(payload),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=config.timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise GraphMemoryAdapterError(
+            f"graft lane {config.name!r} timed out after {config.timeout_seconds}s"
+        ) from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "no output"
+        raise GraphMemoryAdapterError(
+            f"graft lane {config.name!r} failed with exit {completed.returncode}: {detail}"
+        )
+    try:
+        artifact = GraftArtifact.model_validate_json(completed.stdout)
+    except ValidationError as exc:
+        raise GraphMemoryAdapterError(
+            f"graft lane {config.name!r} local output is invalid: {exc}"
+        ) from exc
+    if artifact.task_id != task.task_id:
+        raise GraphMemoryAdapterError(
+            f"graft lane {config.name!r} local output task_id {artifact.task_id!r} "
+            f"does not match benchmark task {task.task_id!r}"
+        )
+    _validate_artifact(config, artifact, source="local output")
+    return _result_from_artifact(config, artifact, run_mode="local")

--- a/src/archex/benchmark/graph_memory.py
+++ b/src/archex/benchmark/graph_memory.py
@@ -103,7 +103,7 @@ def artifact_digest(raw: bytes) -> str:
     return hashlib.sha256(raw).hexdigest()
 
 
-def validate_graph_memory_artifact(
+def validate_graph_memory_identity(
     config: GraphMemoryLaneConfig,
     artifact: GraphMemoryArtifact,
     *,
@@ -111,7 +111,7 @@ def validate_graph_memory_artifact(
     package: str,
     version: str,
 ) -> None:
-    """Fail closed unless ``artifact`` matches ``config``'s pinned lane contract.
+    """Fail closed unless ``artifact`` claims ``config``'s pinned lane identity.
 
     ``package``/``version`` come from the tool's own provenance fields so each
     adapter keeps its registry naming instead of sharing one field name.
@@ -139,6 +139,20 @@ def validate_graph_memory_artifact(
             else "must not include build cost"
         )
         raise GraphMemoryAdapterError(f"graph-memory lane {lane!r} {source} {verb}")
+
+
+def validate_graph_memory_cost_semantics(
+    config: GraphMemoryLaneConfig,
+    artifact: GraphMemoryArtifact,
+    *,
+    source: str,
+) -> None:
+    """Fail closed unless a measured cell's cold/warm cost matches its lane mode.
+
+    Only measured cells carry cost semantics. A recorded failure has no valid
+    timing, so its adapter validates identity and its own failure fields instead.
+    """
+    lane = config.name
     if artifact.cache_state not in {"cold", "warm"}:
         raise GraphMemoryAdapterError(
             f"graph-memory lane {lane!r} {source} cache_state "

--- a/src/archex/benchmark/graphify.py
+++ b/src/archex/benchmark/graphify.py
@@ -28,7 +28,8 @@ from archex.benchmark.graph_memory import (
     GraphMemoryUnavailableError,
     artifact_digest,
     result_from_graph_memory_artifact,
-    validate_graph_memory_artifact,
+    validate_graph_memory_cost_semantics,
+    validate_graph_memory_identity,
 )
 
 if TYPE_CHECKING:
@@ -52,13 +53,14 @@ def _validate_artifact(
     *,
     source: str,
 ) -> None:
-    validate_graph_memory_artifact(
+    validate_graph_memory_identity(
         config,
         artifact,
         source=source,
         package=artifact.graphify_package,
         version=artifact.graphify_version,
     )
+    validate_graph_memory_cost_semantics(config, artifact, source=source)
 
 
 def _result_from_artifact(

--- a/src/archex/benchmark/headtohead.py
+++ b/src/archex/benchmark/headtohead.py
@@ -11,6 +11,7 @@ import yaml
 from pydantic import BaseModel, ValidationError
 
 from archex.benchmark.external_mcp import reset_external_tool_config, set_external_tool_config
+from archex.benchmark.graft import load_graft_artifact
 from archex.benchmark.graph_memory import GraphMemoryAdapterError
 from archex.benchmark.graphify import load_graphify_artifact
 from archex.benchmark.loader import load_tasks
@@ -350,6 +351,7 @@ class _GraphMemoryArtifactLoader(Protocol):
 
 _GRAPH_MEMORY_ARTIFACT_LOADERS: dict[GraphMemoryTool, _GraphMemoryArtifactLoader] = {
     GraphMemoryTool.GRAPHIFY: load_graphify_artifact,
+    GraphMemoryTool.GRAFT: load_graft_artifact,
 }
 
 

--- a/src/archex/benchmark/models.py
+++ b/src/archex/benchmark/models.py
@@ -397,6 +397,7 @@ class GraphMemoryTool(StrEnum):
     """A graph-memory tool with a modeled comparison lane family."""
 
     GRAPHIFY = "graphify"
+    GRAFT = "graft"
 
 
 class GraphMemoryLaneMode(StrEnum):
@@ -413,6 +414,7 @@ class GraphMemoryLaneMode(StrEnum):
 
 GRAPH_MEMORY_TOOL_PACKAGES: dict[GraphMemoryTool, str] = {
     GraphMemoryTool.GRAPHIFY: "graphifyy",
+    GraphMemoryTool.GRAFT: "@nanonets/graft",
 }
 """Released distribution package that each graph-memory tool must be pinned to."""
 

--- a/tests/benchmark/test_graft.py
+++ b/tests/benchmark/test_graft.py
@@ -1,0 +1,572 @@
+"""Tests for the pinned Graft graph-memory comparison-lane adapter."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from archex.benchmark.graft import (
+    GRAFT_NPM_INTEGRITY,
+    GRAFT_SOURCE_COMMIT,
+    GraftExtractionTier,
+    graft_extraction_tier,
+    load_graft_artifact,
+    parse_graft_ask_output,
+    parse_graft_check_output,
+)
+from archex.benchmark.graph_memory import GraphMemoryAdapterError
+from archex.benchmark.headtohead import load_graph_memory_results
+from archex.benchmark.models import (
+    BenchmarkTask,
+    GraphMemoryLaneConfig,
+    GraphMemoryLaneMode,
+    GraphMemoryTool,
+    Strategy,
+)
+
+_RUNNER = Path(__file__).resolve().parents[2] / "scripts" / "run_graft_headtohead_lane.py"
+
+# Two symbol hits and one whole-file hit, with scores deliberately out of order:
+# the pinned release emits `hits` in rank order while `hits[].score` is not
+# monotonically descending, so rank must come from the emitted order.
+_ASK_JSON = json.dumps(
+    {
+        "query": "how is auth registered",
+        "mode": "lexical",
+        "hits": [
+            {
+                "kind": "symbol",
+                "title": "register_auth · function",
+                "pointer": "src/auth.py:L10-L20",
+                "score": 1.5,
+                "code": "def register_auth(app):\n    app.use(auth)\n",
+            },
+            {
+                "kind": "symbol",
+                "title": "server.py · file",
+                "pointer": "src/server.py",
+                "score": 0.97,
+            },
+            {
+                "kind": "symbol",
+                "title": "Auth · class",
+                "pointer": "src/auth.py:L1-L8",
+                "score": 1.42,
+                "code": "class Auth:\n    pass\n",
+            },
+        ],
+        "coverage": 1,
+        "coverageStrong": 0.44,
+    }
+).encode("utf-8")
+
+_CHECK_JSON = json.dumps(
+    {
+        "context": {"ok": False, "missing": True, "coverage": []},
+        "graph": {"ok": True, "missing": False, "added": [], "nodes": 7},
+    }
+).encode("utf-8")
+
+
+def _task() -> BenchmarkTask:
+    return BenchmarkTask(
+        task_id="task_a",
+        repo="owner/repo",
+        commit="abc123",
+        question="Where is the auth middleware registered?",
+        expected_files=["src/auth.py", "src/server.py"],
+        languages=["python"],
+    )
+
+
+def _config(
+    *,
+    mode: GraphMemoryLaneMode = GraphMemoryLaneMode.BUILD_PLUS_QUERY,
+    version: str = "0.16.0",
+    command: str = "graft",
+    artifact_dir: Path | None = None,
+) -> GraphMemoryLaneConfig:
+    return GraphMemoryLaneConfig(
+        tool=GraphMemoryTool.GRAFT,
+        mode=mode,
+        package_name="@nanonets/graft",
+        version=version,
+        command=command,
+        artifact_dir=str(artifact_dir) if artifact_dir is not None else None,
+    )
+
+
+def _artifact_payload(
+    *,
+    mode: GraphMemoryLaneMode = GraphMemoryLaneMode.BUILD_PLUS_QUERY,
+) -> dict[str, object]:
+    includes_build_cost = mode is GraphMemoryLaneMode.BUILD_PLUS_QUERY
+    return {
+        "task_id": "task_a",
+        "lane": f"graft_{mode.value}",
+        "command": "graft --dir <graph-dir> ask '...' -n 10 --source --no-refresh --json <repo>",
+        "includes_build_cost": includes_build_cost,
+        "graft_package": "@nanonets/graft",
+        "graft_version": "0.16.0",
+        "npm_integrity": GRAFT_NPM_INTEGRITY,
+        "source_commit": GRAFT_SOURCE_COMMIT,
+        "status": "ok",
+        "timing_mode": mode.value,
+        "extraction_tier": "depth",
+        "query_mode": "lexical",
+        "rank_basis": "emitted_hits_order",
+        "freshness_source": "check_json_graph",
+        "result_cardinality": 10,
+        "deep_summaries": False,
+        "no_refresh": True,
+        "graph_dir_outside_repo": True,
+        "telemetry_disabled": True,
+        "returned_units": 3,
+        "symbol_hits": 2,
+        "whole_file_hits": 1,
+        "returned_source_units": 2,
+        "graph_ok": True,
+        "graph_nodes": 7,
+        "output_digest": "a" * 64,
+        "tokens_total": 120,
+        "tokens_input": 800,
+        "tokens_output": 120,
+        "tool_calls": 2 if includes_build_cost else 1,
+        "files_accessed": 2,
+        "recall": 1.0,
+        "precision": 0.5,
+        "f1_score": 0.67,
+        "mrr": 1.0,
+        "ndcg": 1.0,
+        "map_score": 1.0,
+        "required_file_recall": 1.0,
+        "missed_required_file_rate": 0.0,
+        "missed_required_task_rate": 0.0,
+        "all_required_files_present": True,
+        "required_files_present": ["src/auth.py", "src/server.py"],
+        "required_files_missing": [],
+        "result_files": ["src/auth.py", "src/server.py"],
+        "task_completion_result": "pass",
+        "bundle_completion_tokens": 0,
+        "bundle_completion_files": [],
+        "token_efficiency": 0.85,
+        "token_efficiency_with_completion": 0.85,
+        "cold_start_ms": 4200.0 if includes_build_cost else 0.0,
+        "warm_latency_ms": 210.0,
+        "wall_time_ms": 4410.0 if includes_build_cost else 210.0,
+        "cache_state": "cold" if includes_build_cost else "warm",
+        "cached": not includes_build_cost,
+        "freshness_latency_ms": 30.0,
+        "freshness_measured": True,
+        "freshness_correct": True,
+        "timestamp": "2026-09-09T00:00:00Z",
+        "backend": "graft-structural",
+        "local_offline_posture": "local structural graph only; no model call",
+    }
+
+
+def _write_artifact(
+    artifact_dir: Path,
+    *,
+    mode: GraphMemoryLaneMode = GraphMemoryLaneMode.BUILD_PLUS_QUERY,
+    overrides: dict[str, object] | None = None,
+    task_id: str = "task_a",
+) -> Path:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    payload = _artifact_payload(mode=mode)
+    payload["task_id"] = task_id
+    if overrides:
+        payload.update(overrides)
+    path = artifact_dir / f"{task_id}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_graft_extraction_tier_separates_native_and_wasm_coverage() -> None:
+    assert graft_extraction_tier(["python"]) is GraftExtractionTier.DEPTH
+    assert graft_extraction_tier(["go"]) is GraftExtractionTier.DEPTH
+    assert graft_extraction_tier(["javascript"]) is GraftExtractionTier.DEPTH
+    # The two Rust tasks are covered only by the signature-only WASM breadth tier.
+    assert graft_extraction_tier(["rust"]) is GraftExtractionTier.BREADTH
+    assert graft_extraction_tier(["python", "rust"]) is GraftExtractionTier.BREADTH
+    # An unlabeled task cannot claim depth coverage.
+    assert graft_extraction_tier(None) is GraftExtractionTier.BREADTH
+
+
+def test_parse_graft_ask_output_ranks_by_emitted_order_not_score() -> None:
+    ask = parse_graft_ask_output(_ASK_JSON)
+
+    assert [hit.rank for hit in ask.hits] == [1, 2, 3]
+    assert [hit.pointer for hit in ask.hits] == [
+        "src/auth.py:L10-L20",
+        "src/server.py",
+        "src/auth.py:L1-L8",
+    ]
+    # Returned files keep the emitted order and are deduplicated by path.
+    assert ask.result_files == ("src/auth.py", "src/server.py")
+    assert ask.query_mode == "lexical"
+
+
+def test_parse_graft_ask_output_excludes_whole_file_hits_from_returned_source() -> None:
+    ask = parse_graft_ask_output(_ASK_JSON)
+
+    whole_file = ask.hits[1]
+    assert whole_file.is_whole_file
+    assert whole_file.code is None
+    assert whole_file.path == "src/server.py"
+    assert ask.symbol_hits == 2
+    assert ask.whole_file_hits == 1
+    # A whole-file hit names a required file but contributes no returned source.
+    assert [hit.pointer for hit in ask.source_bearing_hits] == [
+        "src/auth.py:L10-L20",
+        "src/auth.py:L1-L8",
+    ]
+
+
+def test_parse_graft_ask_output_rejects_unattributable_hit() -> None:
+    payload = json.dumps({"mode": "lexical", "hits": [{"title": "mystery", "score": 1.0}]})
+
+    with pytest.raises(GraphMemoryAdapterError, match="never inferred"):
+        parse_graft_ask_output(payload.encode("utf-8"))
+
+
+def test_parse_graft_check_output_uses_graph_section_only() -> None:
+    freshness = parse_graft_check_output(_CHECK_JSON)
+
+    assert freshness.ok is True
+    assert freshness.missing is False
+    assert freshness.nodes == 7
+
+
+def test_parse_graft_check_output_rejects_output_without_graph_section() -> None:
+    payload = json.dumps({"context": {"ok": False, "missing": True}})
+
+    with pytest.raises(GraphMemoryAdapterError, match="no 'graph' section"):
+        parse_graft_check_output(payload.encode("utf-8"))
+
+
+def test_load_graft_artifact_records_pinned_provenance(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "graft-build"
+    _write_artifact(artifact_dir)
+    config = _config(artifact_dir=artifact_dir)
+
+    result = load_graft_artifact(config, task_id="task_a", artifact_dir=artifact_dir)
+
+    assert result.strategy is Strategy.EXTERNAL_MCP
+    assert result.strategy_label == "graft_build_plus_query"
+    assert result.provenance["graph_memory_tool"] == "graft"
+    assert result.provenance["graph_memory_mode"] == "build_plus_query"
+    assert result.provenance["graph_memory_package"] == "@nanonets/graft"
+    assert result.provenance["external_tool_version"] == "0.16.0"
+    assert result.provenance["graft_npm_integrity"] == GRAFT_NPM_INTEGRITY
+    assert result.provenance["graft_source_commit"] == GRAFT_SOURCE_COMMIT
+    assert result.provenance["graft_extraction_tier"] == "depth"
+    assert result.provenance["graft_rank_basis"] == "emitted_hits_order"
+    assert result.provenance["graft_freshness_source"] == "check_json_graph"
+    assert result.provenance["graft_no_refresh"] == "true"
+    assert result.provenance["graft_deep_summaries"] == "false"
+    assert result.provenance["graft_telemetry_disabled"] == "true"
+    assert result.provenance["graft_symbol_hits"] == "2"
+    assert result.provenance["graft_whole_file_hits"] == "1"
+    assert result.provenance["graft_returned_source_units"] == "2"
+    assert result.provenance["graft_status"] == "ok"
+    assert len(result.provenance["graph_memory_artifact_sha256"]) == 64
+    assert result.cold_start_ms == 4200.0
+    assert result.warm_latency_ms == 210.0
+    assert result.freshness_latency_ms == 30.0
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"graft_version": "0.15.0"}, "does not match pinned version"),
+        ({"npm_integrity": "sha512-tampered"}, "does not match the pinned released artifact"),
+        ({"source_commit": "0" * 40}, "does not match the pinned"),
+        ({"timing_mode": "query_warm"}, "does not match lane mode"),
+        ({"rank_basis": "score"}, "hits\\[\\].score is not monotonically descending"),
+        ({"freshness_source": "check_json_context"}, "freshness_source must be"),
+        ({"result_cardinality": 8}, "does not match the frozen"),
+        ({"deep_summaries": True}, "paid --deep summaries"),
+        ({"no_refresh": False}, "must be measured with --no-refresh"),
+        ({"graph_dir_outside_repo": False}, "outside the"),
+        ({"telemetry_disabled": False}, "telemetry disabled"),
+        ({"symbol_hits": 1}, "does not equal symbol_hits"),
+        ({"returned_source_units": 3}, "more returned_source_units than symbol"),
+        ({"output_digest": "zz"}, "lowercase SHA-256 digest"),
+        ({"failure_reason": "flaky"}, "records a failure_reason"),
+        ({"result_files": []}, "returned file\\(s\\) disagree"),
+        ({"cold_start_ms": 0.0}, "must report cold_start_ms > 0"),
+    ],
+)
+def test_load_graft_artifact_fails_closed_on_contract_violation(
+    tmp_path: Path,
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    artifact_dir = tmp_path / "graft-build"
+    _write_artifact(artifact_dir, overrides=overrides)
+    config = _config(artifact_dir=artifact_dir)
+
+    with pytest.raises(GraphMemoryAdapterError, match=message):
+        load_graft_artifact(config, task_id="task_a", artifact_dir=artifact_dir)
+
+
+def test_load_graft_artifact_accepts_recorded_failure_cell(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "graft-build"
+    _write_artifact(
+        artifact_dir,
+        overrides={
+            "status": "failed",
+            "failure_reason": "graft ask hit 1 has no pointer",
+            "query_mode": "unattributable",
+            "returned_units": 0,
+            "symbol_hits": 0,
+            "whole_file_hits": 0,
+            "returned_source_units": 0,
+            "result_files": [],
+            "required_files_present": [],
+            "required_files_missing": ["src/auth.py", "src/server.py"],
+            "all_required_files_present": False,
+            "recall": 0.0,
+            "precision": 0.0,
+            "f1_score": 0.0,
+            "mrr": 0.0,
+            "ndcg": 0.0,
+            "map_score": 0.0,
+            "required_file_recall": 0.0,
+            "missed_required_file_rate": 1.0,
+            "missed_required_task_rate": 1.0,
+            "token_efficiency": 0.0,
+            "token_efficiency_with_completion": 0.0,
+            "tokens_total": 0,
+            "tokens_input": 0,
+            "tokens_output": 0,
+            "files_accessed": 0,
+            "cold_start_ms": 0.0,
+            "warm_latency_ms": 0.0,
+            "wall_time_ms": 0.0,
+        },
+    )
+    config = _config(artifact_dir=artifact_dir)
+
+    result = load_graft_artifact(config, task_id="task_a", artifact_dir=artifact_dir)
+
+    assert result.provenance["graft_status"] == "failed"
+    assert result.provenance["graft_failure_reason"] == "graft ask hit 1 has no pointer"
+    assert result.required_file_recall == 0.0
+
+
+def test_load_graft_artifact_rejects_failure_cell_reporting_metrics(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "graft-build"
+    _write_artifact(
+        artifact_dir,
+        overrides={"status": "failed", "failure_reason": "timeout"},
+    )
+    config = _config(artifact_dir=artifact_dir)
+
+    with pytest.raises(GraphMemoryAdapterError, match="reports returned files"):
+        load_graft_artifact(config, task_id="task_a", artifact_dir=artifact_dir)
+
+
+def test_load_graft_artifact_rejects_mislabeled_extraction_tier(tmp_path: Path) -> None:
+    artifact_dir = tmp_path / "graft-build"
+    _write_artifact(artifact_dir, overrides={"extraction_tier": "depth"})
+    config = _config(artifact_dir=artifact_dir)
+
+    with pytest.raises(GraphMemoryAdapterError, match="corrupts the depth-tier subset"):
+        load_graft_artifact(
+            config,
+            task_id="task_a",
+            artifact_dir=artifact_dir,
+            expected_tier=GraftExtractionTier.BREADTH,
+        )
+
+
+def test_load_graph_memory_results_routes_graft_lanes(tmp_path: Path) -> None:
+    build_dir = tmp_path / "graft-build"
+    warm_dir = tmp_path / "graft-warm"
+    _write_artifact(build_dir)
+    _write_artifact(warm_dir, mode=GraphMemoryLaneMode.QUERY_WARM)
+
+    results = load_graph_memory_results(
+        [
+            _config(artifact_dir=build_dir),
+            _config(mode=GraphMemoryLaneMode.QUERY_WARM, artifact_dir=warm_dir),
+        ],
+        ["task_a"],
+    )
+
+    by_lane = {result.strategy_label: result for result in results}
+    assert set(by_lane) == {"graft_build_plus_query", "graft_query_warm"}
+    cold_start = by_lane["graft_build_plus_query"].cold_start_ms
+    assert cold_start is not None and cold_start > 0.0
+    assert by_lane["graft_query_warm"].cold_start_ms == 0.0
+    assert by_lane["graft_query_warm"].cached is True
+
+
+def _fake_graft(tmp_path: Path) -> Path:
+    """A stand-in `graft` that replays the pinned release's observed output shapes."""
+    binary = tmp_path / "fake-graft"
+    binary.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json, pathlib, sys\n"
+        "argv = sys.argv[1:]\n"
+        "graph_dir = pathlib.Path(argv[argv.index('--dir') + 1])\n"
+        "command = argv[2]\n"
+        "if command == 'build':\n"
+        "    graph_dir.mkdir(parents=True, exist_ok=True)\n"
+        "    (graph_dir / 'graph.json').write_text('{}')\n"
+        "    sys.stdout.write('wiring: 7 nodes\\n')\n"
+        "elif command == 'ask':\n"
+        f"    sys.stdout.write({_ASK_JSON.decode('utf-8')!r})\n"
+        "elif command == 'check':\n"
+        "    built = (graph_dir / 'graph.json').is_file()\n"
+        "    sys.stdout.write(json.dumps({'context': {'ok': False, 'missing': True},\n"
+        "        'graph': {'ok': built, 'missing': not built, 'nodes': 7 if built else 0}}))\n"
+        "else:\n"
+        "    sys.stderr.write('unexpected command\\n')\n"
+        "    raise SystemExit(2)\n",
+        encoding="utf-8",
+    )
+    binary.chmod(binary.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return binary
+
+
+def _fixture_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "src" / "auth.py").write_text(
+        "class Auth:\n    pass\n\n\ndef register_auth(app):\n    app.use(auth)\n",
+        encoding="utf-8",
+    )
+    (repo / "src" / "server.py").write_text("from .auth import register_auth\n", encoding="utf-8")
+    return repo
+
+
+def _run_runner(
+    *,
+    repo: Path,
+    graph_dir: Path,
+    mode: GraphMemoryLaneMode,
+    binary: Path,
+) -> subprocess.CompletedProcess[str]:
+    payload = {
+        "task": _task().model_dump(mode="json"),
+        "repo_path": str(repo),
+        "graph_dir": str(graph_dir),
+        "lane": f"graft_{mode.value}",
+        "tool": "graft",
+        "mode": mode.value,
+        "graft": {
+            "package_name": "@nanonets/graft",
+            "version": "0.16.0",
+            "npm_integrity": GRAFT_NPM_INTEGRITY,
+            "source_commit": GRAFT_SOURCE_COMMIT,
+            "result_cardinality": 10,
+        },
+        "binary": str(binary),
+    }
+    return subprocess.run(
+        [sys.executable, str(_RUNNER)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "CI": "1", "DO_NOT_TRACK": "1"},
+    )
+
+
+def test_graft_runner_produces_importable_cold_and_warm_cells(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    graph_dir = tmp_path / "graft-index"
+    binary = _fake_graft(tmp_path)
+
+    cold = _run_runner(
+        repo=repo,
+        graph_dir=graph_dir,
+        mode=GraphMemoryLaneMode.BUILD_PLUS_QUERY,
+        binary=binary,
+    )
+    assert cold.returncode == 0, cold.stderr
+    warm = _run_runner(
+        repo=repo,
+        graph_dir=graph_dir,
+        mode=GraphMemoryLaneMode.QUERY_WARM,
+        binary=binary,
+    )
+    assert warm.returncode == 0, warm.stderr
+
+    build_dir = tmp_path / "cells" / "graft_build_plus_query"
+    warm_dir = tmp_path / "cells" / "graft_query_warm"
+    build_dir.mkdir(parents=True)
+    warm_dir.mkdir(parents=True)
+    (build_dir / "task_a.json").write_text(cold.stdout, encoding="utf-8")
+    (warm_dir / "task_a.json").write_text(warm.stdout, encoding="utf-8")
+
+    cold_result = load_graft_artifact(
+        _config(artifact_dir=build_dir), task_id="task_a", artifact_dir=build_dir
+    )
+    warm_result = load_graft_artifact(
+        _config(mode=GraphMemoryLaneMode.QUERY_WARM, artifact_dir=warm_dir),
+        task_id="task_a",
+        artifact_dir=warm_dir,
+    )
+
+    # Cold pays build cost; warm pays none, and neither folds the freshness probe in.
+    assert cold_result.cold_start_ms is not None and cold_result.cold_start_ms > 0.0
+    assert cold_result.warm_latency_ms is not None and cold_result.warm_latency_ms > 0.0
+    assert warm_result.cold_start_ms == 0.0
+    assert warm_result.warm_latency_ms is not None and warm_result.warm_latency_ms > 0.0
+    assert warm_result.wall_time_ms == warm_result.warm_latency_ms
+    assert warm_result.freshness_latency_ms > 0.0
+    assert warm_result.freshness_measured is True
+    assert warm_result.freshness_correct is True
+
+    # Both required files are recovered, one by a symbol hit and one whole-file hit.
+    assert cold_result.required_file_recall == 1.0
+    assert cold_result.result_files == ["src/auth.py", "src/server.py"]
+    assert cold_result.provenance["graft_returned_units"] == "3"
+    assert cold_result.provenance["graft_symbol_hits"] == "2"
+    assert cold_result.provenance["graft_whole_file_hits"] == "1"
+    assert cold_result.provenance["graft_returned_source_units"] == "2"
+    assert cold_result.provenance["graft_query_mode"] == "lexical"
+    assert cold_result.provenance["graft_graph_nodes"] == "7"
+    assert cold_result.tokens_total > 0
+    assert "--no-refresh" in cold_result.provenance["graph_memory_command"]
+    assert "--deep" not in cold_result.provenance["graph_memory_command"]
+
+
+def test_graft_runner_refuses_warm_lane_without_prebuilt_graph(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    binary = _fake_graft(tmp_path)
+
+    warm = _run_runner(
+        repo=repo,
+        graph_dir=tmp_path / "empty-index",
+        mode=GraphMemoryLaneMode.QUERY_WARM,
+        binary=binary,
+    )
+
+    assert warm.returncode != 0
+    assert "no prebuilt graph" in warm.stderr
+
+
+def test_graft_runner_refuses_graph_dir_inside_task_repository(tmp_path: Path) -> None:
+    repo = _fixture_repo(tmp_path)
+    binary = _fake_graft(tmp_path)
+
+    cold = _run_runner(
+        repo=repo,
+        graph_dir=repo / "graft",
+        mode=GraphMemoryLaneMode.BUILD_PLUS_QUERY,
+        binary=binary,
+    )
+
+    assert cold.returncode != 0
+    assert "inside the task repository" in cold.stderr


### PR DESCRIPTION
## What

Add Graft to the public head-to-head harness as the second graph-memory tool, pinned to the released npm package `@nanonets/graft@0.16.0` (integrity `sha512-L3E5F1aDYJ...jDf4AcQ==`, source commit `aa1e2bb0f6326068ac64886da1e67fa25a7804de`, tag `v0.16.0`, MIT). No archex retrieval code, ranking signal, default, or existing lane changes; both new manifest lanes carry no artifacts yet, so the rendered report is unchanged.

- `src/archex/benchmark/graft.py` — pinned identity as constants plus the output normalization the comparison needs: ranked hits from the emitted `hits` order, a hit's returned file from its `pointer`, and the split between symbol hits (which carry source) and whole-file hits (which carry none even under `--source`). Freshness parses only `check --json`'s `graph` section.
- `scripts/run_graft_headtohead_lane.py` — executes one cell under the frozen protocol. The cold lane builds then asks; the warm lane asks only, against the graph the cold lane built, and refuses to run when no graph is there. The freshness probe is timed separately and never folded into warm latency.
- Manifest rows for `graft_build_plus_query` and `graft_query_warm`.

## Protocol facts this encodes

Each of these is a measured property of the pinned release, frozen in `benchmarks/preregistrations/R19-graft-graph-memory-comparison.md` (merged, commit `af8e547b`), not a convenience choice:

- A default `graft ask` silently repairs graph drift, so every measured query passes `--no-refresh` and the adapter rejects an artifact that does not.
- `check --json` reports `context` as permanently missing in structural mode, so `graph` is the only valid freshness source.
- `hits[].score` is not monotonically descending in emitted order, so rank is the emitted order and `rank_basis` is validated.
- Whole-file hits carry a bare `<path>` pointer and no `code`. They count toward required-file recall and contribute no returned source; `returned_source_units > symbol_hits` is rejected.
- `build` without `--deep` needs no key and spends nothing; `deep_summaries: true` is rejected outright.

## Failure handling

A cell that could not be measured is representable only as an explicit failure artifact: `status: failed`, a non-empty reason, no returned files, and zeroed metrics. Fail-closed validation covers package/version, npm integrity, source commit, timing mode, rank basis, freshness source, result cardinality, `--deep`, `--no-refresh`, graph directory outside the repository, telemetry posture, returned-unit arithmetic, and digest shape.

## Verification

- `uv run pytest tests/benchmark/test_graft.py` — 30 passed, including a deterministic end-to-end smoke that drives the real runner script against a stand-in `graft` binary replaying the pinned release's observed output shapes, then imports both produced cells through the adapter. It asserts cold pays build cost, warm pays none, wall time excludes the freshness probe, and the recorded command contains `--no-refresh` and no `--deep`.
- 17 fail-closed contract violations are covered as a parametrized table, one per protocol clause.
- Full `tests/benchmark/` suite: 1105 passed. `ruff check`, `ruff format --check`, `pyright` clean.
- `uv run archex benchmark headtohead competitive --input benchmarks/headtohead/results --format markdown` still lists exactly the pre-existing lanes, since neither Graft lane has artifacts yet.

Refs #371
