### PR TITLE
docs(policy): define retrieval-candidate carve-out

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,13 @@ Until Gate A passes on R3's external replication verdict, contributors must not:
 - add a new language tier; or
 - add a new MCP tool.
 
-The unstarted forward milestones from the prior plan — M2, M3, M4, M5, and M10 — are **SUSPENDED — pending strategic-reassessment Gate A**. Do not resume them. The historical pre-registration contract and project-level kill criterion are recoverable with `git show 557c5683e5a2622e0a96370a379365c8498d1dc4:.docs/spikes/S0-replication-gate.md`; the public replication evidence artifacts record the arm verdicts. No lift condition is currently authorized.
+The unstarted forward milestones from the prior plan — M2, M3, M4, M5, and M10 — are **SUSPENDED — pending strategic-reassessment Gate A**. Do not resume them. The historical pre-registration contract and project-level kill criterion are recoverable with `git show 557c5683e5a2622e0a96370a379365c8498d1dc4:.docs/spikes/S0-replication-gate.md`; the public replication evidence artifacts record the arm verdicts. No product, implementation, or promotion lift condition is authorized; the documentation-only R26 planning carve-out below does not change Gate A.
 
-R5, MCP retrieval-gated tool disclosure, is the sole carve-out before Gate A. It may change how existing MCP tools are exposed, but must not add or remove a tool capability or change tool behavior.
+R5, MCP retrieval-gated tool disclosure, is the sole product-surface carve-out before Gate A. It may change how existing MCP tools are exposed, but must not add or remove a tool capability or change tool behavior.
+
+R26 adds one separately authorized, documentation-only benchmark-planning carve-out: contributors may define eligibility policy and pre-register failure-mode task requirements for scope-aware monorepo ranking and symbol-aware exhaustive grep. This carve-out does not authorize candidate code, strategy registration, a corpus or run, a new MCP tool, a language tier, a product-default change, or a reinterpretation of Gate A. Any candidate implementation requires a separate plan and fresh design gate. Any later default consideration must satisfy the complete retrieval-default decision protocol.
+
+The allowed and forbidden R26 work is recorded in [`docs/RETRIEVAL_DEFAULT_DECISIONS.md`](docs/RETRIEVAL_DEFAULT_DECISIONS.md#r26-retrieval-candidate-eligibility).
 
 ## Adding a Language Adapter
 

--- a/docs/RETRIEVAL_DEFAULT_DECISIONS.md
+++ b/docs/RETRIEVAL_DEFAULT_DECISIONS.md
@@ -10,6 +10,36 @@ Operator evidence from the 2026-06-09 retrieval-default benchmark keeps `archex_
 - Keep `archex_query` as the product default; the 2026-06-09 run did not satisfy the strategy switch rule.
 - Do not refresh `benchmarks/dogfood_baseline.json` without explicit approval after a proven improvement.
 
+## R26 retrieval-candidate eligibility
+
+On 2026-09-12, a human explicitly authorized reconsideration of the strategic freeze for one purpose: decide whether two Graft-informed candidates may receive a future benchmark-only implementation plan. This is a planning carve-out, not a Gate A pass or an implementation, run, product, or promotion authorization.
+
+### Candidate eligibility matrix
+
+| Candidate or action | Eligibility after R26 | Binding boundary |
+| --- | --- | --- |
+| Scope-aware monorepo ranking | Eligible only for a future benchmark-only implementation plan | Deterministic scope discovery, shared repository-wide IDF, per-scope normalization, a participation gate, byte-identical retrieved-and-packed context on the single-scope fallback, and searched/included/rejected-scope receipts are mandatory. Candidate-specific scope receipt fields are the only permitted single-scope serialization difference. Personalized PageRank is forbidden. |
+| Symbol-aware exhaustive grep | Eligible only for a future benchmark-only implementation plan | Repository-wide regex and fixed-string matching must remain separate from semantic retrieval, preserve exact source lines, group hits by enclosing indexed symbol, expose searched-file and truncation counts, and treat coupling/fan-in only as ordering metadata. |
+| Personalized PageRank | Ineligible | The measured lane regressed recall, F1, and MAP and added latency; it remains retired. |
+| File-first or round-robin default ranking | Ineligible | The archived C6 family did not recover recall across the broader frontier and remains closed. |
+| Candidate implementation or strategy registration | Not authorized | Requires a separate plan and fresh pre-implementation design gate after the R26 documents merge. |
+| Corpus construction, benchmark execution, or result publication | Not authorized | R26 may pre-register task-family requirements only; it produces no task, corpus, run, artifact, or result. |
+| Product-default change | Not authorized | `archex_query` remains the default. Any later candidate must clear every existing promotion gate on a clean run. |
+| New MCP tool or capability | Not authorized | The exhaustive-grep candidate receives no MCP surface under this carve-out. |
+| Gate A reinterpretation | Not authorized | Gate A remains failed and non-renegotiable; R26 does not revive any cancelled milestone. |
+
+### Future-plan admission gates
+
+A later benchmark-only implementation plan is admissible only when all of these statements are true:
+
+1. It names exactly one candidate from the two eligible rows above and preserves that row's mandatory invariants.
+2. It uses the matching tracked R26 pre-registration without changing its hypothesis, primary metric, task-family requirements, margins, latency gate, receipt gate, or terminal disposition after data exists.
+3. It keeps the candidate opt-in and benchmark-only. Registration in product strategy surfaces, MCP disclosure, or defaults is out of scope.
+4. It requires the retrieved and packed context bytes to match `archex_query` exactly on every single-scope control for scope-aware ranking; only the candidate's searched/included/rejected-scope receipt fields may differ. Symbol-aware grep requires exhaustive hit accounting independent of semantic-retrieval output.
+5. It fails closed when the required task family, provenance, receipts, comparison identity, or warm-latency evidence is incomplete.
+
+Eligibility authorizes planning only. It does not establish that either candidate is useful, implementable, non-inferior, or promotion-eligible.
+
 
 ## Candidate region and context-efficiency gate inputs
 


### PR DESCRIPTION
## Summary

- add the explicitly authorized R26 documentation-only benchmark-planning carve-out
- classify scope-aware monorepo ranking and symbol-aware exhaustive grep as eligible only for future benchmark-only implementation plans
- keep Gate A failed, `archex_query` unchanged, retired PPR/file-first families closed, and implementation/default/MCP/corpus work prohibited

## Authorization and boundary

The user explicitly authorized reconsideration of the strategic freeze on 2026-09-12 after the prior R26 design gate stopped for missing authorization. This PR changes policy documentation only. It authorizes no candidate code, strategy registration, task or corpus creation, benchmark run, MCP capability, language work, product-default change, or Gate A reinterpretation.

## Stack

Stack-Id: `r26-retrieval-eligibility-b7c4e1`
Base: `main`
Position: 1/2

1. `docs/r26-retrieval-carveout` -> this PR
2. `docs/r26-candidate-preregistration` -> #652

Depends on: none — root
Upstack: #652

## Validation

- programmatic policy/prohibition consistency checks: passed
- `git diff --check main...HEAD`: passed
- `git diff --name-only main...HEAD -- src/`: empty
- full local gate: ruff passed; format check passed for 561 files; pyright passed with 0 errors; pytest passed with 5,153 tests and 90.98% coverage
- GitHub CI: 13/13 checks passed

## Review

Two-pass local review found no remaining blocking or should-fix findings. The full-stack review verified that the policy leaves Gate A and the product default unchanged and grants planning eligibility only.