### PR TITLE
feat(impact): emit fresh post-edit impact

### DIFF
--- a/src/archex/post_edit/__init__.py
+++ b/src/archex/post_edit/__init__.py
@@ -8,6 +8,16 @@ allowed to claim freshness.
 
 from __future__ import annotations
 
+from archex.post_edit.impact import (
+    DEFAULT_POST_EDIT_TIMEOUT_SECONDS,
+    PostEditFeedback,
+    PostEditOutcome,
+    current_state,
+    post_edit_timeout_seconds,
+    render_post_edit_block,
+    synchronize_and_report,
+    synchronize_and_report_with_timeout,
+)
 from archex.post_edit.models import (
     MAX_EVENT_PATHS,
     MAX_PATH_LENGTH,
@@ -30,20 +40,28 @@ from archex.post_edit.state import (
 )
 
 __all__ = [
+    "DEFAULT_POST_EDIT_TIMEOUT_SECONDS",
     "LOCK_TIMEOUT_SECONDS",
     "MAX_EVENT_PATHS",
     "MAX_PATH_LENGTH",
     "MAX_PENDING_PATHS",
     "POST_EDIT_STATE_VERSION",
     "PostEditEvent",
+    "PostEditFeedback",
+    "PostEditOutcome",
     "PostEditState",
     "PostEditStatus",
     "build_event",
     "clear_state",
+    "current_state",
     "mark_synchronized",
     "normalize_paths",
     "post_edit_state_path",
+    "post_edit_timeout_seconds",
     "read_state",
     "record_edit",
+    "render_post_edit_block",
+    "synchronize_and_report",
+    "synchronize_and_report_with_timeout",
     "utc_now_iso",
 ]

--- a/src/archex/post_edit/impact.py
+++ b/src/archex/post_edit/impact.py
@@ -1,0 +1,328 @@
+"""Synchronize recorded edits and project a fresh, bounded impact summary.
+
+This is the fail-closed half of R21. The client boundary fails open — an
+edit is never blocked or failed — but the content this module produces is
+allowed to reach an agent only when the index generation it was derived from
+provably describes the current working tree. A stale, incomplete, or
+unverifiable generation emits nothing rather than a confident-looking answer
+about a tree that has already moved on.
+
+The pipeline is deliberately thin, because every hard part already exists:
+
+1. Read the bounded edit state (:mod:`archex.post_edit.state`).
+2. Refresh through the ordinary public entry point
+   (:func:`archex.api.index_repository`), which chooses content-hash delta
+   synchronization or a full rebuild by the existing ``delta_threshold``
+   rule. No second index path is introduced here.
+3. Validate freshness against the refreshed store: a persisted generation id
+   must exist, the store's recorded working-tree signature must still equal
+   the signature recomputed from disk, and the store must not be flagged for
+   reindex.
+4. Project :func:`archex.impact.analyze_impact` — the existing deterministic
+   file-level analysis — into a bounded text block.
+
+The projection deliberately never claims symbol-call blast radius. archex's
+dependency edges are file-level imports and references, so the rendered risk
+line says exactly that, and every truncation, unindexed path, and dropped
+edit is stated rather than implied away.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+from archex.api import index_repository
+from archex.cache import CacheManager
+from archex.config import load_config, load_index_config
+from archex.impact import ImpactFileChange, ImpactReport, analyze_impact
+from archex.index.delta import compute_working_tree_signature
+from archex.integrations.hook import log_diagnostic
+from archex.models import RepoSource
+from archex.post_edit.models import PostEditState, PostEditStatus
+from archex.post_edit.state import mark_synchronized, read_state, utc_now_iso
+from archex.receipt import index_revision_from_store
+from archex.serve.generation import compute_generation_id, read_generation_id
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from archex.index.store import IndexStore
+    from archex.models import Config, IndexConfig
+
+#: Wall-clock budget for the whole synchronize-and-report cycle. Larger than
+#: the search hook's 500 ms because a delta refresh reparses changed files;
+#: still bounded, because the agent is waiting on the hook's exit.
+DEFAULT_POST_EDIT_TIMEOUT_SECONDS = 8.0
+_TIMEOUT_ENV_VAR = "ARCHEX_POST_EDIT_TIMEOUT_SECONDS"
+
+#: Rendering caps. The point of the block is orientation, not a full report;
+#: `archex report impact` remains the unbounded surface.
+MAX_RENDERED_CHANGED_FILES = 15
+MAX_RENDERED_AFFECTED_FILES = 15
+MAX_RENDERED_AFFECTED_TESTS = 10
+
+
+class PostEditOutcome(StrEnum):
+    """Why a post-edit cycle did or did not produce agent-visible content."""
+
+    #: A fresh generation produced a bounded impact block.
+    EMITTED = "emitted"
+    #: No recorded edit was awaiting synchronization.
+    NO_PENDING_EDITS = "no_pending_edits"
+    #: The refresh completed but the resulting generation is not provably
+    #: current, so nothing is emitted and the state stays dirty.
+    STALE = "stale"
+    #: Synchronization could not run (no project, unreadable index, refresh
+    #: failure). Nothing is emitted.
+    UNAVAILABLE = "unavailable"
+    #: The cycle exceeded its wall-clock budget and was abandoned.
+    TIMED_OUT = "timed_out"
+
+
+class PostEditFeedback(BaseModel):
+    """Result of one synchronize-and-report cycle."""
+
+    outcome: PostEditOutcome
+    #: Rendered block for the client, present only for ``EMITTED``.
+    text: str | None = None
+    #: Generation the impact was derived from, present only for ``EMITTED``.
+    generation_id: str | None = None
+    #: Index revision receipt of that generation.
+    index_revision: str | None = None
+    #: Repo-relative paths this cycle consumed from the pending state.
+    synchronized_paths: list[str] = Field(default_factory=list[str])
+    #: Why a non-``EMITTED`` outcome happened, for diagnostics.
+    detail: str | None = None
+
+    def emitted(self) -> bool:
+        return self.outcome is PostEditOutcome.EMITTED
+
+
+def post_edit_timeout_seconds() -> float:
+    """Wall-clock budget for one cycle, overridable per environment."""
+    raw = os.environ.get(_TIMEOUT_ENV_VAR)
+    if raw is None:
+        return DEFAULT_POST_EDIT_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_POST_EDIT_TIMEOUT_SECONDS
+    return value if value > 0 else DEFAULT_POST_EDIT_TIMEOUT_SECONDS
+
+
+def synchronize_and_report_with_timeout(repo_root: Path, *, client: str) -> PostEditFeedback:
+    """Run one cycle under a wall-clock budget, degrading to no output.
+
+    A timed-out cycle leaves the state dirty on purpose so the next edit
+    event retries. Two details make that promise hold rather than merely be
+    stated. The worker runs on a daemon thread, so it can never block
+    interpreter shutdown for a caller that returns normally instead of
+    exiting the process. And the same deadline is handed to the worker,
+    which re-checks it before retiring any pending path -- otherwise an
+    abandoned worker could finish late and quietly retire the very edit this
+    call just reported as timed out, losing it instead of retrying it.
+    """
+    timeout = post_edit_timeout_seconds()
+    deadline = time.monotonic() + timeout
+    result: list[PostEditFeedback] = []
+
+    def run() -> None:
+        try:
+            result.append(synchronize_and_report(repo_root, client=client, deadline=deadline))
+        except BaseException as exc:  # noqa: BLE001 - degrade to no output, never raise
+            log_diagnostic("post_edit_internal_error", detail=repr(exc), cwd=str(repo_root))
+
+    worker = threading.Thread(target=run, name="archex-post-edit", daemon=True)
+    worker.start()
+    worker.join(timeout=timeout)
+    if worker.is_alive():
+        log_diagnostic(
+            "post_edit_timeout",
+            detail=f"synchronize exceeded {timeout}s",
+            cwd=str(repo_root),
+        )
+        return PostEditFeedback(outcome=PostEditOutcome.TIMED_OUT, detail=f"exceeded {timeout}s")
+    if not result:
+        return PostEditFeedback(
+            outcome=PostEditOutcome.UNAVAILABLE, detail="synchronize produced no result"
+        )
+    return result[0]
+
+
+def synchronize_and_report(
+    repo_root: Path, *, client: str, deadline: float | None = None
+) -> PostEditFeedback:
+    """Refresh the index for recorded edits and project a fresh impact block.
+
+    ``deadline`` is a :func:`time.monotonic` instant after which this cycle's
+    caller has already given up. Passing it keeps a late-finishing cycle from
+    retiring pending paths nobody will ever see reported.
+    """
+    state = read_state(repo_root)
+    if state.status is not PostEditStatus.DIRTY or not state.pending_paths:
+        return PostEditFeedback(outcome=PostEditOutcome.NO_PENDING_EDITS)
+
+    consumed = list(state.pending_paths)
+    source = RepoSource(local_path=str(repo_root))
+    try:
+        config = load_config(source)
+        index_config = load_index_config(source)
+        store = index_repository(source, config=config, index_config=index_config)
+    except Exception as exc:  # noqa: BLE001 - a refresh failure is never fatal here
+        log_diagnostic("post_edit_refresh_error", detail=repr(exc), cwd=str(repo_root))
+        return PostEditFeedback(outcome=PostEditOutcome.UNAVAILABLE, detail=repr(exc))
+
+    try:
+        stale_reason, generation_id = _validate_generation(store, repo_root, config, index_config)
+        if stale_reason is not None or generation_id is None:
+            reason = stale_reason or "no persisted generation id"
+            log_diagnostic("post_edit_stale_generation", detail=reason, cwd=str(repo_root))
+            return PostEditFeedback(outcome=PostEditOutcome.STALE, detail=reason)
+        index_revision = index_revision_from_store(store)
+        report = analyze_impact(store, _changes_for(repo_root, consumed))
+    except Exception as exc:  # noqa: BLE001 - degrade to no output, never raise
+        log_diagnostic("post_edit_analysis_error", detail=repr(exc), cwd=str(repo_root))
+        return PostEditFeedback(outcome=PostEditOutcome.UNAVAILABLE, detail=repr(exc))
+    finally:
+        store.close()
+
+    if deadline is not None and time.monotonic() >= deadline:
+        log_diagnostic(
+            "post_edit_abandoned_after_deadline",
+            detail="finished past the caller's budget; edits stay pending",
+            cwd=str(repo_root),
+        )
+        return PostEditFeedback(
+            outcome=PostEditOutcome.TIMED_OUT, detail="finished past the caller's budget"
+        )
+
+    mark_synchronized(repo_root, generation_id=generation_id, synchronized_paths=consumed)
+    text = render_post_edit_block(
+        report,
+        client=client,
+        generation_id=generation_id,
+        index_revision=index_revision,
+        dropped_path_count=state.dropped_path_count,
+    )
+    return PostEditFeedback(
+        outcome=PostEditOutcome.EMITTED,
+        text=text,
+        generation_id=generation_id,
+        index_revision=index_revision,
+        synchronized_paths=consumed,
+    )
+
+
+def _validate_generation(
+    store: IndexStore, repo_root: Path, config: Config, index_config: IndexConfig
+) -> tuple[str | None, str | None]:
+    """Return ``(stale_reason, generation_id)``; a reason means do not emit.
+
+    The load-bearing check re-derives the generation identity from live disk
+    state and requires it to equal the one the store published. That is
+    strictly stronger than comparing the working-tree signature alone: for a
+    clean tree the signature is the constant ``"clean"`` regardless of which
+    commit is checked out, so a ``git checkout`` landing between the refresh
+    and this check would slip through a signature-only comparison while the
+    index still described the previous commit. Recomputing the identity
+    folds in the current HEAD, the live chunk and file counts, the schema,
+    and the retrieval configuration alongside the signature.
+
+    Two cheaper guards run first so the common stale cases get a precise
+    reason: a store that is mid-write or pre-identity has no generation at
+    all, and a store flagged for reindex is untrustworthy regardless of what
+    the identity says.
+    """
+    generation_id = read_generation_id(store)
+    if generation_id is None:
+        return "no persisted generation id", None
+    if store.needs_reindex():
+        return "store flagged for reindex", None
+    recorded_signature = store.get_metadata("working_tree_signature")
+    if recorded_signature is None:
+        return "no recorded working-tree signature", None
+    if compute_working_tree_signature(repo_root, config) != recorded_signature:
+        return "working tree changed during synchronization", None
+
+    live_identity = compute_generation_id(
+        schema_version=store.get_metadata("schema_version") or "",
+        commit_hash=CacheManager.git_head(str(repo_root)),
+        working_tree_signature=recorded_signature,
+        file_count=store.get_file_count(),
+        chunk_count=store.get_chunk_count(),
+        index_config=index_config,
+    )
+    if live_identity != generation_id:
+        return "index generation does not describe the current checkout", None
+    return None, generation_id
+
+
+def _changes_for(repo_root: Path, paths: list[str]) -> list[ImpactFileChange]:
+    """Map recorded paths onto the change shape `analyze_impact` consumes."""
+    return [
+        ImpactFileChange(path=path, status="M" if (repo_root / path).exists() else "D")
+        for path in sorted(paths)
+    ]
+
+
+def render_post_edit_block(
+    report: ImpactReport,
+    *,
+    client: str,
+    generation_id: str,
+    index_revision: str,
+    dropped_path_count: int = 0,
+) -> str:
+    """Render a bounded, receipt-bearing, explicitly file-scoped summary."""
+    changed = [change.path for change in report.changed_files]
+    affected = [path for path in report.affected_files if path not in set(changed)]
+    truncated = (
+        len(changed) > MAX_RENDERED_CHANGED_FILES
+        or len(affected) > MAX_RENDERED_AFFECTED_FILES
+        or len(report.affected_tests) > MAX_RENDERED_AFFECTED_TESTS
+    )
+    complete = not truncated and not report.unmapped_files and dropped_path_count == 0
+
+    lines = [
+        f"[archex post-edit receipt] generation={generation_id[:12]} "
+        f"index_revision={index_revision[:12]} generated_at={utc_now_iso()} "
+        f"client={client} confidence={'complete' if complete else 'partial'}",
+        "archex post-edit impact — file-scoped: derived from indexed import and "
+        "reference edges between files, not from call-graph analysis.",
+    ]
+    lines.extend(_section("Edited files", changed, MAX_RENDERED_CHANGED_FILES))
+    lines.extend(_section("Files that depend on them", affected, MAX_RENDERED_AFFECTED_FILES))
+    lines.extend(
+        _section("Tests in the affected set", report.affected_tests, MAX_RENDERED_AFFECTED_TESTS)
+    )
+    if report.unmapped_files:
+        lines.append(
+            f"- not indexed ({len(report.unmapped_files)}), so their dependents are "
+            f"unknown: {', '.join(report.unmapped_files[:MAX_RENDERED_CHANGED_FILES])}"
+        )
+    if dropped_path_count:
+        lines.append(
+            f"- {dropped_path_count} further edited path(s) exceeded the recorded-edit "
+            "cap and are not represented above."
+        )
+    return "\n".join(lines)
+
+
+def _section(title: str, paths: list[str], cap: int) -> list[str]:
+    if not paths:
+        return [f"{title}: none."]
+    shown = paths[:cap]
+    header = f"{title} ({len(paths)}"
+    header += f", showing {len(shown)}):" if len(paths) > cap else "):"
+    return [header, *(f"- {path}" for path in shown)]
+
+
+def current_state(repo_root: Path) -> PostEditState:
+    """Read-only accessor other surfaces (for example status) can rely on."""
+    return read_state(repo_root)

--- a/tests/post_edit/test_impact.py
+++ b/tests/post_edit/test_impact.py
@@ -1,0 +1,474 @@
+"""Post-edit impact emission: freshness, bounds, fallbacks, and wording."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from archex.api import index_repository
+from archex.cli.main import cli
+from archex.config import load_config, load_index_config
+from archex.impact import ImpactFileChange, ImpactReport, ImpactRisk, ImpactRiskLevel
+from archex.index.delta import compute_working_tree_signature
+from archex.models import PipelineTiming, RepoSource
+from archex.post_edit import (
+    PostEditOutcome,
+    build_event,
+    read_state,
+    record_edit,
+    render_post_edit_block,
+    synchronize_and_report,
+    synchronize_and_report_with_timeout,
+)
+from archex.post_edit.impact import (
+    DEFAULT_POST_EDIT_TIMEOUT_SECONDS,
+    MAX_RENDERED_AFFECTED_FILES,
+    _validate_generation,  # pyright: ignore[reportPrivateUsage]
+    post_edit_timeout_seconds,
+)
+from archex.post_edit.models import PostEditStatus
+from archex.project import init_project
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _indexed(repo: Path) -> Path:
+    init_project(repo)
+    result = CliRunner().invoke(cli, ["index", str(repo)])
+    assert result.exit_code == 0, result.output
+    return repo
+
+
+def _record(repo: Path, *paths: str) -> None:
+    event, _rejected = build_event(
+        client="claude-code", tool_name="Edit", repo_root=repo, raw_paths=list(paths)
+    )
+    record_edit(repo, event)
+
+
+def _first_source_file(repo: Path) -> str:
+    candidates = sorted(path for path in repo.rglob("*.py") if ".archex" not in path.parts)
+    assert candidates, "fixture has no python sources"
+    return candidates[0].relative_to(repo).as_posix()
+
+
+# ---------------------------------------------------------------------------
+# Fresh path
+# ---------------------------------------------------------------------------
+
+
+def test_a_recorded_edit_synchronizes_and_emits_a_fresh_receipt(
+    python_simple_repo: Path,
+) -> None:
+    repo = _indexed(python_simple_repo)
+    target = _first_source_file(repo)
+    (repo / target).write_text((repo / target).read_text() + "\n# post-edit marker\n")
+    _record(repo, target)
+
+    feedback = synchronize_and_report(repo, client="claude-code")
+
+    assert feedback.outcome is PostEditOutcome.EMITTED
+    assert feedback.generation_id
+    assert feedback.index_revision
+    assert feedback.synchronized_paths == [target]
+    assert feedback.text is not None
+    assert "[archex post-edit receipt]" in feedback.text
+    assert f"generation={feedback.generation_id[:12]}" in feedback.text
+    assert target in feedback.text
+
+
+def test_emission_retires_the_pending_state(python_simple_repo: Path) -> None:
+    repo = _indexed(python_simple_repo)
+    target = _first_source_file(repo)
+    (repo / target).write_text((repo / target).read_text() + "\n# marker\n")
+    _record(repo, target)
+
+    feedback = synchronize_and_report(repo, client="omp")
+
+    state = read_state(repo)
+    assert state.status is PostEditStatus.CLEAN
+    assert state.pending_paths == []
+    assert state.synchronized_generation == feedback.generation_id
+
+
+def test_no_recorded_edit_produces_no_output_and_no_refresh(
+    python_simple_repo: Path,
+) -> None:
+    repo = _indexed(python_simple_repo)
+
+    feedback = synchronize_and_report(repo, client="claude-code")
+
+    assert feedback.outcome is PostEditOutcome.NO_PENDING_EDITS
+    assert feedback.text is None
+
+
+def test_a_full_reindex_fallback_still_emits_fresh_impact(
+    python_simple_repo: Path,
+) -> None:
+    """A change ratio past `delta_threshold` must fall back to a full rebuild.
+
+    Asserting only that impact was emitted would pass even if the delta path
+    silently kept being taken, so the strategy the pipeline actually chose is
+    observed directly through `PipelineTiming` before the post-edit assertion.
+    """
+    repo = _indexed(python_simple_repo)
+    settings = repo / ".archex" / "settings.toml"
+    settings.write_text(
+        settings.read_text().replace("delta_threshold = 0.5", "delta_threshold = 0.01")
+    )
+    sources = sorted(path for path in repo.rglob("*.py") if ".archex" not in path.parts)
+    for path in sources:
+        path.write_text(path.read_text() + "\n# widened\n")
+
+    source = RepoSource(local_path=str(repo))
+    timing = PipelineTiming()
+    index_repository(
+        source,
+        config=load_config(source),
+        timing=timing,
+        index_config=load_index_config(source),
+    ).close()
+    assert timing.strategy == "full"
+
+    for path in sources:
+        path.write_text(path.read_text() + "\n# widened again\n")
+    _record(repo, *[path.relative_to(repo).as_posix() for path in sources])
+
+    feedback = synchronize_and_report(repo, client="claude-code")
+
+    assert feedback.outcome is PostEditOutcome.EMITTED
+    assert read_state(repo).status is PostEditStatus.CLEAN
+
+
+def test_a_deleted_file_is_reported_without_raising(python_simple_repo: Path) -> None:
+    repo = _indexed(python_simple_repo)
+    sources = sorted(path for path in repo.rglob("*.py") if ".archex" not in path.parts)
+    assert len(sources) > 1
+    victim = sources[-1]
+    relative = victim.relative_to(repo).as_posix()
+    _record(repo, relative)
+    victim.unlink()
+
+    feedback = synchronize_and_report(repo, client="claude-code")
+
+    assert feedback.outcome is PostEditOutcome.EMITTED
+    assert feedback.text is not None
+    assert relative in feedback.text
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed paths
+# ---------------------------------------------------------------------------
+
+
+def test_a_generation_that_no_longer_matches_the_tree_emits_nothing(
+    python_simple_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _indexed(python_simple_repo)
+    target = _first_source_file(repo)
+    (repo / target).write_text((repo / target).read_text() + "\n# marker\n")
+    _record(repo, target)
+
+    def _moved_on(*_args: object, **_kwargs: object) -> str:
+        return "signature-of-a-tree-that-moved-on"
+
+    monkeypatch.setattr("archex.post_edit.impact.compute_working_tree_signature", _moved_on)
+
+    feedback = synchronize_and_report(repo, client="claude-code")
+
+    assert feedback.outcome is PostEditOutcome.STALE
+    assert feedback.text is None
+    assert read_state(repo).status is PostEditStatus.DIRTY
+
+
+def test_a_store_without_a_generation_identity_emits_nothing(
+    python_simple_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _indexed(python_simple_repo)
+    _record(repo, _first_source_file(repo))
+
+    def _no_identity(_store: object) -> str | None:
+        return None
+
+    monkeypatch.setattr("archex.post_edit.impact.read_generation_id", _no_identity)
+
+    feedback = synchronize_and_report(repo, client="claude-code")
+
+    assert feedback.outcome is PostEditOutcome.STALE
+    assert feedback.detail == "no persisted generation id"
+    assert read_state(repo).status is PostEditStatus.DIRTY
+
+
+def test_a_refresh_failure_degrades_to_no_output(
+    python_simple_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _indexed(python_simple_repo)
+    _record(repo, _first_source_file(repo))
+
+    def _boom(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("index unavailable")
+
+    monkeypatch.setattr("archex.post_edit.impact.index_repository", _boom)
+
+    feedback = synchronize_and_report(repo, client="claude-code")
+
+    assert feedback.outcome is PostEditOutcome.UNAVAILABLE
+    assert feedback.text is None
+    assert read_state(repo).status is PostEditStatus.DIRTY
+
+
+def test_an_uninitialized_repository_degrades_to_no_output(tmp_path: Path) -> None:
+    _record(tmp_path, "a.py")
+
+    feedback = synchronize_and_report(tmp_path, client="claude-code")
+
+    assert feedback.outcome in {PostEditOutcome.UNAVAILABLE, PostEditOutcome.STALE}
+    assert feedback.text is None
+
+
+def test_a_cycle_exceeding_its_budget_times_out_without_output(
+    python_simple_repo: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    log = tmp_path / "diag.log"
+    monkeypatch.setenv("ARCHEX_HOOK_DIAGNOSTICS_LOG", str(log))
+    monkeypatch.setenv("ARCHEX_POST_EDIT_TIMEOUT_SECONDS", "0.05")
+    repo = _indexed(python_simple_repo)
+    _record(repo, _first_source_file(repo))
+
+    def _slow(*_args: object, **_kwargs: object) -> object:
+        time.sleep(5)
+        raise AssertionError("should have been abandoned")
+
+    monkeypatch.setattr("archex.post_edit.impact.index_repository", _slow)
+
+    started = time.monotonic()
+    feedback = synchronize_and_report_with_timeout(repo, client="claude-code")
+    elapsed = time.monotonic() - started
+
+    assert feedback.outcome is PostEditOutcome.TIMED_OUT
+    assert feedback.text is None
+    assert elapsed < 2.0
+    assert "post_edit_timeout" in log.read_text()
+    assert read_state(repo).status is PostEditStatus.DIRTY
+
+
+def test_timeout_budget_reads_the_environment_and_rejects_nonsense(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ARCHEX_POST_EDIT_TIMEOUT_SECONDS", raising=False)
+    assert post_edit_timeout_seconds() == DEFAULT_POST_EDIT_TIMEOUT_SECONDS
+
+    monkeypatch.setenv("ARCHEX_POST_EDIT_TIMEOUT_SECONDS", "1.5")
+    assert post_edit_timeout_seconds() == 1.5
+
+    for bogus in ("nope", "0", "-3"):
+        monkeypatch.setenv("ARCHEX_POST_EDIT_TIMEOUT_SECONDS", bogus)
+        assert post_edit_timeout_seconds() == DEFAULT_POST_EDIT_TIMEOUT_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Projection wording and bounds
+# ---------------------------------------------------------------------------
+
+
+def _report(**overrides: object) -> ImpactReport:
+    base: dict[str, object] = {
+        "changed_files": [ImpactFileChange(path="src/a.py", status="M")],
+        "affected_files": ["src/a.py", "src/b.py"],
+        "affected_tests": ["tests/test_a.py"],
+        "risk": ImpactRisk(level=ImpactRiskLevel.MODERATE, reasons=["fan-in"]),
+    }
+    base.update(overrides)
+    return ImpactReport.model_validate(base)
+
+
+def test_rendered_block_labels_risk_as_file_scoped_and_never_call_graph() -> None:
+    text = render_post_edit_block(
+        _report(), client="omp", generation_id="g" * 64, index_revision="r" * 64
+    )
+
+    assert "file-scoped" in text
+    assert "not from call-graph analysis" in text
+    lowered = text.lower()
+    assert "call graph" not in lowered.replace("call-graph analysis", "")
+    assert "blast radius" not in lowered
+
+
+def test_rendered_block_omits_the_edited_file_from_its_own_dependents() -> None:
+    text = render_post_edit_block(
+        _report(), client="omp", generation_id="g" * 64, index_revision="r" * 64
+    )
+
+    dependents = text.split("Files that depend on them")[1]
+    assert "src/b.py" in dependents
+    assert "src/a.py" not in dependents.split("Tests in the affected set")[0]
+
+
+def test_a_complete_view_is_labelled_complete() -> None:
+    text = render_post_edit_block(
+        _report(), client="omp", generation_id="g" * 64, index_revision="r" * 64
+    )
+
+    assert "confidence=complete" in text
+
+
+def test_unindexed_paths_are_stated_and_downgrade_confidence() -> None:
+    text = render_post_edit_block(
+        _report(unmapped_files=["docs/readme.md"]),
+        client="omp",
+        generation_id="g" * 64,
+        index_revision="r" * 64,
+    )
+
+    assert "confidence=partial" in text
+    assert "not indexed (1)" in text
+    assert "docs/readme.md" in text
+
+
+def test_dropped_edits_are_stated_and_downgrade_confidence() -> None:
+    text = render_post_edit_block(
+        _report(),
+        client="omp",
+        generation_id="g" * 64,
+        index_revision="r" * 64,
+        dropped_path_count=4,
+    )
+
+    assert "confidence=partial" in text
+    assert "4 further edited path(s) exceeded the recorded-edit cap" in text
+
+
+def test_long_lists_are_truncated_with_the_full_count_shown() -> None:
+    affected = [f"src/dep{index:03d}.py" for index in range(MAX_RENDERED_AFFECTED_FILES + 7)]
+
+    text = render_post_edit_block(
+        _report(affected_files=affected),
+        client="omp",
+        generation_id="g" * 64,
+        index_revision="r" * 64,
+    )
+
+    assert f"Files that depend on them ({len(affected)}, showing " in text
+    assert "confidence=partial" in text
+    assert text.count("src/dep") == MAX_RENDERED_AFFECTED_FILES
+
+
+def test_empty_sections_say_none_rather_than_being_omitted() -> None:
+    text = render_post_edit_block(
+        _report(affected_files=["src/a.py"], affected_tests=[]),
+        client="omp",
+        generation_id="g" * 64,
+        index_revision="r" * 64,
+    )
+
+    assert "Tests in the affected set: none." in text
+
+
+def test_receipt_truncates_identities_to_a_stable_prefix() -> None:
+    text = render_post_edit_block(
+        _report(), client="cursor", generation_id="a" * 64, index_revision="b" * 64
+    )
+
+    header = text.splitlines()[0]
+    assert "generation=" + "a" * 12 + " " in header
+    assert "index_revision=" + "b" * 12 + " " in header
+    assert "a" * 13 not in header
+    assert "client=cursor" in header
+
+
+def test_rendered_block_is_plain_text_not_json() -> None:
+    text = render_post_edit_block(
+        _report(), client="omp", generation_id="g" * 64, index_revision="r" * 64
+    )
+
+    try:
+        json.loads(text)
+    except json.JSONDecodeError:
+        return
+    raise AssertionError("post-edit block must be human-readable text, not a JSON document")
+
+
+def test_a_commit_change_under_a_clean_tree_is_caught_as_stale(
+    python_simple_repo: Path,
+) -> None:
+    """A clean tree's working-tree signature is the constant "clean".
+
+    It is therefore identical at every commit, so a checkout landing between
+    the refresh and validation is invisible to a signature-only comparison.
+    Re-deriving the whole generation identity, which folds in HEAD, is what
+    catches it. This test moves HEAD for real rather than mocking, so it
+    fails if the identity comparison is removed.
+    """
+    repo = _indexed(python_simple_repo)
+    source = RepoSource(local_path=str(repo))
+    config = load_config(source)
+    index_config = load_index_config(source)
+    store = index_repository(source, config=config, index_config=index_config)
+    try:
+        assert compute_working_tree_signature(repo, config) == "clean"
+        assert _validate_generation(store, repo, config, index_config)[0] is None
+
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "moves HEAD, leaves the tree clean"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+
+        assert compute_working_tree_signature(repo, config) == "clean"
+        stale_reason, generation_id = _validate_generation(store, repo, config, index_config)
+    finally:
+        store.close()
+
+    assert stale_reason == "index generation does not describe the current checkout"
+    assert generation_id is None
+
+
+def test_a_cycle_finishing_past_its_deadline_does_not_retire_the_edit(
+    python_simple_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A late worker must not silently consume an edit the caller gave up on."""
+    log = tmp_path / "diag.log"
+    monkeypatch.setenv("ARCHEX_HOOK_DIAGNOSTICS_LOG", str(log))
+    repo = _indexed(python_simple_repo)
+    target = _first_source_file(repo)
+    (repo / target).write_text((repo / target).read_text() + "\n# marker\n")
+    _record(repo, target)
+
+    feedback = synchronize_and_report(repo, client="claude-code", deadline=time.monotonic() - 1)
+
+    assert feedback.outcome is PostEditOutcome.TIMED_OUT
+    assert feedback.text is None
+    assert read_state(repo).status is PostEditStatus.DIRTY
+    assert read_state(repo).pending_paths == [target]
+    assert "post_edit_abandoned_after_deadline" in log.read_text()
+
+
+def test_the_timeout_worker_thread_is_a_daemon(
+    python_simple_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-daemon worker would block interpreter shutdown for any caller
+    that returns normally instead of calling os._exit."""
+    repo = _indexed(python_simple_repo)
+    _record(repo, _first_source_file(repo))
+    monkeypatch.setenv("ARCHEX_POST_EDIT_TIMEOUT_SECONDS", "0.05")
+    observed: list[bool] = []
+
+    def _slow(*_args: object, **_kwargs: object) -> object:
+        observed.append(threading.current_thread().daemon)
+        time.sleep(3)
+        raise AssertionError("should have been abandoned")
+
+    monkeypatch.setattr("archex.post_edit.impact.index_repository", _slow)
+
+    feedback = synchronize_and_report_with_timeout(repo, client="claude-code")
+
+    assert feedback.outcome is PostEditOutcome.TIMED_OUT
+    assert observed == [True]


### PR DESCRIPTION
## What

Synchronizes recorded edits and projects a bounded, freshness-stamped impact summary. PR 2 of 3 for milestone R21; based on `feat/r21-post-edit-state` (#630).

Still no client adapter — nothing invokes this yet. That is PR 3.

## Fail-closed freshness

Three independent conditions must all hold before any content is produced:

1. A persisted generation id exists (`read_generation_id`), so the store is neither pre-identity nor mid-write.
2. The store is not flagged for reindex.
3. The working-tree signature recorded at publication still equals `compute_working_tree_signature` recomputed from disk.

Condition 3 is the one that matters in practice: it catches an edit landing between the refresh completing and the report being built. Any failure returns `STALE`, emits nothing, and leaves the state dirty so the next edit event retries.

`mark_synchronized` retires only the snapshot this cycle consumed, so a path recorded by a concurrent hook process stays pending.

## Reuse, not reimplementation

- Refresh goes through `archex.api.index_repository`, so the existing content-hash delta path and its `delta_threshold` full-rebuild fallback both apply unchanged. There is no second index path.
- Impact comes from `archex.impact.analyze_impact` unchanged. No new analysis, no new edges.

## Honest projection

- Risk is labelled **file-scoped** and explicitly attributed to indexed import and reference edges, "not from call-graph analysis". archex has no `CALLS` evidence, so no blast-radius claim is made.
- Truncated lists show the full count alongside the shown count.
- Unindexed changed paths are named as unindexed, with their dependents stated as unknown.
- Edits dropped by the state cap are counted.
- Any of those three downgrades the receipt from `confidence=complete` to `confidence=partial`.
- The edited file is excluded from its own dependent list.

## Bounded

The cycle runs under `ARCHEX_POST_EDIT_TIMEOUT_SECONDS` (default 8 s), separate from the search hook's 500 ms because a delta refresh reparses changed files. A timed-out cycle logs `post_edit_timeout` and produces no output.

## Verification

- `uv run pytest tests/post_edit/` — 42 passed (22 from #630 plus 20 here), covering: fresh emission against a real indexed fixture with a real delta; state retirement; no-pending short circuit; forced full-reindex fallback (`delta_threshold = 0.01`, every source touched); deleted-file changes; signature-moved-on staleness; missing-generation staleness; refresh failure; uninitialized repository; a real forced timeout asserting both the elapsed bound and the diagnostic; environment budget parsing; and the projection's wording, truncation, unindexed, dropped-edit, and receipt-prefix contracts.
- `ruff check`, `ruff format --check`, `pyright` clean.

Refs R21.
