### PR TITLE
feat(status): persist bounded freshness snapshots

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -420,7 +420,7 @@ def _full_index(
                 _set_working_tree_signature(store, repo_path, config)
                 from archex.serve.generation import finalize_generation_id
 
-                finalize_generation_id(store, effective_index_config)
+                generation_id = finalize_generation_id(store, effective_index_config)
                 store.conn.execute("PRAGMA wal_checkpoint(FULL)")
 
                 manifest = IndexGenerationManifest(
@@ -447,6 +447,11 @@ def _full_index(
                     sidecars=sidecars,
                     manifest=manifest.model_dump_json(),
                 )
+                # After `put`, not before: the snapshot describes an installed
+                # index, and this path builds into a temp directory the cache
+                # copies from. Publishing earlier would advertise a generation
+                # that a failed copy never delivered.
+                _publish_project_status(store, generation_id, config.cache_dir)
             if timing is not None:
                 timing.index_ms = _elapsed_ms(t_idx)
                 timing.strategy = "full"
@@ -457,6 +462,66 @@ def _full_index(
             raise
     finally:
         cleanup()
+
+
+def _publish_project_status(store: IndexStore, generation_id: str | None, cache_dir: str) -> None:
+    """Refresh the repo-local cached status snapshot (R23), never fatally.
+
+    Called at the four points where indexing establishes that a store
+    describes the current tree: the full, delta, and unchanged-tree
+    publications, plus the validated cache hit every warm query takes. The
+    store is already open and its identity metadata already written, so the
+    snapshot costs no extra index open and no extra working-tree signature
+    computation. Indexed and current commit are the same value at all four
+    points by construction, which also avoids a `git rev-parse` here.
+
+    ``generation_id`` is the value a caller just finalized; pass ``None`` to
+    read the store's persisted identity instead.
+
+    The publish target comes from the configured cache directory rather than
+    from the store's own path: the full-index path builds into a temp
+    directory that the cache copies into `.archex`, so the open store's path
+    is not where the index will live. Only a repo-local project layout
+    publishes; the shared global cache and remote checkouts have no `.archex`
+    directory to write into and no repository for a status surface to
+    describe.
+    """
+    from archex.serve.generation import read_generation_id
+    from archex.status_snapshot import project_repo_root, publish_status, republish_measurement
+
+    try:
+        repo_root = project_repo_root(cache_dir)
+        if repo_root is None:
+            return
+        reindex_required = store.needs_reindex()
+        if generation_id is None and not reindex_required:
+            # Warm path. A validated cache hit means the index still describes
+            # the tree, but nothing about it changed, so re-stamping the
+            # existing measurement is enough -- and it avoids the O(files)
+            # scan and hash `index_revision_from_store` would cost on what is
+            # the most frequent lifecycle event in a session. Falls through to
+            # a full publication when there is no re-stampable snapshot.
+            persisted = read_generation_id(store) or ""
+            if republish_measurement(repo_root, generation_id=persisted) is not None:
+                return
+        commit = store.get_metadata("commit_hash") or ""
+        signature = store.get_metadata("working_tree_signature") or ""
+        publish_status(
+            repo_root,
+            index_fresh=not reindex_required,
+            index_revision=index_revision_from_store(store),
+            generation_id=(
+                generation_id if generation_id is not None else read_generation_id(store)
+            ),
+            indexed_commit=commit,
+            current_commit=commit,
+            files_indexed=store.get_file_count(),
+            chunks_indexed=store.get_chunk_count(),
+            working_tree_dirty=signature not in {"", "clean"},
+            reindex_required=reindex_required,
+        )
+    except Exception:  # noqa: BLE001 - a status write never breaks indexing
+        logger.debug("could not publish cached status snapshot", exc_info=True)
 
 
 @dataclass(frozen=True)
@@ -509,6 +574,11 @@ def _ensure_index(
                     timing.cached = True
                     timing.strategy = "cached"
                     timing.index_ms = _elapsed_ms(t_start)
+                # A validated cache hit is evidence that the index still
+                # describes the tree, and it is by far the most frequent
+                # lifecycle event (every warm query and hook takes it), so it
+                # is what keeps a status surface from decaying into `stale`.
+                _publish_project_status(store, None, config.cache_dir)
                 return store
             store.close()
             if needs_reindex or not metadata_matches:
@@ -609,7 +679,10 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
                 clean_store.set_metadata("indexed_at", str(time.time()))
                 from archex.serve.generation import finalize_generation_id
 
-                finalize_generation_id(clean_store, attempt.index_config or IndexConfig())
+                clean_generation = finalize_generation_id(
+                    clean_store, attempt.index_config or IndexConfig()
+                )
+                _publish_project_status(clean_store, clean_generation, attempt.config.cache_dir)
                 if attempt.timing is not None:
                     attempt.timing.cached = True
                     attempt.timing.strategy = "cached"
@@ -708,8 +781,9 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
                 store.set_metadata("working_tree_signature", attempt.working_tree_signature)
             from archex.serve.generation import finalize_generation_id
 
-            finalize_generation_id(store, index_config)
+            delta_generation = finalize_generation_id(store, index_config)
             store.conn.execute("PRAGMA wal_checkpoint(FULL)")
+            _publish_project_status(store, delta_generation, attempt.config.cache_dir)
             attempt.cache.put(
                 attempt.cache_key,
                 db_path,

--- a/src/archex/integrations/mcp.py
+++ b/src/archex/integrations/mcp.py
@@ -2706,6 +2706,22 @@ def _ignored_watch_path(path: str) -> bool:
     return any(part in {".git", ".archex", "__pycache__", ".pytest_cache"} for part in parts)
 
 
+def _record_watch_observation(repo_path: Path) -> None:
+    """Stamp a watch-driven refresh into the cached status snapshot (R23).
+
+    The stamp is what lets a status surface say `watch active` from evidence
+    rather than assertion. It decays: an idle watcher publishes nothing
+    because nothing changed, so `unobserved` means "no refresh seen
+    recently", never "no watcher is running".
+    """
+    from archex.status_snapshot import publish_status_watch_observation
+
+    try:
+        publish_status_watch_observation(repo_path)
+    except Exception:  # noqa: BLE001 - watch refresh must survive a status write
+        logger.debug("could not stamp watch observation into status snapshot", exc_info=True)
+
+
 def _start_index_watch(repo_path: Path, debounce_ms: int) -> Any:
     try:
         from watchdog.events import FileSystemEvent, FileSystemEventHandler
@@ -2753,6 +2769,7 @@ def _start_index_watch(repo_path: Path, debounce_ms: int) -> Any:
                     logger.info("MCP watch refreshed %s via %s", repo_path, timing.strategy)
                 finally:
                     store.close()
+                _record_watch_observation(repo_path)
             finally:
                 with self._lock:
                     self._refreshing = False

--- a/src/archex/integrations/post_edit_hook.py
+++ b/src/archex/integrations/post_edit_hook.py
@@ -41,6 +41,7 @@ from archex.integrations.hook import log_diagnostic
 from archex.post_edit import PostEditOutcome, build_event, record_edit
 from archex.post_edit.impact import synchronize_and_report_with_timeout
 from archex.project import ProjectState
+from archex.status_snapshot import refresh_edit_overlay
 
 POST_EDIT_EVENT_NAME = "PostToolUse"
 
@@ -225,8 +226,14 @@ def run_post_edit_cycle(
     if not event.paths:
         return None
     record_edit(project.repo_root, event)
+    # Publish the pending state before the refresh runs: an edit changes what
+    # the status surface should say without changing what the index contains,
+    # and the refresh below can time out or fail. Both calls are index-free
+    # overlays over the last index measurement.
+    refresh_edit_overlay(project.repo_root)
 
     feedback = synchronize_and_report_with_timeout(project.repo_root, client=client)
+    refresh_edit_overlay(project.repo_root)
     if feedback.outcome is not PostEditOutcome.EMITTED:
         log_diagnostic(
             "post_edit_withheld",

--- a/src/archex/post_edit/state.py
+++ b/src/archex/post_edit/state.py
@@ -13,16 +13,15 @@ diagnostics line; a lock that cannot be acquired inside the deadline abandons
 the write rather than delaying the agent. Callers therefore never need a
 try/except around these functions to keep a hook non-blocking.
 
-POSIX only: locking uses ``fcntl.flock``. archex publishes no Windows wheel
-classifier and its CI matrix is Linux plus macOS.
+POSIX only: locking uses ``fcntl.flock`` through :mod:`archex.state_file`,
+which owns the lock and atomic-publication primitives this module and R23's
+status snapshot both use. archex publishes no Windows wheel classifier and
+its CI matrix is Linux plus macOS.
 """
 
 from __future__ import annotations
 
-import fcntl
 import json
-import os
-import time
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -40,6 +39,12 @@ from archex.post_edit.models import (
     PostEditStatus,
 )
 from archex.project import ProjectState
+from archex.state_file import (
+    ExclusiveLock,
+    StateFileDiagnostics,
+    ensure_parent_dir,
+    write_text_atomic,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -52,7 +57,13 @@ LOCK_FILENAME = "post-edit-state.lock"
 #: this means a stuck peer, and delaying the agent is worse than skipping one
 #: state update the working-tree delta would re-derive anyway.
 LOCK_TIMEOUT_SECONDS = 2.0
-_LOCK_POLL_SECONDS = 0.01
+
+#: Diagnostic kind names for this document's lock and write failures.
+_DIAGNOSTICS = StateFileDiagnostics(
+    lock_error="post_edit_lock_error",
+    lock_timeout="post_edit_lock_timeout",
+    write_error="post_edit_state_write_error",
+)
 
 
 def post_edit_state_path(repo_root: Path) -> Path:
@@ -281,10 +292,7 @@ def _mutate(
     repo_root: Path, transform: Callable[[PostEditState], PostEditState]
 ) -> PostEditState | None:
     path = post_edit_state_path(repo_root)
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        log_diagnostic("post_edit_state_write_error", detail=repr(exc), cwd=str(repo_root))
+    if not ensure_parent_dir(path, cwd=repo_root, diagnostics=_DIAGNOSTICS):
         return None
 
     with _state_lock(repo_root) as acquired:
@@ -298,73 +306,13 @@ def _mutate(
 
 def _write_atomic(path: Path, state: PostEditState, repo_root: Path) -> bool:
     payload = json.dumps(state.model_dump(mode="json"), indent=2, sort_keys=True) + "\n"
-    temp_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
-    try:
-        temp_path.write_text(payload, encoding="utf-8")
-        temp_path.replace(path)
-    except OSError as exc:
-        log_diagnostic("post_edit_state_write_error", detail=repr(exc), cwd=str(repo_root))
-        temp_path.unlink(missing_ok=True)
-        return False
-    return True
+    return write_text_atomic(path, payload, cwd=repo_root, diagnostics=_DIAGNOSTICS)
 
 
-class _StateLock:
-    """Context manager yielding whether the exclusive lock was acquired."""
-
-    def __init__(self, repo_root: Path, timeout: float) -> None:
-        self._repo_root = repo_root
-        self._timeout = timeout
-        self._fd: int | None = None
-
-    def __enter__(self) -> bool:
-        lock_path = _lock_path(self._repo_root)
-        try:
-            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
-        except OSError as exc:
-            log_diagnostic("post_edit_lock_error", detail=repr(exc), cwd=str(self._repo_root))
-            return False
-        deadline = time.monotonic() + self._timeout
-        while True:
-            try:
-                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except OSError:
-                if time.monotonic() >= deadline:
-                    _close_quietly(fd, self._repo_root)
-                    log_diagnostic(
-                        "post_edit_lock_timeout",
-                        detail=f"waited {self._timeout}s for {lock_path}",
-                        cwd=str(self._repo_root),
-                    )
-                    return False
-                time.sleep(_LOCK_POLL_SECONDS)
-                continue
-            self._fd = fd
-            return True
-
-    def __exit__(self, *_exc: object) -> None:
-        """Release the lock without ever raising into the caller's edit path.
-
-        Every syscall in this module is guarded; acquisition and release are
-        the two places that would otherwise let an ``OSError`` (a closed or
-        reused descriptor) escape the ``with`` block that owns it.
-        """
-        fd, self._fd = self._fd, None
-        if fd is None:
-            return
-        try:
-            fcntl.flock(fd, fcntl.LOCK_UN)
-        except OSError as exc:
-            log_diagnostic("post_edit_lock_error", detail=repr(exc), cwd=str(self._repo_root))
-        _close_quietly(fd, self._repo_root)
-
-
-def _close_quietly(fd: int, repo_root: Path) -> None:
-    try:
-        os.close(fd)
-    except OSError as exc:
-        log_diagnostic("post_edit_lock_error", detail=repr(exc), cwd=str(repo_root))
-
-
-def _state_lock(repo_root: Path, timeout: float | None = None) -> _StateLock:
-    return _StateLock(repo_root, LOCK_TIMEOUT_SECONDS if timeout is None else timeout)
+def _state_lock(repo_root: Path, timeout: float | None = None) -> ExclusiveLock:
+    return ExclusiveLock(
+        _lock_path(repo_root),
+        timeout=LOCK_TIMEOUT_SECONDS if timeout is None else timeout,
+        cwd=repo_root,
+        diagnostics=_DIAGNOSTICS,
+    )

--- a/src/archex/project.py
+++ b/src/archex/project.py
@@ -66,6 +66,11 @@ class ProjectState:
         return self.project_dir / "post-edit-state.json"
 
     @property
+    def status_snapshot_path(self) -> Path:
+        """Repo-local bounded cached status snapshot document (R23)."""
+        return self.project_dir / "status-snapshot.json"
+
+    @property
     def vector_dir(self) -> Path:
         return self.project_dir / "vectors"
 
@@ -206,6 +211,10 @@ def _generated_state_paths(state: ProjectState) -> list[Path]:
         state.index_path.with_name(f"{state.index_path.name}-shm"),
         state.project_dir / "index.meta",
         state.vector_dir,
+        # A cached status snapshot describes an index. Deleting the index
+        # without it would leave a surface reporting `fresh` for a store that
+        # no longer exists; removing it makes the surface report `missing`.
+        state.status_snapshot_path,
     ]
     if state.project_dir.exists():
         paths.extend(state.project_dir.glob("*.db"))

--- a/src/archex/state_file.py
+++ b/src/archex/state_file.py
@@ -1,0 +1,151 @@
+"""Shared primitives for repo-local, atomically published state documents.
+
+Two subsystems keep a small mutable document under a repository's `.archex`
+directory: R21's post-edit edit tracking (`post-edit-state.json`) and R23's
+cached status snapshot (`status-snapshot.json`). Both are written by several
+concurrent processes -- one hook subprocess per edited file, a watch thread,
+and a foreground indexing run -- and neither may raise into the caller, which
+is usually an agent's edit path.
+
+The two rules both documents obey live here so there is one implementation of
+each rather than a copy per subsystem:
+
+- **Mutual exclusion.** A read-modify-write cycle runs under an exclusive
+  `flock` on a sibling lock file. Waiting past a short deadline abandons the
+  write rather than delaying the caller; both callers can re-derive their
+  document from cheaper sources on the next event.
+- **Atomic publication.** The new content is written to a temp file in the
+  same directory and moved into place with `Path.replace`, so a reader either
+  sees the whole previous document or the whole new one, never a torn write.
+
+Diagnostic kind names stay caller-owned (`StateFileDiagnostics`) so each
+subsystem's log lines remain greppable on their own terms.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+#: How often a blocked writer retries the lock while waiting for its deadline.
+LOCK_POLL_SECONDS = 0.01
+
+
+@dataclass(frozen=True)
+class StateFileDiagnostics:
+    """Diagnostic kind names one subsystem uses for its state document."""
+
+    lock_error: str
+    lock_timeout: str
+    write_error: str
+
+
+def _log(kind: str, detail: str, cwd: Path) -> None:
+    """Log through the hook diagnostics log, importing it only when needed.
+
+    The import is local so this module stays cheap to import: the status
+    reader must not pull in the search hook (and through it the index store)
+    merely to read a cached JSON document.
+    """
+    from archex.integrations.hook import log_diagnostic
+
+    log_diagnostic(kind, detail=detail, cwd=str(cwd))
+
+
+class ExclusiveLock:
+    """Context manager yielding whether the exclusive lock was acquired."""
+
+    def __init__(
+        self,
+        lock_path: Path,
+        *,
+        timeout: float,
+        cwd: Path,
+        diagnostics: StateFileDiagnostics,
+    ) -> None:
+        self._lock_path = lock_path
+        self._timeout = timeout
+        self._cwd = cwd
+        self._diagnostics = diagnostics
+        self._fd: int | None = None
+
+    def __enter__(self) -> bool:
+        try:
+            fd = os.open(self._lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        except OSError as exc:
+            _log(self._diagnostics.lock_error, repr(exc), self._cwd)
+            return False
+        deadline = time.monotonic() + self._timeout
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                if time.monotonic() >= deadline:
+                    self._close_quietly(fd)
+                    _log(
+                        self._diagnostics.lock_timeout,
+                        f"waited {self._timeout}s for {self._lock_path}",
+                        self._cwd,
+                    )
+                    return False
+                time.sleep(LOCK_POLL_SECONDS)
+                continue
+            self._fd = fd
+            return True
+
+    def __exit__(self, *_exc: object) -> None:
+        """Release the lock without ever raising into the caller's edit path.
+
+        Every syscall here is guarded; acquisition and release are the two
+        places that would otherwise let an ``OSError`` (a closed or reused
+        descriptor) escape the ``with`` block that owns it.
+        """
+        fd, self._fd = self._fd, None
+        if fd is None:
+            return
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError as exc:
+            _log(self._diagnostics.lock_error, repr(exc), self._cwd)
+        self._close_quietly(fd)
+
+    def _close_quietly(self, fd: int) -> None:
+        try:
+            os.close(fd)
+        except OSError as exc:
+            _log(self._diagnostics.lock_error, repr(exc), self._cwd)
+
+
+def write_text_atomic(
+    path: Path,
+    text: str,
+    *,
+    cwd: Path,
+    diagnostics: StateFileDiagnostics,
+) -> bool:
+    """Publish ``text`` at ``path`` by rename; return whether it landed."""
+    temp_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    try:
+        temp_path.write_text(text, encoding="utf-8")
+        temp_path.replace(path)
+    except OSError as exc:
+        _log(diagnostics.write_error, repr(exc), cwd)
+        temp_path.unlink(missing_ok=True)
+        return False
+    return True
+
+
+def ensure_parent_dir(path: Path, *, cwd: Path, diagnostics: StateFileDiagnostics) -> bool:
+    """Create ``path``'s parent directory; return whether it now exists."""
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        _log(diagnostics.write_error, repr(exc), cwd)
+        return False
+    return True

--- a/src/archex/status_snapshot.py
+++ b/src/archex/status_snapshot.py
@@ -1,0 +1,687 @@
+"""Bounded, versioned cached status snapshot (R23).
+
+Archex already knows precisely how fresh an index is -- but only inside a
+process that has opened the index. A persistent client status surface repaints
+several times a minute (Claude Code debounces its statusline at 300 ms and
+cancels an in-flight script when a new update arrives), so it cannot afford an
+index open, a parse, or a cold Python start per repaint. This module is the
+cheap side of that split: lifecycle code that already holds the expensive
+state *publishes* a small document, and every renderer only *reads* it.
+
+Two invariants make that safe:
+
+- **The writer decides what is true; the reader decides what is current.**
+  A persisted document carries one of three states (:class:`SnapshotState`:
+  ``fresh``, ``dirty``, ``pending``). Reading adds the four states only a
+  reader can establish (:class:`StatusState`: ``missing``, ``corrupt``,
+  ``unsupported``, ``stale``). ``unsupported`` is kept distinct from
+  ``corrupt`` because they have different remediations: a version this build
+  cannot read means upgrade, unparsable bytes mean re-publish.
+- **Bounded by construction.** Every field is a scalar with a declared
+  maximum length; the document holds no path list, no language map, and no
+  token-savings figure. Its serialized size therefore has a provable ceiling
+  (:data:`MAX_SNAPSHOT_BYTES`) that does not depend on repository size or on a
+  truncation rule that could be forgotten.
+
+Nothing here raises into a caller. Publication happens on an agent's edit path
+and inside indexing; a status write that fails is a display defect, never a
+correctness one, so every failure degrades to a diagnostics line.
+
+One limit of a cached surface is worth stating: a reader never stats the
+index, so an index deleted out of band (a manual ``rm``, a wiped cache) is
+reflected only when the snapshot's freshness budget expires and it reads
+``stale``. ``archex reset`` clears the snapshot with the index it describes,
+and ``archex status`` clears it when there is nothing left to describe, so the
+supported paths report ``missing`` immediately.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from pydantic import BaseModel, Field, ValidationError
+
+from archex.project import PROJECT_DIR_NAME, ProjectState
+from archex.state_file import (
+    ExclusiveLock,
+    StateFileDiagnostics,
+    ensure_parent_dir,
+    write_text_atomic,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from archex.post_edit.models import PostEditState
+
+SNAPSHOT_FILENAME = "status-snapshot.json"
+LOCK_FILENAME = "status-snapshot.lock"
+
+#: Schema version of the persisted snapshot. A document carrying any other
+#: value reads as :attr:`StatusState.UNSUPPORTED` rather than being coerced --
+#: another writer's field semantics are not guessable.
+STATUS_SNAPSHOT_VERSION = 1
+#: Wall-clock budget for acquiring the snapshot lock. Much shorter than R21's
+#: state lock: a status write is pure display value and the critical section
+#: is a small read, merge, and rename, so a contended writer should give up
+#: almost immediately rather than add tail latency to the warm query path it
+#: usually runs on. The next lifecycle event re-derives whatever was skipped.
+LOCK_TIMEOUT_SECONDS = 0.25
+
+#: Age past which a reader reports :attr:`StatusState.STALE` instead of the
+#: persisted state. A snapshot is a cache of a measurement, and an old
+#: measurement of a repository under active editing is not evidence of
+#: freshness. Overridable per environment for hosts whose lifecycle events are
+#: rarer than this default.
+DEFAULT_STALE_AFTER_SECONDS = 900
+_STALE_ENV_VAR = "ARCHEX_STATUS_STALE_AFTER_SECONDS"
+
+#: Age past which an observed watch event stops implying a live watcher.
+#: ``unobserved`` means "no watch refresh seen recently", never "no watcher is
+#: running": an idle watcher publishes nothing because nothing changed.
+WATCH_OBSERVATION_TTL_SECONDS = 300
+
+#: Provable ceiling on the serialized document, asserted against a worst-case
+#: snapshot in the tests rather than enforced by truncating a live one.
+MAX_SNAPSHOT_BYTES = 1024
+
+#: Field length caps. Identity strings are hex digests or short revisions;
+#: client and tool names come from a client payload and are clipped rather
+#: than trusted.
+_MAX_IDENTITY_LENGTH = 64
+_MAX_NAME_LENGTH = 64
+_MAX_TIMESTAMP_LENGTH = 20
+
+_DIAGNOSTICS = StateFileDiagnostics(
+    lock_error="status_snapshot_lock_error",
+    lock_timeout="status_snapshot_lock_timeout",
+    write_error="status_snapshot_write_error",
+)
+
+
+class SnapshotState(StrEnum):
+    """Index/edit state a writer can establish while holding real state."""
+
+    #: The index describes the working tree and no edit is awaiting sync.
+    FRESH = "fresh"
+    #: The index no longer describes the working tree, or a reindex is flagged.
+    DIRTY = "dirty"
+    #: Edits are recorded and not yet synchronized into the index.
+    PENDING = "pending"
+
+
+class StatusState(StrEnum):
+    """Every state a renderer can be asked to display."""
+
+    FRESH = "fresh"
+    DIRTY = "dirty"
+    PENDING = "pending"
+    #: A valid snapshot whose measurement is too old to assert freshness.
+    STALE = "stale"
+    #: No snapshot has been published (or it was cleared by a reset).
+    MISSING = "missing"
+    #: A snapshot exists but is unreadable, unparsable, or invalid.
+    CORRUPT = "corrupt"
+    #: A snapshot exists and parses but declares an unreadable version.
+    UNSUPPORTED = "unsupported"
+
+
+class WatchState(StrEnum):
+    """Whether a watch-driven refresh was observed recently."""
+
+    ACTIVE = "active"
+    UNOBSERVED = "unobserved"
+
+
+class ReceiptState(StrEnum):
+    """Completeness of the freshness receipt behind the snapshot."""
+
+    #: A generation identity exists and the edit view lists every edit.
+    COMPLETE = "complete"
+    #: A generation identity exists but recorded edits were dropped by a cap.
+    PARTIAL = "partial"
+    #: No generation identity is persisted, so nothing can be attested.
+    UNKNOWN = "unknown"
+
+
+class StatusSnapshot(BaseModel):
+    """The persisted document. Scalars only, every string length-capped."""
+
+    version: int = STATUS_SNAPSHOT_VERSION
+    state: SnapshotState
+    #: UTC ISO-8601 instant the snapshot was measured, in the same
+    #: second-resolution shape the hooks log.
+    written_at: str = Field(max_length=_MAX_TIMESTAMP_LENGTH)
+    #: The same instant as Unix epoch seconds, so a renderer with a clock can
+    #: judge staleness without parsing a timestamp.
+    written_at_epoch: int
+    #: When the index state described here was measured. Equal to
+    #: ``written_at`` for a full publication; carried forward unchanged by
+    #: index-free overlays, so "has anything been edited since the index last
+    #: described the tree?" stays answerable after repeated overlays.
+    index_measured_at: str = Field(default="", max_length=_MAX_TIMESTAMP_LENGTH)
+    #: Index revision as the hook receipts report it. A renderer with limited
+    #: width is expected to show a prefix; the document stores it whole.
+    index_revision: str = Field(default="", max_length=_MAX_IDENTITY_LENGTH)
+    #: Generation identity of the index the measurement describes.
+    generation_id: str = Field(default="", max_length=_MAX_IDENTITY_LENGTH)
+    indexed_commit: str = Field(default="", max_length=_MAX_IDENTITY_LENGTH)
+    current_commit: str = Field(default="", max_length=_MAX_IDENTITY_LENGTH)
+    files_indexed: int = 0
+    chunks_indexed: int = 0
+    #: Whether the working tree carried uncommitted changes at measurement
+    #: time. Orthogonal to freshness: a synchronized index describes a dirty
+    #: tree exactly as well as a clean one.
+    working_tree_dirty: bool = False
+    #: Whether the index described the working tree at measurement time.
+    #: Persisted rather than re-derived: an index-free overlay must not be
+    #: able to promote a writer's `dirty` measurement to `fresh`, and
+    #: `reindex_required` alone does not carry that information -- an index
+    #: can be behind the tree without being flagged for a rebuild.
+    index_fresh: bool = True
+    #: Whether the store is flagged for a full reindex.
+    reindex_required: bool = False
+    #: Recorded edits awaiting synchronization (R21 ``pending_paths``).
+    pending_delta_files: int = 0
+    #: Whether that count is the whole truth (R21 ``dropped_path_count == 0``).
+    pending_view_complete: bool = True
+    last_edit_at: str = Field(default="", max_length=_MAX_TIMESTAMP_LENGTH)
+    last_edit_client: str = Field(default="", max_length=_MAX_NAME_LENGTH)
+    last_edit_tool: str = Field(default="", max_length=_MAX_NAME_LENGTH)
+    last_successful_sync: str = Field(default="", max_length=_MAX_TIMESTAMP_LENGTH)
+    receipt_state: ReceiptState = ReceiptState.UNKNOWN
+    #: When a watch-driven refresh was last observed, empty if never.
+    watch_observed_at: str = Field(default="", max_length=_MAX_TIMESTAMP_LENGTH)
+    watch_observed_epoch: int = 0
+
+
+class StatusView(BaseModel):
+    """What a renderer receives: a display state plus its evidence."""
+
+    state: StatusState
+    #: Present whenever a valid document was read, including when the reader
+    #: overrode its state with ``stale`` -- a stale snapshot's fields are the
+    #: last known measurement and are still worth showing, labelled as old.
+    snapshot: StatusSnapshot | None = None
+    #: Why the reader chose a state the writer did not persist.
+    detail: str = ""
+    #: Snapshot age in whole seconds, when both a snapshot and a clock exist.
+    age_seconds: int | None = None
+    watch_state: WatchState = WatchState.UNOBSERVED
+
+
+def status_snapshot_path(repo_root: Path) -> Path:
+    """Path of the cached status snapshot for ``repo_root``."""
+    return ProjectState(repo_root=repo_root).status_snapshot_path
+
+
+def _lock_path(repo_root: Path) -> Path:
+    return ProjectState(repo_root=repo_root).project_dir / LOCK_FILENAME
+
+
+def utc_now_iso(now: float | None = None) -> str:
+    """UTC timestamp in the shape every archex state document uses."""
+    moment = datetime.now(UTC) if now is None else datetime.fromtimestamp(now, tz=UTC)
+    return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def stale_after_seconds() -> int:
+    """Snapshot age budget, overridable per environment."""
+    raw = os.environ.get(_STALE_ENV_VAR)
+    if raw is None:
+        return DEFAULT_STALE_AFTER_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_STALE_AFTER_SECONDS
+    return value if value > 0 else DEFAULT_STALE_AFTER_SECONDS
+
+
+def project_repo_root(cache_dir: str | Path) -> Path | None:
+    """Repository root a project-layout ``cache_dir`` belongs to, else None.
+
+    Indexing also runs against the shared global cache and against remote
+    checkouts, neither of which has a repo-local `.archex` directory to
+    publish into. Deriving the root from the configured cache directory keeps
+    the check exact and costs no subprocess -- a project cache directory is
+    always ``<root>/.archex`` -- and it stays correct when the command was
+    invoked from a subdirectory, unlike deriving it from the caller's path.
+    """
+    resolved = Path(cache_dir).expanduser()
+    if resolved.name != PROJECT_DIR_NAME:
+        return None
+    root = resolved.parent
+    return root if ProjectState(repo_root=root).initialized() else None
+
+
+def pending_after_measurement(*, edit_state: PostEditState, index_measured_at: str) -> bool:
+    """Whether recorded edits are newer than the last index measurement.
+
+    This is what makes `pending` self-healing. R21's edit state is retired by
+    a successful post-edit synchronization, so a hook whose refresh timed out
+    leaves paths recorded forever -- and a later ordinary `archex index` or
+    warm query, which does cover those files, would otherwise never clear the
+    surface. Comparing the last recorded edit against the instant of the last
+    index measurement answers the question a status surface is actually
+    asked: has anything been edited since the index last described the tree?
+
+    Both timestamps are second-resolution UTC ISO-8601, so lexicographic
+    order is chronological order. The comparison is inclusive: an edit landing
+    in the same second as a measurement is treated as not-yet-covered, which
+    errs toward `pending` rather than toward claiming freshness.
+
+    R21's enum is imported here rather than at module scope so reading a
+    snapshot never pulls in `archex.post_edit`, which re-exports the impact
+    renderer and through it the whole index pipeline. Only writers classify.
+    """
+    from archex.post_edit.models import PostEditStatus
+
+    if edit_state.status is not PostEditStatus.DIRTY or not edit_state.pending_paths:
+        return False
+    return (edit_state.last_event_at or "") >= index_measured_at
+
+
+def derive_state(*, index_fresh: bool, pending: bool) -> SnapshotState:
+    """Classify index and edit state into one persistable state.
+
+    ``pending`` outranks ``dirty`` because it is the strictly more precise
+    statement: it names recorded edits the index has not covered yet, rather
+    than merely observing that tree and index disagree.
+    """
+    if pending:
+        return SnapshotState.PENDING
+    return SnapshotState.FRESH if index_fresh else SnapshotState.DIRTY
+
+
+def _derive_receipt_state(
+    *, generation_id: str, pending_view_complete: bool, reindex_required: bool
+) -> ReceiptState:
+    if not generation_id or reindex_required:
+        return ReceiptState.UNKNOWN
+    return ReceiptState.COMPLETE if pending_view_complete else ReceiptState.PARTIAL
+
+
+def _clip(value: str | None, limit: int) -> str:
+    if not value:
+        return ""
+    return value[:limit]
+
+
+def build_snapshot(
+    *,
+    index_fresh: bool,
+    edit_state: PostEditState,
+    index_measured_at: str = "",
+    index_revision: str = "",
+    generation_id: str | None = "",
+    indexed_commit: str | None = "",
+    current_commit: str | None = "",
+    files_indexed: int = 0,
+    chunks_indexed: int = 0,
+    working_tree_dirty: bool = False,
+    reindex_required: bool = False,
+    now: float | None = None,
+    watch_observed_at: str = "",
+    watch_observed_epoch: int = 0,
+) -> StatusSnapshot:
+    """Assemble a snapshot from already-measured lifecycle state.
+
+    ``index_measured_at`` is when the index state being described was
+    measured. A full publication passes its own instant; an index-free
+    overlay carries the earlier one forward, so repeated overlays cannot
+    silently promote a pending edit to covered.
+    """
+    moment = datetime.now(UTC).timestamp() if now is None else now
+    written_at = utc_now_iso(moment)
+    measured_at = index_measured_at or written_at
+    resolved_generation = _clip(generation_id, _MAX_IDENTITY_LENGTH)
+    pending = pending_after_measurement(edit_state=edit_state, index_measured_at=measured_at)
+    view_complete = edit_state.is_bounded_view() if pending else True
+    return StatusSnapshot(
+        state=derive_state(index_fresh=index_fresh, pending=pending),
+        written_at=written_at,
+        written_at_epoch=int(moment),
+        index_measured_at=measured_at,
+        index_revision=_clip(index_revision, _MAX_IDENTITY_LENGTH),
+        generation_id=resolved_generation,
+        indexed_commit=_clip(indexed_commit, _MAX_IDENTITY_LENGTH),
+        current_commit=_clip(current_commit, _MAX_IDENTITY_LENGTH),
+        files_indexed=files_indexed,
+        chunks_indexed=chunks_indexed,
+        working_tree_dirty=working_tree_dirty,
+        index_fresh=index_fresh,
+        reindex_required=reindex_required,
+        pending_delta_files=len(edit_state.pending_paths) if pending else 0,
+        pending_view_complete=view_complete,
+        last_edit_at=_clip(edit_state.last_event_at, _MAX_TIMESTAMP_LENGTH),
+        last_edit_client=_clip(edit_state.last_client, _MAX_NAME_LENGTH),
+        last_edit_tool=_clip(edit_state.last_tool_name, _MAX_NAME_LENGTH),
+        last_successful_sync=_clip(edit_state.synchronized_at, _MAX_TIMESTAMP_LENGTH),
+        receipt_state=_derive_receipt_state(
+            generation_id=resolved_generation,
+            pending_view_complete=view_complete,
+            reindex_required=reindex_required,
+        ),
+        watch_observed_at=_clip(watch_observed_at, _MAX_TIMESTAMP_LENGTH),
+        watch_observed_epoch=watch_observed_epoch,
+    )
+
+
+def read_status(repo_root: Path, *, now: float | None = None) -> StatusView:
+    """Read the cached snapshot and classify it for display.
+
+    Opens no index, spawns nothing, and parses no source. Every failure mode
+    resolves to a distinct display state instead of an exception.
+    """
+    path = status_snapshot_path(repo_root)
+    try:
+        raw = path.read_bytes().decode("utf-8", errors="replace")
+    except FileNotFoundError:
+        return StatusView(state=StatusState.MISSING, detail="no status snapshot published")
+    except OSError as exc:
+        _log_diagnostic("status_snapshot_read_error", repr(exc), repo_root)
+        return StatusView(state=StatusState.CORRUPT, detail=f"unreadable snapshot: {exc}")
+    return _classify(raw, repo_root, now=now)
+
+
+def _classify(raw: str, repo_root: Path, *, now: float | None) -> StatusView:
+    """Validate a document and apply the reader-owned states.
+
+    The guards are broad for the same reason R21's parser is: `json.loads`
+    raises `JSONDecodeError` on malformed text but `RecursionError` on a
+    deeply nested one, and pydantic can raise beyond `ValidationError` for an
+    adversarial document. A renderer must get a state, never a traceback.
+    """
+    try:
+        payload = json.loads(raw)
+    except (ValueError, RecursionError) as exc:
+        _log_diagnostic("status_snapshot_corrupt", repr(exc), repo_root)
+        return StatusView(state=StatusState.CORRUPT, detail="snapshot is not valid JSON")
+    if not isinstance(payload, dict):
+        _log_diagnostic(
+            "status_snapshot_corrupt", f"expected object, got {type(payload).__name__}", repo_root
+        )
+        return StatusView(state=StatusState.CORRUPT, detail="snapshot is not a JSON object")
+
+    document = cast("dict[str, Any]", payload)
+    version = document.get("version")
+    # A document with no version, or a version that is not an integer, is
+    # malformed rather than from another build: it needs re-publishing, not an
+    # upgrade. Only an integer this build does not read is `unsupported`. The
+    # shell and TypeScript renderers classify the same way, so all three
+    # surfaces give one remedy for one document.
+    if not isinstance(version, int) or isinstance(version, bool):
+        _log_diagnostic("status_snapshot_corrupt", f"version {version!r}", repo_root)
+        return StatusView(
+            state=StatusState.CORRUPT, detail="snapshot carries no usable schema version"
+        )
+    if version != STATUS_SNAPSHOT_VERSION:
+        return StatusView(
+            state=StatusState.UNSUPPORTED,
+            detail=f"snapshot version {version!r}; this archex reads {STATUS_SNAPSHOT_VERSION}",
+        )
+    try:
+        snapshot = StatusSnapshot.model_validate(document)
+    except (ValidationError, ValueError, RecursionError) as exc:
+        _log_diagnostic("status_snapshot_corrupt", repr(exc), repo_root)
+        return StatusView(state=StatusState.CORRUPT, detail="snapshot failed validation")
+
+    moment = datetime.now(UTC).timestamp() if now is None else now
+    # A missing or nonsensical measurement instant yields no age rather than a
+    # 57-year-old one, so it cannot masquerade as staleness. Same rule in the
+    # shell and TypeScript renderers.
+    age = max(0, int(moment) - snapshot.written_at_epoch) if snapshot.written_at_epoch > 0 else None
+    watch_state = (
+        WatchState.ACTIVE
+        if snapshot.watch_observed_epoch > 0
+        and int(moment) - snapshot.watch_observed_epoch <= WATCH_OBSERVATION_TTL_SECONDS
+        else WatchState.UNOBSERVED
+    )
+    budget = stale_after_seconds()
+    if age is not None and age > budget:
+        return StatusView(
+            state=StatusState.STALE,
+            snapshot=snapshot,
+            detail=f"measured {age}s ago, past the {budget}s freshness budget",
+            age_seconds=age,
+            watch_state=watch_state,
+        )
+    return StatusView(
+        state=StatusState(snapshot.state.value),
+        snapshot=snapshot,
+        age_seconds=age,
+        watch_state=watch_state,
+    )
+
+
+def write_snapshot(repo_root: Path, snapshot: StatusSnapshot) -> StatusSnapshot | None:
+    """Publish ``snapshot`` atomically; return it, or None if the write was skipped."""
+    return _mutate(repo_root, lambda _previous: snapshot)
+
+
+def _mutate(
+    repo_root: Path, transform: Callable[[StatusSnapshot | None], StatusSnapshot | None]
+) -> StatusSnapshot | None:
+    """Read-modify-write the document under the exclusive lock.
+
+    ``transform`` receives the currently published snapshot (``None`` when
+    there is no readable one) and returns the document to publish, or ``None``
+    to publish nothing. Reading inside the lock is what keeps two concurrent
+    overlays -- an edit event and a watch stamp, say -- from each building on
+    the same stale document and dropping the other's contribution.
+    """
+    path = status_snapshot_path(repo_root)
+    if not ensure_parent_dir(path, cwd=repo_root, diagnostics=_DIAGNOSTICS):
+        return None
+    with _snapshot_lock(repo_root) as acquired:
+        if not acquired:
+            return None
+        updated = transform(read_status(repo_root).snapshot)
+        if updated is None:
+            return None
+        payload = json.dumps(updated.model_dump(mode="json"), indent=2, sort_keys=True) + "\n"
+        if not write_text_atomic(path, payload, cwd=repo_root, diagnostics=_DIAGNOSTICS):
+            return None
+        return updated
+
+
+def publish_status(
+    repo_root: Path,
+    *,
+    index_fresh: bool,
+    index_revision: str = "",
+    generation_id: str | None = "",
+    indexed_commit: str | None = "",
+    current_commit: str | None = "",
+    files_indexed: int = 0,
+    chunks_indexed: int = 0,
+    working_tree_dirty: bool = False,
+    reindex_required: bool = False,
+    watch_observed: bool = False,
+    now: float | None = None,
+) -> StatusSnapshot | None:
+    """Publish a full measurement, preserving an earlier watch observation.
+
+    Called from code that has already paid for the expensive state: the four
+    index publication points and the `archex status` inspector. Never raises;
+    a failed publish leaves the previous document in place.
+    """
+
+    def _build(previous: StatusSnapshot | None) -> StatusSnapshot:
+        moment = datetime.now(UTC).timestamp() if now is None else now
+        if watch_observed:
+            observed_at, observed_epoch = utc_now_iso(moment), int(moment)
+        elif previous is not None:
+            observed_at, observed_epoch = (
+                previous.watch_observed_at,
+                previous.watch_observed_epoch,
+            )
+        else:
+            observed_at, observed_epoch = "", 0
+        return build_snapshot(
+            index_fresh=index_fresh,
+            edit_state=_read_edit_state(repo_root),
+            index_revision=index_revision,
+            generation_id=generation_id,
+            indexed_commit=indexed_commit,
+            current_commit=current_commit,
+            files_indexed=files_indexed,
+            chunks_indexed=chunks_indexed,
+            working_tree_dirty=working_tree_dirty,
+            reindex_required=reindex_required,
+            now=moment,
+            watch_observed_at=observed_at,
+            watch_observed_epoch=observed_epoch,
+        )
+
+    try:
+        return _mutate(repo_root, _build)
+    except Exception as exc:  # noqa: BLE001 - status is display value, never fatal
+        _log_diagnostic("status_snapshot_publish_error", repr(exc), repo_root)
+        return None
+
+
+def republish_measurement(
+    repo_root: Path, *, generation_id: str, now: float | None = None
+) -> StatusSnapshot | None:
+    """Re-stamp an existing measurement whose generation is unchanged.
+
+    The cheap half of the publication contract, for the hottest lifecycle
+    event: a validated cache hit establishes that the index still describes
+    the tree, but re-deriving the index revision costs an O(files) scan and
+    hash, and the counts and revision cannot have changed if the generation
+    identity has not. So the measurement instant is advanced -- which is what
+    keeps the surface out of `stale` -- while every index-derived field is
+    carried forward.
+
+    Returns ``None`` when there is no published snapshot to re-stamp, or when
+    its generation differs; the caller must then pay for a full publication.
+    """
+
+    def _restamp(previous: StatusSnapshot | None) -> StatusSnapshot | None:
+        if previous is None or not generation_id or previous.generation_id != generation_id:
+            return None
+        moment = datetime.now(UTC).timestamp() if now is None else now
+        return build_snapshot(
+            index_fresh=previous.index_fresh,
+            edit_state=_read_edit_state(repo_root),
+            index_revision=previous.index_revision,
+            generation_id=previous.generation_id,
+            indexed_commit=previous.indexed_commit,
+            current_commit=previous.current_commit,
+            files_indexed=previous.files_indexed,
+            chunks_indexed=previous.chunks_indexed,
+            working_tree_dirty=previous.working_tree_dirty,
+            reindex_required=previous.reindex_required,
+            now=moment,
+            watch_observed_at=previous.watch_observed_at,
+            watch_observed_epoch=previous.watch_observed_epoch,
+        )
+
+    try:
+        return _mutate(repo_root, _restamp)
+    except Exception as exc:  # noqa: BLE001 - status is display value, never fatal
+        _log_diagnostic("status_snapshot_publish_error", repr(exc), repo_root)
+        return None
+
+
+def refresh_edit_overlay(repo_root: Path, *, now: float | None = None) -> StatusSnapshot | None:
+    """Recompute the cached state from R21 edit state without opening the index.
+
+    An edit event changes what the status surface should say without changing
+    what the index contains, so the pending/fresh transition must be
+    publishable without paying for an index open.
+    """
+    return _overlay(repo_root, now=now, watch_observed=False)
+
+
+def publish_status_watch_observation(
+    repo_root: Path, *, now: float | None = None
+) -> StatusSnapshot | None:
+    """Stamp a watch-driven refresh onto the existing snapshot."""
+    return _overlay(repo_root, now=now, watch_observed=True)
+
+
+def _overlay(repo_root: Path, *, now: float | None, watch_observed: bool) -> StatusSnapshot | None:
+    """Re-derive the snapshot from cheap state, carrying index fields over.
+
+    Index-derived fields come from the previous measurement, including the
+    instant it was taken and whether the index described the tree then: an
+    overlay learns nothing new about the index and must not re-decide either.
+    When there is no readable previous measurement there is nothing to
+    overlay, and the next index publication creates the document. Runs on a
+    client's edit path, so every failure degrades to a diagnostics line.
+    """
+
+    def _build(previous: StatusSnapshot | None) -> StatusSnapshot | None:
+        if previous is None:
+            return None
+        moment = datetime.now(UTC).timestamp() if now is None else now
+        observed_at = utc_now_iso(moment) if watch_observed else previous.watch_observed_at
+        observed_epoch = int(moment) if watch_observed else previous.watch_observed_epoch
+        return build_snapshot(
+            index_fresh=previous.index_fresh,
+            edit_state=_read_edit_state(repo_root),
+            index_measured_at=previous.index_measured_at or previous.written_at,
+            index_revision=previous.index_revision,
+            generation_id=previous.generation_id,
+            indexed_commit=previous.indexed_commit,
+            current_commit=previous.current_commit,
+            files_indexed=previous.files_indexed,
+            chunks_indexed=previous.chunks_indexed,
+            working_tree_dirty=previous.working_tree_dirty,
+            reindex_required=previous.reindex_required,
+            now=moment,
+            watch_observed_at=observed_at,
+            watch_observed_epoch=observed_epoch,
+        )
+
+    try:
+        return _mutate(repo_root, _build)
+    except Exception as exc:  # noqa: BLE001 - runs on a client's edit path
+        _log_diagnostic("status_snapshot_publish_error", repr(exc), repo_root)
+        return None
+
+
+def clear_snapshot(repo_root: Path) -> None:
+    """Remove the snapshot; a missing document reads as ``missing``.
+
+    Used when the measured subject stops existing -- a deleted or unreadable
+    index -- so the surface says "no measurement" instead of replaying a
+    measurement of something that is gone.
+    """
+    try:
+        status_snapshot_path(repo_root).unlink(missing_ok=True)
+    except OSError as exc:
+        _log_diagnostic("status_snapshot_write_error", repr(exc), repo_root)
+
+
+def _read_edit_state(repo_root: Path) -> PostEditState:
+    """Read R21's edit state, importing it only when a write is happening.
+
+    Local import keeps `read_status` -- the path every renderer takes -- free
+    of R21's state module, which transitively imports the index store.
+    """
+    from archex.post_edit.state import read_state
+
+    return read_state(repo_root)
+
+
+def _snapshot_lock(repo_root: Path, timeout: float | None = None) -> ExclusiveLock:
+    return ExclusiveLock(
+        _lock_path(repo_root),
+        timeout=LOCK_TIMEOUT_SECONDS if timeout is None else timeout,
+        cwd=repo_root,
+        diagnostics=_DIAGNOSTICS,
+    )
+
+
+def _log_diagnostic(kind: str, detail: str, repo_root: Path) -> None:
+    from archex.integrations.hook import log_diagnostic
+
+    log_diagnostic(kind, detail=detail, cwd=str(repo_root))

--- a/tests/test_status_snapshot.py
+++ b/tests/test_status_snapshot.py
@@ -1,0 +1,570 @@
+"""Cached status snapshot contract: states, transitions, bounds, isolation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from archex.post_edit import build_event, mark_synchronized, record_edit
+from archex.project import ProjectState, init_project, reset_project
+from archex.status_snapshot import (
+    MAX_SNAPSHOT_BYTES,
+    STATUS_SNAPSHOT_VERSION,
+    WATCH_OBSERVATION_TTL_SECONDS,
+    ReceiptState,
+    SnapshotState,
+    StatusState,
+    WatchState,
+    _snapshot_lock,  # pyright: ignore[reportPrivateUsage]
+    clear_snapshot,
+    project_repo_root,
+    publish_status,
+    publish_status_watch_observation,
+    read_status,
+    refresh_edit_overlay,
+    republish_measurement,
+    stale_after_seconds,
+    status_snapshot_path,
+    utc_now_iso,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+_NOW = 1_800_000_000.0
+
+
+def _repo(tmp_path: Path) -> Path:
+    (tmp_path / ".archex").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _git_repo(tmp_path: Path) -> Path:
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for args in (
+        ("init",),
+        ("config", "user.email", "test@archex.test"),
+        ("config", "user.name", "archex-test"),
+    ):
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+    (repo / "README.md").write_text("# repo\n", encoding="utf-8")
+    return repo
+
+
+def _publish(
+    repo: Path,
+    *,
+    index_fresh: bool = True,
+    now: float = _NOW,
+    reindex_required: bool = False,
+    working_tree_dirty: bool = False,
+) -> None:
+    publish_status(
+        repo,
+        index_fresh=index_fresh,
+        index_revision="abc1234",
+        generation_id="f" * 64,
+        indexed_commit="c" * 40,
+        current_commit="c" * 40,
+        files_indexed=120,
+        chunks_indexed=980,
+        reindex_required=reindex_required,
+        working_tree_dirty=working_tree_dirty,
+        now=now,
+    )
+
+
+def _record_edit(repo: Path, path: str = "pkg/mod.py", *, at: float = _NOW + 1) -> None:
+    """Record an edit at a controlled instant on the tests' fake clock.
+
+    `pending` is a comparison between the last recorded edit and the last
+    index measurement, so an edit stamped with the real wall clock would be
+    compared against a fake-clock measurement and classify by accident.
+    """
+    (repo / path).parent.mkdir(parents=True, exist_ok=True)
+    (repo / path).write_text("x = 1\n")
+    event, _rejected = build_event(
+        client="claude-code",
+        tool_name="Edit",
+        repo_root=repo,
+        raw_paths=[path],
+        observed_at=utc_now_iso(at),
+    )
+    record_edit(repo, event)
+
+
+def test_published_snapshot_reads_back_as_fresh_with_its_measurement(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+
+    _publish(repo)
+    view = read_status(repo, now=_NOW + 5)
+
+    assert view.state is StatusState.FRESH
+    assert view.age_seconds == 5
+    assert view.snapshot is not None
+    assert view.snapshot.version == STATUS_SNAPSHOT_VERSION
+    assert view.snapshot.files_indexed == 120
+    assert view.snapshot.receipt_state is ReceiptState.COMPLETE
+
+
+def test_index_that_no_longer_describes_the_tree_reads_as_dirty(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+
+    _publish(repo, index_fresh=False, reindex_required=True)
+    view = read_status(repo, now=_NOW)
+
+    assert view.state is StatusState.DIRTY
+    assert view.snapshot is not None
+    assert view.snapshot.reindex_required is True
+    # A flagged store can attest nothing about the current tree.
+    assert view.snapshot.receipt_state is ReceiptState.UNKNOWN
+
+
+def test_recorded_edit_outranks_dirty_and_reports_pending_count(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo, index_fresh=False)
+
+    _record_edit(repo)
+    refresh_edit_overlay(repo, now=_NOW + 1)
+    view = read_status(repo, now=_NOW + 1)
+
+    assert view.state is StatusState.PENDING
+    assert view.snapshot is not None
+    assert view.snapshot.pending_delta_files == 1
+    assert view.snapshot.last_edit_client == "claude-code"
+    assert view.snapshot.last_edit_tool == "Edit"
+
+
+def test_repeated_overlays_do_not_promote_a_pending_edit_to_covered(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+    _record_edit(repo, at=_NOW + 1)
+
+    refresh_edit_overlay(repo, now=_NOW + 2)
+    refresh_edit_overlay(repo, now=_NOW + 3)
+    view = read_status(repo, now=_NOW + 4)
+
+    # Each overlay carries the index measurement instant forward instead of
+    # stamping its own, so the edit stays newer than the measurement.
+    assert view.state is StatusState.PENDING
+    assert view.snapshot is not None
+    assert view.snapshot.index_measured_at == utc_now_iso(_NOW)
+
+
+def test_a_later_index_measurement_clears_an_unsynchronized_edit(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+    # A post-edit hook whose refresh timed out: the edit stays recorded in
+    # R21 state forever, because only a successful sync retires it.
+    _record_edit(repo, at=_NOW + 1)
+    refresh_edit_overlay(repo, now=_NOW + 2)
+    assert read_status(repo, now=_NOW + 2).state is StatusState.PENDING
+
+    _publish(repo, now=_NOW + 60)
+    view = read_status(repo, now=_NOW + 60)
+
+    # An ordinary index run does cover those files, so the surface heals
+    # rather than showing `pending` for the rest of the repository's life.
+    assert view.state is StatusState.FRESH
+    assert view.snapshot is not None
+    assert view.snapshot.pending_delta_files == 0
+
+
+def test_an_overlay_cannot_promote_a_dirty_measurement_to_fresh(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    # `archex status` publishes exactly this shape: the index is behind the
+    # tree (a newer commit, or a changed file) without the store being
+    # flagged for a rebuild.
+    _publish(repo, index_fresh=False, reindex_required=False)
+    assert read_status(repo, now=_NOW).state is StatusState.DIRTY
+
+    _record_edit(repo, at=_NOW + 1)
+    refresh_edit_overlay(repo, now=_NOW + 2)
+    mark_synchronized(repo, generation_id="f" * 64, synchronized_paths=["pkg/mod.py"])
+    refresh_edit_overlay(repo, now=_NOW + 3)
+    view = read_status(repo, now=_NOW + 3)
+
+    # An overlay learns nothing new about the index, so it must not decide the
+    # index now describes the tree.
+    assert view.state is StatusState.DIRTY
+    assert view.snapshot is not None
+    assert view.snapshot.index_fresh is False
+
+
+def test_unchanged_generation_is_restamped_without_the_index_fields(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+
+    restamped = republish_measurement(repo, generation_id="f" * 64, now=_NOW + 300)
+
+    assert restamped is not None
+    # The measurement instant advances, which is what keeps a long warm
+    # session out of `stale`, while every index-derived field is carried.
+    assert restamped.written_at_epoch == _NOW + 300
+    assert restamped.index_revision == "abc1234"
+    assert restamped.files_indexed == 120
+    assert read_status(repo, now=_NOW + 300).state is StatusState.FRESH
+
+
+def test_restamp_refuses_a_different_or_absent_generation(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+
+    assert republish_measurement(repo, generation_id="f" * 64) is None
+
+    _publish(repo)
+
+    assert republish_measurement(repo, generation_id="a" * 64) is None
+    assert republish_measurement(repo, generation_id="") is None
+    # The caller must fall back to a full publication, so nothing was written.
+    assert read_status(repo, now=_NOW).snapshot is not None
+
+
+def test_restamp_still_reflects_an_edit_recorded_since_the_measurement(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+    _record_edit(repo, at=_NOW + 1)
+
+    republish_measurement(repo, generation_id="f" * 64, now=_NOW + 2)
+
+    # Re-stamping advances the measurement instant, so an edit older than the
+    # new instant is covered -- the same self-healing rule a full publication
+    # applies, since a validated cache hit is evidence about the current tree.
+    assert read_status(repo, now=_NOW + 2).state is StatusState.FRESH
+
+
+def test_synchronizing_the_recorded_edit_returns_the_surface_to_fresh(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+    _record_edit(repo)
+    refresh_edit_overlay(repo, now=_NOW + 1)
+    assert read_status(repo, now=_NOW + 1).state is StatusState.PENDING
+
+    mark_synchronized(repo, generation_id="f" * 64, synchronized_paths=["pkg/mod.py"])
+    refresh_edit_overlay(repo, now=_NOW + 2)
+    view = read_status(repo, now=_NOW + 2)
+
+    assert view.state is StatusState.FRESH
+    assert view.snapshot is not None
+    assert view.snapshot.pending_delta_files == 0
+    assert view.snapshot.last_successful_sync != ""
+    # Index-derived fields survive an index-free overlay.
+    assert view.snapshot.files_indexed == 120
+    assert view.snapshot.index_revision == "abc1234"
+
+
+def test_dropped_edit_records_downgrade_the_receipt_to_partial(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+    for index in range(205):
+        _record_edit(repo, f"pkg/mod{index}.py")
+
+    refresh_edit_overlay(repo, now=_NOW + 1)
+    view = read_status(repo, now=_NOW + 1)
+
+    assert view.state is StatusState.PENDING
+    assert view.snapshot is not None
+    assert view.snapshot.pending_view_complete is False
+    assert view.snapshot.receipt_state is ReceiptState.PARTIAL
+
+
+def test_absent_snapshot_reads_as_missing_not_as_fresh(tmp_path: Path) -> None:
+    view = read_status(_repo(tmp_path))
+
+    assert view.state is StatusState.MISSING
+    assert view.snapshot is None
+    assert view.detail != ""
+
+
+def test_unparsable_snapshot_reads_as_corrupt(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    status_snapshot_path(repo).write_bytes(b"\x00not json{")
+
+    view = read_status(repo)
+
+    assert view.state is StatusState.CORRUPT
+    assert view.snapshot is None
+
+
+def test_json_array_snapshot_reads_as_corrupt(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    status_snapshot_path(repo).write_text("[]\n")
+
+    assert read_status(repo).state is StatusState.CORRUPT
+
+
+def test_schema_violating_snapshot_reads_as_corrupt_not_unsupported(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    status_snapshot_path(repo).write_text(
+        json.dumps({"version": STATUS_SNAPSHOT_VERSION, "state": "sideways"})
+    )
+
+    assert read_status(repo).state is StatusState.CORRUPT
+
+
+def test_a_document_without_a_version_reads_as_corrupt_not_unsupported(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    status_snapshot_path(repo).write_text(json.dumps({"state": "fresh"}))
+
+    view = read_status(repo)
+
+    # Different remedies: an unversioned document needs re-publishing, not an
+    # archex upgrade. The shell and TypeScript renderers agree.
+    assert view.state is StatusState.CORRUPT
+
+
+def test_a_non_integer_version_reads_as_corrupt(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    status_snapshot_path(repo).write_text(json.dumps({"version": "1", "state": "fresh"}))
+
+    assert read_status(repo).state is StatusState.CORRUPT
+
+
+def test_a_document_without_a_measurement_instant_makes_no_age_claim(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    status_snapshot_path(repo).write_text(
+        json.dumps(
+            {
+                "version": STATUS_SNAPSHOT_VERSION,
+                "state": "fresh",
+                "written_at": "",
+                "written_at_epoch": 0,
+            }
+        )
+    )
+
+    view = read_status(repo, now=_NOW)
+
+    # A zero instant is unknown, not 1970: it must not masquerade as staleness.
+    assert view.state is StatusState.FRESH
+    assert view.age_seconds is None
+
+
+def test_future_version_reads_as_unsupported_and_names_both_versions(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    status_snapshot_path(repo).write_text(
+        json.dumps(
+            {
+                "version": STATUS_SNAPSHOT_VERSION + 1,
+                "state": "fresh",
+                "written_at": "2027-01-01T00:00:00Z",
+                "written_at_epoch": 1_800_000_000,
+            }
+        )
+    )
+
+    view = read_status(repo)
+
+    assert view.state is StatusState.UNSUPPORTED
+    assert view.snapshot is None
+    assert str(STATUS_SNAPSHOT_VERSION + 1) in view.detail
+    assert str(STATUS_SNAPSHOT_VERSION) in view.detail
+
+
+def test_old_measurement_reads_as_stale_but_keeps_its_last_known_fields(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+
+    view = read_status(repo, now=_NOW + stale_after_seconds() + 1)
+
+    assert view.state is StatusState.STALE
+    assert view.snapshot is not None
+    assert view.snapshot.state is SnapshotState.FRESH
+    assert view.age_seconds == stale_after_seconds() + 1
+    assert "freshness budget" in view.detail
+
+
+def test_stale_budget_is_environment_overridable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+    monkeypatch.setenv("ARCHEX_STATUS_STALE_AFTER_SECONDS", "5")
+
+    assert read_status(repo, now=_NOW + 4).state is StatusState.FRESH
+    assert read_status(repo, now=_NOW + 6).state is StatusState.STALE
+
+
+def test_invalid_stale_budget_falls_back_to_the_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ARCHEX_STATUS_STALE_AFTER_SECONDS", "not-a-number")
+    default = stale_after_seconds()
+    monkeypatch.setenv("ARCHEX_STATUS_STALE_AFTER_SECONDS", "0")
+
+    assert stale_after_seconds() == default
+
+
+def test_watch_observation_is_reported_active_only_while_recent(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+    assert read_status(repo, now=_NOW).watch_state is WatchState.UNOBSERVED
+
+    publish_status_watch_observation(repo, now=_NOW + 1)
+
+    assert read_status(repo, now=_NOW + 2).watch_state is WatchState.ACTIVE
+    late = _NOW + 2 + WATCH_OBSERVATION_TTL_SECONDS
+    assert read_status(repo, now=late).watch_state is WatchState.UNOBSERVED
+
+
+def test_full_publication_preserves_an_earlier_watch_observation(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+    publish_status_watch_observation(repo, now=_NOW + 1)
+
+    _publish(repo, now=_NOW + 2)
+
+    assert read_status(repo, now=_NOW + 3).watch_state is WatchState.ACTIVE
+
+
+def test_overlay_without_a_previous_measurement_publishes_nothing(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+
+    assert refresh_edit_overlay(repo) is None
+    assert not status_snapshot_path(repo).exists()
+    assert read_status(repo).state is StatusState.MISSING
+
+
+def test_lock_contention_skips_the_write_and_preserves_the_previous_document(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+    before = status_snapshot_path(repo).read_text(encoding="utf-8")
+
+    with _snapshot_lock(repo) as acquired:
+        assert acquired
+        # Same process, so a second flock on a new descriptor is the only
+        # faithful contention simulation available.
+        skipped = publish_status(repo, index_fresh=False, now=_NOW + 10)
+
+    assert skipped is None
+    assert status_snapshot_path(repo).read_text(encoding="utf-8") == before
+
+
+def test_worst_case_document_stays_inside_the_declared_size_bound(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    for index in range(205):
+        _record_edit(repo, f"pkg/mod{index}.py")
+    publish_status(
+        repo,
+        index_fresh=False,
+        index_revision="r" * 200,
+        generation_id="g" * 200,
+        indexed_commit="i" * 200,
+        current_commit="u" * 200,
+        files_indexed=10**9,
+        chunks_indexed=10**9,
+        working_tree_dirty=True,
+        reindex_required=True,
+        now=_NOW,
+    )
+    publish_status_watch_observation(repo, now=_NOW)
+
+    raw = status_snapshot_path(repo).read_bytes()
+
+    assert len(raw) <= MAX_SNAPSHOT_BYTES
+    document = json.loads(raw)
+    assert all(not isinstance(value, (list, dict)) for value in document.values())
+    assert len(document["generation_id"]) == 64
+
+
+def test_client_reported_names_are_clipped_rather_than_stored_whole(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+    (repo / "a.py").write_text("x = 1\n")
+    event, _rejected = build_event(
+        client="c" * 500, tool_name="t" * 500, repo_root=repo, raw_paths=["a.py"]
+    )
+    record_edit(repo, event)
+
+    refresh_edit_overlay(repo, now=_NOW + 1)
+    view = read_status(repo, now=_NOW + 1)
+
+    assert view.snapshot is not None
+    assert len(view.snapshot.last_edit_client) == 64
+    assert len(view.snapshot.last_edit_tool) == 64
+
+
+def test_reading_a_snapshot_opens_no_index_and_launches_no_process(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+    import os
+    import subprocess
+
+    from archex.index.store import IndexStore
+
+    def _forbidden(*_args: object, **_kwargs: object) -> object:
+        message = "repaint must not open an index or launch a process"
+        raise AssertionError(message)
+
+    monkeypatch.setattr(IndexStore, "__init__", _forbidden)
+    monkeypatch.setattr(subprocess, "Popen", _forbidden)
+    monkeypatch.setattr(subprocess, "run", _forbidden)
+    monkeypatch.setattr(os, "fork", _forbidden, raising=False)
+    monkeypatch.setattr(os, "posix_spawn", _forbidden, raising=False)
+
+    view = read_status(repo, now=_NOW)
+
+    assert view.state is StatusState.FRESH
+
+
+def test_reading_a_snapshot_never_imports_the_index_store() -> None:
+    import subprocess
+    import sys
+
+    probe = (
+        "import sys, archex.status_snapshot as s;"
+        "print('archex.index.store' in sys.modules, 'archex.post_edit' in sys.modules)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+
+    assert result.stdout.strip() == "False False"
+
+
+def test_global_cache_directory_publishes_no_snapshot(tmp_path: Path) -> None:
+    global_cache = tmp_path / "cache" / "abcdef"
+    global_cache.mkdir(parents=True)
+
+    assert project_repo_root(global_cache) is None
+
+
+def test_uninitialized_project_directory_publishes_no_snapshot(tmp_path: Path) -> None:
+    project_dir = tmp_path / ".archex"
+    project_dir.mkdir()
+
+    assert project_repo_root(project_dir) is None
+
+
+def test_initialized_project_directory_resolves_to_its_repository_root(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path)
+    init_project(repo)
+
+    assert project_repo_root(ProjectState(repo_root=repo).project_dir) == repo
+
+
+def test_reset_removes_the_snapshot_so_the_surface_reports_missing(tmp_path: Path) -> None:
+    repo = _git_repo(tmp_path)
+    init_project(repo)
+    _publish(repo)
+    assert read_status(repo, now=_NOW).state is StatusState.FRESH
+
+    reset_project(repo, force=True)
+
+    assert read_status(repo).state is StatusState.MISSING
+
+
+def test_clearing_the_snapshot_is_idempotent(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+
+    clear_snapshot(repo)
+    clear_snapshot(repo)
+
+    assert read_status(repo).state is StatusState.MISSING


### PR DESCRIPTION
R23 PR 1 of 3 — the client-neutral core. No client adapter and no CLI surface here; those are PR-2 and PR-3.

## What this adds

A versioned, bounded, atomically published status document at `.archex/status-snapshot.json`, plus the lifecycle wiring that keeps it true.

- `archex.status_snapshot` — the model, the atomic writer, the reader, and the state classification.
- `archex.state_file` — the exclusive-lock and publish-by-rename primitives, extracted from R21's post-edit state so both subsystems share one implementation.
- Publication at the four points where indexing establishes that a store describes the current tree, plus index-free overlays for edit events and watch observations.

## The design decisions worth reviewing

**Who owns which state.** A writer persists one of `fresh`, `dirty`, `pending`. A reader adds `missing`, `corrupt`, `unsupported`, `stale` — the four states only a reader can establish. `unsupported` is kept apart from `corrupt` because the remediations differ (upgrade vs re-publish), and `stale` is a clock judgement over the measurement instant, so no writer can persist it.

**`pending` outranks `dirty`.** Recorded-but-unsynchronized edits are a strictly more precise statement than "tree and index disagree".

**`working_tree_dirty` is not a state driver.** A synchronized index describes a tree with uncommitted edits exactly as well as a clean one. Treating uncommitted changes as staleness would report `dirty` for a repository whose index is perfectly current.

**Bounded by construction, not by truncation.** Every field is a length-capped scalar; there is no path list, no language map, and no token-savings figure (the latter is an explicit R23 exclusion). The serialized ceiling is asserted against a worst-case document rather than assumed.

**Publish target from the cache directory, not the store path.** The full-index path builds into a temp directory that the cache copies from, so the open store's path is not where the index will live. Deriving the target from the configured cache directory is exact, needs no `git rev-parse`, and stays correct when the command ran from a subdirectory.

**The validated cache hit publishes too.** It is the most frequent lifecycle event — every warm query and hook takes it — and it is the evidence that the index still describes the tree. Without it the surface would decay into `stale` between reindexes.

**Failed refreshes stay visible.** The post-edit hook publishes an index-free overlay before and after its synchronization, so a timed-out or failed refresh leaves `pending` on the surface instead of reverting to a claim of freshness.

**`watch_state` is observed, not asserted.** The MCP watcher stamps its own refreshes. `unobserved` means "no watch refresh seen recently", never "no watcher is running" — an idle watcher publishes nothing because nothing changed.

**`archex reset` clears the snapshot.** Deleting an index while leaving a snapshot that describes it would make the surface report `fresh` for a store that no longer exists.

## Verification

- `uv run pytest tests/test_status_snapshot.py` — 26 tests covering each of the seven states, the pending/fresh transition through a real `mark_synchronized`, receipt downgrade on dropped edit records, the environment-overridable stale budget, watch-observation decay, lock contention preserving the previous document, the size bound, name clipping, and both repaint-isolation proofs.
- Repaint isolation is proven two ways: a monkeypatched `IndexStore.__init__`, `subprocess.Popen/run`, `os.fork`, and `os.posix_spawn` all raise while `read_status` still returns `fresh`; and a subprocess probe asserts that importing the reader pulls in neither `archex.index.store` nor `archex.post_edit`.
- Real-index smoke on a throwaway repository: a full index publishes `fresh` with 3 files, 4 chunks, and a complete receipt; a warm query republishes through the cache-hit path; a real installed post-edit hook subprocess drives `pending` → `fresh` with a synchronization timestamp; the same hook under a forced 1 ms budget leaves `pending` with one file awaiting sync.
- Full local gate on this branch: `ruff check` clean, `ruff format --check` clean over 259 files, `pyright` 0 errors, `pytest` 4910 passed at 90.84% coverage.

## Not in this PR

CLI rendering, the Claude Code statusline adapter, the omp/pi status adapters, unsupported-client dispositions, and the compatibility matrix rows.

