### PR TITLE
fix(dogfood): report missing tasks directory instead of raising FileNotFoundError

### DIFF
--- a/src/archex/cli/dogfood_cmd.py
+++ b/src/archex/cli/dogfood_cmd.py
@@ -52,7 +52,12 @@ def dogfood_cmd(
     baseline_path: str | None,
     output_format: str,
 ) -> None:
-    """Run self-benchmark dogfood tasks and gate against a stored baseline."""
+    """Run self-benchmark dogfood tasks and gate against a stored baseline.
+
+    Tasks are read from SOURCE's own benchmark directory (benchmarks/tasks by
+    default, overridable via [dogfood] tasks_dir in .archex/settings.toml), so
+    this command only works in a repository that ships dogfood tasks.
+    """
     del run_all_self
     try:
         result = run_dogfood(

--- a/src/archex/dogfood.py
+++ b/src/archex/dogfood.py
@@ -71,6 +71,13 @@ def run_dogfood(
     state = ProjectState.resolve(source)
     settings = _load_dogfood_settings(state)
     tasks_dir = _resolve_repo_path(settings.tasks_dir, state.repo_root)
+    if not tasks_dir.is_dir():
+        raise ValueError(
+            f"Dogfood tasks directory not found: {tasks_dir}. "
+            "Dogfood runs benchmark tasks stored in the target repository, so it only works "
+            "in a repository that ships them. Set [dogfood] tasks_dir in "
+            f"{state.settings_path} to point at a task directory."
+        )
     output_dir = _resolve_repo_path(settings.output_dir, state.repo_root)
     selected_tasks = _select_tasks(
         tasks_dir,

--- a/tests/benchmark/test_dogfood.py
+++ b/tests/benchmark/test_dogfood.py
@@ -554,3 +554,15 @@ def test_dogfood_command_exits_nonzero_on_ranking_violation(
     assert result.exit_code == 1
     assert "Ranking violations:" in result.output
     assert "symbol_count" in result.output
+
+
+def test_dogfood_command_reports_missing_tasks_dir_without_traceback(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["dogfood", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "Dogfood tasks directory not found" in result.output
+    assert "tasks_dir" in result.output


### PR DESCRIPTION
## Problem

Running `archex dogfood` in any repository that does not ship benchmark tasks crashes with an unhandled traceback instead of a usable message:

```
$ archex dogfood
Traceback (most recent call last):
  ...
  File ".../archex/benchmark/loader.py", line 116, in load_tasks
    raise FileNotFoundError(f"Tasks directory not found: {directory}")
FileNotFoundError: Tasks directory not found: /path/to/my-project/benchmarks/tasks
```

`dogfood` resolves `tasks_dir` against the *target* repository's root, so this is the expected outcome for every repo but archex itself — yet nothing in the output says so, and `--help` does not mention that tasks come from the target repo or that `[dogfood] tasks_dir` overrides the path.

## Change

- `run_dogfood` validates `tasks_dir` before `load_tasks` and raises a `ValueError`, which `dogfood_cmd` already converts into a clean `ClickException` (exit 1, no traceback). The message names the resolved path and the settings key that overrides it.
- The command docstring documents the task source and the `[dogfood] tasks_dir` override, so it shows up in `--help`.

After:

```
$ archex dogfood /path/to/my-project
Error: Dogfood tasks directory not found: /path/to/my-project/benchmarks/tasks. Dogfood runs
benchmark tasks stored in the target repository, so it only works in a repository that ships
them. Set [dogfood] tasks_dir in /path/to/my-project/.archex/settings.toml to point at a task
directory.
```

## Verification

- New test `test_dogfood_command_reports_missing_tasks_dir_without_traceback`: fails on `main` (the `FileNotFoundError` propagates out of the CLI), passes with this change.
- `pytest tests/benchmark/test_dogfood.py` — 14 passed.
- `ruff check` / `ruff format --check` clean, `pyright` 0 errors on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)