### PR TITLE
feat(clients): add omp and Pi status renderers

### DIFF
--- a/docs/CLIENT_COMPATIBILITY_MATRIX.md
+++ b/docs/CLIENT_COMPATIBILITY_MATRIX.md
@@ -31,6 +31,8 @@ This matrix separates config-shape verification from actual client smoke tests. 
 | Cursor `beforeSubmitPrompt` hook (opt-in, diagnostics-only, prompt-level) | Config-shape tested end-to-end (install, remove, idempotent reinstall, preserves unrelated `hooks.json` content, `beforeReadFile`-never-wired assertion); no live Cursor UI smoke | `archex install-client cursor --hooks` writes `~/.cursor/hooks.json` (global) or `.cursor/hooks.json` (project) — a different file from the MCP config above. `--dry-run` previews, `--remove-hooks` uninstalls. See [below](#cursor-beforesubmitprompt-hook-opt-in-diagnostics-only) for the full contract and the confirmation-spike findings. | N/A — one subprocess per submitted prompt, not a warm process | Diagnostics-only — no injected context, ever (see limitations); a missing/stale index degrades to no diagnostic, or the same `index_not_fresh`/`status_error` diagnostic the other hooks log. | Prompt-level, not per-tool-call: fires on every submitted prompt regardless of whether a lookup is relevant. Cursor's `beforeSubmitPrompt` output schema has no context-injection field at all (confirmed against Cursor's own docs), so this is diagnostics-only, unlike the augmenting Claude Code/omp/Pi/OpenCode hooks above. | 2026-07-06 |
 | Cursor post-edit impact hook | **Not supported** — `archex install-client cursor --post-edit-hooks` fails with the reason rather than writing anything | N/A | N/A | N/A | `afterFileEdit` is Cursor's only event carrying an edited file path (`{file_path, edits}`) and its documented schema has **no output fields at all**, so it cannot return impact to the agent. `postToolUse` does document an `additional_context` output and lists `Write` among its matchers, but documents no path field for that tool's input, so edited paths cannot be extracted from the one event that could surface text. Archex ships no adapter it cannot show to work. | 2026-09-10 |
 | Claude Code status line (opt-in) | Config-shape tested end-to-end (install, remove, idempotent reinstall, foreign-statusLine refusal, coexistence with all three hook surfaces) and the installed renderer executed for real against every snapshot state under an empty `PATH` | `archex install-client claude-code --statusline` writes `~/.claude/settings.json` (global) or `.claude/settings.json` (project) plus the renderer script `archex-statusline.sh` beside it. `--dry-run` previews; `--remove-statusline` uninstalls. See [below](#persistent-status-surfaces-opt-in). | N/A — reports whether a watch refresh was observed; starts no watcher | Renders the cached snapshot only: `fresh`, `dirty`, `pending`, `stale`, `missing`, `corrupt`, and `unsupported` are distinct. Never opens the index, runs a parser, or starts an archex process on repaint. | Opt-in. `statusLine` is a scalar settings key, so a status line archex did not install is refused rather than replaced. The `stale` label needs a shell clock (`$EPOCHSECONDS`, bash 5+/zsh); under macOS `/bin/sh` (bash 3.2) the renderer reports the measured state without an age instead of forking `date`. Never reports token savings. | 2026-09-10 |
+| oh-my-pi (omp) / Pi status extension (opt-in) | Config-shape tested end-to-end (per-host placement, byte-identical modules, idempotent reinstall, independence from the search and post-edit modules in the same directory) **and executed under Bun**: the rendered module was loaded in a real runtime, all three events dispatched, and every snapshot state rendered through a captured `ctx.ui.setStatus` | `archex install-client omp --statusline` writes `.omp/extensions/archex-status.ts` (project) or `~/.omp/agent/extensions/archex-status.ts` (user); `archex install-client pi --statusline` writes `.pi/extensions/archex-status.ts` or `~/.pi/agent/extensions/archex-status.ts`. `--dry-run` previews; `--remove-statusline` uninstalls. | N/A — reports whether a watch refresh was observed; starts no watcher | Same cached-snapshot contract as the Claude Code row, including `stale`, which this renderer can always compute because it has a real clock. | Opt-in. Refreshes on `turn_start`, `tool_result`, and `turn_end`; a host with `hasUI` false (print/RPC mode) receives no call. Verified against `@oh-my-pi/pi-coding-agent` 18.1.16 and `@mariozechner/pi-coding-agent` 0.68.1, whose `ExtensionUIContext` both declare `setStatus(key, text)`. No live TUI session was driven: the status refresh fires on turn events, and running one would require a hosted model call. | 2026-09-10 |
+| Status surfaces for codex, cursor, and opencode | **Not supported** — `archex install-client <client> --statusline` fails with the reason rather than writing anything | N/A | N/A | N/A | The Codex CLI exposes no status-line configuration and no persistently rendered hook output field. Cursor's configuration surface is hooks only, with no status or footer API. OpenCode's plugin surface exposes tool and chat hooks plus observable TUI events whose only status-shaped member is the transient `tui.toast.show`; a toast disappears, so it cannot carry a persistent freshness indicator. Use `archex status --cached`. | 2026-09-10 |
 | Dockerized MCP server | Server path tested; client smoke unverified | Run `docker run -d --name archex-mcp -v "$PWD:/workspace" -w /workspace ghcr.io/mathews-tom/archex:slim sleep infinity` then point the client to `docker exec -i archex-mcp archex mcp`. | Yes — run the MCP process with `--watch`. | Same server-side freshness semantics as stdio. | Client-specific Docker registration varies; use the same client config shapes above, but replace the command with `docker` / `exec`. | 2026-06-16 |
 
 ## First-party bootstrap command
@@ -410,7 +412,7 @@ Tests in the affected set (1):
 
 ## Persistent status surfaces (opt-in)
 
-Installed separately from every other archex surface with `--statusline`, removed with `--remove-statusline`. Never installed by default.
+Installed separately from every other archex surface with `--statusline`, removed with `--remove-statusline`. Never installed by default. Supported on `claude-code` (a `statusLine` command), `omp`, and `pi` (a status extension module); `codex`, `cursor`, and `opencode` have no persistent status surface and are refused explicitly.
 
 Archex publishes a bounded, versioned status snapshot to `.archex/status-snapshot.json` whenever indexing establishes that the store describes the current tree (a full, delta, or unchanged-tree publication, and the validated cache hit every warm query takes), whenever a post-edit hook records or synchronizes an edit, and whenever `archex status` runs. Renderers only read that file. **No renderer opens the index, runs a parser, or starts an archex process on repaint.**
 
@@ -492,13 +494,51 @@ Claude Code re-runs the status-line command on every repaint, debounced at 300 m
 
 One consequence is handled rather than hidden: computing the `stale` label needs a clock, and POSIX `sh` has no builtin one. The renderer reads `$EPOCHSECONDS`, which bash 5+ provides natively and zsh provides after the builtin `zmodload zsh/datetime`, and the installer therefore picks a clock-bearing interpreter when the host has one. On a host where none does, the renderer reports the measured state without an age or `stale` label instead of spending a `date` fork on every repaint, and `archex status --cached` — which always has a clock — remains the surface that always reports `stale`.
 
-### Verification performed
+### Verification performed for the Claude Code status line
 
 - The installed script was executed through `/bin/sh` **with an empty `PATH`** against `fresh`, `dirty` (both variants), `pending` (complete and truncated views), `missing`, `corrupt` (unparsable bytes and an unknown state value), and `unsupported` snapshots. Every run printed the expected line, exited 0, and wrote nothing to stderr — which no renderer that shelled out to `jq`, `python`, `date`, or `archex` could do.
 - The `stale`, age, and watch segments were exercised under `/bin/zsh`, the local shell that can read a clock without forking.
 - Session-directory resolution was exercised three ways: the stdin `cwd` payload from an unrelated working directory, a subdirectory of the session repository, and an unrelated directory (which reports `missing` rather than another repository's status).
 - `archex status --cached` was verified to render every state, to resolve the snapshot from a subdirectory, and to work with `IndexStore.__init__` patched to raise.
 - A refused install (a `statusLine` archex did not write) was verified to leave no renderer script behind.
+
+### oh-my-pi (omp) and Pi status extension
+
+```bash
+archex install-client omp --statusline                    # user: ~/.omp/agent/extensions/archex-status.ts
+archex install-client omp . --statusline --scope project  # repo-local: .omp/extensions/archex-status.ts
+archex install-client pi --statusline                     # user: ~/.pi/agent/extensions/archex-status.ts
+archex install-client omp --remove-statusline             # clean uninstall
+```
+
+Both hosts receive a byte-identical TypeScript module, a different file from the search hook's `archex-hook.ts` and the post-edit hook's `archex-post-edit-hook.ts`, so all three surfaces install and remove independently.
+
+Unlike the Claude Code status line — a command the client re-runs per repaint — this is a module the host already has loaded. It registers `turn_start`, `tool_result`, and `turn_end` handlers, and each one reads the snapshot with `readFileSync` and pushes the rendered line through `ctx.ui.setStatus("archex", …)`, which both hosts render in the footer and in the `status` status-line segment. A repaint therefore launches nothing at all: no subprocess, no index, no parser. A host reporting `hasUI: false` (print and RPC modes, where `setStatus` is a documented no-op) receives no call.
+
+Because the module runs in a JavaScript runtime it always has a clock, so it reports `stale` on every platform, and it reads `ARCHEX_STATUS_STALE_AFTER_SECONDS` like the other two renderers, so a tuned freshness budget cannot make the three surfaces disagree about one snapshot.
+
+The snapshot version, freshness budget, watch TTL, and artifact path are substituted into the module from the Python constants at install time, so this renderer cannot drift from the document it reads.
+
+### Clients with no persistent status surface
+
+`archex install-client <client> --statusline` fails with the upstream reason and writes nothing for `codex`, `cursor`, and `opencode`:
+
+| Client | Upstream reason |
+| --- | --- |
+| codex | The Codex CLI exposes no status-line configuration, and no hook output field that renders persistently — its hooks surface text only as `additional_context` on a tool event. |
+| cursor | Cursor's configuration surface is hooks only; there is no status or footer API for an extension to write into. |
+| opencode | The plugin surface exposes tool and chat hooks plus observable TUI events, whose only status-shaped member is the transient `tui.toast.show`. A toast disappears, so it cannot carry a persistent freshness indicator. |
+
+`archex status --cached` is the supported surface for those clients. Archex ships no adapter it cannot show to work.
+
+### Verification performed for the omp/Pi module
+
+- The rendered module was loaded under Bun in a real runtime, all three events were dispatched, and every published status was captured from `ctx.ui.setStatus`: `fresh`, `pending` (complete and truncated views), `dirty` (both variants), `stale`, `missing`, `corrupt` (unparsable bytes and an unknown state value), `unsupported`, and the watch segment all rendered distinctly.
+- Snapshot discovery was exercised through the real upward walk from the process working directory, not only through the test override. A present-but-unreadable snapshot classifies as `corrupt` rather than being walked past to a parent repository's document.
+- The `ARCHEX_STATUS_STALE_AFTER_SECONDS` override was exercised: the same snapshot renders `fresh` under the default budget and `stale` under a tightened one.
+- A host reporting `hasUI: false` received no `setStatus` call.
+- Placement, byte identity between the two hosts, idempotent reinstall, and independence from the post-edit module in the same directory are covered by `tests/cli/test_install_client_status_adapters.py`; the Bun execution lives in `tests/integrations/test_status_extension_module.py` and skips where `bun` is absent.
+- No live omp or Pi TUI session was driven: the refresh fires on turn events, and producing one would require a hosted model call. Upstream support rests on each host's own type declarations (`ExtensionUIContext.setStatus`, plus the `turn_start`/`tool_result`/`turn_end` event declarations) at the installed versions, and on the executed module.
 
 ## Cursor `beforeSubmitPrompt` hook (opt-in, diagnostics-only)
 

--- a/src/archex/cli/install_client_cmd.py
+++ b/src/archex/cli/install_client_cmd.py
@@ -8,6 +8,7 @@ from typing import cast
 import click
 
 from archex.client_setup import (
+    ClaudeCodeStatuslineInstallPlan,
     ClientName,
     ClientScope,
     HookAction,
@@ -132,7 +133,9 @@ def _is_interactive() -> bool:
         "Install the opt-in persistent status surface (R23). Renders the "
         "cached freshness snapshot in the client's own status line, reading "
         "only that snapshot -- it opens no index and starts no archex "
-        "process on repaint. claude-code only."
+        "process on repaint. Supported on claude-code (a statusLine command), "
+        "omp, and pi (a status extension module); codex, cursor, and opencode "
+        "have no persistent status surface and are refused explicitly."
     ),
 )
 @click.option(
@@ -515,7 +518,8 @@ def _run_statusline_action(
     except (ValueError, OSError) as exc:
         raise click.ClickException(str(exc)) from exc
     if action == "install":
-        click.echo(f"Installed archex status line for {client}: {target}")
-        click.echo(f"Renderer: {plan.script_path}")
+        click.echo(f"Installed archex status surface for {client}: {target}")
+        if isinstance(plan, ClaudeCodeStatuslineInstallPlan):
+            click.echo(f"Renderer: {plan.script_path}")
     else:
-        click.echo(f"Removed archex status line for {client} (if present): {target}")
+        click.echo(f"Removed archex status surface for {client} (if present): {target}")

--- a/src/archex/client_setup.py
+++ b/src/archex/client_setup.py
@@ -2505,36 +2505,351 @@ class ClaudeCodeStatuslineInstallPlan:
     statusline_entry: dict[str, object]
 
 
+#: Filename of the installed omp/Pi status extension module. Its own name is
+#: the ownership marker, exactly as the hook modules' filenames are.
+_TS_STATUS_MODULE_FILENAME = "archex-status.ts"
+
+#: Status key the extension registers under. Both hosts sort footer statuses
+#: by key and render them inline, so the key is user-visible ordering.
+TS_STATUS_KEY = "archex"
+
+#: Clients with no persistent status surface, and the upstream reason.
+#: Surfaced by the CLI so an unsupported client is refused explicitly rather
+#: than silently no-op'ing or being given a transient stand-in.
+STATUSLINE_UNSUPPORTED_CLIENTS: dict[ClientName, str] = {
+    "opencode": (
+        "OpenCode's plugin surface exposes tool and chat hooks plus observable "
+        "TUI events, whose only status-shaped member is the transient "
+        "tui.toast.show. A toast disappears, so it cannot carry a persistent "
+        "freshness indicator; archex ships no adapter it cannot show to work."
+    ),
+    "codex": (
+        "The Codex CLI exposes no status-line configuration and no hook output "
+        "field that renders persistently; its hooks surface text only as "
+        "additional_context on a tool event."
+    ),
+    "cursor": (
+        "Cursor's configuration surface is hooks only, with no status or "
+        "footer API for an extension to write into."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class TsStatusInstallPlan:
+    """Install or remove the omp/Pi status extension module (R23).
+
+    Unlike the Claude Code status line -- a command the client re-runs per
+    repaint -- this is a module the host already has loaded. It reads the
+    snapshot in-process with `readFileSync` and pushes the rendered line
+    through `ctx.ui.setStatus`, so a repaint launches nothing at all.
+    """
+
+    client: ClientName
+    scope: ClientScope
+    target_path: Path
+    action: HookAction
+    module_content: str
+
+
+StatusInstallPlan = ClaudeCodeStatuslineInstallPlan | TsStatusInstallPlan
+
+
+def _ts_status_module_path(client: ClientName, repo_root: Path, scope: ClientScope) -> Path:
+    if client == "omp":
+        return (
+            repo_root / ".omp" / "extensions" / _TS_STATUS_MODULE_FILENAME
+            if scope == "project"
+            else Path.home() / ".omp" / "agent" / "extensions" / _TS_STATUS_MODULE_FILENAME
+        )
+    return (
+        repo_root / ".pi" / "extensions" / _TS_STATUS_MODULE_FILENAME
+        if scope == "project"
+        else Path.home() / ".pi" / "agent" / "extensions" / _TS_STATUS_MODULE_FILENAME
+    )
+
+
+def render_ts_status_module() -> str:
+    """Render the omp/Pi status module with the snapshot contract baked in."""
+    return (
+        _TS_STATUS_MODULE_TEMPLATE.replace(
+            "__ARCHEX_SNAPSHOT_VERSION__", str(STATUS_SNAPSHOT_VERSION)
+        )
+        .replace("__ARCHEX_STALE_DEFAULT__", str(DEFAULT_STALE_AFTER_SECONDS))
+        .replace("__ARCHEX_WATCH_TTL__", str(WATCH_OBSERVATION_TTL_SECONDS))
+        .replace("__ARCHEX_PROJECT_DIR__", PROJECT_DIR_NAME)
+        .replace("__ARCHEX_SNAPSHOT_FILENAME__", SNAPSHOT_FILENAME)
+        .replace("__ARCHEX_STATUS_KEY__", TS_STATUS_KEY)
+    )
+
+
+_TS_STATUS_MODULE_TEMPLATE = r"""/**
+ * archex status extension module (R23 - oh-my-pi / Pi).
+ *
+ * Installed by `archex install-client omp --statusline` /
+ * `archex install-client pi --statusline` (opt-in; never installed by
+ * default). A separate file from the search and post-edit hook modules, so
+ * every surface installs and removes independently.
+ *
+ * Upstream contract (verified against each host's own type declarations, not
+ * docs):
+ * - `ctx.ui.setStatus(key, text)` sets keyed footer/status-bar text, rendered
+ *   by the built-in footer and by the `status` status-line segment, sorted by
+ *   key (oh-my-pi `src/modes/controllers/extension-ui-controller.ts` wires it
+ *   to `setHookStatus`; Pi `dist/core/extensions/types.d.ts` declares it on
+ *   `ExtensionUIContext`).
+ * - Both hosts declare `turn_start`, `turn_end`, and `tool_result` events with
+ *   the same `(event, ctx)` handler shape, and `ctx.hasUI` is false in
+ *   print/RPC modes where `setStatus` is a documented no-op.
+ *
+ * Unlike the hook modules, this one spawns no subprocess and opens no index:
+ * a repaint is a single `readFileSync` of the bounded snapshot archex
+ * publishes plus string formatting, inside a process the host already runs.
+ * Every path resolves without throwing; an unreadable, malformed, or
+ * unknown-version snapshot renders as an explicit state instead.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join, parse } from "node:path";
+
+// --- Baked in at install time from the Python contract ---
+
+const ARCHEX_SNAPSHOT_VERSION = __ARCHEX_SNAPSHOT_VERSION__;
+const ARCHEX_STALE_AFTER_SECONDS = __ARCHEX_STALE_DEFAULT__;
+const ARCHEX_WATCH_TTL_SECONDS = __ARCHEX_WATCH_TTL__;
+const ARCHEX_PROJECT_DIR = "__ARCHEX_PROJECT_DIR__";
+const ARCHEX_SNAPSHOT_FILENAME = "__ARCHEX_SNAPSHOT_FILENAME__";
+const ARCHEX_STATUS_KEY = "__ARCHEX_STATUS_KEY__";
+
+/** Override for tests and for a host started outside the repository. */
+const ARCHEX_SNAPSHOT_ENV_VAR = "ARCHEX_STATUS_SNAPSHOT";
+
+/** Freshness-budget override, honoured by every archex status renderer. */
+const ARCHEX_STALE_ENV_VAR = "ARCHEX_STATUS_STALE_AFTER_SECONDS";
+
+/** Reader-state lines, worded exactly as the shell renderer words them. */
+const ARCHEX_MISSING_LINE = "archex missing - no status snapshot - run: archex index";
+const ARCHEX_CORRUPT_LINE = "archex corrupt - unreadable snapshot - run: archex status";
+
+interface ArchexSnapshot {
+  version?: unknown;
+  state?: unknown;
+  index_revision?: unknown;
+  files_indexed?: unknown;
+  chunks_indexed?: unknown;
+  pending_delta_files?: unknown;
+  pending_view_complete?: unknown;
+  reindex_required?: unknown;
+  written_at_epoch?: unknown;
+  watch_observed_epoch?: unknown;
+}
+
+function snapshotPath(start: string): string | null {
+  const override = process.env[ARCHEX_SNAPSHOT_ENV_VAR];
+  if (override && override.trim().length > 0) return override;
+  let current = start;
+  for (;;) {
+    const candidate = join(current, ARCHEX_PROJECT_DIR, ARCHEX_SNAPSHOT_FILENAME);
+    // Existence, not readability: a present-but-unreadable snapshot must
+    // classify as `corrupt` here, exactly as it does in the shell renderer
+    // and the Python reader. Probing with a read would skip it and report
+    // either `missing` or -- worse -- a parent repository's status.
+    if (existsSync(candidate)) return candidate;
+    const parent = parse(current).dir;
+    if (!parent || parent === current) return null;
+    current = parent;
+  }
+}
+
+/** Freshness budget in seconds, overridable exactly as the CLI allows. */
+function staleAfterSeconds(): number {
+  const raw = process.env[ARCHEX_STALE_ENV_VAR];
+  if (raw === undefined) return ARCHEX_STALE_AFTER_SECONDS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : ARCHEX_STALE_AFTER_SECONDS;
+}
+
+function readNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function readText(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function ageSegment(writtenAtEpoch: number, now: number): string {
+  if (writtenAtEpoch <= 0) return "";
+  const age = Math.max(0, now - writtenAtEpoch);
+  if (age < 60) return ` - ${age}s ago`;
+  if (age < 3600) return ` - ${Math.floor(age / 60)}m ago`;
+  return ` - ${Math.floor(age / 3600)}h ago`;
+}
+
+/** Render the status text for `cwd`, or a state naming why it cannot. */
+export function renderArchexStatus(cwd: string, nowSeconds?: number): string {
+  const path = snapshotPath(cwd);
+  if (path === null) return ARCHEX_MISSING_LINE;
+
+  // An absent file is `missing`; unreadable or malformed bytes are
+  // `corrupt`. The two have different remedies -- publish one versus
+  // re-publish this one -- so they must not collapse into each other.
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    return code === "ENOENT" ? ARCHEX_MISSING_LINE : ARCHEX_CORRUPT_LINE;
+  }
+
+  let parsed: ArchexSnapshot;
+  try {
+    const document: unknown = JSON.parse(raw);
+    if (typeof document !== "object" || document === null || Array.isArray(document)) {
+      return ARCHEX_CORRUPT_LINE;
+    }
+    parsed = document as ArchexSnapshot;
+  } catch {
+    return ARCHEX_CORRUPT_LINE;
+  }
+
+  if (typeof parsed.version !== "number") return ARCHEX_CORRUPT_LINE;
+  if (parsed.version !== ARCHEX_SNAPSHOT_VERSION) {
+    return `archex unsupported - snapshot v${parsed.version} - upgrade archex`;
+  }
+
+  const persisted = readText(parsed.state);
+  if (persisted !== "fresh" && persisted !== "dirty" && persisted !== "pending") {
+    return ARCHEX_CORRUPT_LINE;
+  }
+
+  const now = nowSeconds ?? Math.floor(Date.now() / 1000);
+  const writtenAtEpoch = readNumber(parsed.written_at_epoch);
+  const age = writtenAtEpoch > 0 ? Math.max(0, now - writtenAtEpoch) : null;
+  const stale = age !== null && age > staleAfterSeconds();
+  const state = stale ? "stale" : persisted;
+
+  let detail = "";
+  if (state === "fresh") {
+    const files = readNumber(parsed.files_indexed);
+    const chunks = readNumber(parsed.chunks_indexed);
+    detail = ` - ${files} files, ${chunks} chunks`;
+  } else if (state === "pending") {
+    const pending = readNumber(parsed.pending_delta_files);
+    const complete = parsed.pending_view_complete !== false;
+    detail = ` - ${pending}${complete ? "" : "+"} awaiting sync`;
+  } else if (state === "dirty") {
+    detail = parsed.reindex_required === true ? " - reindex required" : " - index behind tree";
+  } else {
+    detail = " - unverified since measurement";
+  }
+
+  const revision = readText(parsed.index_revision);
+  const revisionSegment = revision.length > 0 ? ` - rev ${revision.slice(0, 8)}` : "";
+
+  const watchEpoch = readNumber(parsed.watch_observed_epoch);
+  const watching = watchEpoch > 0 && now - watchEpoch <= ARCHEX_WATCH_TTL_SECONDS;
+
+  return `archex ${state}${detail}${revisionSegment}${ageSegment(writtenAtEpoch, now)}${
+    watching ? " - watch" : ""
+  }`;
+}
+
+// --- Minimal structural types for the events used ---
+//
+// Declared locally (never imported from either host package) so this module
+// has zero import-resolution dependency on which host loaded it.
+
+interface StatusUiLike {
+  setStatus(key: string, text: string | undefined): void;
+}
+
+interface StatusContextLike {
+  ui?: StatusUiLike;
+  hasUI?: boolean;
+}
+
+type StatusHandler = (event: unknown, ctx: StatusContextLike) => void;
+
+interface StatusHost {
+  on(event: "turn_start" | "turn_end" | "tool_result", handler: StatusHandler): unknown;
+}
+
+/** Refresh the footer status, swallowing every failure. */
+export function publishArchexStatus(ctx: StatusContextLike): void {
+  try {
+    if (ctx.hasUI === false || !ctx.ui) return;
+    ctx.ui.setStatus(ARCHEX_STATUS_KEY, renderArchexStatus(process.cwd()));
+  } catch {
+    // A status refresh must never disturb the host's turn.
+  }
+}
+
+export default function archexStatusExtension(pi: StatusHost): void {
+  const refresh: StatusHandler = (_event, ctx) => {
+    publishArchexStatus(ctx);
+  };
+  // Three refresh points: entering a turn, after each tool result (so an edit
+  // shows as pending mid-turn), and at rest. All three read one small file.
+  pi.on("turn_start", refresh);
+  pi.on("tool_result", refresh);
+  pi.on("turn_end", refresh);
+}
+"""
+
+
 def build_statusline_install_plan(
     client: ClientName,
     source: str | Path | None = None,
     *,
     scope: ClientScope | None = None,
     action: HookAction,
-) -> ClaudeCodeStatuslineInstallPlan:
-    """Build a status-line plan, refusing clients with no such surface."""
-    if client != "claude-code":
+) -> StatusInstallPlan:
+    """Build a status plan, refusing clients with no persistent surface."""
+    if client in STATUSLINE_UNSUPPORTED_CLIENTS:
         message = (
-            f"status-line installation is implemented for claude-code; got {client}. "
-            "Run `archex status --cached` for a client without a persistent status surface."
+            f"{client} has no persistent status surface. "
+            f"{STATUSLINE_UNSUPPORTED_CLIENTS[client]} "
+            "Use `archex status --cached` instead."
         )
         raise ValueError(message)
     repo_root = Path(source if source is not None else ".").expanduser().resolve()
     selected_scope = _resolve_hook_scope(source, scope)
-    script_path = _statusline_script_path(repo_root, selected_scope)
-    return ClaudeCodeStatuslineInstallPlan(
-        client=client,
-        scope=selected_scope,
-        target_path=_hook_settings_path(repo_root, selected_scope),
-        script_path=script_path,
-        action=action,
-        script_content=render_statusline_script(),
-        statusline_entry=_render_statusline_entry(script_path),
-    )
+    if client == "claude-code":
+        script_path = _statusline_script_path(repo_root, selected_scope)
+        return ClaudeCodeStatuslineInstallPlan(
+            client=client,
+            scope=selected_scope,
+            target_path=_hook_settings_path(repo_root, selected_scope),
+            script_path=script_path,
+            action=action,
+            script_content=render_statusline_script(),
+            statusline_entry=_render_statusline_entry(script_path),
+        )
+    if client in {"omp", "pi"}:
+        return TsStatusInstallPlan(
+            client=client,
+            scope=selected_scope,
+            target_path=_ts_status_module_path(client, repo_root, selected_scope),
+            action=action,
+            module_content=render_ts_status_module(),
+        )
+    message = f"status surfaces are supported for claude-code, omp, and pi; got {client}"
+    raise ValueError(message)
 
 
-def write_statusline_install_plan(plan: ClaudeCodeStatuslineInstallPlan) -> Path:
-    """Apply a status-line plan, leaving unrelated configuration intact."""
+def write_statusline_install_plan(plan: StatusInstallPlan) -> Path:
+    """Apply a status plan, leaving unrelated configuration intact."""
+    if isinstance(plan, TsStatusInstallPlan):
+        target = plan.target_path
+        if plan.action == "remove":
+            if target.exists():
+                target.unlink()
+            return target
+        existing_module = target.read_text(encoding="utf-8") if target.exists() else None
+        if existing_module != plan.module_content:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(plan.module_content, encoding="utf-8")
+        return target
+
     target = plan.target_path
     existing = _read_json_object(target) if target.exists() else {}
     # Decided before anything is written: a foreign status line raises here,
@@ -2559,9 +2874,28 @@ def write_statusline_install_plan(plan: ClaudeCodeStatuslineInstallPlan) -> Path
     return target
 
 
-def render_statusline_install_preview(plan: ClaudeCodeStatuslineInstallPlan) -> str:
+def render_statusline_install_preview(plan: StatusInstallPlan) -> str:
     """Render a no-write preview of exactly what the plan would change."""
     action_label = "Install" if plan.action == "install" else "Remove"
+    if isinstance(plan, TsStatusInstallPlan):
+        header = [
+            f"Client: {plan.client}",
+            f"Scope: {plan.scope}",
+            f"Target: {plan.target_path}",
+            f"Action: {action_label} status extension module",
+        ]
+        existing_module = (
+            plan.target_path.read_text(encoding="utf-8") if plan.target_path.exists() else None
+        )
+        if plan.action == "install" and existing_module == plan.module_content:
+            header.append("No change: module already installed (idempotent no-op).")
+        elif plan.action == "remove" and existing_module is None:
+            header.append("No change: no archex status module is installed.")
+        else:
+            header.append("Dry run. Re-run without --dry-run to write this module.")
+        body = "" if plan.action == "remove" else plan.module_content
+        return "\n".join([*header, "", body]).rstrip("\n") + "\n"
+
     existing = _read_json_object(plan.target_path) if plan.target_path.exists() else {}
     updated, changed = _apply_statusline_action(existing, plan)
     lines = [

--- a/tests/cli/test_install_client_status_adapters.py
+++ b/tests/cli/test_install_client_status_adapters.py
@@ -1,0 +1,181 @@
+"""omp/Pi status extension installs, and unsupported-client refusals (R23).
+
+The Claude Code surface is a command the client re-runs; these two are a
+module the host already has loaded, which reads the snapshot in-process. The
+tests pin what makes that safe to ship: per-client file placement, byte
+identity between the two hosts, independence from the other TypeScript
+surfaces that share the same directory, and an explicit refusal (with the
+upstream reason) for every client that has no persistent status surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from archex.cli.main import cli
+from archex.client_setup import (
+    STATUSLINE_UNSUPPORTED_CLIENTS,
+    ClientName,
+    TsStatusInstallPlan,
+    build_post_edit_hook_install_plan,
+    build_statusline_install_plan,
+    render_statusline_install_preview,
+    render_ts_status_module,
+    write_post_edit_hook_install_plan,
+    write_statusline_install_plan,
+)
+
+_MODULE_NAME = "archex-status.ts"
+
+
+def _install(client: ClientName, repo: Path, *, scope: str = "project") -> Path:
+    plan = build_statusline_install_plan(client, repo, scope=scope, action="install")  # type: ignore[arg-type]
+    return write_statusline_install_plan(plan)
+
+
+def _remove(client: ClientName, repo: Path, *, scope: str = "project") -> Path:
+    plan = build_statusline_install_plan(client, repo, scope=scope, action="remove")  # type: ignore[arg-type]
+    return write_statusline_install_plan(plan)
+
+
+def test_omp_module_lands_in_the_omp_extension_directory(tmp_path: Path) -> None:
+    target = _install("omp", tmp_path)
+
+    assert target == tmp_path / ".omp" / "extensions" / _MODULE_NAME
+    assert target.exists()
+
+
+def test_pi_module_lands_in_the_pi_extension_directory(tmp_path: Path) -> None:
+    target = _install("pi", tmp_path)
+
+    assert target == tmp_path / ".pi" / "extensions" / _MODULE_NAME
+
+
+def test_both_hosts_receive_byte_identical_modules(tmp_path: Path) -> None:
+    omp = _install("omp", tmp_path)
+    pi = _install("pi", tmp_path)
+
+    assert omp.read_text(encoding="utf-8") == pi.read_text(encoding="utf-8")
+
+
+def test_module_bakes_in_the_python_snapshot_contract(tmp_path: Path) -> None:
+    from archex.project import PROJECT_DIR_NAME
+    from archex.status_snapshot import (
+        DEFAULT_STALE_AFTER_SECONDS,
+        SNAPSHOT_FILENAME,
+        STATUS_SNAPSHOT_VERSION,
+        WATCH_OBSERVATION_TTL_SECONDS,
+    )
+
+    module = _install("omp", tmp_path).read_text(encoding="utf-8")
+
+    assert "__ARCHEX" not in module, "every placeholder must be substituted"
+    assert f"const ARCHEX_SNAPSHOT_VERSION = {STATUS_SNAPSHOT_VERSION};" in module
+    assert f"const ARCHEX_STALE_AFTER_SECONDS = {DEFAULT_STALE_AFTER_SECONDS};" in module
+    assert f"const ARCHEX_WATCH_TTL_SECONDS = {WATCH_OBSERVATION_TTL_SECONDS};" in module
+    assert f'const ARCHEX_PROJECT_DIR = "{PROJECT_DIR_NAME}";' in module
+    assert f'const ARCHEX_SNAPSHOT_FILENAME = "{SNAPSHOT_FILENAME}";' in module
+
+
+def test_module_spawns_nothing_and_imports_no_host_package() -> None:
+    module = render_ts_status_module()
+
+    assert "child_process" not in module, "a repaint must not spawn a process"
+    assert "spawn(" not in module
+    assert "@oh-my-pi" not in module
+    assert "@mariozechner" not in module
+    # The only filesystem read is the bounded snapshot.
+    assert 'from "node:fs"' in module
+    assert "readFileSync" in module
+
+
+def test_reinstall_is_an_idempotent_no_op(tmp_path: Path) -> None:
+    target = _install("omp", tmp_path)
+    first = target.read_text(encoding="utf-8")
+    mtime = target.stat().st_mtime_ns
+
+    _install("omp", tmp_path)
+
+    assert target.read_text(encoding="utf-8") == first
+    assert target.stat().st_mtime_ns == mtime, "an unchanged module must not be rewritten"
+
+
+def test_remove_deletes_only_the_status_module(tmp_path: Path) -> None:
+    _install("omp", tmp_path)
+    write_post_edit_hook_install_plan(
+        build_post_edit_hook_install_plan("omp", tmp_path, scope="project", action="install")
+    )
+    post_edit = tmp_path / ".omp" / "extensions" / "archex-post-edit-hook.ts"
+    assert post_edit.exists()
+
+    _remove("omp", tmp_path)
+
+    assert not (tmp_path / ".omp" / "extensions" / _MODULE_NAME).exists()
+    assert post_edit.exists(), "removing the status module must not touch the post-edit hook"
+
+
+def test_remove_without_an_install_is_a_no_op(tmp_path: Path) -> None:
+    target = _remove("pi", tmp_path)
+
+    assert not target.exists()
+
+
+def test_dry_run_previews_the_module_without_writing(tmp_path: Path) -> None:
+    plan = build_statusline_install_plan("omp", tmp_path, scope="project", action="install")
+
+    preview = render_statusline_install_preview(plan)
+
+    assert isinstance(plan, TsStatusInstallPlan)
+    assert "Dry run" in preview
+    assert "renderArchexStatus" in preview
+    assert not plan.target_path.exists()
+
+
+def test_every_unsupported_client_is_refused_with_its_reason(tmp_path: Path) -> None:
+    assert set(STATUSLINE_UNSUPPORTED_CLIENTS) == {"opencode", "codex", "cursor"}
+    runner = CliRunner()
+
+    for client, reason in STATUSLINE_UNSUPPORTED_CLIENTS.items():
+        result = runner.invoke(
+            cli, ["install-client", client, str(tmp_path), "--scope", "project", "--statusline"]
+        )
+
+        assert result.exit_code != 0, client
+        assert "no persistent status surface" in result.output
+        # The reason names the upstream fact, not a generic apology.
+        assert reason.split(".")[0][:40] in result.output.replace("\n", " ")
+        assert "archex status --cached" in result.output
+
+
+def test_refusal_writes_nothing(tmp_path: Path) -> None:
+    CliRunner().invoke(
+        cli, ["install-client", "opencode", str(tmp_path), "--scope", "project", "--statusline"]
+    )
+
+    assert not (tmp_path / ".opencode").exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_cli_install_and_remove_report_the_target(tmp_path: Path) -> None:
+    runner = CliRunner()
+
+    installed = runner.invoke(
+        cli, ["install-client", "omp", str(tmp_path), "--scope", "project", "--statusline"]
+    )
+    removed = runner.invoke(
+        cli, ["install-client", "omp", str(tmp_path), "--scope", "project", "--remove-statusline"]
+    )
+
+    assert installed.exit_code == 0, installed.output
+    assert "Installed archex status surface for omp" in installed.output
+    assert removed.exit_code == 0, removed.output
+    assert "Removed archex status surface for omp" in removed.output
+
+
+def test_user_scope_targets_the_host_agent_directory(tmp_path: Path) -> None:
+    plan = build_statusline_install_plan("omp", tmp_path, scope="user", action="install")
+
+    assert isinstance(plan, TsStatusInstallPlan)
+    assert plan.target_path == Path.home() / ".omp" / "agent" / "extensions" / _MODULE_NAME

--- a/tests/cli/test_install_client_statusline.py
+++ b/tests/cli/test_install_client_statusline.py
@@ -207,7 +207,7 @@ def test_clients_without_a_persistent_status_surface_are_refused(tmp_path: Path)
     )
 
     assert result.exit_code != 0
-    assert "claude-code" in result.output
+    assert "no persistent status surface" in result.output
 
 
 def test_statusline_cannot_be_combined_with_another_surface(tmp_path: Path) -> None:
@@ -256,5 +256,5 @@ def test_cli_install_reports_both_artifacts(
     )
 
     assert result.exit_code == 0, result.output
-    assert "Installed archex status line for claude-code" in result.output
+    assert "Installed archex status surface for claude-code" in result.output
     assert STATUSLINE_SCRIPT_FILENAME in result.output

--- a/tests/integrations/test_status_extension_module.py
+++ b/tests/integrations/test_status_extension_module.py
@@ -1,0 +1,271 @@
+"""The omp/Pi status extension module, executed under Bun (R23).
+
+The module is TypeScript that runs inside the host process, so the only
+faithful test is to load it in a real runtime and dispatch real events. These
+tests write the rendered module to a temporary directory, drive it from a Bun
+driver script, and assert on what it passed to `ctx.ui.setStatus` — the same
+call the host's footer renders.
+
+Skipped where `bun` is absent (including CI images without it); the structural
+contract of the module is covered separately in
+`tests/cli/test_install_client_status_adapters.py`.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import TypedDict, cast
+
+import pytest
+
+from archex.client_setup import render_ts_status_module
+from archex.status_snapshot import STATUS_SNAPSHOT_VERSION
+
+pytestmark = pytest.mark.skipif(shutil.which("bun") is None, reason="bun is not installed")
+
+_DRIVER = """
+import archexStatusExtension, { renderArchexStatus } from "./archex-status.ts";
+
+const calls: Array<[string, string | undefined]> = [];
+const ctx = {
+  hasUI: true,
+  ui: {
+    setStatus: (key: string, text: string | undefined) => {
+      calls.push([key, text]);
+    },
+  },
+};
+
+const handlers: Record<string, Array<(event: unknown, context: unknown) => void>> = {};
+archexStatusExtension({
+  on(event: string, handler: (event: unknown, context: unknown) => void) {
+    (handlers[event] ??= []).push(handler);
+    return undefined;
+  },
+} as never);
+
+for (const event of Object.keys(handlers)) {
+  for (const handler of handlers[event] ?? []) handler({ toolName: "edit" }, ctx);
+}
+
+const snapshots: Record<string, string> = JSON.parse(process.env.ARCHEX_TEST_SNAPSHOTS ?? "{}");
+const rendered: Record<string, string> = {};
+for (const [label, path] of Object.entries(snapshots)) {
+  process.env.ARCHEX_STATUS_SNAPSHOT = path;
+  rendered[label] = renderArchexStatus(process.cwd());
+}
+
+const budgetOverride: Record<string, string> = {};
+if (snapshots.recent) {
+  process.env.ARCHEX_STATUS_SNAPSHOT = snapshots.recent;
+  budgetOverride.default = renderArchexStatus(process.cwd());
+  process.env.ARCHEX_STATUS_STALE_AFTER_SECONDS = "5";
+  budgetOverride.tightened = renderArchexStatus(process.cwd());
+  delete process.env.ARCHEX_STATUS_STALE_AFTER_SECONDS;
+}
+
+const withoutUi: Array<[string, string | undefined]> = [];
+const headless = {
+  hasUI: false,
+  ui: {
+    setStatus: (key: string, text: string | undefined) => {
+      withoutUi.push([key, text]);
+    },
+  },
+};
+for (const handler of handlers.turn_end ?? []) handler({}, headless);
+
+const events = Object.keys(handlers).sort();
+console.log(JSON.stringify({ events, calls, rendered, withoutUi, budgetOverride }));
+"""
+
+
+class _DriverResult(TypedDict):
+    """Shape the Bun driver prints as its single line of stdout."""
+
+    events: list[str]
+    calls: list[list[str]]
+    rendered: dict[str, str]
+    withoutUi: list[list[str]]
+    budgetOverride: dict[str, str]
+
+
+def _drive(tmp_path: Path, snapshots: dict[str, Path]) -> _DriverResult:
+    (tmp_path / "archex-status.ts").write_text(render_ts_status_module(), encoding="utf-8")
+    driver = tmp_path / "driver.ts"
+    driver.write_text(_DRIVER, encoding="utf-8")
+    result = subprocess.run(
+        ["bun", "run", str(driver)],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+        env={
+            "PATH": "/usr/bin:/bin:/usr/local/bin:" + str(Path.home() / ".bun" / "bin"),
+            "HOME": str(Path.home()),
+            "ARCHEX_TEST_SNAPSHOTS": json.dumps({k: str(v) for k, v in snapshots.items()}),
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    return cast("_DriverResult", json.loads(result.stdout.strip().splitlines()[-1]))
+
+
+def _snapshot_file(tmp_path: Path, name: str, document: dict[str, object]) -> Path:
+    path = tmp_path / f"{name}.json"
+    path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_module_registers_three_refresh_events_and_sets_status(tmp_path: Path) -> None:
+    now = int(time.time())
+    # Written where the module discovers it by walking up from the process
+    # working directory, so this covers discovery as well as dispatch.
+    project = tmp_path / ".archex"
+    project.mkdir()
+    (project / "status-snapshot.json").write_text(
+        json.dumps(
+            {
+                "version": STATUS_SNAPSHOT_VERSION,
+                "state": "fresh",
+                "files_indexed": 12,
+                "chunks_indexed": 34,
+                "index_revision": "0123456789abcdef",
+                "written_at_epoch": now,
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    payload = _drive(tmp_path, {})
+
+    assert payload["events"] == ["tool_result", "turn_end", "turn_start"]
+    calls = payload["calls"]
+    assert len(calls) == len(payload["events"]), "every registered event publishes a status"
+    assert {call[0] for call in calls} == {"archex"}
+    assert all("archex fresh - 12 files, 34 chunks - rev 01234567" in call[1] for call in calls)
+
+
+def test_a_host_without_ui_receives_no_status_call(tmp_path: Path) -> None:
+    payload = _drive(tmp_path, {})
+
+    assert payload["withoutUi"] == [], "print and RPC modes have no status surface"
+
+
+def test_every_state_renders_distinctly_under_bun(tmp_path: Path) -> None:
+    now = int(time.time())
+    base = {"version": STATUS_SNAPSHOT_VERSION, "index_revision": "0123456789abcdef"}
+    snapshots = {
+        "fresh": _snapshot_file(
+            tmp_path,
+            "fresh",
+            {
+                **base,
+                "state": "fresh",
+                "files_indexed": 12,
+                "chunks_indexed": 34,
+                "written_at_epoch": now,
+            },
+        ),
+        "pending": _snapshot_file(
+            tmp_path,
+            "pending",
+            {
+                **base,
+                "state": "pending",
+                "pending_delta_files": 3,
+                "pending_view_complete": True,
+                "written_at_epoch": now,
+            },
+        ),
+        "pending_truncated": _snapshot_file(
+            tmp_path,
+            "pending_truncated",
+            {
+                **base,
+                "state": "pending",
+                "pending_delta_files": 200,
+                "pending_view_complete": False,
+                "written_at_epoch": now,
+            },
+        ),
+        "dirty": _snapshot_file(
+            tmp_path, "dirty", {**base, "state": "dirty", "written_at_epoch": now}
+        ),
+        "reindex": _snapshot_file(
+            tmp_path,
+            "reindex",
+            {**base, "state": "dirty", "reindex_required": True, "written_at_epoch": now},
+        ),
+        "stale": _snapshot_file(
+            tmp_path, "stale", {**base, "state": "fresh", "written_at_epoch": now - 100_000}
+        ),
+        "unsupported": _snapshot_file(
+            tmp_path, "unsupported", {"version": STATUS_SNAPSHOT_VERSION + 1, "state": "fresh"}
+        ),
+        "unknown_state": _snapshot_file(tmp_path, "unknown_state", {**base, "state": "sideways"}),
+        "watching": _snapshot_file(
+            tmp_path,
+            "watching",
+            {**base, "state": "fresh", "written_at_epoch": now, "watch_observed_epoch": now},
+        ),
+        "missing": tmp_path / "absent.json",
+    }
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("not json", encoding="utf-8")
+    snapshots["corrupt"] = corrupt
+
+    rendered = _drive(tmp_path, snapshots)["rendered"]
+
+    assert rendered["fresh"].startswith("archex fresh - 12 files, 34 chunks - rev 01234567")
+    assert "archex pending - 3 awaiting sync" in rendered["pending"]
+    assert "archex pending - 200+ awaiting sync" in rendered["pending_truncated"]
+    assert "archex dirty - index behind tree" in rendered["dirty"]
+    assert "archex dirty - reindex required" in rendered["reindex"]
+    assert rendered["stale"].startswith("archex stale - unverified since measurement")
+    assert rendered["missing"] == "archex missing - no status snapshot - run: archex index"
+    assert rendered["corrupt"] == "archex corrupt - unreadable snapshot - run: archex status"
+    assert rendered["unknown_state"] == "archex corrupt - unreadable snapshot - run: archex status"
+    assert rendered["unsupported"] == (
+        f"archex unsupported - snapshot v{STATUS_SNAPSHOT_VERSION + 1} - upgrade archex"
+    )
+    assert rendered["watching"].endswith(" - watch")
+
+
+def test_the_stale_budget_override_is_honoured(tmp_path: Path) -> None:
+    now = int(time.time())
+    recent = _snapshot_file(
+        tmp_path,
+        "recent",
+        {"version": STATUS_SNAPSHOT_VERSION, "state": "fresh", "written_at_epoch": now - 60},
+    )
+
+    payload = _drive(tmp_path, {"recent": recent})["budgetOverride"]
+
+    # Every renderer reads ARCHEX_STATUS_STALE_AFTER_SECONDS, so a tuned
+    # budget cannot make the three surfaces disagree about one snapshot.
+    assert payload["default"].startswith("archex fresh")
+    assert payload["tightened"].startswith("archex stale")
+
+
+def test_an_unreadable_snapshot_renders_corrupt_rather_than_being_skipped(tmp_path: Path) -> None:
+    project = tmp_path / ".archex"
+    project.mkdir()
+    unreadable = project / "status-snapshot.json"
+    unreadable.write_text("{}", encoding="utf-8")
+    unreadable.chmod(0o000)
+    try:
+        payload = _drive(tmp_path, {})
+    finally:
+        unreadable.chmod(0o600)
+
+    calls = payload["calls"]
+    # A present-but-unreadable document must classify, not be walked past to a
+    # parent repository's snapshot.
+    assert all("archex corrupt" in call[1] for call in calls)

--- a/tests/test_statusline_renderer.py
+++ b/tests/test_statusline_renderer.py
@@ -20,6 +20,7 @@ import pytest
 
 from archex.client_setup import (
     STATUSLINE_SCRIPT_FILENAME,
+    ClaudeCodeStatuslineInstallPlan,
     build_statusline_install_plan,
     write_statusline_install_plan,
 )
@@ -57,6 +58,7 @@ _FORBIDDEN_COMMANDS = (
 
 def _installed_script(repo: Path) -> Path:
     plan = build_statusline_install_plan("claude-code", repo, scope="project", action="install")
+    assert isinstance(plan, ClaudeCodeStatuslineInstallPlan)
     write_statusline_install_plan(plan)
     return plan.script_path
 


### PR DESCRIPTION
R23 PR 3 of 3 — the remaining proven adapters and the explicit refusals. Based on #635.

## What this adds

- `archex install-client omp --statusline` / `pi --statusline` — a byte-identical TypeScript status extension module per host, with `--dry-run` and `--remove-statusline`.
- Explicit refusals with upstream reasons for `codex`, `cursor`, and `opencode`.
- Compatibility matrix rows and documentation for both, completing the R23 client support matrix.

## Client support matrix

| Client | Status surface | Disposition |
| --- | --- | --- |
| claude-code | `statusLine` command (settings key) | Supported (#635) |
| omp | `ctx.ui.setStatus` via an extension module | Supported, this PR |
| pi | `ctx.ui.setStatus` via an extension module | Supported, this PR |
| codex | none | Refused with reason |
| cursor | none | Refused with reason |
| opencode | transient `tui.toast.show` only | Refused with reason |

Support claims come from each host's own type declarations at the installed version, not from documentation: `@oh-my-pi/pi-coding-agent` 18.1.16 wires `setStatus` at `src/modes/controllers/extension-ui-controller.ts:111` and declares `turn_start`/`tool_result`/`turn_end` at `src/extensibility/extensions/types.ts`; `@mariozechner/pi-coding-agent` 0.68.1 declares `setStatus(key, text)` on `ExtensionUIContext` at `dist/core/extensions/types.d.ts:76` and the same three events at `:762-772`.

## The design decisions worth reviewing

**A loaded module, not a re-run command.** The Claude Code surface is a command the client executes per repaint; these two already live in the host process. A refresh is one `readFileSync` of the bounded snapshot plus string formatting — no subprocess, no index, no parser. The module imports nothing from either host package and declares the two structural types it needs locally, so it has no import-resolution dependency on which host loaded it.

**Three refresh points.** `turn_start` (status present as work begins), `tool_result` (an edit shows as `pending` mid-turn), `turn_end` (status at rest). A host reporting `hasUI: false` — print and RPC modes, where `setStatus` is a documented no-op — receives no call.

**This renderer can always report `stale`.** A JavaScript runtime always has a clock, unlike POSIX `sh`. Both renderers share one vocabulary and one set of thresholds because the snapshot version, freshness budget, watch TTL, and artifact path are substituted from the Python constants at install time; a test asserts no placeholder survives and that each constant matches.

**Refusals name the upstream fact.** Not "unsupported" but why: no status-line configuration and no persistently rendered hook output (codex), a hooks-only configuration surface (cursor), and only a transient toast that by construction cannot hold a freshness indicator (opencode). Each refusal points at `archex status --cached` and writes nothing.

## Verification

**Executed under Bun, not asserted.** `tests/integrations/test_status_extension_module.py` writes the rendered module to a temporary directory, loads it in a real Bun runtime, dispatches all three events, and captures what reached `ctx.ui.setStatus`. Every state renders distinctly: `fresh`, `pending` (complete and truncated), `dirty` (both variants), `stale`, `missing`, `corrupt` (unparsable bytes and an unknown state value), `unsupported`, and the watch segment. Snapshot discovery is exercised through the real upward walk from the process working directory, and a `hasUI: false` host receives no call. The file skips where `bun` is absent.

**Installer contract.** 13 tests: per-host placement for both scopes, byte identity between the two hosts, every Python constant present in the rendered module with no placeholder left, no `child_process` import and no `spawn(`, idempotent reinstall that does not rewrite an unchanged file, removal that leaves the post-edit module in the same directory intact, removal without install as a no-op, dry-run writing nothing, and every unsupported client refused with its reason while writing nothing at all.

**Commands.** `uv run pytest tests/cli/test_install_client_status_adapters.py tests/integrations/test_status_extension_module.py tests/cli/test_install_client_statusline.py tests/cli/test_install_client_hooks.py tests/cli/test_install_client_post_edit_hooks.py tests/test_statusline_renderer.py tests/test_status_snapshot.py tests/cli/test_status_cached.py` — 194 passed. Full local gate on this branch: `ruff check` clean, `ruff format --check` clean over 536 files, `pyright` 0 errors, `pytest` 4968 passed at 90.86% coverage.

**Honest gap, recorded in the matrix.** No live omp or Pi TUI session was driven. The refresh fires on turn events, so producing one requires a hosted model call, which this milestone does not authorize. Support therefore rests on each host's own type declarations plus the executed module — the same standard R21's `tool_result` adapters were held to.

## Note for reviewers of the stack

Two assertions in `tests/cli/test_install_client_statusline.py` (from #635) are updated here, because this PR broadens the installer's success message from "status line" to "status surface": two of the three supported clients have no status line to install into.
