### PR TITLE
fix(index): keep inbound edges through a delta reparse

### DIFF
--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -528,7 +528,17 @@ class IndexStore:
         new_edges: list[Edge],
         new_surrogates: list[ChunkSurrogate] | None = None,
     ) -> None:
-        """Atomically replace chunks and edges for the given files."""
+        """Atomically replace chunks and edges for the given files.
+
+        Edges are deleted by ``source`` only, never by ``target``. An edge is
+        produced by parsing its source file, so reparsing that file
+        regenerates every edge it owns. Deleting by target would instead
+        discard edges owned by files this call does not reparse -- the
+        inbound dependencies of every modified file -- and nothing here would
+        rebuild them, emptying the graph one delta at a time. Removing a
+        file's inbound edges is correct only once the file itself is gone,
+        which is ``delete_edges_for_files``' job.
+        """
         try:
             if file_paths:
                 placeholders = ",".join("?" for _ in file_paths)
@@ -550,9 +560,8 @@ class IndexStore:
                     file_paths,
                 )
                 self._conn.execute(
-                    f"DELETE FROM edges WHERE source IN ({placeholders}) "
-                    f"OR target IN ({placeholders})",
-                    file_paths + file_paths,
+                    f"DELETE FROM edges WHERE source IN ({placeholders})",
+                    file_paths,
                 )
             self._insert_chunks_no_commit(new_chunks)
             self._insert_edges_no_commit(new_edges)

--- a/tests/index/test_store.py
+++ b/tests/index/test_store.py
@@ -929,6 +929,68 @@ class TestStoreBatchOperations:
         assert len(edges) == 1
         assert edges[0].target == "z.py"
 
+    def test_reparse_preserves_inbound_edges_from_untouched_files(self, store: IndexStore) -> None:
+        """A modified file must not lose the edges other files point at it with.
+
+        Only the modified file is reparsed, so it can only regenerate its own
+        outgoing edges. Deleting by target here discarded another file's
+        edge permanently, which emptied the dependency graph one delta at a
+        time and made impact analysis report no dependents.
+        """
+        _init_bm25(store)
+        store.insert_edges(
+            [
+                Edge(source="consumer.py", target="core.py", kind=EdgeKind.IMPORTS),
+                Edge(source="other.py", target="core.py", kind=EdgeKind.IMPORTS),
+            ]
+        )
+
+        store.delete_and_insert_for_files(["core.py"], [], [])
+
+        assert {(edge.source, edge.target) for edge in store.get_edges()} == {
+            ("consumer.py", "core.py"),
+            ("other.py", "core.py"),
+        }
+
+    def test_reparse_replaces_only_the_reparsed_files_outgoing_edges(
+        self, store: IndexStore
+    ) -> None:
+        """Reparsing a file replaces its own edges and no others.
+
+        `downstream.py -> consumer.py` is the discriminating case: it points
+        *at* the reparsed file, so a delete matching on `target` destroys it
+        even though `downstream.py` was never reparsed and nothing will
+        regenerate it.
+        """
+        _init_bm25(store)
+        store.insert_edges(
+            [
+                Edge(source="consumer.py", target="core.py", kind=EdgeKind.IMPORTS),
+                Edge(source="other.py", target="core.py", kind=EdgeKind.IMPORTS),
+                Edge(source="downstream.py", target="consumer.py", kind=EdgeKind.IMPORTS),
+            ]
+        )
+
+        store.delete_and_insert_for_files(
+            ["consumer.py"],
+            [],
+            [Edge(source="consumer.py", target="helper.py", kind=EdgeKind.IMPORTS)],
+        )
+
+        assert {(edge.source, edge.target) for edge in store.get_edges()} == {
+            ("consumer.py", "helper.py"),
+            ("other.py", "core.py"),
+            ("downstream.py", "consumer.py"),
+        }
+
+    def test_deleting_a_file_still_removes_its_inbound_edges(self, store: IndexStore) -> None:
+        _init_bm25(store)
+        store.insert_edges([Edge(source="consumer.py", target="core.py", kind=EdgeKind.IMPORTS)])
+
+        store.delete_edges_for_files(["core.py"])
+
+        assert store.get_edges() == []
+
     def test_delete_and_insert_empty_new_chunks(self, store: IndexStore) -> None:
         _init_bm25(store)
         old = [


### PR DESCRIPTION
## What

`IndexStore.delete_and_insert_for_files` deleted edges matching the reparsed files by `source` **or** `target`. Only the modified files are reparsed, so they can only regenerate their own *outgoing* edges. Every edge pointing **at** a modified file is owned by a file the call never reparses — so it was deleted and never rebuilt.

The dependency graph therefore emptied one delta at a time.

## Reproduction (no archex API, two CLI calls)

```
pkg/core.py           def core(): ...
pkg/consumer.py       from pkg.core import core
pkg/other.py          from pkg.core import core

archex init . && archex index .
  edges: consumer.py -> core.py, other.py -> core.py     (2)

# touch pkg/core.py, then:
archex index .        Strategy: delta
  edges: (0)
```

Both edges are gone permanently. Everything downstream of the graph — impact analysis, graph expansion, centrality — silently degrades toward reporting nothing, with no error and no diagnostic.

Found while building the R21 post-edit impact loop, which runs a delta on every edit: after the first edit the loop confidently reported "Files that depend on them: none" for a file with two dependents. That is a false negative dressed as a complete answer, which is why this is fixed rather than worked around downstream.

## Fix

Delete by `source` only. An edge is produced by parsing its source file, so a reparse regenerates exactly the set of edges that file owns:

| scenario | before | after |
| --- | --- | --- |
| modify the import *target* | inbound edges destroyed | inbound edges preserved |
| modify the importing file | edge rebuilt | edge rebuilt, not duplicated |
| remove an import | edge dropped | edge dropped |
| delete a file | inbound edges dropped | inbound edges dropped |

Removing a file's inbound edges is correct only once that file is gone, which is `delete_edges_for_files`' job — it keeps its `OR target` clause and is covered by a test asserting that.

## Verification

- Three regression tests in `tests/index/test_store.py`. The first fails on the pre-fix code (`get_edges()` returns `[]` instead of both edges) and passes after; the other two pin the outgoing-replacement and file-deletion behaviours that must not change.
- The four-scenario table above re-verified end to end through the real `archex index` CLI on a throwaway repository.
- Full suite: `uv run pytest tests/` — **4823 passed**, 9 deselected. No fallout.
- `ruff check`, `ruff format --check`, `pyright` clean.

Part of the R21 stack; based on `feat/r21-post-edit-impact` (#631). Independent of the post-edit code — it is a standalone indexing correctness fix.
