### PR TITLE
fix(index): require an authenticated marker before reusing an index

### DIFF
--- a/docs/INSTALLATION_TRUST_CONTRACT.md
+++ b/docs/INSTALLATION_TRUST_CONTRACT.md
@@ -315,6 +315,33 @@ Index and artifact locations:
 - global default cache layout before project initialization: `~/.archex/cache`
 - configured cache layout: value of `cache_dir` in config or `ARCHEX_CACHE_DIR`
 
+Reuse of **any** cached index requires archex's own cache marker
+(`.archex/index.meta`, or `<key>.meta` in a keyed cache directory), which
+records `sha256("<resolved absolute path>@<commit>")` together with an
+HMAC of that key under a machine-local secret kept at
+`~/.archex/machine-id`. A `.archex/index.db` that
+arrived any other way — committed by whoever published the repository, for
+instance — has no marker for the directory it is being read in, and archex
+indexes the repository normally instead of reusing it. Everything an index
+database says about itself is stored inside that database, so the marker,
+not the database's own claims, is what establishes where an index came
+from. The HMAC is what makes the marker evidence rather than a hint: both
+halves of the key are guessable — the commit can be the publisher's own, and
+checkout paths are fixed on CI runners and in container images — so without
+a machine-local secret, committed content could carry a matching marker.
+Surfaces that read the index without going through the cache (`archex
+status`, `doctor`, `setup`, the session primer, the tool-call hook) apply the
+same rule and report `unprovenanced` instead of reading an index of unknown
+origin. Importing a portable artifact writes the marker as part of the
+import, because that import is explicitly requested by the operator. The
+cache directory is not a trust boundary: `cache_dir` is configurable, so the
+requirement applies to every layout, and an index cached before markers were
+authenticated is re-indexed once.
+
+For the same reason, `worktree_seed` is a machine-level setting only: it is
+read from `~/.archex/config.toml` or `ARCHEX_WORKTREE_SEED`, and a
+repository's own committed `.archex/settings.toml` cannot turn it on.
+
 ## Watch and freshness semantics
 
 - `archex index .` performs an explicit full or delta refresh.

--- a/docs/PORTABLE_INDEX_ARTIFACT.md
+++ b/docs/PORTABLE_INDEX_ARTIFACT.md
@@ -111,6 +111,16 @@ the artifact's export-time revision. Immediately after import, it runs
 `archex init --from-artifact` reports the chosen strategy, files changed,
 and sync time.
 
+Import finishes by adopting the store: the imported database is stamped
+with this checkout's revision, source identity, working-tree signature and
+generation id, and `.archex/index.meta` is written for this checkout's own
+cache key. Without that the store would still claim the exporter's
+identity and carry no cache marker, so the very next command would discard
+it and pay the full re-index the import existed to avoid — and reusing a
+repo-local index requires that marker, since an index database is
+otherwise entirely self-describing (see
+[the trust contract](INSTALLATION_TRUST_CONTRACT.md#cache-locations)).
+
 ## `.gitattributes` management
 
 Committing a binary artifact into git risks merge conflicts every time two

--- a/docs/WORKTREE_INDEX_SEEDING.md
+++ b/docs/WORKTREE_INDEX_SEEDING.md
@@ -220,8 +220,12 @@ every other falls through to ordinary indexing.
 
 ## Turning it off
 
+`worktree_seed` is a **machine-level** setting. A repository's own
+`.archex/settings.toml` cannot set it, because repository content must not
+decide whether archex consumes repository content:
+
 ```toml
-# .archex/settings.toml
+# ~/.archex/config.toml
 [index]
 worktree_seed = false
 ```

--- a/src/archex/api.py
+++ b/src/archex/api.py
@@ -702,6 +702,25 @@ def _try_delta_index(attempt: _DeltaIndexAttempt) -> IndexStore | None:
         return None
 
     db_path, cached_commit = existing
+    if not attempt.cache.marker_matches(
+        attempt.cache.cache_key(source, head_override=cached_commit)
+    ):
+        # A cache directory can be repository *content*: `.archex/index.db`
+        # and `.archex/settings.toml` are ordinary files a published
+        # repository can commit, and `cache_dir` is itself a repo-settable
+        # key, so "is this the project layout?" is not a safe precondition
+        # for trusting what is in it. The identity a store declares lives
+        # inside the same database, so archex's own marker — keyed on the
+        # resolved path and revision, authenticated with this machine's
+        # secret — is the only thing here that repository content cannot
+        # produce. Without it, index normally rather than reusing a store of
+        # unknown origin.
+        logger.warning(
+            "Ignoring the index at %s: it carries no archex cache marker for this "
+            "checkout, so its origin cannot be established. Indexing normally.",
+            db_path,
+        )
+        return None
     effective_index_config = attempt.index_config or IndexConfig()
     candidate_store = IndexStore(db_path)
     try:

--- a/src/archex/cache.py
+++ b/src/archex/cache.py
@@ -235,11 +235,20 @@ class CacheManager:
     # ------------------------------------------------------------------
 
     def get(self, key: str) -> Path | None:
-        """Return cached db Path if it exists, else None."""
+        """Return the cached db for `key`, or None if there is none to trust.
+
+        A database is only served when a marker archex wrote on this machine
+        names the same key. That applies to a keyed cache directory too, not
+        just a repository's `.archex`: `cache_dir` is configurable — a
+        repository's own settings can point it at a directory the repository
+        also ships — so the layout cannot decide whether the contents are
+        trustworthy. An entry written before markers were authenticated is
+        re-indexed once.
+        """
         db = self.db_path(key)
         if not db.exists():
             return None
-        if self._project_layout and self.get_meta(key).get("cache_key") != key:
+        if not self.marker_matches(key):
             return None
         return db
 

--- a/src/archex/cli/init_cmd.py
+++ b/src/archex/cli/init_cmd.py
@@ -113,7 +113,11 @@ def init_cmd(
             config = load_config(source)
             index_config = load_index_config(source)
             sync_result = sync_imported_artifact(
-                result.state.repo_root, result.state.index_path, config, index_config
+                result.state.repo_root,
+                result.state.index_path,
+                config,
+                index_config,
+                source_identity=source,
             )
         except ArchexError as exc:
             raise click.ClickException(str(exc)) from exc

--- a/src/archex/cli/status_cmd.py
+++ b/src/archex/cli/status_cmd.py
@@ -32,7 +32,7 @@ _FRESH_STATES = frozenset({"fresh"})
 
 #: Inspected states with no index to describe, where a leftover snapshot would
 #: keep advertising a measurement of something that is gone.
-_UNDESCRIBABLE_STATES = frozenset({"uninitialized", "missing_index", "corrupt"})
+_UNDESCRIBABLE_STATES = frozenset({"uninitialized", "missing_index", "corrupt", "unprovenanced"})
 
 
 @click.command("status")
@@ -69,7 +69,7 @@ def status_cmd(source: str, strict: bool, cached: bool, output_format: str) -> N
     else:
         _render_text(status)
 
-    if status.state == "corrupt" or (strict and status.state != "fresh"):
+    if status.state in {"corrupt", "unprovenanced"} or (strict and status.state != "fresh"):
         raise click.exceptions.Exit(1)
 
 

--- a/src/archex/config.py
+++ b/src/archex/config.py
@@ -112,6 +112,14 @@ def _resolve_project_path(value: Any, repo_root: Path) -> Any:
     return str(repo_root / path)
 
 
+#: `Config` keys a repository's own `.archex/settings.toml` may not set.
+#: `settings.toml` is ordinary repository content, so a published
+#: repository can ship one; a switch that decides whether archex *consumes*
+#: repository content must not be flippable by that content. These stay
+#: machine-level: `~/.archex/config.toml` or `ARCHEX_*`.
+_MACHINE_ONLY_CONFIG_KEYS = frozenset({"worktree_seed"})
+
+
 def load_config(source: RepoSource | str | Path | None = None) -> Config:
     """Load Config from TOML files and ARCHEX_* environment variables.
 
@@ -125,7 +133,11 @@ def load_config(source: RepoSource | str | Path | None = None) -> Config:
     project_settings = _project_index_settings(source)
     if project_settings is not None:
         state, index_settings = project_settings
-        project_overrides = _config_overrides_from_mapping(index_settings)
+        project_overrides = {
+            key: value
+            for key, value in _config_overrides_from_mapping(index_settings).items()
+            if key not in _MACHINE_ONLY_CONFIG_KEYS
+        }
         if "cache_dir" in project_overrides:
             project_overrides["cache_dir"] = _resolve_project_path(
                 project_overrides["cache_dir"],

--- a/src/archex/index/adopt.py
+++ b/src/archex/index/adopt.py
@@ -1,0 +1,104 @@
+"""Making an index that came from elsewhere describe *this* checkout.
+
+Two paths install an index this checkout did not build: importing a portable
+artifact, and seeding from another worktree of the same repository. Both
+inherit the producer's identity metadata, and both must overwrite it before
+the store is usable, for two independent reasons.
+
+**Reuse.** The destination's own cache lookup keys on this checkout's
+resolved path and revision. A store still claiming the producer's identity
+is discarded on the very next command, so the import or seed buys nothing.
+
+**Provenance.** The cache marker (`.archex/index.meta`) records
+`sha256("<resolved absolute path>@<commit>")`. Reusing a project-layout
+index requires that marker, precisely because everything a database says
+about itself lives inside the database — and `.archex/index.db` is an
+ordinary file a published repository can commit. Writing the marker is
+therefore an assertion this machine makes about a store it has just
+validated and installed, not a property the store carries in from outside.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from archex.index.store import IndexStore
+    from archex.models import Config, IndexConfig
+
+
+def stamp_project_index_identity(
+    store: IndexStore,
+    *,
+    repo_root: Path,
+    source_identity: str,
+    commit_hash: str,
+    config: Config,
+    index_config: IndexConfig,
+) -> None:
+    """Record `repo_root`'s identity on an open store, as a full index would.
+
+    These are the same fields, in the same order, that the ordinary
+    full-index and delta paths write when they publish a store: revision,
+    source identity, measurement time, working-tree signature, and the
+    derived generation id. The WAL is checkpointed last so the database file
+    alone carries every write — callers publish by copying that file.
+    """
+    from archex.index.delta import compute_working_tree_signature
+    from archex.serve.generation import finalize_generation_id
+
+    store.set_metadata("commit_hash", commit_hash)
+    store.set_metadata("source_identity", source_identity)
+    store.set_metadata("indexed_at", str(time.time()))
+    store.set_metadata("working_tree_signature", compute_working_tree_signature(repo_root, config))
+    finalize_generation_id(store, index_config)
+    store.conn.execute("PRAGMA wal_checkpoint(FULL)")
+
+
+def project_index_is_provenanced(repo_root: Path, index_path: Path) -> bool:
+    """Whether `index_path` carries archex's own marker for `repo_root`.
+
+    Any surface that serves a repo-local index has to answer this, not just
+    the cache-mediated ones: `.archex/index.db` is an ordinary file a
+    published repository can commit, and an index database describes itself,
+    so its own metadata cannot be the evidence for trusting it.
+
+    The marker is keyed on the checkout's resolved path and the revision the
+    index was published at, and authenticated with this machine's secret, so
+    both the live HEAD and the revision the store records are tried — a
+    legitimate index keeps its marker across commits until the next index
+    run republishes it. Reading the store's recorded revision is safe
+    because it only selects which key to verify; the secret is what decides
+    whether the marker is genuine.
+    """
+    from archex.cache import CacheManager
+    from archex.models import RepoSource
+
+    cache = CacheManager(cache_dir=str(index_path.parent), project_layout=True)
+    source = RepoSource(local_path=str(repo_root))
+    commits = [CacheManager.git_head(str(repo_root)) or "", _recorded_commit(index_path)]
+    return any(
+        commit and cache.marker_matches(cache.cache_key(source, head_override=commit))
+        for commit in commits
+    )
+
+
+def _recorded_commit(index_path: Path) -> str:
+    """Read an index's recorded revision without opening it for writing."""
+    import sqlite3
+    from urllib.parse import quote
+
+    try:
+        conn = sqlite3.connect(f"file:{quote(str(index_path))}?mode=ro", uri=True, timeout=5.0)
+    except sqlite3.Error:
+        return ""
+    try:
+        row = conn.execute("SELECT value FROM metadata WHERE key = 'commit_hash'").fetchone()
+    except sqlite3.Error:
+        return ""
+    finally:
+        conn.close()
+    return "" if row is None else str(row[0])

--- a/src/archex/index/artifact.py
+++ b/src/archex/index/artifact.py
@@ -457,11 +457,74 @@ def _full_reindex_in_place(
         shutil.rmtree(scratch_dir, ignore_errors=True)
 
 
+def _adopt_imported_store(
+    repo_root: Path,
+    dest_db_path: Path,
+    config: Config,
+    index_config: IndexConfig,
+    source_identity: str,
+) -> None:
+    """Make a just-imported store this checkout's own, marker included.
+
+    An imported store still carries the exporting machine's identity, and
+    carries no cache marker at all — so without this the destination's own
+    cache lookup discards it and the next command pays the full re-index the
+    import existed to avoid. Reusing a repo-local index also *requires* the
+    marker, since an index database is otherwise self-describing: the marker
+    is this machine's assertion about a store it has just installed.
+
+    Identity is stamped for any destination. The marker is published only
+    when the destination really is a repository's own `.archex/index.db`,
+    because that is the only shape `CacheManager`'s project layout
+    addresses; publishing it for another path would copy the freshly synced
+    database to a second file and then describe that copy instead.
+    """
+    from archex.cache import CacheManager
+    from archex.index.adopt import stamp_project_index_identity
+    from archex.models import RepoSource
+    from archex.project import PROJECT_DIR_NAME
+
+    store = IndexStore(dest_db_path)
+    try:
+        commit_hash = (
+            CacheManager.git_head(str(repo_root)) or store.get_metadata("commit_hash") or ""
+        )
+        stamp_project_index_identity(
+            store,
+            repo_root=repo_root,
+            source_identity=source_identity,
+            commit_hash=commit_hash,
+            config=config,
+            index_config=index_config,
+        )
+    finally:
+        store.close()
+
+    is_project_index = (
+        dest_db_path.name == "index.db"
+        and dest_db_path.parent.name == PROJECT_DIR_NAME
+        and dest_db_path.parent.parent.resolve() == repo_root.resolve()
+    )
+    if not commit_hash or not is_project_index:
+        logger.info(
+            "Imported store at %s stamped but not marked: %s",
+            dest_db_path,
+            "no resolvable revision" if not commit_hash else "not a repo-local project index",
+        )
+        return
+
+    cache = CacheManager(cache_dir=str(dest_db_path.parent), project_layout=True)
+    key = cache.cache_key(RepoSource(local_path=str(repo_root)), head_override=commit_hash)
+    cache.put(key, dest_db_path, resolved_commit=commit_hash, source_identity=source_identity)
+
+
 def sync_imported_artifact(
     repo_root: Path,
     dest_db_path: str | Path,
     config: Config,
     index_config: IndexConfig | None = None,
+    *,
+    source_identity: str | None = None,
 ) -> ArtifactSyncResult:
     """Bring a freshly-imported artifact store up to date with the working tree.
 
@@ -474,14 +537,36 @@ def sync_imported_artifact(
     that point a targeted delta costs more than starting fresh, and a loud
     fallback is safer than silently syncing a misleadingly "close enough"
     index.
+
+    The synchronized store is then adopted as this checkout's own —
+    identity metadata plus the cache marker — so the next command reuses it
+    instead of re-indexing.
     """
+    dest_db_path = Path(dest_db_path)
+    effective_index_config = index_config or IndexConfig()
+    result = _sync_imported_store(repo_root, dest_db_path, config, effective_index_config)
+    _adopt_imported_store(
+        repo_root,
+        dest_db_path,
+        config,
+        effective_index_config,
+        source_identity if source_identity is not None else str(repo_root),
+    )
+    return result
+
+
+def _sync_imported_store(
+    repo_root: Path,
+    dest_db_path: Path,
+    config: Config,
+    effective_index_config: IndexConfig,
+) -> ArtifactSyncResult:
+    """Delta-sync an imported store to the working tree, or re-index it in place."""
     from archex.acquire import discover_files
     from archex.cache import CacheManager
     from archex.index.delta import apply_delta, compute_working_tree_delta
     from archex.index.graph import DependencyGraph
 
-    dest_db_path = Path(dest_db_path)
-    effective_index_config = index_config or IndexConfig()
     t_start = time.perf_counter()
 
     store = IndexStore(dest_db_path)

--- a/src/archex/index/worktree_seed.py
+++ b/src/archex/index/worktree_seed.py
@@ -46,6 +46,7 @@ from urllib.parse import quote
 
 from archex.cache import CacheManager
 from archex.exceptions import ArchexError
+from archex.index.adopt import stamp_project_index_identity
 from archex.index.compat import INDEX_CONFIG_METADATA_KEYS, index_config_metadata_mismatch
 from archex.index.store import CURRENT_SCHEMA_VERSION, IndexStore
 from archex.models import RepoSource
@@ -720,18 +721,17 @@ def _stamp_destination_identity(
     A copied index still carries the source checkout's identity metadata.
     Left that way the destination's own cache lookup would reject it and
     re-index from scratch on the very next command, so the seed would buy
-    nothing. These are the same fields, written in the same order, that the
-    ordinary full-index path records when it publishes a store.
+    nothing. The artifact-import path needs exactly the same treatment, so
+    the fields live in `archex.index.adopt`.
     """
-    from archex.index.delta import compute_working_tree_signature
-    from archex.serve.generation import finalize_generation_id
-
-    store.set_metadata("commit_hash", destination_head)
-    store.set_metadata("source_identity", source_identity)
-    store.set_metadata("indexed_at", str(time.time()))
-    store.set_metadata("working_tree_signature", compute_working_tree_signature(repo_root, config))
-    finalize_generation_id(store, index_config)
-    store.conn.execute("PRAGMA wal_checkpoint(FULL)")
+    stamp_project_index_identity(
+        store,
+        repo_root=repo_root,
+        source_identity=source_identity,
+        commit_hash=destination_head,
+        config=config,
+        index_config=index_config,
+    )
 
 
 @dataclass(frozen=True)

--- a/src/archex/project.py
+++ b/src/archex/project.py
@@ -24,7 +24,6 @@ vector = false
 splade = false
 module_prefilter = false
 delta_threshold = 0.5
-worktree_seed = true
 
 [dogfood]
 tasks_dir = "benchmarks/tasks"

--- a/src/archex/status.py
+++ b/src/archex/status.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from archex.cache import CacheManager
 from archex.config import load_config
+from archex.index.adopt import project_index_is_provenanced
 from archex.index.delta import compute_working_tree_signature
 from archex.index.store import IndexStore
 from archex.metrics.storage import MetricsStore, metrics_db_path
@@ -80,6 +81,30 @@ def inspect_project_status(source: str | Path) -> ProjectStatus:
             languages={},
             vector_index_available=False,
             dogfood_latest_path=dogfood_latest if dogfood_latest.exists() else None,
+        )
+
+    if not project_index_is_provenanced(project.repo_root, index_path):
+        # Every surface built on this inspection serves the store it names —
+        # `archex status`, `doctor`, `setup`, the session primer, and the
+        # tool-call hook, which injects symbol rows straight into an agent's
+        # context. `.archex/index.db` is an ordinary file a published
+        # repository can commit, so an index without archex's own marker is
+        # of unknown origin: it is reported as such rather than read.
+        return ProjectStatus(
+            repo_root=project.repo_root,
+            initialized=True,
+            state="unprovenanced",
+            index_path=index_path,
+            current_commit=current_commit,
+            indexed_commit="",
+            working_tree="unknown",
+            files_indexed=0,
+            chunks_indexed=0,
+            chunks_fts=0,
+            languages={},
+            vector_index_available=False,
+            dogfood_latest_path=dogfood_latest if dogfood_latest.exists() else None,
+            error="index carries no archex cache marker for this checkout",
         )
 
     config = load_config(project.repo_root)

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -7,12 +7,13 @@ import pytest
 from click.testing import CliRunner
 
 from archex import doctor
+from archex.api import index_repository
 from archex.cli.main import cli
 from archex.doctor import DoctorCheck, DoctorReport, render_doctor_text
 from archex.languages import LanguageSupport
 from archex.metrics.health import record_metrics_failure
 from archex.metrics.storage import metrics_db_path
-from archex.models import LanguageTier
+from archex.models import Config, IndexConfig, LanguageTier, RepoSource
 from archex.project import init_project
 
 
@@ -46,10 +47,25 @@ def test_doctor_json_reports_healthy_project(python_simple_repo: Path) -> None:
     assert checks["model_security"]["details"]["embedding"]["enabled"] is False
 
 
+def _corrupt_a_marked_index(repo: Path) -> None:
+    """Build a real index, then corrupt its bytes but keep its cache marker.
+
+    Truncating the database is what corruption looks like for an index this
+    machine legitimately published; a garbage file with no marker at all is a
+    different state (`unprovenanced`), checked before the store is opened.
+    """
+    store = index_repository(
+        RepoSource(local_path=str(repo)),
+        config=Config(cache=True, cache_dir=str(repo / ".archex")),
+        index_config=IndexConfig(),
+    )
+    store.close()
+    (repo / ".archex" / "index.db").write_text("not sqlite", encoding="utf-8")
+
+
 def test_doctor_json_fails_on_corrupt_index(python_simple_repo: Path) -> None:
     init_project(python_simple_repo)
-    index_path = python_simple_repo / ".archex" / "index.db"
-    index_path.write_text("not sqlite", encoding="utf-8")
+    _corrupt_a_marked_index(python_simple_repo)
     runner = CliRunner()
 
     result = runner.invoke(cli, ["doctor", str(python_simple_repo), "--format", "json"])

--- a/tests/index/test_index_provenance.py
+++ b/tests/index/test_index_provenance.py
@@ -1,0 +1,344 @@
+"""Tests that a project-layout index is only reused when its origin is provable.
+
+`.archex/index.db` and `.archex/settings.toml` are ordinary files, so a
+published repository can commit both. Everything a store says about itself —
+its revision, its source identity, its index-config shape — lives inside that
+same database, so it cannot be the evidence for trusting it. The cache marker
+can: it is keyed on `sha256("<resolved absolute path>@<commit>")`, which
+committed content cannot forge for a clone directory nobody knows in advance.
+
+The scenario built here is the real one, with real `git`: a repository that
+ships a poisoned index, cloned by a victim who then indexes or queries it.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from archex.api import index_repository
+from archex.cli.main import cli
+from archex.config import load_config
+from archex.index.artifact import export_artifact, import_artifact, sync_imported_artifact
+from archex.index.store import IndexStore
+from archex.integrations.hook import _lookup  # pyright: ignore[reportPrivateUsage]
+from archex.models import Config, IndexConfig, PipelineTiming, RepoSource
+from archex.project import init_project
+from archex.status import inspect_project_status
+
+POISON = "ATTACKER_CONTROLLED_PAYLOAD"
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def _commit_all(repo: Path, message: str) -> None:
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", message)
+
+
+def _init_repo(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-b", "main")
+    for index in range(6):
+        (root / f"mod_{index}.py").write_text(
+            f"def value_{index}() -> int:\n    return {index}\n", encoding="utf-8"
+        )
+    _commit_all(root, "initial")
+    return root
+
+
+def _build_project_index(repo: Path) -> None:
+    init_project(repo)
+    store = index_repository(
+        RepoSource(local_path=str(repo)),
+        config=Config(cache=True, cache_dir=str(repo / ".archex")),
+        index_config=IndexConfig(),
+    )
+    store.close()
+
+
+def _poison_chunks(index_path: Path) -> int:
+    """Rewrite chunk bodies and claim the identity a CLI invocation produces.
+
+    `source_identity` is the raw source string a caller passed, and the CLI's
+    default is `.`, so that is what an attacker plants: it matches whatever
+    directory the victim happens to run in.
+    """
+    conn = sqlite3.connect(index_path)
+    try:
+        cursor = conn.execute(
+            "UPDATE chunks SET content = ? WHERE file_path LIKE 'mod_%'", (POISON,)
+        )
+        conn.execute("UPDATE metadata SET value = '.' WHERE key = 'source_identity'")
+        conn.commit()
+        return cursor.rowcount
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def hostile_repo(tmp_path: Path) -> Path:
+    """A repository that commits a poisoned `.archex` index of its own tree.
+
+    The recorded revision is deliberately the *previous* commit, which is
+    what an attacker can do: a database cannot contain the hash of the
+    commit that adds it.
+    """
+    repo = _init_repo(tmp_path / "hostile")
+    _build_project_index(repo)
+    assert _poison_chunks(repo / ".archex" / "index.db") == 6
+    (repo / ".gitignore").write_text("", encoding="utf-8")
+    for name in (".archex/index.db", ".archex/settings.toml", ".gitignore"):
+        _git(repo, "add", "-f", name)
+    _commit_all(repo, "chore: add project config")
+    return repo
+
+
+class TestPlantedIndexIsNotReused:
+    def test_cloned_poisoned_index_is_not_served(self, hostile_repo: Path, tmp_path: Path) -> None:
+        """The committed index must not answer a query on the victim's clone."""
+        victim = tmp_path / "victim"
+        _git(tmp_path, "clone", "-q", str(hostile_repo), str(victim))
+        assert (victim / ".archex" / "index.db").is_file()
+
+        result = CliRunner().invoke(cli, ["query", str(victim), "value_3", "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        assert POISON not in result.output
+
+    def test_cloned_poisoned_index_is_replaced_by_a_real_index(
+        self, hostile_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        victim = tmp_path / "victim"
+        _git(tmp_path, "clone", "-q", str(hostile_repo), str(victim))
+        monkeypatch.chdir(victim)
+
+        timing = PipelineTiming()
+        store = index_repository(
+            RepoSource(local_path="."),
+            config=Config(cache=True, cache_dir=str(victim / ".archex")),
+            index_config=IndexConfig(),
+            timing=timing,
+        )
+        try:
+            contents = [chunk.content for chunk in store.get_chunks()]
+        finally:
+            store.close()
+
+        assert timing.strategy == "full"
+        assert POISON not in contents
+
+    def test_a_marker_from_another_directory_does_not_transfer(
+        self, hostile_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Committing the producer's own marker alongside the index does not help."""
+        marker = json.loads((hostile_repo / ".archex" / "index.meta").read_text(encoding="utf-8"))
+        victim = tmp_path / "victim"
+        _git(tmp_path, "clone", "-q", str(hostile_repo), str(victim))
+        (victim / ".archex" / "index.meta").write_text(json.dumps(marker), encoding="utf-8")
+        monkeypatch.chdir(victim)
+
+        result = CliRunner().invoke(cli, ["query", "value_3", "--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        assert POISON not in result.output
+
+    def test_a_legitimately_built_index_is_still_reused(self, tmp_path: Path) -> None:
+        """The check must not cost an honest project its warm cache."""
+        repo = _init_repo(tmp_path / "honest")
+        _build_project_index(repo)
+
+        timing = PipelineTiming()
+        store = index_repository(
+            RepoSource(local_path=str(repo)),
+            config=Config(cache=True, cache_dir=str(repo / ".archex")),
+            index_config=IndexConfig(),
+            timing=timing,
+        )
+        store.close()
+
+        assert timing.strategy == "cached"
+
+    def test_a_legitimate_index_is_reused_across_a_commit(self, tmp_path: Path) -> None:
+        """A new commit changes the cache key, so reuse then rests on the marker."""
+        repo = _init_repo(tmp_path / "honest")
+        _build_project_index(repo)
+        (repo / "added.py").write_text("def added() -> int:\n    return 9\n", encoding="utf-8")
+        _commit_all(repo, "feat: add a module")
+
+        timing = PipelineTiming()
+        store = index_repository(
+            RepoSource(local_path=str(repo)),
+            config=Config(cache=True, cache_dir=str(repo / ".archex")),
+            index_config=IndexConfig(),
+            timing=timing,
+        )
+        store.close()
+
+        assert timing.strategy == "delta"
+
+
+class TestImportedArtifactIsAdopted:
+    def test_imported_artifact_is_reused_by_the_next_index_run(self, tmp_path: Path) -> None:
+        """An import that is not adopted would be discarded on the next command."""
+        producer = _init_repo(tmp_path / "producer")
+        _build_project_index(producer)
+        artifact = tmp_path / "artifact.xz"
+        store = IndexStore(producer / ".archex" / "index.db")
+        try:
+            export_artifact(store, artifact)
+        finally:
+            store.close()
+
+        consumer = tmp_path / "consumer"
+        _git(tmp_path, "clone", "-q", str(producer), str(consumer))
+        init_project(consumer)
+        (consumer / ".archex" / "index.db").unlink(missing_ok=True)
+        import_artifact(artifact, consumer / ".archex" / "index.db")
+        sync_imported_artifact(
+            consumer,
+            consumer / ".archex" / "index.db",
+            load_config(str(consumer)),
+            IndexConfig(),
+            source_identity=str(consumer),
+        )
+
+        assert (consumer / ".archex" / "index.meta").is_file()
+        timing = PipelineTiming()
+        reused = index_repository(
+            RepoSource(local_path=str(consumer)),
+            config=Config(cache=True, cache_dir=str(consumer / ".archex")),
+            index_config=IndexConfig(),
+            timing=timing,
+        )
+        reused.close()
+
+        assert timing.strategy == "cached"
+
+
+class TestWorktreeSeedIsNotRepoConfigurable:
+    def test_committed_settings_cannot_change_seeding(self, tmp_path: Path) -> None:
+        """A repository must not switch the feature that consumes its content.
+
+        The key is written into the repo-local settings explicitly here,
+        because the generated template no longer contains it: a test that
+        only relied on the template would assert nothing.
+        """
+        repo = _init_repo(tmp_path / "repo")
+        init_project(repo)
+        settings = repo / ".archex" / "settings.toml"
+        original = settings.read_text(encoding="utf-8")
+        assert "worktree_seed" not in original
+
+        settings.write_text(
+            original.replace("[index]", "[index]\nworktree_seed = false"), encoding="utf-8"
+        )
+        assert load_config(str(repo)).worktree_seed is True
+
+        settings.write_text(
+            original.replace("[index]", "[index]\nworktree_seed = true"), encoding="utf-8"
+        )
+        assert load_config(str(repo)).worktree_seed is True
+
+    def test_user_config_and_environment_still_control_seeding(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        repo = _init_repo(tmp_path / "repo")
+        init_project(repo)
+        monkeypatch.setenv("ARCHEX_WORKTREE_SEED", "0")
+
+        assert load_config(str(repo)).worktree_seed is False
+
+
+class TestSurfacesThatReadTheIndexDirectly:
+    def test_status_refuses_an_unprovenanced_index(
+        self, hostile_repo: Path, tmp_path: Path
+    ) -> None:
+        """`archex status` and everything built on it must not read a planted index.
+
+        The tool-call hook gates on this inspection reporting `fresh`, and
+        injects symbol rows straight into an agent's context, so a planted
+        index reading as `fresh` would put attacker-chosen content in front
+        of the agent.
+        """
+        victim = tmp_path / "victim"
+        _git(tmp_path, "clone", "-q", str(hostile_repo), str(victim))
+
+        status = inspect_project_status(victim)
+
+        assert status.state == "unprovenanced"
+        assert status.files_indexed == 0
+        assert status.chunks_indexed == 0
+
+    def test_status_accepts_a_legitimately_built_index(self, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path / "honest")
+        _build_project_index(repo)
+
+        assert inspect_project_status(repo).state == "fresh"
+
+    def test_hook_lookup_declines_an_unprovenanced_index(
+        self, hostile_repo: Path, tmp_path: Path
+    ) -> None:
+        victim = tmp_path / "victim"
+        _git(tmp_path, "clone", "-q", str(hostile_repo), str(victim))
+
+        assert _lookup(str(victim), "value_3") is None
+
+
+class TestRelocatedCacheDirIsNotTrusted:
+    def test_repo_committed_cache_dir_does_not_bypass_the_marker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`cache_dir` is repo-settable, so it cannot gate the marker requirement.
+
+        A published repository can point `cache_dir` at any directory it
+        also commits, which would take the store outside the project layout.
+        The marker is therefore required for every cache-mediated reuse, not
+        only for `.archex`.
+        """
+        repo = _init_repo(tmp_path / "relocated")
+        init_project(repo)
+        settings = repo / ".archex" / "settings.toml"
+        settings.write_text(
+            settings.read_text(encoding="utf-8").replace(
+                'cache_dir = ".archex"', 'cache_dir = "vendor"'
+            ),
+            encoding="utf-8",
+        )
+        vendor = repo / "vendor"
+        vendor.mkdir()
+        store = index_repository(
+            RepoSource(local_path=str(repo)),
+            config=Config(cache=True, cache_dir=str(vendor)),
+            index_config=IndexConfig(),
+        )
+        store.close()
+        assert _poison_chunks(next(vendor.glob("*.db"))) == 6
+        # Drop the marker the honest build wrote, leaving only what a
+        # repository could have committed.
+        for marker in vendor.glob("*.meta"):
+            marker.unlink()
+        monkeypatch.chdir(repo)
+
+        timing = PipelineTiming()
+        rebuilt = index_repository(
+            RepoSource(local_path="."),
+            config=load_config(str(repo)),
+            index_config=IndexConfig(),
+            timing=timing,
+        )
+        try:
+            contents = [chunk.content for chunk in rebuilt.get_chunks()]
+        finally:
+            rebuilt.close()
+
+        assert timing.strategy == "full"
+        assert POISON not in contents

--- a/tests/index/test_worktree_seed.py
+++ b/tests/index/test_worktree_seed.py
@@ -1148,17 +1148,12 @@ class TestIndexingIntegration:
         assert "seed_disposition" not in summary
         assert "Worktree seed" not in result.output
 
-    def test_seeding_can_be_disabled_in_project_settings(
-        self, seed_destination: tuple[Path, Path]
+    def test_seeding_can_be_disabled_for_the_machine(
+        self, seed_destination: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """`worktree_seed` is machine-level: a repository cannot flip it either way."""
         _main, linked = seed_destination
-        settings = linked / ".archex" / "settings.toml"
-        settings.write_text(
-            settings.read_text(encoding="utf-8").replace(
-                "worktree_seed = true", "worktree_seed = false"
-            ),
-            encoding="utf-8",
-        )
+        monkeypatch.setenv("ARCHEX_WORKTREE_SEED", "0")
 
         result = CliRunner().invoke(cli, ["index", str(linked), "--format", "json"])
 

--- a/tests/session/test_service.py
+++ b/tests/session/test_service.py
@@ -14,6 +14,7 @@ from archex.config import load_config
 from archex.index.delta import compute_working_tree_signature
 from archex.index.store import IndexStore
 from archex.integrations.mcp import handle_session
+from archex.models import RepoSource
 from archex.project import ProjectState, init_project
 from archex.session import (
     SessionRecordKind,
@@ -24,16 +25,31 @@ from archex.session import (
 
 
 def _make_fresh_index(repo: Path) -> None:
+    """Hand-build the state a real index run leaves, marker included.
+
+    The cache marker is part of that state, not an optional extra: an index
+    without one is of unknown origin (`.archex/index.db` is an ordinary file
+    a published repository can commit), so every surface that reads the
+    index refuses it.
+    """
     init_project(repo)
     project = ProjectState.resolve(repo)
     config = load_config(project.repo_root)
+    commit = CacheManager.git_head(str(repo)) or ""
     with IndexStore(project.index_path) as store:
-        store.set_metadata("commit_hash", CacheManager.git_head(str(repo)) or "")
+        store.set_metadata("commit_hash", commit)
         store.set_metadata(
             "working_tree_signature",
             compute_working_tree_signature(project.repo_root, config),
         )
         store.clear_reindex_flag()
+    cache = CacheManager(cache_dir=str(project.project_dir), project_layout=True)
+    cache.put(
+        cache.cache_key(RepoSource(local_path=str(repo)), head_override=commit),
+        project.index_path,
+        resolved_commit=commit,
+        source_identity=str(repo),
+    )
 
 
 def test_primer_renders_explicit_records_and_rejects_stale_index(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -430,9 +430,23 @@ def test_status_command_strict_fails_on_dirty_index(python_simple_repo: Path) ->
 
 
 def test_status_command_fails_on_corrupt_index(python_simple_repo: Path) -> None:
+    """A legitimately published index whose bytes went bad reports `corrupt`.
+
+    The index is built (so it carries this machine's cache marker) and then
+    truncated: an unmarked garbage file is a different, earlier state
+    (`unprovenanced`), refused before the store is opened.
+    """
+    from archex.api import index_repository
+    from archex.models import Config, IndexConfig, RepoSource
     from archex.project import init_project
 
     init_project(python_simple_repo)
+    store = index_repository(
+        RepoSource(local_path=str(python_simple_repo)),
+        config=Config(cache=True, cache_dir=str(python_simple_repo / ".archex")),
+        index_config=IndexConfig(),
+    )
+    store.close()
     index_path = python_simple_repo / ".archex" / "index.db"
     index_path.write_text("not sqlite", encoding="utf-8")
     runner = CliRunner()


### PR DESCRIPTION
## Summary

R22 PR-4 of 4, based on #644. Closes a **pre-existing** hole the milestone's security review surfaced: a repo-local `.archex/index.db` was reused on the strength of what it said about itself, so a repository could commit a poisoned index and have a victim's clone serve it.

## The defect, reproduced

`source_identity` and `commit_hash` live *inside* the index database, and `.archex/index.db` / `.archex/settings.toml` are ordinary files. So a published repository can commit both, and:

1. `uses_project_cache_layout` is satisfied by the committed `settings.toml`, with no `archex init`;
2. `CacheManager.get` refuses the committed database (its marker cannot carry the victim's clone key) — but `_try_delta_index` then found it via `find_store_for_source`, which matched on the `source_identity` string the attacker chose (`.`, the CLI default);
3. the recorded `commit_hash` is an ancestor the attacker published, so the delta is small and only the files changed since then get re-parsed;
4. every query answers out of attacker-authored chunk rows attributed to real file paths.

Verified against a real clone with real `git` before the fix: `archex query` returned the planted payload. `tests/index/test_index_provenance.py` reproduces it; with the new gate disabled, two of its tests fail (mutation-checked).

## The fix

Reusing a **project-layout** index now also requires archex's own cache marker. `index.meta` records `sha256("<resolved absolute path>@<commit>")`, so:

- a legitimate index has one, because archex wrote it after building the index in that directory;
- committed content cannot forge one, because the clone directory is not knowable in advance.

This is the binding the exact-hit path already required; the delta path skipped it, which is where the committed database got in. Keyed cache directories are untouched — they live outside the repository and only archex writes them, so no existing global cache entry is invalidated.

## Two consequences, both handled here

**Artifact import is adopted.** `sync_imported_artifact` now stamps the imported store with this checkout's revision, source identity, working-tree signature and generation id, and publishes `index.meta` for this checkout's own cache key. That was already the behavior to want — an unadopted import was discarded by the next command, paying the full re-index the import existed to avoid — and it is now required, since an unmarked store cannot be reused at all. The stamping is shared with the worktree-seed installer (`archex.index.adopt`) rather than duplicated.

**`worktree_seed` becomes machine-level.** A repository's own committed `settings.toml` must not be able to switch on the feature that consumes repository content, so the key is read from `~/.archex/config.toml` or `ARCHEX_WORKTREE_SEED` only, and dropped from the generated project settings template. PR-3's test of the repo-local switch is replaced by one for the machine-level switch, and the docs' "Turning it off" section is corrected.

## Verification

```
uv run pytest tests/index/test_index_provenance.py --no-cov                  -> 8 passed
uv run pytest tests/index tests/cli tests/test_config.py \
              tests/test_project.py --no-cov -p no:randomly                   -> 1045 passed
uv run ruff check .                                                           -> All checks passed
uv run ruff format --check .                                                  -> 558 files already formatted
uv run pyright .                                                              -> 0 errors
```

Mutation check: disabling the marker requirement in `_try_delta_index` makes `test_cloned_poisoned_index_is_not_served` and `test_cloned_poisoned_index_is_replaced_by_a_real_index` fail — the planted payload is served — and both pass with it. Two tests additionally pin that an honest project keeps its warm cache (`cached`) and still deltas across a new commit (`delta`), so the check does not cost legitimate reuse.


## Round-2 remediation (security review findings applied)

The first version of this fix gated the marker requirement on `CacheManager.project_layout`. That was itself bypassable, and the review reproduced it:

- **`cache_dir` is repo-settable.** A published repository commits `cache_dir = "vendor"` plus `vendor/<key>.db`, the cache stops being "project layout", and the gate was skipped. The requirement is now **unconditional** — `CacheManager.get` and the delta-reuse path demand a marker in every layout, because the cache directory is not a trust boundary.
- **The marker was forgeable at a predictable path.** `cache_key` is `sha256("<abs path>@<commit>")`: the commit can be the publisher's own, and checkout paths are fixed on CI runners (`/home/runner/work/<repo>/<repo>`) and in container images. The marker now also carries an HMAC of that key under a machine-local secret at `~/.archex/machine-id`, so repository content cannot produce a valid marker at any path.
- **Surfaces that bypass the cache entirely.** `inspect_project_status` opened `.archex/index.db` directly, and a committed index claiming `commit_hash=""` read as `fresh` — which the tool-call hook uses as its gate before injecting symbol rows into an agent's context. That inspection now reports `unprovenanced`, closing `archex status`, `doctor`, `setup`, the session primer and the hook in one place.
- **Import adoption was over-eager.** `_adopt_imported_store` assumed every `dest_db_path` was a project-layout `index.db`, which for any other path copied the whole freshly-synced database to a second file and marked the copy. It now stamps identity for every destination and publishes the marker only for a real repo-local project index, and no longer skips stamping when HEAD cannot be resolved.
- **Two weak tests replaced.** `test_committed_settings_cannot_enable_seeding` never wrote `worktree_seed` at all (the template no longer contains it), so it asserted only the default; and the headline poisoned-index test invoked the CLI with an absolute path while the fixture plants `source_identity='.'`, so it passed with the gate removed. Both now fail without the fix.

Cost of the unconditional requirement, stated plainly: an index cached before markers were authenticated (including every existing global cache entry) is re-indexed once. A moved or renamed checkout likewise pays one full re-index rather than a delta. Both self-heal on the next run; no flow loses its cache permanently.

Two existing tests that wrote a garbage `index.db` and expected `corrupt` now build a real index first and then truncate it, because an unmarked garbage file is the earlier `unprovenanced` state — the corruption case they are named for is still tested, and now on a store that genuinely carries this machine's marker.
