### PR TITLE
ci(report): deliver read-only review artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+# Declared explicitly rather than inherited: this workflow runs on every pull
+# request, and an omitted `permissions` block silently takes the repository's
+# default token scope, which may include write access. It only needs to read
+# the checkout.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -3,6 +3,12 @@ name: Dogfood
 on:
   workflow_dispatch:
 
+# Declared explicitly rather than inherited: an omitted `permissions` block
+# silently takes the repository's default token scope. This workflow only
+# reads the checkout and uploads its own report as a build artifact.
+permissions:
+  contents: read
+
 jobs:
   dogfood:
     runs-on: ubuntu-latest

--- a/.github/workflows/report-diff.yml
+++ b/.github/workflows/report-diff.yml
@@ -48,6 +48,30 @@ jobs:
           uv run archex report diff . --base "origin/${{ github.base_ref || 'main' }}" \
             --format json > report-diff.json
 
+      - name: Export the architecture graph
+        run: uv run archex graph export . --output arch-graph.json
+
+      # The uploaded bundle is a projection of the two canonical artifacts
+      # above, produced by the same view models and renderers the local
+      # `archex explore` server uses. It is static HTML with no script, no
+      # remote reference, and no session token, so a reviewer opens it from a
+      # `file://` URL after downloading the artifact.
+      - name: Export the offline review explorer
+        run: |
+          uv run archex explore report-diff.json --graph arch-graph.json \
+            --export explorer-site
+          {
+            echo ""
+            echo "### Offline review explorer"
+            echo ""
+            echo "Download the \`report-diff\` artifact and open"
+            echo "\`explorer-site/index.html\` in a browser. It renders the diff review,"
+            echo "module map, node index, per-node dependency neighborhoods with inbound"
+            echo "and outbound orientation, the context receipt, and index health from the"
+            echo "uploaded \`report-diff.json\` and \`arch-graph.json\` -- offline, with no"
+            echo "script and no network access."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload report artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -56,3 +80,5 @@ jobs:
             report-delta.json
             report-delta.md
             report-diff.json
+            arch-graph.json
+            explorer-site

--- a/README.md
+++ b/README.md
@@ -306,7 +306,8 @@ The mounted repository owns `.archex/`, so indexes survive container restarts an
 | Local usage metrics | Calculation rules, privacy boundaries, default-off versus opt-in behavior, export/delete controls, and retention live in [LOCAL_METRICS](docs/LOCAL_METRICS.md). |
 | `archex report status-card` | Opt-in, dimensioned documentation/release status summary: doc-link, ADR, and CODEOWNERS-style ownership evidence (each disabled unless its `documentation_evidence_providers` entry is configured) plus local CHANGELOG/CI-workflow evidence. Every dimension links to immutable local evidence; there is no composite score or letter grade, and the output is never written back into the repository automatically — paste it into your own README by hand if you want to publish it. |
 | `archex report release-artifact` | Per-release compatibility + benchmark evidence bundle: archex's own installed version, supported Python range, report/index schema versions, a pointer to any checked-in benchmark manifest, and an embedded status card, as one read-only JSON document suitable for attaching to a GitHub release. |
-| Read-only CI examples | `.github/workflows/report-diff.yml` and `.github/workflows/status-card.yml` grant only `contents: read`, pin every Action to a full commit SHA (never a floating tag), and upload only their own declared report/status/compatibility outputs — verified by `tests/test_report_ci_workflow.py`. |
+| `archex explore` | Local review viewer over artifacts other commands already produced — one `AnalysisArtifactV1` and one optional exported graph. It performs no repository indexing, parses no source, and constructs no graph edge. The server binds loopback only, requires a per-process session token, answers `GET` only, and serves a CSP that grants no `script-src` at all, so every page is script-free and references nothing remote. Oversized report or graph artifacts are refused by byte size and by node/edge count rather than rendered partially. `--export DIR` writes the same views as offline HTML with no server and no token. |
+| Read-only CI examples | `.github/workflows/report-diff.yml` and `.github/workflows/status-card.yml` grant only `contents: read`, pin every Action to a full commit SHA (never a floating tag), and upload only their own declared report/status/compatibility outputs — including the `report-diff` bundle's exported graph and offline explorer site, which are projections of the uploaded canonical artifacts rather than a second analysis. Delivery is by build artifact and job summary only: no pull-request comment, no write scope, and therefore identical behavior on a fork's read-only token. Every workflow in the repository declares its `permissions:` explicitly so none inherits the repository default token scope, and the only write grant anywhere is `packages: write` on the image-publish workflow — all verified by `tests/test_report_ci_workflow.py`. |
 
 ## Measured results
 
@@ -363,6 +364,12 @@ archex report diff --base origin/main --format html > report.html
 archex report delta --base origin/main --format markdown
 archex report status-card --format markdown  # M9, opt-in: dimensioned doc/ADR/ownership + release evidence, disabled unless configured
 archex report release-artifact  # M9: per-release compatibility + benchmark evidence bundle (version, schema versions, status card)
+
+# Local review explorer — loopback-only, token-gated, script-free, artifact-only
+archex report diff --base origin/main --format json > report-diff.json
+archex graph export --output arch-graph.json
+archex explore report-diff.json --graph arch-graph.json                       # serve locally
+archex explore report-diff.json --graph arch-graph.json --export explorer-site  # offline bundle
 
 # Benchmarks and gates
 archex benchmark headtohead report --input .archex/headtohead --format markdown
@@ -449,6 +456,7 @@ Authority chain: README → [System Design](docs/SYSTEM_DESIGN.md) / [archex vs.
 - [Local Metrics](docs/LOCAL_METRICS.md) — token-savings math, privacy boundary, and default-off versus opt-in behavior
 - [Portable Index Artifact](docs/PORTABLE_INDEX_ARTIFACT.md) — export/import format, compression, staleness fallback, and `.gitattributes` handling for team-shared index bootstrap
 - [Language Promotion Gate](docs/LANGUAGE_PROMOTION_GATE.md) — the recall/ranking-stability regression gate every language-tier promotion runs against
+- [Explorer Usability Evidence](docs/EXPLORER_USABILITY_EVIDENCE.md) — the timed orientation paths, browser verification, and offline-export evidence behind `archex explore`
 
 ## License
 

--- a/docs/EXPLORER_USABILITY_EVIDENCE.md
+++ b/docs/EXPLORER_USABILITY_EVIDENCE.md
@@ -36,35 +36,102 @@ The script:
 3. Builds a real `AnalysisArtifactV1` (`archex report diff`'s underlying builder) and a real
    `ArchGraph` (`archex graph export`'s underlying builder) from the edited repository.
 4. Starts a real `ExplorerServer` loaded with both artifacts.
-5. Times two navigation paths over real HTTP requests against the running server:
+5. Times five navigation paths, the first two over real HTTP requests against the running
+   server, the next two exercising the R25 interactive additions, and the last against the
+   offline static bundle with the server already stopped:
    - **Diff Review** (`GET /view/diff`): does the rendered page name `hub.py` as the changed
      file?
    - **Target Neighborhood** (`GET /view/neighborhood?node=file:hub.py`): does searching for
      `hub.py` surface all four of its real importers?
+   - **Node Search** (`GET /view/search?q=hub`): does a substring query reach `hub.py` and link
+     to its neighborhood, without the reader already knowing the exact node id?
+   - **Inbound-only Neighborhood** (`GET /view/neighborhood?node=file:hub.py&direction=in`):
+     does the page report every importer, mark each row inbound, and contain no outbound row?
+   - **Static export** (`export_explorer_site` then read from disk): does the offline bundle's
+     per-node page carry the same four importers with inbound orientation, does its node index
+     list `hub.py`, and does it contain no `<script>` and no session token?
 
 ## Scenario ground truth
 
-`tests/fixtures/impact_diff`'s own documented graph shape (`tests/conftest.py`): `hub.py` is
-imported by four files (`leaf.py`, `consumer_a.py`, `consumer_b.py`, `consumer_c.py`) and is
-transitively reachable from the entry point `main.py` -- a deliberate hub for diff-scoped risk
-classification tests. A contributor who just cloned this repository and asks "what changed, and
-what does it affect?" should be able to answer "`hub.py`, and its four importers" from the
-explorer alone, without reading source.
+`tests/fixtures/impact_diff` is a deliberate hub built for diff-scoped risk classification tests.
+Read from the fixture source rather than from prose: `hub.py` is imported **directly** by five
+files -- `leaf.py`, `consumer_a.py`, `consumer_b.py`, `consumer_c.py` (each `from hub import
+shared_helper`), and the entry point `main.py:4` (`from hub import other_helper`). The four
+`shared_helper` importers are the set the evidence script asserts, because they exercise the
+shared-symbol fan-in the risk classifier keys on; `main.py` is the fifth direct importer and
+appears in every inbound-edge count below. A contributor who just cloned this repository and asks
+"what changed, and what does it affect?" should be able to answer "`hub.py`, and the files that
+import it" from the explorer alone, without reading source.
 
-## Measured evidence (2026-07-24, reference dev machine)
+## Measured evidence (2026-09-10, reference dev machine)
 
 | Navigation path | Elapsed | Correct |
 | --- | ---: | :---: |
-| Diff Review (`/view/diff`) | 0.005s-0.009s (3 runs) | yes |
+| Diff Review (`/view/diff`) | 0.005s | yes |
 | Target Neighborhood (`/view/neighborhood`) | 0.001s | yes |
+| Node Search (`/view/search`) | 0.001s | yes |
+| Inbound-only Neighborhood (`direction=in`) | 0.001s | yes |
+| Static export (offline, server stopped) | 0.004s | yes |
 
-Both navigation paths reached the objectively correct file/symbol on every run. Elapsed time is
-dominated by Python HTTP request/response overhead, not by any per-request graph-index
+Every navigation path reached the objectively correct file/symbol. Elapsed time for the served
+paths is dominated by Python HTTP request/response overhead, not by any per-request graph-index
 reconstruction: `archex.explorer.server.ExplorerServer` builds its `GraphQuery` once at startup
 (see `scripts/m5_explorer_projection_benchmark.py` and
 `tests/explorer/test_projection_benchmark.py` for the corresponding 10k/100k-node scale evidence),
 so every subsequent neighborhood lookup during one explorer session is a bounded, already-indexed
-traversal.
+traversal. The static-export figure is whole-bundle generation, not per-page: one call writes the
+index, every view, and one pre-rendered neighborhood page per high-degree node.
+
+## Browser verification (2026-09-10, Chromium via CDP)
+
+The measurements above are HTTP-level. The R25 views were additionally exercised in a real
+browser against a live `archex explore` server loaded with a real `AnalysisArtifactV1` and a real
+exported graph (22 nodes, 20 edges) built from the same fixture, and then against the static
+export over `file://`. What the browser confirmed, rather than what the HTML string contains:
+
+- **Node search.** `/view/search?q=hub` rendered five matches -- the `hub.py` file node, its two
+  interface nodes, and its two symbol nodes -- each linking to a percent-encoded neighborhood
+  URL (`/view/neighborhood?node=file%3Ahub.py`). `document.querySelectorAll('script').length`
+  was `0`.
+- **Directional highlighting.** `/view/neighborhood?node=file:hub.py&depth=2&limit=40` rendered
+  14 outbound, 5 inbound, and 1 lateral edge row, with distinct computed background colours per
+  orientation (`rgb(238, 246, 255)`, `rgb(255, 246, 238)`, `rgb(246, 246, 246)`) -- so the
+  distinction is visible in a browser, not just present as a class name. `consumer_a.py imports
+  hub.py` rendered as inbound, which is the semantics a reviewer needs: the consumer depends on
+  the seed.
+- **Typed-edge filtering.** Checking the `imports` box and submitting the real form navigated to
+  `?node=file%3Ahub.py&direction=both&depth=2&limit=40&edge_type=imports`, authenticated by the
+  session cookie with no token in the URL, and rendered 6 `imports` rows with the node table
+  narrowed from 14 to 6 and the note "Filtered to imports: 14 of this neighborhood's edges
+  hidden. The filter narrows the bounded traversal above, not the whole graph."
+- **Direction control.** `direction=in` rendered exactly the five importers, every row inbound,
+  with the select element reflecting `in`.
+- **Rejection paths.** An unresolvable node rendered "No graph node matches 'does-not-exist'" and
+  a non-matching search rendered "No node matches zzz-nothing." with no table at all -- neither
+  fabricated a result.
+- **Offline export.** Opening `file:///.../index.html` resolved all six relative nav links,
+  reported zero `<script>` elements and zero remote `src`/`href` values, and the per-node page
+  for `hub.py` showed 5 inbound and 4 outbound rows with zero `<form>` elements and the note
+  explaining that the interactive controls need the local server.
+- **Clean install.** The bundle produced by a wheel installed into a fresh virtualenv was
+  byte-identical to the source-tree bundle (`diff -r`), and an oversized artifact was refused by
+  the installed CLI with "above the explorer's 33554432-byte limit".
+
+## Two static-HTML surfaces, deliberately distinct
+
+archex renders the same `AnalysisArtifactV1` to static HTML in two places, and they are not
+interchangeable:
+
+| Surface | Produced by | Shape | Row caps |
+| --- | --- | --- | --- |
+| Single-page diff report | `archex report diff --format html` (`src/archex/report/render_html.py`) | One self-contained document: provenance table, summary, a Mermaid structure block embedded as `<pre>` text, and diff tables. Includes `file://`/editor links built from `source_root`. | `MAX_HTML_ROWS = 50` |
+| Explorer bundle | `archex explore ... --export DIR` (`src/archex/explorer/export.py`) | A directory: diff review, module map, node index, per-node dependency neighborhoods, context receipt, and index health, cross-linked by relative filename. No editor links, no Mermaid block. | 100 per diff table, 200 module rows, 1000 index rows, 200 node pages |
+
+The caps differ because the budgets differ: a single page a reviewer opens standalone needs a
+tighter ceiling than a multi-page bundle whose tables are one view among several. The explorer
+bundle's tables come from `archex.explorer.viewmodel`, which the loopback server also uses, so the
+served and exported explorer views cannot drift from each other. They can drift from
+`report diff --format html`, which is why both surfaces are named here rather than left implicit.
 
 ## Reproducing this evidence
 

--- a/scripts/m5_explorer_usability_evidence.py
+++ b/scripts/m5_explorer_usability_evidence.py
@@ -16,25 +16,36 @@ a page whose rendered content contains an objectively correct answer
 by this script).
 
 Scenario (`tests/fixtures/impact_diff`, also used by
-`tests/test_report_artifact.py` and friends): `hub.py` is imported by four
-files (`leaf.py`, `consumer_a.py`, `consumer_b.py`, `consumer_c.py`) and is
-transitively reachable from the entry point `main.py` -- a deliberate hub.
-Editing `hub.py` makes it the diff's own single changed file and its
-riskiest symbol candidate (public-interface change, high fan-in). A
-contributor who just cloned this repository and asks "what changed, and
-what does it affect?" should be able to answer "hub.py, and its four
-importers" from the explorer alone.
+`tests/test_report_artifact.py` and friends): `hub.py` is imported directly
+by five files -- `leaf.py`, `consumer_a.py`, `consumer_b.py` and
+`consumer_c.py` each import `shared_helper`, and the entry point `main.py`
+imports `other_helper` -- a deliberate hub. `EXPECTED_IMPORTERS` below is
+the four `shared_helper` importers, the set that exercises the shared-symbol
+fan-in the risk classifier keys on; `main.py` is the fifth direct importer
+and is why the inbound-edge counts read five, not four. Editing `hub.py`
+makes it the diff's own single changed file and its riskiest symbol
+candidate (public-interface change, high fan-in). A contributor who just
+cloned this repository and asks "what changed, and what does it affect?"
+should be able to answer "hub.py, and the files that import it" from the
+explorer alone.
 
-Two navigation paths are timed:
+Five navigation paths are timed:
 
 1. Diff Review: does the rendered `/view/diff` page name `hub.py` as the
    changed file and (if the risk classifier flagged one) surfaces it as a
    symbol risk candidate?
 2. Target Neighborhood: does searching `/view/neighborhood?node=file:hub.py`
    surface all four real importers?
+3. Node Search (R25): does `/view/search?q=hub` find `hub.py` without the
+   reader already knowing its exact node id -- the step that previously had
+   no surface at all?
+4. Inbound-only Neighborhood (R25): does `direction=in` report exactly the
+   files that depend on `hub.py`, each marked inbound, and nothing outbound?
+5. Static export (R25): does the offline bundle answer the same question
+   from a `file://` path with no server running at all?
 
-Both are graded pass/fail against the fixture's documented ground truth to
-keep "correct" objective, not just fast.
+Every path is graded pass/fail against the fixture's documented ground truth
+to keep "correct" objective, not just fast.
 """
 
 from __future__ import annotations
@@ -47,6 +58,7 @@ import time
 import urllib.request
 from pathlib import Path
 
+from archex.explorer.export import NODES_FILE, export_explorer_site, node_page_name
 from archex.explorer.loader import ExplorerData
 from archex.explorer.server import create_server
 from archex.graph_artifact import build_arch_graph_from_store
@@ -114,20 +126,66 @@ def main() -> int:
             neighborhood_correct = all(
                 importer in neighborhood_html for importer in EXPECTED_IMPORTERS
             )
+
+            # R25: reaching the node without already knowing its id.
+            start = time.perf_counter()
+            search_html = _get(f"http://127.0.0.1:{port}/view/search?q=hub&token={server.token}")
+            search_elapsed = time.perf_counter() - start
+            search_correct = (
+                "file:hub.py" in search_html
+                and "/view/neighborhood?node=file%3Ahub.py" in search_html
+            )
+
+            # R25: "what depends on my change" answered directionally.
+            start = time.perf_counter()
+            inbound_html = _get(
+                f"http://127.0.0.1:{port}/view/neighborhood"
+                f"?node=file:hub.py&direction=in&token={server.token}"
+            )
+            inbound_elapsed = time.perf_counter() - start
+            inbound_correct = (
+                all(importer in inbound_html for importer in EXPECTED_IMPORTERS)
+                and '<tr class="orientation-in">' in inbound_html
+                and '<tr class="orientation-out">' not in inbound_html
+            )
         finally:
             server.shutdown()
             server.server_close()
             thread.join(timeout=5)
 
-    print("Scenario: tests/fixtures/impact_diff, hub.py edited (deliberate hub, 4 importers)\n")
-    print(f"{'path':<28} {'elapsed':>10}  {'correct':>8}")
-    print(f"{'Diff Review (/view/diff)':<28} {diff_elapsed:>9.3f}s  {diff_correct!s:>8}")
-    print(f"{'Target Neighborhood':<28} {neighborhood_elapsed:>9.3f}s  {neighborhood_correct!s:>8}")
+        # R25: the same question, offline, with no server running.
+        export_dir = Path(tmp) / "explorer-site"
+        start = time.perf_counter()
+        export_explorer_site(data, export_dir)
+        export_elapsed = time.perf_counter() - start
+        hub_page = (export_dir / node_page_name("file:hub.py")).read_text(encoding="utf-8")
+        index_page = (export_dir / NODES_FILE).read_text(encoding="utf-8")
+        export_correct = (
+            all(importer in hub_page for importer in EXPECTED_IMPORTERS)
+            and '<tr class="orientation-in">' in hub_page
+            and "file:hub.py" in index_page
+            and "<script" not in hub_page
+            and "token=" not in hub_page
+        )
 
-    if not (diff_correct and neighborhood_correct):
+    print(
+        "Scenario: tests/fixtures/impact_diff, hub.py edited (deliberate hub, 5 direct importers)\n"
+    )
+    rows = (
+        ("Diff Review (/view/diff)", diff_elapsed, diff_correct),
+        ("Target Neighborhood", neighborhood_elapsed, neighborhood_correct),
+        ("Node Search (/view/search)", search_elapsed, search_correct),
+        ("Inbound-only Neighborhood", inbound_elapsed, inbound_correct),
+        ("Static export (offline)", export_elapsed, export_correct),
+    )
+    print(f"{'path':<28} {'elapsed':>10}  {'correct':>8}")
+    for label, elapsed, correct in rows:
+        print(f"{label:<28} {elapsed:>9.3f}s  {correct!s:>8}")
+
+    if not all(correct for _, _, correct in rows):
         print("\nFAILED: the explorer did not surface the objectively correct answer.")
         return 1
-    print("\nPASSED: both navigation paths reached the correct file/symbol.")
+    print("\nPASSED: every navigation path reached the correct file/symbol.")
     print(
         "\nNote: this is an automated, deterministic proxy measuring real HTTP wall-clock "
         "time against a real server -- not a live human trial. No self-reported satisfaction "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,9 +210,10 @@ def monorepo_simple_repo(tmp_path: Path) -> Path:
 def impact_diff_repo(tmp_path: Path) -> Path:
     """Copy tests/fixtures/impact_diff to a temp dir and initialise a git repo.
 
-    Graph shape: hub.py is imported by four files (leaf.py, consumer_a/b/c.py)
-    plus transitively reachable from the entry point main.py -- a deliberate
-    hub for diff-scoped risk classification tests. leaf.py has zero importers
-    and is unreachable from any entry point within a bounded distance.
+    Graph shape: hub.py is imported directly by five files -- leaf.py and
+    consumer_a/b/c.py all import `shared_helper`, and the entry point main.py
+    imports `other_helper` -- a deliberate hub for diff-scoped risk
+    classification tests. leaf.py has zero importers and is unreachable from
+    any entry point within a bounded distance.
     """
     return _init_fixture_repo(tmp_path, "impact_diff")

--- a/tests/test_report_ci_workflow.py
+++ b/tests/test_report_ci_workflow.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 import yaml
@@ -36,7 +36,15 @@ _MUTATING_PATTERNS = (
 #: the workflow file it belongs to. Uploading anything outside this
 #: whitelist would be a scope change the test must catch.
 _ALLOWED_UPLOAD_PATHS: dict[str, frozenset[str]] = {
-    "report-diff.yml": frozenset({"report-delta.json", "report-delta.md", "report-diff.json"}),
+    "report-diff.yml": frozenset(
+        {
+            "report-delta.json",
+            "report-delta.md",
+            "report-diff.json",
+            "arch-graph.json",
+            "explorer-site",
+        }
+    ),
     "status-card.yml": frozenset(
         {"status-card.json", "status-card.md", "compatibility-artifact.json"}
     ),
@@ -116,3 +124,125 @@ def test_status_card_workflow_runs_the_m9_status_and_compatibility_commands() ->
 
     assert "archex report status-card" in run_bodies
     assert "archex report release-artifact" in run_bodies
+
+
+#: `packages: write` on the image-publish workflow is the one write scope this
+#: repository grants. It reaches a container registry, never the repository
+#: contents, an issue, or a pull request. Any other write grant, and any
+#: workflow that omits a `permissions:` block and therefore inherits the
+#: repository's default token scope, must fail this audit.
+_ALLOWED_WRITE_SCOPES: dict[str, frozenset[str]] = {"docker.yml": frozenset({"packages"})}
+
+#: Scopes that can mutate the repository or its pull requests. Deliberately
+#: not the full GitHub scope list: the allowlist check below rejects every
+#: undeclared write scope anyway, so this set exists to produce a specific
+#: message for the scopes that matter most, not to be the only gate.
+_FORBIDDEN_WRITE_SCOPES = frozenset(
+    {"contents", "pull-requests", "issues", "actions", "checks", "deployments", "statuses"}
+)
+
+#: GitHub executes both extensions, so an audit that globs one of them can be
+#: bypassed by naming a workflow with the other.
+_WORKFLOW_GLOBS = ("*.yml", "*.yaml")
+
+
+def _every_workflow() -> list[str]:
+    return sorted(path.name for pattern in _WORKFLOW_GLOBS for path in _WORKFLOWS_DIR.glob(pattern))
+
+
+def _permission_blocks(workflow: dict[str, Any]) -> list[tuple[str, object]]:
+    """Every `permissions:` mapping in the file, workflow-level and job-level.
+
+    A job-level block REPLACES the workflow-level one for that job, so auditing
+    only the top level would pass a workflow that declares `contents: read`
+    globally and grants write on one job.
+    """
+    blocks: list[tuple[str, object]] = [("workflow", workflow.get("permissions"))]
+    jobs = cast("dict[str, dict[str, Any]]", workflow.get("jobs") or {})
+    for job_id, job in jobs.items():
+        if "permissions" in job:
+            blocks.append((f"job {job_id}", job["permissions"]))
+    return blocks
+
+
+def test_the_audit_sees_every_workflow_file() -> None:
+    """An empty parametrize list would make every audit below vacuously pass."""
+    names = _every_workflow()
+
+    assert names
+    assert set(names) >= set(_WORKFLOW_NAMES)
+
+
+@pytest.mark.parametrize("workflow_name", _every_workflow())
+def test_every_workflow_declares_its_permissions_explicitly(workflow_name: str) -> None:
+    """An omitted block inherits the repository default, which may include write."""
+    workflow = _load_workflow(workflow_name)
+
+    assert "permissions" in workflow, (
+        f"{workflow_name} omits `permissions:` and inherits the repository default token scope"
+    )
+
+
+@pytest.mark.parametrize("workflow_name", _every_workflow())
+def test_no_workflow_grants_repository_or_pull_request_write(workflow_name: str) -> None:
+    workflow = _load_workflow(workflow_name)
+    allowed_writes = _ALLOWED_WRITE_SCOPES.get(workflow_name, frozenset())
+
+    for origin, raw_permissions in _permission_blocks(workflow):
+        assert isinstance(raw_permissions, dict), (
+            f"{workflow_name} ({origin}) must enumerate scopes explicitly, "
+            f"not omit them or use a `write-all`/`read-all` preset"
+        )
+        permissions = cast("dict[str, str]", raw_permissions)
+        for scope, level in permissions.items():
+            if level != "write":
+                continue
+            assert scope not in _FORBIDDEN_WRITE_SCOPES, (
+                f"{workflow_name} ({origin}) grants {scope}: write, which can mutate the "
+                f"repository or its pull requests"
+            )
+            assert scope in allowed_writes, (
+                f"{workflow_name} ({origin}) grants an undeclared {scope}: write"
+            )
+
+
+def test_report_diff_workflow_delivers_the_canonical_artifacts_and_explorer_bundle() -> None:
+    workflow = _load_workflow("report-diff.yml")
+    run_bodies = "\n".join(
+        step["run"] for job in workflow["jobs"].values() for step in job["steps"] if "run" in step
+    )
+
+    # The canonical artifacts, then a projection of them -- not a second analysis.
+    assert "archex report diff . --base" in run_bodies
+    assert "archex graph export ." in run_bodies
+    assert "archex explore report-diff.json --graph arch-graph.json" in run_bodies
+    assert "--export explorer-site" in run_bodies
+
+
+def test_report_diff_workflow_stays_read_only_and_comments_nothing() -> None:
+    workflow = _load_workflow("report-diff.yml")
+
+    assert workflow["permissions"] == {"contents": "read"}
+    assert _permission_blocks(workflow) == [("workflow", {"contents": "read"})]
+
+    # Scan every step surface, not just `run`: a credential can reach a step
+    # through `env:` or an action's `with:` block without appearing in a shell
+    # body, and `${{ github.token }}` does not contain the string GITHUB_TOKEN.
+    steps = [step for job in workflow["jobs"].values() for step in job["steps"]]
+    run_bodies = "\n".join(step["run"] for step in steps if "run" in step)
+    every_surface = yaml.safe_dump(steps)
+
+    assert "GITHUB_STEP_SUMMARY" in run_bodies
+    for forbidden in (
+        "gh api",
+        "gh pr",
+        "gh issue",
+        "GITHUB_TOKEN",
+        "github.token",
+        "secrets.",
+        "curl -X POST",
+        "curl -X PATCH",
+    ):
+        assert forbidden not in every_surface, (
+            f"{forbidden!r} implies a write, a credential, or an authenticated call"
+        )


### PR DESCRIPTION
## Summary

R25 PR 3 of 3, based on PR 2. Makes the uploaded review artifact readable and hardens the permission audit that certifies it read-only.

- **Delivery.** `report-diff.yml` now also exports the architecture graph and the offline Explorer bundle, and the job summary says where to open it. The bundle is a projection of the two canonical artifacts uploaded alongside it, produced by the same view models and renderers the local server uses — not a second analysis to reconcile against the JSON.
- **Read-only by construction.** Delivery is a build artifact plus a step summary. A PR comment would need `pull-requests: write` and would fail outright on a fork, where `pull_request` hands the job a read-only token; artifact upload behaves identically for forks and same-repo branches with no write scope. The workflow keeps `contents: read`.
- **A real gap the audit missed.** The audit asserted `permissions == {"contents": "read"}` only over the two workflows in its upload allowlist. `ci.yml` — which runs on every pull request — declared no `permissions:` block at all and silently inherited the repository default token scope; `dogfood.yml` had the same omission. Both now declare `contents: read`, and the audit is widened to every workflow: each must enumerate its scopes, none may grant `contents`/`pull-requests`/`issues`/`actions`/`checks`/`deployments`/`statuses` write, and the one remaining write grant (`packages: write` on the image-publish workflow, which reaches a container registry and never the repository) must be explicitly declared to be allowed.
- **Docs.** README gains an `archex explore` trust-contract row, the explorer commands, and a documentation-map entry; the CI row now states the fork behaviour and the explicit-permissions rule.

## Verification

`uv run pytest tests/test_report_ci_workflow.py tests/explorer/test_usability_evidence.py` — 27 passed. `ruff check`, `ruff format --check`, `pyright` clean over the changed files.

Permission audit is mutation-checked: reverting the `ci.yml` block made `test_every_workflow_declares_its_permissions_explicitly[ci.yml]` and `test_no_workflow_grants_repository_or_pull_request_write[ci.yml]` fail before the fix was accepted.

The workflow's step sequence was replayed locally against a throwaway git repository (`report delta` json+markdown, `report diff` json, `graph export`, `explore --export`), producing all five outputs and a 30-file explorer site.

The usability evidence script grows from two timed paths to five — node search, inbound-only orientation, and the offline bundle read from disk with the server stopped — and all five pass. `docs/EXPLORER_USABILITY_EVIDENCE.md` records those timings plus the browser verification.

## Risks

`docker.yml`'s pre-existing `packages: write` is now explicitly allowlisted rather than silently tolerated; any future write grant fails the audit until it is declared.

No hosted service, GitHub App, webhook, PR comment, or write scope is introduced anywhere in this stack.

---

## Review round 1 (applied)

A read-only security review found no blocking defect and confirmed the boundary (no hosted service, no webhook, no PR write permission, no source upload). Four findings are fixed in `75a907c2`:

- **The audit read only top-level `permissions`.** A job-level `permissions:` block *replaces* the workflow-level one, so a workflow could declare `contents: read` globally and grant `contents: write` + `pull-requests: write` on a job and still pass. No workflow does that today, so the hole was latent — but the audit is the entire basis of the README's "verified by tests" claim. It now checks every permissions mapping in the file, workflow-level and job-level, and reports which one failed.
- **The audit globbed `*.yml` only.** GitHub executes `.yaml` too, so a workflow named `release.yaml` would never be parametrized in and could omit `permissions:` entirely with CI green. Both extensions are now enumerated, plus a guard test asserting the list is non-empty so an empty parametrize can never masquerade as a passing audit.
- **The read-only assertion missed non-`run` surfaces and `${{ github.token }}`.** It scanned only `run:` bodies for four literals; a credential can reach a step through `env:` or an action's `with:` block, and `github.token` does not contain the substring `GITHUB_TOKEN`. The scan now covers every step surface and adds `github.token`, `secrets.`, `gh issue`, and `curl -X PATCH`.
- **The evidence doc's ground truth was wrong.** It claimed `hub.py` has four importers with `main.py` only "transitively reachable", but `tests/fixtures/impact_diff/main.py:4` is `from hub import other_helper` — a direct import, so there are five. The doc's own browser section already reported five, contradicting itself. Corrected in the doc, in `tests/conftest.py`'s fixture docstring, and in the evidence script's docstring and printed header. `EXPECTED_IMPORTERS` stays the four `shared_helper` importers, and the doc now says why.

Both new audit gaps are mutation-verified: adding a job-level `contents: write` override to `report-diff.yml` and adding a `.yaml` workflow with no `permissions:` block each made the audit fail before the fixes were accepted.

The whole-stack review also asked that the two static-HTML surfaces be reconciled or documented. `archex report diff --format html` (single page, `MAX_HTML_ROWS = 50`, Mermaid block, editor links) and the explorer bundle (multi-page, different caps, no editor links) are now named side by side in `docs/EXPLORER_USABILITY_EVIDENCE.md` with why their caps differ.

### Accepted, out of scope

- `docker.yml`'s four third-party actions run on floating tags while holding the repository's only write scope (`packages: write`). Real asymmetry, but SHA-pinning the image-publish workflow is workflow hardening outside R25; recorded rather than silently expanded into.
- `packages: write` is declared workflow-level in `docker.yml` so it is present on every trigger, though both consumers are gated on push-to-main. Pre-existing, same workflow.
- The `curl -LsSf https://astral.sh/uv/install.sh | sh` bootstrap is unpinned in every workflow. Pre-existing and repo-wide.
- `arch-graph.json` embeds the runner's absolute `repo_root` (`/home/runner/work/archex/archex`). The already-uploaded `report-diff.json` carries `source_root` identically, so this adds no new exposure class — and the explorer renders neither field.

Verification after the fixes: `uv run pytest tests/test_report_ci_workflow.py tests/explorer` — 126 passed. Full local gate on the leaf: ruff clean, `ruff format --check` clean over 553 files, pyright 0 errors, 5045 passed at 90.92% coverage.

Note on CI coverage: `report-diff.yml` triggers on `pull_request: branches: [main]`, so it does not run on this PR while its base is a stack branch. Its new steps were replayed locally against a throwaway repository, and the workflow will run for real once this PR is retargeted to `main` during the merge — that run is the merge gate.
