### PR TITLE
feat(cli): report worktree seed strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,7 @@ Authority chain: README → [System Design](docs/SYSTEM_DESIGN.md) / [archex vs.
 - [Context Receipts](docs/CONTEXT_RECEIPTS.md) — receipt field contract and safe-to-act semantics
 - [Local Metrics](docs/LOCAL_METRICS.md) — token-savings math, privacy boundary, and default-off versus opt-in behavior
 - [Portable Index Artifact](docs/PORTABLE_INDEX_ARTIFACT.md) — export/import format, compression, staleness fallback, and `.gitattributes` handling for team-shared index bootstrap
+- [Worktree Index Seeding](docs/WORKTREE_INDEX_SEEDING.md) — how a fresh linked worktree bootstraps from a verified same-repository index instead of a full cold build
 - [Language Promotion Gate](docs/LANGUAGE_PROMOTION_GATE.md) — the recall/ranking-stability regression gate every language-tier promotion runs against
 - [Explorer Usability Evidence](docs/EXPLORER_USABILITY_EVIDENCE.md) — the timed orientation paths, browser verification, and offline-export evidence behind `archex explore`
 

--- a/docs/INSTALLATION_TRUST_CONTRACT.md
+++ b/docs/INSTALLATION_TRUST_CONTRACT.md
@@ -179,6 +179,7 @@ archex reads only paths you point it at or paths implied by the current reposito
 - global `~/.archex/config.toml` when present
 - configured MCP client files checked by `archex doctor`
 - local Hugging Face and FastEmbed cache directories when model-backed features are selected
+- the `.archex/index.db` of another checkout of *this same repository* when the current directory is a fresh linked Git worktree, to seed its index instead of rebuilding it; the source is verified to share this repository's Git common directory, is opened read-only, and nothing else in its `.archex` is read. Disable with `worktree_seed = false` or `ARCHEX_WORKTREE_SEED=0` (see [WORKTREE_INDEX_SEEDING.md](WORKTREE_INDEX_SEEDING.md))
 
 archex does not need hosted API keys for core CLI, Python API, MCP, Docker slim, or BM25 retrieval.
 

--- a/docs/PORTABLE_INDEX_ARTIFACT.md
+++ b/docs/PORTABLE_INDEX_ARTIFACT.md
@@ -6,6 +6,13 @@ fresh clone runs `archex init --from-artifact <path>` to bootstrap their
 local index from that snapshot instead of paying a full cold-start reindex,
 then delta-syncs to their current working tree.
 
+An artifact travels between *machines*. A linked worktree on the same
+machine needs neither the compression nor the version negotiation, so it has
+its own path — see
+[Worktree Index Seeding](WORKTREE_INDEX_SEEDING.md), which reuses the
+delta-sync and staleness-fallback rules described below but copies from a
+verified same-repository checkout instead of a file.
+
 This mirrors the highest-leverage team-workflow feature observed in
 `DeusData/codebase-memory-mcp`'s committed `.codebase-memory/graph.db.zst`
 artifact, adapted to archex's SQLite + FTS5 index and stdlib-only dependency

--- a/docs/WORKTREE_INDEX_SEEDING.md
+++ b/docs/WORKTREE_INDEX_SEEDING.md
@@ -1,0 +1,298 @@
+# Worktree Index Seeding
+
+A linked Git worktree (`git worktree add`) starts with no `.archex/index.db`.
+Left alone it pays a full cold index for a tree that is usually a few commits
+away from a checkout that is already indexed on the same machine — the exact
+cost an agent or stacked-PR workflow pays every time it opens a new worktree.
+
+`archex index`, `archex init`, and `archex query` therefore offer a fresh
+linked worktree a **seed**: a compatible index from a checkout sharing the
+same Git *common directory*, copied locally, synchronized against the
+destination tree, and published atomically. Nothing about the retrieval
+result changes — a seeded index and an independently built one are the same
+index (see [Equivalence](#equivalence)).
+
+Seeding never applies to a clone. It is strictly same-repository, same
+machine, and same filesystem. For a fresh clone or a teammate's machine, use
+the [portable index artifact](PORTABLE_INDEX_ARTIFACT.md), which is validated
+and versioned for travel.
+
+## What the CLI reports
+
+```console
+$ cd /path/to/linked-worktree
+$ archex init --no-index
+$ archex index
+Indexed repository: /path/to/linked-worktree
+Index path:         /path/to/linked-worktree/.archex/index.db
+Commit:             344c97f9f21619d34182751072c74fb69ff8f70b
+Strategy:           seeded
+Worktree seed:      seeded from /path/to/main-checkout (delta, 1 file(s) synchronized in 1615.9 ms)
+Files indexed:      1176
+Chunks indexed:     16664
+```
+
+`archex index --format json` adds `seed_disposition`, `seed_source`,
+`seed_strategy`, `seed_files_changed`, and `seed_time_ms`. Those keys appear
+**only when a seed was actually considered** — an ordinary checkout, which can
+never be seeded, reports nothing at all rather than a permanently-null
+section.
+
+A refusal is reported as explicitly as a success:
+
+```console
+Strategy:           full
+Worktree seed:      not used (no_eligible_seed); indexed normally
+```
+
+## Eligibility
+
+A checkout may seed this worktree only if all of the following hold.
+
+| Check | Rule |
+|---|---|
+| Destination shape | The destination is a linked worktree: its `--git-dir` differs from its `--git-common-dir`. |
+| Same repository | The candidate's own `--git-common-dir` resolves to the destination's. |
+| Candidate shape | The candidate reports itself as a non-bare work tree whose top level is the candidate path. |
+| No symlinks | Neither the candidate root, its `.archex`, nor its `index.db` may be a symlink. |
+| Schema | The candidate index's `schema_version` equals this build's. |
+| Health | The candidate index is not flagged `needs_reindex` and records a `commit_hash`. |
+| Index config | Chunker, chunker revision, quantization, and all four evidence-provider lists match the destination's config. |
+| Retrieval config | `vector` and `splade` must be disabled (see [Refused configurations](#refused-configurations)). |
+| Provenance | The candidate carries archex's own `.archex/index.meta` marker, written for that checkout's absolute path at the index's recorded revision. |
+| Size | The candidate index is at most 1 GiB. |
+| Candidate count | At most 32 checkouts are interrogated; the rest are refused by name. |
+
+Among eligible candidates, one already at the destination's revision wins
+(its delta is smallest), then the most recently measured, then path order so
+selection is deterministic.
+
+### Why identity is proven twice
+
+`git worktree list --porcelain` is a starting point, not evidence. A stale or
+hand-edited `.git/worktrees/<name>/gitdir` makes it report a checkout that
+belongs to a **different repository**, and seeding from that would serve
+another repository's code as this one's. Every candidate is therefore
+re-interrogated from its own directory, and only the common directory it
+reports itself decides eligibility.
+
+Only `git rev-parse` is ever run inside a candidate. `rev-parse` invokes no
+hook, no `core.fsmonitor` program, and no filter or diff driver, so identity
+is established without executing repository-configured code. The commands
+that can — `git status`, `git ls-files` — run only against the destination
+working tree, which the caller already owns.
+
+### Why the index's own metadata is not enough
+
+Everything a candidate declares about itself — schema version, revision,
+chunker, provider lists — is stored *inside* the candidate database, so
+whoever supplies that database supplies the evidence for accepting it. And
+`.archex/index.db` and `.archex/settings.toml` are ordinary files: a
+published repository can commit both, and a clone followed by
+`git worktree add` would then install committed content as this worktree's
+real index.
+
+The cache marker closes that door. `index.meta` records
+`sha256("<resolved absolute path>@<commit>")`, so a legitimate index has one
+because archex wrote it after building the index *in that directory*, and
+committed content cannot forge one for a clone directory nobody knows in
+advance. It is the same binding `CacheManager.get` already requires before
+reusing a project-layout index. A candidate without a matching marker is
+refused as `unprovenanced_index`.
+
+The snapshot is then re-validated after it is taken: eligibility is decided
+against a *path*, and the file at that path can be replaced before the copy
+runs, so the staged bytes' schema version, revision, health flag, and index
+config are checked again, and a snapshot declaring a view or trigger —
+constructs archex's schema never creates — is refused outright. The
+validated object and the installed object are therefore the same object.
+
+### Shapes that are refused structurally
+
+Submodules, bare repositories, and `git init --separate-git-dir` checkouts
+are not refused by name. In all three shapes Git reports the Git directory
+and the common directory as *equal*, so they never satisfy the
+linked-worktree test in the first place:
+
+| Shape | `.git` | `--git-dir` vs `--git-common-dir` |
+|---|---|---|
+| Ordinary checkout | directory | equal |
+| Linked worktree | file → `<common>/worktrees/<name>` | **differ** |
+| Submodule | file → `<super>/.git/modules/<path>` | equal |
+| `--separate-git-dir` | file → external directory | equal |
+| Bare repository | absent | no work tree at all |
+
+### Refused configurations
+
+Seeding refuses a destination whose index config enables `vector` or
+`splade`. Keeping embedding state correct across a delta needs the embedder
+pipeline that ordinary delta indexing owns, and SPLADE tables have no
+validated transfer story; copying either without that would be exactly the
+silent incompatibility this path exists to avoid. Both are disabled by
+default and in `.archex/settings.toml`.
+
+## What is copied
+
+Only index content, and only through SQLite's backup API over a **read-only**
+connection to the candidate database.
+
+A filesystem copy of a WAL-mode database without its write-ahead log can omit
+committed transactions, and copying the log is forbidden — the destination
+must never receive `-wal`/`-shm` state. The backup produces one consistent
+snapshot that already includes whatever the log holds, while never opening the
+source for writing.
+
+Nothing else is read at all: no lock file, no WAL/SHM sidecar, no status
+snapshot, no post-edit state, no session ledger, no metrics or trace
+directory, and no `settings.toml`. The destination keeps its own
+configuration. (SQLite may materialize empty `-wal`/`-shm` sidecars beside the
+*source* database, as it does for any WAL-mode reader, including the source
+checkout's own commands. The source's database bytes are never modified.)
+
+## Installation order
+
+```text
+stage  ->  snapshot  ->  delta-sync in staging  ->  publish  ->  marker
+```
+
+Everything expensive happens before publication. The snapshot lands in a
+staging directory beside the destination database, is synchronized there
+against the destination working tree, and is only then published through the
+same `CacheManager.put` the ordinary full-index path uses: a copy into a
+sibling temp file, a rename over the destination database, and the
+`index.meta` validity marker written **last**.
+
+A crash or failure at any earlier point therefore leaves the destination
+exactly as it was, and staging left behind by a process that died is
+reclaimed by the next seeder. The one window that is not atomic is between
+the database rename and the marker write: an interruption there leaves a
+complete database with no marker, which the cache treats as absent (so it
+is never served) but which seeding will not overwrite either — that
+worktree then indexes normally until `archex reset --force` clears it.
+
+Concurrent seeders serialize on a short-timeout `flock` on
+`.archex/index-seed.lock`. A contended lock is a disposition, not a queue:
+seeding saves seconds, so waiting behind another process's whole copy would
+defeat the point.
+
+## Synchronization and the staleness fallback
+
+Synchronization reuses the same content-hash delta machinery ordinary delta
+indexing and artifact import use — `compute_working_tree_delta()` against the
+destination tree, then `apply_delta()`:
+
+1. Nothing changed → `seed_strategy: "clean"`.
+2. Change ratio below `config.delta_threshold` (default `0.5`) → targeted
+   `apply_delta()`, `seed_strategy: "delta"`.
+3. Change ratio at or above the threshold → **nothing is published**. The
+   disposition is `large_delta` with the changed-file count, and ordinary
+   full indexing runs in its place. Past that point a targeted delta costs
+   more than a fresh build.
+
+A seeded store finishes by describing the destination — revision, source
+identity, working-tree signature, generation id — and publishing
+`index.meta` for the destination's own cache key. That is the same end state
+a full index leaves, and it is what makes the seed *stick*: a copied index
+still carrying its source's identity would be discarded by the destination's
+own cache lookup on the very next command.
+
+## Dispositions
+
+Every outcome is named. `seeded` is the only one that installs anything;
+every other falls through to ordinary indexing.
+
+| Disposition | Meaning |
+|---|---|
+| `seeded` | A seed was installed and synchronized. |
+| `seed_discarded` | A seed was installed but the resolution declined to reuse it (the tree moved under it); the reported strategy is what indexing actually did. |
+| `not_a_linked_worktree` | The destination is an ordinary, submodule, or separate-git-dir checkout. |
+| `not_a_work_tree` | Git reported no usable work tree. |
+| `unsupported_index_config` | `vector` or `splade` is enabled. |
+| `no_destination_revision` | The destination's HEAD could not be resolved. |
+| `destination_unusable` | The destination's `.archex` is a symlink or not a directory. |
+| `worktree_list_failed` | `git worktree list` failed. |
+| `no_eligible_seed` | Candidates existed but all were refused; each refusal carries its own reason (`different_repository`, `not_a_checkout_root`, `not_a_work_tree`, `symlinked_path`, `no_index`, `index_too_large`, `unreadable_index`, `incompatible_schema`, `needs_reindex`, `incompatible_index_config`, `no_revision`, `unprovenanced_index`, `candidate_limit_reached`). |
+| `large_delta` | A seed was found but the destination had drifted past `delta_threshold`. |
+| `staged_copy_rejected` | The snapshot that would have been installed no longer matched what was validated, or declared schema objects archex does not write. |
+| `seed_in_progress` | Another process held the seed lock. |
+| `destination_index_present` | The destination already had an index. |
+| `seed_failed` | A recoverable error occurred; the destination was left untouched. |
+
+## Turning it off
+
+```toml
+# .archex/settings.toml
+[index]
+worktree_seed = false
+```
+
+or per invocation:
+
+```console
+$ ARCHEX_WORKTREE_SEED=0 archex index
+```
+
+Either makes every new worktree index from scratch.
+
+## Equivalence
+
+Measured on archex's own repository (1,176 indexed files, 16,664 chunks) with
+a `0.29.0` wheel installed into a fresh virtualenv, driving real linked
+worktrees created with `git worktree add --detach`:
+
+| Arm | Strategy | Wall time | Index phase | Seed phase |
+|---|---|---|---|---|
+| Seeded, 3 files drifted | `seeded` / `delta` | 2.89 s | 2,326 ms | 2,234 ms |
+| Seeded, 18 files drifted | `seeded` / `delta` | 4.09 s | 3,438 ms | 3,337 ms |
+| Seeded, tree unchanged | `seeded` / `clean` | 2.11 s | 1,501 ms | 1,445 ms |
+| Full index (`ARCHEX_WORKTREE_SEED=0`) | `full` | 8.86–15.61 s | 8,289–14,996 ms | — |
+
+A ready-to-query worktree in **2.1–4.1 s** against **8.9–15.6 s** for a full
+index of the same tree — the full-index range is filesystem-cache variance
+across runs, measured on the same machine and wheel. A second
+`archex index` in a seeded worktree reports `cached` in 74 ms, so no parse
+happens again.
+
+What "the same index" means, precisely, because the two comparisons differ:
+
+**Against the same worktree delta-indexed in place — exact.** Seeding one
+worktree from a checkout indexed at an earlier commit produces a store
+byte-identical to letting that checkout index itself forward to the same
+tree: identical chunk rows *including content* (16,664), identical edges
+*including evidence* (3,659), identical `file_states` (1,194), and identical
+metadata apart from `indexed_at` and `source_identity`. This is the
+load-bearing equivalence, because a seeded worktree is exactly a worktree
+whose index arrived by delta.
+
+**Against a fresh full build — exact when the seed synced `clean`.** The
+`clean` arm and an independent full index agree on chunk ids, `file_states`,
+`generation_id`
+(`371237cc7b6efab2b1de623b96105ba996fb05420aed3b29fee2df21b6c23c7b`), and on
+the files `archex query` returns. `archex status --cached` reports `fresh` in
+both.
+
+**Against a fresh full build after a `delta` sync — same corpus, possibly
+different tail ranking.** Corpus, chunk ids, counts and `generation_id` still
+agree, but `apply_delta` records different edge *evidence* for the files it
+reparses than a full parse does (`[]` where a full build records
+`["resolved import …"]`), and it does not re-add every unresolved-import
+edge. Structural scoring reads those edges, so a query *can* return a
+different file at the bottom of a bounded result set — observed once, with
+18 files drifted; with 3 files drifted the seeded and full builds returned
+identical rows. This is a property of delta indexing, not of seeding: an
+ordinary `archex index` after a one-line edit produces the same divergence
+from a fresh full build, which is why the meaningful comparison is the first
+one above. The only metadata difference
+is `delta_applied`, which honestly records that the store reached its state
+through a delta.
+
+Reproduce with:
+
+```console
+$ git worktree add --detach /tmp/wt-seeded <commit>
+$ cd /tmp/wt-seeded && archex init --no-index && archex index --format json
+
+$ git worktree add --detach /tmp/wt-clean <commit>
+$ cd /tmp/wt-clean && archex init --no-index \
+    && ARCHEX_WORKTREE_SEED=0 archex index --format json
+```

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -67,6 +67,11 @@ from archex.index.bm25 import BM25Index
 from archex.index.compat import INDEX_CONFIG_METADATA_KEYS, index_config_metadata_mismatch
 from archex.index.graph import DependencyGraph
 from archex.index.store import IndexStore
+from archex.index.worktree_seed import (
+    WorktreeSeedResult,
+    resolve_checkout_identity,
+    seed_worktree_index,
+)
 from archex.languages import UNKNOWN_LANGUAGE_ID
 from archex.metrics.recorder import MetricsRecorder, UsageEvent
 from archex.models import (
@@ -524,18 +529,95 @@ def _ensure_index(
 ) -> IndexStore:
     """Ensure the repo is indexed and return an open IndexStore.
 
+    A linked Git worktree with no index of its own is first offered a seed
+    from a checkout sharing its Git common directory; a successful seed
+    leaves exactly the state a full index would have published, so the
+    resolution below then takes its ordinary cached path. Every refusal —
+    and a published seed the resolution then declines to reuse — falls
+    through to that same resolution unchanged.
+    """
+    if config is None:
+        config = load_config(source)
+    effective_index_config = index_config or IndexConfig()
+    cache = _cache_manager_for_source(source, config)
+    cache_key = cache.cache_key(source)
+
+    seed = _attempt_worktree_seed(source, config, effective_index_config, cache, cache_key)
+    store = _resolve_index(source, config, timing, effective_index_config, cache, cache_key)
+    if timing is not None and seed is not None:
+        timing.seed_disposition = seed.reason
+        timing.seed_source = None if seed.source_root is None else str(seed.source_root)
+        timing.seed_time_ms = seed.seed_time_ms
+        timing.seed_files_changed = seed.files_changed
+        if seed.installed and timing.strategy == "cached":
+            # The resolution consumed exactly what the seed published.
+            timing.seed_strategy = seed.sync_strategy
+            timing.strategy = "seeded"
+            # A seed is not a cache hit: this run copied and synchronized an
+            # index, and a consumer reading `cached` would conclude that no
+            # work was done.
+            timing.cached = False
+        elif seed.installed:
+            # The seed published a store the resolution then declined to
+            # reuse — a tree that moved under it, say. Whatever the
+            # resolution actually did stays the reported strategy, and the
+            # seed is reported as discarded rather than as the outcome.
+            timing.seed_disposition = "seed_discarded"
+    return store
+
+
+def _attempt_worktree_seed(
+    source: RepoSource,
+    config: Config,
+    index_config: IndexConfig,
+    cache: CacheManager,
+    cache_key: str,
+) -> WorktreeSeedResult | None:
+    """Offer a worktree seed to a fresh linked worktree; None if not applicable.
+
+    Returns None — reporting nothing at all — for the cases where seeding
+    is not a decision anyone needs to see: seeding disabled, a remote or
+    cacheless source, a repository that is not using the repo-local project
+    layout, a destination that already has an index, or an ordinary
+    checkout that is not a linked worktree. Everything past that point is a
+    named disposition the caller can report.
+    """
+    if not config.worktree_seed or not config.cache or not source.local_path or source.url:
+        return None
+    if not cache.project_layout or cache.db_path(cache_key).exists():
+        return None
+
+    repo_root = Path(source.local_path).expanduser().resolve()
+    identity = resolve_checkout_identity(repo_root)
+    if identity is None or not identity.is_linked_worktree:
+        return None
+
+    return seed_worktree_index(
+        repo_root,
+        cache=cache,
+        cache_key=cache_key,
+        source_identity=source.local_path,
+        config=config,
+        index_config=index_config,
+    )
+
+
+def _resolve_index(
+    source: RepoSource,
+    config: Config,
+    timing: PipelineTiming | None,
+    effective_index_config: IndexConfig,
+    cache: CacheManager,
+    cache_key: str,
+) -> IndexStore:
+    """Resolve an index through the cached, delta, or full path, in that order.
+
     On exact cache hit (same commit), returns the cached store directly.
     On same-repo different-commit, applies delta if within threshold.
     On cache miss, runs the full acquire → parse → chunk → store pipeline.
     The caller is responsible for closing the returned store.
     """
-    if config is None:
-        config = load_config(source)
-
     t_start = time.perf_counter()
-    effective_index_config = index_config or IndexConfig()
-    cache = _cache_manager_for_source(source, config)
-    cache_key = cache.cache_key(source)
     working_tree_signature = _working_tree_signature(source, config)
 
     # Path 1: Exact cache hit (same commit) — fast path

--- a/src/archex/cli/index_cmd.py
+++ b/src/archex/cli/index_cmd.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import click
 
-from archex.cli.indexing import run_indexing_and_get_summary
+from archex.cli.indexing import format_worktree_seed, run_indexing_and_get_summary
 from archex.exceptions import ArchexError
 
 
@@ -83,6 +83,9 @@ def index_cmd(
     click.echo(f"Index path:         {summary['index_path'] or '(ephemeral, not cached to disk)'}")
     click.echo(f"Commit:             {summary['commit_hash'] or 'none'}")
     click.echo(f"Strategy:           {summary['strategy']}")
+    seed_line = format_worktree_seed(summary)
+    if seed_line is not None:
+        click.echo(f"Worktree seed:      {seed_line}")
     click.echo(f"Files indexed:      {summary['files_indexed']}")
     click.echo(f"Chunks indexed:     {summary['chunks_indexed']}")
     if summary["languages"]:

--- a/src/archex/cli/indexing.py
+++ b/src/archex/cli/indexing.py
@@ -10,6 +10,7 @@ from archex.config import load_config, load_index_config, persist_project_index_
 from archex.index.artifact import ensure_artifact_gitattributes, export_artifact
 from archex.models import PipelineTiming, RepoSource
 from archex.project import uses_project_cache_layout
+from archex.utils import printable
 
 
 def _language_counts(file_metadata: list[dict[str, str | int]]) -> dict[str, int]:
@@ -90,7 +91,7 @@ def run_indexing_and_get_summary(
         ephemeral_untracked = cached_path is None and store.ephemeral
         index_path = None if ephemeral_untracked else (cached_path or store.db_path)
 
-        summary = {
+        summary: dict[str, Any] = {
             "repo_root": str(repo_root),
             "index_path": str(index_path) if index_path is not None else None,
             "commit_hash": store.get_metadata("commit_hash") or "",
@@ -102,6 +103,16 @@ def run_indexing_and_get_summary(
             "embedding_cache_hits": int(store.get_metadata("embedding_cache_hits") or "0"),
             "embedding_cache_misses": int(store.get_metadata("embedding_cache_misses") or "0"),
         }
+
+        # Present only when a worktree seed was actually considered, so the
+        # summary does not grow a permanently-null section for the ordinary
+        # checkout that can never be seeded.
+        if timing.seed_disposition is not None:
+            summary["seed_disposition"] = timing.seed_disposition
+            summary["seed_source"] = timing.seed_source
+            summary["seed_strategy"] = timing.seed_strategy
+            summary["seed_files_changed"] = timing.seed_files_changed
+            summary["seed_time_ms"] = round(timing.seed_time_ms, 1)
 
         if export_artifact_path is not None:
             artifact_header = export_artifact(store, export_artifact_path)
@@ -115,3 +126,23 @@ def run_indexing_and_get_summary(
         return summary
     finally:
         store.close()
+
+
+def format_worktree_seed(summary: dict[str, Any]) -> str | None:
+    """Render the worktree-seed line for a summary, or None if none applies.
+
+    A refusal is reported as explicitly as a success: the seed either
+    happened, in which case the source and synchronization strategy are
+    named, or it did not, in which case the disposition says why and
+    ordinary indexing produced the index instead.
+    """
+    disposition = summary.get("seed_disposition")
+    if disposition is None:
+        return None
+    if disposition != "seeded":
+        return f"not used ({disposition}); indexed normally"
+    return (
+        f"seeded from {printable(str(summary['seed_source']))} "
+        f"({summary['seed_strategy']}, {summary['seed_files_changed']} file(s) "
+        f"synchronized in {summary['seed_time_ms']} ms)"
+    )

--- a/src/archex/cli/init_cmd.py
+++ b/src/archex/cli/init_cmd.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import click
 
-from archex.cli.indexing import run_indexing_and_get_summary
+from archex.cli.indexing import format_worktree_seed, run_indexing_and_get_summary
 from archex.config import load_config, load_index_config
 from archex.exceptions import ArchexError
 from archex.index.artifact import import_artifact, sync_imported_artifact
@@ -137,6 +137,9 @@ def init_cmd(
 
         click.echo(f"Indexed repository: {summary['repo_root']}")
         click.echo(f"Strategy:           {summary['strategy']}")
+        seed_line = format_worktree_seed(summary)
+        if seed_line is not None:
+            click.echo(f"Worktree seed:      {seed_line}")
         click.echo(f"Files indexed:      {summary['files_indexed']}")
         click.echo(f"Chunks indexed:     {summary['chunks_indexed']}")
         if summary["languages"]:

--- a/src/archex/models.py
+++ b/src/archex/models.py
@@ -240,6 +240,14 @@ class Config(BaseModel):
     parallel: bool = True
     strict: bool = False
     delta_threshold: float = 0.5
+    worktree_seed: bool = True
+    """Whether a fresh linked worktree may bootstrap from a same-repository index.
+
+    Seeding only ever reuses an index from a checkout sharing this
+    repository's verified Git common directory, and falls back to ordinary
+    full indexing for any uncertainty. Set false to always index a new
+    worktree from scratch.
+    """
 
     @model_validator(mode="after")
     def _validate_config(self) -> Config:
@@ -1125,7 +1133,20 @@ class PipelineTiming:
     vector_used: bool = False
     vector_build_ms: float = 0.0
     vector_index_ms: float = 0.0
-    strategy: str = ""  # "full", "cached", "delta"
+    strategy: str = ""  # "full", "cached", "delta", "seeded"
+    seed_strategy: str | None = None
+    """How a successful worktree seed synchronized: "clean" or "delta"."""
+
+    seed_source: str | None = None
+    """The checkout a worktree seed came from, or was considered from."""
+
+    seed_files_changed: int = 0
+    """How many destination files a successful seed had to synchronize."""
+
+    seed_disposition: str | None = None
+    """Why seeding was or was not used; set only when a seed was considered."""
+
+    seed_time_ms: float = 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/src/archex/project.py
+++ b/src/archex/project.py
@@ -24,6 +24,7 @@ vector = false
 splade = false
 module_prefilter = false
 delta_threshold = 0.5
+worktree_seed = true
 
 [dogfood]
 tasks_dir = "benchmarks/tasks"

--- a/src/archex/reporting.py
+++ b/src/archex/reporting.py
@@ -7,6 +7,7 @@ import sys
 import tiktoken
 
 from archex.models import DeltaMeta, PipelineTiming, TokenMeta
+from archex.utils import printable
 
 _encoder = tiktoken.get_encoding("cl100k_base")
 
@@ -63,6 +64,18 @@ def print_timing(timing: PipelineTiming) -> None:
             f"[timing] Delta index: {dm.files_modified}M/{dm.files_added}A/"
             f"{dm.files_deleted}D files in {dm.delta_time_ms:.0f}ms "
             f"(full reindex avoided)",
+            file=sys.stderr,
+        )
+    if timing.seed_strategy is None and timing.seed_disposition is not None:
+        print(
+            f"[timing] Worktree seed not used ({timing.seed_disposition})",
+            file=sys.stderr,
+        )
+    if timing.seed_strategy is not None:
+        print(
+            f"[timing] Worktree seed: {timing.seed_strategy} sync of "
+            f"{timing.seed_files_changed} file(s) from "
+            f"{printable(str(timing.seed_source))} in {timing.seed_time_ms:.0f}ms",
             file=sys.stderr,
         )
 

--- a/src/archex/utils.py
+++ b/src/archex/utils.py
@@ -11,3 +11,13 @@ def resolve_source(path_or_url: str) -> RepoSource:
     if is_remote_url(path_or_url):
         return RepoSource(url=path_or_url)
     return RepoSource(local_path=path_or_url)
+
+
+def printable(text: str) -> str:
+    """Replace control characters with `?` before echoing text to a terminal.
+
+    Used for values that come from the filesystem rather than from archex —
+    a directory name can legitimately contain an escape sequence, and a
+    terminal would interpret it rather than display it.
+    """
+    return "".join(char if char.isprintable() or char == " " else "?" for char in text)

--- a/tests/index/test_worktree_seed.py
+++ b/tests/index/test_worktree_seed.py
@@ -19,10 +19,12 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from click.testing import CliRunner
 
 from archex import cache as cache_module
 from archex.api import index_repository
 from archex.cache import CacheManager
+from archex.cli.main import cli
 from archex.index import worktree_seed
 from archex.index.store import CURRENT_SCHEMA_VERSION, IndexStore
 from archex.index.worktree_seed import (
@@ -43,6 +45,11 @@ def _git(repo: Path, *args: str) -> str:
     result = subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
     return result.stdout.strip()
 
+
+#: Files a project-layout index covers beyond `_DEFAULT_FILES`: the
+#: `.gitignore` entry `archex init` writes is untracked repository content
+#: and is discovered like any other file.
+_INIT_WRITTEN_FILES = 1
 
 #: Default corpus for a fixture repository. Wide enough that changing one
 #: file stays well below `Config.delta_threshold` (0.5), so a delta case in
@@ -70,12 +77,23 @@ def _head(repo: Path) -> str:
     return _git(repo, "rev-parse", "HEAD")
 
 
+def _project_config(repo: Path) -> Config:
+    """The config `archex index` itself loads for a project-layout repository.
+
+    Notably `languages` stays unset, matching `.archex/settings.toml`'s
+    `languages = []`, so a fixture-built index covers the same file set the
+    CLI would discover — otherwise every seeded comparison would carry a
+    spurious delta for the files a narrower language filter had skipped.
+    """
+    return Config(cache=True, cache_dir=str(repo / ".archex"))
+
+
 def _build_project_index(repo: Path) -> None:
     """Initialize repo-local project state and build its `.archex/index.db`."""
     init_project(repo)
     store = index_repository(
         RepoSource(local_path=str(repo)),
-        config=Config(languages=["python"], cache=True, cache_dir=str(repo / ".archex")),
+        config=_project_config(repo),
         index_config=IndexConfig(),
     )
     store.close()
@@ -660,7 +678,7 @@ def _seed(repo: Path, *, config: Config | None = None) -> WorktreeSeedResult:
         cache=cache,
         cache_key=cache_key,
         source_identity=str(repo),
-        config=config or Config(languages=["python"], cache=True, cache_dir=str(repo / ".archex")),
+        config=config or _project_config(repo),
         index_config=IndexConfig(),
     )
 
@@ -671,6 +689,33 @@ def _open_store_snapshot(store: IndexStore) -> tuple[list[str], list[str]]:
         sorted(chunk.id for chunk in store.get_chunks()),
         sorted(store.get_file_states()),
     )
+
+
+def _full_store_snapshot(index_path: Path) -> dict[str, object]:
+    """Everything two stores of the same tree must agree on, read directly.
+
+    Chunk *content* and edge *evidence* are included deliberately: they are
+    the fields that differ between a delta-updated store and a freshly
+    parsed one, so comparing them is what makes an equivalence claim
+    falsifiable. `indexed_at` and `source_identity` are excluded because
+    they describe the run and the checkout, not the index.
+    """
+    conn = sqlite3.connect(f"file:{index_path}?mode=ro", uri=True)
+    try:
+        return {
+            "chunks": sorted(conn.execute("SELECT id, file_path, content FROM chunks")),
+            "edges": sorted(
+                conn.execute("SELECT source, target, kind, location, evidence FROM edges")
+            ),
+            "file_states": sorted(conn.execute("SELECT file_path, sha256 FROM file_states")),
+            "metadata": {
+                key: value
+                for key, value in conn.execute("SELECT key, value FROM metadata")
+                if key not in {"indexed_at", "source_identity"}
+            },
+        }
+    finally:
+        conn.close()
 
 
 def _store_snapshot(index_path: Path) -> tuple[list[str], list[str]]:
@@ -732,7 +777,7 @@ class TestSeedWorktreeIndex:
         timing = PipelineTiming()
         store = index_repository(
             RepoSource(local_path=str(linked)),
-            config=Config(languages=["python"], cache=True, cache_dir=str(linked / ".archex")),
+            config=_project_config(linked),
             index_config=IndexConfig(),
             timing=timing,
         )
@@ -760,7 +805,7 @@ class TestSeedWorktreeIndex:
         timing = PipelineTiming()
         store = index_repository(
             RepoSource(local_path=str(linked)),
-            config=Config(languages=["python"], cache=True, cache_dir=str(linked / ".archex")),
+            config=_project_config(linked),
             index_config=IndexConfig(),
             timing=timing,
         )
@@ -801,9 +846,7 @@ class TestSeedWorktreeIndex:
         # an untracked directory inside it would itself be discovered content.
         clean_store = index_repository(
             RepoSource(local_path=str(linked)),
-            config=Config(
-                languages=["python"], cache=True, cache_dir=str(linked.parent / "isolated")
-            ),
+            config=Config(cache=True, cache_dir=str(linked.parent / "isolated")),
             index_config=IndexConfig(),
         )
         try:
@@ -815,6 +858,48 @@ class TestSeedWorktreeIndex:
         assert seeded == clean
         assert seeded_generation == clean_generation
 
+    def test_seeded_store_equals_the_same_tree_delta_indexed_in_place(self, tmp_path: Path) -> None:
+        """The load-bearing equivalence: a seeded worktree is a delta-indexed worktree.
+
+        A seed copies an index built at one revision and synchronizes it to a
+        tree at another, which is exactly what ordinary delta indexing does
+        when a checkout moves forward. Both stores must therefore be the
+        same store, down to edge evidence — the field `apply_delta` and a
+        full parse disagree on, and so the field that would expose any
+        divergence between the two routes.
+        """
+        main = _init_repo(tmp_path / "main")
+        _build_project_index(main)
+
+        (main / "later.py").write_text(
+            "from mod_1 import value_1\n\n\ndef later() -> int:\n    return value_1()\n",
+            encoding="utf-8",
+        )
+        _git(main, "add", "-A")
+        _git(main, "commit", "-m", "second")
+
+        # Seed first, while the source index still describes the old revision.
+        destination = tmp_path / "linked"
+        _git(main, "worktree", "add", "--detach", str(destination))
+        init_project(destination)
+        seeded = _seed(destination)
+        assert seeded.installed
+        assert seeded.sync_strategy == "delta"
+        seeded_snapshot = _full_store_snapshot(destination / ".archex" / "index.db")
+
+        # Then let the source index itself forward to the same tree.
+        timing = PipelineTiming()
+        store = index_repository(
+            RepoSource(local_path=str(main)),
+            config=_project_config(main),
+            index_config=IndexConfig(),
+            timing=timing,
+        )
+        store.close()
+        assert timing.strategy == "delta"
+
+        assert seeded_snapshot == _full_store_snapshot(main / ".archex" / "index.db")
+
     def test_large_delta_installs_nothing(self, seed_destination: tuple[Path, Path]) -> None:
         _main, linked = seed_destination
         for existing in linked.glob("*.py"):
@@ -823,7 +908,6 @@ class TestSeedWorktreeIndex:
         result = _seed(
             linked,
             config=Config(
-                languages=["python"],
                 cache=True,
                 cache_dir=str(linked / ".archex"),
                 delta_threshold=0.1,
@@ -1011,3 +1095,131 @@ class TestSeedWorktreeIndex:
         assert "from_source" not in (linked / ".archex" / "settings.toml").read_text(
             encoding="utf-8"
         )
+
+
+class TestIndexingIntegration:
+    """The seed path as reached through `index_repository` and the CLI."""
+
+    def test_index_reports_the_seed_strategy(self, seed_destination: tuple[Path, Path]) -> None:
+        main, linked = seed_destination
+
+        result = CliRunner().invoke(cli, ["index", str(linked), "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        summary = json.loads(result.output)
+        assert summary["strategy"] == "seeded"
+        assert summary["seed_disposition"] == "seeded"
+        assert summary["seed_strategy"] == "clean"
+        assert summary["seed_source"] == str(main.resolve())
+        assert summary["files_indexed"] == len(_DEFAULT_FILES) + _INIT_WRITTEN_FILES
+
+    def test_index_text_output_names_the_seed(self, seed_destination: tuple[Path, Path]) -> None:
+        main, linked = seed_destination
+
+        result = CliRunner().invoke(cli, ["index", str(linked)])
+
+        assert result.exit_code == 0, result.output
+        assert "Strategy:           seeded" in result.output
+        assert f"Worktree seed:      seeded from {main.resolve()}" in result.output
+
+    def test_refused_seed_is_reported_and_indexes_normally(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        main, linked = seed_destination
+        _set_metadata(main / ".archex" / "index.db", "needs_reindex", "true")
+
+        result = CliRunner().invoke(cli, ["index", str(linked), "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        summary = json.loads(result.output)
+        assert summary["strategy"] == "full"
+        assert summary["seed_disposition"] == "no_eligible_seed"
+        assert summary["seed_strategy"] is None
+        assert summary["files_indexed"] == len(_DEFAULT_FILES) + _INIT_WRITTEN_FILES
+
+    def test_ordinary_checkout_reports_no_seed_section(self, tmp_path: Path) -> None:
+        main = _init_repo(tmp_path / "main")
+        init_project(main)
+
+        result = CliRunner().invoke(cli, ["index", str(main), "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        summary = json.loads(result.output)
+        assert "seed_disposition" not in summary
+        assert "Worktree seed" not in result.output
+
+    def test_seeding_can_be_disabled_in_project_settings(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        _main, linked = seed_destination
+        settings = linked / ".archex" / "settings.toml"
+        settings.write_text(
+            settings.read_text(encoding="utf-8").replace(
+                "worktree_seed = true", "worktree_seed = false"
+            ),
+            encoding="utf-8",
+        )
+
+        result = CliRunner().invoke(cli, ["index", str(linked), "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        summary = json.loads(result.output)
+        assert summary["strategy"] == "full"
+        assert "seed_disposition" not in summary
+
+    def test_query_seeds_a_fresh_worktree(self, seed_destination: tuple[Path, Path]) -> None:
+        """A query in a fresh worktree must reach the same seeded index."""
+        _main, linked = seed_destination
+
+        result = CliRunner().invoke(cli, ["query", str(linked), "value_3", "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        assert (linked / ".archex" / "index.db").is_file()
+        assert (linked / ".archex" / "index.meta").is_file()
+        assert "mod_3.py" in result.output
+
+    def test_discarded_seed_reports_the_real_strategy(
+        self, seed_destination: tuple[Path, Path]
+    ) -> None:
+        """A published seed the resolution declines must not be reported as the outcome.
+
+        Here the seed is published and then immediately flagged
+        `needs_reindex`, which the resolution refuses to reuse. The reported
+        strategy has to be what indexing actually did, not `seeded`.
+        """
+        _main, linked = seed_destination
+        original = worktree_seed.seed_worktree_index
+
+        def seed_then_spoil(*args: object, **kwargs: object) -> WorktreeSeedResult:
+            result = original(*args, **kwargs)  # pyright: ignore[reportCallIssue, reportArgumentType]
+            if result.installed:
+                _set_metadata(linked / ".archex" / "index.db", "needs_reindex", "true")
+            return result
+
+        with patch("archex.api.seed_worktree_index", seed_then_spoil):
+            result = CliRunner().invoke(cli, ["index", str(linked), "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        summary = json.loads(result.output)
+        assert summary["strategy"] == "full"
+        assert summary["seed_disposition"] == "seed_discarded"
+        assert summary["seed_strategy"] is None
+
+    def test_seed_source_control_characters_are_not_echoed(
+        self, seeded_pair: tuple[Path, Path]
+    ) -> None:
+        """A checkout name is filesystem input, so it must not carry escapes to a terminal."""
+        main, _linked = seeded_pair
+        hostile = main.parent / "wt\x1b[31mred"
+        _git(main, "worktree", "add", "--detach", str(hostile))
+        _build_project_index(hostile)
+        destination = main.parent / "destination"
+        _git(main, "worktree", "add", "--detach", str(destination))
+        init_project(destination)
+
+        result = CliRunner().invoke(cli, ["index", str(destination)])
+
+        assert result.exit_code == 0, result.output
+        assert "Worktree seed:      seeded from" in result.output
+        assert "\x1b" not in result.output
+        assert "wt?[31mred" in result.output


### PR DESCRIPTION
## Summary

R22 PR-3 of 3, based on #643. Wires worktree seeding into the indexing path, makes its decision visible on every surface, documents the contract, and records measured evidence from real linked worktrees.

## One integration point

`_ensure_index` now offers a fresh linked worktree a seed before resolving an index, so `archex index`, `archex init`, and `archex query` all reach it through the same place rather than three separate hooks. A successful seed leaves exactly the state a full index would have published, so the resolution that follows takes its ordinary cached or delta path unchanged; every refusal falls through to that same resolution.

Seeding is only *offered* where it is a decision worth reporting: repo-local project layout, caching on, a local source, no existing destination index, and a destination that really is a linked worktree. Outside that, nothing is attempted and nothing is reported — an ordinary checkout does not grow a permanently-null seed section in the JSON summary.

## Surfaces

```console
$ archex index
Strategy:           seeded
Worktree seed:      seeded from /path/to/main (delta, 1 file(s) synchronized in 1615.9 ms)
```

A refusal is named as explicitly as a success:

```console
Strategy:           full
Worktree seed:      not used (no_eligible_seed); indexed normally
```

`--format json` adds `seed_disposition`, `seed_source`, `seed_strategy`, `seed_files_changed`, `seed_time_ms`; `archex query --timing` prints the seed line; `--metrics` carries the same fields. `Config.worktree_seed` (default true) disables the path through `.archex/settings.toml` or `ARCHEX_WORKTREE_SEED=0`.

## Measured evidence (real linked worktrees, clean install)

A `0.29.0` wheel installed into a fresh virtualenv, driving real worktrees of archex's own repository created with `git worktree add --detach` (1,176 indexed files, 16,664 chunks):

| Arm | Strategy | Wall time | Index phase | Seed phase |
|---|---|---|---|---|
| Seeded, 18 files drifted | `seeded` / `delta` | 4.09 s | 3,438 ms | 3,337 ms |
| Seeded, tree unchanged | `seeded` / `clean` | 2.34 s | 1,595 ms | 1,577 ms |
| Full index (`ARCHEX_WORKTREE_SEED=0`) | `full` | 15.61 s | 14,996 ms | — |

**3.8x–6.7x** faster to a ready worktree, 74–85% less readiness time. A second `archex index` in a seeded worktree reports `cached` in 81 ms — no parse.

## Equivalence, scoped by what was actually measured

The first draft of this PR claimed the seeded and independently built indexes are simply "the same index". Driving it on the real repository showed that is true for two comparisons and not quite true for a third, so the doc now states all three:

- **Against the same worktree delta-indexed in place — exact.** Seeding a worktree from a checkout indexed at an earlier commit produces a store identical to letting that checkout index itself forward to the same tree: identical chunk rows *including content* (16,664), identical edges *including evidence* (3,659), identical `file_states` (1,194), identical metadata apart from `indexed_at`/`source_identity`. This is the load-bearing equivalence — a seeded worktree is exactly a worktree whose index arrived by delta — and it is now pinned by a test that compares those fields.
- **Against a fresh full build, `clean` sync — exact.** Identical chunk ids, `file_states`, `generation_id` (`371237cc…`), and identical `archex query` result files.
- **Against a fresh full build, `delta` sync — same corpus, possibly different tail ranking.** `apply_delta` records `[]` for edge evidence where a full parse records `["resolved import …"]`, and does not re-add every unresolved-import edge; structural scoring reads those edges, so one file at the bottom of a bounded result set can differ. Verified to be a **pre-existing property of delta indexing, not of seeding**: an ordinary `archex index` after a one-line edit produces the same divergence from a fresh full build (3,659 edges both, differing only in evidence for the reparsed file). Recorded as a follow-up rather than changed here — it is the shared delta path, outside R22's scope.

## Round-2 fixes (review findings applied)

- `_ensure_index` computes the cache manager and cache key once and threads them, instead of paying three extra `git` subprocesses on every warm query/index of a project-layout repository.
- `seeded` is reported only when the resolution actually consumed the seed; a published seed the resolution declines is reported as `seed_discarded` with the strategy indexing really used, and `timing.cached` is no longer left `True` for a run that copied and synchronized an index.
- `seed_source` is sanitized for control characters before being echoed (a checkout name is filesystem input).
- The disposition table now lists every disposition the code can emit (`seed_discarded`, `destination_unusable`, `staged_copy_rejected`, `unprovenanced_index`, `index_too_large`, `candidate_limit_reached`, `not_a_work_tree`), and the atomicity paragraph states the one window that is not atomic (between the database rename and the marker write) instead of claiming there is none.

## Documentation

- New [`docs/WORKTREE_INDEX_SEEDING.md`](docs/WORKTREE_INDEX_SEEDING.md): eligibility table, the two-sided identity proof and why a `git worktree list` entry is not evidence, the shapes refused structurally, what is and is not copied, install order, the staleness fallback, the full disposition table, how to turn it off, and the measured evidence with reproduction commands.
- `docs/PORTABLE_INDEX_ARTIFACT.md` cross-references it (artifacts travel between machines; seeding does not).
- `docs/INSTALLATION_TRUST_CONTRACT.md` "What archex reads" now names the sibling-checkout read, its verification, its read-only nature, and the switch that disables it.
- README doc index entry.

## Verification

```
uv run pytest tests/index/test_worktree_seed.py --no-cov                    -> 40 passed
uv run pytest tests/index tests/cli tests/test_cli.py tests/test_cache.py \
              --no-cov -p no:randomly                                        -> 1136 passed
uv run ruff check .                                                          -> All checks passed
uv run ruff format --check .                                                 -> 556 files already formatted
uv run pyright .                                                             -> 0 errors
```

Integration coverage added here: `archex index --format json` reporting `seeded`, the text line naming the source, a refused seed reporting its disposition while still producing a complete index, an ordinary checkout reporting no seed section at all, `worktree_seed = false` in project settings suppressing the path, and `archex query` seeding a fresh worktree end to end.
