### PR TITLE
docs(status): pin the snapshot wire format as contract

### DIFF
--- a/docs/CLIENT_COMPATIBILITY_MATRIX.md
+++ b/docs/CLIENT_COMPATIBILITY_MATRIX.md
@@ -430,6 +430,8 @@ Archex publishes a bounded, versioned status snapshot to `.archex/status-snapsho
 
 `working_tree_dirty` is reported as its own field and never drives the state: a synchronized index describes a tree with uncommitted edits exactly as well as a clean one. Status never reports estimated token savings.
 
+The snapshot's serialized layout is part of its versioned contract: sorted keys and two-space indentation, so every scalar sits on its own `  "key": value` line. That is what lets the POSIX `sh` renderer read it with shell builtins and no JSON parser, and a test pins it. A document that archex did not write — hand-edited, or reformatted — may therefore read as `corrupt` in that renderer even where a JSON parser would accept it; `archex status` re-publishes it in the canonical form.
+
 ### CLI
 
 ```bash

--- a/src/archex/status_snapshot.py
+++ b/src/archex/status_snapshot.py
@@ -8,7 +8,7 @@ index open, a parse, or a cold Python start per repaint. This module is the
 cheap side of that split: lifecycle code that already holds the expensive
 state *publishes* a small document, and every renderer only *reads* it.
 
-Two invariants make that safe:
+Three invariants make that safe:
 
 - **The writer decides what is true; the reader decides what is current.**
   A persisted document carries one of three states (:class:`SnapshotState`:
@@ -22,6 +22,13 @@ Two invariants make that safe:
   token-savings figure. Its serialized size therefore has a provable ceiling
   (:data:`MAX_SNAPSHOT_BYTES`) that does not depend on repository size or on a
   truncation rule that could be forgotten.
+- **The serialized form is part of the contract, not an implementation
+  detail.** The document is written with sorted keys and two-space
+  indentation, which puts every scalar on its own ``  "key": value`` line.
+  That is what lets a renderer with no JSON parser -- the POSIX ``sh`` status
+  line -- read it with shell builtins alone. A future schema may add or
+  remove fields, but changing this layout is a breaking change for those
+  renderers and requires a version bump, so a test pins it.
 
 Nothing here raises into a caller. Publication happens on an agent's edit path
 and inside indexing; a status write that fails is a display defect, never a

--- a/tests/test_status_snapshot.py
+++ b/tests/test_status_snapshot.py
@@ -471,6 +471,30 @@ def test_worst_case_document_stays_inside_the_declared_size_bound(tmp_path: Path
     assert len(document["generation_id"]) == 64
 
 
+def test_published_document_puts_every_scalar_on_its_own_line(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    _publish(repo)
+
+    lines = status_snapshot_path(repo).read_text(encoding="utf-8").splitlines()
+
+    # The POSIX `sh` status-line renderer has no JSON parser: it reads this
+    # document with shell builtins, one `  "key": value` line at a time. That
+    # layout is therefore part of the versioned contract, and changing it
+    # silently would break every non-Python renderer.
+    assert lines[0] == "{"
+    assert lines[-1] == "}"
+    body = lines[1:-1]
+    keys = [line.split('"')[1] for line in body]
+    assert keys == sorted(keys), "keys must be sorted so the layout is deterministic"
+    assert len(keys) == len(set(keys))
+    for line in body:
+        assert line.startswith('  "'), line
+        key, _, value = line.partition('": ')
+        assert value, f"no scalar on its own line: {line}"
+        assert '": ' not in value.rstrip(","), f"more than one field on a line: {line}"
+        assert key.count('"') == 1
+
+
 def test_client_reported_names_are_clipped_rather_than_stored_whole(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     _publish(repo)


### PR DESCRIPTION
Follow-up to the R23 stack (#634, #635, #636), found by smoke-testing merged `main`.

## The gap

The POSIX `sh` status-line renderer has no JSON parser. It reads the snapshot with shell builtins, one `  "key": value` line at a time, which works only because the writer serializes with `json.dumps(..., indent=2, sort_keys=True)`. That coupling was an implementation detail: a future change to the serialization — compact output, different indentation, two fields on a line — would have broken the shell renderer and the omp/Pi module's parity with no test failing.

Observable today: a compact single-line document renders as `corrupt` in the shell renderer while the Python reader classifies it by version. archex never writes that form, so no real snapshot is affected, but the dependency deserved to be a contract rather than a coincidence.

## The change

- The serialized layout is now the schema's third stated invariant, alongside the writer/reader state split and the size bound.
- A test pins it: the document opens and closes on their own lines, keys are sorted and unique, and every body line carries exactly one `"key": value` scalar.
- The compatibility matrix records the consequence for a document archex did not write: the shell renderer may read a reformatted snapshot as `corrupt` where a JSON parser would accept it, and `archex status` re-publishes it canonically.

No behaviour change; this makes an existing dependency explicit and enforced.

## Verification

`uv run pytest tests/test_status_snapshot.py tests/test_statusline_renderer.py tests/cli` — 286 passed. `ruff check`, `ruff format --check`, and `pyright` over the full include set are clean.
