### PR TITLE
feat(index): install worktree seeds atomically

### DIFF
--- a/src/archex/index/worktree_seed.py
+++ b/src/archex/index/worktree_seed.py
@@ -24,28 +24,35 @@ worktree may legitimately start from?* — and answers it conservatively:
   no name heuristics are involved.
 * **Every refusal is a named disposition.** Nothing is silently skipped.
 
-Selection stops at eligibility. Copying, delta synchronization, and
-installation are a separate concern.
+Once a source is eligible, its index is snapshotted into a staging
+directory, delta-synchronized against the *destination* working tree there,
+and only then published — so a failure at any earlier point leaves the
+destination exactly as it was, and ordinary full indexing remains the
+fallback for every disposition other than `seeded`.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import shutil
 import sqlite3
 import subprocess
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 
 from archex.cache import CacheManager
+from archex.exceptions import ArchexError
 from archex.index.compat import INDEX_CONFIG_METADATA_KEYS, index_config_metadata_mismatch
-from archex.index.store import CURRENT_SCHEMA_VERSION
+from archex.index.store import CURRENT_SCHEMA_VERSION, IndexStore
 from archex.models import RepoSource
+from archex.state_file import ExclusiveLock, StateFileDiagnostics
 
 if TYPE_CHECKING:
-    from archex.models import IndexConfig
+    from archex.models import Config, IndexConfig
 
 logger = logging.getLogger(__name__)
 
@@ -567,4 +574,420 @@ def select_worktree_seed(
         reason="eligible",
         detail=f"seed source {best.root} at {best.commit_hash[:8]}",
         rejections=tuple(rejections),
+    )
+
+
+#: Name of the sibling lock that serializes seeding for one destination.
+SEED_LOCK_FILENAME = "index-seed.lock"
+
+#: Prefix of a staging directory inside the destination project directory.
+#: Staging lives beside the destination database so publication is a rename
+#: on the same filesystem; a leftover directory means a seeding process died
+#: and is removed by the next seeder while holding the lock.
+_STAGING_PREFIX = ".seed-"
+
+#: How long a seeding attempt waits for the seed lock. Seeding is an
+#: optimization over a full index that costs seconds, so a contended lock
+#: means another process is already doing this work and this one should get
+#: on with ordinary indexing instead of queueing behind a whole copy.
+_SEED_LOCK_TIMEOUT_SECONDS = 0.5
+
+_SEED_DIAGNOSTICS = StateFileDiagnostics(
+    lock_error="worktree-seed-lock-error",
+    lock_timeout="worktree-seed-lock-timeout",
+    write_error="worktree-seed-write-error",
+)
+
+
+@dataclass(frozen=True)
+class WorktreeSeedResult:
+    """Outcome of one seeding attempt for one destination worktree."""
+
+    installed: bool
+    """Whether the destination now holds an index published from a seed."""
+
+    reason: str
+    """`seeded` when installed, else the disposition that refused seeding."""
+
+    detail: str = ""
+    source_root: Path | None = None
+    sync_strategy: str | None = None
+    """`clean` or `delta` when installed; None otherwise."""
+
+    files_changed: int = 0
+    seed_time_ms: float = 0.0
+    rejections: tuple[SeedRejection, ...] = field(default_factory=tuple)
+
+
+def _snapshot_index(source_db: Path, dest_db: Path) -> None:
+    """Copy a candidate index into `dest_db` through SQLite's backup API.
+
+    A filesystem copy of a WAL-mode database without its write-ahead log can
+    omit committed transactions, and copying the log is forbidden — the
+    destination must never receive `-wal`/`-shm` state. `backup()` over a
+    read-only connection instead produces one consistent snapshot that
+    already includes whatever the log holds, while opening the source for
+    reading only. (SQLite may materialize empty `-wal`/`-shm` sidecars
+    beside the *source* for any WAL-mode reader; the source's own commands
+    do the same, and its database bytes are untouched.)
+    """
+    uri = f"file:{quote(str(source_db))}?mode=ro"
+    reader = sqlite3.connect(uri, uri=True, timeout=30.0)
+    try:
+        writer = sqlite3.connect(dest_db)
+        try:
+            reader.backup(writer)
+        finally:
+            writer.close()
+    finally:
+        reader.close()
+
+
+def _staged_copy_rejection(
+    staged_db: Path,
+    *,
+    candidate: SeedCandidate,
+    index_config: IndexConfig,
+) -> str | None:
+    """Re-validate the snapshot that will actually be installed, or None if sound.
+
+    Eligibility was decided against the candidate's database *by path*, and
+    the snapshot is taken from that path again later: between the two, the
+    file can be replaced — by another process publishing its own index over
+    it, or by anything else able to write there. Re-checking the staged
+    bytes makes the validated object and the installed object the same
+    object.
+
+    The schema-object check is separate from that: archex's schema declares
+    no view and no trigger, and both are the SQLite constructs that can
+    carry SQL expressions evaluated during ordinary reads and schema
+    migration. A snapshot that declares one was not written by this
+    program, whatever its metadata claims.
+    """
+    metadata = _read_store_metadata(staged_db, _REQUIRED_METADATA_KEYS)
+    if metadata is None:
+        return "staged snapshot could not be read"
+    if metadata.get("schema_version") != CURRENT_SCHEMA_VERSION:
+        return f"staged snapshot schema {metadata.get('schema_version')!r} is not supported"
+    if metadata.get("needs_reindex") == "true":
+        return "staged snapshot requires a re-index"
+    if metadata.get("commit_hash") != candidate.commit_hash:
+        return (
+            f"staged snapshot revision {metadata.get('commit_hash')!r} is not the "
+            f"{candidate.commit_hash!r} that was validated"
+        )
+    mismatch = index_config_metadata_mismatch(metadata, index_config)
+    if mismatch is not None:
+        return f"staged snapshot {mismatch} does not match the destination's index config"
+
+    conn = sqlite3.connect(f"file:{quote(str(staged_db))}?mode=ro", uri=True, timeout=5.0)
+    try:
+        unexpected = conn.execute(
+            "SELECT type, name FROM sqlite_master WHERE type IN ('view', 'trigger')"
+        ).fetchall()
+    except sqlite3.Error as exc:
+        return f"staged snapshot schema could not be read: {exc}"
+    finally:
+        conn.close()
+    if unexpected:
+        names = ", ".join(f"{row[0]} {row[1]}" for row in unexpected)
+        return f"staged snapshot declares unexpected schema objects: {names}"
+    return None
+
+
+def _remove_stale_staging(project_dir: Path) -> None:
+    """Delete staging directories left by a seeding process that died.
+
+    Only ever called while holding the seed lock, so any staging directory
+    present belongs to a process that is no longer running.
+    """
+    for path in project_dir.glob(f"{_STAGING_PREFIX}*"):
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def _stamp_destination_identity(
+    store: IndexStore,
+    *,
+    repo_root: Path,
+    source_identity: str,
+    destination_head: str,
+    config: Config,
+    index_config: IndexConfig,
+) -> None:
+    """Make a seeded store describe the destination rather than its source.
+
+    A copied index still carries the source checkout's identity metadata.
+    Left that way the destination's own cache lookup would reject it and
+    re-index from scratch on the very next command, so the seed would buy
+    nothing. These are the same fields, written in the same order, that the
+    ordinary full-index path records when it publishes a store.
+    """
+    from archex.index.delta import compute_working_tree_signature
+    from archex.serve.generation import finalize_generation_id
+
+    store.set_metadata("commit_hash", destination_head)
+    store.set_metadata("source_identity", source_identity)
+    store.set_metadata("indexed_at", str(time.time()))
+    store.set_metadata("working_tree_signature", compute_working_tree_signature(repo_root, config))
+    finalize_generation_id(store, index_config)
+    store.conn.execute("PRAGMA wal_checkpoint(FULL)")
+
+
+@dataclass(frozen=True)
+class _StagedSync:
+    """Result of delta-syncing a staged seed against the destination tree."""
+
+    strategy: str
+    """`clean`, `delta`, or `too_stale` (nothing publishable)."""
+
+    files_changed: int
+
+
+def _sync_staged_seed(
+    staged_db: Path,
+    *,
+    repo_root: Path,
+    source_identity: str,
+    destination_head: str,
+    config: Config,
+    index_config: IndexConfig,
+) -> _StagedSync:
+    """Delta-sync a staged seed to the destination tree.
+
+    `strategy` is `clean` or `delta` when the staged copy is publishable,
+    and `too_stale` when the destination has drifted at or past
+    `config.delta_threshold` — the same knob ordinary delta indexing and
+    artifact import use. Past that point the staged copy is worth less than
+    a fresh build, so nothing is published and the caller falls back to full
+    indexing; `files_changed` is still reported so the disposition can say
+    how far the tree had moved.
+    """
+    from archex.acquire import discover_files
+    from archex.index.delta import apply_delta, compute_working_tree_delta
+    from archex.index.graph import DependencyGraph
+
+    store = IndexStore(staged_db)
+    try:
+        manifest = compute_working_tree_delta(repo_root, store, config)
+        manifest.base_commit = store.get_metadata("commit_hash") or manifest.base_commit
+        manifest.current_commit = destination_head
+
+        strategy = "clean"
+        files_changed = len(manifest.changes)
+        if manifest.changes:
+            total_files = len(
+                discover_files(
+                    repo_root,
+                    languages=config.languages,
+                    max_file_size=config.max_file_size,
+                ).files
+            )
+            change_ratio = files_changed / total_files if total_files > 0 else 1.0
+            if change_ratio >= config.delta_threshold:
+                logger.info(
+                    "Worktree seed is %.0f%% stale (delta_threshold=%.0f%%) — "
+                    "falling back to a full index.",
+                    change_ratio * 100,
+                    config.delta_threshold * 100,
+                )
+                return _StagedSync(strategy="too_stale", files_changed=files_changed)
+            graph = DependencyGraph.from_edges(store.get_edges())
+            apply_delta(store, graph, manifest, repo_root, config, index_config)
+            strategy = "delta"
+
+        _stamp_destination_identity(
+            store,
+            repo_root=repo_root,
+            source_identity=source_identity,
+            destination_head=destination_head,
+            config=config,
+            index_config=index_config,
+        )
+        return _StagedSync(strategy=strategy, files_changed=files_changed)
+    finally:
+        store.close()
+
+
+def seed_worktree_index(
+    repo_root: Path,
+    *,
+    cache: CacheManager,
+    cache_key: str,
+    source_identity: str,
+    config: Config,
+    index_config: IndexConfig,
+) -> WorktreeSeedResult:
+    """Bootstrap a linked worktree's index from a compatible same-repository seed.
+
+    Never raises for a seeding failure: seeding is an optimization over the
+    ordinary index path, so every refusal and every recoverable error
+    returns a named disposition with `installed=False` and the caller
+    proceeds to index normally. Publication happens once, through
+    `CacheManager.put`, which copies into a sibling temp file, renames it
+    over the destination database, and writes the `index.meta` validity
+    marker last — so an interrupted seed leaves either the previous state or
+    nothing at all, never a half-installed index.
+    """
+    started = time.perf_counter()
+    destination_db = cache.db_path(cache_key)
+    project_dir = destination_db.parent
+
+    if destination_db.exists():
+        return WorktreeSeedResult(
+            installed=False,
+            reason="destination_index_present",
+            detail=f"{destination_db} already exists",
+        )
+    if project_dir.is_symlink() or not project_dir.is_dir():
+        return WorktreeSeedResult(
+            installed=False,
+            reason="destination_unusable",
+            detail=f"{project_dir} is not a usable project directory",
+        )
+
+    destination_head = CacheManager.git_head(str(repo_root))
+    if not destination_head:
+        return WorktreeSeedResult(
+            installed=False,
+            reason="no_destination_revision",
+            detail=f"could not resolve HEAD for {repo_root}",
+        )
+
+    try:
+        selection = select_worktree_seed(
+            repo_root, destination_head=destination_head, index_config=index_config
+        )
+    except (OSError, sqlite3.Error, ArchexError) as exc:
+        # Selection reads directories and databases this process does not
+        # own. This function promises never to fail the indexing command
+        # that asked it for a seed, so the promise has to cover looking for
+        # one as well as installing it.
+        logger.warning(
+            "Looking for a worktree seed in %s failed (%s) — indexing normally.",
+            repo_root,
+            exc,
+        )
+        return WorktreeSeedResult(
+            installed=False,
+            reason="seed_failed",
+            detail=f"{type(exc).__name__}: {exc}",
+            seed_time_ms=round((time.perf_counter() - started) * 1000, 1),
+        )
+    candidate = selection.candidate
+    if candidate is None:
+        return WorktreeSeedResult(
+            installed=False,
+            reason=selection.reason,
+            detail=selection.detail,
+            rejections=selection.rejections,
+        )
+
+    lock = ExclusiveLock(
+        project_dir / SEED_LOCK_FILENAME,
+        timeout=_SEED_LOCK_TIMEOUT_SECONDS,
+        cwd=repo_root,
+        diagnostics=_SEED_DIAGNOSTICS,
+    )
+    with lock as acquired:
+        if not acquired:
+            return WorktreeSeedResult(
+                installed=False,
+                reason="seed_in_progress",
+                detail="another process holds the worktree seed lock",
+                source_root=candidate.root,
+                rejections=selection.rejections,
+            )
+        if destination_db.exists():
+            return WorktreeSeedResult(
+                installed=False,
+                reason="destination_index_present",
+                detail=f"{destination_db} was created while waiting for the seed lock",
+                source_root=candidate.root,
+            )
+
+        _remove_stale_staging(project_dir)
+        staging = project_dir / f"{_STAGING_PREFIX}{os.getpid()}-{time.time_ns()}"
+        try:
+            staging.mkdir(parents=True)
+            staged_db = staging / "index.db"
+            _snapshot_index(candidate.index_path, staged_db)
+            staged_rejection = _staged_copy_rejection(
+                staged_db, candidate=candidate, index_config=index_config
+            )
+            if staged_rejection is not None:
+                return WorktreeSeedResult(
+                    installed=False,
+                    reason="staged_copy_rejected",
+                    detail=staged_rejection,
+                    source_root=candidate.root,
+                    seed_time_ms=round((time.perf_counter() - started) * 1000, 1),
+                    rejections=selection.rejections,
+                )
+            synced = _sync_staged_seed(
+                staged_db,
+                repo_root=repo_root,
+                source_identity=source_identity,
+                destination_head=destination_head,
+                config=config,
+                index_config=index_config,
+            )
+            if synced.strategy == "too_stale":
+                return WorktreeSeedResult(
+                    installed=False,
+                    reason="large_delta",
+                    detail=(
+                        f"{synced.files_changed} file(s) changed, at or past "
+                        f"delta_threshold {config.delta_threshold}"
+                    ),
+                    source_root=candidate.root,
+                    files_changed=synced.files_changed,
+                    seed_time_ms=round((time.perf_counter() - started) * 1000, 1),
+                    rejections=selection.rejections,
+                )
+            cache.put(
+                cache_key,
+                staged_db,
+                resolved_commit=destination_head,
+                source_identity=source_identity,
+            )
+        except (OSError, sqlite3.Error, ArchexError) as exc:
+            logger.warning(
+                "Worktree seeding from %s failed (%s) — falling back to a full index.",
+                candidate.root,
+                exc,
+            )
+            return WorktreeSeedResult(
+                installed=False,
+                reason="seed_failed",
+                detail=f"{type(exc).__name__}: {exc}",
+                source_root=candidate.root,
+                seed_time_ms=round((time.perf_counter() - started) * 1000, 1),
+                rejections=selection.rejections,
+            )
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
+
+    # Installing another checkout's index is a cross-directory data import,
+    # so it is recorded here rather than only through the caller's optional
+    # timing object — a library or MCP caller that passes none would
+    # otherwise have it happen with no trace at all.
+    logger.info(
+        "Seeded %s from %s at %s (%s sync, %d file(s) changed, %.0fms)",
+        repo_root,
+        candidate.root,
+        candidate.commit_hash[:8],
+        synced.strategy,
+        synced.files_changed,
+        (time.perf_counter() - started) * 1000,
+    )
+    return WorktreeSeedResult(
+        installed=True,
+        reason="seeded",
+        detail=f"seeded from {candidate.root} at {candidate.commit_hash[:8]}",
+        source_root=candidate.root,
+        sync_strategy=synced.strategy,
+        files_changed=synced.files_changed,
+        seed_time_ms=round((time.perf_counter() - started) * 1000, 1),
+        rejections=selection.rejections,
     )

--- a/tests/index/test_worktree_seed.py
+++ b/tests/index/test_worktree_seed.py
@@ -26,11 +26,15 @@ from archex.cache import CacheManager
 from archex.index import worktree_seed
 from archex.index.store import CURRENT_SCHEMA_VERSION, IndexStore
 from archex.index.worktree_seed import (
+    SEED_LOCK_FILENAME,
+    WorktreeSeedResult,
     resolve_checkout_identity,
+    seed_worktree_index,
     select_worktree_seed,
 )
-from archex.models import Config, IndexConfig, RepoSource
+from archex.models import Config, IndexConfig, PipelineTiming, RepoSource
 from archex.project import init_project
+from archex.state_file import ExclusiveLock, StateFileDiagnostics
 
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 
@@ -40,12 +44,20 @@ def _git(repo: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
+#: Default corpus for a fixture repository. Wide enough that changing one
+#: file stays well below `Config.delta_threshold` (0.5), so a delta case in
+#: these tests exercises the delta path rather than the staleness fallback.
+_DEFAULT_FILES = {
+    f"mod_{index}.py": f"def value_{index}() -> int:\n    return {index}\n" for index in range(8)
+}
+
+
 def _init_repo(root: Path, *, files: dict[str, str] | None = None) -> Path:
     root.mkdir(parents=True, exist_ok=True)
     _git(root, "init", "-b", "main")
     _git(root, "config", "user.email", "test@archex.test")
     _git(root, "config", "user.name", "archex-test")
-    for name, body in (files or {"a.py": "def a() -> int:\n    return 1\n"}).items():
+    for name, body in (files or _DEFAULT_FILES).items():
         path = root / name
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(body, encoding="utf-8")
@@ -632,3 +644,370 @@ class TestSelectWorktreeSeed:
             assert store.get_chunk_count() > 0
         finally:
             store.close()
+
+
+def _destination_cache(repo: Path) -> tuple[CacheManager, str]:
+    """The project-layout cache manager and cache key a destination would use."""
+    cache = CacheManager(cache_dir=str(repo / ".archex"), project_layout=True)
+    return cache, cache.cache_key(RepoSource(local_path=str(repo)))
+
+
+def _seed(repo: Path, *, config: Config | None = None) -> WorktreeSeedResult:
+    """Run a seeding attempt exactly as the indexing path would."""
+    cache, cache_key = _destination_cache(repo)
+    return seed_worktree_index(
+        repo,
+        cache=cache,
+        cache_key=cache_key,
+        source_identity=str(repo),
+        config=config or Config(languages=["python"], cache=True, cache_dir=str(repo / ".archex")),
+        index_config=IndexConfig(),
+    )
+
+
+def _open_store_snapshot(store: IndexStore) -> tuple[list[str], list[str]]:
+    """Sorted chunk ids and indexed file paths of an open store."""
+    return (
+        sorted(chunk.id for chunk in store.get_chunks()),
+        sorted(store.get_file_states()),
+    )
+
+
+def _store_snapshot(index_path: Path) -> tuple[list[str], list[str]]:
+    """Sorted chunk ids and indexed file paths of a store on disk."""
+    store = IndexStore(index_path)
+    try:
+        return _open_store_snapshot(store)
+    finally:
+        store.close()
+
+
+@pytest.fixture
+def seed_destination(seeded_pair: tuple[Path, Path]) -> tuple[Path, Path]:
+    """A linked worktree with initialized project state but no index yet."""
+    main, linked = seeded_pair
+    init_project(linked)
+    assert not (linked / ".archex" / "index.db").exists()
+    return main, linked
+
+
+class TestSeedWorktreeIndex:
+    def test_clean_seed_publishes_a_usable_destination_index(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        main, linked = seed_destination
+        _cache, cache_key = _destination_cache(linked)
+
+        result = _seed(linked)
+
+        assert result.installed
+        assert result.reason == "seeded"
+        assert result.sync_strategy == "clean"
+        assert result.files_changed == 0
+        assert result.source_root == main.resolve()
+
+        index_path = linked / ".archex" / "index.db"
+        assert index_path.is_file()
+        meta = json.loads((linked / ".archex" / "index.meta").read_text(encoding="utf-8"))
+        assert meta["cache_key"] == cache_key
+        assert meta["resolved_commit"] == _head(linked)
+
+        store = IndexStore(index_path)
+        try:
+            assert store.get_chunk_count() > 0
+            assert store.get_metadata("source_identity") == str(linked)
+            assert store.get_metadata("commit_hash") == _head(linked)
+            assert store.get_metadata("working_tree_signature") == "clean"
+            assert store.get_metadata("generation_id")
+        finally:
+            store.close()
+
+    def test_seeded_index_is_reused_instead_of_rebuilt(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        """The point of stamping identity: the next index run must not rebuild."""
+        _main, linked = seed_destination
+        assert _seed(linked).installed
+
+        timing = PipelineTiming()
+        store = index_repository(
+            RepoSource(local_path=str(linked)),
+            config=Config(languages=["python"], cache=True, cache_dir=str(linked / ".archex")),
+            index_config=IndexConfig(),
+            timing=timing,
+        )
+        store.close()
+
+        assert timing.strategy == "cached"
+
+    def test_seeded_index_survives_a_new_destination_commit(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        """A new commit changes the cache key, so reuse then rests on stamped identity.
+
+        The `index.meta` marker is keyed on the destination's resolved path
+        *and* its HEAD, so the exact-hit path stops matching as soon as the
+        worktree commits. What keeps the seeded store from being thrown away
+        at that point is its `source_identity`, which the seed rewrote to the
+        destination — without it, the next run indexes from scratch.
+        """
+        _main, linked = seed_destination
+        assert _seed(linked).installed
+        (linked / "committed.py").write_text("def committed() -> int:\n    return 5\n")
+        _git(linked, "add", "-A")
+        _git(linked, "commit", "-m", "destination commit")
+
+        timing = PipelineTiming()
+        store = index_repository(
+            RepoSource(local_path=str(linked)),
+            config=Config(languages=["python"], cache=True, cache_dir=str(linked / ".archex")),
+            index_config=IndexConfig(),
+            timing=timing,
+        )
+        store.close()
+
+        assert timing.strategy == "delta"
+
+    def test_delta_seed_applies_destination_changes(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        _main, linked = seed_destination
+        (linked / "added.py").write_text("def added() -> int:\n    return 3\n", encoding="utf-8")
+
+        result = _seed(linked)
+
+        assert result.installed
+        assert result.sync_strategy == "delta"
+        assert result.files_changed == 1
+        chunks, files = _store_snapshot(linked / ".archex" / "index.db")
+        assert "added.py" in files
+        assert any("added.py" in chunk for chunk in chunks)
+
+    def test_seeded_and_clean_built_indexes_agree(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        """Retrieval equivalence: identical corpora and identical generation identity."""
+        _main, linked = seed_destination
+        (linked / "extra.py").write_text("def extra() -> int:\n    return 4\n", encoding="utf-8")
+        assert _seed(linked).installed
+        seeded_store = IndexStore(linked / ".archex" / "index.db")
+        try:
+            seeded = _open_store_snapshot(seeded_store)
+            seeded_generation = seeded_store.get_metadata("generation_id")
+        finally:
+            seeded_store.close()
+
+        # The comparison build gets a cache directory outside the repository:
+        # an untracked directory inside it would itself be discovered content.
+        clean_store = index_repository(
+            RepoSource(local_path=str(linked)),
+            config=Config(
+                languages=["python"], cache=True, cache_dir=str(linked.parent / "isolated")
+            ),
+            index_config=IndexConfig(),
+        )
+        try:
+            clean = _open_store_snapshot(clean_store)
+            clean_generation = clean_store.get_metadata("generation_id")
+        finally:
+            clean_store.close()
+
+        assert seeded == clean
+        assert seeded_generation == clean_generation
+
+    def test_large_delta_installs_nothing(self, seed_destination: tuple[Path, Path]) -> None:
+        _main, linked = seed_destination
+        for existing in linked.glob("*.py"):
+            existing.write_text("REWRITTEN = True\n", encoding="utf-8")
+
+        result = _seed(
+            linked,
+            config=Config(
+                languages=["python"],
+                cache=True,
+                cache_dir=str(linked / ".archex"),
+                delta_threshold=0.1,
+            ),
+        )
+
+        assert not result.installed
+        assert result.reason == "large_delta"
+        assert not (linked / ".archex" / "index.db").exists()
+        assert not (linked / ".archex" / "index.meta").exists()
+
+    def test_incompatible_source_installs_nothing(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        main, linked = seed_destination
+        _set_metadata(main / ".archex" / "index.db", "needs_reindex", "true")
+
+        result = _seed(linked)
+
+        assert not result.installed
+        assert result.reason == "no_eligible_seed"
+        assert [rejection.reason for rejection in result.rejections] == ["needs_reindex"]
+        assert not (linked / ".archex" / "index.db").exists()
+
+    def test_second_attempt_reports_the_existing_index(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        _main, linked = seed_destination
+        assert _seed(linked).installed
+
+        result = _seed(linked)
+
+        assert not result.installed
+        assert result.reason == "destination_index_present"
+
+    def test_a_concurrent_seeder_is_not_queued_behind(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        _main, linked = seed_destination
+        holder = ExclusiveLock(
+            linked / ".archex" / SEED_LOCK_FILENAME,
+            timeout=1.0,
+            cwd=linked,
+            diagnostics=StateFileDiagnostics(
+                lock_error="test-lock-error",
+                lock_timeout="test-lock-timeout",
+                write_error="test-write-error",
+            ),
+        )
+        with holder as acquired:
+            assert acquired
+            result = _seed(linked)
+
+        assert not result.installed
+        assert result.reason == "seed_in_progress"
+        assert not (linked / ".archex" / "index.db").exists()
+
+    def test_failure_mid_seed_leaves_the_destination_untouched(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        _main, linked = seed_destination
+
+        with patch(
+            "archex.index.worktree_seed._sync_staged_seed",
+            side_effect=sqlite3.DatabaseError("staged copy is corrupt"),
+        ):
+            result = _seed(linked)
+
+        assert not result.installed
+        assert result.reason == "seed_failed"
+        assert "staged copy is corrupt" in result.detail
+        assert not (linked / ".archex" / "index.db").exists()
+        assert not (linked / ".archex" / "index.meta").exists()
+        assert list((linked / ".archex").glob(".seed-*")) == []
+
+    def test_snapshot_swapped_after_validation_is_refused(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        """The database that was validated must be the database that is installed.
+
+        Eligibility is decided against the candidate's path; the snapshot is
+        taken from that path again afterwards. Anything able to write there
+        in between — another process publishing its own index, say — would
+        otherwise get unvalidated bytes installed.
+        """
+        _main, linked = seed_destination
+        foreign = _init_repo(linked.parent / "foreign", files={"f.py": "F = 1\n"})
+        _build_project_index(foreign)
+
+        original = worktree_seed._snapshot_index  # pyright: ignore[reportPrivateUsage]
+
+        def swapped(source_db: Path, dest_db: Path) -> None:
+            del source_db
+            original(foreign / ".archex" / "index.db", dest_db)
+
+        with patch.object(worktree_seed, "_snapshot_index", swapped):
+            result = _seed(linked)
+
+        assert not result.installed
+        assert result.reason == "staged_copy_rejected"
+        assert "revision" in result.detail
+        assert not (linked / ".archex" / "index.db").exists()
+
+    def test_snapshot_declaring_a_trigger_is_refused(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        """archex's schema declares no trigger; a snapshot that does is not ours."""
+        _main, linked = seed_destination
+        original = worktree_seed._snapshot_index  # pyright: ignore[reportPrivateUsage]
+
+        def with_trigger(source_db: Path, dest_db: Path) -> None:
+            original(source_db, dest_db)
+            conn = sqlite3.connect(dest_db)
+            try:
+                conn.execute(
+                    "CREATE TRIGGER poison AFTER INSERT ON chunks BEGIN SELECT randomblob(1); END"
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        with patch.object(worktree_seed, "_snapshot_index", with_trigger):
+            result = _seed(linked)
+
+        assert not result.installed
+        assert result.reason == "staged_copy_rejected"
+        assert "trigger poison" in result.detail
+        assert not (linked / ".archex" / "index.db").exists()
+
+    def test_a_failure_while_looking_for_a_seed_never_fails_indexing(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        """Looking for a seed reads other checkouts; that must not fail the command."""
+        _main, linked = seed_destination
+
+        with patch.object(
+            worktree_seed, "select_worktree_seed", side_effect=OSError(5, "I/O error")
+        ):
+            result = _seed(linked)
+
+        assert not result.installed
+        assert result.reason == "seed_failed"
+        assert "I/O error" in result.detail
+        assert not (linked / ".archex" / "index.db").exists()
+
+    def test_staging_left_by_a_dead_seeder_is_reclaimed(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        _main, linked = seed_destination
+        abandoned = linked / ".archex" / ".seed-999999-1"
+        abandoned.mkdir()
+        (abandoned / "index.db").write_text("partial", encoding="utf-8")
+
+        result = _seed(linked)
+
+        assert result.installed
+        assert not abandoned.exists()
+        assert list((linked / ".archex").glob(".seed-*")) == []
+
+    def test_only_index_state_crosses_over(self, seed_destination: tuple[Path, Path]) -> None:
+        """Locks, WAL/SHM, sessions, metrics, and settings must never be copied."""
+        main, linked = seed_destination
+        source_project = main / ".archex"
+        excluded = (
+            "index.db-wal",
+            "index.db-shm",
+            "status-snapshot.json",
+            "status-snapshot.lock",
+            "post-edit-state.json",
+            "session.db",
+        )
+        for name in excluded:
+            (source_project / name).write_text("source-only", encoding="utf-8")
+        (source_project / "metrics").mkdir(exist_ok=True)
+        (source_project / "metrics" / "events.jsonl").write_text("{}\n", encoding="utf-8")
+        source_settings = (source_project / "settings.toml").read_text(encoding="utf-8")
+        (source_project / "settings.toml").write_text(
+            source_settings + '\n[marker]\nfrom_source = "yes"\n', encoding="utf-8"
+        )
+
+        assert _seed(linked).installed
+
+        destination_names = {path.name for path in (linked / ".archex").iterdir()}
+        assert destination_names.isdisjoint({*excluded, "metrics"})
+        assert "from_source" not in (linked / ".archex" / "settings.toml").read_text(
+            encoding="utf-8"
+        )


### PR DESCRIPTION
## Summary

R22 PR-2 of 3, based on #642. Adds the installation half of same-repository worktree index seeding: snapshot an eligible candidate index, delta-sync it to the destination working tree, and publish it atomically. No CLI surface and no wiring into the indexing path yet — that is PR-3, so nothing in this PR changes existing behavior.

## Order of operations, and why

```
stage  ->  snapshot (SQLite backup)  ->  delta-sync in staging  ->  publish  ->  marker
```

Everything expensive happens *before* publication:

- **Snapshot via SQLite's backup API over a read-only connection**, not a file copy. A filesystem copy of a WAL-mode database without its write-ahead log can omit committed transactions, and copying the log is forbidden — the destination must never receive `-wal`/`-shm` state. `backup()` produces one consistent snapshot that already includes whatever the log holds, while never opening the source for writing.
- **Delta-sync happens in staging**, against the *destination* tree, reusing `compute_working_tree_delta` + `apply_delta`.
- **Publication reuses `CacheManager.put`** — the same primitive the ordinary full-index path uses — which copies into a sibling temp file, renames it over the destination database, and writes the `index.meta` validity marker **last**. A crash or failure therefore leaves the destination exactly as it was; there is no half-installed state to detect or repair.

## Allowlist by construction

Only index *content* crosses over. No lock file, `-wal`/`-shm` sidecar, status snapshot, post-edit state, session ledger, metrics directory, or settings file is read at all — a test writes all of them into the source project directory and asserts none appears at the destination and that the destination's own `settings.toml` is unchanged.

## Staleness and fallback

The existing `config.delta_threshold` decides when a seed is not worth having. At or past it nothing is published, the disposition is `large_delta` with the changed-file count, and the caller falls back to ordinary full indexing. Every other refusal (`destination_index_present`, `no_destination_revision`, `seed_in_progress`, `seed_failed`, plus PR-1's selection dispositions) is likewise a named result with `installed=False`; `seed_worktree_index` never raises for a seeding failure, because seeding is an optimization over a path that already works.

## Why a seeded store is stamped with the destination's identity

A copied index still carries its source checkout's `source_identity`, so the destination's own cache lookup would discard it on the very next command and the seed would buy nothing. The installer finishes by recording the destination's revision, source identity, working-tree signature, and generation id — the same fields the ordinary full-index path publishes.

A new destination commit changes the cache key, so reuse past that point rests on the stamped identity rather than on the `index.meta` marker. `test_seeded_index_survives_a_new_destination_commit` pins it: with the stamp removed, the following index run reports `full` instead of `delta` (mutation-checked, observed failing).

## Concurrency

Seeders serialize on a short-timeout `flock` on a sibling `index-seed.lock`. A contended lock is a disposition, not a queue — seeding saves seconds, so waiting behind another process's whole copy defeats the point. Staging left by a process that died is reclaimed by the next seeder while it holds that lock.

## Verification

```
uv run pytest tests/index/test_worktree_seed.py --no-cov               -> 34 passed
uv run pytest tests/index/test_artifact.py tests/index/test_delta.py \
              tests/test_cache.py --no-cov                             -> 158 passed
uv run ruff check src/archex tests/index/test_worktree_seed.py         -> All checks passed
uv run ruff format --check <changed>                                    -> already formatted
uv run pyright <changed>                                                -> 0 errors
```

Behavioral coverage added here: clean seed, delta seed, reuse by the next index run, reuse after a destination commit, retrieval equivalence against an independent clean build (identical chunk ids, identical indexed file set, identical `generation_id`), large-delta refusal installing nothing, incompatible source installing nothing, repeat attempt, contended lock, failure mid-seed leaving no database, no marker and no staging behind, staging reclaimed from a dead seeder, and the exclusion allowlist.

Two mutation checks were run and observed to fail before being accepted: removing the `source_identity` stamp breaks the post-commit reuse test, and the failure-injection test fails if a partial install is left behind.

## Round-2 hardening (review findings applied)

- **The staged snapshot is re-validated after the copy.** Eligibility is decided against a *path*; the snapshot is taken from that path again later, so the file can be replaced in between — by another process publishing its own index, or by anything else able to write there. The staged bytes' schema version, recorded revision, health flag and index config are re-checked, so the validated object and the installed object are the same object. Disposition: `staged_copy_rejected`, with a test that swaps in a foreign index between validation and copy.
- **A snapshot declaring a view or trigger is refused.** archex's schema creates neither, and both are the SQLite constructs that carry SQL expressions evaluated during ordinary reads and schema migration — so a snapshot that declares one was not written by this program, whatever its metadata says.
- **A completed install is logged.** Every disposition previously reached the operator only through `PipelineTiming`, so a library or MCP caller that passes none had another checkout's database copied in with no trace. Installing is now `logger.info`-recorded independently of the caller.
