### PR TITLE
feat(status): render cached status in the CLI and Claude Code

### DIFF
--- a/docs/CLIENT_COMPATIBILITY_MATRIX.md
+++ b/docs/CLIENT_COMPATIBILITY_MATRIX.md
@@ -30,6 +30,7 @@ This matrix separates config-shape verification from actual client smoke tests. 
 | Cursor | Config shape verified; client smoke unverified | `archex install-client cursor` writes `~/.cursor/mcp.json` (global); `archex install-client cursor . --scope project` writes `.cursor/mcp.json` with `mcpServers.archex.command = "archex"`, `args = ["mcp"]`. `--dry-run` previews. | Yes — with a warm `archex mcp --watch --watch-path .` process. | Inline query refresh by default; watch keeps a warm process subscribed to file events. | No Cursor UI smoke in this stack. | 2026-06-16 |
 | Cursor `beforeSubmitPrompt` hook (opt-in, diagnostics-only, prompt-level) | Config-shape tested end-to-end (install, remove, idempotent reinstall, preserves unrelated `hooks.json` content, `beforeReadFile`-never-wired assertion); no live Cursor UI smoke | `archex install-client cursor --hooks` writes `~/.cursor/hooks.json` (global) or `.cursor/hooks.json` (project) — a different file from the MCP config above. `--dry-run` previews, `--remove-hooks` uninstalls. See [below](#cursor-beforesubmitprompt-hook-opt-in-diagnostics-only) for the full contract and the confirmation-spike findings. | N/A — one subprocess per submitted prompt, not a warm process | Diagnostics-only — no injected context, ever (see limitations); a missing/stale index degrades to no diagnostic, or the same `index_not_fresh`/`status_error` diagnostic the other hooks log. | Prompt-level, not per-tool-call: fires on every submitted prompt regardless of whether a lookup is relevant. Cursor's `beforeSubmitPrompt` output schema has no context-injection field at all (confirmed against Cursor's own docs), so this is diagnostics-only, unlike the augmenting Claude Code/omp/Pi/OpenCode hooks above. | 2026-07-06 |
 | Cursor post-edit impact hook | **Not supported** — `archex install-client cursor --post-edit-hooks` fails with the reason rather than writing anything | N/A | N/A | N/A | `afterFileEdit` is Cursor's only event carrying an edited file path (`{file_path, edits}`) and its documented schema has **no output fields at all**, so it cannot return impact to the agent. `postToolUse` does document an `additional_context` output and lists `Write` among its matchers, but documents no path field for that tool's input, so edited paths cannot be extracted from the one event that could surface text. Archex ships no adapter it cannot show to work. | 2026-09-10 |
+| Claude Code status line (opt-in) | Config-shape tested end-to-end (install, remove, idempotent reinstall, foreign-statusLine refusal, coexistence with all three hook surfaces) and the installed renderer executed for real against every snapshot state under an empty `PATH` | `archex install-client claude-code --statusline` writes `~/.claude/settings.json` (global) or `.claude/settings.json` (project) plus the renderer script `archex-statusline.sh` beside it. `--dry-run` previews; `--remove-statusline` uninstalls. See [below](#persistent-status-surfaces-opt-in). | N/A — reports whether a watch refresh was observed; starts no watcher | Renders the cached snapshot only: `fresh`, `dirty`, `pending`, `stale`, `missing`, `corrupt`, and `unsupported` are distinct. Never opens the index, runs a parser, or starts an archex process on repaint. | Opt-in. `statusLine` is a scalar settings key, so a status line archex did not install is refused rather than replaced. The `stale` label needs a shell clock (`$EPOCHSECONDS`, bash 5+/zsh); under macOS `/bin/sh` (bash 3.2) the renderer reports the measured state without an age instead of forking `date`. Never reports token savings. | 2026-09-10 |
 | Dockerized MCP server | Server path tested; client smoke unverified | Run `docker run -d --name archex-mcp -v "$PWD:/workspace" -w /workspace ghcr.io/mathews-tom/archex:slim sleep infinity` then point the client to `docker exec -i archex-mcp archex mcp`. | Yes — run the MCP process with `--watch`. | Same server-side freshness semantics as stdio. | Client-specific Docker registration varies; use the same client config shapes above, but replace the command with `docker` / `exec`. | 2026-06-16 |
 
 ## First-party bootstrap command
@@ -406,6 +407,98 @@ Tests in the affected set (1):
 - The Codex adapter, and the omp, pi, and OpenCode modules, were each executed against a live index: the Python hooks as real subprocesses driven by the installed configuration, the TypeScript modules loaded under Bun and dispatched with a real event. Each returned a fresh receipt naming the correct client.
 - A forced 1 ms budget produced exit 0, no output, a `post_edit_timeout` diagnostic, and a still-dirty state ready for the next event.
 - The Codex CLI itself was not driven end to end: the local OAuth refresh token was expired at verification time.
+
+## Persistent status surfaces (opt-in)
+
+Installed separately from every other archex surface with `--statusline`, removed with `--remove-statusline`. Never installed by default.
+
+Archex publishes a bounded, versioned status snapshot to `.archex/status-snapshot.json` whenever indexing establishes that the store describes the current tree (a full, delta, or unchanged-tree publication, and the validated cache hit every warm query takes), whenever a post-edit hook records or synchronizes an edit, and whenever `archex status` runs. Renderers only read that file. **No renderer opens the index, runs a parser, or starts an archex process on repaint.**
+
+### States
+
+| State | Meaning | Who determines it |
+| --- | --- | --- |
+| `fresh` | The index describes the working tree and nothing is awaiting synchronization. | Writer |
+| `dirty` | The index no longer describes the tree, or the store is flagged for a reindex. | Writer |
+| `pending` | An edit was recorded at or after the last index measurement and has not been synchronized. | Writer |
+| `stale` | The snapshot is valid but older than the freshness budget (`900s`, override with `ARCHEX_STATUS_STALE_AFTER_SECONDS`), so it is no longer evidence of freshness. | Reader, needs a clock |
+| `missing` | No snapshot has been published, or `archex reset` cleared it. | Reader |
+| `corrupt` | A snapshot exists but is unreadable, unparsable, or invalid. Remedy: re-publish with `archex status`. | Reader |
+| `unsupported` | A snapshot exists and parses but declares a schema version this build does not read. Remedy: upgrade archex. | Reader |
+
+`working_tree_dirty` is reported as its own field and never drives the state: a synchronized index describes a tree with uncommitted edits exactly as well as a clean one. Status never reports estimated token savings.
+
+### CLI
+
+```bash
+archex status .                      # authoritative: opens the index, and refreshes the snapshot
+archex status . --cached             # reads only the cached snapshot; never opens the index
+archex status . --cached --format json
+archex status . --cached --strict    # exit 1 unless the cached state is fresh
+```
+
+`--cached` exits 1 for `corrupt` and `unsupported`, and (with `--strict`) for anything but `fresh`. It is the mode for scripts and repeated calls; the default mode is the one to run when a client's status surface looks wrong, because it re-measures and republishes.
+
+Both modes work from a subdirectory. `--cached` walks up to the nearest published snapshot, exactly as the shell and TypeScript renderers do, so all three surfaces answer for the same document.
+
+### Claude Code status line
+
+```bash
+archex install-client claude-code --statusline                     # global: ~/.claude/settings.json
+archex install-client claude-code . --statusline --scope project    # repo-local: .claude/settings.json
+archex install-client claude-code --statusline --dry-run            # preview only, writes nothing
+archex install-client claude-code --remove-statusline               # clean uninstall
+```
+
+Two artifacts: the renderer script at `~/.claude/archex-statusline.sh` (or `.claude/archex-statusline.sh` for project scope), and a `statusLine` entry in the same `settings.json` the hook installers merge into:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "/bin/zsh \"/abs/path/.claude/archex-statusline.sh\"",
+    "padding": 0,
+    "refreshInterval": 10
+  }
+}
+```
+
+The interpreter is chosen at install time from the shells present on the host, preferring one that can read a clock without forking (`zsh` after the builtin `zmodload zsh/datetime`, or bash 5+); `sh` is the fallback where none can. That choice is what makes the `stale` label reachable on macOS, whose `/bin/sh` and `/bin/bash` are both bash 3.2.
+
+`statusLine` is a scalar settings key, not a matcher group, so there is no way for two status lines to coexist. Consequences, both tested:
+
+- A `statusLine` that archex did not install is **refused, not replaced** — the command fails and changes nothing. Remove it first, or install into the other scope.
+- `--remove-statusline` deletes only an archex-owned entry (its command names `archex-statusline.sh`) and only an archex-owned script (its body carries the `archex:statusline` marker). A foreign status line and a foreign script of the same name are both left untouched.
+
+Unrelated settings keys, the `PreToolUse` search hook, the `SessionStart` primer, and the `PostToolUse` post-edit hook all survive install and removal; each surface owns its own key or marker.
+
+Sample output:
+
+```text
+archex fresh - 1234 files, 5678 chunks - rev 01234567 - 12s ago
+archex pending - 3 awaiting sync - rev 01234567 - 4s ago
+archex dirty - reindex required - rev 01234567
+archex stale - unverified since measurement - rev 01234567 - 31m ago
+archex missing - no status snapshot - run: archex index
+archex corrupt - unreadable snapshot - run: archex status
+archex unsupported - snapshot v2 - upgrade archex
+```
+
+A trailing ` - watch` appears when a watch-driven refresh was observed within the last `300s`. Its absence means "no recent watch refresh", never "no watcher is running" — an idle watcher publishes nothing because nothing changed.
+
+### Why the renderer is a shell script
+
+Claude Code re-runs the status-line command on every repaint, debounced at 300 ms, and cancels an in-flight script when a new update arrives. A cold Python start per repaint is exactly what R23 excludes, so the renderer is POSIX `sh` using **shell builtins only**: no `jq`, no `python`, no `date`, no `archex`, and no command substitution anywhere. It reads the session directory out of the JSON payload Claude Code writes to stdin (falling back to `$PWD`), walks up to the nearest `.archex/status-snapshot.json`, and parses that document line by line with parameter expansion.
+
+One consequence is handled rather than hidden: computing the `stale` label needs a clock, and POSIX `sh` has no builtin one. The renderer reads `$EPOCHSECONDS`, which bash 5+ provides natively and zsh provides after the builtin `zmodload zsh/datetime`, and the installer therefore picks a clock-bearing interpreter when the host has one. On a host where none does, the renderer reports the measured state without an age or `stale` label instead of spending a `date` fork on every repaint, and `archex status --cached` — which always has a clock — remains the surface that always reports `stale`.
+
+### Verification performed
+
+- The installed script was executed through `/bin/sh` **with an empty `PATH`** against `fresh`, `dirty` (both variants), `pending` (complete and truncated views), `missing`, `corrupt` (unparsable bytes and an unknown state value), and `unsupported` snapshots. Every run printed the expected line, exited 0, and wrote nothing to stderr — which no renderer that shelled out to `jq`, `python`, `date`, or `archex` could do.
+- The `stale`, age, and watch segments were exercised under `/bin/zsh`, the local shell that can read a clock without forking.
+- Session-directory resolution was exercised three ways: the stdin `cwd` payload from an unrelated working directory, a subdirectory of the session repository, and an unrelated directory (which reports `missing` rather than another repository's status).
+- `archex status --cached` was verified to render every state, to resolve the snapshot from a subdirectory, and to work with `IndexStore.__init__` patched to raise.
+- A refused install (a `statusLine` archex did not write) was verified to leave no renderer script behind.
 
 ## Cursor `beforeSubmitPrompt` hook (opt-in, diagnostics-only)
 

--- a/src/archex/cli/install_client_cmd.py
+++ b/src/archex/cli/install_client_cmd.py
@@ -16,15 +16,18 @@ from archex.client_setup import (
     build_hook_install_plan,
     build_post_edit_hook_install_plan,
     build_session_primer_install_plan,
+    build_statusline_install_plan,
     render_agent_guidance_preview,
     render_client_install_preview,
     render_hook_install_preview,
     render_post_edit_hook_install_preview,
     render_session_primer_install_preview,
+    render_statusline_install_preview,
     write_client_install_plan,
     write_hook_install_plan,
     write_post_edit_hook_install_plan,
     write_session_primer_install_plan,
+    write_statusline_install_plan,
 )
 
 
@@ -122,6 +125,23 @@ def _is_interactive() -> bool:
     help="Remove the archex post-edit impact hook previously installed by --post-edit-hooks.",
 )
 @click.option(
+    "--statusline",
+    is_flag=True,
+    default=False,
+    help=(
+        "Install the opt-in persistent status surface (R23). Renders the "
+        "cached freshness snapshot in the client's own status line, reading "
+        "only that snapshot -- it opens no index and starts no archex "
+        "process on repaint. claude-code only."
+    ),
+)
+@click.option(
+    "--remove-statusline",
+    is_flag=True,
+    default=False,
+    help="Remove the archex status line previously installed by --statusline.",
+)
+@click.option(
     "--allow-missing-mcp",
     is_flag=True,
     default=False,
@@ -164,6 +184,8 @@ def install_client_cmd(  # noqa: PLR0913 - one flag per installable client surfa
     remove_session_primer: bool,
     post_edit_hooks: bool,
     remove_post_edit_hooks: bool,
+    statusline: bool,
+    remove_statusline: bool,
     allow_missing_mcp: bool,
     all_detected: bool,
     yes: bool,
@@ -181,17 +203,20 @@ def install_client_cmd(  # noqa: PLR0913 - one flag per installable client surfa
         raise click.ClickException(
             "--post-edit-hooks and --remove-post-edit-hooks are mutually exclusive"
         )
+    if statusline and remove_statusline:
+        raise click.ClickException("--statusline and --remove-statusline are mutually exclusive")
     selected_surfaces = sum(
         (
             hooks or remove_hooks,
             session_primer or remove_session_primer,
             post_edit_hooks or remove_post_edit_hooks,
+            statusline or remove_statusline,
         )
     )
     if selected_surfaces > 1:
         raise click.ClickException(
-            "Search hooks, session-primer hooks, and post-edit hooks must be "
-            "installed or removed separately"
+            "Search hooks, session-primer hooks, post-edit hooks, and the status "
+            "line must be installed or removed separately"
         )
     valid_clients = ["claude-code", "codex", "cursor", "opencode", "pi", "omp"]
 
@@ -242,6 +267,18 @@ def install_client_cmd(  # noqa: PLR0913 - one flag per installable client surfa
             scope=cast("ClientScope | None", scope),
             dry_run=dry_run,
             action="install" if post_edit_hooks else "remove",
+        )
+        return
+
+    if statusline or remove_statusline:
+        if client is None:
+            raise click.ClickException("Must specify a client when using --statusline")
+        _run_statusline_action(
+            cast("ClientName", client),
+            source,
+            scope=cast("ClientScope | None", scope),
+            dry_run=dry_run,
+            action="install" if statusline else "remove",
         )
         return
     import importlib.util
@@ -459,3 +496,26 @@ def _run_post_edit_hook_action(
         click.echo(f"Installed archex post-edit hook for {client}: {target}")
     else:
         click.echo(f"Removed archex post-edit hook for {client} (if present): {target}")
+
+
+def _run_statusline_action(
+    client: ClientName,
+    source: str | None,
+    *,
+    scope: ClientScope | None,
+    dry_run: bool,
+    action: HookAction,
+) -> None:
+    try:
+        plan = build_statusline_install_plan(client, source, scope=scope, action=action)
+        if dry_run:
+            click.echo(render_statusline_install_preview(plan), nl=False)
+            return
+        target = write_statusline_install_plan(plan)
+    except (ValueError, OSError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    if action == "install":
+        click.echo(f"Installed archex status line for {client}: {target}")
+        click.echo(f"Renderer: {plan.script_path}")
+    else:
+        click.echo(f"Removed archex status line for {client} (if present): {target}")

--- a/src/archex/cli/status_cmd.py
+++ b/src/archex/cli/status_cmd.py
@@ -1,17 +1,49 @@
-"""Project lifecycle status command."""
+"""Project lifecycle status command.
+
+Two modes over the same subject. The default inspects the index directly --
+authoritative, and the point at which the cached status snapshot (R23) is
+refreshed. `--cached` reads only that snapshot: no index open, no parse, and
+therefore the mode a scripted or repeated caller should use.
+"""
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import click
 
 from archex.status import ProjectStatus, inspect_project_status
+from archex.status_snapshot import (
+    STATUS_SNAPSHOT_VERSION,
+    ReceiptState,
+    StatusState,
+    StatusView,
+    WatchState,
+    clear_snapshot,
+    publish_status,
+    read_status,
+    resolve_status_root,
+    status_snapshot_path,
+)
+
+#: Inspected states that mean the index describes the current working tree.
+_FRESH_STATES = frozenset({"fresh"})
+
+#: Inspected states with no index to describe, where a leftover snapshot would
+#: keep advertising a measurement of something that is gone.
+_UNDESCRIBABLE_STATES = frozenset({"uninitialized", "missing_index", "corrupt"})
 
 
 @click.command("status")
 @click.argument("source", required=False, default=".")
 @click.option("--strict", is_flag=True, default=False, help="Fail unless the index is fresh.")
+@click.option(
+    "--cached",
+    is_flag=True,
+    default=False,
+    help="Read the cached status snapshot only; never opens the index.",
+)
 @click.option(
     "--format",
     "output_format",
@@ -19,12 +51,18 @@ from archex.status import ProjectStatus, inspect_project_status
     type=click.Choice(["text", "json"]),
     help="Output format.",
 )
-def status_cmd(source: str, strict: bool, output_format: str) -> None:
+def status_cmd(source: str, strict: bool, cached: bool, output_format: str) -> None:
     """Inspect repo-local archex project status without indexing."""
+    if cached:
+        _run_cached(source, strict=strict, output_format=output_format)
+        return
+
     try:
         status = inspect_project_status(source)
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
+
+    _refresh_snapshot(status)
 
     if output_format == "json":
         click.echo(json.dumps(_status_payload(status), indent=2, sort_keys=True))
@@ -33,6 +71,45 @@ def status_cmd(source: str, strict: bool, output_format: str) -> None:
 
     if status.state == "corrupt" or (strict and status.state != "fresh"):
         raise click.exceptions.Exit(1)
+
+
+def _run_cached(source: str, *, strict: bool, output_format: str) -> None:
+    """Render the cached snapshot for ``source`` without opening the index."""
+    repo_root = resolve_status_root(source)
+    view = read_status(repo_root)
+
+    if output_format == "json":
+        click.echo(json.dumps(_cached_payload(repo_root, view), indent=2, sort_keys=True))
+    else:
+        _render_cached_text(repo_root, view)
+
+    unusable = view.state in {StatusState.CORRUPT, StatusState.UNSUPPORTED}
+    if unusable or (strict and view.state is not StatusState.FRESH):
+        raise click.exceptions.Exit(1)
+
+
+def _refresh_snapshot(status: ProjectStatus) -> None:
+    """Publish what this inspection just measured, or clear a stale claim.
+
+    `archex status` is the command a user reaches for when a client's status
+    surface looks wrong, so it is also the command that should repair it. It
+    has already opened the index, so republishing costs nothing extra.
+    """
+    if status.state in _UNDESCRIBABLE_STATES:
+        clear_snapshot(status.repo_root)
+        return
+    publish_status(
+        status.repo_root,
+        index_fresh=status.state in _FRESH_STATES,
+        index_revision=status.index_revision,
+        generation_id=status.generation_id,
+        indexed_commit=status.indexed_commit,
+        current_commit=status.current_commit,
+        files_indexed=status.files_indexed,
+        chunks_indexed=status.chunks_indexed,
+        working_tree_dirty=status.working_tree != "clean",
+        reindex_required=status.state == "needs_reindex",
+    )
 
 
 def _status_payload(status: ProjectStatus) -> dict[str, object]:
@@ -48,11 +125,26 @@ def _status_payload(status: ProjectStatus) -> dict[str, object]:
         "chunks_indexed": status.chunks_indexed,
         "languages": status.languages,
         "vector_index_available": status.vector_index_available,
+        "generation_id": status.generation_id,
+        "index_revision": status.index_revision,
         "dogfood_latest_path": (
             str(status.dogfood_latest_path) if status.dogfood_latest_path is not None else ""
         ),
         "error": status.error,
         "metrics_savings": status.metrics_savings,
+    }
+
+
+def _cached_payload(repo_root: Path, view: StatusView) -> dict[str, object]:
+    return {
+        "repo_root": str(repo_root),
+        "snapshot_path": str(status_snapshot_path(repo_root)),
+        "reader_version": STATUS_SNAPSHOT_VERSION,
+        "state": view.state.value,
+        "detail": view.detail,
+        "age_seconds": view.age_seconds,
+        "watch_state": view.watch_state.value,
+        "snapshot": view.snapshot.model_dump(mode="json") if view.snapshot is not None else None,
     }
 
 
@@ -78,3 +170,47 @@ def _render_text(status: ProjectStatus) -> None:
         click.echo(f"Dogfood latest:     {status.dogfood_latest_path}")
     if status.error:
         click.echo(f"Error:              {status.error}")
+
+
+def _render_cached_text(repo_root: Path, view: StatusView) -> None:
+    click.echo(f"Repository:         {repo_root}")
+    click.echo(f"Cached state:       {view.state.value}")
+    if view.detail:
+        click.echo(f"Detail:             {view.detail}")
+    snapshot = view.snapshot
+    if snapshot is None:
+        click.echo(f"Snapshot:           {status_snapshot_path(repo_root)}")
+        click.echo("Remedy:             run `archex index` or `archex status`")
+        return
+    age = "unknown" if view.age_seconds is None else f"{view.age_seconds}s ago"
+    click.echo(f"Measured:           {snapshot.written_at} ({age})")
+    click.echo(f"Index revision:     {snapshot.index_revision or 'none'}")
+    click.echo(f"Indexed commit:     {snapshot.indexed_commit or 'none'}")
+    click.echo(f"Files indexed:      {snapshot.files_indexed}")
+    click.echo(f"Chunks indexed:     {snapshot.chunks_indexed}")
+    click.echo(f"Working tree:       {'dirty' if snapshot.working_tree_dirty else 'clean'}")
+    click.echo(f"Reindex required:   {'yes' if snapshot.reindex_required else 'no'}")
+    pending = f"{snapshot.pending_delta_files}"
+    if not snapshot.pending_view_complete:
+        pending = f"{pending} (incomplete list)"
+    click.echo(f"Pending edits:      {pending}")
+    if snapshot.last_edit_at:
+        edit_source = snapshot.last_edit_client or "unknown client"
+        click.echo(f"Last edit:          {snapshot.last_edit_at} via {edit_source}")
+    click.echo(f"Last sync:          {snapshot.last_successful_sync or 'none'}")
+    click.echo(f"Receipt:            {_receipt_label(snapshot.receipt_state)}")
+    click.echo(f"Watch:              {_watch_label(view.watch_state)}")
+
+
+def _receipt_label(state: ReceiptState) -> str:
+    if state is ReceiptState.COMPLETE:
+        return "complete"
+    if state is ReceiptState.PARTIAL:
+        return "partial (some recorded edits were dropped by a cap)"
+    return "unknown (no persisted generation identity)"
+
+
+def _watch_label(state: WatchState) -> str:
+    if state is WatchState.ACTIVE:
+        return "active (a watch refresh was observed recently)"
+    return "unobserved (no recent watch refresh; a watcher may still be idle)"

--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,6 +16,13 @@ from archex.integrations.hook import HOOK_MATCHER
 from archex.integrations.mcp import resolve_tool_scope
 from archex.integrations.post_edit_hook import POST_EDIT_MATCHER
 from archex.integrations.session_hook import SESSION_START_MATCHER
+from archex.project import PROJECT_DIR_NAME
+from archex.status_snapshot import (
+    DEFAULT_STALE_AFTER_SECONDS,
+    SNAPSHOT_FILENAME,
+    STATUS_SNAPSHOT_VERSION,
+    WATCH_OBSERVATION_TTL_SECONDS,
+)
 
 ClientName = Literal["claude-code", "codex", "cursor", "opencode", "pi", "omp"]
 ClientScope = Literal["project", "user"]
@@ -2455,4 +2463,514 @@ export const ArchexPostEditPlugin: Plugin = async ({ directory }) => {
 };
 
 export default ArchexPostEditPlugin;
+"""
+
+
+# ---------------------------------------------------------------------------
+# Persistent status surfaces (R23)
+# ---------------------------------------------------------------------------
+
+#: Filename of the installed Claude Code status-line renderer. Doubles as the
+#: ownership marker: ``statusLine`` is a single settings key rather than a
+#: list, so install and remove only ever touch an entry whose command
+#: references this filename. Any other configured status line is a user's own
+#: and is refused rather than replaced.
+STATUSLINE_SCRIPT_FILENAME = "archex-statusline.sh"
+
+#: Marker comment inside the script, so an installed file is identifiable as
+#: archex-owned even after it is moved or copied.
+STATUSLINE_SCRIPT_MARKER = "archex:statusline"
+
+#: How often Claude Code re-runs the command in addition to its event-driven
+#: repaints. The renderer's freshness and age segments are time-based, so
+#: without a timer a snapshot would appear fresh through an idle session.
+STATUSLINE_REFRESH_INTERVAL_SECONDS = 10
+
+
+@dataclass(frozen=True)
+class ClaudeCodeStatuslineInstallPlan:
+    """Install or remove the Claude Code status-line renderer (R23).
+
+    Two artifacts, one plan: the renderer script beside the client's other
+    archex-owned files, and the ``statusLine`` entry in the same
+    ``settings.json`` the hook installers merge into.
+    """
+
+    client: ClientName
+    scope: ClientScope
+    target_path: Path
+    script_path: Path
+    action: HookAction
+    script_content: str
+    statusline_entry: dict[str, object]
+
+
+def build_statusline_install_plan(
+    client: ClientName,
+    source: str | Path | None = None,
+    *,
+    scope: ClientScope | None = None,
+    action: HookAction,
+) -> ClaudeCodeStatuslineInstallPlan:
+    """Build a status-line plan, refusing clients with no such surface."""
+    if client != "claude-code":
+        message = (
+            f"status-line installation is implemented for claude-code; got {client}. "
+            "Run `archex status --cached` for a client without a persistent status surface."
+        )
+        raise ValueError(message)
+    repo_root = Path(source if source is not None else ".").expanduser().resolve()
+    selected_scope = _resolve_hook_scope(source, scope)
+    script_path = _statusline_script_path(repo_root, selected_scope)
+    return ClaudeCodeStatuslineInstallPlan(
+        client=client,
+        scope=selected_scope,
+        target_path=_hook_settings_path(repo_root, selected_scope),
+        script_path=script_path,
+        action=action,
+        script_content=render_statusline_script(),
+        statusline_entry=_render_statusline_entry(script_path),
+    )
+
+
+def write_statusline_install_plan(plan: ClaudeCodeStatuslineInstallPlan) -> Path:
+    """Apply a status-line plan, leaving unrelated configuration intact."""
+    target = plan.target_path
+    existing = _read_json_object(target) if target.exists() else {}
+    # Decided before anything is written: a foreign status line raises here,
+    # and a refused install must leave no renderer script behind.
+    updated, changed = _apply_statusline_action(existing, plan)
+
+    if plan.action == "install":
+        plan.script_path.parent.mkdir(parents=True, exist_ok=True)
+        existing_script = (
+            plan.script_path.read_text(encoding="utf-8") if plan.script_path.exists() else None
+        )
+        if existing_script != plan.script_content:
+            plan.script_path.write_text(plan.script_content, encoding="utf-8")
+        plan.script_path.chmod(0o755)
+    elif plan.script_path.exists() and _is_archex_statusline_script(plan.script_path):
+        plan.script_path.unlink()
+
+    if not changed:
+        return target
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(updated, indent=2) + "\n", encoding="utf-8")
+    return target
+
+
+def render_statusline_install_preview(plan: ClaudeCodeStatuslineInstallPlan) -> str:
+    """Render a no-write preview of exactly what the plan would change."""
+    action_label = "Install" if plan.action == "install" else "Remove"
+    existing = _read_json_object(plan.target_path) if plan.target_path.exists() else {}
+    updated, changed = _apply_statusline_action(existing, plan)
+    lines = [
+        f"Client: {plan.client}",
+        f"Scope: {plan.scope}",
+        f"Target: {plan.target_path}",
+        f"Renderer: {plan.script_path}",
+        f"Action: {action_label} statusLine command",
+    ]
+    if not changed:
+        lines.append(
+            "No change: status line already in the requested state (idempotent no-op)."
+            if plan.action == "install"
+            else "No change: no archex status line is installed."
+        )
+    else:
+        lines.append("Dry run. Re-run without --dry-run to write this config.")
+    body = json.dumps(updated, indent=2)
+    return "\n".join([*lines, "", body]).rstrip("\n") + "\n"
+
+
+def _statusline_script_path(repo_root: Path, scope: ClientScope) -> Path:
+    return (
+        repo_root / ".claude" / STATUSLINE_SCRIPT_FILENAME
+        if scope == "project"
+        else Path.home() / ".claude" / STATUSLINE_SCRIPT_FILENAME
+    )
+
+
+def statusline_interpreter() -> str:
+    """Shell to run the renderer with, preferring one that can read a clock.
+
+    The renderer reports `stale` and an age only when the shell exposes a
+    builtin clock, because forking `date` on every repaint is what R23
+    excludes. `sh` is bash 3.2 on macOS and dash on many Linux images, and
+    neither has one -- so the interpreter is chosen at install time from the
+    shells present on the host, and `sh` remains the fallback. Probing costs
+    one subprocess per install, never per repaint.
+    """
+    for candidate, probe in (
+        ("/bin/zsh", "zmodload zsh/datetime 2>/dev/null; echo ${EPOCHSECONDS:-}"),
+        ("/opt/homebrew/bin/bash", "echo ${EPOCHSECONDS:-}"),
+        ("/usr/local/bin/bash", "echo ${EPOCHSECONDS:-}"),
+        ("/bin/bash", "echo ${EPOCHSECONDS:-}"),
+    ):
+        if not Path(candidate).exists():
+            continue
+        try:
+            result = subprocess.run(  # noqa: S603 - fixed argv, absolute path
+                [candidate, "-c", probe],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if result.stdout.strip().isdigit():
+            return candidate
+    return "sh"
+
+
+def _render_statusline_entry(script_path: Path) -> dict[str, object]:
+    # The path is quoted rather than interpolated bare: a home or repository
+    # directory containing a space would otherwise split into two arguments.
+    # Invoking through an interpreter also keeps the entry working if the
+    # executable bit is lost (a copied dotfiles tree, a restored backup).
+    return {
+        "type": "command",
+        "command": f'{statusline_interpreter()} "{script_path}"',
+        "padding": 0,
+        "refreshInterval": STATUSLINE_REFRESH_INTERVAL_SECONDS,
+    }
+
+
+def _is_archex_statusline(entry: object) -> bool:
+    """Whether a configured ``statusLine`` value is the archex-owned one."""
+    if not isinstance(entry, dict):
+        return False
+    command = cast("dict[str, object]", entry).get("command")
+    return isinstance(command, str) and STATUSLINE_SCRIPT_FILENAME in command
+
+
+def _is_archex_statusline_script(path: Path) -> bool:
+    """Whether the file at ``path`` is an archex-owned renderer script."""
+    try:
+        return STATUSLINE_SCRIPT_MARKER in path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
+def _apply_statusline_action(
+    payload: dict[str, object], plan: ClaudeCodeStatuslineInstallPlan
+) -> tuple[dict[str, object], bool]:
+    """Return ``(updated_payload, changed)`` without mutating ``payload``.
+
+    ``statusLine`` is a scalar key, so there is no matcher group to merge
+    into and no way to coexist with another status line. A foreign entry is
+    therefore refused rather than replaced -- the same rule the MCP installer
+    applies to a foreign ``archex`` server entry -- and remove leaves a
+    foreign entry alone.
+    """
+    existing = payload.get("statusLine")
+    if plan.action == "remove":
+        if existing is None or not _is_archex_statusline(existing):
+            return payload, False
+        updated = copy.deepcopy(payload)
+        del updated["statusLine"]
+        return updated, True
+    if existing is not None and not _is_archex_statusline(existing):
+        message = (
+            f"{plan.target_path} already configures a different statusLine command. "
+            "Remove it first, or install into the other scope; archex will not overwrite it."
+        )
+        raise ValueError(message)
+    if existing == plan.statusline_entry:
+        return payload, False
+    updated = copy.deepcopy(payload)
+    updated["statusLine"] = plan.statusline_entry
+    return updated, True
+
+
+def render_statusline_script() -> str:
+    """Render the status-line script with the snapshot contract baked in."""
+    return (
+        _STATUSLINE_SCRIPT_TEMPLATE.replace(
+            "__ARCHEX_SNAPSHOT_VERSION__", str(STATUS_SNAPSHOT_VERSION)
+        )
+        .replace("__ARCHEX_STALE_DEFAULT__", str(DEFAULT_STALE_AFTER_SECONDS))
+        .replace("__ARCHEX_WATCH_TTL__", str(WATCH_OBSERVATION_TTL_SECONDS))
+        .replace("__ARCHEX_SNAPSHOT_RELATIVE_PATH__", f"{PROJECT_DIR_NAME}/{SNAPSHOT_FILENAME}")
+    )
+
+
+_STATUSLINE_SCRIPT_TEMPLATE = r"""#!/bin/sh
+# archex:statusline - Claude Code status line renderer (R23).
+#
+# Installed by `archex install-client claude-code --statusline`, removed by
+# `--remove-statusline`. Renders the bounded status snapshot archex publishes
+# at <repo>/__ARCHEX_SNAPSHOT_RELATIVE_PATH__.
+#
+# Claude Code re-runs this command on every repaint (debounced at 300ms, and
+# it cancels an in-flight script when a new update arrives), so the renderer
+# uses shell builtins exclusively: no `jq`, no `python`, no `date`, no
+# `archex`, and no command substitution anywhere. It therefore forks no
+# process, opens no index, and parses no source. The test suite proves that
+# by running it with an empty PATH.
+#
+# Snapshot version this renderer understands: __ARCHEX_SNAPSHOT_VERSION__.
+# A different version prints `unsupported` rather than guessing at fields.
+
+set -u
+
+archex_version_supported=__ARCHEX_SNAPSHOT_VERSION__
+archex_stale_default=__ARCHEX_STALE_DEFAULT__
+archex_watch_ttl=__ARCHEX_WATCH_TTL__
+
+# --- Locate the snapshot ----------------------------------------------------
+# Claude Code writes one line of session JSON to stdin, carrying the session
+# directory as "cwd". Extracting it by parameter expansion avoids a JSON
+# parser; an unreadable payload falls back to the process working directory,
+# and the upward walk then handles being started in a subdirectory.
+payload=""
+IFS= read -r payload 2>/dev/null || :
+
+archex_dir=""
+case $payload in
+*'"cwd":'*)
+	archex_rest=${payload#*'"cwd":'}
+	while :; do
+		case $archex_rest in
+		' '*) archex_rest=${archex_rest# } ;;
+		*) break ;;
+		esac
+	done
+	case $archex_rest in
+	'"'*)
+		archex_rest=${archex_rest#\"}
+		archex_dir=${archex_rest%%\"*}
+		;;
+	esac
+	;;
+esac
+# Only an absolute, existing directory is trusted. A payload whose earlier
+# values happen to contain the literal `"cwd":` text, or a relative or
+# nonexistent path, falls back to the process working directory rather than
+# steering the walk below somewhere else.
+case $archex_dir in
+/*) ;;
+*) archex_dir="" ;;
+esac
+if [ -z "$archex_dir" ] || [ ! -d "$archex_dir" ]; then
+	archex_dir=$PWD
+fi
+
+archex_snapshot=${ARCHEX_STATUS_SNAPSHOT:-}
+if [ -z "$archex_snapshot" ]; then
+	archex_probe=$archex_dir
+	while [ -n "$archex_probe" ]; do
+		if [ -f "$archex_probe/__ARCHEX_SNAPSHOT_RELATIVE_PATH__" ]; then
+			archex_snapshot="$archex_probe/__ARCHEX_SNAPSHOT_RELATIVE_PATH__"
+			break
+		fi
+		case $archex_probe in
+		*/?*) archex_probe=${archex_probe%/*} ;;
+		*) archex_probe="" ;;
+		esac
+	done
+fi
+
+if [ -z "$archex_snapshot" ] || [ ! -f "$archex_snapshot" ]; then
+	printf 'archex missing - no status snapshot - run: archex index\n'
+	exit 0
+fi
+
+# --- Read it ----------------------------------------------------------------
+# The document is written with sorted keys and two-space indentation, so every
+# scalar occupies one line as `  "key": value,`. Splitting that with
+# parameter expansion is exact for this writer and degrades to an empty field
+# (hence `corrupt`) for anything else.
+archex_field_version=""
+archex_field_state=""
+archex_field_revision=""
+archex_field_files=0
+archex_field_chunks=0
+archex_field_pending=0
+archex_field_pending_complete=""
+archex_field_reindex=""
+archex_field_epoch=0
+archex_field_watch_epoch=0
+
+archex_line=""
+while IFS= read -r archex_line || [ -n "$archex_line" ]; do
+	case $archex_line in
+	*'": '*) ;;
+	*) continue ;;
+	esac
+	archex_key=${archex_line#*\"}
+	archex_key=${archex_key%%\"*}
+	archex_value=${archex_line#*\": }
+	archex_value=${archex_value%,}
+	case $archex_value in
+	\"*\")
+		archex_value=${archex_value#\"}
+		archex_value=${archex_value%\"}
+		;;
+	esac
+	case $archex_key in
+	version) archex_field_version=$archex_value ;;
+	state) archex_field_state=$archex_value ;;
+	index_revision) archex_field_revision=$archex_value ;;
+	files_indexed) archex_field_files=$archex_value ;;
+	chunks_indexed) archex_field_chunks=$archex_value ;;
+	pending_delta_files) archex_field_pending=$archex_value ;;
+	pending_view_complete) archex_field_pending_complete=$archex_value ;;
+	reindex_required) archex_field_reindex=$archex_value ;;
+	written_at_epoch) archex_field_epoch=$archex_value ;;
+	watch_observed_epoch) archex_field_watch_epoch=$archex_value ;;
+	esac
+done < "$archex_snapshot"
+
+# Numeric fields are normalized before any arithmetic. Non-digits become 0,
+# and a leading zero is stripped: POSIX arithmetic reads `08` as octal and
+# aborts the whole script on the invalid digit, which would replace a
+# `corrupt` line with an error on stderr and no status at all.
+for archex_numeric in files chunks pending epoch watch_epoch; do
+	case $archex_numeric in
+	files) archex_probe_value=$archex_field_files ;;
+	chunks) archex_probe_value=$archex_field_chunks ;;
+	pending) archex_probe_value=$archex_field_pending ;;
+	epoch) archex_probe_value=$archex_field_epoch ;;
+	*) archex_probe_value=$archex_field_watch_epoch ;;
+	esac
+	case $archex_probe_value in
+	'' | *[!0-9]*) archex_probe_value=0 ;;
+	*)
+		while :; do
+			case $archex_probe_value in
+			0?*) archex_probe_value=${archex_probe_value#0} ;;
+			*) break ;;
+			esac
+		done
+		;;
+	esac
+	case $archex_numeric in
+	files) archex_field_files=$archex_probe_value ;;
+	chunks) archex_field_chunks=$archex_probe_value ;;
+	pending) archex_field_pending=$archex_probe_value ;;
+	epoch) archex_field_epoch=$archex_probe_value ;;
+	*) archex_field_watch_epoch=$archex_probe_value ;;
+	esac
+done
+
+# --- Classify ---------------------------------------------------------------
+# `corrupt` and `unsupported` are deliberately separate: a document that is
+# unparsable or carries no usable version needs re-publishing, while a
+# document from a schema this build does not read needs an archex upgrade.
+# The Python reader and the omp/Pi module classify identically.
+case $archex_field_version in
+'' | *[!0-9]*)
+	printf 'archex corrupt - unreadable snapshot - run: archex status\n'
+	exit 0
+	;;
+esac
+if [ "$archex_field_version" != "$archex_version_supported" ]; then
+	printf 'archex unsupported - snapshot v%s - upgrade archex\n' "$archex_field_version"
+	exit 0
+fi
+case $archex_field_state in
+fresh | dirty | pending) ;;
+*)
+	printf 'archex corrupt - unreadable snapshot - run: archex status\n'
+	exit 0
+	;;
+esac
+
+# `EPOCHSECONDS` is a shell builtin variable in bash 5+ and zsh, and absent in
+# dash and bash 3.2 (macOS `/bin/sh`). Where it is absent this renderer has no
+# clock it can read without forking `date`, so it reports the measured state
+# and its measurement time and leaves the `stale` judgement to
+# `archex status --cached`, which has a clock. Paying a fork on every repaint
+# to gain one label is the wrong trade.
+if [ -n "${ZSH_VERSION:-}" ]; then
+	# `zmodload` is a zsh builtin, so this costs no process. Guarded on
+	# ZSH_VERSION because under sh/dash the word would be an external
+	# command, which is exactly what this renderer refuses to launch.
+	zmodload zsh/datetime 2>/dev/null || :
+fi
+archex_now=${EPOCHSECONDS:-}
+case $archex_now in
+'' | *[!0-9]*) archex_now="" ;;
+esac
+
+archex_age=""
+if [ -n "$archex_now" ] && [ "$archex_field_epoch" -gt 0 ]; then
+	archex_age=$((archex_now - archex_field_epoch))
+	if [ "$archex_age" -lt 0 ]; then
+		archex_age=0
+	fi
+fi
+
+archex_budget=${ARCHEX_STATUS_STALE_AFTER_SECONDS:-$archex_stale_default}
+case $archex_budget in
+'' | *[!0-9]*) archex_budget=$archex_stale_default ;;
+esac
+if [ -n "$archex_age" ] && [ "$archex_age" -gt "$archex_budget" ]; then
+	archex_field_state=stale
+fi
+
+archex_watch=""
+if [ -n "$archex_now" ] && [ "$archex_field_watch_epoch" -gt 0 ]; then
+	if [ $((archex_now - archex_field_watch_epoch)) -le "$archex_watch_ttl" ]; then
+		archex_watch=" - watch"
+	fi
+fi
+
+# --- Render -----------------------------------------------------------------
+archex_detail=""
+case $archex_field_state in
+fresh) archex_detail=" - $archex_field_files files, $archex_field_chunks chunks" ;;
+pending)
+	# The model's field defaults to true, so an absent field means a complete
+	# view here too; only an explicit `false` marks the count as a lower bound.
+	if [ "$archex_field_pending_complete" = "false" ]; then
+		archex_detail=" - $archex_field_pending+ awaiting sync"
+	else
+		archex_detail=" - $archex_field_pending awaiting sync"
+	fi
+	;;
+dirty)
+	if [ "$archex_field_reindex" = "true" ]; then
+		archex_detail=" - reindex required"
+	else
+		archex_detail=" - index behind tree"
+	fi
+	;;
+stale) archex_detail=" - unverified since measurement" ;;
+esac
+
+archex_revision_segment=""
+if [ -n "$archex_field_revision" ]; then
+	archex_revision_short=$archex_field_revision
+	# Trim to the first eight characters, but only when there are more than
+	# eight: for a shorter value the `????????` pattern does not match and the
+	# suffix trim would collapse the whole string to empty.
+	case $archex_field_revision in
+	?????????*)
+		archex_revision_tail=${archex_field_revision#????????}
+		archex_revision_short=${archex_field_revision%"$archex_revision_tail"}
+		;;
+	esac
+	archex_revision_segment=" - rev $archex_revision_short"
+fi
+
+archex_age_segment=""
+if [ -n "$archex_age" ]; then
+	if [ "$archex_age" -lt 60 ]; then
+		archex_age_segment=" - ${archex_age}s ago"
+	elif [ "$archex_age" -lt 3600 ]; then
+		archex_age_segment=" - $((archex_age / 60))m ago"
+	else
+		archex_age_segment=" - $((archex_age / 3600))h ago"
+	fi
+fi
+
+printf 'archex %s%s%s%s%s\n' \
+	"$archex_field_state" \
+	"$archex_detail" \
+	"$archex_revision_segment" \
+	"$archex_age_segment" \
+	"$archex_watch"
 """

--- a/src/archex/status.py
+++ b/src/archex/status.py
@@ -12,6 +12,8 @@ from archex.index.delta import compute_working_tree_signature
 from archex.index.store import IndexStore
 from archex.metrics.storage import MetricsStore, metrics_db_path
 from archex.project import ProjectState
+from archex.receipt import index_revision_from_store
+from archex.serve.generation import read_generation_id
 
 
 @dataclass(frozen=True)
@@ -31,6 +33,12 @@ class ProjectStatus:
     dogfood_latest_path: Path | None = None
     error: str = ""
     metrics_savings: dict[str, int | float] | None = None
+    #: Persisted generation identity and index revision of the inspected
+    #: store, empty when there is no readable index. Carried so a caller can
+    #: refresh the cached status snapshot (R23) with the same receipt fields
+    #: indexing publishes, instead of downgrading it to "unknown".
+    generation_id: str = ""
+    index_revision: str = ""
 
 
 def inspect_project_status(source: str | Path) -> ProjectStatus:
@@ -105,6 +113,8 @@ def inspect_project_status(source: str | Path) -> ProjectStatus:
         languages = _language_counts(store.get_file_metadata())
         chunks_fts = store.get_fts_chunk_count()
         needs_reindex = store.needs_reindex()
+        generation_id = read_generation_id(store) or ""
+        index_revision = index_revision_from_store(store)
     except Exception as exc:
         return ProjectStatus(
             repo_root=project.repo_root,
@@ -149,6 +159,8 @@ def inspect_project_status(source: str | Path) -> ProjectStatus:
         vector_index_available=_vector_index_available(project),
         dogfood_latest_path=dogfood_latest if dogfood_latest.exists() else None,
         metrics_savings=_metrics_savings(project.repo_root),
+        generation_id=generation_id,
+        index_revision=index_revision,
     )
 
 

--- a/src/archex/status_snapshot.py
+++ b/src/archex/status_snapshot.py
@@ -259,6 +259,25 @@ def project_repo_root(cache_dir: str | Path) -> Path | None:
     return root if ProjectState(repo_root=root).initialized() else None
 
 
+def resolve_status_root(source: str | Path) -> Path:
+    """Repository root whose snapshot describes ``source``.
+
+    A renderer is usually started somewhere inside a repository rather than at
+    its root, so it walks up to the nearest published snapshot. The shell and
+    TypeScript renderers do the same walk, so all three surfaces answer for
+    the same document. Falls back to the resolved source when no snapshot is
+    found, which then reads as ``missing`` at the place the caller named.
+
+    Deliberately not a `git rev-parse`: a renderer must stay subprocess-free,
+    and an upward walk is what the other two renderers can do.
+    """
+    start = Path(source).expanduser().resolve()
+    for candidate in (start, *start.parents):
+        if (candidate / PROJECT_DIR_NAME / SNAPSHOT_FILENAME).is_file():
+            return candidate
+    return start
+
+
 def pending_after_measurement(*, edit_state: PostEditState, index_measured_at: str) -> bool:
     """Whether recorded edits are newer than the last index measurement.
 

--- a/tests/cli/test_install_client_statusline.py
+++ b/tests/cli/test_install_client_statusline.py
@@ -1,0 +1,260 @@
+"""`install-client --statusline` contract (R23).
+
+`statusLine` is a scalar settings key, not a matcher group, so unlike the hook
+installers there is no way to coexist with another status line. These tests
+pin the consequences: a foreign status line is refused rather than replaced,
+removal only touches archex's own entry, and the surface installs and removes
+independently of the three hook surfaces that share `settings.json`.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+from archex.client_setup import (
+    STATUSLINE_SCRIPT_FILENAME,
+    STATUSLINE_SCRIPT_MARKER,
+    build_hook_install_plan,
+    build_statusline_install_plan,
+    render_statusline_install_preview,
+    statusline_interpreter,
+    write_hook_install_plan,
+    write_statusline_install_plan,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def _settings(repo: Path) -> Path:
+    return repo / ".claude" / "settings.json"
+
+
+def _script(repo: Path) -> Path:
+    return repo / ".claude" / STATUSLINE_SCRIPT_FILENAME
+
+
+def _install(repo: Path) -> Path:
+    plan = build_statusline_install_plan("claude-code", repo, scope="project", action="install")
+    return write_statusline_install_plan(plan)
+
+
+def _remove(repo: Path) -> Path:
+    plan = build_statusline_install_plan("claude-code", repo, scope="project", action="remove")
+    return write_statusline_install_plan(plan)
+
+
+def test_install_writes_the_renderer_and_an_owned_statusline_entry(tmp_path: Path) -> None:
+    target = _install(tmp_path)
+
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    entry = payload["statusLine"]
+    assert entry["type"] == "command"
+    assert STATUSLINE_SCRIPT_FILENAME in entry["command"]
+    assert str(_script(tmp_path)) in entry["command"]
+    script = _script(tmp_path)
+    assert script.exists()
+    assert STATUSLINE_SCRIPT_MARKER in script.read_text(encoding="utf-8")
+    assert script.stat().st_mode & 0o111
+
+
+def test_installed_command_quotes_a_path_containing_spaces(tmp_path: Path) -> None:
+    repo = tmp_path / "my repo"
+    repo.mkdir()
+
+    target = _install(repo)
+
+    entry = json.loads(target.read_text(encoding="utf-8"))["statusLine"]
+    script = repo / ".claude" / STATUSLINE_SCRIPT_FILENAME
+    assert entry["command"] == f'{statusline_interpreter()} "{script}"'
+
+
+def test_installed_interpreter_can_read_a_clock_when_the_host_has_one() -> None:
+    interpreter = statusline_interpreter()
+
+    if interpreter != "sh":
+        probe = subprocess.run(
+            [interpreter, "-c", "zmodload zsh/datetime 2>/dev/null; echo ${EPOCHSECONDS:-}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        assert probe.stdout.strip().isdigit(), "a chosen interpreter must expose a clock"
+
+
+def test_a_refused_install_leaves_no_renderer_script(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    settings.parent.mkdir(parents=True)
+    settings.write_text(
+        json.dumps({"statusLine": {"type": "command", "command": "~/.claude/mine.sh"}}),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        cli, ["install-client", "claude-code", str(tmp_path), "--scope", "project", "--statusline"]
+    )
+
+    assert result.exit_code != 0
+    assert not _script(tmp_path).exists(), "a refused install must write nothing"
+
+
+def test_reinstall_is_an_idempotent_no_op(tmp_path: Path) -> None:
+    target = _install(tmp_path)
+    first = target.read_text(encoding="utf-8")
+
+    _install(tmp_path)
+
+    assert target.read_text(encoding="utf-8") == first
+
+
+def test_install_preserves_unrelated_settings(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    settings.parent.mkdir(parents=True)
+    settings.write_text(
+        json.dumps({"model": "opus", "permissions": {"allow": ["Read"]}}), encoding="utf-8"
+    )
+
+    _install(tmp_path)
+
+    payload = json.loads(settings.read_text(encoding="utf-8"))
+    assert payload["model"] == "opus"
+    assert payload["permissions"] == {"allow": ["Read"]}
+    assert "statusLine" in payload
+
+
+def test_a_foreign_statusline_is_refused_rather_than_replaced(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    settings.parent.mkdir(parents=True)
+    foreign = {"type": "command", "command": "~/.claude/my-own-statusline.sh"}
+    settings.write_text(json.dumps({"statusLine": foreign}), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        cli, ["install-client", "claude-code", str(tmp_path), "--scope", "project", "--statusline"]
+    )
+
+    assert result.exit_code != 0
+    assert "will not overwrite" in result.output
+    assert json.loads(settings.read_text(encoding="utf-8"))["statusLine"] == foreign
+
+
+def test_remove_deletes_the_entry_and_the_renderer(tmp_path: Path) -> None:
+    _install(tmp_path)
+
+    target = _remove(tmp_path)
+
+    assert "statusLine" not in json.loads(target.read_text(encoding="utf-8"))
+    assert not _script(tmp_path).exists()
+
+
+def test_remove_leaves_a_foreign_statusline_and_script_alone(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    settings.parent.mkdir(parents=True)
+    foreign = {"type": "command", "command": "~/.claude/my-own-statusline.sh"}
+    settings.write_text(json.dumps({"statusLine": foreign}), encoding="utf-8")
+    unowned_script = _script(tmp_path)
+    unowned_script.write_text("#!/bin/sh\necho mine\n", encoding="utf-8")
+
+    _remove(tmp_path)
+
+    assert json.loads(settings.read_text(encoding="utf-8"))["statusLine"] == foreign
+    assert unowned_script.read_text(encoding="utf-8") == "#!/bin/sh\necho mine\n"
+
+
+def test_remove_without_an_install_is_a_no_op(tmp_path: Path) -> None:
+    target = _remove(tmp_path)
+
+    assert not target.exists()
+    assert not _script(tmp_path).exists()
+
+
+def test_dry_run_previews_the_entry_without_writing(tmp_path: Path) -> None:
+    plan = build_statusline_install_plan("claude-code", tmp_path, scope="project", action="install")
+
+    preview = render_statusline_install_preview(plan)
+
+    assert "Dry run" in preview
+    assert STATUSLINE_SCRIPT_FILENAME in preview
+    assert not _settings(tmp_path).exists()
+    assert not _script(tmp_path).exists()
+
+
+def test_statusline_and_search_hook_install_independently(tmp_path: Path) -> None:
+    write_hook_install_plan(
+        build_hook_install_plan("claude-code", tmp_path, scope="project", action="install")
+    )
+
+    _install(tmp_path)
+    payload = json.loads(_settings(tmp_path).read_text(encoding="utf-8"))
+    assert "statusLine" in payload
+    assert payload["hooks"]["PreToolUse"]
+
+    _remove(tmp_path)
+    after = json.loads(_settings(tmp_path).read_text(encoding="utf-8"))
+    assert "statusLine" not in after
+    assert after["hooks"]["PreToolUse"], "removing the status line must not disturb hooks"
+
+
+def test_clients_without_a_persistent_status_surface_are_refused(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        cli, ["install-client", "codex", str(tmp_path), "--scope", "project", "--statusline"]
+    )
+
+    assert result.exit_code != 0
+    assert "claude-code" in result.output
+
+
+def test_statusline_cannot_be_combined_with_another_surface(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        cli,
+        [
+            "install-client",
+            "claude-code",
+            str(tmp_path),
+            "--scope",
+            "project",
+            "--statusline",
+            "--hooks",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "separately" in result.output
+
+
+def test_install_and_remove_are_mutually_exclusive(tmp_path: Path) -> None:
+    result = CliRunner().invoke(
+        cli,
+        [
+            "install-client",
+            "claude-code",
+            str(tmp_path),
+            "--scope",
+            "project",
+            "--statusline",
+            "--remove-statusline",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+def test_cli_install_reports_both_artifacts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(
+        cli, ["install-client", "claude-code", ".", "--scope", "project", "--statusline"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Installed archex status line for claude-code" in result.output
+    assert STATUSLINE_SCRIPT_FILENAME in result.output

--- a/tests/cli/test_status_cached.py
+++ b/tests/cli/test_status_cached.py
@@ -1,0 +1,218 @@
+"""`archex status --cached` contract (R23).
+
+The default mode is authoritative and refreshes the cached snapshot; `--cached`
+reads only that snapshot. These tests pin the split: the cached mode never
+opens the index, it distinguishes every state the snapshot can be in, and the
+authoritative mode keeps the cache honest -- including clearing it when there
+is no longer an index to describe.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+from archex.project import init_project
+from archex.status_snapshot import (
+    STATUS_SNAPSHOT_VERSION,
+    SnapshotState,
+    StatusSnapshot,
+    publish_status,
+    read_status,
+    stale_after_seconds,
+    status_snapshot_path,
+    utc_now_iso,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+_NOW = 1_800_000_000.0
+
+
+def _publish(repo: Path, *, now: float = _NOW, index_fresh: bool = True) -> None:
+    publish_status(
+        repo,
+        index_fresh=index_fresh,
+        index_revision="abc1234",
+        generation_id="f" * 64,
+        indexed_commit="c" * 40,
+        current_commit="c" * 40,
+        files_indexed=42,
+        chunks_indexed=99,
+        now=now,
+    )
+
+
+def _write_raw(repo: Path, payload: object) -> None:
+    path = status_snapshot_path(repo)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_cached_text_reports_the_measurement(python_simple_repo: Path) -> None:
+    init_project(python_simple_repo)
+    _publish(python_simple_repo)
+
+    result = CliRunner().invoke(cli, ["status", str(python_simple_repo), "--cached"])
+
+    assert result.exit_code == 0, result.output
+    assert "Cached state:       fresh" in result.output
+    assert "Files indexed:      42" in result.output
+    assert "Receipt:            complete" in result.output
+
+
+def test_cached_json_carries_the_state_and_the_whole_snapshot(python_simple_repo: Path) -> None:
+    init_project(python_simple_repo)
+    _publish(python_simple_repo)
+
+    result = CliRunner().invoke(
+        cli, ["status", str(python_simple_repo), "--cached", "--format", "json"]
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["state"] == "fresh"
+    assert payload["reader_version"] == STATUS_SNAPSHOT_VERSION
+    assert payload["snapshot"]["generation_id"] == "f" * 64
+    assert payload["snapshot_path"].endswith("status-snapshot.json")
+
+
+def test_cached_mode_reports_missing_without_failing(python_simple_repo: Path) -> None:
+    init_project(python_simple_repo)
+
+    result = CliRunner().invoke(cli, ["status", str(python_simple_repo), "--cached"])
+
+    assert result.exit_code == 0, result.output
+    assert "Cached state:       missing" in result.output
+    assert "archex index" in result.output
+
+
+def test_strict_cached_mode_fails_when_the_state_is_not_fresh(python_simple_repo: Path) -> None:
+    init_project(python_simple_repo)
+
+    result = CliRunner().invoke(cli, ["status", str(python_simple_repo), "--cached", "--strict"])
+
+    assert result.exit_code == 1
+
+
+def test_corrupt_snapshot_fails_the_cached_command(python_simple_repo: Path) -> None:
+    init_project(python_simple_repo)
+    path = status_snapshot_path(python_simple_repo)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+
+    result = CliRunner().invoke(cli, ["status", str(python_simple_repo), "--cached"])
+
+    assert result.exit_code == 1
+    assert "Cached state:       corrupt" in result.output
+
+
+def test_unsupported_version_fails_and_names_the_remedy(python_simple_repo: Path) -> None:
+    init_project(python_simple_repo)
+    _write_raw(
+        python_simple_repo,
+        {"version": STATUS_SNAPSHOT_VERSION + 1, "state": "fresh"},
+    )
+
+    result = CliRunner().invoke(cli, ["status", str(python_simple_repo), "--cached"])
+
+    assert result.exit_code == 1
+    assert "Cached state:       unsupported" in result.output
+    assert str(STATUS_SNAPSHOT_VERSION + 1) in result.output
+
+
+def test_old_measurement_reports_stale_with_its_age(python_simple_repo: Path) -> None:
+    init_project(python_simple_repo)
+    # The command reads the real clock, so the fixture is dated against it.
+    stale_epoch = int(time.time()) - stale_after_seconds() - 60
+    snapshot = StatusSnapshot(
+        state=SnapshotState.FRESH,
+        written_at=utc_now_iso(stale_epoch),
+        written_at_epoch=stale_epoch,
+        index_measured_at=utc_now_iso(stale_epoch),
+        files_indexed=42,
+    )
+    _write_raw(python_simple_repo, snapshot.model_dump(mode="json"))
+
+    result = CliRunner().invoke(cli, ["status", str(python_simple_repo), "--cached"])
+
+    assert "Cached state:       stale" in result.output
+    assert "freshness budget" in result.output
+    # A stale snapshot still shows its last known measurement, labelled old.
+    assert "Files indexed:      42" in result.output
+
+
+def test_cached_mode_reads_the_snapshot_from_a_subdirectory(python_simple_repo: Path) -> None:
+    init_project(python_simple_repo)
+    _publish(python_simple_repo)
+    nested = python_simple_repo / "src" / "pkg"
+    nested.mkdir(parents=True, exist_ok=True)
+
+    result = CliRunner().invoke(cli, ["status", str(nested), "--cached"])
+
+    # The shell and TypeScript renderers walk up to the nearest snapshot; the
+    # CLI reader must answer for the same document rather than reporting
+    # `missing` because it was invoked below the root.
+    assert result.exit_code == 0, result.output
+    assert "Cached state:       fresh" in result.output
+
+
+def test_cached_mode_outside_any_repository_reports_missing(tmp_path: Path) -> None:
+    result = CliRunner().invoke(cli, ["status", str(tmp_path), "--cached"])
+
+    assert "Cached state:       missing" in result.output
+
+
+def test_cached_mode_opens_no_index(
+    python_simple_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    init_project(python_simple_repo)
+    _publish(python_simple_repo)
+    from archex.index.store import IndexStore
+
+    def _forbidden(*_args: object, **_kwargs: object) -> object:
+        message = "--cached must not open the index"
+        raise AssertionError(message)
+
+    monkeypatch.setattr(IndexStore, "__init__", _forbidden)
+
+    result = CliRunner().invoke(cli, ["status", str(python_simple_repo), "--cached"])
+
+    assert result.exit_code == 0, result.output
+    assert "Cached state:       fresh" in result.output
+
+
+def test_authoritative_status_refreshes_the_snapshot(python_simple_repo: Path) -> None:
+    init_project(python_simple_repo)
+    runner = CliRunner()
+    indexed = runner.invoke(cli, ["index", str(python_simple_repo), "--format", "json"])
+    assert indexed.exit_code == 0, indexed.output
+    status_snapshot_path(python_simple_repo).unlink()
+
+    result = runner.invoke(cli, ["status", str(python_simple_repo), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    view = read_status(python_simple_repo)
+    assert view.state.value == json.loads(result.output)["state"]
+    assert view.snapshot is not None
+    assert view.snapshot.generation_id != "", "the refresh must carry the real receipt fields"
+
+
+def test_authoritative_status_clears_a_snapshot_with_no_index_left(
+    python_simple_repo: Path,
+) -> None:
+    init_project(python_simple_repo)
+    runner = CliRunner()
+    assert runner.invoke(cli, ["index", str(python_simple_repo)]).exit_code == 0
+    assert read_status(python_simple_repo).snapshot is not None
+    (python_simple_repo / ".archex" / "index.db").unlink()
+
+    runner.invoke(cli, ["status", str(python_simple_repo)])
+
+    assert read_status(python_simple_repo).state.value == "missing"

--- a/tests/test_statusline_renderer.py
+++ b/tests/test_statusline_renderer.py
@@ -1,0 +1,368 @@
+"""The installed Claude Code status-line renderer, executed for real (R23).
+
+Every test here runs the actual installed script through `/bin/sh` with an
+**empty PATH**. That is the repaint-isolation proof: a renderer that shelled
+out to `jq`, `python`, `date`, `stat`, or `archex` could not produce correct
+output under an empty PATH, and one that opened the index could not run at all
+without a Python interpreter. Correct output plus empty stderr means the
+repaint touched nothing but the cached snapshot.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from archex.client_setup import (
+    STATUSLINE_SCRIPT_FILENAME,
+    build_statusline_install_plan,
+    write_statusline_install_plan,
+)
+from archex.status_snapshot import (
+    DEFAULT_STALE_AFTER_SECONDS,
+    STATUS_SNAPSHOT_VERSION,
+    ReceiptState,
+    SnapshotState,
+    StatusSnapshot,
+    status_snapshot_path,
+    utc_now_iso,
+)
+
+_NOW = 1_800_000_000
+
+#: Commands a repaint must never launch. `archex` is deliberately absent:
+#: the rendered output names it as a remedy ("run: archex index"), and an
+#: actual invocation is already caught by the empty-PATH executions.
+_FORBIDDEN_COMMANDS = (
+    "jq",
+    "python",
+    "python3",
+    "date",
+    "stat",
+    "cat",
+    "grep",
+    "sed",
+    "awk",
+    "env",
+    "node",
+    "bun",
+    "git",
+)
+
+
+def _installed_script(repo: Path) -> Path:
+    plan = build_statusline_install_plan("claude-code", repo, scope="project", action="install")
+    write_statusline_install_plan(plan)
+    return plan.script_path
+
+
+def _snapshot(**overrides: object) -> StatusSnapshot:
+    base: dict[str, object] = {
+        "state": SnapshotState.FRESH,
+        "written_at": utc_now_iso(_NOW),
+        "written_at_epoch": _NOW,
+        "index_measured_at": utc_now_iso(_NOW),
+        "index_revision": "0123456789abcdef" * 4,
+        "generation_id": "f" * 64,
+        "indexed_commit": "c" * 40,
+        "current_commit": "c" * 40,
+        "files_indexed": 1234,
+        "chunks_indexed": 5678,
+        "receipt_state": ReceiptState.COMPLETE,
+    }
+    base.update(overrides)
+    return StatusSnapshot.model_validate(base)
+
+
+def _write_snapshot(repo: Path, snapshot: StatusSnapshot) -> Path:
+    path = status_snapshot_path(repo)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(snapshot.model_dump(mode="json"), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _render(
+    script: Path,
+    *,
+    snapshot_path: Path | None = None,
+    cwd: Path | None = None,
+    stdin: str = "",
+    shell: str = "/bin/sh",
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    environment: dict[str, str] = {"PATH": ""}
+    if snapshot_path is not None:
+        environment["ARCHEX_STATUS_SNAPSHOT"] = str(snapshot_path)
+    if env is not None:
+        environment.update(env)
+    return subprocess.run(
+        [shell, str(script)],
+        cwd=str(cwd) if cwd is not None else str(script.parent),
+        input=stdin,
+        capture_output=True,
+        text=True,
+        env=environment,
+        check=False,
+        timeout=30,
+    )
+
+
+def test_renderer_names_no_external_command(tmp_path: Path) -> None:
+    """Structural tripwire beside the empirical empty-PATH runs below.
+
+    The empty-PATH executions are the real proof that today's renderer forks
+    nothing. This guards the branches those runs do not take: a future edit
+    that reaches for `date` or `jq` inside a rare code path fails here even
+    if no parameterized case exercises it.
+    """
+    body = _installed_script(tmp_path).read_text(encoding="utf-8")
+    code = "\n".join(
+        line for line in body.splitlines() if line.strip() and not line.lstrip().startswith("#")
+    )
+
+    # `$((...))` is arithmetic expansion, evaluated by the shell itself;
+    # `$(...)` is command substitution, which forks.
+    assert re.findall(r"\$\((?!\()", code) == [], "command substitution would fork a process"
+    assert "`" not in code, "backtick substitution would fork a process on every repaint"
+    for command in _FORBIDDEN_COMMANDS:
+        found = re.search(rf"(?<![\w./-]){re.escape(command)}(?![\w./-])", code)
+        assert found is None, f"{command} would be launched on every repaint"
+
+
+def test_fresh_snapshot_renders_state_size_and_revision_prefix(tmp_path: Path) -> None:
+    script = _installed_script(tmp_path)
+    snapshot = _write_snapshot(tmp_path, _snapshot())
+
+    result = _render(script, snapshot_path=snapshot)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert result.stdout.startswith("archex fresh - 1234 files, 5678 chunks - rev 01234567")
+
+
+def test_pending_snapshot_names_the_edits_awaiting_synchronization(tmp_path: Path) -> None:
+    script = _installed_script(tmp_path)
+    snapshot = _write_snapshot(
+        tmp_path,
+        _snapshot(state=SnapshotState.PENDING, pending_delta_files=3, pending_view_complete=True),
+    )
+
+    result = _render(script, snapshot_path=snapshot)
+
+    assert result.stderr == ""
+    assert "archex pending - 3 awaiting sync" in result.stdout
+
+
+def test_incomplete_pending_view_is_marked_as_a_lower_bound(tmp_path: Path) -> None:
+    script = _installed_script(tmp_path)
+    snapshot = _write_snapshot(
+        tmp_path,
+        _snapshot(
+            state=SnapshotState.PENDING,
+            pending_delta_files=200,
+            pending_view_complete=False,
+            receipt_state=ReceiptState.PARTIAL,
+        ),
+    )
+
+    result = _render(script, snapshot_path=snapshot)
+
+    assert "archex pending - 200+ awaiting sync" in result.stdout
+
+
+def test_dirty_snapshot_distinguishes_a_required_reindex(tmp_path: Path) -> None:
+    script = _installed_script(tmp_path)
+
+    behind = _write_snapshot(tmp_path, _snapshot(state=SnapshotState.DIRTY))
+    assert "archex dirty - index behind tree" in _render(script, snapshot_path=behind).stdout
+
+    flagged = _write_snapshot(tmp_path, _snapshot(state=SnapshotState.DIRTY, reindex_required=True))
+    assert "archex dirty - reindex required" in _render(script, snapshot_path=flagged).stdout
+
+
+def test_missing_snapshot_renders_missing_with_a_remedy(tmp_path: Path) -> None:
+    script = _installed_script(tmp_path)
+
+    result = _render(script, snapshot_path=tmp_path / "absent.json")
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert result.stdout.strip() == "archex missing - no status snapshot - run: archex index"
+
+
+def test_unparsable_snapshot_renders_corrupt(tmp_path: Path) -> None:
+    script = _installed_script(tmp_path)
+    path = status_snapshot_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not json at all\n", encoding="utf-8")
+
+    result = _render(script, snapshot_path=path)
+
+    assert result.stdout.strip() == "archex corrupt - unreadable snapshot - run: archex status"
+
+
+def test_valid_json_with_an_unknown_state_renders_corrupt(tmp_path: Path) -> None:
+    script = _installed_script(tmp_path)
+    path = status_snapshot_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"version": STATUS_SNAPSHOT_VERSION, "state": "sideways"}, indent=2),
+        encoding="utf-8",
+    )
+
+    result = _render(script, snapshot_path=path)
+
+    assert "archex corrupt" in result.stdout
+
+
+def test_future_version_renders_unsupported_not_corrupt(tmp_path: Path) -> None:
+    script = _installed_script(tmp_path)
+    path = status_snapshot_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"version": STATUS_SNAPSHOT_VERSION + 1, "state": "fresh"}, indent=2),
+        encoding="utf-8",
+    )
+
+    result = _render(script, snapshot_path=path)
+
+    assert result.stdout.strip() == (
+        f"archex unsupported - snapshot v{STATUS_SNAPSHOT_VERSION + 1} - upgrade archex"
+    )
+
+
+def test_session_directory_is_read_from_the_stdin_payload(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    script = _installed_script(repo)
+    _write_snapshot(repo, _snapshot())
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    payload = json.dumps({"session_id": "s", "cwd": str(repo), "model": {"id": "opus"}})
+
+    result = _render(script, cwd=elsewhere, stdin=f"{payload}\n")
+
+    assert "archex fresh" in result.stdout
+
+
+def test_snapshot_is_found_from_a_subdirectory_of_the_session(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    nested = repo / "src" / "pkg"
+    nested.mkdir(parents=True)
+    script = _installed_script(repo)
+    _write_snapshot(repo, _snapshot())
+
+    result = _render(script, cwd=nested, stdin=json.dumps({"cwd": str(nested)}) + "\n")
+
+    assert "archex fresh" in result.stdout
+
+
+def test_unrelated_directory_renders_missing_rather_than_another_repository(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    script = _installed_script(repo)
+    _write_snapshot(repo, _snapshot())
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir()
+
+    result = _render(script, cwd=unrelated, stdin=json.dumps({"cwd": str(unrelated)}) + "\n")
+
+    assert "archex missing" in result.stdout
+
+
+def _clock_shell() -> str | None:
+    """A shell where the renderer can read a clock, or None if none exists.
+
+    macOS ships bash 3.2 as both `/bin/sh` and `/bin/bash`, neither of which
+    has a builtin clock, so the age and stale segments are only exercisable
+    under zsh (whose `zsh/datetime` module the renderer loads through the
+    `zmodload` builtin) or bash 5+.
+    """
+    probes = (
+        ("/bin/zsh", "zmodload zsh/datetime 2>/dev/null; echo ${EPOCHSECONDS:-}"),
+        ("/opt/homebrew/bin/bash", "echo ${EPOCHSECONDS:-}"),
+        ("/usr/local/bin/bash", "echo ${EPOCHSECONDS:-}"),
+        ("/bin/bash", "echo ${EPOCHSECONDS:-}"),
+    )
+    for candidate, script in probes:
+        if not Path(candidate).exists():
+            continue
+        probe = subprocess.run(
+            [candidate, "-c", script], capture_output=True, text=True, check=False, timeout=30
+        )
+        if probe.stdout.strip().isdigit():
+            return candidate
+    return None
+
+
+def test_a_shell_with_a_builtin_clock_reports_age_and_stale(tmp_path: Path) -> None:
+    shell = _clock_shell()
+    if shell is None:
+        pytest.skip("no host shell exposes EPOCHSECONDS")
+    script = _installed_script(tmp_path)
+    now = int(time.time())
+    recent = _write_snapshot(
+        tmp_path, _snapshot(written_at=utc_now_iso(now - 90), written_at_epoch=now - 90)
+    )
+
+    fresh_result = _render(script, snapshot_path=recent, shell=shell)
+
+    assert "archex fresh" in fresh_result.stdout
+    assert "1m ago" in fresh_result.stdout
+
+    old_epoch = now - DEFAULT_STALE_AFTER_SECONDS - 60
+    old = _write_snapshot(
+        tmp_path, _snapshot(written_at=utc_now_iso(old_epoch), written_at_epoch=old_epoch)
+    )
+
+    stale_result = _render(script, snapshot_path=old, shell=shell)
+
+    assert stale_result.stdout.startswith("archex stale - unverified since measurement")
+
+
+def test_a_shell_without_a_builtin_clock_reports_the_measured_state(tmp_path: Path) -> None:
+    script = _installed_script(tmp_path)
+    ancient = _write_snapshot(tmp_path, _snapshot(written_at=utc_now_iso(1), written_at_epoch=1))
+
+    result = _render(script, snapshot_path=ancient, shell="/bin/sh", env={"EPOCHSECONDS": ""})
+
+    # No clock, so no `stale` claim and no age segment: the renderer reports
+    # what was measured instead of inventing a freshness judgement.
+    assert result.stdout.strip() == "archex fresh - 1234 files, 5678 chunks - rev 01234567"
+
+
+def test_recent_watch_observation_is_surfaced(tmp_path: Path) -> None:
+    shell = _clock_shell()
+    if shell is None:
+        pytest.skip("no host shell exposes EPOCHSECONDS")
+    script = _installed_script(tmp_path)
+    now = int(time.time())
+    snapshot = _write_snapshot(
+        tmp_path,
+        _snapshot(
+            written_at=utc_now_iso(now),
+            written_at_epoch=now,
+            watch_observed_at=utc_now_iso(now),
+            watch_observed_epoch=now,
+        ),
+    )
+
+    result = _render(script, snapshot_path=snapshot, shell=shell)
+
+    assert result.stdout.rstrip().endswith("- watch")
+
+
+def test_installed_script_name_is_the_ownership_marker(tmp_path: Path) -> None:
+    script = _installed_script(tmp_path)
+
+    assert script.name == STATUSLINE_SCRIPT_FILENAME


### PR DESCRIPTION
R23 PR 2 of 3 — the CLI reader and the Claude Code status line. Based on #634. The omp/pi adapters, the unsupported-client dispositions, and the rest of the compatibility matrix are PR-3.

## What this adds

- `archex status --cached` — renders the snapshot only. No index open, all seven states, exit 1 for `corrupt`/`unsupported` and (with `--strict`) for anything but `fresh`.
- `archex status` (default mode) now refreshes the snapshot from the inspection it already performed, and clears it when there is no index left to describe.
- `archex install-client claude-code --statusline` / `--remove-statusline` / `--dry-run` — a POSIX `sh` renderer plus an owned `statusLine` entry.
- The compatibility matrix row and a `Persistent status surfaces` section documenting states, install, sample output, and the verification actually performed.

## The design decisions worth reviewing

**The renderer forks nothing.** Claude Code re-runs the status-line command on every repaint, debounces at 300 ms, and cancels an in-flight script when a new update arrives. The renderer therefore uses shell builtins exclusively — no `jq`, no `python`, no `date`, no `archex`, and no command substitution anywhere. It reads the session directory from the stdin payload (falling back to `$PWD`), walks up to the nearest `.archex/status-snapshot.json`, and parses that document with parameter expansion.

**The shell contract cannot drift from the model.** Snapshot version, freshness budget, watch TTL, and the artifact path are substituted into the script from the Python constants at install time.

**The `stale` limitation is documented, not hidden.** Computing `stale` needs a clock, and POSIX `sh` has no builtin one. The renderer reads `$EPOCHSECONDS` (bash 5+ natively; zsh after the builtin `zmodload zsh/datetime`) and, where neither exists — notably macOS, whose `/bin/sh` and `/bin/bash` are both bash 3.2 — reports the measured state without an age rather than spending a `date` fork on every repaint. `archex status --cached` always has a clock and always reports `stale`.

**A foreign status line is refused, not replaced.** `statusLine` is a scalar settings key, so two status lines cannot coexist and there is no matcher group to merge into. Install fails and writes nothing when the key holds something archex did not install — the same rule the MCP installer applies to a foreign `archex` server entry. Removal touches only an entry whose command names `archex-statusline.sh` and only a script carrying the `archex:statusline` marker.

**`archex status` repairs what it reports.** It is the command a user runs when a status surface looks wrong, it has already opened the index, and it now carries the store's generation identity and index revision so a manual refresh publishes the same receipt fields indexing does instead of downgrading the receipt to `unknown`. Where the index is gone or unreadable it clears the snapshot, so the surface says `missing` instead of replaying a measurement of a store that no longer exists.

## Verification

**Live in a real Claude Code session (v2.1.267).** With the status line installed at project scope in a throwaway repository, an interactive `claude` session rendered:

```text
archex pending - 1 awaiting sync - rev e2d43649
```

in its own status bar — `pending` because a forced-timeout post-edit smoke had left one unsynchronized edit. Running `archex status` in that repository then re-measured the index, and the `refreshInterval` timer repainted the same bar to:

```text
archex fresh - 3 files, 4 chunks
```

That is the state transition and the repaint, observed in the client rather than asserted.

**Repaint isolation, empirically.** Every renderer test runs the installed script through `/bin/sh` with an **empty `PATH`**, against `fresh`, `dirty` (both variants), `pending` (complete and truncated views), `missing`, `corrupt` (unparsable bytes and an unknown state value), and `unsupported` snapshots. Every run printed the expected line, exited 0, and wrote nothing to stderr — which no renderer that shelled out to `jq`, `python`, `date`, or `archex` could do. A structural tripwire additionally rejects command substitution, backticks, and forbidden command names in the script body, so a future edit that reaches for `date` inside a rarely-taken branch fails even if no run exercises it.

**Clock-dependent segments.** `stale`, the age segment, and the watch segment are exercised under `/bin/zsh`, the local shell that can read a clock without forking. The no-clock path is exercised separately and asserts the absence of an age claim.

**Session-directory resolution.** Three ways: the stdin `cwd` payload from an unrelated working directory, a subdirectory of the session repository, and an unrelated directory — which reports `missing` rather than another repository's status.

**Installer contract.** 14 tests: install writes both artifacts with an executable bit, the command quotes a path containing spaces, reinstall is byte-identical, unrelated settings survive, a foreign `statusLine` is refused and left intact, remove deletes both artifacts, remove leaves a foreign entry and a foreign script of the same name alone, remove without install is a no-op, dry-run writes nothing, and the status line installs and removes without disturbing the `PreToolUse` search hook.

**Commands.** `uv run pytest tests/test_statusline_renderer.py tests/cli/test_status_cached.py tests/cli/test_install_client_statusline.py tests/cli/test_install_client_hooks.py tests/cli/test_install_client_post_edit_hooks.py tests/test_status_snapshot.py` — 178 passed. Full local gate on this branch: `ruff check` clean, `ruff format --check` clean over 534 files, `pyright` 0 errors, `pytest` 4952 passed at 90.86% coverage.

## Not in this PR

The omp and Pi status adapters, the explicit unsupported dispositions for opencode/codex/cursor, and their matrix rows.
