### PR TITLE
feat(benchmark): add deterministic scope ranking

### DIFF
--- a/src/archex/benchmark/scope_aware_candidate.py
+++ b/src/archex/benchmark/scope_aware_candidate.py
@@ -1,0 +1,305 @@
+"""Deterministic benchmark-only ranking for R26 Candidate A."""
+
+from __future__ import annotations
+
+import math
+import sqlite3
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from archex.index.bm25 import BM25Index
+from archex.models import CodeChunk
+
+if TYPE_CHECKING:
+    from archex.index.store import IndexStore
+
+SCOPE_MARKERS = ("package.json", "Cargo.toml")
+CANDIDATE_LIMIT_PER_SCOPE = 150
+PARTICIPATION_THRESHOLD = 0.25
+
+ScopeSearch = Callable[[str, str, int], list[tuple[CodeChunk, float]]]
+
+
+class ScopeAwareRankingError(ValueError):
+    """Raised when the candidate cannot establish its frozen scope contract."""
+
+
+@dataclass(frozen=True)
+class ScopeMap:
+    """Deterministic marker-root ownership for every indexed chunk path."""
+
+    marker_roots: tuple[str, ...]
+    scopes: tuple[str, ...]
+    owners_by_path: dict[str, str]
+
+
+@dataclass(frozen=True)
+class ScopeSearchResult:
+    """One scope's bounded raw BM25 candidates and participation decision."""
+
+    scope: str
+    candidates: tuple[tuple[CodeChunk, float], ...]
+    raw_top_score: float
+    normalized_top_score: float
+    included: bool
+    reason: str
+    post_dedup_contribution_count: int
+
+
+@dataclass(frozen=True)
+class RankedScopeCandidate:
+    """One deduplicated candidate with its repository-normalized score."""
+
+    chunk: CodeChunk
+    normalized_score: float
+    scope: str
+
+
+@dataclass(frozen=True)
+class ScopeRanking:
+    """Candidate ranking plus the counts needed by the R27 receipt contract."""
+
+    searches: tuple[ScopeSearchResult, ...]
+    candidates: tuple[RankedScopeCandidate, ...]
+    repository_global_max_raw_score: float
+    pre_dedup_candidate_count: int
+    duplicate_candidate_count: int
+    post_dedup_candidate_count: int
+
+
+def scope_roots(repo_root: Path) -> tuple[str, ...]:
+    """Return bytewise-sorted package/Cargo marker roots, matching the R27 freeze."""
+    roots: set[str] = set()
+    for marker in SCOPE_MARKERS:
+        for path in repo_root.rglob(marker):
+            if ".git" in path.parts:
+                continue
+            relative = path.parent.relative_to(repo_root).as_posix()
+            roots.add("" if relative == "." else relative)
+    return tuple(sorted(roots))
+
+
+def owner_scope(path: str, roots: Sequence[str]) -> str | None:
+    """Resolve one repository-relative path to its deepest marker-root prefix."""
+    owners = [root for root in roots if not root or path == root or path.startswith(f"{root}/")]
+    if not owners:
+        return None
+    return max(owners, key=lambda value: (len(value.split("/")), value))
+
+
+def resolve_scope_map(repo_root: Path, chunks: Sequence[CodeChunk]) -> ScopeMap:
+    """Resolve indexed chunks to non-empty scopes and discard empty marker roots."""
+    roots = scope_roots(repo_root)
+    owners_by_path: dict[str, str] = {}
+    for path in sorted({chunk.file_path for chunk in chunks}):
+        owner = owner_scope(path, roots)
+        if owner is not None:
+            owners_by_path[path] = owner
+    scopes = tuple(sorted(set(owners_by_path.values())))
+    if not scopes:
+        raise ScopeAwareRankingError("no non-empty marker-root scope owns an indexed chunk")
+    return ScopeMap(marker_roots=roots, scopes=scopes, owners_by_path=owners_by_path)
+
+
+class _ScopedBM25Index(BM25Index):
+    """BM25Index using one shared FTS corpus with a scope-owner predicate."""
+
+    def __init__(self, store: IndexStore, scope_map: ScopeMap) -> None:
+        super().__init__(store)
+        self._scope = ""
+        self._owners_by_path = scope_map.owners_by_path
+        self._owner_function = f"archex_scope_owner_{id(self):x}"
+        store.conn.create_function(
+            self._owner_function,
+            1,
+            self._owner_for_sql,
+            deterministic=True,
+        )
+
+    def _owner_for_sql(self, value: object) -> str | None:
+        return self._owners_by_path.get(str(value))
+
+    @staticmethod
+    def _apply_path_bonus(
+        results: list[tuple[CodeChunk, float]],
+        tokens: list[str],
+    ) -> list[tuple[CodeChunk, float]]:
+        boosted = BM25Index._apply_path_bonus(  # pyright: ignore[reportPrivateUsage]
+            results,
+            tokens,
+        )
+        return sorted(
+            boosted,
+            key=lambda result: (
+                -result[1],
+                result[0].file_path,
+                result[0].start_line,
+                result[0].id,
+            ),
+        )
+
+    def _execute_fts(
+        self,
+        escaped: str,
+        top_k: int,
+        weights: tuple[float, float, float, float, float, float] = (
+            1.0,
+            10.0,
+            1.5,
+            6.0,
+            5.0,
+            8.0,
+        ),
+    ) -> list[tuple[str, float]]:
+        """Run the existing BM25 formula over rows owned by the active scope."""
+        w_content, w_symbol, w_path, w_docstring, w_bc, w_summary = weights
+        try:
+            cursor = self._store.conn.execute(
+                "SELECT chunk_id, "
+                f"bm25(chunks_fts, {w_content}, {w_symbol}, {w_path}, "
+                f"{w_docstring}, {w_bc}, {w_summary}) AS score "
+                "FROM chunks_fts WHERE chunks_fts MATCH ? "
+                f"AND {self._owner_function}(file_path) = ? "
+                "ORDER BY score, file_path, chunk_id LIMIT ?",
+                (escaped, self._scope, top_k),
+            )
+        except sqlite3.OperationalError as exc:
+            raise ScopeAwareRankingError(
+                f"scope-aware FTS5 query failed for scope {self._scope!r}: {escaped}"
+            ) from exc
+        return [(str(row[0]), float(row[1])) for row in cursor.fetchall()]
+
+    def search_scope(
+        self,
+        scope: str,
+        query: str,
+        top_k: int = CANDIDATE_LIMIT_PER_SCOPE,
+    ) -> list[tuple[CodeChunk, float]]:
+        """Search one owner scope without changing the repository-wide BM25 corpus."""
+        self._scope = scope
+        return self.search(query, top_k=top_k)
+
+    def close(self) -> None:
+        """Remove the connection-local owner function installed for this search."""
+        self._store.conn.create_function(self._owner_function, 1, None)
+
+
+def rank_scope_candidates(
+    scope_map: ScopeMap,
+    query: str,
+    search_scope: ScopeSearch,
+) -> ScopeRanking | None:
+    """Apply the frozen normalization, participation, deduplication, and order.
+
+    ``None`` is the exact single-scope bypass signal. The caller must delegate
+    that case to unchanged ``archex_query`` without invoking ``search_scope``.
+    """
+    if len(scope_map.scopes) == 1:
+        return None
+    if not scope_map.scopes:
+        raise ScopeAwareRankingError("scope map contains no non-empty scopes")
+
+    raw_results: list[tuple[str, tuple[tuple[CodeChunk, float], ...]]] = []
+    for scope in scope_map.scopes:
+        candidates = tuple(search_scope(scope, query, CANDIDATE_LIMIT_PER_SCOPE))
+        if len(candidates) > CANDIDATE_LIMIT_PER_SCOPE:
+            raise ScopeAwareRankingError(
+                f"scope {scope!r} returned {len(candidates)} candidates; "
+                f"limit is {CANDIDATE_LIMIT_PER_SCOPE}"
+            )
+        if any(not math.isfinite(score) for _, score in candidates):
+            raise ScopeAwareRankingError(f"scope {scope!r} returned a non-finite score")
+        raw_results.append((scope, candidates))
+    raw_by_scope = tuple(raw_results)
+    global_max = max(
+        (score for _, candidates in raw_by_scope for _, score in candidates if score > 0.0),
+        default=0.0,
+    )
+    pre_dedup_count = sum(len(candidates) for _, candidates in raw_by_scope)
+
+    all_winners: dict[str, RankedScopeCandidate] = {}
+    decisions: list[ScopeSearchResult] = []
+    provisional: list[tuple[str, tuple[tuple[CodeChunk, float], ...], float, float, bool, str]] = []
+    for scope, candidates in raw_by_scope:
+        raw_top = max((score for _, score in candidates), default=0.0)
+        if global_max <= 0.0:
+            normalized_top = 0.0
+            included = False
+            reason = "non_positive_global_max"
+        else:
+            normalized_top = raw_top / global_max
+            included = normalized_top >= PARTICIPATION_THRESHOLD
+            reason = (
+                "normalized_top_at_or_above_threshold"
+                if included
+                else "normalized_top_below_threshold"
+            )
+        provisional.append((scope, candidates, raw_top, normalized_top, included, reason))
+        for chunk, raw_score in candidates:
+            normalized = raw_score / global_max if global_max > 0.0 else 0.0
+            candidate = RankedScopeCandidate(
+                chunk=chunk,
+                normalized_score=normalized,
+                scope=scope,
+            )
+            previous = all_winners.get(chunk.id)
+            if previous is None or candidate.normalized_score > previous.normalized_score:
+                all_winners[chunk.id] = candidate
+
+    contribution_counts: dict[str, int] = dict.fromkeys(scope_map.scopes, 0)
+    for candidate in all_winners.values():
+        contribution_counts[candidate.scope] += 1
+
+    included_scopes = {scope for scope, _, _, _, included, _ in provisional if included}
+    ranked = tuple(
+        sorted(
+            (candidate for candidate in all_winners.values() if candidate.scope in included_scopes),
+            key=lambda candidate: (
+                -candidate.normalized_score,
+                candidate.chunk.file_path,
+                candidate.chunk.start_line,
+                candidate.chunk.id,
+            ),
+        )
+    )
+    for scope, candidates, raw_top, normalized_top, included, reason in provisional:
+        decisions.append(
+            ScopeSearchResult(
+                scope=scope,
+                candidates=candidates,
+                raw_top_score=raw_top,
+                normalized_top_score=normalized_top,
+                included=included,
+                reason=reason,
+                post_dedup_contribution_count=contribution_counts[scope],
+            )
+        )
+
+    post_dedup_count = len(all_winners)
+    return ScopeRanking(
+        searches=tuple(decisions),
+        candidates=ranked,
+        repository_global_max_raw_score=global_max,
+        pre_dedup_candidate_count=pre_dedup_count,
+        duplicate_candidate_count=pre_dedup_count - post_dedup_count,
+        post_dedup_candidate_count=post_dedup_count,
+    )
+
+
+def rank_scopes(
+    store: IndexStore,
+    repo_root: Path,
+    query: str,
+    chunks: Sequence[CodeChunk],
+) -> tuple[ScopeMap, ScopeRanking | None]:
+    """Resolve scopes and rank them through one repository-wide BM25 store."""
+    scope_map = resolve_scope_map(repo_root, chunks)
+    if len(scope_map.scopes) == 1:
+        return scope_map, None
+    index = _ScopedBM25Index(store, scope_map)
+    try:
+        return scope_map, rank_scope_candidates(scope_map, query, index.search_scope)
+    finally:
+        index.close()

--- a/tests/benchmark/test_scope_aware_candidate.py
+++ b/tests/benchmark/test_scope_aware_candidate.py
@@ -1,0 +1,233 @@
+"""Behavioral guards for the benchmark-only R28 scope-aware ranker."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from archex.benchmark.scope_aware_candidate import (
+    CANDIDATE_LIMIT_PER_SCOPE,
+    ScopeAwareRankingError,
+    ScopeMap,
+    owner_scope,
+    rank_scope_candidates,
+    rank_scopes,
+    resolve_scope_map,
+)
+from archex.index.bm25 import BM25Index
+from archex.index.store import IndexStore
+from archex.models import CodeChunk
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _chunk(chunk_id: str, path: str, *, line: int = 1, content: str = "needle") -> CodeChunk:
+    return CodeChunk(
+        id=chunk_id,
+        content=content,
+        file_path=path,
+        start_line=line,
+        end_line=line,
+        language="python",
+        token_count=4,
+    )
+
+
+def _scope_map(*scopes: str) -> ScopeMap:
+    return ScopeMap(
+        marker_roots=tuple(scopes),
+        scopes=tuple(scopes),
+        owners_by_path={f"{scope}/file.py": scope for scope in scopes},
+    )
+
+
+def test_scope_resolution_uses_deepest_prefix_and_discards_empty_roots(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text("{}")
+    (tmp_path / "packages" / "api" / "empty").mkdir(parents=True)
+    (tmp_path / "packages" / "api" / "package.json").write_text("{}")
+    (tmp_path / "packages" / "api" / "empty" / "package.json").write_text("{}")
+    chunks = [
+        _chunk("root", "src/root.py"),
+        _chunk("api", "packages/api/src/api.py"),
+    ]
+
+    resolved = resolve_scope_map(tmp_path, chunks)
+
+    assert resolved.marker_roots == ("", "packages/api", "packages/api/empty")
+    assert resolved.scopes == ("", "packages/api")
+    assert resolved.owners_by_path == {
+        "packages/api/src/api.py": "packages/api",
+        "src/root.py": "",
+    }
+    assert owner_scope("packages/api/src/nested.py", resolved.marker_roots) == "packages/api"
+
+
+def test_single_scope_returns_bypass_without_searching() -> None:
+    searched = False
+
+    def _unexpected_search(_scope: str, _query: str, _limit: int) -> list[tuple[CodeChunk, float]]:
+        nonlocal searched
+        searched = True
+        return []
+
+    ranking = rank_scope_candidates(_scope_map("packages/api"), "needle", _unexpected_search)
+
+    assert ranking is None
+    assert searched is False
+
+
+def test_one_store_filters_and_bounds_each_scope(tmp_path: Path) -> None:
+    for scope in ("packages/api", "packages/web"):
+        marker = tmp_path / scope / "package.json"
+        marker.parent.mkdir(parents=True)
+        marker.write_text("{}")
+    chunks = [
+        _chunk(f"api-{index:03d}", f"packages/api/src/file_{index:03d}.py")
+        for index in range(CANDIDATE_LIMIT_PER_SCOPE + 1)
+    ] + [
+        _chunk(f"web-{index:03d}", f"packages/web/src/file_{index:03d}.py")
+        for index in range(CANDIDATE_LIMIT_PER_SCOPE + 1)
+    ]
+    store = IndexStore(tmp_path / "index.db")
+    try:
+        store.insert_chunks(chunks)
+        BM25Index(store).build(chunks)
+
+        scope_map, ranking = rank_scopes(store, tmp_path, "needle", chunks)
+
+        assert scope_map.scopes == ("packages/api", "packages/web")
+        assert ranking is not None
+        assert ranking.repository_global_max_raw_score > 0.0
+        assert [len(search.candidates) for search in ranking.searches] == [
+            CANDIDATE_LIMIT_PER_SCOPE,
+            CANDIDATE_LIMIT_PER_SCOPE,
+        ]
+        assert all(
+            chunk.file_path.startswith(f"{search.scope}/")
+            for search in ranking.searches
+            for chunk, _score in search.candidates
+        )
+    finally:
+        store.close()
+
+
+def test_scoped_search_uses_repository_wide_idf(tmp_path: Path) -> None:
+    for scope in ("packages/api", "packages/web"):
+        marker = tmp_path / scope / "package.json"
+        marker.parent.mkdir(parents=True)
+        marker.write_text("{}")
+    matching = _chunk("match", "packages/api/src/match.py")
+    unrelated = [
+        _chunk(
+            f"web-{index:03d}",
+            f"packages/web/src/file_{index:03d}.py",
+            content="unrelated",
+        )
+        for index in range(100)
+    ]
+    shared_chunks = [matching, *unrelated]
+    shared_store = IndexStore(tmp_path / "shared.db")
+    isolated_store = IndexStore(tmp_path / "isolated.db")
+    try:
+        shared_store.insert_chunks(shared_chunks)
+        BM25Index(shared_store).build(shared_chunks)
+        _scope_map_result, ranking = rank_scopes(
+            shared_store,
+            tmp_path,
+            "needle",
+            shared_chunks,
+        )
+        assert ranking is not None
+        shared_score = ranking.searches[0].raw_top_score
+
+        isolated_store.insert_chunks([matching])
+        isolated_index = BM25Index(isolated_store)
+        isolated_index.build([matching])
+        isolated_score = isolated_index.search("needle", top_k=1)[0][1]
+
+        assert shared_score > isolated_score
+    finally:
+        shared_store.close()
+        isolated_store.close()
+
+
+def test_scope_candidate_limit_fails_closed() -> None:
+    candidates = [
+        (_chunk(f"chunk-{index}", f"a/file_{index}.py"), 1.0)
+        for index in range(CANDIDATE_LIMIT_PER_SCOPE + 1)
+    ]
+
+    with pytest.raises(ScopeAwareRankingError, match="limit is 150"):
+        rank_scope_candidates(
+            _scope_map("a", "b"),
+            "needle",
+            lambda _scope, _query, _limit: candidates,
+        )
+
+
+def test_global_normalization_inclusive_gate_dedup_and_order() -> None:
+    top = _chunk("top", "a/top.py")
+    duplicate_a = _chunk("duplicate", "a/duplicate.py")
+    duplicate_b = duplicate_a.model_copy(update={"file_path": "b/duplicate.py"})
+    boundary_late = _chunk("boundary-late", "z.py", line=1)
+    boundary_early = _chunk("boundary-early", "a.py", line=2)
+    boundary_first = _chunk("boundary-first", "a.py", line=1)
+    rejected = _chunk("rejected", "c/rejected.py")
+    raw = {
+        "a": [(top, 4.0), (duplicate_a, 2.0)],
+        "b": [
+            (duplicate_b, 3.0),
+            (boundary_late, 1.0),
+            (boundary_early, 1.0),
+            (boundary_first, 1.0),
+        ],
+        "c": [(rejected, 0.99)],
+    }
+
+    ranking = rank_scope_candidates(
+        _scope_map("a", "b", "c"),
+        "needle",
+        lambda scope, _query, _limit: raw[scope],
+    )
+
+    assert ranking is not None
+    assert ranking.repository_global_max_raw_score == 4.0
+    assert [search.included for search in ranking.searches] == [True, True, False]
+    assert [search.reason for search in ranking.searches] == [
+        "normalized_top_at_or_above_threshold",
+        "normalized_top_at_or_above_threshold",
+        "normalized_top_below_threshold",
+    ]
+    assert ranking.searches[1].normalized_top_score == 0.75
+    assert ranking.pre_dedup_candidate_count == 7
+    assert ranking.duplicate_candidate_count == 1
+    assert ranking.post_dedup_candidate_count == 6
+    assert sum(search.post_dedup_contribution_count for search in ranking.searches) == 6
+    assert [candidate.chunk.id for candidate in ranking.candidates] == [
+        "top",
+        "duplicate",
+        "boundary-first",
+        "boundary-early",
+        "boundary-late",
+    ]
+    assert ranking.candidates[-3].normalized_score == 0.25
+
+
+def test_non_positive_global_max_rejects_every_scope() -> None:
+    raw = {
+        "a": [(_chunk("a", "a/file.py"), 0.0)],
+        "b": [(_chunk("b", "b/file.py"), -1.0)],
+    }
+
+    ranking = rank_scope_candidates(
+        _scope_map("a", "b"),
+        "needle",
+        lambda scope, _query, _limit: raw[scope],
+    )
+
+    assert ranking is not None
+    assert ranking.repository_global_max_raw_score == 0.0
+    assert ranking.candidates == ()
+    assert all(search.reason == "non_positive_global_max" for search in ranking.searches)


### PR DESCRIPTION
## Summary

- add deterministic marker-root scope ownership with deepest-prefix selection
- search every scope through one repository-wide BM25/IDF store with a 150-candidate cap
- apply frozen global-max normalization, inclusive participation, chunk-ID deduplication, and deterministic ordering
- bypass candidate search entirely for exact one-scope repositories

## Scope

Benchmark-only Candidate A implementation for R28. R27 population, cells, manifest, and corpus remain immutable. This PR does not add receipts, source identity, treatment results, candidate implementation data, product CLI/MCP behavior, or product defaults.

## Validation

- `uv run ruff check src/archex/benchmark/scope_aware_candidate.py tests/benchmark/test_scope_aware_candidate.py`
- `uv run ruff format --check src/archex/benchmark/scope_aware_candidate.py tests/benchmark/test_scope_aware_candidate.py`
- `uv run pyright src/archex/benchmark/scope_aware_candidate.py tests/benchmark/test_scope_aware_candidate.py`
- `uv run pytest tests/benchmark/test_scope_aware_candidate.py --no-cov`
- independent review: PASS, no blocking or should-fix findings

## Stack

Stack-Id: `r28-scope-ranking-20260912`

1. `feat/r28-scope-ranking` — deterministic ranking
2. `feat/r28-scope-receipts` — strict receipts and benchmark-only registration
