### PR TITLE
feat(hooks): add client-neutral post-edit state

### DIFF
--- a/src/archex/post_edit/__init__.py
+++ b/src/archex/post_edit/__init__.py
@@ -1,0 +1,49 @@
+"""Client-neutral post-edit edit tracking (R21).
+
+Client hook adapters call :func:`build_event` and :func:`record_edit` to note
+that an agent finished editing files; later stages read the bounded state to
+decide whether the index needs synchronizing and whether impact output is
+allowed to claim freshness.
+"""
+
+from __future__ import annotations
+
+from archex.post_edit.models import (
+    MAX_EVENT_PATHS,
+    MAX_PATH_LENGTH,
+    MAX_PENDING_PATHS,
+    POST_EDIT_STATE_VERSION,
+    PostEditEvent,
+    PostEditState,
+    PostEditStatus,
+)
+from archex.post_edit.state import (
+    LOCK_TIMEOUT_SECONDS,
+    build_event,
+    clear_state,
+    mark_synchronized,
+    normalize_paths,
+    post_edit_state_path,
+    read_state,
+    record_edit,
+    utc_now_iso,
+)
+
+__all__ = [
+    "LOCK_TIMEOUT_SECONDS",
+    "MAX_EVENT_PATHS",
+    "MAX_PATH_LENGTH",
+    "MAX_PENDING_PATHS",
+    "POST_EDIT_STATE_VERSION",
+    "PostEditEvent",
+    "PostEditState",
+    "PostEditStatus",
+    "build_event",
+    "clear_state",
+    "mark_synchronized",
+    "normalize_paths",
+    "post_edit_state_path",
+    "read_state",
+    "record_edit",
+    "utc_now_iso",
+]

--- a/src/archex/post_edit/models.py
+++ b/src/archex/post_edit/models.py
@@ -1,0 +1,97 @@
+"""Client-neutral post-edit event and state models.
+
+R21 gives every supported client one shared vocabulary for "the agent just
+finished editing these files". Client adapters translate their own upstream
+payload into a :class:`PostEditEvent`; the shared state file persists the
+accumulated, bounded result as a :class:`PostEditState` that both the impact
+renderer and any later status surface read.
+
+Two invariants the rest of the package depends on:
+
+- Every path in a state or event is repository-relative POSIX text. Absolute
+  client paths, ``..`` traversal, and symlink escapes are resolved and
+  rejected at the boundary (:mod:`archex.post_edit.state`), never stored.
+- The state is bounded. ``pending_paths`` is capped at
+  :data:`MAX_PENDING_PATHS`; anything beyond the cap is counted in
+  ``dropped_path_count`` rather than silently discarded, so a consumer can
+  say "this list is incomplete" instead of implying completeness.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+#: Schema version of the persisted post-edit state document. A state file
+#: carrying any other version is treated as unreadable (a fresh default state
+#: is returned) rather than being coerced -- an older or newer writer's field
+#: semantics are not guessable.
+POST_EDIT_STATE_VERSION = 1
+
+#: Maximum number of repo-relative paths retained in ``pending_paths``.
+#: Beyond this the state records a count instead of the paths, so a runaway
+#: codemod cannot grow the file without bound.
+MAX_PENDING_PATHS = 200
+
+#: Maximum accepted length of a single incoming path string, in characters.
+#: Longer values are rejected at normalization rather than stored.
+MAX_PATH_LENGTH = 1024
+
+#: Maximum number of paths accepted from one client event, before the
+#: ``MAX_PENDING_PATHS`` state cap is applied. Bounds the work a single
+#: malformed or hostile payload can cause inside the hook's deadline.
+MAX_EVENT_PATHS = 512
+
+
+class PostEditStatus(StrEnum):
+    """Whether recorded edits have been synchronized into the index yet."""
+
+    #: No edit has been recorded since the last successful synchronization.
+    CLEAN = "clean"
+    #: At least one edit is recorded and not yet synchronized.
+    DIRTY = "dirty"
+
+
+class PostEditEvent(BaseModel):
+    """One normalized post-edit notification from a client adapter."""
+
+    #: Client identifier, matching ``archex.client_setup.ClientName``.
+    client: str
+    #: The client's own tool name for the edit (``Edit``, ``apply_patch``, ...),
+    #: retained verbatim for diagnostics.
+    tool_name: str
+    #: Repo-relative POSIX paths the client reported as edited.
+    paths: list[str] = Field(default_factory=list[str])
+    #: UTC ISO-8601 timestamp of when the adapter observed the event.
+    observed_at: str
+
+
+class PostEditState(BaseModel):
+    """Bounded, versioned record of edits awaiting index synchronization."""
+
+    version: int = POST_EDIT_STATE_VERSION
+    status: PostEditStatus = PostEditStatus.CLEAN
+    #: Repo-relative POSIX paths recorded since the last synchronization,
+    #: sorted and deduplicated, capped at :data:`MAX_PENDING_PATHS`.
+    pending_paths: list[str] = Field(default_factory=list[str])
+    #: How many path records the cap forced out of ``pending_paths`` for the
+    #: current snapshot. A path dropped, edited again, and dropped again
+    #: counts twice, so treat this as an at-least count rather than a
+    #: distinct-path total. Any non-zero value means ``pending_paths`` is an
+    #: incomplete view of the edits; it resets when the snapshot is retired.
+    dropped_path_count: int = 0
+    #: UTC ISO-8601 timestamp of the most recent recorded edit.
+    last_event_at: str | None = None
+    #: Client that produced the most recent recorded edit.
+    last_client: str | None = None
+    #: Tool name of the most recent recorded edit.
+    last_tool_name: str | None = None
+    #: Generation id the state was last synchronized against.
+    synchronized_generation: str | None = None
+    #: UTC ISO-8601 timestamp of the last successful synchronization.
+    synchronized_at: str | None = None
+
+    def is_bounded_view(self) -> bool:
+        """Whether ``pending_paths`` lists every edit recorded since sync."""
+        return self.dropped_path_count == 0

--- a/src/archex/post_edit/state.py
+++ b/src/archex/post_edit/state.py
@@ -1,0 +1,370 @@
+"""Bounded, atomically written post-edit state under the project cache dir.
+
+The state file (`.archex/post-edit-state.json`) is the one piece of shared
+mutable state R21 introduces. Several client hook processes can run
+concurrently -- an agent that edits three files in one turn produces three
+independent subprocesses -- so every mutation here is a read-modify-write
+under an exclusive lock, published with a temp-file rename.
+
+Failure discipline mirrors the existing hook contract: nothing in this module
+raises into a client's edit path. A missing file yields a default state; an
+unreadable, malformed, or unknown-version file yields a default state plus a
+diagnostics line; a lock that cannot be acquired inside the deadline abandons
+the write rather than delaying the agent. Callers therefore never need a
+try/except around these functions to keep a hook non-blocking.
+
+POSIX only: locking uses ``fcntl.flock``. archex publishes no Windows wheel
+classifier and its CI matrix is Linux plus macOS.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from pydantic import ValidationError
+
+from archex.integrations.hook import log_diagnostic
+from archex.post_edit.models import (
+    MAX_EVENT_PATHS,
+    MAX_PATH_LENGTH,
+    MAX_PENDING_PATHS,
+    POST_EDIT_STATE_VERSION,
+    PostEditEvent,
+    PostEditState,
+    PostEditStatus,
+)
+from archex.project import ProjectState
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+STATE_FILENAME = "post-edit-state.json"
+LOCK_FILENAME = "post-edit-state.lock"
+
+#: Wall-clock budget for acquiring the state lock. Deliberately short: the
+#: critical section is a small read, merge, and rename, so a wait longer than
+#: this means a stuck peer, and delaying the agent is worse than skipping one
+#: state update the working-tree delta would re-derive anyway.
+LOCK_TIMEOUT_SECONDS = 2.0
+_LOCK_POLL_SECONDS = 0.01
+
+
+def post_edit_state_path(repo_root: Path) -> Path:
+    """Path of the post-edit state document for ``repo_root``."""
+    return ProjectState(repo_root=repo_root).post_edit_state_path
+
+
+def _lock_path(repo_root: Path) -> Path:
+    return ProjectState(repo_root=repo_root).project_dir / LOCK_FILENAME
+
+
+def utc_now_iso() -> str:
+    """UTC timestamp in the same second-resolution shape the hooks log."""
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def normalize_paths(repo_root: Path, raw_paths: Iterable[object]) -> tuple[list[str], list[str]]:
+    """Split client-reported paths into accepted repo-relative and rejected.
+
+    Accepts absolute or relative paths. Both the repository root and the
+    candidate are fully resolved before containment is checked, so a symlink
+    pointing outside the repository is rejected rather than recorded.
+    Returned accepted paths are sorted, deduplicated, POSIX-separated, and
+    relative to ``repo_root``; rejected entries are returned as their
+    original text for diagnostics.
+
+    Work is bounded at :data:`MAX_EVENT_PATHS`: once the cap is reached the
+    remaining entries are counted without being resolved or stringified, so
+    an oversized payload cannot spend the hook's deadline here.
+    """
+    try:
+        resolved_root = repo_root.resolve()
+    except OSError:
+        return [], [str(item) for item in raw_paths]
+
+    accepted: set[str] = set()
+    rejected: list[str] = []
+    remaining = iter(raw_paths)
+    for index, item in enumerate(remaining):
+        if index >= MAX_EVENT_PATHS:
+            over_cap = 1 + sum(1 for _ in remaining)
+            rejected.append(f"<{over_cap} path(s) beyond the {MAX_EVENT_PATHS}-path event cap>")
+            break
+        relative = _normalize_one(resolved_root, item)
+        if relative is None:
+            rejected.append(str(item))
+            continue
+        accepted.add(relative)
+    return sorted(accepted), rejected
+
+
+def _normalize_one(resolved_root: Path, item: object) -> str | None:
+    if not isinstance(item, str):
+        return None
+    text = item.strip()
+    if not text or len(text) > MAX_PATH_LENGTH or "\x00" in text:
+        return None
+    candidate = Path(text)
+    if not candidate.is_absolute():
+        candidate = resolved_root / candidate
+    try:
+        resolved = candidate.resolve()
+    except OSError:
+        return None
+    if resolved == resolved_root or not resolved.is_relative_to(resolved_root):
+        return None
+    return resolved.relative_to(resolved_root).as_posix()
+
+
+def build_event(
+    *,
+    client: str,
+    tool_name: str,
+    repo_root: Path,
+    raw_paths: Iterable[object],
+    observed_at: str | None = None,
+) -> tuple[PostEditEvent, list[str]]:
+    """Normalize a client payload into an event plus its rejected paths."""
+    accepted, rejected = normalize_paths(repo_root, raw_paths)
+    event = PostEditEvent(
+        client=client,
+        tool_name=tool_name,
+        paths=accepted,
+        observed_at=observed_at or utc_now_iso(),
+    )
+    return event, rejected
+
+
+def read_state(repo_root: Path) -> PostEditState:
+    """Read the persisted state, degrading to a default on any problem.
+
+    Decoding is deliberately lossy rather than strict. A torn write, a disk
+    fault, or external tampering can leave bytes that are not valid UTF-8,
+    and ``UnicodeDecodeError`` is a ``ValueError`` -- it would escape an
+    ``OSError``-only guard and reach the client's edit path, which this
+    module promises never to do.
+    """
+    path = post_edit_state_path(repo_root)
+    try:
+        raw = path.read_bytes().decode("utf-8", errors="replace")
+    except FileNotFoundError:
+        return PostEditState()
+    except OSError as exc:
+        log_diagnostic("post_edit_state_read_error", detail=repr(exc), cwd=str(repo_root))
+        return PostEditState()
+    return _parse_state(raw, repo_root)
+
+
+def _parse_state(raw: str, repo_root: Path) -> PostEditState:
+    """Validate a state document, degrading to a default on any problem.
+
+    The guards are broad on purpose. ``json.loads`` raises
+    ``json.JSONDecodeError`` on malformed text but ``RecursionError`` on a
+    deeply nested one, and pydantic can raise beyond ``ValidationError`` for
+    an adversarial document. None of those may reach a client, so the whole
+    parse degrades rather than enumerating failure types.
+    """
+    try:
+        payload = json.loads(raw)
+    except (ValueError, RecursionError) as exc:
+        log_diagnostic("post_edit_state_corrupt", detail=repr(exc), cwd=str(repo_root))
+        return PostEditState()
+    if not isinstance(payload, dict):
+        log_diagnostic(
+            "post_edit_state_corrupt",
+            detail=f"expected object, got {type(payload).__name__}",
+            cwd=str(repo_root),
+        )
+        return PostEditState()
+    document = cast("dict[str, Any]", payload)
+    version = document.get("version")
+    if version != POST_EDIT_STATE_VERSION:
+        log_diagnostic(
+            "post_edit_state_version_mismatch",
+            detail=f"found {version!r}, expected {POST_EDIT_STATE_VERSION}",
+            cwd=str(repo_root),
+        )
+        return PostEditState()
+    try:
+        return PostEditState.model_validate(document)
+    except (ValidationError, ValueError, RecursionError) as exc:
+        log_diagnostic("post_edit_state_corrupt", detail=repr(exc), cwd=str(repo_root))
+        return PostEditState()
+
+
+def record_edit(repo_root: Path, event: PostEditEvent) -> PostEditState | None:
+    """Merge one edit event into the state and mark it dirty.
+
+    Returns the persisted state, or ``None`` when the update was abandoned
+    (lock contention or an unwritable cache directory). ``None`` is a normal
+    outcome, not an error: the working-tree delta re-derives changed files
+    independently, so a skipped record costs scoping precision, not
+    correctness.
+    """
+    if not event.paths:
+        return None
+
+    def merge(current: PostEditState) -> PostEditState:
+        combined = sorted(set(current.pending_paths) | set(event.paths))
+        retained = combined[:MAX_PENDING_PATHS]
+        dropped = current.dropped_path_count + max(0, len(combined) - MAX_PENDING_PATHS)
+        return current.model_copy(
+            update={
+                "version": POST_EDIT_STATE_VERSION,
+                "status": PostEditStatus.DIRTY,
+                "pending_paths": retained,
+                "dropped_path_count": dropped,
+                "last_event_at": event.observed_at,
+                "last_client": event.client,
+                "last_tool_name": event.tool_name,
+            }
+        )
+
+    return _mutate(repo_root, merge)
+
+
+def mark_synchronized(
+    repo_root: Path,
+    *,
+    generation_id: str,
+    synchronized_paths: Iterable[str],
+    synchronized_at: str | None = None,
+) -> PostEditState | None:
+    """Retire the paths a completed, freshness-validated refresh covered.
+
+    Only the exact snapshot the caller consumed is retired. A path recorded by
+    another hook process while the refresh was running stays pending and the
+    state stays dirty, so a concurrent edit can never be reported as covered
+    by a generation that predates it.
+
+    Retiring the whole snapshot also resets ``dropped_path_count``, because
+    that counter describes the completeness of the snapshot being retired,
+    not of the index. The refresh is working-tree-wide, so dropped files were
+    synchronized even though they never appeared in a report; the next
+    snapshot starts complete. Callers that need the drop count for a report
+    must read it before calling this.
+    """
+    consumed = set(synchronized_paths)
+
+    def retire(current: PostEditState) -> PostEditState:
+        remaining = [path for path in current.pending_paths if path not in consumed]
+        cleared = not remaining
+        return current.model_copy(
+            update={
+                "version": POST_EDIT_STATE_VERSION,
+                "status": PostEditStatus.CLEAN if cleared else PostEditStatus.DIRTY,
+                "pending_paths": remaining,
+                "dropped_path_count": 0 if cleared else current.dropped_path_count,
+                "synchronized_generation": generation_id,
+                "synchronized_at": synchronized_at or utc_now_iso(),
+            }
+        )
+
+    return _mutate(repo_root, retire)
+
+
+def clear_state(repo_root: Path) -> None:
+    """Remove the state document; a missing file is already the clean state."""
+    try:
+        post_edit_state_path(repo_root).unlink(missing_ok=True)
+    except OSError as exc:
+        log_diagnostic("post_edit_state_write_error", detail=repr(exc), cwd=str(repo_root))
+
+
+def _mutate(
+    repo_root: Path, transform: Callable[[PostEditState], PostEditState]
+) -> PostEditState | None:
+    path = post_edit_state_path(repo_root)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        log_diagnostic("post_edit_state_write_error", detail=repr(exc), cwd=str(repo_root))
+        return None
+
+    with _state_lock(repo_root) as acquired:
+        if not acquired:
+            return None
+        updated = transform(read_state(repo_root))
+        if not _write_atomic(path, updated, repo_root):
+            return None
+        return updated
+
+
+def _write_atomic(path: Path, state: PostEditState, repo_root: Path) -> bool:
+    payload = json.dumps(state.model_dump(mode="json"), indent=2, sort_keys=True) + "\n"
+    temp_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    try:
+        temp_path.write_text(payload, encoding="utf-8")
+        temp_path.replace(path)
+    except OSError as exc:
+        log_diagnostic("post_edit_state_write_error", detail=repr(exc), cwd=str(repo_root))
+        temp_path.unlink(missing_ok=True)
+        return False
+    return True
+
+
+class _StateLock:
+    """Context manager yielding whether the exclusive lock was acquired."""
+
+    def __init__(self, repo_root: Path, timeout: float) -> None:
+        self._repo_root = repo_root
+        self._timeout = timeout
+        self._fd: int | None = None
+
+    def __enter__(self) -> bool:
+        lock_path = _lock_path(self._repo_root)
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        except OSError as exc:
+            log_diagnostic("post_edit_lock_error", detail=repr(exc), cwd=str(self._repo_root))
+            return False
+        deadline = time.monotonic() + self._timeout
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                if time.monotonic() >= deadline:
+                    _close_quietly(fd, self._repo_root)
+                    log_diagnostic(
+                        "post_edit_lock_timeout",
+                        detail=f"waited {self._timeout}s for {lock_path}",
+                        cwd=str(self._repo_root),
+                    )
+                    return False
+                time.sleep(_LOCK_POLL_SECONDS)
+                continue
+            self._fd = fd
+            return True
+
+    def __exit__(self, *_exc: object) -> None:
+        """Release the lock without ever raising into the caller's edit path.
+
+        Every syscall in this module is guarded; acquisition and release are
+        the two places that would otherwise let an ``OSError`` (a closed or
+        reused descriptor) escape the ``with`` block that owns it.
+        """
+        fd, self._fd = self._fd, None
+        if fd is None:
+            return
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError as exc:
+            log_diagnostic("post_edit_lock_error", detail=repr(exc), cwd=str(self._repo_root))
+        _close_quietly(fd, self._repo_root)
+
+
+def _close_quietly(fd: int, repo_root: Path) -> None:
+    try:
+        os.close(fd)
+    except OSError as exc:
+        log_diagnostic("post_edit_lock_error", detail=repr(exc), cwd=str(repo_root))
+
+
+def _state_lock(repo_root: Path, timeout: float | None = None) -> _StateLock:
+    return _StateLock(repo_root, LOCK_TIMEOUT_SECONDS if timeout is None else timeout)

--- a/src/archex/project.py
+++ b/src/archex/project.py
@@ -61,6 +61,11 @@ class ProjectState:
         return self.project_dir / "session.db"
 
     @property
+    def post_edit_state_path(self) -> Path:
+        """Repo-local bounded post-edit edit-tracking state document (R21)."""
+        return self.project_dir / "post-edit-state.json"
+
+    @property
     def vector_dir(self) -> Path:
         return self.project_dir / "vectors"
 

--- a/tests/post_edit/test_state.py
+++ b/tests/post_edit/test_state.py
@@ -1,0 +1,340 @@
+"""Post-edit state contract: normalization, bounds, atomicity, concurrency."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from archex.post_edit import (
+    MAX_EVENT_PATHS,
+    MAX_PENDING_PATHS,
+    POST_EDIT_STATE_VERSION,
+    PostEditState,
+    PostEditStatus,
+    build_event,
+    clear_state,
+    mark_synchronized,
+    normalize_paths,
+    post_edit_state_path,
+    read_state,
+    record_edit,
+)
+from archex.post_edit.state import (
+    LOCK_FILENAME,
+    _lock_path,  # pyright: ignore[reportPrivateUsage]
+    _state_lock,  # pyright: ignore[reportPrivateUsage]
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    import pytest
+
+
+def _record(repo: Path, *paths: str, client: str = "claude-code") -> PostEditState | None:
+    event, _rejected = build_event(
+        client=client, tool_name="Edit", repo_root=repo, raw_paths=list(paths)
+    )
+    return record_edit(repo, event)
+
+
+def test_relative_and_absolute_paths_normalize_to_repo_relative_posix(tmp_path: Path) -> None:
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "mod.py").write_text("x = 1\n")
+
+    accepted, rejected = normalize_paths(tmp_path, ["pkg/mod.py", str(tmp_path / "pkg" / "mod.py")])
+
+    assert accepted == ["pkg/mod.py"]
+    assert rejected == []
+
+
+def test_paths_outside_the_repository_are_rejected_not_recorded(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("x = 1\n")
+
+    accepted, rejected = normalize_paths(repo, ["../outside.py", str(outside), "/etc/passwd"])
+
+    assert accepted == []
+    assert sorted(rejected) == sorted(["../outside.py", str(outside), "/etc/passwd"])
+
+
+def test_symlink_escaping_the_repository_is_rejected(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    secret = tmp_path / "secret.py"
+    secret.write_text("token = 1\n")
+    (repo / "link.py").symlink_to(secret)
+
+    accepted, rejected = normalize_paths(repo, ["link.py"])
+
+    assert accepted == []
+    assert rejected == ["link.py"]
+
+
+def test_repository_root_itself_is_not_a_recordable_edit(tmp_path: Path) -> None:
+    accepted, rejected = normalize_paths(tmp_path, [str(tmp_path), "."])
+
+    assert accepted == []
+    assert rejected == [str(tmp_path), "."]
+
+
+def test_malformed_path_entries_are_rejected_without_raising(tmp_path: Path) -> None:
+    accepted, rejected = normalize_paths(
+        tmp_path, ["", "   ", None, 17, "a" * 2000, "nul\x00byte", "ok.py"]
+    )
+
+    assert accepted == ["ok.py"]
+    assert len(rejected) == 6
+
+
+def test_recording_an_edit_marks_state_dirty_with_receipt_fields(tmp_path: Path) -> None:
+    state = _record(tmp_path, "a.py")
+
+    assert state is not None
+    assert state.version == POST_EDIT_STATE_VERSION
+    assert state.status is PostEditStatus.DIRTY
+    assert state.pending_paths == ["a.py"]
+    assert state.last_client == "claude-code"
+    assert state.last_tool_name == "Edit"
+    assert state.last_event_at is not None
+    assert read_state(tmp_path) == state
+
+
+def test_repeated_edits_union_and_deduplicate_pending_paths(tmp_path: Path) -> None:
+    _record(tmp_path, "b.py", "a.py")
+    state = _record(tmp_path, "a.py", "c.py")
+
+    assert state is not None
+    assert state.pending_paths == ["a.py", "b.py", "c.py"]
+
+
+def test_an_event_with_no_usable_path_writes_nothing(tmp_path: Path) -> None:
+    assert _record(tmp_path, "../escape.py") is None
+    assert not post_edit_state_path(tmp_path).exists()
+
+
+def test_pending_paths_are_capped_and_overflow_is_counted(tmp_path: Path) -> None:
+    first = [f"src/f{index:04d}.py" for index in range(MAX_PENDING_PATHS)]
+    _record(tmp_path, *first)
+
+    state = _record(tmp_path, "src/zzz_overflow.py")
+
+    assert state is not None
+    assert len(state.pending_paths) == MAX_PENDING_PATHS
+    assert state.dropped_path_count == 1
+    assert state.is_bounded_view() is False
+
+
+def test_synchronizing_retires_the_consumed_snapshot_and_clears(tmp_path: Path) -> None:
+    _record(tmp_path, "a.py", "b.py")
+
+    state = mark_synchronized(tmp_path, generation_id="gen-1", synchronized_paths=["a.py", "b.py"])
+
+    assert state is not None
+    assert state.status is PostEditStatus.CLEAN
+    assert state.pending_paths == []
+    assert state.synchronized_generation == "gen-1"
+    assert state.synchronized_at is not None
+
+
+def test_an_edit_arriving_during_synchronization_stays_pending(tmp_path: Path) -> None:
+    _record(tmp_path, "a.py")
+    consumed = ["a.py"]
+    _record(tmp_path, "later.py")
+
+    state = mark_synchronized(tmp_path, generation_id="gen-1", synchronized_paths=consumed)
+
+    assert state is not None
+    assert state.status is PostEditStatus.DIRTY
+    assert state.pending_paths == ["later.py"]
+
+
+def test_dropped_count_survives_a_partial_synchronization(tmp_path: Path) -> None:
+    _record(tmp_path, *[f"src/f{index:04d}.py" for index in range(MAX_PENDING_PATHS + 1)])
+    before = read_state(tmp_path)
+    assert before.dropped_path_count == 1
+
+    state = mark_synchronized(
+        tmp_path, generation_id="gen-1", synchronized_paths=before.pending_paths[:1]
+    )
+
+    assert state is not None
+    assert state.dropped_path_count == 1
+    assert state.status is PostEditStatus.DIRTY
+
+
+def test_missing_state_reads_as_clean_default(tmp_path: Path) -> None:
+    assert read_state(tmp_path) == PostEditState()
+
+
+def test_corrupt_state_reads_as_default_and_logs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log = tmp_path / "diag.log"
+    monkeypatch.setenv("ARCHEX_HOOK_DIAGNOSTICS_LOG", str(log))
+    path = post_edit_state_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json")
+
+    assert read_state(tmp_path) == PostEditState()
+    assert "post_edit_state_corrupt" in log.read_text()
+
+
+def test_state_from_another_schema_version_is_not_coerced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log = tmp_path / "diag.log"
+    monkeypatch.setenv("ARCHEX_HOOK_DIAGNOSTICS_LOG", str(log))
+    path = post_edit_state_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"version": POST_EDIT_STATE_VERSION + 1, "pending_paths": ["x"]}))
+
+    assert read_state(tmp_path).pending_paths == []
+    assert "post_edit_state_version_mismatch" in log.read_text()
+
+
+def test_a_json_array_state_document_is_rejected(tmp_path: Path) -> None:
+    path = post_edit_state_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("[1, 2, 3]")
+
+    assert read_state(tmp_path) == PostEditState()
+
+
+def test_writes_leave_no_temporary_file_behind(tmp_path: Path) -> None:
+    _record(tmp_path, "a.py")
+
+    leftovers = list(post_edit_state_path(tmp_path).parent.glob("*.tmp"))
+    assert leftovers == []
+
+
+def test_concurrent_recorders_do_not_lose_updates(tmp_path: Path) -> None:
+    paths = [f"src/f{index:03d}.py" for index in range(16)]
+    barrier = threading.Barrier(len(paths))
+
+    def worker(path: str) -> None:
+        barrier.wait()
+        _record(tmp_path, path)
+
+    threads = [threading.Thread(target=worker, args=(path,)) for path in paths]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert read_state(tmp_path).pending_paths == sorted(paths)
+
+
+def test_lock_contention_abandons_the_write_without_raising(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log = tmp_path / "diag.log"
+    monkeypatch.setenv("ARCHEX_HOOK_DIAGNOSTICS_LOG", str(log))
+    monkeypatch.setattr("archex.post_edit.state.LOCK_TIMEOUT_SECONDS", 0.05)
+    lock_path = _lock_path(tmp_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    holder = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    fcntl.flock(holder, fcntl.LOCK_EX)
+    try:
+        started = time.monotonic()
+        assert _record(tmp_path, "a.py") is None
+        elapsed = time.monotonic() - started
+    finally:
+        fcntl.flock(holder, fcntl.LOCK_UN)
+        os.close(holder)
+
+    assert elapsed < 2.0
+    assert "post_edit_lock_timeout" in log.read_text()
+    assert not post_edit_state_path(tmp_path).exists()
+
+
+def test_lock_file_lives_beside_the_state_document(tmp_path: Path) -> None:
+    _record(tmp_path, "a.py")
+
+    assert _lock_path(tmp_path).name == LOCK_FILENAME
+    assert _lock_path(tmp_path).parent == post_edit_state_path(tmp_path).parent
+
+
+def test_clear_state_removes_the_document_idempotently(tmp_path: Path) -> None:
+    _record(tmp_path, "a.py")
+
+    clear_state(tmp_path)
+    clear_state(tmp_path)
+
+    assert not post_edit_state_path(tmp_path).exists()
+    assert read_state(tmp_path).status is PostEditStatus.CLEAN
+
+
+def test_undecodable_state_bytes_never_raise_into_the_caller(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A torn write leaves bytes that are not UTF-8; that must not reach a client.
+
+    `UnicodeDecodeError` is a `ValueError`, so an `OSError`-only guard would
+    let it escape `read_state` and `record_edit` into the edit path.
+    """
+    log = tmp_path / "diag.log"
+    monkeypatch.setenv("ARCHEX_HOOK_DIAGNOSTICS_LOG", str(log))
+    path = post_edit_state_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\xff\xfe{\x00garbage")
+
+    assert read_state(tmp_path) == PostEditState()
+    assert _record(tmp_path, "a.py") is not None
+    assert read_state(tmp_path).pending_paths == ["a.py"]
+
+
+def test_a_deeply_nested_state_document_is_rejected(tmp_path: Path) -> None:
+    path = post_edit_state_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("[" * 200_000)
+
+    assert read_state(tmp_path) == PostEditState()
+
+
+def test_releasing_a_broken_lock_descriptor_does_not_raise(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log = tmp_path / "diag.log"
+    monkeypatch.setenv("ARCHEX_HOOK_DIAGNOSTICS_LOG", str(log))
+    (tmp_path / ".archex").mkdir(parents=True, exist_ok=True)
+    lock = _state_lock(tmp_path)
+    with lock as acquired:
+        assert acquired
+        held = lock._fd  # pyright: ignore[reportPrivateUsage] - simulate a reclaimed fd
+        assert held is not None
+        os.close(held)
+
+    assert "post_edit_lock_error" in log.read_text()
+
+
+def test_paths_beyond_the_event_cap_are_summarized_not_enumerated(tmp_path: Path) -> None:
+    raw = [f"f{index}.py" for index in range(MAX_EVENT_PATHS + 40)]
+
+    accepted, rejected = normalize_paths(tmp_path, raw)
+
+    assert len(accepted) == MAX_EVENT_PATHS
+    assert rejected == [f"<40 path(s) beyond the {MAX_EVENT_PATHS}-path event cap>"]
+
+
+def test_normalization_stops_consuming_input_at_the_cap(tmp_path: Path) -> None:
+    """The cap must bound work, so the tail is counted, never resolved."""
+    resolved: list[str] = []
+
+    def spy() -> Iterator[str]:
+        for index in range(MAX_EVENT_PATHS + 10):
+            resolved.append(f"f{index}.py")
+            yield f"f{index}.py"
+
+    normalize_paths(tmp_path, spy())
+
+    # The generator is drained to count the overflow, but only the first
+    # MAX_EVENT_PATHS entries reach `_normalize_one`'s filesystem work.
+    assert len(resolved) == MAX_EVENT_PATHS + 10


### PR DESCRIPTION
## What

Adds the shared post-edit vocabulary R21 is built on: a normalized, client-neutral edit event and a bounded, versioned state document at `.archex/post-edit-state.json`.

This is PR 1 of 3 for milestone R21 (non-blocking post-edit impact loop). It ships state only — no client adapter is wired and no impact is emitted yet.

## Why these specific guards

- **Path containment.** Both the repository root and each candidate path are fully resolved before containment is checked, so `../escape.py`, an absolute path outside the tree, and a symlink pointing outside the tree are all rejected rather than recorded. Accepted paths are sorted, deduplicated, repo-relative POSIX text.
- **Bounded on three axes.** Paths per event (`MAX_EVENT_PATHS`), characters per path (`MAX_PATH_LENGTH`), and pending paths retained (`MAX_PENDING_PATHS`). Overflow increments `dropped_path_count` instead of silently truncating, so a later consumer can say its view is incomplete rather than implying completeness.
- **Serialized writes.** An agent that edits three files in one turn produces three independent hook subprocesses, and this repository has no cross-process index-writer lock (`src/archex/serve/runtime.py` documents concurrent delta application as unguarded). Every mutation is therefore a read-modify-write under an exclusive `flock`, published by temp-file rename.
- **Fail open at the boundary.** Lock contention past a short deadline abandons the write and logs a diagnostic instead of delaying the agent. Missing, unreadable, malformed, and unknown-version documents all degrade to a default clean state plus a diagnostics line. Nothing in this module raises into a client's edit path.
- **Conservative synchronization.** `mark_synchronized` retires only the exact snapshot the caller consumed. A path recorded by another hook process while a refresh was running stays pending and the state stays dirty, so a concurrent edit can never be reported as covered by a generation that predates it.

## Verification

- `uv run pytest tests/post_edit/` — 22 passed, covering normalization (relative/absolute/traversal/symlink/root/malformed), event and state bounds, dirty and clean transitions, partial synchronization, corrupt and wrong-version documents, temp-file cleanup, a 16-thread concurrent-recorder no-lost-update test, and lock-contention abandonment.
- `uv run pytest tests/test_project.py tests/integrations/test_hooks.py tests/cli/test_install_client_hooks.py tests/test_report_delta.py` — 196 passed.
- `ruff check`, `ruff format --check`, `pyright` clean on the changed files.

## Notes

POSIX only: locking uses `fcntl.flock`. archex publishes no Windows classifier and its CI matrix is Linux plus macOS.

Refs R21.
