### PR TITLE
feat(explorer): add interactive graph navigation

### DIFF
--- a/src/archex/explorer/render.py
+++ b/src/archex/explorer/render.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from html import escape
 from typing import TYPE_CHECKING
+from urllib.parse import quote
 
 if TYPE_CHECKING:
     from archex.explorer.viewmodel import (
@@ -24,12 +25,14 @@ if TYPE_CHECKING:
         ManifestView,
         ModuleMapView,
         NeighborhoodView,
+        NodeSearchView,
         ReceiptView,
     )
 
 NAV_ITEMS: list[tuple[str, str]] = [
     ("Module Map", "/view/modules"),
     ("Diff Review", "/view/diff"),
+    ("Node Search", "/view/search"),
     ("Target Neighborhood", "/view/neighborhood"),
     ("Receipt Inspector", "/view/receipt"),
     ("Index Health", "/view/health"),
@@ -56,6 +59,24 @@ th { background: #f0f0f5; }
 .badge-low { background: #d1e7dd; color: #0f5132; }
 .note { color: #666; font-size: 0.8rem; font-style: italic; }
 .empty { color: #666; font-style: italic; }
+form.controls { margin-bottom: 1rem; font-size: 0.85rem; }
+form.controls input, form.controls select, form.controls button { font-size: 0.85rem;
+       margin-right: 0.4rem; }
+form.controls fieldset { border: 1px solid #ddd; margin: 0.5rem 0; padding: 0.4rem 0.6rem; }
+form.controls legend { font-size: 0.75rem; color: #666; }
+form.controls label.facet { margin-right: 0.75rem; white-space: nowrap; }
+tr.orientation-out { background: #eef6ff; }
+tr.orientation-in { background: #fff6ee; }
+tr.orientation-lateral { background: #f6f6f6; }
+td.orientation { font-weight: 600; }
+tr.orientation-out td.orientation { color: #0b57d0; }
+tr.orientation-in td.orientation { color: #a04a00; }
+tr.orientation-lateral td.orientation { color: #666; }
+.legend { font-size: 0.8rem; color: #444; margin-bottom: 0.75rem; }
+.legend span { margin-right: 1rem; padding: 0.1rem 0.4rem; border-radius: 3px; }
+.legend .orientation-out { background: #eef6ff; color: #0b57d0; }
+.legend .orientation-in { background: #fff6ee; color: #a04a00; }
+.legend .orientation-lateral { background: #f6f6f6; color: #666; }
 """.strip()
 
 
@@ -348,10 +369,29 @@ def render_health_page(manifest: ManifestView, view: HealthView) -> str:
     return render_page("Index Health", manifest, body)
 
 
-def render_neighborhood_page(manifest: ManifestView, view: NeighborhoodView) -> str:
-    form = (
-        '<form method="get" action="/view/neighborhood">'
-        f'<input type="text" name="node" placeholder="file or symbol id" '
+def _neighborhood_link(node_id: str) -> str:
+    return f"/view/neighborhood?node={quote(node_id, safe='')}"
+
+
+def _edge_type_fieldset(view: NeighborhoodView) -> str:
+    if not view.edge_type_facets:
+        return ""
+    boxes = "".join(
+        '<label class="facet"><input type="checkbox" name="edge_type" '
+        f'value="{escape(facet.type)}"{" checked" if facet.selected else ""}> '
+        f"{escape(facet.type)} ({facet.count})</label>"
+        for facet in view.edge_type_facets
+    )
+    return (
+        "<fieldset><legend>Edge types in this neighborhood "
+        "(none checked shows every type)</legend>" + boxes + "</fieldset>"
+    )
+
+
+def _neighborhood_form(view: NeighborhoodView) -> str:
+    return (
+        '<form class="controls" method="get" action="/view/neighborhood">'
+        '<input type="text" name="node" placeholder="file or symbol id" '
         f'value="{escape(view.query or "")}">'
         '<select name="direction">'
         + "".join(
@@ -361,9 +401,22 @@ def render_neighborhood_page(manifest: ManifestView, view: NeighborhoodView) -> 
         + "</select>"
         f'<input type="number" name="depth" min="1" value="{view.depth}">'
         f'<input type="number" name="limit" min="1" value="{view.limit}">'
-        '<button type="submit">Find neighbors</button>'
-        "</form>"
+        '<button type="submit">Find neighbors</button>' + _edge_type_fieldset(view) + "</form>"
     )
+
+
+_ORIENTATION_LEGEND = (
+    '<p class="legend">'
+    '<span class="orientation-out">out</span> the seed side depends on the far side &middot; '
+    '<span class="orientation-in">in</span> the far side depends on the seed side &middot; '
+    '<span class="orientation-lateral">lateral</span> both endpoints sit the same distance '
+    "from the seed"
+    "</p>"
+)
+
+
+def render_neighborhood_page(manifest: ManifestView, view: NeighborhoodView) -> str:
+    form = _neighborhood_form(view)
     if not view.available:
         body = (
             "<h2>Target Neighborhood</h2>" + form + '<p class="empty">No graph artifact provided. '
@@ -380,17 +433,21 @@ def render_neighborhood_page(manifest: ManifestView, view: NeighborhoodView) -> 
             "<h2>Target Neighborhood</h2>"
             + form
             + '<p class="empty">Enter a file path or symbol id to see its bounded '
-            "neighborhood.</p>"
+            'neighborhood, or use <a href="/view/search">Node Search</a> to find one.</p>'
         )
         return render_page("Target Neighborhood", manifest, body)
 
     node_rows = "".join(
-        f"<tr><td>{escape(node.id)}</td><td>{escape(node.type)}</td>"
+        f'<tr><td><a href="{_neighborhood_link(node.id)}">{escape(node.id)}</a></td>'
+        f"<td>{escape(node.type)}</td>"
         f"<td>{escape(node.label)}</td><td>{node.degree}</td></tr>"
         for node in view.nodes
     )
     edge_rows = "".join(
-        f"<tr><td>{escape(edge.source_id)}</td><td>{escape(edge.type)}</td>"
+        f'<tr class="orientation-{escape(edge.orientation)}">'
+        f"<td>{escape(edge.source_id)}</td>"
+        f'<td class="orientation">{escape(edge.orientation)}</td>'
+        f"<td>{escape(edge.type)}</td>"
         f"<td>{escape(edge.target_id)}</td><td>{escape(edge.confidence)}</td></tr>"
         for edge in view.edges
     )
@@ -402,19 +459,84 @@ def render_neighborhood_page(manifest: ManifestView, view: NeighborhoodView) -> 
         if view.truncated
         else ""
     )
+    filtered = (
+        f'<p class="note">Filtered to {escape(", ".join(view.selected_edge_types))}: '
+        f"{view.filtered_edges} of this neighborhood's edges hidden. The filter narrows the "
+        "bounded traversal above, not the whole graph.</p>"
+        if view.selected_edge_types
+        else ""
+    )
     body = (
         "<h2>Target Neighborhood</h2>" + form + f"<p>Seed: <code>{escape(view.seed.id)}</code> "
         f"({escape(view.seed.type)}, degree {view.seed.degree}) &middot; "
         f"direction: {escape(view.direction)} &middot; depth: {view.depth}</p>"
         + truncation
+        + filtered
         + "<h3>Nodes</h3>"
         "<table><tr><th>ID</th><th>Type</th><th>Label</th><th>Degree</th></tr>"
         + node_rows
         + "</table>"
         "<h3>Edges</h3>"
-        "<table><tr><th>Source</th><th>Type</th><th>Target</th><th>Confidence</th></tr>"
-        + edge_rows
-        + "</table>"
+        + _ORIENTATION_LEGEND
+        + "<table><tr><th>Source</th><th>Orientation</th><th>Type</th><th>Target</th>"
+        "<th>Confidence</th></tr>" + edge_rows + "</table>"
         "<h3>Hubs skipped (high fan-out)</h3><ul>" + hub_rows + "</ul>"
     )
     return render_page("Target Neighborhood", manifest, body)
+
+
+def render_node_search_page(manifest: ManifestView, view: NodeSearchView) -> str:
+    form = (
+        '<form class="controls" method="get" action="/view/search">'
+        '<input type="text" name="q" placeholder="id, label, or path substring" '
+        f'value="{escape(view.query or "")}">'
+        f'<input type="number" name="limit" min="1" value="{view.limit}">'
+        '<button type="submit">Search nodes</button>'
+        "</form>"
+    )
+    if not view.available:
+        body = (
+            "<h2>Node Search</h2>" + form + '<p class="empty">No graph artifact provided. '
+            "Pass <code>--graph</code> to <code>archex explore</code> to enable this view.</p>"
+        )
+        return render_page("Node Search", manifest, body)
+
+    if not view.query:
+        body = (
+            "<h2>Node Search</h2>"
+            + form
+            + '<p class="empty">Search the exported graph by node id, symbol label, or file '
+            "path. Matches link straight to their bounded neighborhood.</p>"
+        )
+        return render_page("Node Search", manifest, body)
+
+    if not view.matches:
+        body = (
+            "<h2>Node Search</h2>"
+            + form
+            + f'<p class="empty">No node matches {escape(view.query)}.</p>'
+        )
+        return render_page("Node Search", manifest, body)
+
+    rows = "".join(
+        f'<tr><td><a href="{_neighborhood_link(match.id)}">{escape(match.id)}</a></td>'
+        f"<td>{escape(match.type)}</td><td>{escape(match.label)}</td>"
+        f"<td>{escape(match.path or '-')}</td><td>{escape(match.module or '-')}</td>"
+        f"<td>{match.degree}</td></tr>"
+        for match in view.matches
+    )
+    truncation = (
+        f'<p class="note">Truncated: {view.omitted} further matches omitted at limit '
+        f"{view.limit}.</p>"
+        if view.truncated
+        else ""
+    )
+    body = (
+        "<h2>Node Search</h2>" + form + f'<p class="note">{len(view.matches)} match(es) for '
+        f"<code>{escape(view.query)}</code> &middot; match kind: "
+        f"{escape(view.match_kind or 'none')}</p>"
+        + truncation
+        + "<table><tr><th>ID</th><th>Type</th><th>Label</th><th>Path</th><th>Module</th>"
+        "<th>Degree</th></tr>" + rows + "</table>"
+    )
+    return render_page("Node Search", manifest, body)

--- a/src/archex/explorer/server.py
+++ b/src/archex/explorer/server.py
@@ -27,6 +27,7 @@ from archex.explorer.render import (
     render_health_page,
     render_module_map_page,
     render_neighborhood_page,
+    render_node_search_page,
     render_page,
     render_receipt_page,
 )
@@ -44,18 +45,20 @@ from archex.explorer.security import (
 from archex.explorer.viewmodel import (
     DEFAULT_NEIGHBORHOOD_DEPTH,
     DEFAULT_NEIGHBORHOOD_LIMIT,
+    MAX_NODE_SEARCH_ROWS,
     build_diff_view,
     build_health_view,
     build_manifest_view,
     build_module_map_view,
     build_neighborhood_view,
+    build_node_search_view,
     build_receipt_view,
 )
 from archex.graph_query import GraphQuery
 
 if TYPE_CHECKING:
     from archex.explorer.loader import ExplorerData
-    from archex.explorer.viewmodel import ManifestView, NeighborhoodView
+    from archex.explorer.viewmodel import ManifestView, NeighborhoodView, NodeSearchView
     from archex.graph_query import GraphDirection
 
 LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1"})
@@ -183,6 +186,8 @@ class _ExplorerRequestHandler(BaseHTTPRequestHandler):
             return render_health_page(manifest, build_health_view(server.data))
         if route == "/view/neighborhood":
             return render_neighborhood_page(manifest, self._neighborhood_view(params, server))
+        if route == "/view/search":
+            return render_node_search_page(manifest, self._node_search_view(params, server))
         return None
 
     def _neighborhood_view(
@@ -203,6 +208,17 @@ class _ExplorerRequestHandler(BaseHTTPRequestHandler):
             direction=direction,
             depth=depth,
             limit=limit,
+            edge_types=params.get("edge_type", []),
+            graph_query=server.graph_query,
+        )
+
+    def _node_search_view(
+        self, params: dict[str, list[str]], server: ExplorerServer
+    ) -> NodeSearchView:
+        return build_node_search_view(
+            server.data,
+            params.get("q", [None])[0],
+            limit=_parse_positive_int(params.get("limit", [None])[0], MAX_NODE_SEARCH_ROWS),
             graph_query=server.graph_query,
         )
 

--- a/src/archex/explorer/viewmodel.py
+++ b/src/archex/explorer/viewmodel.py
@@ -10,13 +10,16 @@ than silently truncating.
 
 from __future__ import annotations
 
-from collections import defaultdict
+from collections import defaultdict, deque
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from archex.graph_artifact import GraphEdgeType
 from archex.graph_query import DEFAULT_GRAPH_LIMIT, GraphQuery, GraphQueryError
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from archex.explorer.loader import ExplorerData
     from archex.graph_query import GraphDirection, GraphEdgeSummary, GraphNodeSummary
     from archex.report.artifact import EvidenceLocation
@@ -357,6 +360,27 @@ class NeighborEdgeRow:
     target_id: str
     type: str
     confidence: str
+    orientation: str
+
+
+@dataclass(frozen=True)
+class EdgeTypeFacet:
+    """One typed-edge filter checkbox: how many edges carry it, is it selected."""
+
+    type: str
+    count: int
+    selected: bool
+
+
+#: Orientation of an edge relative to the seed, derived from the bounded
+#: traversal subgraph rather than from any new graph data: `out` runs away
+#: from the seed (the seed side depends on the far side), `in` runs toward it
+#: (the far side depends on the seed side), and `lateral` connects two nodes
+#: the traversal reached at the same distance, where neither endpoint is
+#: closer to the seed and no dependency direction relative to the seed exists.
+ORIENTATION_OUT = "out"
+ORIENTATION_IN = "in"
+ORIENTATION_LATERAL = "lateral"
 
 
 @dataclass(frozen=True)
@@ -375,6 +399,51 @@ class NeighborhoodView:
     hubs: list[NeighborNodeRow]
     truncated: bool
     omitted_edges: int
+    edge_type_facets: list[EdgeTypeFacet]
+    selected_edge_types: list[str]
+    filtered_edges: int
+
+
+def _empty_neighborhood(
+    *,
+    available: bool,
+    query: str | None,
+    error: str | None,
+    direction: str,
+    depth: int,
+    limit: int,
+    selected_edge_types: list[str],
+) -> NeighborhoodView:
+    return NeighborhoodView(
+        available=available,
+        query=query,
+        error=error,
+        seed=None,
+        direction=direction,
+        depth=depth,
+        limit=limit,
+        nodes=[],
+        edges=[],
+        hubs=[],
+        truncated=False,
+        omitted_edges=0,
+        edge_type_facets=[],
+        selected_edge_types=selected_edge_types,
+        filtered_edges=0,
+    )
+
+
+def normalize_edge_types(requested: Iterable[str] | None) -> list[str]:
+    """Keep only recognized `GraphEdgeType` values, sorted and deduplicated.
+
+    An unrecognized value is dropped rather than honored, so a malformed
+    filter degrades to "no filter" instead of silently hiding every edge --
+    the same convention the depth/limit/direction parameters already use.
+    """
+    if requested is None:
+        return []
+    known = {member.value for member in GraphEdgeType}
+    return sorted({value for value in requested if value in known})
 
 
 def build_neighborhood_view(
@@ -384,57 +453,51 @@ def build_neighborhood_view(
     direction: GraphDirection = "both",
     depth: int = DEFAULT_NEIGHBORHOOD_DEPTH,
     limit: int = DEFAULT_NEIGHBORHOOD_LIMIT,
+    edge_types: Iterable[str] | None = None,
     graph_query: GraphQuery | None = None,
 ) -> NeighborhoodView:
+    selected = normalize_edge_types(edge_types)
     if data.graph is None:
-        return NeighborhoodView(
+        return _empty_neighborhood(
             available=False,
             query=query,
             error="no graph artifact provided",
-            seed=None,
             direction=direction,
             depth=depth,
             limit=limit,
-            nodes=[],
-            edges=[],
-            hubs=[],
-            truncated=False,
-            omitted_edges=0,
+            selected_edge_types=selected,
         )
     if not query:
-        return NeighborhoodView(
+        return _empty_neighborhood(
             available=True,
             query=query,
             error=None,
-            seed=None,
             direction=direction,
             depth=depth,
             limit=limit,
-            nodes=[],
-            edges=[],
-            hubs=[],
-            truncated=False,
-            omitted_edges=0,
+            selected_edge_types=selected,
         )
 
     engine = graph_query if graph_query is not None else GraphQuery(data.graph)
     try:
         result = engine.neighbors(query, direction=direction, depth=depth, limit=limit)
     except GraphQueryError as exc:
-        return NeighborhoodView(
+        return _empty_neighborhood(
             available=True,
             query=query,
             error=str(exc),
-            seed=None,
             direction=direction,
             depth=depth,
             limit=limit,
-            nodes=[],
-            edges=[],
-            hubs=[],
-            truncated=False,
-            omitted_edges=0,
+            selected_edge_types=selected,
         )
+
+    seed_id = result.seed.id
+    distances = _seed_distances(seed_id, result.edges)
+    all_rows = _dedupe_edge_rows(_edge_row(edge, distances) for edge in result.edges)
+    facets = _edge_type_facets(all_rows, selected)
+    rows = [row for row in all_rows if not selected or row.type in selected]
+    nodes = _retained_nodes(result.traversed_nodes, rows, seed_id=seed_id, filtered=bool(selected))
 
     return NeighborhoodView(
         available=True,
@@ -444,12 +507,96 @@ def build_neighborhood_view(
         direction=result.direction,
         depth=result.depth,
         limit=limit,
-        nodes=[_node_row(node) for node in result.traversed_nodes],
-        edges=[_edge_row(edge) for edge in result.edges],
+        nodes=nodes,
+        edges=rows,
         hubs=[_node_row(node) for node in result.hubs],
         truncated=result.truncated,
         omitted_edges=result.omitted_edges,
+        edge_type_facets=facets,
+        selected_edge_types=selected,
+        filtered_edges=len(all_rows) - len(rows),
     )
+
+
+def _seed_distances(seed_id: str, edges: list[GraphEdgeSummary]) -> dict[str, int]:
+    """Undirected hop distance from the seed, over the traversal's own edges only.
+
+    Pure projection: it reads the bounded edge list the traversal already
+    returned and constructs no adjacency the graph does not contain. Nodes the
+    bounded edge set does not connect to the seed are simply absent, which the
+    caller reads as `lateral`.
+    """
+    adjacency: defaultdict[str, set[str]] = defaultdict(set)
+    for edge in edges:
+        adjacency[edge.source.id].add(edge.target.id)
+        adjacency[edge.target.id].add(edge.source.id)
+
+    distances = {seed_id: 0}
+    queue: deque[str] = deque([seed_id])
+    while queue:
+        current = queue.popleft()
+        for neighbor in sorted(adjacency[current]):
+            if neighbor not in distances:
+                distances[neighbor] = distances[current] + 1
+                queue.append(neighbor)
+    return distances
+
+
+def _dedupe_edge_rows(rows: Iterable[NeighborEdgeRow]) -> list[NeighborEdgeRow]:
+    """One display row per distinct edge, in traversal order.
+
+    `GraphQuery.neighbors` walks with `direction="both"` from every frontier
+    node, so an edge between two traversed nodes is legitimately selected once
+    from each endpoint and appears twice in its `edges` list at depth > 1.
+    That is correct for the traversal's own edge budget -- and `truncated` /
+    `omitted_edges` are reported against that budget and left untouched here --
+    but a rendered table that lists the same relationship twice, and a type
+    facet that counts it twice, are display defects. This collapses duplicates
+    only for display; it drops no distinct relationship, because the key covers
+    every field a row shows.
+    """
+    seen: set[tuple[str, str, str, str]] = set()
+    deduped: list[NeighborEdgeRow] = []
+    for row in rows:
+        key = (row.source_id, row.target_id, row.type, row.confidence)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(row)
+    return deduped
+
+
+def _edge_type_facets(rows: list[NeighborEdgeRow], selected: list[str]) -> list[EdgeTypeFacet]:
+    counts: defaultdict[str, int] = defaultdict(int)
+    for row in rows:
+        counts[row.type] += 1
+    chosen = set(selected)
+    return [
+        EdgeTypeFacet(type=edge_type, count=count, selected=edge_type in chosen)
+        for edge_type, count in sorted(counts.items())
+    ]
+
+
+def _retained_nodes(
+    traversed: list[GraphNodeSummary],
+    rows: list[NeighborEdgeRow],
+    *,
+    seed_id: str,
+    filtered: bool,
+) -> list[NeighborNodeRow]:
+    """The traversed nodes, narrowed to the seed and the retained edges' endpoints.
+
+    Without a filter this is the traversal's own node set unchanged. With one
+    it drops nodes only the hidden edges reached, so the node table never
+    claims a relationship the edge table no longer shows.
+    """
+    if not filtered:
+        return [_node_row(node) for node in traversed]
+    reachable = {seed_id}
+    for row in rows:
+        reachable.add(row.source_id)
+        reachable.add(row.target_id)
+    return [_node_row(node) for node in traversed if node.id in reachable]
 
 
 def _node_row(node: GraphNodeSummary) -> NeighborNodeRow:
@@ -462,10 +609,97 @@ def _node_row(node: GraphNodeSummary) -> NeighborNodeRow:
     )
 
 
-def _edge_row(edge: GraphEdgeSummary) -> NeighborEdgeRow:
+def _edge_row(edge: GraphEdgeSummary, distances: dict[str, int]) -> NeighborEdgeRow:
     return NeighborEdgeRow(
         source_id=edge.source.id,
         target_id=edge.target.id,
         type=edge.type,
         confidence=edge.confidence,
+        orientation=_orientation(edge.source.id, edge.target.id, distances),
+    )
+
+
+def _orientation(source_id: str, target_id: str, distances: dict[str, int]) -> str:
+    source_distance = distances.get(source_id)
+    target_distance = distances.get(target_id)
+    if source_distance is None or target_distance is None:
+        return ORIENTATION_LATERAL
+    if source_distance < target_distance:
+        return ORIENTATION_OUT
+    if target_distance < source_distance:
+        return ORIENTATION_IN
+    return ORIENTATION_LATERAL
+
+
+MAX_NODE_SEARCH_ROWS = 100
+
+
+@dataclass(frozen=True)
+class NodeSearchRow:
+    id: str
+    type: str
+    label: str
+    path: str | None
+    module: str | None
+    degree: int
+
+
+@dataclass(frozen=True)
+class NodeSearchView:
+    """Which node did I mean? Bounded exact-then-fuzzy lookup over the graph."""
+
+    available: bool
+    query: str | None
+    match_kind: str | None
+    limit: int
+    matches: list[NodeSearchRow]
+    truncated: bool
+    omitted: int
+
+
+def build_node_search_view(
+    data: ExplorerData,
+    query: str | None,
+    *,
+    limit: int = MAX_NODE_SEARCH_ROWS,
+    graph_query: GraphQuery | None = None,
+) -> NodeSearchView:
+    """Resolve QUERY to candidate graph nodes via `GraphQuery.lookup`.
+
+    Adds no matcher of its own: `lookup` already implements the exact-then-
+    fuzzy id/label/path resolution every other archex graph surface uses, so
+    the explorer and `archex graph neighbors` agree on what a query names.
+    """
+    capped = min(max(limit, 1), MAX_NODE_SEARCH_ROWS)
+    if data.graph is None or not query:
+        return NodeSearchView(
+            available=data.graph is not None,
+            query=query,
+            match_kind=None,
+            limit=capped,
+            matches=[],
+            truncated=False,
+            omitted=0,
+        )
+
+    engine = graph_query if graph_query is not None else GraphQuery(data.graph)
+    result = engine.lookup(query, limit=capped)
+    return NodeSearchView(
+        available=True,
+        query=query,
+        match_kind=result.match_kind,
+        limit=capped,
+        matches=[
+            NodeSearchRow(
+                id=node.id,
+                type=node.type,
+                label=node.label,
+                path=node.path,
+                module=node.module,
+                degree=node.degree,
+            )
+            for node in result.matches
+        ],
+        truncated=result.truncated,
+        omitted=result.omitted,
     )

--- a/tests/explorer/test_render.py
+++ b/tests/explorer/test_render.py
@@ -8,12 +8,14 @@ from archex.explorer.render import (
     render_health_page,
     render_module_map_page,
     render_neighborhood_page,
+    render_node_search_page,
     render_page,
     render_receipt_page,
 )
 from archex.explorer.viewmodel import (
     DiffFileRow,
     DiffView,
+    EdgeTypeFacet,
     HealthView,
     ManifestView,
     ModuleMapView,
@@ -21,6 +23,8 @@ from archex.explorer.viewmodel import (
     NeighborEdgeRow,
     NeighborhoodView,
     NeighborNodeRow,
+    NodeSearchRow,
+    NodeSearchView,
     ReceiptView,
 )
 
@@ -176,6 +180,9 @@ def test_render_neighborhood_page_reports_unavailable_without_graph() -> None:
         hubs=[],
         truncated=False,
         omitted_edges=0,
+        edge_type_facets=[],
+        selected_edge_types=[],
+        filtered_edges=0,
     )
 
     html = render_neighborhood_page(_manifest(), view)
@@ -203,11 +210,15 @@ def test_render_neighborhood_page_escapes_node_and_edge_ids() -> None:
                 target_id="file:b.py",
                 type="imports",
                 confidence="extracted",
+                orientation="out",
             )
         ],
         hubs=[],
         truncated=False,
         omitted_edges=0,
+        edge_type_facets=[EdgeTypeFacet(type="imports", count=1, selected=False)],
+        selected_edge_types=[],
+        filtered_edges=0,
     )
 
     html = render_neighborhood_page(_manifest(), view)
@@ -230,6 +241,9 @@ def test_render_neighborhood_page_reports_unresolved_query_error() -> None:
         hubs=[],
         truncated=False,
         omitted_edges=0,
+        edge_type_facets=[],
+        selected_edge_types=[],
+        filtered_edges=0,
     )
 
     html = render_neighborhood_page(_manifest(), view)
@@ -249,3 +263,167 @@ def test_render_health_page_shows_identity_fields() -> None:
 
     assert "gen1" in html
     assert "tree-sitter-python" in html
+
+
+def _oriented_neighborhood(
+    *,
+    selected: list[str] | None = None,
+    filtered_edges: int = 0,
+) -> NeighborhoodView:
+    seed = NeighborNodeRow(id="file:a.py", type="file", label="a.py", path="a.py", degree=2)
+    far = NeighborNodeRow(id="file:b.py", type="file", label="b.py", path="b.py", degree=1)
+    return NeighborhoodView(
+        available=True,
+        query="file:a.py",
+        error=None,
+        seed=seed,
+        direction="both",
+        depth=1,
+        limit=25,
+        nodes=[seed, far],
+        edges=[
+            NeighborEdgeRow(
+                source_id="file:a.py",
+                target_id="file:b.py",
+                type="imports",
+                confidence="extracted",
+                orientation="out",
+            ),
+            NeighborEdgeRow(
+                source_id="file:z.py",
+                target_id="file:a.py",
+                type="imports",
+                confidence="extracted",
+                orientation="in",
+            ),
+        ],
+        hubs=[],
+        truncated=False,
+        omitted_edges=0,
+        edge_type_facets=[
+            EdgeTypeFacet(type="contains", count=1, selected="contains" in (selected or [])),
+            EdgeTypeFacet(type="imports", count=2, selected="imports" in (selected or [])),
+        ],
+        selected_edge_types=selected or [],
+        filtered_edges=filtered_edges,
+    )
+
+
+def test_render_neighborhood_page_marks_each_edge_with_its_orientation() -> None:
+    html = render_neighborhood_page(_manifest(), _oriented_neighborhood())
+
+    assert '<tr class="orientation-out">' in html
+    assert '<tr class="orientation-in">' in html
+    assert "<th>Orientation</th>" in html
+    # The legend must say what each direction means, not just colour the row.
+    assert "the seed side depends on the far side" in html
+    assert "the far side depends on the seed side" in html
+
+
+def test_render_neighborhood_page_offers_a_checkbox_per_edge_type_with_counts() -> None:
+    html = render_neighborhood_page(_manifest(), _oriented_neighborhood())
+
+    assert 'name="edge_type" value="contains"> contains (1)' in html
+    assert 'name="edge_type" value="imports"> imports (2)' in html
+
+
+def test_render_neighborhood_page_checks_and_reports_the_active_filter() -> None:
+    view = _oriented_neighborhood(selected=["imports"], filtered_edges=1)
+
+    html = render_neighborhood_page(_manifest(), view)
+
+    assert 'value="imports" checked' in html
+    assert "1 of this neighborhood's edges hidden" in html
+    # The filter must not be misread as narrowing the whole graph.
+    assert "not the whole graph" in html
+
+
+def test_render_neighborhood_page_links_nodes_to_their_own_neighborhood() -> None:
+    html = render_neighborhood_page(_manifest(), _oriented_neighborhood())
+
+    assert 'href="/view/neighborhood?node=file%3Ab.py"' in html
+
+
+def test_render_node_search_page_links_matches_to_their_neighborhood() -> None:
+    view = NodeSearchView(
+        available=True,
+        query="a.py",
+        match_kind="fuzzy",
+        limit=100,
+        matches=[
+            NodeSearchRow(
+                id="file:a.py",
+                type="file",
+                label="a.py",
+                path="a.py",
+                module="pkg",
+                degree=2,
+            )
+        ],
+        truncated=False,
+        omitted=0,
+    )
+
+    html = render_node_search_page(_manifest(), view)
+
+    assert 'href="/view/neighborhood?node=file%3Aa.py"' in html
+    assert "match kind: fuzzy" in html
+
+
+def test_render_node_search_page_escapes_the_query_and_match_fields() -> None:
+    view = NodeSearchView(
+        available=True,
+        query="<script>x</script>",
+        match_kind="fuzzy",
+        limit=100,
+        matches=[
+            NodeSearchRow(
+                id="<script>y</script>",
+                type="file",
+                label="a.py",
+                path=None,
+                module=None,
+                degree=0,
+            )
+        ],
+        truncated=False,
+        omitted=0,
+    )
+
+    html = render_node_search_page(_manifest(), view)
+
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_render_node_search_page_reports_no_match_without_claiming_one() -> None:
+    view = NodeSearchView(
+        available=True,
+        query="nope",
+        match_kind=None,
+        limit=100,
+        matches=[],
+        truncated=False,
+        omitted=0,
+    )
+
+    html = render_node_search_page(_manifest(), view)
+
+    assert "No node matches nope" in html
+    assert "<table" not in html
+
+
+def test_render_node_search_page_reports_unavailable_without_graph() -> None:
+    view = NodeSearchView(
+        available=False,
+        query="a.py",
+        match_kind=None,
+        limit=100,
+        matches=[],
+        truncated=False,
+        omitted=0,
+    )
+
+    html = render_node_search_page(_manifest(), view)
+
+    assert "No graph artifact provided" in html

--- a/tests/explorer/test_server.py
+++ b/tests/explorer/test_server.py
@@ -22,6 +22,8 @@ from archex.explorer.loader import ExplorerData, load_explorer_data
 from archex.explorer.server import ExplorerSecurityError, ExplorerServer, create_server
 from archex.graph_artifact import (
     ArchGraph,
+    GraphEdge,
+    GraphEdgeType,
     GraphExportMetadata,
     GraphNode,
     GraphNodeType,
@@ -279,3 +281,101 @@ def test_neighborhood_view_finds_seed_with_graph(
 
     assert response.status == 200
     assert "file:a.py" in response.read().decode("utf-8")
+
+
+def _linked_graph() -> ArchGraph:
+    return ArchGraph(
+        project=GraphProject(name="widget", total_files=2),
+        metadata=GraphExportMetadata(archex_version="0.22.0"),
+        nodes=[
+            GraphNode(id="file:a.py", type=GraphNodeType.FILE, label="a.py", module="pkg"),
+            GraphNode(id="file:b.py", type=GraphNodeType.FILE, label="b.py", module="pkg"),
+            GraphNode(
+                id="symbol:a.py::f#function",
+                type=GraphNodeType.SYMBOL,
+                label="f",
+                module="pkg",
+            ),
+        ],
+        edges=[
+            GraphEdge(source="file:a.py", target="file:b.py", type=GraphEdgeType.IMPORTS),
+            GraphEdge(
+                source="file:a.py",
+                target="symbol:a.py::f#function",
+                type=GraphEdgeType.CONTAINS,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def running_server_with_linked_graph(tmp_path: Path) -> Iterator[ExplorerServer]:
+    data = ExplorerData(
+        artifact=load_explorer_data(_artifact_json(tmp_path)).artifact, graph=_linked_graph()
+    )
+    server = create_server(data, port=0)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _body(server: ExplorerServer, path_and_query: str) -> str:
+    port = server.server_address[1]
+    return _get(f"http://127.0.0.1:{port}{path_and_query}&token={server.token}").read().decode()
+
+
+def test_node_search_view_is_reachable_without_graph(running_server: ExplorerServer) -> None:
+    body = _body(running_server, "/view/search?q=a.py")
+
+    assert "No graph artifact provided" in body
+
+
+def test_node_search_view_resolves_a_query_over_http(
+    running_server_with_linked_graph: ExplorerServer,
+) -> None:
+    body = _body(running_server_with_linked_graph, "/view/search?q=b.py")
+
+    assert "file:b.py" in body
+    assert "/view/neighborhood?node=file%3Ab.py" in body
+
+
+def test_neighborhood_view_honors_the_edge_type_filter_over_http(
+    running_server_with_linked_graph: ExplorerServer,
+) -> None:
+    unfiltered = _body(running_server_with_linked_graph, "/view/neighborhood?node=file:a.py")
+    filtered = _body(
+        running_server_with_linked_graph,
+        "/view/neighborhood?node=file:a.py&edge_type=contains",
+    )
+
+    assert "file:b.py" in unfiltered
+    assert "symbol:a.py::f#function" in unfiltered
+    # The filter drops the imports edge and the node only it reached.
+    assert "file:b.py" not in filtered
+    assert "symbol:a.py::f#function" in filtered
+    assert "edges hidden" in filtered
+
+
+def test_neighborhood_view_renders_orientation_over_http(
+    running_server_with_linked_graph: ExplorerServer,
+) -> None:
+    body = _body(running_server_with_linked_graph, "/view/neighborhood?node=file:b.py")
+
+    assert '<tr class="orientation-in">' in body
+
+
+def test_search_and_neighborhood_pages_carry_no_script_or_remote_reference(
+    running_server_with_linked_graph: ExplorerServer,
+) -> None:
+    for path in ("/view/search?q=a.py", "/view/neighborhood?node=file:a.py"):
+        body = _body(running_server_with_linked_graph, path)
+
+        assert "<script" not in body
+        assert "http://" not in body.replace("http://127.0.0.1", "")
+        assert "https://" not in body
+        assert "//cdn" not in body

--- a/tests/explorer/test_viewmodel.py
+++ b/tests/explorer/test_viewmodel.py
@@ -7,12 +7,16 @@ from pathlib import Path
 from archex.explorer.loader import ExplorerData
 from archex.explorer.viewmodel import (
     MAX_DIFF_FILE_ROWS,
+    MAX_NODE_SEARCH_ROWS,
+    NeighborhoodView,
     build_diff_view,
     build_health_view,
     build_manifest_view,
     build_module_map_view,
     build_neighborhood_view,
+    build_node_search_view,
     build_receipt_view,
+    normalize_edge_types,
 )
 from archex.graph_artifact import (
     ArchGraph,
@@ -144,6 +148,35 @@ def _small_graph() -> ArchGraph:
     )
 
 
+_SYMBOL_ID = "symbol:a.py::f#function"
+
+
+def _chain_graph() -> ArchGraph:
+    """`z -> a -> b -> c` plus `a -> f` and `b -> f`, for orientation/filter coverage."""
+    return ArchGraph(
+        project=GraphProject(name="widget", total_files=4),
+        metadata=GraphExportMetadata(archex_version="0.22.0"),
+        nodes=[
+            GraphNode(id="file:a.py", type=GraphNodeType.FILE, label="a.py", module="pkg"),
+            GraphNode(id="file:b.py", type=GraphNodeType.FILE, label="b.py", module="pkg"),
+            GraphNode(id="file:c.py", type=GraphNodeType.FILE, label="c.py", module="pkg"),
+            GraphNode(id="file:z.py", type=GraphNodeType.FILE, label="z.py", module="pkg"),
+            GraphNode(id=_SYMBOL_ID, type=GraphNodeType.SYMBOL, label="f", module="pkg"),
+        ],
+        edges=[
+            GraphEdge(source="file:z.py", target="file:a.py", type=GraphEdgeType.IMPORTS),
+            GraphEdge(source="file:a.py", target="file:b.py", type=GraphEdgeType.IMPORTS),
+            GraphEdge(source="file:b.py", target="file:c.py", type=GraphEdgeType.IMPORTS),
+            GraphEdge(source="file:a.py", target=_SYMBOL_ID, type=GraphEdgeType.CONTAINS),
+            GraphEdge(source="file:b.py", target=_SYMBOL_ID, type=GraphEdgeType.EXPOSES),
+        ],
+    )
+
+
+def _orientations(view: NeighborhoodView) -> dict[tuple[str, str], str]:
+    return {(edge.source_id, edge.target_id): edge.orientation for edge in view.edges}
+
+
 def test_build_module_map_view_without_graph_is_unavailable() -> None:
     data = ExplorerData(artifact=_minimal_artifact(), graph=None)
 
@@ -216,6 +249,128 @@ def test_build_neighborhood_view_never_constructs_new_edges() -> None:
     build_neighborhood_view(data, "file:a.py")
 
     assert len(graph.edges) == original_edge_count
+
+
+def test_neighborhood_edges_are_oriented_relative_to_the_seed() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=_chain_graph())
+
+    view = build_neighborhood_view(data, "file:a.py", depth=2, limit=25)
+
+    orientations = _orientations(view)
+    # `z` imports the seed, so the seed is the dependency: inbound.
+    assert orientations[("file:z.py", "file:a.py")] == "in"
+    # The seed imports `b`, and `b` imports `c` further out: both outbound.
+    assert orientations[("file:a.py", "file:b.py")] == "out"
+    assert orientations[("file:b.py", "file:c.py")] == "out"
+    # `b` and `f` are both one hop from the seed, so neither is closer to it.
+    assert orientations[("file:b.py", _SYMBOL_ID)] == "lateral"
+
+
+def test_neighborhood_orientation_follows_the_requested_direction() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=_chain_graph())
+
+    inbound = build_neighborhood_view(data, "file:a.py", direction="in", depth=1)
+    outbound = build_neighborhood_view(data, "file:a.py", direction="out", depth=1)
+
+    assert {edge.orientation for edge in inbound.edges} == {"in"}
+    assert {edge.orientation for edge in outbound.edges} == {"out"}
+
+
+def test_neighborhood_reports_edge_type_facets_over_the_unfiltered_traversal() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=_chain_graph())
+
+    view = build_neighborhood_view(data, "file:a.py", depth=2, limit=25)
+
+    assert {facet.type: facet.count for facet in view.edge_type_facets} == {
+        "imports": 3,
+        "contains": 1,
+        "exposes": 1,
+    }
+    assert all(facet.selected is False for facet in view.edge_type_facets)
+
+
+def test_neighborhood_edge_type_filter_hides_other_types_and_narrows_nodes() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=_chain_graph())
+
+    view = build_neighborhood_view(data, "file:a.py", depth=2, limit=25, edge_types=["contains"])
+
+    assert {edge.type for edge in view.edges} == {"contains"}
+    assert view.filtered_edges == 4
+    assert view.selected_edge_types == ["contains"]
+    # A node the hidden edges were the only route to must not stay in the table.
+    assert {node.id for node in view.nodes} == {"file:a.py", _SYMBOL_ID}
+    # Facets still describe the whole neighborhood, so the filter can be widened again.
+    assert {facet.type for facet in view.edge_type_facets} == {"imports", "contains", "exposes"}
+    assert [facet.type for facet in view.edge_type_facets if facet.selected] == ["contains"]
+
+
+def test_neighborhood_unrecognized_edge_type_is_ignored_rather_than_hiding_everything() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=_chain_graph())
+
+    view = build_neighborhood_view(
+        data, "file:a.py", depth=2, limit=25, edge_types=["not-an-edge-type"]
+    )
+
+    assert view.selected_edge_types == []
+    assert view.filtered_edges == 0
+    assert len(view.edges) == 5
+
+
+def test_normalize_edge_types_keeps_only_known_types_sorted() -> None:
+    assert normalize_edge_types(["exposes", "imports", "bogus", "imports"]) == [
+        "exposes",
+        "imports",
+    ]
+    assert normalize_edge_types(None) == []
+
+
+def test_build_node_search_view_without_graph_is_unavailable() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=None)
+
+    view = build_node_search_view(data, "a.py")
+
+    assert view.available is False
+    assert view.matches == []
+
+
+def test_build_node_search_view_without_query_returns_no_matches() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=_chain_graph())
+
+    view = build_node_search_view(data, None)
+
+    assert view.available is True
+    assert view.matches == []
+    assert view.match_kind is None
+
+
+def test_build_node_search_view_resolves_exact_and_fuzzy_matches() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=_chain_graph())
+
+    exact = build_node_search_view(data, "file:a.py")
+    fuzzy = build_node_search_view(data, "a.p")
+
+    assert [match.id for match in exact.matches] == ["file:a.py"]
+    assert exact.match_kind == "id"
+    assert [match.id for match in fuzzy.matches] == ["file:a.py", _SYMBOL_ID]
+    assert fuzzy.match_kind == "fuzzy"
+
+
+def test_build_node_search_view_reports_truncation_at_its_limit() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=_chain_graph())
+
+    view = build_node_search_view(data, ".py", limit=2)
+
+    assert len(view.matches) == 2
+    assert view.truncated is True
+    assert view.omitted == 3
+
+
+def test_build_node_search_view_caps_an_oversized_limit() -> None:
+    data = ExplorerData(artifact=_minimal_artifact(), graph=_chain_graph())
+
+    view = build_node_search_view(data, ".py", limit=MAX_NODE_SEARCH_ROWS * 10)
+
+    assert view.limit == MAX_NODE_SEARCH_ROWS
 
 
 def test_build_receipt_view_projects_evidence_and_counts() -> None:


### PR DESCRIPTION
## Summary

R25 PR 1 of 3. Adds node search, directional dependency orientation, and typed-edge filtering to the existing artifact-only Explorer. No new data source, no new matcher, no new edge, no security relaxation.

- **Node search** (`/view/search`) reuses `GraphQuery.lookup`, so the Explorer and `archex graph neighbors` resolve a query identically. Every match links to its own bounded neighborhood.
- **Edge orientation** is derived from hop distance to the seed over the edges the bounded traversal already returned: `out` (the seed side depends on the far side), `in` (the far side depends on the seed side), `lateral` (equal distance, no direction relative to the seed). The page states what each label means rather than relying on colour.
- **Typed-edge filtering** applies in the view model over that bounded traversal, deliberately not inside `GraphQuery.neighbors`, which is shared with the graph CLI surface. The page says so: the filter narrows the bounded neighborhood, not the whole graph. Facets are computed over the unfiltered result so a filter can be widened again; an unrecognized type is dropped rather than honoured; the node table narrows with the edge table so it never claims a hidden relationship.
- **Display dedupe.** `neighbors` legitimately selects an edge once from each endpoint at depth > 1, so the same relationship appeared twice in the table and twice in the type counts. Rows are deduplicated for display only, keyed on every field a row shows; `truncated`/`omitted_edges` still report against the traversal's own budget.

## Security posture (unchanged)

Loopback-only bind, per-process session token, GET-only, CSP granting no `script-src`. Interactivity is `<a href>` links and one `<form method="get">`; pages stay script-free with no remote reference. Verified over HTTP in `tests/explorer/test_server.py`.

## Verification

`uv run pytest tests/explorer` — 79 passed. `ruff check`, `ruff format --check`, `pyright` clean over the changed files.

Real browser (Chromium via CDP) against a live server with a real artifact and a real 22-node/20-edge exported graph:

- `/view/search?q=hub` rendered 5 matches, each linking to a percent-encoded neighborhood URL; `document.querySelectorAll('script').length === 0`.
- `/view/neighborhood?node=file:hub.py&depth=2&limit=40` rendered 14 outbound, 5 inbound, 1 lateral row with distinct computed background colours (`rgb(238,246,255)` / `rgb(255,246,238)` / `rgb(246,246,246)`). `consumer_a.py imports hub.py` rendered inbound.
- Checking `imports` and submitting the real form navigated to `?...&edge_type=imports` authenticated by the session cookie with no token in the URL, rendering 6 rows, the node table narrowed 14 -> 6, and the filter note.
- `direction=in` rendered exactly the 5 importers, all inbound.
- Unresolvable node and non-matching search each declined to fabricate a result.

## Risks

Orientation at depth > 1 is a derived reading of a bounded subgraph, not a claim about the whole graph; `lateral` is reported rather than guessed. The type filter is scoped to the bounded traversal and the page says so.
