### PR TITLE
feat(index): identify compatible worktree seeds

### DIFF
--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -64,6 +64,7 @@ from archex.context_facade import (
 )
 from archex.exceptions import ArchexIndexError, DeltaIndexError
 from archex.index.bm25 import BM25Index
+from archex.index.compat import INDEX_CONFIG_METADATA_KEYS, index_config_metadata_mismatch
 from archex.index.graph import DependencyGraph
 from archex.index.store import IndexStore
 from archex.languages import UNKNOWN_LANGUAGE_ID
@@ -157,29 +158,8 @@ def _cache_manager_for_source(source: RepoSource, config: Config) -> CacheManage
 
 
 def _index_config_metadata_matches(store: IndexStore, index_config: IndexConfig) -> bool:
-    if store.get_metadata("chunker") != index_config.chunker or store.get_metadata(
-        "chunker_revision"
-    ) != chunker_revision(index_config.chunker):
-        return False
-    stored_quantize = store.get_metadata("quantize_vectors")
-    stored_quantize_enabled = stored_quantize == "True" if stored_quantize is not None else False
-    if stored_quantize_enabled != index_config.quantize_vectors:
-        return False
-    if index_config.quantize_vectors and store.get_metadata("quantize_bits") != str(
-        index_config.quantize_bits
-    ):
-        return False
-    stored_semantic_providers = store.get_metadata("semantic_evidence_providers") or ""
-    if stored_semantic_providers != ",".join(index_config.semantic_evidence_providers):
-        return False
-    stored_runtime_providers = store.get_metadata("runtime_evidence_providers") or ""
-    if stored_runtime_providers != ",".join(index_config.runtime_evidence_providers):
-        return False
-    stored_history_providers = store.get_metadata("history_evidence_providers") or ""
-    if stored_history_providers != ",".join(index_config.history_evidence_providers):
-        return False
-    stored_documentation_providers = store.get_metadata("documentation_evidence_providers") or ""
-    return stored_documentation_providers == ",".join(index_config.documentation_evidence_providers)
+    metadata = {key: store.get_metadata(key) for key in INDEX_CONFIG_METADATA_KEYS}
+    return index_config_metadata_mismatch(metadata, index_config) is None
 
 
 def _set_index_config_metadata(store: IndexStore, index_config: IndexConfig) -> None:

--- a/src/archex/cache.py
+++ b/src/archex/cache.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
+import os
 import re
+import secrets
 import shutil
 import sqlite3
 import subprocess
@@ -23,6 +26,40 @@ _KEY_RE = re.compile(r"^[0-9a-f]{64}$")
 # indexes many repos or many past commits of one repo. put() opportunistically
 # bounds this without requiring a manual `archex cache clean` invocation.
 _DEFAULT_MAX_CACHE_ENTRIES = 500
+
+#: Where this machine's cache-marker secret lives. Deliberately outside any
+#: repository and outside any configurable cache directory: its whole
+#: purpose is to be something repository content cannot contain.
+MACHINE_SECRET_PATH = Path("~/.archex/machine-id")
+
+
+def _machine_secret() -> bytes:
+    """Return this machine's cache-marker secret, creating it on first use.
+
+    Read failures fall back to a process-lifetime random value rather than
+    to a constant: a secret that cannot be persisted must make markers
+    unverifiable (costing a re-index) instead of making them forgeable.
+    """
+    path = MACHINE_SECRET_PATH.expanduser()
+    try:
+        if path.exists():
+            recorded = path.read_bytes().strip()
+            if recorded:
+                return recorded
+        secret = secrets.token_hex(32).encode()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        tmp.write_bytes(secret + b"\n")
+        tmp.chmod(0o600)
+        tmp.replace(path)
+        return secret
+    except OSError:
+        return secrets.token_hex(32).encode()
+
+
+def marker_hmac(key: str) -> str:
+    """Authentication tag a cache marker must carry for `key` on this machine."""
+    return hmac.new(_machine_secret(), key.encode(), hashlib.sha256).hexdigest()
 
 
 class CacheManager:
@@ -120,6 +157,40 @@ class CacheManager:
             pass
         return None
 
+    @property
+    def project_layout(self) -> bool:
+        """Whether this cache is a repository's own `.archex` directory.
+
+        A project-layout cache lives inside the repository, so its files can
+        be repository *content* — committed by whoever published the
+        repository — while a keyed cache directory is only ever written by
+        archex itself.
+        """
+        return self._project_layout
+
+    def marker_matches(self, key: str) -> bool:
+        """Whether archex itself wrote this cache marker, for exactly `key`.
+
+        Two independent things are checked. The marker must name `key` —
+        `cache_key` is `sha256("<resolved absolute path>@<commit>")`, so it
+        describes one directory at one revision. And it must carry a valid
+        `marker_hmac` over that key, keyed on this machine's secret.
+
+        The HMAC is what makes the marker evidence rather than a hint. Both
+        halves of `cache_key` are guessable: the commit can be the
+        attacker's own, and checkout paths are fixed on CI runners
+        (`/home/runner/work/<repo>/<repo>`) and in container images
+        (`/workspace`, `/app`). Without a secret, anyone who can predict the
+        path could commit a marker beside a database and have it accepted.
+        The secret never leaves `~/.archex/machine-id`, so repository
+        content cannot produce a matching HMAC for any path.
+        """
+        meta = self.get_meta(key)
+        if meta.get("cache_key") != key:
+            return False
+        recorded = meta.get("marker_hmac", "")
+        return bool(recorded) and hmac.compare_digest(recorded, marker_hmac(key))
+
     def _validate_key(self, key: str) -> None:
         if not _KEY_RE.match(key):
             raise CacheError(
@@ -210,6 +281,10 @@ class CacheManager:
         meta = self.meta_path(key)
         meta_data: dict[str, Any] = {
             "cache_key": key,
+            # Authenticates the marker to this machine. A marker is the only
+            # evidence that archex, rather than repository content, produced
+            # the store beside it.
+            "marker_hmac": marker_hmac(key),
             "created_at": str(time.time()),
             "resolved_commit": resolved_commit or "",
             "source_identity": source_identity or "",
@@ -223,13 +298,21 @@ class CacheManager:
         return dest
 
     def get_meta(self, key: str) -> dict[str, str]:
-        """Read cache metadata for a key. Returns empty dict if missing."""
+        """Read cache metadata for a key. Returns an empty dict if unusable.
+
+        A marker that cannot be read at all — non-UTF-8 bytes, a directory
+        where a file belongs, a permission error — is indistinguishable from
+        a missing one for every caller's purpose, and callers use this to
+        *decide* whether a cache entry may be reused. Reading it must
+        therefore never raise into them.
+        """
         import json
 
         meta = self.meta_path(key)
-        if not meta.exists():
+        try:
+            raw = meta.read_text().strip()
+        except (OSError, UnicodeDecodeError):
             return {}
-        raw = meta.read_text().strip()
         # Backward compat: old meta files contain bare timestamp
         if raw and not raw.startswith("{"):
             return {"created_at": raw}

--- a/src/archex/index/compat.py
+++ b/src/archex/index/compat.py
@@ -1,0 +1,71 @@
+"""Index-config compatibility predicates over stored index metadata.
+
+An index records the `IndexConfig` fields that shaped its contents (chunker
+identity, quantization, evidence providers). Anything that wants to reuse an
+existing store — the ordinary cache hit path, delta indexing, or worktree
+seeding — must first decide whether that recorded shape still matches the
+config it is about to serve. This module holds that decision in one place,
+keyed on a plain metadata mapping so a caller can answer it without opening
+the store through `IndexStore` (whose constructor migrates the schema).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from archex.pipeline.chunker import chunker_revision
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from archex.models import IndexConfig
+
+#: Metadata keys that record the index-config shape of a built store. Read
+#: these to build the mapping `index_config_metadata_mismatch` expects.
+INDEX_CONFIG_METADATA_KEYS: tuple[str, ...] = (
+    "chunker",
+    "chunker_revision",
+    "quantize_vectors",
+    "quantize_bits",
+    "semantic_evidence_providers",
+    "runtime_evidence_providers",
+    "history_evidence_providers",
+    "documentation_evidence_providers",
+)
+
+
+def index_config_metadata_mismatch(
+    metadata: Mapping[str, str | None],
+    index_config: IndexConfig,
+) -> str | None:
+    """Return the first metadata key that disagrees with `index_config`, else None.
+
+    A missing key is normalized to the value a store built with default
+    settings would have recorded (absent quantization means disabled; an
+    absent provider list means no providers), so a store written before a
+    key existed is not treated as incompatible.
+    """
+    if metadata.get("chunker") != index_config.chunker:
+        return "chunker"
+    if metadata.get("chunker_revision") != chunker_revision(index_config.chunker):
+        return "chunker_revision"
+
+    stored_quantize = metadata.get("quantize_vectors")
+    stored_quantize_enabled = stored_quantize == "True" if stored_quantize is not None else False
+    if stored_quantize_enabled != index_config.quantize_vectors:
+        return "quantize_vectors"
+    if index_config.quantize_vectors and metadata.get("quantize_bits") != str(
+        index_config.quantize_bits
+    ):
+        return "quantize_bits"
+
+    providers = (
+        ("semantic_evidence_providers", index_config.semantic_evidence_providers),
+        ("runtime_evidence_providers", index_config.runtime_evidence_providers),
+        ("history_evidence_providers", index_config.history_evidence_providers),
+        ("documentation_evidence_providers", index_config.documentation_evidence_providers),
+    )
+    for key, configured in providers:
+        if (metadata.get(key) or "") != ",".join(configured):
+            return key
+    return None

--- a/src/archex/index/store.py
+++ b/src/archex/index/store.py
@@ -41,6 +41,11 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from types import TracebackType
 
+#: Schema version this build writes into every store's metadata. A store
+#: recording a different value was built by a different schema generation
+#: and cannot be reused without a migration pass.
+CURRENT_SCHEMA_VERSION = "5"
+
 _SEMANTIC_PROVIDER_RECEIPTS_KEY = "semantic_provider_receipts"
 _RUNTIME_PROVIDER_RECEIPTS_KEY = "runtime_provider_receipts"
 _RUNTIME_COVERAGE_EVIDENCE_KEY = "runtime_coverage_evidence"
@@ -1141,7 +1146,7 @@ class IndexStore:
             self._conn.execute("ALTER TABLE file_states ADD COLUMN token_count INTEGER")
 
         # Set schema version and detect stale data needing re-index
-        self.set_metadata("schema_version", "5")
+        self.set_metadata("schema_version", CURRENT_SCHEMA_VERSION)
         cur = self._conn.execute("SELECT COUNT(*) FROM chunks WHERE symbol_id IS NULL")
         null_count = cur.fetchone()[0]
         if null_count > 0:

--- a/src/archex/index/worktree_seed.py
+++ b/src/archex/index/worktree_seed.py
@@ -1,0 +1,570 @@
+"""Same-repository worktree index seed discovery.
+
+A linked Git worktree (`git worktree add`) starts with no `.archex/index.db`
+and, left alone, pays a full cold index for a tree that is usually a few
+commits away from a checkout that is already indexed on the same machine.
+This module answers one question — *is there a checkout whose index this
+worktree may legitimately start from?* — and answers it conservatively:
+
+* **Identity is proven twice.** Candidates are enumerated with
+  `git worktree list --porcelain`, then each candidate is re-interrogated
+  from its own directory and must report the same Git *common directory*.
+  A one-sided listing is not proof: a stale or hand-edited
+  `.git/worktrees/<name>/gitdir` makes `git worktree list` report an
+  unrelated checkout as a worktree, and that checkout would then serve
+  another repository's code.
+* **Only `git rev-parse` runs inside a candidate.** `rev-parse` executes no
+  hook, no `core.fsmonitor` program, and no filter or diff driver, so
+  identity is established without running repository-configured code.
+  Commands that can (`git status`, `git ls-files`) run only against the
+  destination working tree, which the caller already owns.
+* **Submodules, bare repositories, and `--separate-git-dir` checkouts are
+  refused structurally.** In all three shapes the Git directory *equals*
+  the common directory, so they never satisfy the linked-worktree test —
+  no name heuristics are involved.
+* **Every refusal is a named disposition.** Nothing is silently skipped.
+
+Selection stops at eligibility. Copying, delta synchronization, and
+installation are a separate concern.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.parse import quote
+
+from archex.cache import CacheManager
+from archex.index.compat import INDEX_CONFIG_METADATA_KEYS, index_config_metadata_mismatch
+from archex.index.store import CURRENT_SCHEMA_VERSION
+from archex.models import RepoSource
+
+if TYPE_CHECKING:
+    from archex.models import IndexConfig
+
+logger = logging.getLogger(__name__)
+
+#: Timeout for every `git` invocation this module makes. Matches
+#: `ProjectState.resolve`'s existing `rev-parse` budget; all calls here are
+#: metadata reads that touch no object database.
+GIT_TIMEOUT_SECONDS = 10
+
+_REV_PARSE_FLAGS = (
+    "--git-common-dir",
+    "--git-dir",
+    "--show-toplevel",
+    "--is-bare-repository",
+    "--is-inside-work-tree",
+)
+
+#: Store metadata a candidate must carry before it can be a seed. The
+#: index-config keys come from `archex.index.compat`; the rest establish
+#: schema compatibility and a delta base.
+_REQUIRED_METADATA_KEYS: tuple[str, ...] = (
+    "schema_version",
+    "needs_reindex",
+    "commit_hash",
+    "indexed_at",
+    *INDEX_CONFIG_METADATA_KEYS,
+)
+
+
+@dataclass(frozen=True)
+class CheckoutIdentity:
+    """Resolved Git identity of one directory, as reported by `git rev-parse`."""
+
+    root: Path
+    """The checkout's own top level (`--show-toplevel`), resolved."""
+
+    git_dir: Path
+    """This checkout's Git directory (`--git-dir`), resolved."""
+
+    common_dir: Path
+    """The repository-wide Git directory (`--git-common-dir`), resolved."""
+
+    @property
+    def is_linked_worktree(self) -> bool:
+        """Whether this checkout is a linked worktree of another checkout.
+
+        True only when the per-checkout Git directory differs from the
+        repository-wide common directory. Ordinary checkouts, submodules,
+        and `--separate-git-dir` checkouts all report the two as equal.
+        """
+        return self.git_dir != self.common_dir
+
+
+@dataclass(frozen=True)
+class SeedRejection:
+    """One candidate checkout that was considered and refused."""
+
+    root: Path
+    reason: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class SeedCandidate:
+    """A checkout whose index is eligible to seed the destination worktree."""
+
+    root: Path
+    """The candidate checkout's top level."""
+
+    index_path: Path
+    """The candidate's `.archex/index.db`."""
+
+    commit_hash: str
+    """The revision the candidate's index reflects."""
+
+    indexed_at: float
+    """When the candidate's index was last measured against its tree."""
+
+    same_commit: bool
+    """Whether the candidate index's revision equals the destination's HEAD."""
+
+
+@dataclass(frozen=True)
+class SeedSelection:
+    """Outcome of looking for a seed source for one destination worktree."""
+
+    candidate: SeedCandidate | None
+    reason: str
+    """`eligible` when a candidate was selected, else the refusal disposition."""
+
+    detail: str = ""
+    rejections: tuple[SeedRejection, ...] = field(default_factory=tuple)
+
+    @property
+    def eligible(self) -> bool:
+        return self.candidate is not None
+
+
+#: Environment variables that redirect Git away from the directory it is
+#: invoked in. They are removed from every invocation here because this
+#: module's whole guarantee is that a *directory* reports its own
+#: repository: an ambient `GIT_DIR`/`GIT_WORK_TREE` pair makes two
+#: unrelated checkouts resolve to one common directory, which would defeat
+#: the candidate-side identity check. archex inherits these when it runs
+#: from inside a Git hook or an env-exporting wrapper.
+_GIT_LOCATION_ENV_VARS = (
+    "GIT_DIR",
+    "GIT_COMMON_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+)
+
+
+def _git_env() -> dict[str, str]:
+    return {key: value for key, value in os.environ.items() if key not in _GIT_LOCATION_ENV_VARS}
+
+
+def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str] | None:
+    """Run a `git` command, returning None when it cannot be run at all."""
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=GIT_TIMEOUT_SECONDS,
+            check=False,
+            env=_git_env(),
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("git %s failed in %s: %s", " ".join(args), cwd, exc)
+        return None
+
+
+def _rev_parse_values(path: Path) -> list[str] | None:
+    """Read `_REV_PARSE_FLAGS` for one directory, or None if Git refuses.
+
+    One batched call is the fast path. `git rev-parse` separates its answers
+    with newlines and does not escape a newline *inside* a path, so a value
+    that contains one makes positional parsing ambiguous; that case falls
+    back to asking for each value separately, where the whole of stdout is
+    the value.
+    """
+    batched = _run_git(["rev-parse", "--path-format=absolute", *_REV_PARSE_FLAGS], path)
+    if batched is None or batched.returncode != 0:
+        return None
+    lines = batched.stdout.splitlines()
+    if len(lines) == len(_REV_PARSE_FLAGS):
+        return lines
+
+    values: list[str] = []
+    for flag in _REV_PARSE_FLAGS:
+        single = _run_git(["rev-parse", "--path-format=absolute", flag], path)
+        if single is None or single.returncode != 0:
+            return None
+        values.append(single.stdout.removesuffix("\n"))
+    return values
+
+
+def resolve_checkout_identity(path: Path) -> CheckoutIdentity | None:
+    """Resolve one directory's Git identity, or None if it is not a work tree.
+
+    Returns None for a path that is not inside a repository, for a bare
+    repository, and for anything Git refuses to answer for — every one of
+    which is a reason not to treat the path as a seed source or destination.
+    `--path-format=absolute` is passed because `--git-common-dir` is
+    otherwise reported relative to the current directory.
+    """
+    if not path.is_dir():
+        return None
+    values = _rev_parse_values(path)
+    if values is None:
+        return None
+    common_dir, git_dir, toplevel, is_bare, is_work_tree = values
+    if is_bare.strip() != "false" or is_work_tree.strip() != "true" or not toplevel:
+        return None
+    return CheckoutIdentity(
+        root=Path(toplevel).resolve(),
+        git_dir=Path(git_dir).resolve(),
+        common_dir=Path(common_dir).resolve(),
+    )
+
+
+def _parse_worktree_list(stdout: str, *, nul_terminated: bool) -> list[Path]:
+    """Extract checkout paths from `git worktree list --porcelain` output.
+
+    Both framings are records of attribute entries with an empty entry
+    between records: newline-terminated lines separated by a blank line,
+    or — with `-z` — NUL-terminated entries separated by an empty one. The
+    NUL framing is preferred because Git does **not** escape a newline
+    inside a worktree path, which makes the line-oriented output of a
+    worktree whose path contains one ambiguous.
+
+    Bare and prunable records are dropped: a bare repository has no tree to
+    read an index from, and a prunable record points at a directory that is
+    gone or unreadable. Paths are returned unresolved — Git echoes an
+    injected `gitdir` pointer verbatim, so resolution belongs with the
+    per-candidate verification that also checks identity.
+    """
+    paths: list[Path] = []
+    current: str | None = None
+    usable = True
+    for raw in stdout.split("\0" if nul_terminated else "\n"):
+        # A path may legitimately end in whitespace, so only the newline
+        # framing's own line ending is removed.
+        entry = raw if nul_terminated else raw.rstrip("\r")
+        if entry.startswith("worktree "):
+            if current is not None and usable:
+                paths.append(Path(current))
+            current = entry[len("worktree ") :]
+            usable = True
+        elif entry == "bare" or entry.startswith("prunable"):
+            usable = False
+    if current is not None and usable:
+        paths.append(Path(current))
+    return paths
+
+
+def _read_store_metadata(db_path: Path, keys: tuple[str, ...]) -> dict[str, str | None] | None:
+    """Read metadata keys from an index database without opening it for writing.
+
+    `IndexStore`'s constructor creates and migrates schema, which would
+    write to a checkout this process does not own, so a read-only URI
+    connection is used instead. Returns None when the database cannot be
+    read or carries no `metadata` table.
+    """
+    uri = f"file:{quote(str(db_path))}?mode=ro"
+    try:
+        conn = sqlite3.connect(uri, uri=True, timeout=5.0)
+    except sqlite3.Error as exc:
+        logger.debug("could not open seed candidate %s read-only: %s", db_path, exc)
+        return None
+    try:
+        placeholders = ",".join("?" for _ in keys)
+        rows = conn.execute(
+            f"SELECT key, value FROM metadata WHERE key IN ({placeholders})",  # noqa: S608
+            keys,
+        ).fetchall()
+    except sqlite3.Error as exc:
+        logger.debug("could not read metadata from seed candidate %s: %s", db_path, exc)
+        return None
+    finally:
+        conn.close()
+    stored = {str(key): (None if value is None else str(value)) for key, value in rows}
+    return {key: stored.get(key) for key in keys}
+
+
+def _unsupported_index_config(index_config: IndexConfig) -> str | None:
+    """Return why `index_config` cannot be served by a seed, or None.
+
+    Vector and SPLADE state is not transferable by this path: keeping
+    embeddings correct across a delta needs the embedder pipeline ordinary
+    delta indexing owns, and copying either without that would be a silent
+    incompatibility. Both are off by default.
+    """
+    if index_config.vector:
+        return "vector retrieval is enabled"
+    if index_config.splade:
+        return "SPLADE retrieval is enabled"
+    return None
+
+
+def _reject_symlinked(path: Path, label: str) -> SeedRejection | None:
+    if path.is_symlink():
+        return SeedRejection(root=path, reason="symlinked_path", detail=f"{label} is a symlink")
+    return None
+
+
+#: Hard ceiling on a candidate index's file size. A seed exists to be
+#: cheaper than a full index; copying an arbitrarily large database (twice,
+#: since publication copies the staged file again) is not. Mirrors the
+#: ceiling `archex.index.artifact` puts on a decompressed artifact, and is
+#: far above any index this format legitimately carries.
+MAX_SEED_INDEX_BYTES = 1024**3
+
+#: Hard ceiling on how many checkouts are interrogated. Each costs a `git`
+#: subprocess and a SQLite open, so an unbounded list would let a
+#: repository with hundreds of worktrees make seeding slower than the full
+#: index it replaces. The remainder is refused by name, never dropped
+#: silently.
+MAX_SEED_CANDIDATES = 32
+
+
+def _index_is_provenanced(checkout_root: Path, commit_hash: str) -> bool:
+    """Whether a checkout's index carries archex's own cache marker for itself.
+
+    A candidate index is otherwise validated entirely from metadata stored
+    *inside* the candidate database — which means whoever supplies the
+    database supplies the evidence for accepting it. `.archex/index.db` and
+    `.archex/settings.toml` are ordinary files, so a published repository
+    can commit both, and a clone plus `git worktree add` would then install
+    that content as a real index.
+
+    The cache marker closes that door because it is keyed on
+    `sha256("<resolved absolute path>@<commit>")`: a legitimate index has
+    one because archex wrote it after building the index in that directory,
+    and committed repository content cannot forge one for a clone directory
+    nobody knows in advance. This is the same binding
+    `CacheManager.get` already requires before reusing a project-layout
+    index.
+    """
+    cache = CacheManager(cache_dir=str(checkout_root / ".archex"), project_layout=True)
+    key = cache.cache_key(RepoSource(local_path=str(checkout_root)), head_override=commit_hash)
+    return cache.marker_matches(key)
+
+
+def _evaluate_candidate(
+    candidate_path: Path,
+    *,
+    destination: CheckoutIdentity,
+    destination_head: str,
+    index_config: IndexConfig,
+) -> tuple[SeedCandidate | None, SeedRejection | None]:
+    """Verify one listed checkout and decide whether its index may seed us."""
+    resolved = candidate_path.resolve()
+    if resolved == destination.root:
+        return None, None
+
+    root_rejection = _reject_symlinked(candidate_path, "candidate root")
+    if root_rejection is not None:
+        return None, root_rejection
+
+    identity = resolve_checkout_identity(resolved)
+    if identity is None:
+        return None, SeedRejection(
+            root=resolved,
+            reason="not_a_work_tree",
+            detail="git rev-parse did not report a usable work tree",
+        )
+    if identity.common_dir != destination.common_dir:
+        return None, SeedRejection(
+            root=resolved,
+            reason="different_repository",
+            detail=(
+                f"common directory {identity.common_dir} does not match {destination.common_dir}"
+            ),
+        )
+    if identity.root != resolved:
+        return None, SeedRejection(
+            root=resolved,
+            reason="not_a_checkout_root",
+            detail=f"git reports its top level as {identity.root}",
+        )
+
+    project_dir = resolved / ".archex"
+    index_path = project_dir / "index.db"
+    for path, label in ((project_dir, "project directory"), (index_path, "index database")):
+        rejection = _reject_symlinked(path, label)
+        if rejection is not None:
+            return None, rejection
+    if not index_path.is_file():
+        return None, SeedRejection(
+            root=resolved, reason="no_index", detail=f"{index_path} does not exist"
+        )
+    size_bytes = index_path.stat().st_size
+    if size_bytes > MAX_SEED_INDEX_BYTES:
+        return None, SeedRejection(
+            root=resolved,
+            reason="index_too_large",
+            detail=f"{size_bytes} bytes exceeds the {MAX_SEED_INDEX_BYTES} byte seed limit",
+        )
+
+    metadata = _read_store_metadata(index_path, _REQUIRED_METADATA_KEYS)
+    if metadata is None:
+        return None, SeedRejection(
+            root=resolved, reason="unreadable_index", detail=f"could not read {index_path}"
+        )
+    if metadata.get("schema_version") != CURRENT_SCHEMA_VERSION:
+        return None, SeedRejection(
+            root=resolved,
+            reason="incompatible_schema",
+            detail=(
+                f"index schema {metadata.get('schema_version')!r} != {CURRENT_SCHEMA_VERSION!r}"
+            ),
+        )
+    if metadata.get("needs_reindex") == "true":
+        return None, SeedRejection(
+            root=resolved, reason="needs_reindex", detail="candidate index requires a re-index"
+        )
+    mismatch = index_config_metadata_mismatch(metadata, index_config)
+    if mismatch is not None:
+        return None, SeedRejection(
+            root=resolved,
+            reason="incompatible_index_config",
+            detail=f"{mismatch} differs from the destination's index config",
+        )
+    commit_hash = metadata.get("commit_hash")
+    if not commit_hash:
+        return None, SeedRejection(
+            root=resolved, reason="no_revision", detail="candidate index records no commit_hash"
+        )
+
+    try:
+        indexed_at = float(metadata.get("indexed_at") or 0.0)
+    except ValueError:
+        indexed_at = 0.0
+
+    if not _index_is_provenanced(resolved, commit_hash):
+        return None, SeedRejection(
+            root=resolved,
+            reason="unprovenanced_index",
+            detail=(
+                "candidate index carries no cache marker written for "
+                f"{resolved} at {commit_hash[:8]}"
+            ),
+        )
+
+    return (
+        SeedCandidate(
+            root=resolved,
+            index_path=index_path,
+            commit_hash=commit_hash,
+            indexed_at=indexed_at,
+            same_commit=commit_hash == destination_head,
+        ),
+        None,
+    )
+
+
+def select_worktree_seed(
+    repo_root: Path,
+    *,
+    destination_head: str,
+    index_config: IndexConfig,
+) -> SeedSelection:
+    """Select an eligible seed source for the linked worktree at `repo_root`.
+
+    `destination_head` is the destination's resolved HEAD; it only ranks
+    candidates (an index already at the destination's revision needs the
+    smallest delta) and is never used to establish identity.
+    """
+    unsupported = _unsupported_index_config(index_config)
+    if unsupported is not None:
+        return SeedSelection(candidate=None, reason="unsupported_index_config", detail=unsupported)
+
+    destination = resolve_checkout_identity(repo_root)
+    if destination is None:
+        return SeedSelection(
+            candidate=None,
+            reason="not_a_work_tree",
+            detail=f"{repo_root} is not a usable Git work tree",
+        )
+    if not destination.is_linked_worktree:
+        return SeedSelection(
+            candidate=None,
+            reason="not_a_linked_worktree",
+            detail=f"git directory {destination.git_dir} is the repository's common directory",
+        )
+
+    # `-z` (Git 2.36+) is the unambiguous framing; older Git rejects the
+    # flag, in which case the line-oriented output is parsed instead.
+    nul_terminated = True
+    listing = _run_git(["worktree", "list", "--porcelain", "-z"], destination.root)
+    if listing is None or listing.returncode != 0:
+        nul_terminated = False
+        listing = _run_git(["worktree", "list", "--porcelain"], destination.root)
+    if listing is None or listing.returncode != 0:
+        return SeedSelection(
+            candidate=None,
+            reason="worktree_list_failed",
+            detail=(listing.stderr.strip() if listing is not None else "git could not be run"),
+        )
+
+    candidates: list[SeedCandidate] = []
+    rejections: list[SeedRejection] = []
+    listed = _parse_worktree_list(listing.stdout, nul_terminated=nul_terminated)
+    for skipped in listed[MAX_SEED_CANDIDATES:]:
+        rejections.append(
+            SeedRejection(
+                root=skipped,
+                reason="candidate_limit_reached",
+                detail=f"more than {MAX_SEED_CANDIDATES} checkouts share this repository",
+            )
+        )
+    for candidate_path in listed[:MAX_SEED_CANDIDATES]:
+        try:
+            candidate, rejection = _evaluate_candidate(
+                candidate_path,
+                destination=destination,
+                destination_head=destination_head,
+                index_config=index_config,
+            )
+        except (OSError, sqlite3.Error) as exc:
+            # A candidate is another checkout this process does not own: its
+            # files can be removed or replaced while it is being examined,
+            # and reading one must never be able to fail the indexing
+            # command that merely asked whether a seed exists.
+            candidate = None
+            rejection = SeedRejection(
+                root=candidate_path,
+                reason="candidate_unreadable",
+                detail=f"{type(exc).__name__}: {exc}",
+            )
+        if candidate is not None:
+            candidates.append(candidate)
+        elif rejection is not None:
+            rejections.append(rejection)
+
+    if not candidates:
+        return SeedSelection(
+            candidate=None,
+            reason="no_eligible_seed",
+            detail=f"{len(rejections)} candidate checkout(s) refused",
+            rejections=tuple(rejections),
+        )
+
+    # An index already at the destination's revision needs the smallest
+    # delta; among equals, the most recently measured one; path breaks ties
+    # so selection is deterministic across runs.
+    best = min(
+        candidates,
+        key=lambda candidate: (
+            not candidate.same_commit,
+            -candidate.indexed_at,
+            str(candidate.root),
+        ),
+    )
+    return SeedSelection(
+        candidate=best,
+        reason="eligible",
+        detail=f"seed source {best.root} at {best.commit_hash[:8]}",
+        rejections=tuple(rejections),
+    )

--- a/tests/index/test_worktree_seed.py
+++ b/tests/index/test_worktree_seed.py
@@ -1,0 +1,634 @@
+"""Tests for same-repository worktree seed discovery against real Git shapes.
+
+Every checkout shape here is created with real `git` commands rather than
+mocked, because the whole point of the module under test is that the shapes
+are distinguishable on disk: a linked worktree's `.git` is a file, a
+submodule's and a `--separate-git-dir` checkout's Git directory equals the
+repository common directory, and a stale worktree pointer makes
+`git worktree list` name a checkout that belongs to another repository.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import sqlite3
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from archex import cache as cache_module
+from archex.api import index_repository
+from archex.cache import CacheManager
+from archex.index import worktree_seed
+from archex.index.store import CURRENT_SCHEMA_VERSION, IndexStore
+from archex.index.worktree_seed import (
+    resolve_checkout_identity,
+    select_worktree_seed,
+)
+from archex.models import Config, IndexConfig, RepoSource
+from archex.project import init_project
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def _init_repo(root: Path, *, files: dict[str, str] | None = None) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "test@archex.test")
+    _git(root, "config", "user.name", "archex-test")
+    for name, body in (files or {"a.py": "def a() -> int:\n    return 1\n"}).items():
+        path = root / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-m", "initial")
+    return root
+
+
+def _head(repo: Path) -> str:
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _build_project_index(repo: Path) -> None:
+    """Initialize repo-local project state and build its `.archex/index.db`."""
+    init_project(repo)
+    store = index_repository(
+        RepoSource(local_path=str(repo)),
+        config=Config(languages=["python"], cache=True, cache_dir=str(repo / ".archex")),
+        index_config=IndexConfig(),
+    )
+    store.close()
+
+
+def _set_metadata(index_path: Path, key: str, value: str) -> None:
+    conn = sqlite3.connect(index_path)
+    try:
+        conn.execute(
+            "INSERT INTO metadata (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (key, value),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _read_metadata(index_path: Path, key: str) -> str | None:
+    conn = sqlite3.connect(f"file:{index_path}?mode=ro", uri=True)
+    try:
+        row = conn.execute("SELECT value FROM metadata WHERE key = ?", (key,)).fetchone()
+    finally:
+        conn.close()
+    return None if row is None else str(row[0])
+
+
+@pytest.fixture
+def seeded_pair(tmp_path: Path) -> tuple[Path, Path]:
+    """A main checkout with a built index plus a linked worktree with none."""
+    main = _init_repo(tmp_path / "main")
+    _build_project_index(main)
+    linked = tmp_path / "linked"
+    _git(main, "worktree", "add", "-b", "feature", str(linked))
+    return main, linked
+
+
+class TestResolveCheckoutIdentity:
+    def test_ordinary_checkout_is_not_a_linked_worktree(self, tmp_path: Path) -> None:
+        main = _init_repo(tmp_path / "main")
+
+        identity = resolve_checkout_identity(main)
+
+        assert identity is not None
+        assert identity.root == main.resolve()
+        assert identity.git_dir == identity.common_dir
+        assert identity.is_linked_worktree is False
+
+    def test_linked_worktree_shares_the_common_directory(self, tmp_path: Path) -> None:
+        main = _init_repo(tmp_path / "main")
+        linked = tmp_path / "linked"
+        _git(main, "worktree", "add", "-b", "feature", str(linked))
+
+        main_identity = resolve_checkout_identity(main)
+        linked_identity = resolve_checkout_identity(linked)
+
+        assert main_identity is not None
+        assert linked_identity is not None
+        assert (linked / ".git").is_file()
+        assert linked_identity.is_linked_worktree is True
+        assert linked_identity.common_dir == main_identity.common_dir
+        assert linked_identity.git_dir != linked_identity.common_dir
+
+    def test_identity_resolves_from_a_subdirectory(self, tmp_path: Path) -> None:
+        main = _init_repo(tmp_path / "main")
+        linked = tmp_path / "linked"
+        _git(main, "worktree", "add", "-b", "feature", str(linked))
+        nested = linked / "pkg" / "deep"
+        nested.mkdir(parents=True)
+
+        identity = resolve_checkout_identity(nested)
+
+        assert identity is not None
+        assert identity.root == linked.resolve()
+        assert identity.is_linked_worktree is True
+
+    def test_submodule_is_not_a_linked_worktree(self, tmp_path: Path) -> None:
+        child = _init_repo(tmp_path / "child", files={"c.py": "C = 1\n"})
+        parent = _init_repo(tmp_path / "parent", files={"p.py": "P = 1\n"})
+        _git(
+            parent,
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            str(child),
+            "vendor/child",
+        )
+        _git(parent, "commit", "-m", "add submodule")
+
+        identity = resolve_checkout_identity(parent / "vendor" / "child")
+
+        assert identity is not None
+        assert (parent / "vendor" / "child" / ".git").is_file()
+        assert identity.git_dir == identity.common_dir
+        assert identity.is_linked_worktree is False
+
+    def test_separate_git_dir_checkout_is_not_a_linked_worktree(self, tmp_path: Path) -> None:
+        work = tmp_path / "work"
+        work.mkdir()
+        _git(work, "init", "--separate-git-dir", str(tmp_path / "elsewhere.git"))
+
+        identity = resolve_checkout_identity(work)
+
+        assert identity is not None
+        assert (work / ".git").is_file()
+        assert identity.git_dir == identity.common_dir
+        assert identity.is_linked_worktree is False
+
+    def test_bare_repository_has_no_usable_identity(self, tmp_path: Path) -> None:
+        bare = tmp_path / "bare.git"
+        bare.mkdir()
+        _git(bare, "init", "--bare")
+
+        assert resolve_checkout_identity(bare) is None
+
+    def test_non_repository_has_no_identity(self, tmp_path: Path) -> None:
+        plain = tmp_path / "plain"
+        plain.mkdir()
+
+        assert resolve_checkout_identity(plain) is None
+        assert resolve_checkout_identity(tmp_path / "missing") is None
+
+
+class TestSelectWorktreeSeed:
+    def test_selects_the_main_checkout_index(self, seeded_pair: tuple[Path, Path]) -> None:
+        main, linked = seeded_pair
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert selection.eligible
+        assert selection.reason == "eligible"
+        candidate = selection.candidate
+        assert candidate is not None
+        assert candidate.root == main.resolve()
+        assert candidate.index_path == main.resolve() / ".archex" / "index.db"
+        assert candidate.commit_hash == _head(main)
+        assert candidate.same_commit is True
+
+    def test_ordinary_checkout_is_refused(self, tmp_path: Path) -> None:
+        main = _init_repo(tmp_path / "main")
+        _build_project_index(main)
+
+        selection = select_worktree_seed(
+            main, destination_head=_head(main), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        assert selection.reason == "not_a_linked_worktree"
+
+    def test_submodule_checkout_is_refused(self, tmp_path: Path) -> None:
+        child = _init_repo(tmp_path / "child", files={"c.py": "C = 1\n"})
+        parent = _init_repo(tmp_path / "parent", files={"p.py": "P = 1\n"})
+        _git(
+            parent,
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-q",
+            str(child),
+            "vendor/child",
+        )
+        _git(parent, "commit", "-m", "add submodule")
+        submodule = parent / "vendor" / "child"
+
+        selection = select_worktree_seed(
+            submodule, destination_head=_head(submodule), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        assert selection.reason == "not_a_linked_worktree"
+
+    def test_unrelated_repository_behind_a_stale_pointer_is_refused(self, tmp_path: Path) -> None:
+        """A repointed `worktrees/<name>/gitdir` must not serve another repo's index.
+
+        `git worktree list` reports whatever that pointer names, so the
+        listing alone would offer `unrelated` as a seed. Only the
+        candidate-side common-directory check catches it.
+        """
+        main = _init_repo(tmp_path / "main")
+        linked = tmp_path / "linked"
+        _git(main, "worktree", "add", "-b", "feature", str(linked))
+        unrelated = _init_repo(tmp_path / "unrelated", files={"u.py": "U = 1\n"})
+        _build_project_index(unrelated)
+
+        # Repoint the main checkout's record for `linked` at the unrelated tree.
+        pointer = main / ".git" / "worktrees" / "linked" / "gitdir"
+        pointer.write_text(f"{unrelated / '.git'}\n", encoding="utf-8")
+        listing = _git(linked, "worktree", "list", "--porcelain")
+        assert str(unrelated) in listing
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        assert selection.reason == "no_eligible_seed"
+        reasons = {rejection.reason for rejection in selection.rejections}
+        assert "different_repository" in reasons
+        assert unrelated.resolve() in {rejection.root for rejection in selection.rejections}
+
+    def test_pruned_worktree_directory_is_not_offered(self, tmp_path: Path) -> None:
+        main = _init_repo(tmp_path / "main")
+        _build_project_index(main)
+        linked = tmp_path / "linked"
+        _git(main, "worktree", "add", "-b", "feature", str(linked))
+        gone = tmp_path / "gone"
+        _git(main, "worktree", "add", "-b", "gone-branch", str(gone))
+        shutil.rmtree(gone)
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert selection.eligible
+        assert gone.resolve() not in {rejection.root for rejection in selection.rejections}
+
+    def test_worktree_path_containing_a_newline_is_parsed_whole(self, tmp_path: Path) -> None:
+        """Git does not escape a newline in a worktree path; the parser must not split on it."""
+        main = _init_repo(tmp_path / "main")
+        linked = tmp_path / "linked"
+        _git(main, "worktree", "add", "-b", "feature", str(linked))
+        awkward = tmp_path / "wt\nINJECTED"
+        _git(main, "worktree", "add", "--detach", str(awkward))
+        _build_project_index(awkward)
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert selection.eligible
+        candidate = selection.candidate
+        assert candidate is not None
+        assert candidate.root == awkward.resolve()
+
+    def test_ambient_git_location_env_cannot_redirect_identity(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An inherited GIT_DIR/GIT_WORK_TREE pair must not make two repos look like one.
+
+        The same-repository proof rests on a directory reporting its own
+        common directory. Git honours these variables over the working
+        directory, so leaving them in the environment would let an unrelated
+        checkout answer for this one.
+        """
+        main = _init_repo(tmp_path / "main")
+        unrelated = _init_repo(tmp_path / "unrelated", files={"u.py": "U = 1\n"})
+        monkeypatch.setenv("GIT_DIR", str(main / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(unrelated))
+
+        identity = resolve_checkout_identity(unrelated)
+
+        assert identity is not None
+        assert identity.root == unrelated.resolve()
+        assert identity.common_dir == (unrelated / ".git").resolve()
+        assert identity.is_linked_worktree is False
+
+    def test_planted_index_without_a_cache_marker_is_refused(
+        self, seeded_pair: tuple[Path, Path]
+    ) -> None:
+        """A committed or planted `index.db` must not be trusted on its own.
+
+        Everything else about a candidate is read out of the candidate's own
+        database, so whoever supplies the database supplies the evidence for
+        accepting it. `.archex/index.db` and `.archex/settings.toml` are
+        ordinary files, so a published repository can commit both. The cache
+        marker is the one thing committed content cannot forge, because it
+        is keyed on the checkout's absolute path.
+        """
+        main, linked = seeded_pair
+        (main / ".archex" / "index.meta").unlink()
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        assert [rejection.reason for rejection in selection.rejections] == ["unprovenanced_index"]
+
+    def test_marker_for_a_different_directory_is_refused(
+        self, seeded_pair: tuple[Path, Path]
+    ) -> None:
+        """A marker copied from elsewhere does not bind to this checkout."""
+        main, linked = seeded_pair
+        marker = main / ".archex" / "index.meta"
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+        payload["cache_key"] = "0" * 64
+        marker.write_text(json.dumps(payload), encoding="utf-8")
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        assert [rejection.reason for rejection in selection.rejections] == ["unprovenanced_index"]
+
+    def test_marker_forged_for_a_predictable_path_is_refused(
+        self, seeded_pair: tuple[Path, Path]
+    ) -> None:
+        """Knowing the checkout path is not enough to produce a valid marker.
+
+        Both halves of the cache key are guessable — the commit can be the
+        attacker's own, and checkout paths are fixed on CI runners and in
+        container images — so the marker is authenticated with a secret
+        that only this machine holds.
+        """
+        main, linked = seeded_pair
+        marker = main / ".archex" / "index.meta"
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+        # The forger knows the path and the revision, so it computes the
+        # key correctly; it does not hold this machine's secret.
+        cache = CacheManager(cache_dir=str(main / ".archex"), project_layout=True)
+        forged_key = cache.cache_key(RepoSource(local_path=str(main)), head_override=_head(main))
+        assert payload["cache_key"] == forged_key
+        payload["marker_hmac"] = hashlib.sha256(forged_key.encode()).hexdigest()
+        marker.write_text(json.dumps(payload), encoding="utf-8")
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        assert [rejection.reason for rejection in selection.rejections] == ["unprovenanced_index"]
+
+    def test_marker_from_another_machine_is_refused(
+        self, seeded_pair: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A marker copied from a machine with a different secret does not verify."""
+        _main, linked = seeded_pair
+        monkeypatch.setattr(cache_module, "_machine_secret", lambda: b"a-different-machine")
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        assert [rejection.reason for rejection in selection.rejections] == ["unprovenanced_index"]
+
+    def test_unreadable_marker_is_a_refusal_not_a_crash(
+        self, seeded_pair: tuple[Path, Path]
+    ) -> None:
+        """Reading a sibling checkout must never fail the command that asked."""
+        main, linked = seeded_pair
+        (main / ".archex" / "index.meta").write_bytes(b"\xff\xfe\x00not utf-8")
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        assert [rejection.reason for rejection in selection.rejections] == ["unprovenanced_index"]
+
+    def test_candidate_failing_mid_evaluation_is_a_refusal(
+        self, seeded_pair: tuple[Path, Path]
+    ) -> None:
+        """A candidate can be reset or replaced while this checkout examines it.
+
+        A candidate is another checkout this process does not own, so any
+        read of it can fail at any point. That must produce a refusal, not
+        fail the indexing command that merely asked whether a seed exists.
+        """
+        _main, linked = seeded_pair
+
+        with patch.object(
+            worktree_seed,
+            "_read_store_metadata",
+            side_effect=OSError(2, "No such file or directory"),
+        ):
+            selection = select_worktree_seed(
+                linked, destination_head=_head(linked), index_config=IndexConfig()
+            )
+
+        assert not selection.eligible
+        assert [rejection.reason for rejection in selection.rejections] == ["candidate_unreadable"]
+
+    def test_oversized_candidate_index_is_refused(
+        self, seeded_pair: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        main, linked = seeded_pair
+        size = (main / ".archex" / "index.db").stat().st_size
+        monkeypatch.setattr(worktree_seed, "MAX_SEED_INDEX_BYTES", size - 1)
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        assert [rejection.reason for rejection in selection.rejections] == ["index_too_large"]
+
+    def test_candidate_list_is_bounded(
+        self, seeded_pair: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Interrogating every checkout of a many-worktree repository is not free."""
+        main, linked = seeded_pair
+        for name in ("extra_one", "extra_two"):
+            _git(main, "worktree", "add", "--detach", str(linked.parent / name))
+        monkeypatch.setattr(worktree_seed, "MAX_SEED_CANDIDATES", 1)
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        reasons = [rejection.reason for rejection in selection.rejections]
+        assert reasons.count("candidate_limit_reached") == 3
+
+    def test_missing_candidate_index_is_reported(self, tmp_path: Path) -> None:
+        main = _init_repo(tmp_path / "main")
+        linked = tmp_path / "linked"
+        _git(main, "worktree", "add", "-b", "feature", str(linked))
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        assert selection.reason == "no_eligible_seed"
+        assert [rejection.reason for rejection in selection.rejections] == ["no_index"]
+
+    def test_incompatible_schema_is_refused(self, seeded_pair: tuple[Path, Path]) -> None:
+        main, linked = seeded_pair
+        index_path = main / ".archex" / "index.db"
+        _set_metadata(index_path, "schema_version", "4")
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        assert [rejection.reason for rejection in selection.rejections] == ["incompatible_schema"]
+
+    def test_candidate_index_is_never_written_by_inspection(
+        self, seeded_pair: tuple[Path, Path]
+    ) -> None:
+        """Inspecting a candidate must not modify a checkout this process does not own.
+
+        `IndexStore`'s constructor migrates schema on open, which would
+        rewrite `schema_version` in the sibling's database; the read-only
+        connection the module uses cannot. SQLite may still materialize
+        empty `-wal`/`-shm` sidecars for any WAL-mode reader — the
+        sibling's own commands do the same — so the invariant asserted
+        here is that the database's bytes are untouched.
+        """
+        main, linked = seeded_pair
+        index_path = main / ".archex" / "index.db"
+        _set_metadata(index_path, "schema_version", "4")
+        digest_before = hashlib.sha256(index_path.read_bytes()).hexdigest()
+
+        select_worktree_seed(linked, destination_head=_head(linked), index_config=IndexConfig())
+
+        assert _read_metadata(index_path, "schema_version") == "4"
+        assert hashlib.sha256(index_path.read_bytes()).hexdigest() == digest_before
+
+    def test_needs_reindex_candidate_is_refused(self, seeded_pair: tuple[Path, Path]) -> None:
+        main, linked = seeded_pair
+        _set_metadata(main / ".archex" / "index.db", "needs_reindex", "true")
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        assert [rejection.reason for rejection in selection.rejections] == ["needs_reindex"]
+
+    def test_incompatible_index_config_is_refused(self, seeded_pair: tuple[Path, Path]) -> None:
+        main, linked = seeded_pair
+        _set_metadata(main / ".archex" / "index.db", "chunker_revision", "not-this-build")
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        rejection = selection.rejections[0]
+        assert rejection.reason == "incompatible_index_config"
+        assert "chunker_revision" in rejection.detail
+
+    def test_candidate_without_a_revision_is_refused(self, seeded_pair: tuple[Path, Path]) -> None:
+        main, linked = seeded_pair
+        _set_metadata(main / ".archex" / "index.db", "commit_hash", "")
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        assert [rejection.reason for rejection in selection.rejections] == ["no_revision"]
+
+    def test_vector_or_splade_index_config_is_unsupported(
+        self, seeded_pair: tuple[Path, Path]
+    ) -> None:
+        _main, linked = seeded_pair
+
+        vector = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig(vector=True)
+        )
+        splade = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig(splade=True)
+        )
+
+        assert vector.reason == "unsupported_index_config"
+        assert "vector" in vector.detail
+        assert splade.reason == "unsupported_index_config"
+        assert "SPLADE" in splade.detail
+
+    def test_symlinked_candidate_project_dir_is_refused(
+        self, seeded_pair: tuple[Path, Path]
+    ) -> None:
+        main, linked = seeded_pair
+        project_dir = main / ".archex"
+        elsewhere = main.parent / "elsewhere"
+        project_dir.rename(elsewhere)
+        project_dir.symlink_to(elsewhere, target_is_directory=True)
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert not selection.eligible
+        assert [rejection.reason for rejection in selection.rejections] == ["symlinked_path"]
+
+    def test_same_commit_candidate_wins_over_a_newer_diverged_one(self, tmp_path: Path) -> None:
+        main = _init_repo(tmp_path / "main")
+        _build_project_index(main)
+        same_commit_worktree = tmp_path / "sibling"
+        _git(main, "worktree", "add", "--detach", str(same_commit_worktree), "main")
+        _build_project_index(same_commit_worktree)
+
+        # Move the main checkout to a different revision and re-index it, so
+        # it is the most recently measured candidate but no longer matches.
+        (main / "b.py").write_text("def b() -> int:\n    return 2\n", encoding="utf-8")
+        _git(main, "add", "-A")
+        _git(main, "commit", "-m", "second")
+        _build_project_index(main)
+
+        destination = tmp_path / "linked"
+        _git(main, "worktree", "add", "-b", "feature", str(destination), "main")
+        _git(destination, "reset", "--hard", _head(same_commit_worktree))
+
+        selection = select_worktree_seed(
+            destination, destination_head=_head(destination), index_config=IndexConfig()
+        )
+
+        assert selection.eligible
+        candidate = selection.candidate
+        assert candidate is not None
+        assert candidate.root == same_commit_worktree.resolve()
+        assert candidate.same_commit is True
+
+    def test_selected_candidate_index_is_a_usable_store(
+        self, seeded_pair: tuple[Path, Path]
+    ) -> None:
+        _main, linked = seeded_pair
+
+        selection = select_worktree_seed(
+            linked, destination_head=_head(linked), index_config=IndexConfig()
+        )
+
+        assert selection.candidate is not None
+        store = IndexStore(selection.candidate.index_path)
+        try:
+            assert store.get_metadata("schema_version") == CURRENT_SCHEMA_VERSION
+            assert store.get_chunk_count() > 0
+        finally:
+            store.close()


### PR DESCRIPTION
## Summary

R22 PR-1 of 3. Adds the discovery half of same-repository worktree index seeding: given a linked Git worktree with no repo-local index, decide whether some checkout sharing its Git common directory holds an index that may legitimately seed it. No copying, no installation, no CLI surface — those are PR-2 and PR-3.

## Why identity is proven twice

`git worktree list --porcelain` is a starting point, not evidence. Repointing `.git/worktrees/<name>/gitdir` at an unrelated repository makes the listing report that repository's checkout as a worktree; seeding from it would serve another repository's code. Every candidate is therefore re-interrogated from its own directory and must report:

- the same `--git-common-dir` as the destination,
- its own path as `--show-toplevel`,
- `--is-inside-work-tree` true and `--is-bare-repository` false.

Only `git rev-parse` runs inside a candidate. `rev-parse` invokes no hook, no `core.fsmonitor` program, and no filter or diff driver, so identity is established without executing repository-configured code. The commands that can (`git status`, `git ls-files`) run only against the destination working tree.

## Shapes refused structurally

Verified against real `git` on macOS with git 2.55.0:

| Shape | `--git-dir` vs `--git-common-dir` | Disposition |
|---|---|---|
| Ordinary checkout | equal | `not_a_linked_worktree` |
| Linked worktree | differ | candidate source |
| Submodule | equal (`<super>/.git/modules/...`) | `not_a_linked_worktree` |
| `git init --separate-git-dir` | equal | `not_a_linked_worktree` |
| Bare repository | `--show-toplevel` fails, bare true | no usable identity |

No name heuristics are involved: submodules and separate-git-dir checkouts fail the same inequality test that identifies a linked worktree.

## Compatibility, without touching the sibling's store

A candidate's metadata is read through a read-only SQLite URI connection, never through `IndexStore` — whose constructor creates and migrates schema and would rewrite `schema_version` in a checkout this process does not own. Required to match: `schema_version`, `needs_reindex` unset, a recorded `commit_hash`, and the full index-config shape. `vector`/`splade` configurations are refused outright, because transferring embedding state correctly across a delta needs the embedder pipeline ordinary delta indexing owns; both are off in `IndexConfig`'s defaults.

The index-config comparison moved into `archex.index.compat` so the existing cache-hit predicate (`_index_config_metadata_matches`) and seed eligibility answer it identically, with the same missing-key normalization as before. `IndexStore`'s schema version is now the named `CURRENT_SCHEMA_VERSION`.

## Verification

```
uv run pytest tests/index/test_worktree_seed.py --no-cov     -> 22 passed
uv run pytest tests/index/test_artifact.py tests/index/test_delta.py \
              tests/test_cache.py tests/cli/test_index_cmd.py --no-cov -> 162 passed
uv run ruff check <changed>                                  -> All checks passed
uv run ruff format --check <changed>                          -> 5 files already formatted
uv run pyright <changed>                                      -> 0 errors
```

Every checkout shape in the tests is built with real `git` commands, including the stale-pointer case (which asserts the listing does name the unrelated repository, then asserts it is refused) and a pruned worktree directory. One test pins the no-write invariant by hashing the candidate database before and after inspection.

## Round-2 hardening (review findings applied)

- **Ambient Git location variables are scrubbed.** `GIT_DIR`/`GIT_COMMON_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` are removed from every `git` invocation here. The identity proof rests on a *directory* reporting its own repository, and an inherited `GIT_DIR`+`GIT_WORK_TREE` pair makes two unrelated checkouts resolve to one common directory. Reproduced, then fixed and pinned.
- **`git worktree list --porcelain -z`** (with a newline-framing fallback for Git < 2.36), because Git does not escape a newline inside a worktree path; `git rev-parse` likewise falls back to per-flag invocations when a value contains one. A worktree whose path contains a newline is now offered correctly instead of being parsed into a nonexistent path.
- **Provenance is required.** Everything a candidate declares lives inside the candidate database, and `.archex/index.db` is an ordinary file a published repository can commit. A candidate must now carry archex's own `index.meta` marker, keyed on `sha256("<resolved absolute path>@<commit>")` — unforgeable for a clone directory nobody knows in advance. Disposition: `unprovenanced_index`.
- **Bounds.** A candidate index above 1 GiB is refused (`index_too_large`) and at most 32 checkouts are interrogated (`candidate_limit_reached`, refused by name rather than dropped) — the artifact path carries comparable ceilings and the seed path had none.

Tests added for all four, including a marker copied from another directory.
