### PR TITLE
feat(explorer): export self-contained review artifacts

### DIFF
--- a/src/archex/cli/explore_cmd.py
+++ b/src/archex/cli/explore_cmd.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import click
 
+from archex.explorer.export import ExplorerExportError, export_explorer_site
 from archex.explorer.loader import ExplorerDataError, load_explorer_data
 from archex.explorer.server import ExplorerSecurityError, create_server
 
@@ -26,16 +27,41 @@ from archex.explorer.server import ExplorerSecurityError, create_server
     show_default=True,
     help="Loopback port to bind (0 selects an OS-assigned ephemeral port).",
 )
-def explore_cmd(artifact: Path, graph_path: Path | None, port: int) -> None:
+@click.option(
+    "--export",
+    "export_dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Write the views as self-contained offline HTML to this directory instead of serving.",
+)
+def explore_cmd(
+    artifact: Path, graph_path: Path | None, port: int, export_dir: Path | None
+) -> None:
     """Render ARTIFACT (an `archex report diff --format json` output) locally.
 
-    Starts a loopback-only, session-token-gated HTTP server; nothing is
-    reachable outside this machine and no repository indexing runs.
+    Without `--export`, starts a loopback-only, session-token-gated HTTP
+    server; nothing is reachable outside this machine and no repository
+    indexing runs. With `--export`, writes the same views as static HTML that
+    opens from a `file://` URL with no server and no token, and exits.
     """
     try:
         data = load_explorer_data(artifact, graph_path)
     except ExplorerDataError as exc:
         raise click.ClickException(str(exc)) from exc
+
+    if export_dir is not None:
+        try:
+            result = export_explorer_site(data, export_dir)
+        except ExplorerExportError as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(f"wrote {len(result.files)} files to {result.destination}")
+        click.echo(f"open {result.destination / 'index.html'}")
+        if result.node_pages_omitted:
+            click.echo(
+                f"per-node pages: {result.node_pages} written, "
+                f"{result.node_pages_omitted} omitted at the export cap"
+            )
+        return
 
     try:
         server = create_server(data, port=port)

--- a/src/archex/explorer/export.py
+++ b/src/archex/explorer/export.py
@@ -1,0 +1,238 @@
+"""Self-contained static export of the explorer's views.
+
+Writes the same view models the loopback server renders into a directory of
+sibling HTML files that open directly from a `file://` URL: no server, no
+session token, no client-side script, no remote stylesheet, font, or image,
+and no query-string routing. Everything a reviewer needs travels in the
+directory, so the bundle can be attached to a pull request as a read-only
+build artifact and opened offline.
+
+Three properties are load-bearing:
+
+* **Canonical semantics.** Every page is produced by the same
+  `archex.explorer.viewmodel` builder and the same `archex.explorer.render`
+  renderer the server uses, selected through a non-interactive `LinkScheme`.
+  The export adds no second interpretation of the artifact, no parsing, and no
+  graph construction.
+* **No source body.** `AnalysisArtifactV1` and `ArchGraph` carry no raw source
+  text, so neither does the export. It writes exactly what the server would
+  show and nothing more, which keeps the redaction contract structural rather
+  than dependent on this module getting an escape right.
+* **Bounded payload.** A static bundle cannot paginate the way a server can,
+  so the node index and the per-node neighborhood pages are capped, each cap
+  is reported on the page rather than applied silently, and the per-node pages
+  cover the highest-degree nodes -- the ones a reviewer asks about.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from archex.explorer.render import (
+    LinkScheme,
+    render_diff_page,
+    render_health_page,
+    render_module_map_page,
+    render_neighborhood_page,
+    render_node_search_page,
+    render_page,
+    render_receipt_page,
+)
+from archex.explorer.viewmodel import (
+    build_diff_view,
+    build_health_view,
+    build_manifest_view,
+    build_module_map_view,
+    build_neighborhood_view,
+    build_node_index_view,
+    build_receipt_view,
+)
+from archex.graph_query import GraphQuery
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from archex.explorer.loader import ExplorerData
+
+#: Per-node neighborhood pages written for the highest-degree nodes. A bundle
+#: is opened in a browser and carried around as a CI artifact; an unbounded
+#: page-per-node export of a large repository is neither reviewable nor safe
+#: to attach.
+MAX_EXPORT_NODE_PAGES = 200
+
+#: Rows in the exported node index -- one document a reviewer scans with
+#: find-in-page, so its cap is independent of the per-node page cap.
+MAX_EXPORT_INDEX_ROWS = 1000
+
+INDEX_FILE = "index.html"
+MODULES_FILE = "modules.html"
+DIFF_FILE = "diff.html"
+NODES_FILE = "nodes.html"
+NEIGHBORHOOD_FILE = "neighborhood.html"
+RECEIPT_FILE = "receipt.html"
+HEALTH_FILE = "health.html"
+
+_UNSAFE_SLUG_CHARS = re.compile(r"[^a-zA-Z0-9._-]+")
+
+
+class ExplorerExportError(ValueError):
+    """Raised when the export destination cannot be used."""
+
+
+@dataclass(frozen=True)
+class ExportResult:
+    """What was written, and what the caps left out."""
+
+    destination: Path
+    files: list[str]
+    node_pages: int
+    node_pages_omitted: int
+    index_rows: int
+    index_rows_omitted: int
+
+
+def node_page_name(node_id: str) -> str:
+    """A deterministic, filesystem-safe filename for NODE_ID's neighborhood.
+
+    Node ids carry `:`, `#`, and `/`, so the readable part is sanitized for
+    orientation while a digest of the full id guarantees uniqueness -- two ids
+    that sanitize identically still get separate files.
+    """
+    readable = _UNSAFE_SLUG_CHARS.sub("-", node_id).strip("-")[:60]
+    digest = hashlib.blake2b(node_id.encode("utf-8"), digest_size=6).hexdigest()
+    return f"node-{readable}-{digest}.html" if readable else f"node-{digest}.html"
+
+
+def export_explorer_site(
+    data: ExplorerData,
+    destination: Path,
+    *,
+    max_node_pages: int = MAX_EXPORT_NODE_PAGES,
+    max_index_rows: int = MAX_EXPORT_INDEX_ROWS,
+) -> ExportResult:
+    """Write the explorer's views into DESTINATION as offline-openable HTML.
+
+    DESTINATION is treated as owned by the export: any HTML left by an earlier
+    export is removed first. Per-node filenames are keyed on the current
+    artifact's node ids, so a previous export's pages would otherwise survive
+    under different names, unlinked from the regenerated index but still
+    openable -- and carrying the earlier artifact's identity and revision into
+    a bundle attached for review of a different change.
+    """
+    if destination.exists() and not destination.is_dir():
+        raise ExplorerExportError(f"export destination {destination} is not a directory")
+    try:
+        destination.mkdir(parents=True, exist_ok=True)
+        for stale in destination.glob("*.html"):
+            stale.unlink()
+    except OSError as exc:
+        raise ExplorerExportError(
+            f"cannot prepare export destination {destination}: {exc}"
+        ) from exc
+
+    graph_query = GraphQuery(data.graph) if data.graph is not None else None
+    index_view = build_node_index_view(data, limit=max_index_rows, graph_query=graph_query)
+    page_node_ids = [match.id for match in index_view.matches[: max(max_node_pages, 0)]]
+    node_pages = {node_id: node_page_name(node_id) for node_id in page_node_ids}
+    total_nodes = len(index_view.matches) + index_view.omitted
+    pages_omitted = max(total_nodes - len(page_node_ids), 0)
+
+    links = LinkScheme(
+        modules=MODULES_FILE,
+        diff=DIFF_FILE,
+        search=NODES_FILE,
+        neighborhood=NEIGHBORHOOD_FILE,
+        receipt=RECEIPT_FILE,
+        health=HEALTH_FILE,
+        interactive=False,
+        node_pages=node_pages,
+    )
+    manifest = build_manifest_view(data)
+    written: list[str] = []
+
+    def write(name: str, html: str) -> None:
+        try:
+            (destination / name).write_text(html, encoding="utf-8")
+        except OSError as exc:
+            raise ExplorerExportError(f"cannot write {destination / name}: {exc}") from exc
+        written.append(name)
+
+    write(
+        INDEX_FILE,
+        render_page(
+            "archex explorer (static export)",
+            manifest,
+            _index_body(
+                links,
+                node_pages=len(node_pages),
+                node_pages_omitted=pages_omitted,
+                index_omitted=index_view.omitted,
+            ),
+            links=links,
+        ),
+    )
+    write(DIFF_FILE, render_diff_page(manifest, build_diff_view(data), links=links))
+    write(MODULES_FILE, render_module_map_page(manifest, build_module_map_view(data), links=links))
+    write(RECEIPT_FILE, render_receipt_page(manifest, build_receipt_view(data), links=links))
+    write(HEALTH_FILE, render_health_page(manifest, build_health_view(data), links=links))
+    write(NODES_FILE, render_node_search_page(manifest, index_view, links=links))
+    write(
+        NEIGHBORHOOD_FILE,
+        render_neighborhood_page(
+            manifest,
+            build_neighborhood_view(data, None, graph_query=graph_query),
+            links=links,
+        ),
+    )
+    for node_id in page_node_ids:
+        write(
+            node_pages[node_id],
+            render_neighborhood_page(
+                manifest,
+                build_neighborhood_view(data, node_id, graph_query=graph_query),
+                links=links,
+            ),
+        )
+
+    return ExportResult(
+        destination=destination,
+        files=written,
+        node_pages=len(page_node_ids),
+        node_pages_omitted=pages_omitted,
+        index_rows=len(index_view.matches),
+        index_rows_omitted=index_view.omitted,
+    )
+
+
+def _index_body(
+    links: LinkScheme,
+    *,
+    node_pages: int,
+    node_pages_omitted: int,
+    index_omitted: int,
+) -> str:
+    entries = "".join(f'<li><a href="{path}">{label}</a></li>' for label, path in links.nav())
+    pages_note = (
+        f" {node_pages_omitted} further node(s) have no page here at the export's page cap; "
+        "run the local server to reach them."
+        if node_pages_omitted
+        else ""
+    )
+    index_note = (
+        f" {index_omitted} further node(s) are omitted from the node index at its row cap."
+        if index_omitted
+        else ""
+    )
+    return (
+        "<h2>Views</h2>\n"
+        f"<ul>{entries}</ul>\n"
+        '<p class="note">Static export: every page here is the same view the local '
+        "<code>archex explore</code> server renders, written offline with no script, no "
+        "remote reference, and no session token. Node search, direction, depth, and "
+        "edge-type filtering are interactive controls and need that server; this bundle "
+        f"ships {node_pages} pre-rendered per-node neighborhood page(s) for the "
+        f"highest-degree nodes instead.{pages_note}{index_note}</p>"
+    )

--- a/src/archex/explorer/loader.py
+++ b/src/archex/explorer/loader.py
@@ -1,4 +1,4 @@
-"""Artifact-only data loading for the local explorer.
+"""Artifact-only, size-bounded data loading for the local explorer.
 
 Loads a previously generated `AnalysisArtifactV1` (and, optionally, a
 previously generated `ArchGraph`) from disk. This module performs no
@@ -7,6 +7,13 @@ only validates and deserializes artifacts that `archex report diff` and
 `archex graph export` already produced. Neither loaded artifact ever carries
 raw source text (see `RedactionMode` and `ArchGraph`'s node/edge shapes), so
 the explorer has no source content to redact or leak.
+
+The explorer additionally bounds what it will accept. Every view is already
+row-bounded, but the canonical loaders read and validate a whole document
+before any view runs, so an artifact far larger than anything archex produces
+would be materialized in full and -- once exported as static HTML -- handed to
+a browser. The explorer therefore refuses an oversized input outright instead
+of degrading, and says which limit was exceeded.
 """
 
 from __future__ import annotations
@@ -21,6 +28,12 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+MAX_ARTIFACT_BYTES = 32 * 1024 * 1024
+MAX_GRAPH_BYTES = 128 * 1024 * 1024
+MAX_GRAPH_NODES = 200_000
+MAX_GRAPH_EDGES = 400_000
+
+
 class ExplorerDataError(ValueError):
     """Raised when the explorer's input artifacts cannot be loaded."""
 
@@ -33,13 +46,27 @@ class ExplorerData:
     graph: ArchGraph | None
 
 
+def _require_within_byte_budget(path: Path, *, limit: int, label: str) -> None:
+    """Reject an oversized file before it is read, not after."""
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        raise ExplorerDataError(f"Failed to read {label} {path}: {exc}") from exc
+    if size > limit:
+        raise ExplorerDataError(
+            f"{label} {path} is {size} bytes, above the explorer's {limit}-byte limit; "
+            f"the explorer refuses to load it rather than render a partial view"
+        )
+
+
 def load_explorer_data(artifact_path: Path, graph_path: Path | None = None) -> ExplorerData:
     """Load ARTIFACT_PATH (required) and GRAPH_PATH (optional) for the explorer.
 
-    Raises `ExplorerDataError` for a missing, unreadable, or schema-invalid
-    artifact -- the explorer never falls back to a partially loaded or
-    synthesized state.
+    Raises `ExplorerDataError` for a missing, unreadable, schema-invalid, or
+    oversized artifact -- the explorer never falls back to a partially loaded
+    or synthesized state.
     """
+    _require_within_byte_budget(artifact_path, limit=MAX_ARTIFACT_BYTES, label="report artifact")
     try:
         artifact = load_analysis_artifact(artifact_path)
     except ReportArtifactError as exc:
@@ -47,9 +74,20 @@ def load_explorer_data(artifact_path: Path, graph_path: Path | None = None) -> E
 
     graph: ArchGraph | None = None
     if graph_path is not None:
+        _require_within_byte_budget(graph_path, limit=MAX_GRAPH_BYTES, label="graph artifact")
         try:
             graph = load_arch_graph(graph_path)
         except GraphArtifactError as exc:
             raise ExplorerDataError(str(exc)) from exc
+        if len(graph.nodes) > MAX_GRAPH_NODES:
+            raise ExplorerDataError(
+                f"graph artifact {graph_path} declares {len(graph.nodes)} nodes, above the "
+                f"explorer's {MAX_GRAPH_NODES}-node limit"
+            )
+        if len(graph.edges) > MAX_GRAPH_EDGES:
+            raise ExplorerDataError(
+                f"graph artifact {graph_path} declares {len(graph.edges)} edges, above the "
+                f"explorer's {MAX_GRAPH_EDGES}-edge limit"
+            )
 
     return ExplorerData(artifact=artifact, graph=graph)

--- a/src/archex/explorer/render.py
+++ b/src/archex/explorer/render.py
@@ -14,11 +14,14 @@ any).
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from html import escape
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from archex.explorer.viewmodel import (
         DiffView,
         HealthView,
@@ -28,15 +31,6 @@ if TYPE_CHECKING:
         NodeSearchView,
         ReceiptView,
     )
-
-NAV_ITEMS: list[tuple[str, str]] = [
-    ("Module Map", "/view/modules"),
-    ("Diff Review", "/view/diff"),
-    ("Node Search", "/view/search"),
-    ("Target Neighborhood", "/view/neighborhood"),
-    ("Receipt Inspector", "/view/receipt"),
-    ("Index Health", "/view/health"),
-]
 
 _STYLE = """
 body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -80,16 +74,64 @@ tr.orientation-lateral td.orientation { color: #666; }
 """.strip()
 
 
+@dataclass(frozen=True)
+class LinkScheme:
+    """Where this rendering's links point, and whether a server can answer forms.
+
+    The server renders absolute routes and can service `<form method="get">`
+    submissions; a static export is a set of sibling files opened over
+    `file://` with no server behind them, so it renders relative filenames and
+    omits every control that would submit to nothing.
+    """
+
+    modules: str
+    diff: str
+    search: str
+    neighborhood: str
+    receipt: str
+    health: str
+    interactive: bool
+    node_pages: Mapping[str, str] = field(default_factory=dict[str, str])
+
+    def nav(self) -> list[tuple[str, str]]:
+        return [
+            ("Module Map", self.modules),
+            ("Diff Review", self.diff),
+            ("Node Search" if self.interactive else "Node Index", self.search),
+            ("Target Neighborhood", self.neighborhood),
+            ("Receipt Inspector", self.receipt),
+            ("Index Health", self.health),
+        ]
+
+    def node_link(self, node_id: str) -> str | None:
+        """The href for NODE_ID's neighborhood, or None when there is no page for it."""
+        if self.interactive:
+            return f"{self.neighborhood}?node={quote(node_id, safe='')}"
+        return self.node_pages.get(node_id)
+
+
+SERVER_LINKS = LinkScheme(
+    modules="/view/modules",
+    diff="/view/diff",
+    search="/view/search",
+    neighborhood="/view/neighborhood",
+    receipt="/view/receipt",
+    health="/view/health",
+    interactive=True,
+)
+
+NAV_ITEMS: list[tuple[str, str]] = SERVER_LINKS.nav()
+
+
 def render_page(
     title: str,
     manifest: ManifestView,
     body: str,
     *,
-    nav: list[tuple[str, str]] | None = None,
+    links: LinkScheme = SERVER_LINKS,
 ) -> str:
-    nav_items = NAV_ITEMS if nav is None else nav
     nav_html = " ".join(
-        f'<a href="{escape(path)}">{escape(label)}</a>' for label, path in nav_items
+        f'<a href="{escape(path)}">{escape(label)}</a>' for label, path in links.nav()
     )
     return (
         "<!DOCTYPE html>\n"
@@ -122,7 +164,9 @@ def _manifest_banner(manifest: ManifestView) -> str:
     )
 
 
-def render_diff_page(manifest: ManifestView, view: DiffView) -> str:
+def render_diff_page(
+    manifest: ManifestView, view: DiffView, *, links: LinkScheme = SERVER_LINKS
+) -> str:
     body = "".join(
         [
             _diff_summary(view),
@@ -133,7 +177,7 @@ def render_diff_page(manifest: ManifestView, view: DiffView) -> str:
             _unsupported_files_list(view),
         ]
     )
-    return render_page(f"Diff Review: {view.base_ref}", manifest, body)
+    return render_page(f"Diff Review: {view.base_ref}", manifest, body, links=links)
 
 
 def _risk_badge(level: str) -> str:
@@ -261,7 +305,9 @@ def render_error_page(status: int, title: str, message: str) -> str:
     )
 
 
-def render_module_map_page(manifest: ManifestView, view: ModuleMapView) -> str:
+def render_module_map_page(
+    manifest: ManifestView, view: ModuleMapView, *, links: LinkScheme = SERVER_LINKS
+) -> str:
     if not view.available:
         body = (
             "<h2>Module Map</h2>"
@@ -269,11 +315,11 @@ def render_module_map_page(manifest: ManifestView, view: ModuleMapView) -> str:
             "Pass <code>--graph</code> (an <code>archex graph export</code> output) "
             "to <code>archex explore</code> to enable this view.</p>"
         )
-        return render_page("Module Map", manifest, body)
+        return render_page("Module Map", manifest, body, links=links)
 
     if not view.modules:
         body = '<h2>Module Map</h2><p class="empty">The graph has no nodes.</p>'
-        return render_page("Module Map", manifest, body)
+        return render_page("Module Map", manifest, body, links=links)
 
     rows = "".join(
         "<tr>"
@@ -290,10 +336,12 @@ def render_module_map_page(manifest: ManifestView, view: ModuleMapView) -> str:
         "<table><tr><th>Module</th><th>Nodes</th><th>Files</th>"
         "<th>Symbols</th><th>Interfaces</th></tr>" + rows + "</table>" + note
     )
-    return render_page("Module Map", manifest, body)
+    return render_page("Module Map", manifest, body, links=links)
 
 
-def render_receipt_page(manifest: ManifestView, view: ReceiptView) -> str:
+def render_receipt_page(
+    manifest: ManifestView, view: ReceiptView, *, links: LinkScheme = SERVER_LINKS
+) -> str:
     evidence_rows_html = "".join(
         "<tr>"
         f"<td>{escape(item.path)}</td>"
@@ -340,10 +388,12 @@ def render_receipt_page(manifest: ManifestView, view: ReceiptView) -> str:
             else '<p class="empty">none</p>'
         )
     )
-    return render_page("Receipt Inspector", manifest, body)
+    return render_page("Receipt Inspector", manifest, body, links=links)
 
 
-def render_health_page(manifest: ManifestView, view: HealthView) -> str:
+def render_health_page(
+    manifest: ManifestView, view: HealthView, *, links: LinkScheme = SERVER_LINKS
+) -> str:
     parser_rows = (
         "".join(
             f"<li>{escape(language)}: {escape(version)}</li>"
@@ -366,11 +416,15 @@ def render_health_page(manifest: ManifestView, view: HealthView) -> str:
         "</ul>"
         "<h2>Parser versions</h2><ul>" + parser_rows + "</ul>"
     )
-    return render_page("Index Health", manifest, body)
+    return render_page("Index Health", manifest, body, links=links)
 
 
-def _neighborhood_link(node_id: str) -> str:
-    return f"/view/neighborhood?node={quote(node_id, safe='')}"
+def _node_cell(node_id: str, links: LinkScheme) -> str:
+    """A node id, linked to its own neighborhood when a page for it exists."""
+    href = links.node_link(node_id)
+    if href is None:
+        return escape(node_id)
+    return f'<a href="{escape(href)}">{escape(node_id)}</a>'
 
 
 def _edge_type_fieldset(view: NeighborhoodView) -> str:
@@ -388,9 +442,17 @@ def _edge_type_fieldset(view: NeighborhoodView) -> str:
     )
 
 
-def _neighborhood_form(view: NeighborhoodView) -> str:
+def _neighborhood_form(view: NeighborhoodView, links: LinkScheme) -> str:
+    """The interactive controls, or a note explaining their absence offline."""
+    if not links.interactive:
+        return (
+            '<p class="note">This is a static export: node search, direction, depth, and '
+            "edge-type filtering need the local <code>archex explore</code> server. Every "
+            "exported neighborhood below is the default both-direction, depth-1 view, and its "
+            "orientation column still distinguishes inbound from outbound edges.</p>"
+        )
     return (
-        '<form class="controls" method="get" action="/view/neighborhood">'
+        f'<form class="controls" method="get" action="{escape(links.neighborhood)}">'
         '<input type="text" name="node" placeholder="file or symbol id" '
         f'value="{escape(view.query or "")}">'
         '<select name="direction">'
@@ -415,30 +477,33 @@ _ORIENTATION_LEGEND = (
 )
 
 
-def render_neighborhood_page(manifest: ManifestView, view: NeighborhoodView) -> str:
-    form = _neighborhood_form(view)
+def render_neighborhood_page(
+    manifest: ManifestView, view: NeighborhoodView, *, links: LinkScheme = SERVER_LINKS
+) -> str:
+    form = _neighborhood_form(view, links)
     if not view.available:
         body = (
             "<h2>Target Neighborhood</h2>" + form + '<p class="empty">No graph artifact provided. '
             "Pass <code>--graph</code> to <code>archex explore</code> to enable this view.</p>"
         )
-        return render_page("Target Neighborhood", manifest, body)
+        return render_page("Target Neighborhood", manifest, body, links=links)
 
     if view.error is not None:
         body = "<h2>Target Neighborhood</h2>" + form + f'<p class="empty">{escape(view.error)}</p>'
-        return render_page("Target Neighborhood", manifest, body)
+        return render_page("Target Neighborhood", manifest, body, links=links)
 
     if view.seed is None:
         body = (
             "<h2>Target Neighborhood</h2>"
             + form
             + '<p class="empty">Enter a file path or symbol id to see its bounded '
-            'neighborhood, or use <a href="/view/search">Node Search</a> to find one.</p>'
+            "neighborhood, or use "
+            f'<a href="{escape(links.search)}">Node Search</a> to find one.</p>'
         )
-        return render_page("Target Neighborhood", manifest, body)
+        return render_page("Target Neighborhood", manifest, body, links=links)
 
     node_rows = "".join(
-        f'<tr><td><a href="{_neighborhood_link(node.id)}">{escape(node.id)}</a></td>'
+        f"<tr><td>{_node_cell(node.id, links)}</td>"
         f"<td>{escape(node.type)}</td>"
         f"<td>{escape(node.label)}</td><td>{node.degree}</td></tr>"
         for node in view.nodes
@@ -482,61 +547,70 @@ def render_neighborhood_page(manifest: ManifestView, view: NeighborhoodView) -> 
         "<th>Confidence</th></tr>" + edge_rows + "</table>"
         "<h3>Hubs skipped (high fan-out)</h3><ul>" + hub_rows + "</ul>"
     )
-    return render_page("Target Neighborhood", manifest, body)
+    return render_page("Target Neighborhood", manifest, body, links=links)
 
 
-def render_node_search_page(manifest: ManifestView, view: NodeSearchView) -> str:
-    form = (
-        '<form class="controls" method="get" action="/view/search">'
+def render_node_search_page(
+    manifest: ManifestView, view: NodeSearchView, *, links: LinkScheme = SERVER_LINKS
+) -> str:
+    heading = "Node Search" if links.interactive else "Node Index"
+    controls = (
+        f'<form class="controls" method="get" action="{escape(links.search)}">'
         '<input type="text" name="q" placeholder="id, label, or path substring" '
         f'value="{escape(view.query or "")}">'
         f'<input type="number" name="limit" min="1" value="{view.limit}">'
         '<button type="submit">Search nodes</button>'
         "</form>"
+        if links.interactive
+        else (
+            '<p class="note">This is a static export: the index below lists every exported '
+            "node, so the browser's own find-in-page reaches any of them. Incremental search "
+            "needs the local <code>archex explore</code> server.</p>"
+        )
     )
+
     if not view.available:
         body = (
-            "<h2>Node Search</h2>" + form + '<p class="empty">No graph artifact provided. '
+            f"<h2>{heading}</h2>" + controls + '<p class="empty">No graph artifact provided. '
             "Pass <code>--graph</code> to <code>archex explore</code> to enable this view.</p>"
         )
-        return render_page("Node Search", manifest, body)
-
-    if not view.query:
-        body = (
-            "<h2>Node Search</h2>"
-            + form
-            + '<p class="empty">Search the exported graph by node id, symbol label, or file '
-            "path. Matches link straight to their bounded neighborhood.</p>"
-        )
-        return render_page("Node Search", manifest, body)
+        return render_page(heading, manifest, body, links=links)
 
     if not view.matches:
-        body = (
-            "<h2>Node Search</h2>"
-            + form
-            + f'<p class="empty">No node matches {escape(view.query)}.</p>'
+        message = (
+            f'<p class="empty">No node matches {escape(view.query)}.</p>'
+            if view.query
+            else '<p class="empty">Search the exported graph by node id, symbol label, or file '
+            "path. Matches link straight to their bounded neighborhood.</p>"
         )
-        return render_page("Node Search", manifest, body)
+        return render_page(heading, manifest, f"<h2>{heading}</h2>{controls}{message}", links=links)
 
     rows = "".join(
-        f'<tr><td><a href="{_neighborhood_link(match.id)}">{escape(match.id)}</a></td>'
+        f"<tr><td>{_node_cell(match.id, links)}</td>"
         f"<td>{escape(match.type)}</td><td>{escape(match.label)}</td>"
         f"<td>{escape(match.path or '-')}</td><td>{escape(match.module or '-')}</td>"
         f"<td>{match.degree}</td></tr>"
         for match in view.matches
     )
+    summary = (
+        f'<p class="note">{len(view.matches)} match(es) for '
+        f"<code>{escape(view.query)}</code> &middot; match kind: "
+        f"{escape(view.match_kind or 'none')}</p>"
+        if view.query
+        else f'<p class="note">{len(view.matches)} node(s), highest degree first.</p>'
+    )
     truncation = (
-        f'<p class="note">Truncated: {view.omitted} further matches omitted at limit '
+        f'<p class="note">Truncated: {view.omitted} further node(s) omitted at limit '
         f"{view.limit}.</p>"
         if view.truncated
         else ""
     )
     body = (
-        "<h2>Node Search</h2>" + form + f'<p class="note">{len(view.matches)} match(es) for '
-        f"<code>{escape(view.query)}</code> &middot; match kind: "
-        f"{escape(view.match_kind or 'none')}</p>"
+        f"<h2>{heading}</h2>"
+        + controls
+        + summary
         + truncation
         + "<table><tr><th>ID</th><th>Type</th><th>Label</th><th>Path</th><th>Module</th>"
         "<th>Degree</th></tr>" + rows + "</table>"
     )
-    return render_page("Node Search", manifest, body)
+    return render_page(heading, manifest, body, links=links)

--- a/src/archex/explorer/viewmodel.py
+++ b/src/archex/explorer/viewmodel.py
@@ -703,3 +703,63 @@ def build_node_search_view(
         truncated=result.truncated,
         omitted=result.omitted,
     )
+
+
+MAX_NODE_INDEX_ROWS = 1000
+
+
+def build_node_index_view(
+    data: ExplorerData,
+    *,
+    limit: int = MAX_NODE_INDEX_ROWS,
+    graph_query: GraphQuery | None = None,
+) -> NodeSearchView:
+    """Every graph node as a bounded, degree-ranked `NodeSearchView`.
+
+    The static export has no server to answer an incremental search, so it
+    ships one index document instead.
+
+    Degree and identity come from `GraphQuery`, not from a second count over
+    the raw edge list. That matters because the two disagree on real graphs:
+    `GraphQuery` skips an edge unless *both* endpoints exist as nodes, and an
+    import to an unindexed or external file legitimately produces an edge whose
+    target has no node. Counting endpoints directly would inflate that source
+    node's degree, so the index page's degree column and its highest-degree
+    ordering would contradict the degree the same node's neighborhood page
+    shows. One source of truth, so the two agree by construction.
+    """
+    capped = max(limit, 0)
+    if data.graph is None:
+        return NodeSearchView(
+            available=False,
+            query=None,
+            match_kind=None,
+            limit=capped,
+            matches=[],
+            truncated=False,
+            omitted=0,
+        )
+
+    engine = graph_query if graph_query is not None else GraphQuery(data.graph)
+    summaries = engine.node_summaries()
+    ranked = sorted(summaries, key=lambda node: (-node.degree, node.id))
+    selected = ranked[:capped]
+    return NodeSearchView(
+        available=True,
+        query=None,
+        match_kind=None,
+        limit=capped,
+        matches=[
+            NodeSearchRow(
+                id=node.id,
+                type=node.type,
+                label=node.label,
+                path=node.path,
+                module=node.module,
+                degree=node.degree,
+            )
+            for node in selected
+        ],
+        truncated=len(ranked) > len(selected),
+        omitted=len(ranked) - len(selected),
+    )

--- a/src/archex/graph_query.py
+++ b/src/archex/graph_query.py
@@ -163,6 +163,18 @@ class GraphQuery:
         with IndexStore(path) as store:
             return cls.from_store(store, repo_root=repo_root, hub_degree=hub_degree)
 
+    def node_summaries(self) -> list[GraphNodeSummary]:
+        """Every deduplicated node with the degree this engine computed for it.
+
+        A read-only accessor over state built in `__init__`: no traversal, no
+        ranking, no query. It exists so a caller that needs to enumerate nodes
+        (the explorer's static node index) reports the same identity and the
+        same degree as every other surface, instead of re-counting edge
+        endpoints and disagreeing on graphs with duplicate node ids or edges
+        whose other endpoint is not a node.
+        """
+        return [self._summarize_node(node) for node in self._nodes]
+
     def lookup(self, query: str, *, limit: int = DEFAULT_GRAPH_LIMIT) -> GraphNodeLookupResult:
         self._validate_limit(limit)
         node, match_kind = self._resolve_exact(query)

--- a/tests/cli/test_explore_cmd.py
+++ b/tests/cli/test_explore_cmd.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 import json
 import threading
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from archex.cli.main import cli
+from archex.explorer import loader
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def _artifact_json(path: Path) -> Path:
@@ -69,3 +74,48 @@ def test_explore_prints_the_loopback_url_and_stops_on_interrupt(tmp_path: Path) 
     assert "archex explorer listening at http://127.0.0.1:" in result.output
     assert "?token=" in result.output
     assert threading.active_count() == before
+
+
+def test_explore_export_writes_offline_html_and_starts_no_server(tmp_path: Path) -> None:
+    artifact_path = _artifact_json(tmp_path)
+    destination = tmp_path / "site"
+    runner = CliRunner()
+
+    def _must_not_serve(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("--export must not start a server")
+
+    with patch("archex.cli.explore_cmd.create_server", _must_not_serve):
+        result = runner.invoke(cli, ["explore", str(artifact_path), "--export", str(destination)])
+
+    assert result.exit_code == 0, result.output
+    assert "wrote" in result.output
+    index = destination / "index.html"
+    assert index.is_file()
+    html = index.read_text(encoding="utf-8")
+    assert "<script" not in html
+    assert "token=" not in html
+
+
+def test_explore_export_reports_a_clean_error_for_an_unusable_destination(tmp_path: Path) -> None:
+    artifact_path = _artifact_json(tmp_path)
+    occupied = tmp_path / "occupied"
+    occupied.write_text("x")
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["explore", str(artifact_path), "--export", str(occupied)])
+
+    assert result.exit_code != 0
+    assert "Invalid value for '--export'" in result.output
+
+
+def test_explore_reports_a_clean_error_for_an_oversized_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifact_path = _artifact_json(tmp_path)
+    monkeypatch.setattr(loader, "MAX_ARTIFACT_BYTES", 4)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["explore", str(artifact_path)])
+
+    assert result.exit_code != 0
+    assert "above the explorer's 4-byte limit" in result.output

--- a/tests/explorer/test_export.py
+++ b/tests/explorer/test_export.py
@@ -1,0 +1,313 @@
+"""Tests for the self-contained static explorer export.
+
+The properties that matter for a bundle attached to a pull request and opened
+from a `file://` URL: it must be openable with no server, carry no script and
+no remote reference, expose no session token, keep the canonical artifact
+semantics the loopback server renders, leak no source body, and stay bounded.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from archex.explorer.export import (
+    DIFF_FILE,
+    HEALTH_FILE,
+    INDEX_FILE,
+    MODULES_FILE,
+    NEIGHBORHOOD_FILE,
+    NODES_FILE,
+    RECEIPT_FILE,
+    ExplorerExportError,
+    export_explorer_site,
+    node_page_name,
+)
+from archex.explorer.loader import ExplorerData
+from archex.explorer.viewmodel import build_neighborhood_view, build_node_index_view
+from archex.graph_artifact import (
+    ArchGraph,
+    GraphEdge,
+    GraphEdgeType,
+    GraphExportMetadata,
+    GraphNode,
+    GraphNodeType,
+    GraphProject,
+)
+from archex.report.artifact import (
+    AnalysisArtifactV1,
+    DiffAnalysis,
+    DiffFileChange,
+    ReportSchemaVersion,
+)
+
+_REMOTE_REF = re.compile(r"""(?:src|href)\s*=\s*["'](?:https?:)?//""")
+
+
+def _artifact() -> AnalysisArtifactV1:
+    return AnalysisArtifactV1(
+        schema_version=ReportSchemaVersion(),
+        archex_version="0.28.0",
+        generated_at="2026-09-10T00:00:00Z",
+        source_identity="acme/widget",
+        source_root="/repo",
+        source_revision="deadbeef",
+        working_tree_fingerprint="fp",
+        index_generation="gen1",
+        index_schema_version="1",
+        chunker_revision="c1",
+        config_fingerprint="cfg1",
+        diff=DiffAnalysis(
+            base_ref="main",
+            changed_files=[DiffFileChange(path="hub.py", status="M", handle="file:hub.py")],
+            changed_files_total=1,
+        ),
+    )
+
+
+def _graph(extra_nodes: int = 0) -> ArchGraph:
+    nodes = [
+        GraphNode(id="file:hub.py", type=GraphNodeType.FILE, label="hub.py", module="pkg"),
+        GraphNode(id="file:leaf.py", type=GraphNodeType.FILE, label="leaf.py", module="pkg"),
+        GraphNode(
+            id="symbol:hub.py::helper#function",
+            type=GraphNodeType.SYMBOL,
+            label="helper",
+            module="pkg",
+        ),
+    ]
+    nodes.extend(
+        GraphNode(
+            id=f"file:filler_{index}.py",
+            type=GraphNodeType.FILE,
+            label=f"filler_{index}.py",
+            module="pkg",
+        )
+        for index in range(extra_nodes)
+    )
+    return ArchGraph(
+        project=GraphProject(name="widget", total_files=2 + extra_nodes),
+        metadata=GraphExportMetadata(archex_version="0.28.0"),
+        nodes=nodes,
+        edges=[
+            GraphEdge(source="file:leaf.py", target="file:hub.py", type=GraphEdgeType.IMPORTS),
+            GraphEdge(
+                source="file:hub.py",
+                target="symbol:hub.py::helper#function",
+                type=GraphEdgeType.CONTAINS,
+            ),
+        ],
+    )
+
+
+def _data(extra_nodes: int = 0) -> ExplorerData:
+    return ExplorerData(artifact=_artifact(), graph=_graph(extra_nodes))
+
+
+def _pages(destination: Path) -> dict[str, str]:
+    return {path.name: path.read_text(encoding="utf-8") for path in destination.glob("*.html")}
+
+
+def test_export_writes_every_view_as_a_sibling_file(tmp_path: Path) -> None:
+    result = export_explorer_site(_data(), tmp_path / "site")
+
+    written = set(result.files)
+    for name in (
+        INDEX_FILE,
+        DIFF_FILE,
+        MODULES_FILE,
+        NODES_FILE,
+        NEIGHBORHOOD_FILE,
+        RECEIPT_FILE,
+        HEALTH_FILE,
+    ):
+        assert name in written
+        assert (result.destination / name).is_file()
+
+
+def test_exported_pages_carry_no_script_no_remote_reference_and_no_token(tmp_path: Path) -> None:
+    export_explorer_site(_data(), tmp_path / "site")
+
+    for name, html in _pages(tmp_path / "site").items():
+        assert "<script" not in html, name
+        assert _REMOTE_REF.search(html) is None, name
+        assert "token=" not in html, name
+        assert "archex_session" not in html, name
+
+
+def test_exported_links_are_relative_so_the_bundle_opens_over_file_urls(tmp_path: Path) -> None:
+    export_explorer_site(_data(), tmp_path / "site")
+    destination = tmp_path / "site"
+
+    for name, html in _pages(destination).items():
+        for href in re.findall(r'href="([^"]+)"', html):
+            assert not href.startswith("/"), f"{name} links to absolute path {href}"
+            assert "?" not in href, f"{name} links to a query string {href}"
+            assert (destination / href).is_file(), f"{name} links to missing {href}"
+
+
+def test_exported_pages_omit_controls_no_server_can_answer(tmp_path: Path) -> None:
+    export_explorer_site(_data(), tmp_path / "site")
+
+    for name, html in _pages(tmp_path / "site").items():
+        assert "<form" not in html, name
+    index = (tmp_path / "site" / NODES_FILE).read_text(encoding="utf-8")
+    assert "Incremental search needs the local" in index
+
+
+def test_export_node_pages_cover_the_highest_degree_nodes(tmp_path: Path) -> None:
+    result = export_explorer_site(_data(), tmp_path / "site")
+
+    hub_page = tmp_path / "site" / node_page_name("file:hub.py")
+    assert hub_page.is_file()
+    assert result.node_pages == 3
+    html = hub_page.read_text(encoding="utf-8")
+    # The seed's own inbound and outbound edges are both distinguishable offline.
+    assert 'class="orientation-in"' in html
+    assert 'class="orientation-out"' in html
+
+
+def test_export_caps_node_pages_and_reports_what_it_omitted(tmp_path: Path) -> None:
+    result = export_explorer_site(_data(extra_nodes=10), tmp_path / "site", max_node_pages=2)
+
+    assert result.node_pages == 2
+    assert result.node_pages_omitted == 11
+    node_page_files = list((tmp_path / "site").glob("node-*.html"))
+    assert len(node_page_files) == 2
+    # The highest-degree node keeps its page when the cap bites.
+    assert (tmp_path / "site" / node_page_name("file:hub.py")).is_file()
+
+
+def test_export_caps_index_rows_and_reports_the_remainder(tmp_path: Path) -> None:
+    result = export_explorer_site(_data(extra_nodes=10), tmp_path / "site", max_index_rows=4)
+
+    assert result.index_rows == 4
+    assert result.index_rows_omitted == 9
+    html = (tmp_path / "site" / NODES_FILE).read_text(encoding="utf-8")
+    assert "9 further node(s) omitted" in html
+
+
+def test_export_projects_the_same_canonical_artifact_values(tmp_path: Path) -> None:
+    data = _data()
+
+    export_explorer_site(data, tmp_path / "site")
+
+    diff_html = (tmp_path / "site" / DIFF_FILE).read_text(encoding="utf-8")
+    health_html = (tmp_path / "site" / HEALTH_FILE).read_text(encoding="utf-8")
+    assert data.artifact.source_identity in diff_html
+    assert data.artifact.source_revision in diff_html
+    assert data.artifact.diff.changed_files[0].path in diff_html
+    assert data.artifact.index_generation in health_html
+    assert data.artifact.redaction_mode.value in diff_html
+
+
+def test_export_without_a_graph_still_writes_every_page(tmp_path: Path) -> None:
+    data = ExplorerData(artifact=_artifact(), graph=None)
+
+    result = export_explorer_site(data, tmp_path / "site")
+
+    assert result.node_pages == 0
+    assert (tmp_path / "site" / NODES_FILE).is_file()
+    assert "No graph artifact provided" in (tmp_path / "site" / NODES_FILE).read_text()
+
+
+def test_export_rejects_a_destination_that_is_not_a_directory(tmp_path: Path) -> None:
+    occupied = tmp_path / "already-a-file"
+    occupied.write_text("x")
+
+    with pytest.raises(ExplorerExportError, match="not a directory"):
+        export_explorer_site(_data(), occupied)
+
+
+def test_node_page_names_are_filesystem_safe_and_collision_free() -> None:
+    first = node_page_name("symbol:pkg/mod.py::Cls#method")
+    second = node_page_name("symbol:pkg/mod.py::Cls#other")
+
+    for name in (first, second):
+        assert re.fullmatch(r"node-[A-Za-z0-9._-]+\.html", name)
+        assert "/" not in name
+    assert first != second
+    # Two ids that sanitize to the same readable stem still get separate files.
+    assert node_page_name("a:b") != node_page_name("a/b")
+
+
+def _graph_with_dangling_edge() -> ArchGraph:
+    """`hub.py` imports an unindexed module, so one edge target has no node.
+
+    Canonical `archex graph export` output contains exactly this shape whenever
+    a file imports something outside the index (external package, stdlib, or a
+    path the parser skipped).
+    """
+    return ArchGraph(
+        project=GraphProject(name="widget", total_files=2),
+        metadata=GraphExportMetadata(archex_version="0.28.0"),
+        nodes=[
+            GraphNode(id="file:hub.py", type=GraphNodeType.FILE, label="hub.py", module="pkg"),
+            GraphNode(id="file:leaf.py", type=GraphNodeType.FILE, label="leaf.py", module="pkg"),
+        ],
+        edges=[
+            GraphEdge(source="file:leaf.py", target="file:hub.py", type=GraphEdgeType.IMPORTS),
+            GraphEdge(source="file:hub.py", target="file:absent.py", type=GraphEdgeType.IMPORTS),
+        ],
+    )
+
+
+def test_node_index_degree_agrees_with_the_neighborhood_view_it_links_to() -> None:
+    """A dangling edge must not make the index disagree with the node's own page."""
+    data = ExplorerData(artifact=_artifact(), graph=_graph_with_dangling_edge())
+
+    index = build_node_index_view(data)
+    by_id = {row.id: row.degree for row in index.matches}
+
+    for node_id, indexed_degree in by_id.items():
+        neighborhood = build_neighborhood_view(data, node_id)
+        assert neighborhood.seed is not None
+        assert neighborhood.seed.degree == indexed_degree, node_id
+    # The dangling edge contributes to neither, so hub.py and leaf.py both read 1.
+    assert by_id == {"file:hub.py": 1, "file:leaf.py": 1}
+
+
+def test_reexport_into_a_reused_directory_removes_the_previous_bundle(tmp_path: Path) -> None:
+    destination = tmp_path / "site"
+    export_explorer_site(_data(), destination)
+    stale_page = destination / node_page_name("file:leaf.py")
+    assert stale_page.is_file()
+
+    other = ExplorerData(artifact=_artifact(), graph=_graph_with_dangling_edge())
+    result = export_explorer_site(other, destination)
+
+    # The earlier artifact's per-node pages must not survive under their own
+    # filenames; they would still open from a file:// URL and show its identity.
+    assert not (destination / node_page_name("symbol:hub.py::helper#function")).exists()
+    on_disk = {path.name for path in destination.glob("*.html")}
+    assert on_disk == set(result.files)
+
+
+def test_export_reports_the_page_cap_on_the_index_page(tmp_path: Path) -> None:
+    result = export_explorer_site(_data(extra_nodes=10), tmp_path / "site", max_node_pages=2)
+
+    html = (tmp_path / "site" / INDEX_FILE).read_text(encoding="utf-8")
+    assert f"{result.node_pages_omitted} further node(s) have no page here" in html
+    assert "run the local server to reach them" in html
+
+
+def test_export_honors_a_zero_row_cap_instead_of_forcing_one_row(tmp_path: Path) -> None:
+    result = export_explorer_site(_data(), tmp_path / "site", max_index_rows=0)
+
+    assert result.index_rows == 0
+    assert result.node_pages == 0
+    assert result.index_rows_omitted == 3
+
+
+def test_export_reports_a_write_failure_as_an_export_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _fail(_self: Path, _content: str, **_kwargs: object) -> int:
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(Path, "write_text", _fail)
+
+    with pytest.raises(ExplorerExportError, match="no space left on device"):
+        export_explorer_site(_data(), tmp_path / "site")

--- a/tests/explorer/test_loader.py
+++ b/tests/explorer/test_loader.py
@@ -7,8 +7,17 @@ from pathlib import Path
 
 import pytest
 
+from archex.explorer import loader
 from archex.explorer.loader import ExplorerDataError, load_explorer_data
-from archex.graph_artifact import ArchGraph, GraphExportMetadata, GraphProject
+from archex.graph_artifact import (
+    ArchGraph,
+    GraphEdge,
+    GraphEdgeType,
+    GraphExportMetadata,
+    GraphNode,
+    GraphNodeType,
+    GraphProject,
+)
 
 
 def _artifact_json(source_revision: str = "deadbeef") -> dict[str, object]:
@@ -93,3 +102,92 @@ def test_load_explorer_data_rejects_malformed_graph(tmp_path: Path) -> None:
 
     with pytest.raises(ExplorerDataError):
         load_explorer_data(artifact_path, graph_path)
+
+
+def test_oversized_report_artifact_is_rejected_before_it_is_parsed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(json.dumps(_artifact_json()))
+    monkeypatch.setattr(loader, "MAX_ARTIFACT_BYTES", 10)
+
+    def _fail(_path: Path) -> object:
+        raise AssertionError("an oversized artifact must not be parsed")
+
+    monkeypatch.setattr(loader, "load_analysis_artifact", _fail)
+
+    with pytest.raises(ExplorerDataError, match="above the explorer's 10-byte limit"):
+        load_explorer_data(artifact_path)
+
+
+def test_oversized_graph_artifact_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(json.dumps(_artifact_json()))
+    graph_path = tmp_path / "graph.json"
+    graph_path.write_text(
+        ArchGraph(
+            project=GraphProject(name="widget"),
+            metadata=GraphExportMetadata(archex_version="0.22.0"),
+        ).model_dump_json()
+    )
+    monkeypatch.setattr(loader, "MAX_GRAPH_BYTES", 5)
+
+    with pytest.raises(ExplorerDataError, match="above the explorer's 5-byte limit"):
+        load_explorer_data(artifact_path, graph_path)
+
+
+def test_graph_above_the_node_cap_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(json.dumps(_artifact_json()))
+    graph_path = tmp_path / "graph.json"
+    graph_path.write_text(
+        ArchGraph(
+            project=GraphProject(name="widget"),
+            metadata=GraphExportMetadata(archex_version="0.22.0"),
+            nodes=[
+                GraphNode(id=f"file:f{index}.py", type=GraphNodeType.FILE, label=f"f{index}.py")
+                for index in range(3)
+            ],
+        ).model_dump_json()
+    )
+    monkeypatch.setattr(loader, "MAX_GRAPH_NODES", 2)
+
+    with pytest.raises(ExplorerDataError, match="above the explorer's 2-node limit"):
+        load_explorer_data(artifact_path, graph_path)
+
+
+def test_graph_above_the_edge_cap_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    artifact_path = tmp_path / "artifact.json"
+    artifact_path.write_text(json.dumps(_artifact_json()))
+    graph_path = tmp_path / "graph.json"
+    graph_path.write_text(
+        ArchGraph(
+            project=GraphProject(name="widget"),
+            metadata=GraphExportMetadata(archex_version="0.22.0"),
+            nodes=[
+                GraphNode(id=f"file:f{index}.py", type=GraphNodeType.FILE, label=f"f{index}.py")
+                for index in range(3)
+            ],
+            edges=[
+                GraphEdge(
+                    source="file:f0.py", target=f"file:f{index}.py", type=GraphEdgeType.IMPORTS
+                )
+                for index in (1, 2)
+            ],
+        ).model_dump_json()
+    )
+    monkeypatch.setattr(loader, "MAX_GRAPH_EDGES", 1)
+
+    with pytest.raises(ExplorerDataError, match="above the explorer's 1-edge limit"):
+        load_explorer_data(artifact_path, graph_path)
+
+
+def test_missing_artifact_reports_a_read_failure_not_a_size_failure(tmp_path: Path) -> None:
+    with pytest.raises(ExplorerDataError, match="Failed to read report artifact"):
+        load_explorer_data(tmp_path / "absent.json")


### PR DESCRIPTION
## Summary

R25 PR 2 of 3, based on PR 1. Adds `archex explore ARTIFACT --export DIR`, which writes the Explorer's views as a directory of sibling HTML files that open from a `file://` URL with no server, no session token, and no network. Also bounds what the Explorer will load at all.

- **Shared rendering, not a second projection.** A `LinkScheme` decides where links point and whether a server exists behind the controls; the server passes the absolute-route interactive scheme, the export a relative-filename non-interactive one. Both go through the same view-model builders and renderers. The nav list is now derived from that scheme instead of duplicated.
- **Honest about what offline cannot do.** Search, direction, depth, and edge-type filtering are `<form method="get">` controls that would submit to nothing over `file://`, so the export omits them and says they need the local server. In their place: a degree-ranked index of every exported node (reachable by find-in-page) and a pre-rendered depth-1 both-direction neighborhood page per high-degree node, whose orientation column still separates inbound from outbound.
- **Bounded, and the bounds are reported.** Per-node pages and index rows are both capped; the export result and the rendered pages name what was omitted. Page filenames pair a sanitized readable stem with a digest of the full node id, so two ids that sanitize identically still get separate files.
- **Input bounds.** The canonical loaders validate a whole document before any view runs, so an oversized artifact was materialized in full and, exported, handed to a browser. The Explorer now refuses an oversized report artifact or graph by byte size (checked before the parse), node count, and edge count, naming the limit exceeded. These limits live in the Explorer, so `archex report diff` and `archex graph export`/`inspect` semantics are untouched.

## Security posture (unchanged)

Exported pages contain no script, no remote stylesheet/font/image, no absolute path, no query string, and no token; every link resolves to a sibling file. Neither artifact carries raw source text, so the export carries none — it writes exactly what the server would show. Asserted in `tests/explorer/test_export.py`.

## Verification

`uv run pytest tests/explorer tests/cli/test_explore_cmd.py` — 101 passed. `ruff check`, `ruff format --check`, `pyright` clean over the changed files.

Real browser over `file://`: `index.html` resolved all six relative nav links, reported zero `<script>` elements and zero remote `src`/`href` values; the `hub.py` node page showed 5 inbound and 4 outbound rows, zero `<form>` elements, and the static-export note.

Clean install: a wheel installed into a fresh virtualenv produced a bundle byte-identical to the source-tree bundle (`diff -r`), and refused a 33 MB artifact with `above the explorer's 33554432-byte limit`.

## Risks

A static bundle cannot paginate, so the caps are the safety mechanism; both are surfaced rather than silent. Per-node pages cover the highest-degree nodes, which is a deliberate choice stated on the index page.

---

## Review round 1 (applied)

Two independent reviews (PR-scoped and whole-stack) flagged the same defect class; all findings below are fixed in `f0b90730`.

- **Node-index degree diverged from `GraphQuery`.** `build_node_index_view` re-counted edge endpoints, while `GraphQuery` skips an edge unless *both* endpoints are nodes and dedupes node ids. A dangling edge — normal output whenever a file imports something unindexed or external — inflated that node's degree, so the index page's degree column and highest-degree ordering contradicted the same node's neighborhood page. Fixed by adding a read-only `GraphQuery.node_summaries()` accessor (no traversal, no ranking, no query) and ranking/labelling from it, so the two agree by construction. A regression test asserts index degree == neighborhood seed degree for every node on a graph containing a dangling edge; reverting the fix was observed to fail it.
- **Re-export into a reused directory leaked the previous bundle.** Per-node filenames key on the current artifact's node ids, so an earlier export's pages survived under different names — unlinked from the regenerated index but still openable from `file://`, carrying the earlier artifact's identity and revision into a bundle attached for review of a different change. The export now owns the destination and removes pre-existing `*.html` first. Regression test mutation-verified.
- **Page cap was reported only to the terminal**, violating the module's own "each cap is reported on the page" invariant. The index page now names how many nodes have no page and points at the local server.
- **`max_index_rows=0` yielded one row** while `max_node_pages=0` correctly yielded zero. Both caps now honour 0.
- **Per-file write failures raised a bare `OSError`** past the CLI's `except ExplorerExportError`, surfacing a traceback instead of an actionable message. Now wrapped.

Verification after the fixes: `uv run pytest tests/explorer tests/cli/test_explore_cmd.py tests/test_graph_query.py` — 114 passed. Full local gate on the leaf: ruff clean, `ruff format --check` clean over 553 files, pyright 0 errors, 5045 passed at 90.92% coverage.

Browser re-verified on the fixed build: the offline node index shows `file:hub.py` at degree 9, and its per-node page shows 5 inbound + 4 outbound rows — 9, agreeing. Across all 30 exported files: zero non-relative links, zero missing link targets, zero `<script>`, zero `token=`. Clean-install bundle byte-identical to the source-tree bundle; re-exporting without `--graph` into the same directory dropped 30 files to exactly 7, proving the prune.
